### PR TITLE
[I18N] *: create a saas-15.2 specific project

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -2,1312 +2,1288 @@
 host = https://www.transifex.com
 type = PO
 
-[odoo-master.base]
+[odoo-s15-2.base]
 file_filter = odoo/addons/base/i18n/<lang>.po
 source_file = odoo/addons/base/i18n/base.pot
 source_lang = en
 
-[odoo-master.account]
+[odoo-s15-2.account]
 file_filter = addons/account/i18n/<lang>.po
 source_file = addons/account/i18n/account.pot
 source_lang = en
 
-[odoo-master.account_check_printing]
+[odoo-s15-2.account_check_printing]
 file_filter = addons/account_check_printing/i18n/<lang>.po
 source_file = addons/account_check_printing/i18n/account_check_printing.pot
 source_lang = en
 
-[odoo-master.account_debit_note]
+[odoo-s15-2.account_debit_note]
 file_filter = addons/account_debit_note/i18n/<lang>.po
 source_file = addons/account_debit_note/i18n/account_debit_note.pot
 source_lang = en
 
-[odoo-master.account_edi]
+[odoo-s15-2.account_edi]
 file_filter = addons/account_edi/i18n/<lang>.po
 source_file = addons/account_edi/i18n/account_edi.pot
 source_lang = en
 
-[odoo-master.account_edi_facturx]
+[odoo-s15-2.account_edi_facturx]
 file_filter = addons/account_edi_facturx/i18n/<lang>.po
 source_file = addons/account_edi_facturx/i18n/account_edi_facturx.pot
 source_lang = en
 
-[odoo-master.account_edi_proxy_client]
+[odoo-s15-2.account_edi_proxy_client]
 file_filter = addons/account_edi_proxy_client/i18n/<lang>.po
 source_file = addons/account_edi_proxy_client/i18n/account_edi_proxy_client.pot
 source_lang = en
 
-[odoo-master.account_fleet]
+[odoo-s15-2.account_edi_ubl_cii]
+file_filter = addons/account_edi_ubl_cii/i18n/<lang>.po
+source_file = addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
+source_lang = en
+
+[odoo-s15-2.account_fleet]
 file_filter = addons/account_fleet/i18n/<lang>.po
 source_file = addons/account_fleet/i18n/account_fleet.pot
 source_lang = en
 
-[odoo-master.account_lock]
+[odoo-s15-2.account_lock]
 file_filter = addons/account_lock/i18n/<lang>.po
 source_file = addons/account_lock/i18n/account_lock.pot
 source_lang = en
 
-[odoo-master.account_payment]
+[odoo-s15-2.account_payment]
 file_filter = addons/account_payment/i18n/<lang>.po
 source_file = addons/account_payment/i18n/account_payment.pot
 source_lang = en
 
-[odoo-master.account_sale_timesheet]
+[odoo-s15-2.account_sale_timesheet]
 file_filter = addons/account_sale_timesheet/i18n/<lang>.po
 source_file = addons/account_sale_timesheet/i18n/account_sale_timesheet.pot
 source_lang = en
 
-[odoo-master.account_tax_python]
+[odoo-s15-2.account_tax_python]
 file_filter = addons/account_tax_python/i18n/<lang>.po
 source_file = addons/account_tax_python/i18n/account_tax_python.pot
 source_lang = en
 
-[odoo-master.analytic]
+[odoo-s15-2.analytic]
 file_filter = addons/analytic/i18n/<lang>.po
 source_file = addons/analytic/i18n/analytic.pot
 source_lang = en
 
-[odoo-master.auth_ldap]
-file_filter = addons/auth_ldap/i18n/<lang>.po
-source_file = addons/auth_ldap/i18n/auth_ldap.pot
-source_lang = en
-
-[odoo-master.auth_oauth]
+[odoo-s15-2.auth_oauth]
 file_filter = addons/auth_oauth/i18n/<lang>.po
 source_file = addons/auth_oauth/i18n/auth_oauth.pot
 source_lang = en
 
-[odoo-master.auth_password_policy]
+[odoo-s15-2.auth_password_policy]
 file_filter = addons/auth_password_policy/i18n/<lang>.po
 source_file = addons/auth_password_policy/i18n/auth_password_policy.pot
 source_lang = en
 
-[odoo-master.auth_signup]
+[odoo-s15-2.auth_signup]
 file_filter = addons/auth_signup/i18n/<lang>.po
 source_file = addons/auth_signup/i18n/auth_signup.pot
 source_lang = en
 
-[odoo-master.auth_totp]
+[odoo-s15-2.auth_totp]
 file_filter = addons/auth_totp/i18n/<lang>.po
 source_file = addons/auth_totp/i18n/auth_totp.pot
 source_lang = en
 
-[odoo-master.auth_totp_mail]
+[odoo-s15-2.auth_totp_mail]
 file_filter = addons/auth_totp_mail/i18n/<lang>.po
 source_file = addons/auth_totp_mail/i18n/auth_totp_mail.pot
 source_lang = en
 
-[odoo-master.auth_totp_mail_enforce]
+[odoo-s15-2.auth_totp_mail_enforce]
 file_filter = addons/auth_totp_mail_enforce/i18n/<lang>.po
 source_file = addons/auth_totp_mail_enforce/i18n/auth_totp_mail_enforce.pot
 source_lang = en
 
-[odoo-master.auth_totp_portal]
+[odoo-s15-2.auth_totp_portal]
 file_filter = addons/auth_totp_portal/i18n/<lang>.po
 source_file = addons/auth_totp_portal/i18n/auth_totp_portal.pot
 source_lang = en
 
-[odoo-master.barcodes]
+[odoo-s15-2.barcodes]
 file_filter = addons/barcodes/i18n/<lang>.po
 source_file = addons/barcodes/i18n/barcodes.pot
 source_lang = en
 
-[odoo-master.barcodes_gs1_nomenclature]
+[odoo-s15-2.barcodes_gs1_nomenclature]
 file_filter = addons/barcodes_gs1_nomenclature/i18n/<lang>.po
 source_file = addons/barcodes_gs1_nomenclature/i18n/barcodes_gs1_nomenclature.pot
 source_lang = en
 
-[odoo-master.base_address_extended]
+[odoo-s15-2.base_address_extended]
 file_filter = addons/base_address_extended/i18n/<lang>.po
 source_file = addons/base_address_extended/i18n/base_address_extended.pot
 source_lang = en
 
-[odoo-master.base_automation]
+[odoo-s15-2.base_automation]
 file_filter = addons/base_automation/i18n/<lang>.po
 source_file = addons/base_automation/i18n/base_automation.pot
 source_lang = en
 
-[odoo-master.base_geolocalize]
+[odoo-s15-2.base_geolocalize]
 file_filter = addons/base_geolocalize/i18n/<lang>.po
 source_file = addons/base_geolocalize/i18n/base_geolocalize.pot
 source_lang = en
 
-[odoo-master.base_iban]
+[odoo-s15-2.base_iban]
 file_filter = addons/base_iban/i18n/<lang>.po
 source_file = addons/base_iban/i18n/base_iban.pot
 source_lang = en
 
-[odoo-master.base_import]
+[odoo-s15-2.base_import]
 file_filter = addons/base_import/i18n/<lang>.po
 source_file = addons/base_import/i18n/base_import.pot
 source_lang = en
 
-[odoo-master.base_import_module]
+[odoo-s15-2.base_import_module]
 file_filter = addons/base_import_module/i18n/<lang>.po
 source_file = addons/base_import_module/i18n/base_import_module.pot
 source_lang = en
 
-[odoo-master.base_setup]
+[odoo-s15-2.base_setup]
 file_filter = addons/base_setup/i18n/<lang>.po
 source_file = addons/base_setup/i18n/base_setup.pot
 source_lang = en
 
-[odoo-master.base_sparse_field]
+[odoo-s15-2.base_sparse_field]
 file_filter = addons/base_sparse_field/i18n/<lang>.po
 source_file = addons/base_sparse_field/i18n/base_sparse_field.pot
 source_lang = en
 
-[odoo-master.base_vat]
+[odoo-s15-2.base_vat]
 file_filter = addons/base_vat/i18n/<lang>.po
 source_file = addons/base_vat/i18n/base_vat.pot
 source_lang = en
 
