### PR TITLE
[FIX] l10n_it_edi: use currency amounts in edi

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -169,8 +169,8 @@
                                 <AliquotaIVA t-esc="format_numbers(tax_dict['tax'].amount)"/>
                                 <Natura t-if="tax_dict['tax'].l10n_it_has_exoneration" t-esc="tax_dict['tax'].l10n_it_kind_exoneration"/>
                                 <Arrotondamento t-if="tax_dict.get('rounding')" t-esc="format_numbers(tax_dict['rounding'])"/>
-                                <ImponibileImporto t-esc="format_monetary(abs(tax_dict['base_amount']), currency)"/>
-                                <Imposta t-esc="format_monetary(abs(tax_dict['tax_amount']), currency)"/>
+                                <ImponibileImporto t-esc="format_monetary(abs(tax_dict['base_amount_currency']), currency)"/>
+                                <Imposta t-esc="format_monetary(abs(tax_dict['tax_amount_currency']), currency)"/>
                                 <EsigibilitaIVA t-if="not tax_dict['tax'].l10n_it_has_exoneration or tax_dict['tax'].l10n_it_kind_exoneration=='N6'" t-esc="tax_dict['tax'].l10n_it_vat_due_date"/>
                                 <RiferimentoNormativo t-if="tax_dict['tax'].l10n_it_has_exoneration" t-esc="format_alphanumeric(tax_dict['tax'].l10n_it_law_reference[:100])"/>
                             </DatiRiepilogo>

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -167,14 +167,14 @@ class AccountMove(models.Model):
         #   taxable base = sum(taxable base for each unit) + Arrotondamento
         tax_details = self._prepare_edi_tax_details()
         for _tax_name, tax_dict in tax_details['tax_details'].items():
-            base_amount = tax_dict['base_amount']
-            tax_amount = tax_dict['tax_amount']
+            base_amount = tax_dict['base_amount_currency']
+            tax_amount = tax_dict['tax_amount_currency']
             tax_rate = tax_dict['tax'].amount
             if tax_dict['tax'].price_include and tax_dict['tax'].amount_type == 'percent':
                 expected_base_amount = tax_amount * 100 / tax_rate if tax_rate else False
                 if expected_base_amount and float_compare(base_amount, expected_base_amount, 2):
                     tax_dict['rounding'] = base_amount - (tax_amount * 100 / tax_rate)
-                    tax_dict['base_amount'] = base_amount - tax_dict['rounding']
+                    tax_dict['base_amount_currency'] = base_amount - tax_dict['rounding']
 
         # Create file content.
         template_values = {


### PR DESCRIPTION
When adjusting the currency rates, the amounts in the edi invoice become
incorrect and the Italian EDI system rejects them (due to contraints on
the content of these fields).

This commit changes the referenced amount to the 'amount_currency' (for
the taxes and the base) for the fields in the EDI templates.