### PR TITLE
[IMP] sale: make quote/order report fully editable in Studio

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -165,17 +165,17 @@
                 </div>
             </div>
 
-            <div class="oe_structure"/>
-
-            <p t-field="doc.note" />
-            <p t-if="not is_html_empty(doc.payment_term_id.note)">
-                <span t-field="doc.payment_term_id.note"/>
-            </p>
-            <p t-if="doc.fiscal_position_id and not is_html_empty(doc.fiscal_position_id.sudo().note)"
-                id="fiscal_position_remark">
-                <strong>Fiscal Position Remark:</strong>
-                <span t-field="doc.fiscal_position_id.sudo().note"/>
-            </p>
+            <div>
+                <p t-field="doc.note" />
+                <p t-if="not is_html_empty(doc.payment_term_id.note)">
+                    <span t-field="doc.payment_term_id.note"/>
+                </p>
+                <p t-if="doc.fiscal_position_id and not is_html_empty(doc.fiscal_position_id.sudo().note)"
+                    id="fiscal_position_remark">
+                    <strong>Fiscal Position Remark:</strong>
+                    <span t-field="doc.fiscal_position_id.sudo().note"/>
+                </p>
+            </div>
         </div>
     </t>
 </template>


### PR DESCRIPTION
The lack of a div container between the 'page' div and the payment
terms/note/fiscal position section made it impossible to add blocks
at the end of the report, after these elements.

opw-2885434