### PR TITLE
[FIX] base,portal: wrong url in the account security wizard

### DIFF
--- a/doc/cla/individual/grzana12.md
+++ b/doc/cla/individual/grzana12.md
@@ -1,0 +1,11 @@
+Poland, 2022-05-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Łukasz Grzenkowicz lukasz@grzana.pl https://github.com/grzana12


### PR DESCRIPTION
Step to reproduce issue
1. Goto Account -> preferences -> Account Security
2. Developer API Keys -> click the little info icon

Error: 404 page because the url [https://www.odoo.com/documentation/15.0/developer/misc/api/odoo.html#api-keys]
was incorrect

Solution: Changed the url to [https://www.odoo.com/documentation/15.0/developer/misc/api/external_api.html]

opw-2881586

