### PR TITLE
[FIX] base: Force filestore garbage collect if unusual system parameter

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -140,7 +140,7 @@ class IrAttachment(models.Model):
     @api.model
     def _file_gc(self):
         """ Perform the garbage collection of the filestore. """
-        if self._storage() != 'file':
+        if not self._storage().startswith('file'):
             return
 
         # Continue in a new transaction. The LOCK statement below must be the


### PR DESCRIPTION
Before this commit:
If the system parameter `ir_attachment.location` was anything but `file`. The filestore garbage collect process was skipped.
For some reasons, some Odoo users have values of V7 like `file:filestore` in version >= 13. As a consequence, their filestore size was increasing even if the attachment was deleted.

After this commit:
Force the garbage collect except if the parameters is set as `db`.

OPW-2836204

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
