### PR TITLE
[IMP] test_website: strengthen the redirect testing suite

### DIFF
--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -174,3 +174,40 @@ class TestRedirect(HttpCase):
             'href="/empty_controller_test_redirected?a=a"', r.text,
             "Redirection should have been applied, and query string should not have been duplicated.",
         )
+
+    @mute_logger('odoo.addons.http_routing.models.ir_http')  # mute 403 warning
+    def test_04_redirect_301_route_unpublished_record(self):
+        # 1. Accessing published record: Normal case, expecting 200
+        rec1 = self.env['test.model'].create({
+            'name': '301 test record',
+            'is_published': True,
+        })
+        url_rec1 = '/test_website/200/' + slug(rec1)
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 200)
+
+        # 2. Accessing unpublished record: expecting 403 by default
+        rec1.is_published = False
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 403)
+
+        # 3. Accessing unpublished record with redirect to a 404: expecting 404
+        redirect = self.env['website.rewrite'].create({
+            'name': 'Test 301 Redirect route unpublished record',
+            'redirect_type': '301',
+            'url_from': url_rec1,
+            'url_to': '/404',
+        })
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 404)
+
+        # 4. Accessing unpublished record with redirect to another published
+        # record: expecting redirect to that record
+        rec2 = rec1.copy({'is_published': True})
+        url_rec2 = '/test_website/200/' + slug(rec2)
+        redirect.url_to = url_rec2
+        r = self.url_open(url_rec1)
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(
+            r.url.endswith(url_rec2),
+            "Unpublished record should redirect to published record set in redirect")


### PR DESCRIPTION
As an advanced use case was not working anymore in saas-15.3 since
httpocalypse, a test is introduced in 15.0.

The fix in 15.3 is done at https://github.com/odoo/odoo/pull/93932

The use case is the one supported with [1] where people want/need to
display something better than a 403 when they unpublish a record like a
job position for instance (most of the requested cases on opw).
Indeed:
- People have link to that record/job everywhere on the internet
- The job position / record is no more relevant, and people need to
  unpublish it
- People don't want to delete it (or can't sometimes due to record
  relations)
- People don't want visitors to land on a 403, mainly because it is a
  non customizable advanced/technical page (it displays a technical
  message including the record name etc)
- Their need is to either land a their customizable friendly 404 or
  sometimes on another record to promote it.

[1]: https://github.com/odoo/odoo/commit/3b9cd536607b1631dd375ab2e5cc94eb814a6e9b
