### PR TITLE
l10n_eg_edi_eta: rounding error fix

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -270,7 +270,7 @@ class AccountEdiFormat(models.Model):
             totals['total_price_subtotal_before_discount'] += price_subtotal_before_discount
             if invoice.currency_id != self.env.ref('base.EGP'):
                 lines[-1]['unitValue']['currencyExchangeRate'] = self._l10n_eg_edi_round(invoice._l10n_eg_edi_exchange_currency_rate())
-                lines[-1]['unitValue']['amountSold'] = line.price_unit
+                lines[-1]['unitValue']['amountSold'] = self._l10n_eg_edi_round(line.price_unit)
         return lines, totals
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Three tests from TestEdiJson are failing:
- test_6_simple_test_foreign_parter_exempt_discount_foreign_currency
- test_7_simple_test_foreign_parter_exempt_discount_foreign_currency_credit_note
- test_8_test_serialization_function

Desired behavior after PR is merged:
The tests no longer fail



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
