### PR TITLE
[IMP] payment_ogone: add possibility to use sha256

### DIFF
--- a/addons/payment_ogone/data/payment_acquirer_data.xml
+++ b/addons/payment_ogone/data/payment_acquirer_data.xml
@@ -13,4 +13,9 @@
         <field name="payment_type">inbound</field>
     </record>
 
+    <record model="ir.config_parameter" id="payment_ogone_hash_function" forcecreate="False">
+        <field name="key">payment_ogone.hash_function</field>
+        <field name="value">sha1</field>
+    </record>
+
 </odoo>

--- a/addons/payment_ogone/models/payment_acquirer.py
+++ b/addons/payment_ogone/models/payment_acquirer.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from hashlib import sha1
+from hashlib import new as hashnew
 
 import requests
 
@@ -99,7 +99,14 @@ class PaymentAcquirer(models.Model):
             formatted_items = [(k.upper(), v) for k, v in values.items()]
         sorted_items = sorted(formatted_items)
         signing_string = ''.join(f'{k}={v}{key}' for k, v in sorted_items if _filter_key(k) and v)
-        return sha1(signing_string.encode()).hexdigest()
+        signing_string = signing_string.encode()
+        hash_function = self.env['ir.config_parameter'].sudo().get_param('payment_ogone.hash_function')
+        if not hash_function or hash_function.lower() not in ['sha1', 'sha256', 'sha512']:
+            hash_function = 'sha1'
+
+        shasign = hashnew(hash_function)
+        shasign.update(signing_string)
+        return shasign.hexdigest()
 
     def _ogone_make_request(self, payload=None, method='POST'):
         """ Make a request to one of Ogone APIs.


### PR DESCRIPTION
SHA1 is going to be deprecated by ogone.
This change try to keep current behaviour while adding
the possibility to use SHA256 and SHA512

As this change as to be done in stable version,
We use the length of the key to know which version of SHA
we should use.

The goal is to switch add an selection to master to ensure
better code modularity.

The change was requested by PDE/ANV.

opw-2766648

X-original-commit: b0df4af


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
