### PR TITLE
[FIX] stock: do not save product_qty when discarding

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -89,6 +89,7 @@
                     <field name="product_id"/>
                     <field name="show_details_visible"/>
                     <field name="product_uom_qty"/>
+                    <field name="product_qty" readonly="1"/>
                     <field name="quantity_done"/>
                     <field name="reserved_availability"/>
                     <field name="inventory_id"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a new transfer, e.g: internal transfer is fine
- Click on add a product > select any product > Save & close
- Click on the product that was just added
- change the product1_uom_qty
- Click on "Discard" button (Do not use the "Save & Close" nor the
 "Save & New").
- On the picking, click on save.

Problem:
An user error is triggered, because when creating the `stock.move`, we try to save the `product_qty` while it is a technical field:
https://github.com/odoo/odoo/blob/ba3bb9b701a382c4052ddb57392baeee32625937/addons/stock/models/stock_move.py#L375

When we modify the `porudct_uom_qty`, a compute is triggered to calculate the `porudct_qty`:
https://github.com/odoo/odoo/blob/ba3bb9b701a382c4052ddb57392baeee32625937/addons/stock/models/stock_move.py#L278-L279

But when we click on the discard, the changes are not cancelled, and as the kanban view does not have the information from
the form view that the field `product_qty` is readonly, so the `product_qty` is sent in the vals to the server when we save the picking

opw-2638906


https://user-images.githubusercontent.com/78867936/174337945-9a137e22-8e6e-4de0-af5c-c0447d89b419.mp4





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
