### PR TITLE
[IMP] base: allow non-administrators to search res.groups by names

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -162,7 +162,8 @@ class Groups(models.Model):
     def _search_full_name(self, operator, operand):
         lst = True
         if isinstance(operand, bool):
-            domains = [[('name', operator, operand)], [('category_id.name', operator, operand)]]
+            category_ids = self.env['ir.module.category'].sudo().search([('name', operator, operand)]).ids
+            domains = [[('name', operator, operand)], [('category_id', 'in', category_ids)]]
             if operator in expression.NEGATIVE_TERM_OPERATORS == (not operand):
                 return expression.AND(domains)
             else:
@@ -176,7 +177,9 @@ class Groups(models.Model):
             group_name = values.pop().strip()
             category_name = values and '/'.join(values).strip() or group_name
             group_domain = [('name', operator, lst and [group_name] or group_name)]
-            category_domain = [('category_id.name', operator, lst and [category_name] or category_name)]
+            category_ids = self.env['ir.module.category'].sudo().search(
+                [('name', operator, lst and [category_name] or category_name)]).ids
+            category_domain = [('category_id', 'in', category_ids)]
             if operator in expression.NEGATIVE_TERM_OPERATORS and not values:
                 category_domain = expression.OR([category_domain, [('category_id', '=', False)]])
             if (operator in expression.NEGATIVE_TERM_OPERATORS) == (not values):


### PR DESCRIPTION
before this commit:
users without read permission of ir.module.category cannot search
res.groups by names. An access error will be raised.

after this commit:
all users with read permission of res.groups can search res.groups
by names

task-2618406

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
