### PR TITLE
[FIX] *: use request.redirect instead of werkzeug.utils.redirect

### DIFF
--- a/addons/google_gmail/controllers/main.py
+++ b/addons/google_gmail/controllers/main.py
@@ -3,7 +3,6 @@
 
 import json
 import logging
-import werkzeug
 
 from werkzeug.exceptions import Forbidden
 from werkzeug.urls import url_encode
@@ -73,4 +72,4 @@ class GoogleGmailController(http.Controller):
             'view_type': 'form'
         }
         url = '/web?#' + url_encode(url_params)
-        return werkzeug.utils.redirect(url, 303)
+        return request.redirect(url)

--- a/addons/microsoft_outlook/controllers/main.py
+++ b/addons/microsoft_outlook/controllers/main.py
@@ -73,4 +73,4 @@ class MicrosoftOutlookController(http.Controller):
             'microsoft_outlook_access_token_expiration': expiration,
         })
 
-        return werkzeug.utils.redirect(f'/web?#id={rec_id}&model={model_name}&view_type=form', 303)
+        return request.redirect(f'/web?#id={rec_id}&model={model_name}&view_type=form')

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -152,8 +152,11 @@ class Website(Home):
         if lang == 'default':
             lang = request.website.default_lang_id.url_code
             r = '/%s%s' % (lang, r or '/')
-        redirect = werkzeug.utils.redirect(r or ('/%s' % lang), 303)
         lang_code = request.env['res.lang']._lang_get_code(lang)
+        # replace context with correct lang, to avoid that the url_for of request.redirect remove the
+        # default lang in case we switch from /fr -> /en with /en as default lang.
+        request.context = dict(request.context, lang=lang_code)
+        redirect = request.redirect(r or ('/%s' % lang))
         redirect.set_cookie('frontend_lang', lang_code)
         return redirect
 
@@ -606,8 +609,8 @@ class Website(Home):
             return werkzeug.wrappers.Response(url, mimetype='text/plain')
 
         if ext_special_case:  # redirect non html pages to backend to edit
-            return werkzeug.utils.redirect('/web#id=' + str(page.get('view_id')) + '&view_type=form&model=ir.ui.view')
-        return werkzeug.utils.redirect(url + "?enable_editor=1")
+            return request.redirect('/web#id=' + str(page.get('view_id')) + '&view_type=form&model=ir.ui.view')
+        return request.redirect(url + "?enable_editor=1")
 
     @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True)
     def get_switchable_related_views(self, key):

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -694,7 +694,7 @@ class WebsiteSlides(WebsiteProfile):
             raise werkzeug.exceptions.NotFound()
         # redirection to channel's homepage for category slides
         if slide.is_category:
-            return werkzeug.utils.redirect(slide.channel_id.website_url)
+            return request.redirect(slide.channel_id.website_url)
         self._set_viewed_slide(slide)
 
         values = self._get_slide_detail(slide)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -305,7 +305,7 @@ class WebRequest(object):
         if isinstance(location, urls.URL):
             location = location.to_url()
         if local:
-            location = urls.url_parse(location).replace(scheme='', netloc='').to_url()
+            location = '/' + urls.url_parse(location).replace(scheme='', netloc='').to_url().lstrip('/')
         if request and request.db:
             return request.registry['ir.http']._redirect(location, code)
         return werkzeug.utils.redirect(location, code, Response=Response)


### PR DESCRIPTION
It allows to always have a OdooResponse Object and don't allow redirect
to external except when you allow it explicitly with local=False.

Always return to a local url:
    /website/add
    /slides/slide/<model("slide.slide"):slide>
    /microsoft_outlook/confirm

Allow previously external redirect without reason, now blocked
   /website/lang/<lang> -> open redirect

Allow external redirect for good reason and url is controlled by code.
   /social_facebook/redirect_to_profile/

PS: HTTP Code 303 is a better default for generic redirects. It's not historically the default for werkzeug.utils, but it is what we want in general. Contrary to 302, there is no browser-dependent behavior, and no risk of asking the user whether they want to accept the redirect if the original method wasn't GET. It's always a non-permanent GET on the target location.