### PR TITLE
[FIX] account_payment_register: register different payment type

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -407,6 +407,66 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             },
         ])
 
+    def test_register_payment_different_type_single_batch_not_grouped(self):
+        """ Choose to pay a bill and a refund with separated payments (1000 + -2000)."""
+        active_ids = (self.in_invoice_1 + self.in_refund_1).ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'group_payment': False,
+        })._create_payments()
+
+        self.assertRecordValues(payments[0], [
+            {
+                'ref': 'BILL/2017/01/0001',
+                'payment_type': 'outbound',
+            }
+        ])
+
+        self.assertRecordValues(payments[1], [
+            {
+                'ref': 'RBILL/2017/01/0001',
+                'payment_type': 'inbound',
+            },
+        ])
+
+        self.assertRecordValues(payments[0].line_ids.sorted('balance'), [
+            # == Payment 1: to pay in_invoice_1 ==
+            # Liquidity line:
+            {
+                'debit': 0.0,
+                'credit': 1000.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': -1000.0,
+                'reconciled': False,
+            },
+            # Payable line:
+            {
+                'debit': 1000.0,
+                'credit': 0.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': 1000.0,
+                'reconciled': True,
+            },
+        ])
+        self.assertRecordValues(payments[1].line_ids.sorted('balance'), [
+            # == Payment 2: to pay in_refund_1 ==
+            # Payable line:
+            {
+                'debit': 0.0,
+                'credit': 1600.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': -1600.0,
+                'reconciled': True,
+            },
+            # Liquidity line:
+            {
+                'debit': 1600.0,
+                'credit': 0.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': 1600.0,
+                'reconciled': False,
+            },
+        ])
+
     def test_register_payment_single_batch_grouped_with_credit_note(self):
         ''' Pay 1400.0 on two vendor bills (1000.0 + 2000.0) and one credit note (1600.0). '''
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_refund_1).ids

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -657,6 +657,10 @@ class AccountPaymentRegister(models.TransientModel):
                     for line in batch_result['lines']:
                         new_batches.append({
                             **batch_result,
+                            'payment_values': {
+                                **batch_result['payment_values'],
+                                'payment_type': 'inbound' if line.balance > 0 else 'outbound'
+                            },
                             'lines': line,
                         })
                 batches = new_batches


### PR DESCRIPTION
When register a payment for a bill an a credit note,
the two payments have the same type.

Steps:

- Create a Vendor Bill, and a Vendor Bill Credit Note
- Select both and register payment without grouping them
-> The two created payments have the same type

With this commit, if the field group_payment is True, we
set the payment type regarding the balance of the move line.

opw-2852186

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