-[odoo-master.board]
+[odoo-s15-2.board]
 file_filter = addons/board/i18n/<lang>.po
 source_file = addons/board/i18n/board.pot
 source_lang = en
 
-[odoo-master.bus]
+[odoo-s15-2.bus]
 file_filter = addons/bus/i18n/<lang>.po
 source_file = addons/bus/i18n/bus.pot
 source_lang = en
 
-[odoo-master.calendar]
+[odoo-s15-2.calendar]
 file_filter = addons/calendar/i18n/<lang>.po
 source_file = addons/calendar/i18n/calendar.pot
 source_lang = en
 
-[odoo-master.calendar_sms]
+[odoo-s15-2.calendar_sms]
 file_filter = addons/calendar_sms/i18n/<lang>.po
 source_file = addons/calendar_sms/i18n/calendar_sms.pot
 source_lang = en
 
-[odoo-master.contacts]
+[odoo-s15-2.contacts]
 file_filter = addons/contacts/i18n/<lang>.po
 source_file = addons/contacts/i18n/contacts.pot
 source_lang = en
 
-[odoo-master.coupon]
+[odoo-s15-2.coupon]
 file_filter = addons/coupon/i18n/<lang>.po
 source_file = addons/coupon/i18n/coupon.pot
 source_lang = en
 
-[odoo-master.crm]
+[odoo-s15-2.crm]
 file_filter = addons/crm/i18n/<lang>.po
 source_file = addons/crm/i18n/crm.pot
 source_lang = en
 
-[odoo-master.crm_iap_enrich]
+[odoo-s15-2.crm_iap_enrich]
 file_filter = addons/crm_iap_enrich/i18n/<lang>.po
 source_file = addons/crm_iap_enrich/i18n/crm_iap_enrich.pot
 source_lang = en
 
-[odoo-master.crm_iap_mine]
+[odoo-s15-2.crm_iap_mine]
 file_filter = addons/crm_iap_mine/i18n/<lang>.po
 source_file = addons/crm_iap_mine/i18n/crm_iap_mine.pot
 source_lang = en
 
-[odoo-master.crm_livechat]
+[odoo-s15-2.crm_livechat]
 file_filter = addons/crm_livechat/i18n/<lang>.po
 source_file = addons/crm_livechat/i18n/crm_livechat.pot
 source_lang = en
 
-[odoo-master.crm_mail_plugin]
+[odoo-s15-2.crm_mail_plugin]
 file_filter = addons/crm_mail_plugin/i18n/<lang>.po
 source_file = addons/crm_mail_plugin/i18n/crm_mail_plugin.pot
 source_lang = en
 
-[odoo-master.delivery]
+[odoo-s15-2.delivery]
 file_filter = addons/delivery/i18n/<lang>.po
 source_file = addons/delivery/i18n/delivery.pot
 source_lang = en
 
-[odoo-master.delivery_mondialrelay]
+[odoo-s15-2.delivery_mondialrelay]
 file_filter = addons/delivery_mondialrelay/i18n/<lang>.po
 source_file = addons/delivery_mondialrelay/i18n/delivery_mondialrelay.pot
 source_lang = en
 
-[odoo-master.delivery_stock_picking_batch]
+[odoo-s15-2.delivery_stock_picking_batch]
 file_filter = addons/delivery_stock_picking_batch/i18n/<lang>.po
 source_file = addons/delivery_stock_picking_batch/i18n/delivery_stock_picking_batch.pot
 source_lang = en
 
-[odoo-master.digest]
+[odoo-s15-2.digest]
 file_filter = addons/digest/i18n/<lang>.po
 source_file = addons/digest/i18n/digest.pot
 source_lang = en
 
-[odoo-master.event]
+[odoo-s15-2.event]
 file_filter = addons/event/i18n/<lang>.po
 source_file = addons/event/i18n/event.pot
 source_lang = en
 
-[odoo-master.event_booth]
+[odoo-s15-2.event_booth]
 file_filter = addons/event_booth/i18n/<lang>.po
 source_file = addons/event_booth/i18n/event_booth.pot
 source_lang = en
 
-[odoo-master.event_booth_sale]
+[odoo-s15-2.event_booth_sale]
 file_filter = addons/event_booth_sale/i18n/<lang>.po
 source_file = addons/event_booth_sale/i18n/event_booth_sale.pot
 source_lang = en
 
-[odoo-master.event_crm]
+[odoo-s15-2.event_crm]
 file_filter = addons/event_crm/i18n/<lang>.po
 source_file = addons/event_crm/i18n/event_crm.pot
 source_lang = en
 
-[odoo-master.event_sale]
+[odoo-s15-2.event_sale]
 file_filter = addons/event_sale/i18n/<lang>.po
 source_file = addons/event_sale/i18n/event_sale.pot
 source_lang = en
 
-[odoo-master.event_sms]
+[odoo-s15-2.event_sms]
 file_filter = addons/event_sms/i18n/<lang>.po
 source_file = addons/event_sms/i18n/event_sms.pot
 source_lang = en
 
-[odoo-master.fetchmail]
+[odoo-s15-2.fetchmail]
 file_filter = addons/fetchmail/i18n/<lang>.po
 source_file = addons/fetchmail/i18n/fetchmail.pot
 source_lang = en
 
-[odoo-master.fetchmail_gmail]
+[odoo-s15-2.fetchmail_gmail]
 file_filter = addons/fetchmail_gmail/i18n/<lang>.po
 source_file = addons/fetchmail_gmail/i18n/fetchmail_gmail.pot
 source_lang = en
 
-[odoo-master.fetchmail_outlook]
+[odoo-s15-2.fetchmail_outlook]
 file_filter = addons/fetchmail_outlook/i18n/<lang>.po
 source_file = addons/fetchmail_outlook/i18n/fetchmail_outlook.pot
 source_lang = en
 
-[odoo-master.fleet]
+[odoo-s15-2.fleet]
 file_filter = addons/fleet/i18n/<lang>.po
 source_file = addons/fleet/i18n/fleet.pot
 source_lang = en
 
-[odoo-master.gamification]
+[odoo-s15-2.gamification]
 file_filter = addons/gamification/i18n/<lang>.po
 source_file = addons/gamification/i18n/gamification.pot
 source_lang = en
 
-[odoo-master.gamification_sale_crm]
+[odoo-s15-2.gamification_sale_crm]
 file_filter = addons/gamification_sale_crm/i18n/<lang>.po
 source_file = addons/gamification_sale_crm/i18n/gamification_sale_crm.pot
 source_lang = en
 
-[odoo-master.gift_card]
+[odoo-s15-2.gift_card]
 file_filter = addons/gift_card/i18n/<lang>.po
 source_file = addons/gift_card/i18n/gift_card.pot
 source_lang = en
 
-[odoo-master.google_account]
+[odoo-s15-2.google_account]
 file_filter = addons/google_account/i18n/<lang>.po
 source_file = addons/google_account/i18n/google_account.pot
 source_lang = en
 
-[odoo-master.google_calendar]
+[odoo-s15-2.google_calendar]
 file_filter = addons/google_calendar/i18n/<lang>.po
 source_file = addons/google_calendar/i18n/google_calendar.pot
 source_lang = en
 
-[odoo-master.google_drive]
+[odoo-s15-2.google_drive]
 file_filter = addons/google_drive/i18n/<lang>.po
 source_file = addons/google_drive/i18n/google_drive.pot
 source_lang = en
 
-[odoo-master.google_gmail]
+[odoo-s15-2.google_gmail]
 file_filter = addons/google_gmail/i18n/<lang>.po
 source_file = addons/google_gmail/i18n/google_gmail.pot
 source_lang = en
 
-[odoo-master.google_recaptcha]
+[odoo-s15-2.google_recaptcha]
 file_filter = addons/google_recaptcha/i18n/<lang>.po
 source_file = addons/google_recaptcha/i18n/google_recaptcha.pot
 source_lang = en
 
-[odoo-master.google_spreadsheet]
+[odoo-s15-2.google_spreadsheet]
 file_filter = addons/google_spreadsheet/i18n/<lang>.po
 source_file = addons/google_spreadsheet/i18n/google_spreadsheet.pot
 source_lang = en
 
-[odoo-master.hr]
+[odoo-s15-2.hr]
 file_filter = addons/hr/i18n/<lang>.po
 source_file = addons/hr/i18n/hr.pot
 source_lang = en
 
