### PR TITLE
[FIX] website_mass_mailing, *: fix race condition in newsletter tour

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -104,8 +104,7 @@ tour.register('test_custom_snippet', {
     },
     {
         content: "ensure custom snippet disappeared",
-        trigger: "#oe_snippets",
-        extra_trigger: "#oe_snippets:not(:has(.oe_snippet[name='Bruce Banner']))",
+        trigger: "#oe_snippets:not(:has(.oe_snippet[name='Bruce Banner']))",
         run: function () {}, // check
     },
 ]);

--- a/addons/website/static/tests/tours/edit_translated_page.js
+++ b/addons/website/static/tests/tours/edit_translated_page.js
@@ -12,7 +12,7 @@ tour.register('edit_translated_page_redirect', {
     },
     {
         content: 'check editor dashboard',
-        trigger: '#oe_snippets',
+        trigger: '#oe_snippets.o_loaded',
         run: () => {
             // After checking the presence of the editor dashboard, we visit a
             // translated version of the homepage. The homepage is a special
@@ -26,7 +26,7 @@ tour.register('edit_translated_page_redirect', {
     },
     {
         content: 'check editor dashboard',
-        trigger: '#oe_snippets',
+        trigger: '#oe_snippets.o_loaded',
         run: () => {},
     },
 ]);

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -62,7 +62,7 @@ tour.register("snippets_all_drag_and_drop", {
 }, [
     {
         content: "Ensure snippets are actually passed at the test.",
-        trigger: "#oe_snippets",
+        trigger: "body",
         run: function () {
             // safety check, otherwise the test might "break" one day and
             // receive no steps. The test would then not test anything anymore

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
@@ -27,7 +27,7 @@ tour.register('newsletter_block_edition', {
     wTourUtils.clickOnEdit(),
     {
         content: 'Wait for the editor to be fully started',
-        trigger: '#oe_snippets',
+        trigger: '#oe_snippets.o_loaded',
     },
     {
         content: 'Click on the Subscribe button',


### PR DESCRIPTION
*: website, test_website

Since [1], a race condition seems to have become more dominant. It is
actually due to a tour not properly awaiting the editor to be loaded
before using it.

This commit fixes all occurrences of such 'trigger' selectors, even in
tours were it could actually be not a problem. That will prevent devs to
copy paste the problematic trigger.

[1]: https://github.com/odoo/odoo/commit/57793ff912ac5aab8f3d3e014992965d06290bf0