### PR TITLE
[FIX] website: write website-specific views before they get a new id

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -53,7 +53,10 @@ class View(models.Model):
         # We need to consider inactive views when handling multi-website cow
         # feature (to copy inactive children views, to search for specific
         # views, ...)
-        for view in self.with_context(active_test=False):
+        # Website-specific views need to be updated first because they might
+        # be relocated to new ids by the cow if they are involved in the
+        # inheritance tree.
+        for view in self.with_context(active_test=False).sorted(key='website_id', reverse=True):
             # Make sure views which are written in a website context receive
             # a value for their 'key' field
             if not view.key and not vals.get('key'):

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -740,7 +740,7 @@ class TestCowViewSaving(TestViewSavingCommon):
             when copying them on the new specific tree.
             Correct order is the same as the one when applying view arch:
             PRIORITY, ID
-            And not the default one from ir.ui.view (NAME, PRIORIRTY, ID).
+            And not the default one from ir.ui.view (NAME, PRIORITY, ID).
         """
         self.inherit_view.copy({
             'name': 'alphabetically before "Extension"',
@@ -749,6 +749,34 @@ class TestCowViewSaving(TestViewSavingCommon):
         })
         # Next line should not crash, COW loop on inherit_children_ids should be sorted correctly
         self.base_view.with_context(website_id=1).write({'name': 'Product (W1)'})
+
+    def test_write_order_vs_cow_inherit_children_order(self):
+        """ When both a specific inheriting view and a non-specific base view
+            are written simultaneously, the specific inheriting base view
+            must be updated even though its id will change during the COW of
+            the base view.
+        """
+        View = self.env['ir.ui.view']
+        self.inherit_view.with_context(website_id=1).write({'name': 'Specific Inherited View Changed First'})
+        specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
+        views = View.browse([self.base_view.id, specific_view.id])
+        views.with_context(website_id=1).write({'active': False})
+        new_specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
+        self.assertTrue(specific_view.id != new_specific_view.id, "Should have a new id")
+        self.assertFalse(new_specific_view.active, "Should have been deactivated")
+
+    def test_write_order_vs_cow_inherit_children_order_alt(self):
+        """ Same as the previous test, but requesting the update in the
+            opposite order.
+        """
+        View = self.env['ir.ui.view']
+        self.inherit_view.with_context(website_id=1).write({'name': 'Specific Inherited View Changed First'})
+        specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
+        views = View.browse([specific_view.id, self.base_view.id])
+        views.with_context(website_id=1).write({'active': False})
+        new_specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
+        self.assertTrue(specific_view.id != new_specific_view.id, "Should have a new id")
+        self.assertFalse(new_specific_view.active, "Should have been deactivated")
 
     def test_module_new_inherit_view_on_parent_already_forked(self):
         """ If a generic parent view is copied (COW) and that another module


### PR DESCRIPTION
When both a specific inheriting view and a non-specific base view are
written simultaneously, the specific inheriting base view must be
updated even though its id will change during the COW of the base view.

This commit sorts the list of written views in order to first handle the
website-specific ones then the base ones which might change some of the
ids of the already updated view.

Steps to reproduce in 14.0+ (no scenario found in 13.0):
- Create a new website.
- Configure the language selector layout to "Inline".
- Configure the language selector layout to "None".
=> Error notification was displayed and change was not applied.

task-2885882

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