-[odoo-master.hr_attendance]
+[odoo-s15-2.hr_attendance]
 file_filter = addons/hr_attendance/i18n/<lang>.po
 source_file = addons/hr_attendance/i18n/hr_attendance.pot
 source_lang = en
 
-[odoo-master.hr_contract]
+[odoo-s15-2.hr_contract]
 file_filter = addons/hr_contract/i18n/<lang>.po
 source_file = addons/hr_contract/i18n/hr_contract.pot
 source_lang = en
 
-[odoo-master.hr_expense]
+[odoo-s15-2.hr_expense]
 file_filter = addons/hr_expense/i18n/<lang>.po
 source_file = addons/hr_expense/i18n/hr_expense.pot
 source_lang = en
 
-[odoo-master.hr_fleet]
+[odoo-s15-2.hr_fleet]
 file_filter = addons/hr_fleet/i18n/<lang>.po
 source_file = addons/hr_fleet/i18n/hr_fleet.pot
 source_lang = en
 
-[odoo-master.hr_gamification]
+[odoo-s15-2.hr_gamification]
 file_filter = addons/hr_gamification/i18n/<lang>.po
 source_file = addons/hr_gamification/i18n/hr_gamification.pot
 source_lang = en
 
-[odoo-master.hr_holidays]
+[odoo-s15-2.hr_holidays]
 file_filter = addons/hr_holidays/i18n/<lang>.po
 source_file = addons/hr_holidays/i18n/hr_holidays.pot
 source_lang = en
 
-[odoo-master.hr_holidays_attendance]
+[odoo-s15-2.hr_holidays_attendance]
 file_filter = addons/hr_holidays_attendance/i18n/<lang>.po
 source_file = addons/hr_holidays_attendance/i18n/hr_holidays_attendance.pot
 source_lang = en
 
-[odoo-master.hr_maintenance]
+[odoo-s15-2.hr_maintenance]
 file_filter = addons/hr_maintenance/i18n/<lang>.po
 source_file = addons/hr_maintenance/i18n/hr_maintenance.pot
 source_lang = en
 
-[odoo-master.hr_org_chart]
+[odoo-s15-2.hr_org_chart]
 file_filter = addons/hr_org_chart/i18n/<lang>.po
 source_file = addons/hr_org_chart/i18n/hr_org_chart.pot
 source_lang = en
 
-[odoo-master.hr_presence]
+[odoo-s15-2.hr_presence]
 file_filter = addons/hr_presence/i18n/<lang>.po
 source_file = addons/hr_presence/i18n/hr_presence.pot
 source_lang = en
 
-[odoo-master.hr_recruitment]
+[odoo-s15-2.hr_recruitment]
 file_filter = addons/hr_recruitment/i18n/<lang>.po
 source_file = addons/hr_recruitment/i18n/hr_recruitment.pot
 source_lang = en
 
-[odoo-master.hr_recruitment_survey]
+[odoo-s15-2.hr_recruitment_survey]
 file_filter = addons/hr_recruitment_survey/i18n/<lang>.po
 source_file = addons/hr_recruitment_survey/i18n/hr_recruitment_survey.pot
 source_lang = en
 
-[odoo-master.hr_skills]
+[odoo-s15-2.hr_skills]
 file_filter = addons/hr_skills/i18n/<lang>.po
 source_file = addons/hr_skills/i18n/hr_skills.pot
 source_lang = en
 
-[odoo-master.hr_skills_slides]
+[odoo-s15-2.hr_skills_slides]
 file_filter = addons/hr_skills_slides/i18n/<lang>.po
 source_file = addons/hr_skills_slides/i18n/hr_skills_slides.pot
 source_lang = en
 
-[odoo-master.hr_skills_survey]
+[odoo-s15-2.hr_skills_survey]
 file_filter = addons/hr_skills_survey/i18n/<lang>.po
 source_file = addons/hr_skills_survey/i18n/hr_skills_survey.pot
 source_lang = en
 
-[odoo-master.hr_timesheet]
+[odoo-s15-2.hr_timesheet]
 file_filter = addons/hr_timesheet/i18n/<lang>.po
 source_file = addons/hr_timesheet/i18n/hr_timesheet.pot
 source_lang = en
 
-[odoo-master.hr_timesheet_attendance]
+[odoo-s15-2.hr_timesheet_attendance]
 file_filter = addons/hr_timesheet_attendance/i18n/<lang>.po
 source_file = addons/hr_timesheet_attendance/i18n/hr_timesheet_attendance.pot
 source_lang = en
 
-[odoo-master.hr_work_entry]
+[odoo-s15-2.hr_work_entry]
 file_filter = addons/hr_work_entry/i18n/<lang>.po
 source_file = addons/hr_work_entry/i18n/hr_work_entry.pot
 source_lang = en
 
-[odoo-master.hr_work_entry_contract]
+[odoo-s15-2.hr_work_entry_contract]
 file_filter = addons/hr_work_entry_contract/i18n/<lang>.po
 source_file = addons/hr_work_entry_contract/i18n/hr_work_entry_contract.pot
 source_lang = en
 
-[odoo-master.hr_work_entry_holidays]
+[odoo-s15-2.hr_work_entry_holidays]
 file_filter = addons/hr_work_entry_holidays/i18n/<lang>.po
 source_file = addons/hr_work_entry_holidays/i18n/hr_work_entry_holidays.pot
 source_lang = en
 
-[odoo-master.http_routing]
+[odoo-s15-2.http_routing]
 file_filter = addons/http_routing/i18n/<lang>.po
 source_file = addons/http_routing/i18n/http_routing.pot
 source_lang = en
 
-[odoo-master.iap]
+[odoo-s15-2.iap]
 file_filter = addons/iap/i18n/<lang>.po
 source_file = addons/iap/i18n/iap.pot
 source_lang = en
 
-[odoo-master.iap_mail]
+[odoo-s15-2.iap_mail]
 file_filter = addons/iap_mail/i18n/<lang>.po
 source_file = addons/iap_mail/i18n/iap_mail.pot
 source_lang = en
 
-[odoo-master.im_livechat]
+[odoo-s15-2.im_livechat]
 file_filter = addons/im_livechat/i18n/<lang>.po
 source_file = addons/im_livechat/i18n/im_livechat.pot
 source_lang = en
 
-[odoo-master.im_livechat_mail_bot]
+[odoo-s15-2.im_livechat_mail_bot]
 file_filter = addons/im_livechat_mail_bot/i18n/<lang>.po
 source_file = addons/im_livechat_mail_bot/i18n/im_livechat_mail_bot.pot
 source_lang = en
 
-[odoo-master.l10n_multilang]
+[odoo-s15-2.l10n_multilang]
 file_filter = addons/l10n_multilang/i18n/<lang>.po
 source_file = addons/l10n_multilang/i18n/l10n_multilang.pot
 source_lang = en
 
-[odoo-master.link_tracker]
+[odoo-s15-2.link_tracker]
 file_filter = addons/link_tracker/i18n/<lang>.po
 source_file = addons/link_tracker/i18n/link_tracker.pot
 source_lang = en
 
-[odoo-master.lunch]
+[odoo-s15-2.lunch]
 file_filter = addons/lunch/i18n/<lang>.po
 source_file = addons/lunch/i18n/lunch.pot
 source_lang = en
 
-[odoo-master.mail]
+[odoo-s15-2.mail]
 file_filter = addons/mail/i18n/<lang>.po
 source_file = addons/mail/i18n/mail.pot
 source_lang = en
 
-[odoo-master.mail_bot]
+[odoo-s15-2.mail_bot]
 file_filter = addons/mail_bot/i18n/<lang>.po
 source_file = addons/mail_bot/i18n/mail_bot.pot
 source_lang = en
 
-[odoo-master.mail_group]
+[odoo-s15-2.mail_group]
 file_filter = addons/mail_group/i18n/<lang>.po
 source_file = addons/mail_group/i18n/mail_group.pot
 source_lang = en
 
-[odoo-master.mail_plugin]
+[odoo-s15-2.mail_plugin]
 file_filter = addons/mail_plugin/i18n/<lang>.po
 source_file = addons/mail_plugin/i18n/mail_plugin.pot
 source_lang = en
 
-[odoo-master.maintenance]
+[odoo-s15-2.maintenance]
 file_filter = addons/maintenance/i18n/<lang>.po
 source_file = addons/maintenance/i18n/maintenance.pot
 source_lang = en
 
