### PR TITLE
[FIX] http_routing: missing 301/302 on access err

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -626,7 +626,12 @@ class IrHttp(models.AbstractModel):
         code, values = cls._get_exception_code_values(exception)
 
         request.cr.rollback()
-        if code == 500:
+        if code == 403:
+            response = cls._serve_fallback()
+            if response:
+                cls._post_dispatch(response)
+                return response
+        elif code == 500:
             values = cls._get_values_500_error(request.env, values, exception)
         try:
             code, html = cls._get_error_html(request.env, code, values)

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -172,3 +172,40 @@ class TestRedirect(HttpCase):
             'href="/empty_controller_test_redirected?a=a"', r.text,
             "Redirection should have been applied, and query string should not have been duplicated.",
         )
+
+    @mute_logger('odoo.http')  # mute 403 warning
+    def test_04_redirect_301_route_unpublished_record(self):
+        # 1. Accessing published record: Normal case, expecting 200
+        rec1 = self.env['test.model'].create({
+            'name': '301 test record',
+            'is_published': True,
+        })
+        url_rec1 = '/test_website/200/' + slug(rec1)
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 200)
+
+        # 2. Accessing unpublished record: expecting 403 by default
+        rec1.is_published = False
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 403)
+
+        # 3. Accessing unpublished record with redirect to a 404: expecting 404
+        redirect = self.env['website.rewrite'].create({
+            'name': 'Test 301 Redirect route unpublished record',
+            'redirect_type': '301',
+            'url_from': url_rec1,
+            'url_to': '/404',
+        })
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 404)
+
+        # 4. Accessing unpublished record with redirect to another published
+        # record: expecting redirect to that record
+        rec2 = rec1.copy({'is_published': True})
+        url_rec2 = '/test_website/200/' + slug(rec2)
+        redirect.url_to = url_rec2
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(
+            r.url.endswith(url_rec2),
+            "Unpublished record should redirect to published record set in redirect")


### PR DESCRIPTION
Install website and website_hr_recruitment, open /web with ?debug=1, go
to website > configuration > redirect, create a temporary (302)
redirection from `/jobs/detail/experienced-developer-4` to `/404`. Open
the `/jobs/detail/experienced-developer-4` as admin and unpublish the
page. Open the same URL via private browsing (so that you are not
connected), you get the default 403 - Forbidden page, you were not
redirected to the 404 - Not Found page.

Custom 301 (permanent) and 302 (temporary) redirections are fallback
redirections when the requested page does not exist or is not accessible
to the current user. The HTTPocalypse broke the later case, it was not
checking for existing redirection upon access error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
