### PR TITLE
[FIX] website_sale: public user doesn't have access to fpos

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -413,7 +413,7 @@ class Website(models.Model):
 
     @api.model
     def _get_current_fiscal_position_id(self, partner_sudo):
-        AccountFiscalPosition = self.env['account.fiscal.position']
+        AccountFiscalPosition = self.env['account.fiscal.position'].sudo()
         fpos = AccountFiscalPosition
 
         # If the current user is the website public user, the fiscal position
@@ -422,7 +422,7 @@ class Website(models.Model):
             country_code = request.geoip.get('country_code')
             if country_code:
                 country_id = self.env['res.country'].search([('code', '=', country_code)], limit=1).id
-                fpos = self.env['account.fiscal.position'].sudo()._get_fpos_by_region(country_id)
+                fpos = AccountFiscalPosition._get_fpos_by_region(country_id)
 
         if not fpos:
             fpos = AccountFiscalPosition._get_fiscal_position(partner_sudo)


### PR DESCRIPTION
In commit d4b046e2388635d9a328dbdec9315963c9447a6a, a sudo was lost,
leading to 403 errors shown to public users browsing the ecommerce.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