-[odoo-master.mass_mailing]
+[odoo-s15-2.mass_mailing]
 file_filter = addons/mass_mailing/i18n/<lang>.po
 source_file = addons/mass_mailing/i18n/mass_mailing.pot
 source_lang = en
 
-[odoo-master.mass_mailing_crm]
+[odoo-s15-2.mass_mailing_crm]
 file_filter = addons/mass_mailing_crm/i18n/<lang>.po
 source_file = addons/mass_mailing_crm/i18n/mass_mailing_crm.pot
 source_lang = en
 
-[odoo-master.mass_mailing_event]
+[odoo-s15-2.mass_mailing_event]
 file_filter = addons/mass_mailing_event/i18n/<lang>.po
 source_file = addons/mass_mailing_event/i18n/mass_mailing_event.pot
 source_lang = en
 
-[odoo-master.mass_mailing_sale]
+[odoo-s15-2.mass_mailing_sale]
 file_filter = addons/mass_mailing_sale/i18n/<lang>.po
 source_file = addons/mass_mailing_sale/i18n/mass_mailing_sale.pot
 source_lang = en
 
-[odoo-master.mass_mailing_sale_sms]
+[odoo-s15-2.mass_mailing_sale_sms]
 file_filter = addons/mass_mailing_sale_sms/i18n/<lang>.po
 source_file = addons/mass_mailing_sale_sms/i18n/mass_mailing_sale_sms.pot
 source_lang = en
 
-[odoo-master.mass_mailing_sms]
+[odoo-s15-2.mass_mailing_sms]
 file_filter = addons/mass_mailing_sms/i18n/<lang>.po
 source_file = addons/mass_mailing_sms/i18n/mass_mailing_sms.pot
 source_lang = en
 
-[odoo-master.membership]
+[odoo-s15-2.membership]
 file_filter = addons/membership/i18n/<lang>.po
 source_file = addons/membership/i18n/membership.pot
 source_lang = en
 
-[odoo-master.microsoft_account]
+[odoo-s15-2.microsoft_account]
 file_filter = addons/microsoft_account/i18n/<lang>.po
 source_file = addons/microsoft_account/i18n/microsoft_account.pot
 source_lang = en
 
-[odoo-master.microsoft_calendar]
+[odoo-s15-2.microsoft_calendar]
 file_filter = addons/microsoft_calendar/i18n/<lang>.po
 source_file = addons/microsoft_calendar/i18n/microsoft_calendar.pot
 source_lang = en
 
-[odoo-master.microsoft_outlook]
+[odoo-s15-2.microsoft_outlook]
 file_filter = addons/microsoft_outlook/i18n/<lang>.po
 source_file = addons/microsoft_outlook/i18n/microsoft_outlook.pot
 source_lang = en
 
-[odoo-master.mrp]
+[odoo-s15-2.mrp]
 file_filter = addons/mrp/i18n/<lang>.po
 source_file = addons/mrp/i18n/mrp.pot
 source_lang = en
 
-[odoo-master.mrp_account]
+[odoo-s15-2.mrp_account]
 file_filter = addons/mrp_account/i18n/<lang>.po
 source_file = addons/mrp_account/i18n/mrp_account.pot
 source_lang = en
 
-[odoo-master.mrp_landed_costs]
+[odoo-s15-2.mrp_landed_costs]
 file_filter = addons/mrp_landed_costs/i18n/<lang>.po
 source_file = addons/mrp_landed_costs/i18n/mrp_landed_costs.pot
 source_lang = en
 
-[odoo-master.mrp_product_expiry]
+[odoo-s15-2.mrp_product_expiry]
 file_filter = addons/mrp_product_expiry/i18n/<lang>.po
 source_file = addons/mrp_product_expiry/i18n/mrp_product_expiry.pot
 source_lang = en
 
-[odoo-master.mrp_subcontracting]
+[odoo-s15-2.mrp_subcontracting]
 file_filter = addons/mrp_subcontracting/i18n/<lang>.po
 source_file = addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
 source_lang = en
 
-[odoo-master.mrp_subcontracting_dropshipping]
+[odoo-s15-2.mrp_subcontracting_dropshipping]
 file_filter = addons/mrp_subcontracting_dropshipping/i18n/<lang>.po
 source_file = addons/mrp_subcontracting_dropshipping/i18n/mrp_subcontracting_dropshipping.pot
 source_lang = en
 
-[odoo-master.mrp_subcontracting_purchase]
+[odoo-s15-2.mrp_subcontracting_purchase]
 file_filter = addons/mrp_subcontracting_purchase/i18n/<lang>.po
 source_file = addons/mrp_subcontracting_purchase/i18n/mrp_subcontracting_purchase.pot
 source_lang = en
 
-[odoo-master.note]
+[odoo-s15-2.note]
 file_filter = addons/note/i18n/<lang>.po
 source_file = addons/note/i18n/note.pot
 source_lang = en
 
-[odoo-master.partner_autocomplete]
+[odoo-s15-2.partner_autocomplete]
 file_filter = addons/partner_autocomplete/i18n/<lang>.po
 source_file = addons/partner_autocomplete/i18n/partner_autocomplete.pot
 source_lang = en
 
-[odoo-master.payment]
+[odoo-s15-2.payment]
 file_filter = addons/payment/i18n/<lang>.po
 source_file = addons/payment/i18n/payment.pot
 source_lang = en
 
-[odoo-master.payment_adyen]
+[odoo-s15-2.payment_adyen]
 file_filter = addons/payment_adyen/i18n/<lang>.po
 source_file = addons/payment_adyen/i18n/payment_adyen.pot
 source_lang = en
 
-[odoo-master.payment_alipay]
+[odoo-s15-2.payment_alipay]
 file_filter = addons/payment_alipay/i18n/<lang>.po
 source_file = addons/payment_alipay/i18n/payment_alipay.pot
 source_lang = en
 
-[odoo-master.payment_authorize]
+[odoo-s15-2.payment_authorize]
 file_filter = addons/payment_authorize/i18n/<lang>.po
 source_file = addons/payment_authorize/i18n/payment_authorize.pot
 source_lang = en
 
-[odoo-master.payment_buckaroo]
+[odoo-s15-2.payment_buckaroo]
 file_filter = addons/payment_buckaroo/i18n/<lang>.po
 source_file = addons/payment_buckaroo/i18n/payment_buckaroo.pot
 source_lang = en
 
-[odoo-master.payment_mollie]
+[odoo-s15-2.payment_mollie]
 file_filter = addons/payment_mollie/i18n/<lang>.po
 source_file = addons/payment_mollie/i18n/payment_mollie.pot
 source_lang = en
 
-[odoo-master.payment_ogone]
+[odoo-s15-2.payment_ogone]
 file_filter = addons/payment_ogone/i18n/<lang>.po
 source_file = addons/payment_ogone/i18n/payment_ogone.pot
 source_lang = en
 
-[odoo-master.payment_paypal]
+[odoo-s15-2.payment_paypal]
 file_filter = addons/payment_paypal/i18n/<lang>.po
 source_file = addons/payment_paypal/i18n/payment_paypal.pot
 source_lang = en
 
-[odoo-master.payment_payulatam]
+[odoo-s15-2.payment_payulatam]
 file_filter = addons/payment_payulatam/i18n/<lang>.po
 source_file = addons/payment_payulatam/i18n/payment_payulatam.pot
 source_lang = en
 
-[odoo-master.payment_payumoney]
+[odoo-s15-2.payment_payumoney]
 file_filter = addons/payment_payumoney/i18n/<lang>.po
 source_file = addons/payment_payumoney/i18n/payment_payumoney.pot
 source_lang = en
 
-[odoo-master.payment_sips]
+[odoo-s15-2.payment_sips]
 file_filter = addons/payment_sips/i18n/<lang>.po
 source_file = addons/payment_sips/i18n/payment_sips.pot
 source_lang = en
 
-[odoo-master.payment_stripe]
+[odoo-s15-2.payment_stripe]
 file_filter = addons/payment_stripe/i18n/<lang>.po
 source_file = addons/payment_stripe/i18n/payment_stripe.pot
 source_lang = en
 
-[odoo-master.payment_transfer]
+[odoo-s15-2.payment_transfer]
 file_filter = addons/payment_transfer/i18n/<lang>.po
 source_file = addons/payment_transfer/i18n/payment_transfer.pot
 source_lang = en
 
