### PR TITLE
[IMP] project: unarchive tasks when unarchiving stages

### DIFF
--- a/addons/project/wizard/project_task_type_delete.py
+++ b/addons/project/wizard/project_task_type_delete.py
@@ -41,6 +41,11 @@ class ProjectTaskTypeDelete(models.TransientModel):
             'context': self.env.context,
         }
 
+    def action_unarchive_task(self):
+        inactive_tasks = self.env['project.task'].with_context(active_test=False).search(
+            [('active', '=', False), ('stage_id', 'in', self.stage_ids.ids)])
+        inactive_tasks.action_unarchive()
+
     def action_confirm(self):
         tasks = self.with_context(active_test=False).env['project.task'].search([('stage_id', 'in', self.stage_ids.ids)])
         tasks.write({'active': False})

--- a/addons/project/wizard/project_task_type_delete_views.xml
+++ b/addons/project/wizard/project_task_type_delete_views.xml
@@ -46,4 +46,21 @@
             </form>
         </field>
     </record>
+
+    <record id="view_project_task_type_unarchive_wizard" model="ir.ui.view">
+        <field name="name">project.task.type.delete.wizard.form</field>
+        <field name="model">project.task.type.delete.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Delete Stage">
+                <div>
+                    <p>Would you like to unarchive all of the tasks contained in these stages as well?</p>
+                </div>
+                <footer>
+                    <button string="Confirm" type="object" name="action_unarchive_task" class="btn btn-primary"/>
+                    <button string="Discard" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Currently, all of the tasks contained in a stage are archived when the stage is archived. However, the tasks remained archived when the stage is unarchived.

So in this commit, If the user unarchives a stage, ask the user to unarchive the tasks it contains in the process.

task-2835624
