### PR TITLE
[FIX] account: credit card card charged multiple times

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3455,6 +3455,14 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/wizard/account_payment_register.py:0
+#, python-format
+msgid ""
+"Could not reconcile payments due to a concurrent access error. The payment must be reconciled manually.\n"
+"Payment refs in the batch: %s"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "Counterpart Values"
 msgstr ""

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -4,7 +4,7 @@ from psycopg2 import OperationalError
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
-from odoo.odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
+from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 import logging
 _logger = logging.getLogger(__name__)

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -688,7 +688,7 @@ class AccountPaymentRegister(models.TransientModel):
             refs = '\n - '.join([ref for ref in payment_refs])
 
             message = _("Could not reconcile payments due to a concurrent access error. The payment must be reconciled manually.\n"
-                        "Payment refs in the batch: %s" % refs)
+                        "Payment refs in the batch: %s", refs)
 
             for invoice_id in invoice_ids:
                 invoice_id.message_post(body=message)


### PR DESCRIPTION
Video 1 (Issue): https://drive.google.com/file/d/1oXYcDJgaT9gmhkjE08yJlXwIL1qPwS1Y/view?usp=sharing
Video 2 (Behaviour after PR): https://drive.google.com/file/d/1cr53H5tIzT6RDDGnEV74DnJAeNzizEcq/view?usp=sharing

Issue:
When using the register payment with a token with any of the payment acquirers,
if there is a concurrent access error during the reconciliation process,
the payment intent is sent multiple times to the acquirer, making the card charged multiple times.

Steps:
- Have a V14 database (only tested this version) with sale_mmanagement, payment_stripe and invoicing
- Configure Stripe with your public and secret key (2FA is now enforced for Stripe accounts, therefore, we don't have a generic test account anymore. You have to create your own. It is quite fast and easy to do)
- Have a portal user PU with an already registered payment token PT
- Go to Invoicing
- Create a new invoice I:
	- Customer PU
	- Add anything in invoice lines
- Confirm I
- Register a payment for I:
	- Journal: Stripe
	- Saved Payment token: PT
AT THIS STEP, YOU MUST ENSURE A CONCURRENT ACCESS ERROR WILL RAISE DURING THE RECONCILIATION
- Create Payment

Log analysis:
A first payment intent is sent to Stripe. The card is charged and Stripe answers that all went as expected.
We try to process the payment, but a concurrent access error occurs.
A retry is done.
A payment intent is sent again to Stripe, The card is charged AGAIN and Stripe answers that all went as expected.
We try to process the payment, but a concurrent access error occurs.

For each retry, the intent is sent and the card is charged.

If the first retry succeeds, then Odoo can finish the process. There will be only 1 payment transaction on Odoo's side (others have been rollbacked)
but there will be 3 on Stripe's side and the card will be charged 3 times.

This PR mitigate this behaviour.
It doesn't address the root cause (what is causing the concurrent error) but avoids sending the payment intent multiple times.

New Behaviour:
If the process triggers a concurrent access update, the retry doesn't trigger and the payment is not reconciled with the invoice.
Instead, an outstanding balance is shown and the user has the ability to add it manually to the invoice.
A log is posted on the concerned invoice(s)

OPW-2662964