-[odoo-master.phone_validation]
+[odoo-s15-2.phone_validation]
 file_filter = addons/phone_validation/i18n/<lang>.po
 source_file = addons/phone_validation/i18n/phone_validation.pot
 source_lang = en
 
-[odoo-master.point_of_sale]
+[odoo-s15-2.point_of_sale]
 file_filter = addons/point_of_sale/i18n/<lang>.po
 source_file = addons/point_of_sale/i18n/point_of_sale.pot
 source_lang = en
 
-[odoo-master.portal]
+[odoo-s15-2.portal]
 file_filter = addons/portal/i18n/<lang>.po
 source_file = addons/portal/i18n/portal.pot
 source_lang = en
 
-[odoo-master.portal_rating]
+[odoo-s15-2.portal_rating]
 file_filter = addons/portal_rating/i18n/<lang>.po
 source_file = addons/portal_rating/i18n/portal_rating.pot
 source_lang = en
 
-[odoo-master.pos_adyen]
+[odoo-s15-2.pos_adyen]
 file_filter = addons/pos_adyen/i18n/<lang>.po
 source_file = addons/pos_adyen/i18n/pos_adyen.pot
 source_lang = en
 
-[odoo-master.pos_cache]
+[odoo-s15-2.pos_cache]
 file_filter = addons/pos_cache/i18n/<lang>.po
 source_file = addons/pos_cache/i18n/pos_cache.pot
 source_lang = en
 
-[odoo-master.pos_coupon]
+[odoo-s15-2.pos_coupon]
 file_filter = addons/pos_coupon/i18n/<lang>.po
 source_file = addons/pos_coupon/i18n/pos_coupon.pot
 source_lang = en
 
-[odoo-master.pos_discount]
+[odoo-s15-2.pos_discount]
 file_filter = addons/pos_discount/i18n/<lang>.po
 source_file = addons/pos_discount/i18n/pos_discount.pot
 source_lang = en
 
-[odoo-master.pos_epson_printer]
+[odoo-s15-2.pos_epson_printer]
 file_filter = addons/pos_epson_printer/i18n/<lang>.po
 source_file = addons/pos_epson_printer/i18n/pos_epson_printer.pot
 source_lang = en
 
-[odoo-master.pos_epson_printer_restaurant]
+[odoo-s15-2.pos_epson_printer_restaurant]
 file_filter = addons/pos_epson_printer_restaurant/i18n/<lang>.po
 source_file = addons/pos_epson_printer_restaurant/i18n/pos_epson_printer_restaurant.pot
 source_lang = en
 
-[odoo-master.pos_gift_card]
+[odoo-s15-2.pos_gift_card]
 file_filter = addons/pos_gift_card/i18n/<lang>.po
 source_file = addons/pos_gift_card/i18n/pos_gift_card.pot
 source_lang = en
 
-[odoo-master.pos_hr]
+[odoo-s15-2.pos_hr]
 file_filter = addons/pos_hr/i18n/<lang>.po
 source_file = addons/pos_hr/i18n/pos_hr.pot
 source_lang = en
 
-[odoo-master.pos_mercury]
+[odoo-s15-2.pos_mercury]
 file_filter = addons/pos_mercury/i18n/<lang>.po
 source_file = addons/pos_mercury/i18n/pos_mercury.pot
 source_lang = en
 
-[odoo-master.pos_restaurant]
+[odoo-s15-2.pos_restaurant]
 file_filter = addons/pos_restaurant/i18n/<lang>.po
 source_file = addons/pos_restaurant/i18n/pos_restaurant.pot
 source_lang = en
 
-[odoo-master.pos_restaurant_adyen]
+[odoo-s15-2.pos_restaurant_adyen]
 file_filter = addons/pos_restaurant_adyen/i18n/<lang>.po
 source_file = addons/pos_restaurant_adyen/i18n/pos_restaurant_adyen.pot
 source_lang = en
 
-[odoo-master.pos_sale]
+[odoo-s15-2.pos_sale]
 file_filter = addons/pos_sale/i18n/<lang>.po
 source_file = addons/pos_sale/i18n/pos_sale.pot
 source_lang = en
 
-[odoo-master.pos_sale_product_configurator]
+[odoo-s15-2.pos_sale_product_configurator]
 file_filter = addons/pos_sale_product_configurator/i18n/<lang>.po
 source_file = addons/pos_sale_product_configurator/i18n/pos_sale_product_configurator.pot
 source_lang = en
 
-[odoo-master.pos_six]
+[odoo-s15-2.pos_six]
 file_filter = addons/pos_six/i18n/<lang>.po
 source_file = addons/pos_six/i18n/pos_six.pot
 source_lang = en
 
-[odoo-master.product]
+[odoo-s15-2.product]
 file_filter = addons/product/i18n/<lang>.po
 source_file = addons/product/i18n/product.pot
 source_lang = en
 
-[odoo-master.product_email_template]
+[odoo-s15-2.product_email_template]
 file_filter = addons/product_email_template/i18n/<lang>.po
 source_file = addons/product_email_template/i18n/product_email_template.pot
 source_lang = en
 
-[odoo-master.product_expiry]
+[odoo-s15-2.product_expiry]
 file_filter = addons/product_expiry/i18n/<lang>.po
 source_file = addons/product_expiry/i18n/product_expiry.pot
 source_lang = en
 
-[odoo-master.product_images]
+[odoo-s15-2.product_images]
 file_filter = addons/product_images/i18n/<lang>.po
 source_file = addons/product_images/i18n/product_images.pot
 source_lang = en
 
-[odoo-master.product_margin]
+[odoo-s15-2.product_margin]
 file_filter = addons/product_margin/i18n/<lang>.po
 source_file = addons/product_margin/i18n/product_margin.pot
 source_lang = en
 
-[odoo-master.product_matrix]
+[odoo-s15-2.product_matrix]
 file_filter = addons/product_matrix/i18n/<lang>.po
 source_file = addons/product_matrix/i18n/product_matrix.pot
 source_lang = en
 
-[odoo-master.project]
+[odoo-s15-2.project]
 file_filter = addons/project/i18n/<lang>.po
 source_file = addons/project/i18n/project.pot
 source_lang = en
 
-[odoo-master.project_hr_expense]
+[odoo-s15-2.project_hr_expense]
 file_filter = addons/project_hr_expense/i18n/<lang>.po
 source_file = addons/project_hr_expense/i18n/project_hr_expense.pot
 source_lang = en
 
-[odoo-master.project_mail_plugin]
+[odoo-s15-2.project_mail_plugin]
 file_filter = addons/project_mail_plugin/i18n/<lang>.po
 source_file = addons/project_mail_plugin/i18n/project_mail_plugin.pot
 source_lang = en
 
-[odoo-master.project_mrp]
+[odoo-s15-2.project_mrp]
 file_filter = addons/project_mrp/i18n/<lang>.po
 source_file = addons/project_mrp/i18n/project_mrp.pot
 source_lang = en
 
-[odoo-master.project_purchase]
+[odoo-s15-2.project_purchase]
 file_filter = addons/project_purchase/i18n/<lang>.po
 source_file = addons/project_purchase/i18n/project_purchase.pot
 source_lang = en
 
-[odoo-master.project_timesheet_holidays]
+[odoo-s15-2.project_timesheet_holidays]
 file_filter = addons/project_timesheet_holidays/i18n/<lang>.po
 source_file = addons/project_timesheet_holidays/i18n/project_timesheet_holidays.pot
 source_lang = en
 
-[odoo-master.purchase]
+[odoo-s15-2.purchase]
 file_filter = addons/purchase/i18n/<lang>.po
 source_file = addons/purchase/i18n/purchase.pot
 source_lang = en
 
-[odoo-master.purchase_mrp]
+[odoo-s15-2.purchase_mrp]
 file_filter = addons/purchase_mrp/i18n/<lang>.po
 source_file = addons/purchase_mrp/i18n/purchase_mrp.pot
 source_lang = en
 
-[odoo-master.purchase_product_matrix]
+[odoo-s15-2.purchase_product_matrix]
 file_filter = addons/purchase_product_matrix/i18n/<lang>.po
 source_file = addons/purchase_product_matrix/i18n/purchase_product_matrix.pot
 source_lang = en
 
