### PR TITLE
[FIX] pos_coupon: apply order discount on lines' discounted amount

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -934,9 +934,9 @@ odoo.define('pos_coupon.pos', function (require) {
                 if (program.discount_specific_product_ids.has(line.get_product().id)) {
                     const key = this._getGroupKey(line);
                     if (!(key in amountsToDiscount)) {
-                        amountsToDiscount[key] = line.get_quantity() * line.price;
+                        amountsToDiscount[key] = line.get_base_price();
                     } else {
-                        amountsToDiscount[key] += line.get_quantity() * line.price;
+                        amountsToDiscount[key] += line.get_base_price();
                     }
                     productIdsToAccount.add(line.get_product().id);
                 }
@@ -986,9 +986,9 @@ odoo.define('pos_coupon.pos', function (require) {
             for (let line of this._getRegularOrderlines()) {
                 const key = this._getGroupKey(line);
                 if (!(key in amountsToDiscount)) {
-                    amountsToDiscount[key] = line.get_quantity() * line.price;
+                    amountsToDiscount[key] = line.get_base_price();
                 } else {
-                    amountsToDiscount[key] += line.get_quantity() * line.price;
+                    amountsToDiscount[key] += line.get_base_price();
                 }
                 productIdsToAccount.add(line.get_product().id);
             }


### PR DESCRIPTION
Order discount do not take into account the discount on order lines so
the discount amount will be wrong

Steps to reproduce:
1. Install Point of Sale
2. Go to Settings > Point of Sale > Pricing and enable Coupons &
Promotions
3. Go to Point of Sale > Products > Promotion Programs and edit program
'Code for 10% on orders'
4. Change the Promo Code Usage to 'Automatically Applied'
5. Open a new session in Point of Sale 'Shop'
6. Add a product (e.g. Acoustic Bloc Screens, the discount is applied
with value 29.50$)
7. Apply a discount of 20% on the product, the discount value doesn't
change (it should be 23.60$)

Solution:
When computing the amount to discount, take into consideration the
discount already applied on the order line

opw-2883724