### PR TITLE
[FIX] web_editor: always save url from link_tool

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -52,12 +52,12 @@ const LinkTools = Link.extend({
         if (!this.el) {
             return this._super(...arguments);
         }
+        this._super(...arguments);
         const $contents = this.$link.contents();
         if (!this.$link.attr('href') && !this.colorCombinationClass) {
             $contents.unwrap();
         }
         this._observer.disconnect();
-        this._super(...arguments);
         this._removeHintClasses();
     },
 


### PR DESCRIPTION
Ensure the url entered in the link_tool input is always saved in the document

task-2856039


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