-[odoo-master.purchase_requisition]
+[odoo-s15-2.purchase_requisition]
 file_filter = addons/purchase_requisition/i18n/<lang>.po
 source_file = addons/purchase_requisition/i18n/purchase_requisition.pot
 source_lang = en
 
-[odoo-master.purchase_requisition_stock]
+[odoo-s15-2.purchase_requisition_stock]
 file_filter = addons/purchase_requisition_stock/i18n/<lang>.po
 source_file = addons/purchase_requisition_stock/i18n/purchase_requisition_stock.pot
 source_lang = en
 
-[odoo-master.purchase_requisition_stock_dropshipping]
+[odoo-s15-2.purchase_requisition_stock_dropshipping]
 file_filter = addons/purchase_requisition_stock_dropshipping/i18n/<lang>.po
 source_file = addons/purchase_requisition_stock_dropshipping/i18n/purchase_requisition_stock_dropshipping.pot
 source_lang = en
 
-[odoo-master.purchase_stock]
+[odoo-s15-2.purchase_stock]
 file_filter = addons/purchase_stock/i18n/<lang>.po
 source_file = addons/purchase_stock/i18n/purchase_stock.pot
 source_lang = en
 
-[odoo-master.rating]
+[odoo-s15-2.rating]
 file_filter = addons/rating/i18n/<lang>.po
 source_file = addons/rating/i18n/rating.pot
 source_lang = en
 
-[odoo-master.repair]
+[odoo-s15-2.repair]
 file_filter = addons/repair/i18n/<lang>.po
 source_file = addons/repair/i18n/repair.pot
 source_lang = en
 
-[odoo-master.resource]
+[odoo-s15-2.resource]
 file_filter = addons/resource/i18n/<lang>.po
 source_file = addons/resource/i18n/resource.pot
 source_lang = en
 
-[odoo-master.sale]
+[odoo-s15-2.sale]
 file_filter = addons/sale/i18n/<lang>.po
 source_file = addons/sale/i18n/sale.pot
 source_lang = en
 
-[odoo-master.sale_coupon]
+[odoo-s15-2.sale_coupon]
 file_filter = addons/sale_coupon/i18n/<lang>.po
 source_file = addons/sale_coupon/i18n/sale_coupon.pot
 source_lang = en
 
-[odoo-master.sale_coupon_delivery]
+[odoo-s15-2.sale_coupon_delivery]
 file_filter = addons/sale_coupon_delivery/i18n/<lang>.po
 source_file = addons/sale_coupon_delivery/i18n/sale_coupon_delivery.pot
 source_lang = en
 
-[odoo-master.sale_crm]
+[odoo-s15-2.sale_crm]
 file_filter = addons/sale_crm/i18n/<lang>.po
 source_file = addons/sale_crm/i18n/sale_crm.pot
 source_lang = en
 
-[odoo-master.sale_expense]
+[odoo-s15-2.sale_expense]
 file_filter = addons/sale_expense/i18n/<lang>.po
 source_file = addons/sale_expense/i18n/sale_expense.pot
 source_lang = en
 
-[odoo-master.sale_gift_card]
+[odoo-s15-2.sale_gift_card]
 file_filter = addons/sale_gift_card/i18n/<lang>.po
 source_file = addons/sale_gift_card/i18n/sale_gift_card.pot
 source_lang = en
 
-[odoo-master.sale_management]
+[odoo-s15-2.sale_management]
 file_filter = addons/sale_management/i18n/<lang>.po
 source_file = addons/sale_management/i18n/sale_management.pot
 source_lang = en
 
-[odoo-master.sale_margin]
+[odoo-s15-2.sale_margin]
 file_filter = addons/sale_margin/i18n/<lang>.po
 source_file = addons/sale_margin/i18n/sale_margin.pot
 source_lang = en
 
-[odoo-master.sale_mrp]
+[odoo-s15-2.sale_mrp]
 file_filter = addons/sale_mrp/i18n/<lang>.po
 source_file = addons/sale_mrp/i18n/sale_mrp.pot
 source_lang = en
 
-[odoo-master.sale_product_configurator]
+[odoo-s15-2.sale_product_configurator]
 file_filter = addons/sale_product_configurator/i18n/<lang>.po
 source_file = addons/sale_product_configurator/i18n/sale_product_configurator.pot
 source_lang = en
 
-[odoo-master.sale_product_matrix]
+[odoo-s15-2.sale_product_matrix]
 file_filter = addons/sale_product_matrix/i18n/<lang>.po
 source_file = addons/sale_product_matrix/i18n/sale_product_matrix.pot
 source_lang = en
 
-[odoo-master.sale_project]
+[odoo-s15-2.sale_project]
 file_filter = addons/sale_project/i18n/<lang>.po
 source_file = addons/sale_project/i18n/sale_project.pot
 source_lang = en
 
-[odoo-master.sale_project_account]
+[odoo-s15-2.sale_project_account]
 file_filter = addons/sale_project_account/i18n/<lang>.po
 source_file = addons/sale_project_account/i18n/sale_project_account.pot
 source_lang = en
 
-[odoo-master.sale_purchase]
+[odoo-s15-2.sale_purchase]
 file_filter = addons/sale_purchase/i18n/<lang>.po
 source_file = addons/sale_purchase/i18n/sale_purchase.pot
 source_lang = en
 
-[odoo-master.sale_quotation_builder]
+[odoo-s15-2.sale_quotation_builder]
 file_filter = addons/sale_quotation_builder/i18n/<lang>.po
 source_file = addons/sale_quotation_builder/i18n/sale_quotation_builder.pot
 source_lang = en
 
-[odoo-master.sale_stock]
+[odoo-s15-2.sale_stock]
 file_filter = addons/sale_stock/i18n/<lang>.po
 source_file = addons/sale_stock/i18n/sale_stock.pot
 source_lang = en
 
-[odoo-master.sale_timesheet]
+[odoo-s15-2.sale_timesheet]
 file_filter = addons/sale_timesheet/i18n/<lang>.po
 source_file = addons/sale_timesheet/i18n/sale_timesheet.pot
 source_lang = en
 
-[odoo-master.sales_team]
+[odoo-s15-2.sales_team]
 file_filter = addons/sales_team/i18n/<lang>.po
 source_file = addons/sales_team/i18n/sales_team.pot
 source_lang = en
 
-[odoo-master.sms]
+[odoo-s15-2.sms]
 file_filter = addons/sms/i18n/<lang>.po
 source_file = addons/sms/i18n/sms.pot
 source_lang = en
 
-[odoo-master.snailmail]
+[odoo-s15-2.snailmail]
 file_filter = addons/snailmail/i18n/<lang>.po
 source_file = addons/snailmail/i18n/snailmail.pot
 source_lang = en
 
-[odoo-master.snailmail_account]
+[odoo-s15-2.snailmail_account]
 file_filter = addons/snailmail_account/i18n/<lang>.po
 source_file = addons/snailmail_account/i18n/snailmail_account.pot
 source_lang = en
 
-[odoo-master.social_media]
+[odoo-s15-2.social_media]
 file_filter = addons/social_media/i18n/<lang>.po
 source_file = addons/social_media/i18n/social_media.pot
 source_lang = en
 
-[odoo-master.stock]
+[odoo-s15-2.stock]
 file_filter = addons/stock/i18n/<lang>.po
 source_file = addons/stock/i18n/stock.pot
 source_lang = en
 
-[odoo-master.stock_account]
+[odoo-s15-2.stock_account]
 file_filter = addons/stock_account/i18n/<lang>.po
 source_file = addons/stock_account/i18n/stock_account.pot
 source_lang = en
 
-[odoo-master.stock_dropshipping]
+[odoo-s15-2.stock_dropshipping]
 file_filter = addons/stock_dropshipping/i18n/<lang>.po
 source_file = addons/stock_dropshipping/i18n/stock_dropshipping.pot
 source_lang = en
 
-[odoo-master.stock_landed_costs]
+[odoo-s15-2.stock_landed_costs]
 file_filter = addons/stock_landed_costs/i18n/<lang>.po
 source_file = addons/stock_landed_costs/i18n/stock_landed_costs.pot
 source_lang = en
 
-[odoo-master.stock_picking_batch]
+[odoo-s15-2.stock_picking_batch]
 file_filter = addons/stock_picking_batch/i18n/<lang>.po
 source_file = addons/stock_picking_batch/i18n/stock_picking_batch.pot
 source_lang = en
 
