### PR TITLE
[FIX] stock_picking_batch: compute properlyscheduled time on batch

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -104,7 +104,8 @@ class StockPickingBatch(models.Model):
 
     @api.depends('picking_ids', 'picking_ids.scheduled_date')
     def _compute_scheduled_date(self):
-        self.scheduled_date = min(self.picking_ids.filtered('scheduled_date').mapped('scheduled_date'), default=False)
+        for rec in self:
+            rec.scheduled_date = min(rec.picking_ids.filtered('scheduled_date').mapped('scheduled_date'), default=False)
 
     @api.onchange('scheduled_date')
     def onchange_scheduled_date(self):


### PR DESCRIPTION
scheduled_date is not computed correctly as it should respect recordset, current implementation just ignores computation

cla signed https://github.com/odoo/odoo/pull/93921



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
