### PR TITLE
[IMP] *: remove support for empty create with pyenv

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -118,7 +118,7 @@ QUnit.module('hr', {}, function () {
         assert.expect(3);
 
         const pyEnv = await startServer();
-        const resPartnerId1 = pyEnv['res.partner'].create();
+        const resPartnerId1 = pyEnv['res.partner'].create({});
         const resUsersId1 = pyEnv['res.users'].create({ partner_id: resPartnerId1 });
         const hrEmployeePublicId1 = pyEnv['hr.employee.public'].create({ user_id: resUsersId1, user_partner_id: resPartnerId1 });
         pyEnv['m2x.avatar.employee'].create({ employee_id: hrEmployeePublicId1, employee_ids: [hrEmployeePublicId1] });
@@ -389,8 +389,8 @@ QUnit.module('hr', {}, function () {
         assert.expect(10);
 
         const pyEnv = await startServer();
-        const resPartnerId1 = pyEnv['res.partner'].create();
-        const resUsersId1 = pyEnv['res.users'].create();
+        const resPartnerId1 = pyEnv['res.partner'].create({});
+        const resUsersId1 = pyEnv['res.users'].create({});
         const [hrEmployeePublicId1, hrEmployeePublicId2] = pyEnv['hr.employee.public'].create([
             {},
             { user_id: resUsersId1, user_partner_id: resPartnerId1 },

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -188,7 +188,10 @@ const VIEW_TYPE_TO_ARCH = {
                      * @returns {integer[]|integer} array of ids if more than one value was passed,
                      * id of created record otherwise.
                      */
-                    create(values = {}) {
+                    create(values) {
+                        if (!values) {
+                            return;
+                        }
                         if (!Array.isArray(values)) {
                             values = [values];
                         }

--- a/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
+++ b/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
@@ -65,7 +65,7 @@ QUnit.test('auto-select "Inbox" when discuss had channel as active thread', asyn
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
 
     patchUiSize({ height: 360, width: 640 });
     const { click, messaging } = await start({

--- a/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
@@ -96,8 +96,8 @@ QUnit.test('list activity widget with exception', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailActivityId1 = pyEnv['mail.activity'].create();
-    const mailActivityTypeId1 = pyEnv['mail.activity.type'].create();
+    const mailActivityId1 = pyEnv['mail.activity'].create({});
+    const mailActivityTypeId1 = pyEnv['mail.activity.type'].create({});
     pyEnv['res.users'].write([pyEnv.currentUserId], {
         activity_ids: [mailActivityId1],
         activity_state: 'today',
@@ -285,7 +285,7 @@ QUnit.test('list activity widget: done the activity with "ENTER" keyboard shortc
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailActivityTypeId1 = pyEnv['mail.activity.type'].create();
+    const mailActivityTypeId1 = pyEnv['mail.activity.type'].create({});
     const mailActivityId1 = pyEnv['mail.activity'].create([
         {
             display_name: "Call with Al",
@@ -335,7 +335,7 @@ QUnit.test('list activity widget: done and schedule the next activity with "ENTE
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailActivityTypeId1 = pyEnv['mail.activity.type'].create();
+    const mailActivityTypeId1 = pyEnv['mail.activity.type'].create({});
     const mailActivityId1 = pyEnv['mail.activity'].create([
         {
             display_name: "Call with Al",

--- a/addons/mail/static/tests/qunit_suite_tests/components/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/activity_mark_done_popover_tests.js
@@ -12,7 +12,7 @@ QUnit.test('activity mark done popover simplest layout', async function (assert)
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         activity_category: 'not_upload_file',
         can_write: true,
@@ -62,7 +62,7 @@ QUnit.test('activity with force next mark done popover simplest layout', async f
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         activity_category: 'not_upload_file',
         can_write: true,
@@ -113,7 +113,7 @@ QUnit.test('activity mark done popover mark done without feedback', async functi
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailActivityId1 = pyEnv['mail.activity'].create({
         activity_category: 'not_upload_file',
         can_write: true,
@@ -154,7 +154,7 @@ QUnit.test('activity mark done popover mark done with feedback', async function 
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailActivityId1 = pyEnv['mail.activity'].create({
         activity_category: 'not_upload_file',
         can_write: true,
@@ -199,7 +199,7 @@ QUnit.test('activity mark done popover mark done and schedule next', async funct
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailActivityId1 = pyEnv['mail.activity'].create({
         activity_category: 'not_upload_file',
         can_write: true,
@@ -248,7 +248,7 @@ QUnit.test('[technical] activity mark done & schedule next with new action', asy
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         activity_category: 'not_upload_file',
         can_write: true,

--- a/addons/mail/static/tests/qunit_suite_tests/components/activity_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/activity_tests.js
@@ -13,7 +13,7 @@ QUnit.test('activity simplest layout', async function (assert) {
     assert.expect(12);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         res_id: resPartnerId1,
         res_model: 'res.partner',
@@ -89,7 +89,7 @@ QUnit.test('activity with note layout', async function (assert) {
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         note: 'There is no good or bad note',
         res_id: resPartnerId1,
@@ -124,7 +124,7 @@ QUnit.test('activity info layout when planned after tomorrow', async function (a
     const fiveDaysFromNow = new Date();
     fiveDaysFromNow.setDate(today.getDate() + 5);
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         date_deadline: date_to_str(fiveDaysFromNow),
         res_id: resPartnerId1,
@@ -164,7 +164,7 @@ QUnit.test('activity info layout when planned tomorrow', async function (assert)
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         date_deadline: date_to_str(tomorrow),
         res_id: resPartnerId1,
@@ -201,7 +201,7 @@ QUnit.test('activity info layout when planned today', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         date_deadline: date_to_str(new Date()),
         res_id: resPartnerId1,
@@ -241,7 +241,7 @@ QUnit.test('activity info layout when planned yesterday', async function (assert
     const yesterday = new Date();
     yesterday.setDate(today.getDate() - 1);
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         date_deadline: date_to_str(yesterday),
         res_id: resPartnerId1,
@@ -281,7 +281,7 @@ QUnit.test('activity info layout when planned before yesterday', async function 
     const fiveDaysBeforeNow = new Date();
     fiveDaysBeforeNow.setDate(today.getDate() - 5);
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         date_deadline: date_to_str(fiveDaysBeforeNow),
         res_id: resPartnerId1,
@@ -318,7 +318,7 @@ QUnit.test('activity with a summary layout', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         res_id: resPartnerId1,
         res_model: 'res.partner',
@@ -355,7 +355,7 @@ QUnit.test('activity without summary layout', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.activity'].create({
         activity_type_id: 1,
         res_id: resPartnerId1,
@@ -400,7 +400,7 @@ QUnit.test('activity details toggle', async function (assert) {
     const tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const resUsersId1 = pyEnv['res.users'].create({ partner_id: resPartnerId1 });
     pyEnv['mail.activity'].create({
         create_date: date_to_str(today),
@@ -453,7 +453,7 @@ QUnit.test('activity details layout', async function (assert) {
     tomorrow.setDate(today.getDate() + 1);
     const pyEnv = await startServer();
     const resUsersId1 = pyEnv['res.users'].create({ name: 'Pauvre pomme' });
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
         activity_type_id: emailActivityTypeId,
@@ -533,7 +533,7 @@ QUnit.test('activity with mail template layout', async function (assert) {
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailTemplateId1 = pyEnv['mail.template'].create({ name: "Dummy mail template" });
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
@@ -593,7 +593,7 @@ QUnit.test('activity with mail template: preview mail', async function (assert) 
     assert.expect(10);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailTemplateId1 = pyEnv['mail.template'].create({ name: "Dummy mail template" });
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
@@ -663,7 +663,7 @@ QUnit.test('activity with mail template: send mail', async function (assert) {
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailTemplateId1 = pyEnv['mail.template'].create({ name: "Dummy mail template" });
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
@@ -710,7 +710,7 @@ QUnit.test('activity upload document is available', async function (assert) {
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const uploadActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Upload Document']])[0];
     pyEnv['mail.activity'].create({
         activity_category: 'upload_file',
@@ -744,7 +744,7 @@ QUnit.test('activity click on mark as done', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
         activity_category: 'default',
@@ -788,7 +788,7 @@ QUnit.test('activity mark as done popover should focus feedback input on open [R
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
         activity_category: 'default',
@@ -825,7 +825,7 @@ QUnit.test('activity click on edit', async function (assert) {
     assert.expect(9);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailTemplateId1 = pyEnv['mail.template'].create({ name: "Dummy mail template" });
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     const mailActivityId1 = pyEnv['mail.activity'].create({
@@ -893,7 +893,7 @@ QUnit.test('activity edition', async function (assert) {
     assert.expect(14);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailActivityId1 = pyEnv['mail.activity'].create({
         can_write: true,
         icon: 'fa-times',
@@ -984,7 +984,7 @@ QUnit.test('activity click on cancel', async function (assert) {
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     const mailActivityId1 = pyEnv['mail.activity'].create({
         activity_type_id: emailActivityTypeId,
@@ -1033,7 +1033,7 @@ QUnit.test('activity mark done popover close on ESCAPE', async function (assert)
     // component to have a parent in order to allow testing interactions the popover.
     assert.expect(2);
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
         activity_category: 'default',
@@ -1072,7 +1072,7 @@ QUnit.test('activity mark done popover click on discard', async function (assert
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
         activity_category: 'default',
@@ -1110,7 +1110,7 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     pyEnv['mail.activity'].create({
         activity_category: 'default',
@@ -1167,7 +1167,7 @@ QUnit.test('button related to file uploading is replaced when updating activity 
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const uploadActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Upload document']])[0];
     const emailActivityTypeId = pyEnv['mail.activity.type'].search([['name', '=', 'Email']])[0];
     const mailActivityId1 = pyEnv['mail.activity'].create({

--- a/addons/mail/static/tests/qunit_suite_tests/components/attachment_box_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/attachment_box_tests.js
@@ -10,7 +10,7 @@ QUnit.test('base empty rendering', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { createChatterContainerComponent } = await start();
     const chatterContainerComponent = await createChatterContainerComponent({
         isAttachmentBoxVisibleInitially: true,
@@ -42,7 +42,7 @@ QUnit.test('base non-empty rendering', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['ir.attachment'].create([
         {
             mimetype: 'text/plain',
@@ -88,7 +88,7 @@ QUnit.test('view attachments', async function (assert) {
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const [irAttachmentId1] = pyEnv['ir.attachment'].create([
         {
             mimetype: 'text/plain',
@@ -160,7 +160,7 @@ QUnit.test('remove attachment should ask for confirmation', async function (asse
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['ir.attachment'].create({
         mimetype: 'text/plain',
         name: 'Blah.txt',

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -872,7 +872,7 @@ QUnit.test('chat window: composer state conservation on toggle discuss', async f
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const mailChannelId = pyEnv['mail.channel'].create();
+    const mailChannelId = pyEnv['mail.channel'].create({});
     const { click, createMessagingMenuComponent, insertText, openDiscuss, openView } = await start();
     const messagingMenuComponent = await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
@@ -940,7 +940,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     for (let i = 0; i < 10; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
@@ -1478,7 +1478,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     for (let i = 0; i < 10; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
@@ -1628,7 +1628,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     for (let i = 0; i < 10; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
@@ -1968,7 +1968,7 @@ QUnit.test('chat window should open when receiving a new DM', async function (as
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const resUsersId1 = pyEnv['res.users'].create({ partner_id: resPartnerId1 });
     pyEnv['mail.channel'].create({
         channel_last_seen_partner_ids: [

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
@@ -22,7 +22,7 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     for (let i = 0; i < 60; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
@@ -134,7 +134,7 @@ QUnit.test('base rendering when chatter has attachments', async function (assert
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['ir.attachment'].create([
         {
             mimetype: 'text/plain',
@@ -175,7 +175,7 @@ QUnit.test('show attachment box', async function (assert) {
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['ir.attachment'].create([
         {
             mimetype: 'text/plain',
@@ -233,7 +233,7 @@ QUnit.test('chatter: drop attachments', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -295,7 +295,7 @@ QUnit.test('composer show/hide on log note/send message [REQUIRE FOCUS]', async 
     assert.expect(10);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -367,7 +367,7 @@ QUnit.test('should display subject when subject is not the same as the thread na
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.message'].create({
         body: "not empty",
         model: 'res.partner',
@@ -420,7 +420,7 @@ QUnit.test('should not display user notification messages in chatter', async fun
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['mail.message'].create({
         message_type: 'user_notification',
         model: 'res.partner',
@@ -443,7 +443,7 @@ QUnit.test('post message with "CTRL-Enter" keyboard shortcut', async function (a
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent, insertText } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -472,7 +472,7 @@ QUnit.test('post message with "META-Enter" keyboard shortcut', async function (a
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent, insertText } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -504,7 +504,7 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async function 
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent, insertText } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_topbar_tests.js
@@ -12,7 +12,7 @@ QUnit.test('base rendering', async function (assert) {
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -110,7 +110,7 @@ QUnit.test('attachment loading is delayed', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { advanceTime, createChatterContainerComponent } = await start({
         hasTimeControl: true,
         loadingBaseDelayDuration: 100,
@@ -153,7 +153,7 @@ QUnit.test('attachment counter while loading attachments', async function (asser
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { createChatterContainerComponent } = await start({
         async mockRPC(route) {
             if (route.includes('/mail/thread/data')) {
@@ -192,7 +192,7 @@ QUnit.test('attachment counter transition when attachments become loaded)', asyn
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const attachmentPromise = makeTestPromise();
     const { createChatterContainerComponent } = await start({
         async mockRPC(route) {
@@ -249,7 +249,7 @@ QUnit.test('attachment counter without attachments', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -282,7 +282,7 @@ QUnit.test('attachment counter with attachments', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['ir.attachment'].create([
         {
             mimetype: 'text/plain',
@@ -329,7 +329,7 @@ QUnit.test('composer state conserved when clicking on another topbar button', as
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -457,7 +457,7 @@ QUnit.test('log note/send message switching', async function (assert) {
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -513,7 +513,7 @@ QUnit.test('log note toggling', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,
@@ -549,7 +549,7 @@ QUnit.test('send message toggling', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         threadId: resPartnerId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_canned_response_tests.js
@@ -10,7 +10,7 @@ QUnit.test('canned response suggestion displayed', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({
         source: 'hello',
         substitution: "Hello, how are you?",
@@ -35,7 +35,7 @@ QUnit.test('canned response suggestion correct data', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({
         source: 'hello',
         substitution: "Hello, how are you?",
@@ -75,7 +75,7 @@ QUnit.test('canned response suggestion active', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({
         source: 'hello',
         substitution: "Hello, how are you?",

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -98,7 +98,7 @@ QUnit.test('composer text input: basic rendering when linked thread is a mail.ch
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChanelId1,
@@ -173,7 +173,7 @@ QUnit.test('add an emoji', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChanelId1,
@@ -193,7 +193,7 @@ QUnit.test('add an emoji after some text', async function (assert) {
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChanelId1,
@@ -220,7 +220,7 @@ QUnit.test('add emoji replaces (keyboard) text selection', async function (asser
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChanelId1,
@@ -250,7 +250,7 @@ QUnit.test('display canned response suggestions on typing ":"', async function (
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({ source: "hello", substitution: "Hello! How are you?" });
     const { createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -276,7 +276,7 @@ QUnit.test('use a canned response', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({ source: "hello", substitution: "Hello! How are you?" });
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -313,7 +313,7 @@ QUnit.test('use a canned response some text', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({ source: "hello", substitution: "Hello! How are you?" });
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -356,7 +356,7 @@ QUnit.test('add an emoji after a canned response', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChanelId1 = pyEnv['mail.channel'].create();
+    const mailChanelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.shortcode'].create({ source: "hello", substitution: "Hello! How are you?" });
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -575,7 +575,7 @@ QUnit.test('do not send typing notification on typing "/" command', async functi
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -598,7 +598,7 @@ QUnit.test('do not send typing notification on typing after selecting suggestion
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -733,7 +733,7 @@ QUnit.test('display partner mention suggestions on typing "@"', async function (
     const resPartnerId1 = pyEnv['res.partner'].create({ email: "testpartner@odoo.com", name: "TestPartner" });
     pyEnv['res.partner'].create({ email: "testpartner2@odoo.com", name: "TestPartner2" });
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -764,7 +764,7 @@ QUnit.test('mention a partner', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['res.partner'].create({ email: "testpartner@odoo.com", name: "TestPartner" });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -801,7 +801,7 @@ QUnit.test('mention a partner after some text', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['res.partner'].create({ email: "testpartner@odoo.com", name: "TestPartner" });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -844,7 +844,7 @@ QUnit.test('add an emoji after a partner mention', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['res.partner'].create({ email: "testpartner@odoo.com", name: "TestPartner" });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, insertText, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -889,7 +889,7 @@ QUnit.test('composer: add an attachment', async function (assert) {
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -919,7 +919,7 @@ QUnit.test('composer: drop attachments', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -982,7 +982,7 @@ QUnit.test('composer: paste attachments', async function (assert) {
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -1016,7 +1016,7 @@ QUnit.test('composer text input cleared on message post', async function (assert
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, insertText, messaging } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/message/post') {
@@ -1053,7 +1053,7 @@ QUnit.test('composer with thread typing notification status', async function (as
     // channel that is expected to be rendered
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -1081,7 +1081,7 @@ QUnit.test('current partner notify is typing to other thread members', async fun
     // channel that is expected to be rendered
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -1109,7 +1109,7 @@ QUnit.test('current partner is typing should not translate on textual typing sta
     // channel that is expected to be rendered
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -1146,7 +1146,7 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
     // channel that is expected to be rendered
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { advanceTime, insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -1182,7 +1182,7 @@ QUnit.test('current partner notify is typing again to other members every 50s of
     // channel that is expected to be rendered
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { advanceTime, insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
@@ -1224,7 +1224,7 @@ QUnit.test('composer: send button is disabled if attachment upload is not finish
 
     const pyEnv = await startServer();
     const attachmentUploadedPromise = makeTestPromise();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start({
         async mockRPC(route) {
             if (route === '/mail/attachment/upload') {
@@ -1295,7 +1295,7 @@ QUnit.test('remove an attachment from composer does not need any confirmation', 
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -1336,7 +1336,7 @@ QUnit.test('remove an uploading attachment', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, createComposerComponent, messaging } = await start({
         async mockRPC(route) {
             if (route === '/mail/attachment/upload') {
@@ -1389,7 +1389,7 @@ QUnit.test('remove an uploading attachment aborts upload', async function (asser
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { afterEvent, createComposerComponent, messaging } = await start({
         async mockRPC(route) {
             if (route === '/mail/attachment/upload') {
@@ -1437,7 +1437,7 @@ QUnit.test("Show a default status in the recipient status text when the thread d
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const views = {
         'res.partner,false,form':
             `<form string="Partners">
@@ -1505,7 +1505,7 @@ QUnit.test('send message only once when button send is clicked twice quickly', a
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, insertText, messaging } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/message/post') {
@@ -1540,7 +1540,7 @@ QUnit.test('[technical] does not crash when an attachment is removed before its 
     const pyEnv = await startServer();
     // Promise to block attachment uploading
     const uploadPromise = makeTestPromise();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start({
         async mockRPC(route) {
             if (route === '/mail/attachment/upload') {
@@ -1590,7 +1590,7 @@ QUnit.test('send button on mail.channel should have "Send" as label', async func
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { createComposerComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
@@ -128,7 +128,7 @@ QUnit.test('reply: discard on discard button click', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         model: 'res.partner',
@@ -186,7 +186,7 @@ QUnit.test('reply: discard on reply button toggle', async function (assert) {
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         model: 'res.partner',
@@ -238,7 +238,7 @@ QUnit.test('reply: discard on click away', async function (assert) {
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         model: 'res.partner',
@@ -318,7 +318,7 @@ QUnit.test('"reply to" composer should log note if message replied to is a note'
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         is_discussion: false,
@@ -384,7 +384,7 @@ QUnit.test('"reply to" composer should send message if message replied to is not
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         is_discussion: true,
@@ -450,7 +450,7 @@ QUnit.test('error notifications should not be shown in Inbox', async function (a
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         model: 'mail.channel',

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_message_edit_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_message_edit_tests.js
@@ -10,7 +10,7 @@ QUnit.test('click on message edit button should open edit composer', async funct
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'comment',

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
@@ -14,7 +14,7 @@ QUnit.test('sidebar: pinned channel 1: init with one pinned channel', async func
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { messaging } = await start({
         autoOpenDiscuss: true,
     });
@@ -39,7 +39,7 @@ QUnit.test('sidebar: pinned channel 2: open pinned channel', async function (ass
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, messaging } = await start({
         autoOpenDiscuss: true,
     });
@@ -113,7 +113,7 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, messaging } = await start({
         autoOpenDiscuss: true,
     });

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -22,7 +22,7 @@ QUnit.test('channel - counter: should not have a counter if the category is unfo
     assert.expect(1);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
 
     await this.start();
     assert.strictEqual(
@@ -73,7 +73,7 @@ QUnit.test('channel - counter: should not have a counter if category is folded a
     assert.expect(1);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
@@ -193,7 +193,7 @@ QUnit.test('channel - states: close manually by clicking the title', async funct
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
@@ -217,7 +217,7 @@ QUnit.test('channel - states: open manually by clicking the title', async functi
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
@@ -241,7 +241,7 @@ QUnit.test('channel - states: close should update the value on the server', asyn
     assert.expect(2);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
@@ -277,7 +277,7 @@ QUnit.test('channel - states: open should update the value on the server', async
     assert.expect(2);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
@@ -313,7 +313,7 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
@@ -342,7 +342,7 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
@@ -371,7 +371,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, messaging } = await this.start();
 
     assert.containsOnce(
@@ -609,7 +609,7 @@ QUnit.test('chat - states: close should call update server data', async function
     assert.expect(2);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
@@ -645,7 +645,7 @@ QUnit.test('chat - states: open should call update server data', async function 
     assert.expect(2);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
     pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -493,7 +493,7 @@ QUnit.test('sidebar: channel rendering with needaction counter', async function 
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         model: "mail.channel",
@@ -858,7 +858,7 @@ QUnit.test('default thread rendering', async function (assert) {
     assert.expect(16);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, messaging } = await this.start();
     assert.strictEqual(
         document.querySelectorAll(`
@@ -1069,7 +1069,7 @@ QUnit.test('load single message from channel initially', async function (assert)
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         date: "2019-04-20 10:00:00",
@@ -1128,7 +1128,7 @@ QUnit.test('open channel from active_id as channel id', async function (assert) 
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { messaging } = await this.start({
         discuss: {
             context: {
@@ -1152,7 +1152,7 @@ QUnit.test('basic rendering of message', async function (assert) {
     assert.expect(15);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const resPartnerId1 = pyEnv['res.partner'].create({ name: "Demo" });
     const mailMessageId1 = pyEnv['mail.message'].create({
         author_id: resPartnerId1,
@@ -1258,7 +1258,7 @@ QUnit.test('should not be able to reply to temporary/transient messages', async 
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, insertText } = await this.start({
         discuss: {
             params: {
@@ -1286,8 +1286,8 @@ QUnit.test('basic rendering of squashed message', async function (assert) {
     assert.expect(12);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const [mailMessageId1, mailMessageId2] = pyEnv['mail.message'].create([
         {
             author_id: resPartnerId1, // must be same author as other message
@@ -1393,8 +1393,8 @@ QUnit.test('inbox messages are never squashed', async function (assert) {
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const [mailMessageId1, mailMessageId2] = pyEnv['mail.message'].create([
         {
             author_id: resPartnerId1, // must be same author as other message
@@ -1480,9 +1480,9 @@ QUnit.test('load all messages from channel initially, less than fetch limit (29 
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    pyEnv['res.partner'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    pyEnv['res.partner'].create({});
     for (let i = 28; i >= 0; i--) {
         pyEnv['mail.message'].create({
             author_id: resPartnerId1,
@@ -1539,9 +1539,9 @@ QUnit.test('load more messages from channel', async function (assert) {
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    pyEnv['res.partner'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    pyEnv['res.partner'].create({});
     for (let i = 0; i < 40; i++) {
         pyEnv['mail.message'].create({
             author_id: resPartnerId1,
@@ -1609,7 +1609,7 @@ QUnit.test('auto-scroll to bottom of thread', async function (assert) {
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     for (let i = 1; i <= 25; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
@@ -1656,7 +1656,7 @@ QUnit.test('load more messages from channel (auto-load on scroll)', async functi
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     for (let i = 0; i < 40; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
@@ -2255,7 +2255,7 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const [mailMessageId1, mailMessageId2] = pyEnv['mail.message'].create([
         {
             body: "not empty",
@@ -2416,7 +2416,7 @@ QUnit.test('toggle_star message', async function (assert) {
     assert.expect(16);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "not empty",
         model: 'mail.channel',
@@ -2647,7 +2647,7 @@ QUnit.test('post a simple message', async function (assert) {
     assert.expect(16);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, insertText, messaging } = await this.start({
         discuss: {
             params: {
@@ -2744,7 +2744,7 @@ QUnit.test('post message on channel with "Enter" keyboard shortcut', async funct
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { insertText } = await this.start({
         discuss: {
             params: {
@@ -2778,7 +2778,7 @@ QUnit.test('do not post message on channel with "SHIFT-Enter" keyboard shortcut'
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { insertText } = await this.start({
         discuss: {
             params: {
@@ -3197,7 +3197,7 @@ QUnit.test('messages marked as read move to "History" mailbox', async function (
     assert.expect(10);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const [mailMessageId1, mailMessageId2] = pyEnv['mail.message'].create([
         {
             body: "not empty",
@@ -3860,7 +3860,7 @@ QUnit.test('warning on send with shortcut when attempting to post message with s
     assert.expect(7);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { messaging } = await this.start({
         discuss: {
             context: {
@@ -3930,7 +3930,7 @@ QUnit.test('send message only once when enter is pressed twice quickly', async f
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { insertText } = await this.start({
         discuss: {
             context: {
@@ -3962,7 +3962,7 @@ QUnit.test('message being a replied to another message should show message being
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: "1st message",
         model: 'mail.channel',

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
@@ -70,7 +70,7 @@ QUnit.test('base rendering editable', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
 
     const { click, createChatterContainerComponent } = await start({
         async mockRPC(route, args, performRPC) {
@@ -437,7 +437,7 @@ QUnit.test('Show "No Followers" dropdown-item if there are no followers and user
 
     const pyEnv = await startServer();
 
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { click, createChatterContainerComponent } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {

--- a/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -245,7 +245,7 @@ QUnit.test('counter is taking into account failure notification', async function
         },
     });
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         model: 'mail.channel',
         res_id: mailChannelId1,
@@ -685,7 +685,7 @@ QUnit.test('open chat window from preview', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    pyEnv['mail.channel'].create();
+    pyEnv['mail.channel'].create({});
     const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
 
@@ -702,7 +702,7 @@ QUnit.test('no code injection in message body preview', async function (assert) 
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.message'].create({
         body: "<p><em>&shoulnotberaised</em><script>throw new Error('CodeInjectionError');</script></p>",
         model: "mail.channel",
@@ -744,7 +744,7 @@ QUnit.test('no code injection in message body preview from sanitized message', a
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.message'].create({
         body: "<p>&lt;em&gt;&shoulnotberaised&lt;/em&gt;&lt;script&gt;throw new Error('CodeInjectionError');&lt;/script&gt;</p>",
         model: "mail.channel",
@@ -786,7 +786,7 @@ QUnit.test('<br/> tags in message body preview are transformed in spaces', async
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     pyEnv['mail.message'].create({
         body: "<p>a<br/>b<br>c<br   />d<br     ></p>",
         model: "mail.channel",

--- a/addons/mail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -12,7 +12,7 @@ QUnit.test('notification group basic layout', async function (assert) {
     assert.expect(10);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         message_type: 'email', // message must be email (goal of the test)
         model: 'mail.channel', // expected value to link message to channel
@@ -89,7 +89,7 @@ QUnit.test('mark as read', async function (assert) {
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         message_type: 'email', // message must be email (goal of the test)
         model: 'mail.channel', // expected value to link message to channel
@@ -472,7 +472,7 @@ QUnit.test('non-failure notifications are ignored', async function (assert) {
     assert.expect(1);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
             message_type: 'email', // message must be email (goal of the test)
             model: 'res.partner', // random model

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
@@ -12,7 +12,7 @@ QUnit.test('mark as read', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const resPartnerId1 =  pyEnv['res.partner'].create();
+    const resPartnerId1 =  pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         model: 'res.partner',
         needaction: true,
@@ -71,7 +71,7 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         model: 'res.partner',
         needaction: true,
@@ -135,7 +135,7 @@ QUnit.test('click on expand from chat window should close the chat window and op
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         model: 'res.partner',
         needaction: true,
@@ -209,7 +209,7 @@ QUnit.test('[technical] opening a non-channel chat window should not call channe
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         model: 'res.partner',
         needaction: true,
@@ -313,7 +313,7 @@ QUnit.test('chat window header should not have unread counter for non-channel th
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         author_id: resPartnerId1,
         body: 'not empty',

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -1060,7 +1060,7 @@ QUnit.test('mention 2 different partners that have the same name', async functio
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const [resPartnerId1, resPartnerId2] = pyEnv['res.partner'].create([
         {
             email: "partner1@example.com",

--- a/addons/mail/static/tests/qunit_suite_tests/models/messaging_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/messaging_tests.js
@@ -12,7 +12,7 @@ QUnit.test('openChat: display notification for partner without user', async func
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const { messaging } = await start({
         services: {
             notification: makeFakeNotificationService(message => {
@@ -36,7 +36,7 @@ QUnit.test('openChat: display notification for wrong user', async function (asse
     assert.expect(2);
 
     const pyEnv = await startServer();
-    pyEnv['res.users'].create();
+    pyEnv['res.users'].create({});
     const { messaging } = await start({
         services: {
             notification: makeFakeNotificationService(message => {
@@ -61,7 +61,7 @@ QUnit.test('openChat: open new chat for user', async function (assert) {
     assert.expect(3);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
 
     const { messaging } = await start({ data: this.data });
@@ -79,7 +79,7 @@ QUnit.test('openChat: open existing chat for user', async function (assert) {
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
     const mailChannelId1 = pyEnv['mail.channel'].create({
         channel_last_seen_partner_ids: [

--- a/addons/mail/static/tests/qunit_suite_tests/widgets/form_renderer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/widgets/form_renderer_tests.js
@@ -569,7 +569,7 @@ QUnit.test('read more/less links are not duplicated when switching from read to 
     assert.expect(5);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         author_id: resPartnerId1,
         // "data-o-mail-quote" added by server is intended to be compacted in read more/less blocks
@@ -657,7 +657,7 @@ QUnit.test('read more links becomes read less after being clicked', async functi
     assert.expect(6);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create([{
         author_id: resPartnerId1,
         // "data-o-mail-quote" added by server is intended to be compacted in read more/less blocks
@@ -900,7 +900,7 @@ QUnit.test('chatter just contains "creating a new record" message during the cre
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const views = {
         'res.partner,false,form':
             `<form string="Partners">

--- a/addons/sms/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/sms/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -53,7 +53,7 @@ QUnit.test('notifications grouped by notification_type', async function (assert)
     assert.expect(11);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const [mailMessageId1, mailMessageId2] = pyEnv['mail.message'].create([
         {
             message_type: 'sms', // different type from second message

--- a/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -21,7 +21,7 @@ QUnit.test('Sent', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',
@@ -99,7 +99,7 @@ QUnit.test('Canceled', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',
@@ -177,7 +177,7 @@ QUnit.test('Pending', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',
@@ -255,7 +255,7 @@ QUnit.test('No Price Available', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',
@@ -348,7 +348,7 @@ QUnit.test('Credit Error', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',
@@ -446,7 +446,7 @@ QUnit.test('Trial Error', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',
@@ -544,7 +544,7 @@ QUnit.test('Format Error', async function (assert) {
         name: "Someone",
         partner_share: true,
     });
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         body: 'not empty',
         message_type: 'snailmail',

--- a/addons/snailmail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/snailmail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -16,7 +16,7 @@ QUnit.test('mark as read', async function (assert) {
     // The following code simulates the cancel of the notification without using "snailmail.letter" model
 
     const pyEnv = await startServer();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     // message that is expected to have a failure
     const mailMessageId1 = pyEnv['mail.message'].create({
         author_id: pyEnv.currentPartnerId,

--- a/addons/test_mail_full/static/tests/qunit_suite_tests/thread_needaction_preview_tests.js
+++ b/addons/test_mail_full/static/tests/qunit_suite_tests/thread_needaction_preview_tests.js
@@ -9,8 +9,8 @@ QUnit.test('rating value displayed on the thread needaction preview', async func
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    const mailTestRating1 = pyEnv['mail.test.rating'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    const mailTestRating1 = pyEnv['mail.test.rating'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create({
         model: 'mail.test.rating',
         needaction: true,

--- a/addons/test_mail_full/static/tests/qunit_suite_tests/thread_preview_tests.js
+++ b/addons/test_mail_full/static/tests/qunit_suite_tests/thread_preview_tests.js
@@ -9,8 +9,8 @@ QUnit.test('rating value displayed on the thread preview', async function (asser
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    const mailChannelId1 = pyEnv['mail.channel'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
     const mailMessageId1 = pyEnv['mail.message'].create([
         { author_id: resPartnerId1, model: 'mail.channel', res_id: mailChannelId1 },
     ]);

--- a/addons/website_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/website_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -199,7 +199,7 @@ QUnit.test('livechat without visitor should not show visitor banner', async func
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
     const mailChannelId1 = pyEnv['mail.channel'].create({
         channel_last_seen_partner_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],

--- a/addons/website_slides/static/tests/qunit_suite_tests/components/activity_tests.js
+++ b/addons/website_slides/static/tests/qunit_suite_tests/components/activity_tests.js
@@ -10,8 +10,8 @@ QUnit.test('grant course access', async function (assert) {
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    const slideChannelId1 = pyEnv['slide.channel'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    const slideChannelId1 = pyEnv['slide.channel'].create({});
     pyEnv['mail.activity'].create({
         can_write: true,
         res_id: slideChannelId1,
@@ -47,8 +47,8 @@ QUnit.test('refuse course access', async function (assert) {
     assert.expect(8);
 
     const pyEnv = await startServer();
-    const resPartnerId1 = pyEnv['res.partner'].create();
-    const slideChannelId1 = pyEnv['slide.channel'].create();
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    const slideChannelId1 = pyEnv['slide.channel'].create({});
     pyEnv['mail.activity'].create({
         can_write: true,
         res_id: slideChannelId1,


### PR DESCRIPTION
\* mail, test_mail_full, website_livechat

**Current behavior before PR:**

Creating a record with no values has no sense but is sometimes useful during
tests.
The support should be dropped for `default` parameter in `create`.

**Desired behavior after PR is merged:**

All the occurrences of `create()` have been replaced by `create({})`.

Task-2869394


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