-[odoo-master.stock_sms]
+[odoo-s15-2.stock_sms]
 file_filter = addons/stock_sms/i18n/<lang>.po
 source_file = addons/stock_sms/i18n/stock_sms.pot
 source_lang = en
 
-[odoo-master.survey]
+[odoo-s15-2.survey]
 file_filter = addons/survey/i18n/<lang>.po
 source_file = addons/survey/i18n/survey.pot
 source_lang = en
 
-[odoo-master.transifex]
+[odoo-s15-2.transifex]
 file_filter = addons/transifex/i18n/<lang>.po
 source_file = addons/transifex/i18n/transifex.pot
 source_lang = en
 
-[odoo-master.uom]
+[odoo-s15-2.uom]
 file_filter = addons/uom/i18n/<lang>.po
 source_file = addons/uom/i18n/uom.pot
 source_lang = en
 
-[odoo-master.utm]
+[odoo-s15-2.utm]
 file_filter = addons/utm/i18n/<lang>.po
 source_file = addons/utm/i18n/utm.pot
 source_lang = en
 
-[odoo-master.web]
+[odoo-s15-2.web]
 file_filter = addons/web/i18n/<lang>.po
 source_file = addons/web/i18n/web.pot
 source_lang = en
 
-[odoo-master.web_editor]
+[odoo-s15-2.web_editor]
 file_filter = addons/web_editor/i18n/<lang>.po
 source_file = addons/web_editor/i18n/web_editor.pot
 source_lang = en
 
-[odoo-master.web_tour]
+[odoo-s15-2.web_tour]
 file_filter = addons/web_tour/i18n/<lang>.po
 source_file = addons/web_tour/i18n/web_tour.pot
 source_lang = en
 
-[odoo-master.web_unsplash]
+[odoo-s15-2.web_unsplash]
 file_filter = addons/web_unsplash/i18n/<lang>.po
 source_file = addons/web_unsplash/i18n/web_unsplash.pot
 source_lang = en
 
-[odoo-master.website]
+[odoo-s15-2.website]
 file_filter = addons/website/i18n/<lang>.po
 source_file = addons/website/i18n/website.pot
 source_lang = en
 
-[odoo-master.website_blog]
+[odoo-s15-2.website_blog]
 file_filter = addons/website_blog/i18n/<lang>.po
 source_file = addons/website_blog/i18n/website_blog.pot
 source_lang = en
 
-[odoo-master.website_crm]
+[odoo-s15-2.website_crm]
 file_filter = addons/website_crm/i18n/<lang>.po
 source_file = addons/website_crm/i18n/website_crm.pot
 source_lang = en
 
-[odoo-master.website_crm_iap_reveal]
+[odoo-s15-2.website_crm_iap_reveal]
 file_filter = addons/website_crm_iap_reveal/i18n/<lang>.po
 source_file = addons/website_crm_iap_reveal/i18n/website_crm_iap_reveal.pot
 source_lang = en
 
-[odoo-master.website_crm_livechat]
+[odoo-s15-2.website_crm_livechat]
 file_filter = addons/website_crm_livechat/i18n/<lang>.po
 source_file = addons/website_crm_livechat/i18n/website_crm_livechat.pot
 source_lang = en
 
-[odoo-master.website_crm_partner_assign]
+[odoo-s15-2.website_crm_partner_assign]
 file_filter = addons/website_crm_partner_assign/i18n/<lang>.po
 source_file = addons/website_crm_partner_assign/i18n/website_crm_partner_assign.pot
 source_lang = en
 
-[odoo-master.website_customer]
+[odoo-s15-2.website_customer]
 file_filter = addons/website_customer/i18n/<lang>.po
 source_file = addons/website_customer/i18n/website_customer.pot
 source_lang = en
 
-[odoo-master.website_event]
+[odoo-s15-2.website_event]
 file_filter = addons/website_event/i18n/<lang>.po
 source_file = addons/website_event/i18n/website_event.pot
 source_lang = en
 
-[odoo-master.website_event_booth]
+[odoo-s15-2.website_event_booth]
 file_filter = addons/website_event_booth/i18n/<lang>.po
 source_file = addons/website_event_booth/i18n/website_event_booth.pot
 source_lang = en
 
-[odoo-master.website_event_booth_exhibitor]
+[odoo-s15-2.website_event_booth_exhibitor]
 file_filter = addons/website_event_booth_exhibitor/i18n/<lang>.po
 source_file = addons/website_event_booth_exhibitor/i18n/website_event_booth_exhibitor.pot
 source_lang = en
 
-[odoo-master.website_event_booth_sale]
+[odoo-s15-2.website_event_booth_sale]
 file_filter = addons/website_event_booth_sale/i18n/<lang>.po
 source_file = addons/website_event_booth_sale/i18n/website_event_booth_sale.pot
 source_lang = en
 
-[odoo-master.website_event_booth_sale_exhibitor]
+[odoo-s15-2.website_event_booth_sale_exhibitor]
 file_filter = addons/website_event_booth_sale_exhibitor/i18n/<lang>.po
 source_file = addons/website_event_booth_sale_exhibitor/i18n/website_event_booth_sale_exhibitor.pot
 source_lang = en
 
-[odoo-master.website_event_exhibitor]
+[odoo-s15-2.website_event_exhibitor]
 file_filter = addons/website_event_exhibitor/i18n/<lang>.po
 source_file = addons/website_event_exhibitor/i18n/website_event_exhibitor.pot
 source_lang = en
 
-[odoo-master.website_event_meet]
+[odoo-s15-2.website_event_meet]
 file_filter = addons/website_event_meet/i18n/<lang>.po
 source_file = addons/website_event_meet/i18n/website_event_meet.pot
 source_lang = en
 
-[odoo-master.website_event_meet_quiz]
+[odoo-s15-2.website_event_meet_quiz]
 file_filter = addons/website_event_meet_quiz/i18n/<lang>.po
 source_file = addons/website_event_meet_quiz/i18n/website_event_meet_quiz.pot
 source_lang = en
 
-[odoo-master.website_event_questions]
+[odoo-s15-2.website_event_questions]
 file_filter = addons/website_event_questions/i18n/<lang>.po
 source_file = addons/website_event_questions/i18n/website_event_questions.pot
 source_lang = en
 
-[odoo-master.website_event_sale]
+[odoo-s15-2.website_event_sale]
 file_filter = addons/website_event_sale/i18n/<lang>.po
 source_file = addons/website_event_sale/i18n/website_event_sale.pot
 source_lang = en
 
-[odoo-master.website_event_track]
+[odoo-s15-2.website_event_track]
 file_filter = addons/website_event_track/i18n/<lang>.po
 source_file = addons/website_event_track/i18n/website_event_track.pot
 source_lang = en
 
-[odoo-master.website_event_track_live]
+[odoo-s15-2.website_event_track_live]
 file_filter = addons/website_event_track_live/i18n/<lang>.po
 source_file = addons/website_event_track_live/i18n/website_event_track_live.pot
 source_lang = en
 
-[odoo-master.website_event_track_quiz]
+[odoo-s15-2.website_event_track_quiz]
 file_filter = addons/website_event_track_quiz/i18n/<lang>.po
 source_file = addons/website_event_track_quiz/i18n/website_event_track_quiz.pot
 source_lang = en
 
-[odoo-master.website_forum]
+[odoo-s15-2.website_forum]
 file_filter = addons/website_forum/i18n/<lang>.po
 source_file = addons/website_forum/i18n/website_forum.pot
 source_lang = en
 
-[odoo-master.website_hr_recruitment]
+[odoo-s15-2.website_hr_recruitment]
 file_filter = addons/website_hr_recruitment/i18n/<lang>.po
 source_file = addons/website_hr_recruitment/i18n/website_hr_recruitment.pot
 source_lang = en
 
-[odoo-master.website_jitsi]
+[odoo-s15-2.website_jitsi]
 file_filter = addons/website_jitsi/i18n/<lang>.po
 source_file = addons/website_jitsi/i18n/website_jitsi.pot
 source_lang = en
 
-[odoo-master.website_links]
+[odoo-s15-2.website_links]
 file_filter = addons/website_links/i18n/<lang>.po
 source_file = addons/website_links/i18n/website_links.pot
 source_lang = en
 
-[odoo-master.website_livechat]
+[odoo-s15-2.website_livechat]
 file_filter = addons/website_livechat/i18n/<lang>.po
 source_file = addons/website_livechat/i18n/website_livechat.pot
 source_lang = en
 
-[odoo-master.website_mail]
+[odoo-s15-2.website_mail]
 file_filter = addons/website_mail/i18n/<lang>.po
 source_file = addons/website_mail/i18n/website_mail.pot
 source_lang = en
 
-[odoo-master.website_mail_group]
+[odoo-s15-2.website_mail_group]
 file_filter = addons/website_mail_group/i18n/<lang>.po
 source_file = addons/website_mail_group/i18n/website_mail_group.pot
 source_lang = en
 
-[odoo-master.website_mass_mailing]
+[odoo-s15-2.website_mass_mailing]
 file_filter = addons/website_mass_mailing/i18n/<lang>.po
 source_file = addons/website_mass_mailing/i18n/website_mass_mailing.pot
 source_lang = en
 
-[odoo-master.website_membership]
+[odoo-s15-2.website_membership]
 file_filter = addons/website_membership/i18n/<lang>.po
 source_file = addons/website_membership/i18n/website_membership.pot
 source_lang = en
 
-[odoo-master.website_partner]
+[odoo-s15-2.website_partner]
 file_filter = addons/website_partner/i18n/<lang>.po
 source_file = addons/website_partner/i18n/website_partner.pot
 source_lang = en
 
-[odoo-master.website_payment]
+[odoo-s15-2.website_payment]
 file_filter = addons/website_payment/i18n/<lang>.po
 source_file = addons/website_payment/i18n/website_payment.pot
 source_lang = en
 
-[odoo-master.website_profile]
+[odoo-s15-2.website_profile]
 file_filter = addons/website_profile/i18n/<lang>.po
 source_file = addons/website_profile/i18n/website_profile.pot
 source_lang = en
 
-[odoo-master.website_sale]
+[odoo-s15-2.website_sale]
 file_filter = addons/website_sale/i18n/<lang>.po
 source_file = addons/website_sale/i18n/website_sale.pot
 source_lang = en
 
-[odoo-master.website_sale_comparison]
+[odoo-s15-2.website_sale_comparison]
 file_filter = addons/website_sale_comparison/i18n/<lang>.po
 source_file = addons/website_sale_comparison/i18n/website_sale_comparison.pot
 source_lang = en
 
-[odoo-master.website_sale_coupon]
+[odoo-s15-2.website_sale_coupon]
 file_filter = addons/website_sale_coupon/i18n/<lang>.po
 source_file = addons/website_sale_coupon/i18n/website_sale_coupon.pot
 source_lang = en
 
-[odoo-master.website_sale_delivery]
+[odoo-s15-2.website_sale_delivery]
 file_filter = addons/website_sale_delivery/i18n/<lang>.po
 source_file = addons/website_sale_delivery/i18n/website_sale_delivery.pot
 source_lang = en
 
-[odoo-master.website_sale_delivery_mondialrelay]
+[odoo-s15-2.website_sale_delivery_mondialrelay]
 file_filter = addons/website_sale_delivery_mondialrelay/i18n/<lang>.po
 source_file = addons/website_sale_delivery_mondialrelay/i18n/website_sale_delivery_mondialrelay.pot
 source_lang = en
 
-[odoo-master.website_sale_digital]
+[odoo-s15-2.website_sale_digital]
 file_filter = addons/website_sale_digital/i18n/<lang>.po
 source_file = addons/website_sale_digital/i18n/website_sale_digital.pot
 source_lang = en
 
-[odoo-master.website_sale_gift_card]
+[odoo-s15-2.website_sale_gift_card]
 file_filter = addons/website_sale_gift_card/i18n/<lang>.po
 source_file = addons/website_sale_gift_card/i18n/website_sale_gift_card.pot
 source_lang = en
 
-[odoo-master.website_sale_product_configurator]
+[odoo-s15-2.website_sale_product_configurator]
 file_filter = addons/website_sale_product_configurator/i18n/<lang>.po
 source_file = addons/website_sale_product_configurator/i18n/website_sale_product_configurator.pot
 source_lang = en
 
-[odoo-master.website_sale_slides]
+[odoo-s15-2.website_sale_slides]
 file_filter = addons/website_sale_slides/i18n/<lang>.po
 source_file = addons/website_sale_slides/i18n/website_sale_slides.pot
 source_lang = en
 
-[odoo-master.website_sale_stock]
+[odoo-s15-2.website_sale_stock]
 file_filter = addons/website_sale_stock/i18n/<lang>.po
 source_file = addons/website_sale_stock/i18n/website_sale_stock.pot
 source_lang = en
 
-[odoo-master.website_sale_stock_wishlist]
+[odoo-s15-2.website_sale_stock_wishlist]
 file_filter = addons/website_sale_stock_wishlist/i18n/<lang>.po
 source_file = addons/website_sale_stock_wishlist/i18n/website_sale_stock_wishlist.pot
 source_lang = en
 
-[odoo-master.website_sale_wishlist]
+[odoo-s15-2.website_sale_wishlist]
 file_filter = addons/website_sale_wishlist/i18n/<lang>.po
 source_file = addons/website_sale_wishlist/i18n/website_sale_wishlist.pot
 source_lang = en
 
-[odoo-master.website_slides]
+[odoo-s15-2.website_slides]
 file_filter = addons/website_slides/i18n/<lang>.po
 source_file = addons/website_slides/i18n/website_slides.pot
 source_lang = en
 
-[odoo-master.website_slides_forum]
+[odoo-s15-2.website_slides_forum]
 file_filter = addons/website_slides_forum/i18n/<lang>.po
 source_file = addons/website_slides_forum/i18n/website_slides_forum.pot
 source_lang = en
 
-[odoo-master.website_slides_survey]
+[odoo-s15-2.website_slides_survey]
 file_filter = addons/website_slides_survey/i18n/<lang>.po
 source_file = addons/website_slides_survey/i18n/website_slides_survey.pot
 source_lang = en
 
-[odoo-master.website_sms]
+[odoo-s15-2.website_sms]
 file_filter = addons/website_sms/i18n/<lang>.po
 source_file = addons/website_sms/i18n/website_sms.pot
 source_lang = en
 
-[odoo-master.website_twitter]
+[odoo-s15-2.website_twitter]
 file_filter = addons/website_twitter/i18n/<lang>.po
 source_file = addons/website_twitter/i18n/website_twitter.pot
 source_lang = en
 
-[odoo-15-l10n.l10n_be]
-file_filter = addons/l10n_be/i18n/<lang>.po
-source_file = addons/l10n_be/i18n/l10n_be.pot
-source_lang = en
-
-[odoo-15-l10n.l10n_ca]
-file_filter = addons/l10n_ca/i18n/<lang>.po
-source_file = addons/l10n_ca/i18n/l10n_ca.pot
-source_lang = en
-
-[odoo-15-l10n.l10n_ch]
-file_filter = addons/l10n_ch/i18n/<lang>.po
-source_file = addons/l10n_ch/i18n/l10n_ch.pot
-source_lang = en
-
-[odoo-15-l10n.l10n_cn]
-file_filter = addons/l10n_cn/i18n/<lang>.po
-source_file = addons/l10n_cn/i18n/l10n_cn.pot
-source_lang = en
-
-[odoo-15-l10n.l10n_eg_edi_eta]
-file_filter = addons/l10n_eg_edi_eta/i18n/<lang>.po
-source_file = addons/l10n_eg_edi_eta/i18n/l10n_eg_edi_eta.pot
-source_lang = en


### PR DESCRIPTION
Until know, Transifex projects were organised as:
- odoo-14
- odoo-15
- odoo-master

with odoo-master changing frenquently to reflect the
last used saas version, to prepare the future odoo-16 version.

This was ok as most people used stable versions at that time.

Now the saas versions are frequently released and many users of
odoo.com are running these versions, the quality of translations is
more important and preparing for the future version is not the only
goal.

Having only one project synchronised with a saas version is not enough
as we frenquently have to support multiple versions in parallel
(e.g. saas-15.2 for users and saas-15.3 for odoo.com).

Switch to a project for each saas release to be more flexible.
Hopefully, it won't be too much additional work for translators thanks
to TM.

New organisation:
- odoo-14
- odoo-15
- odoo-s15-2
- odoo-s15-3

and delete projects when it is no longer supported
