### PR TITLE
[FIX] purchase_requisition_stock_dropshipping: RFQ delivery address

### DIFF
--- a/addons/purchase_requisition_stock_dropshipping/models/purchase.py
+++ b/addons/purchase_requisition_stock_dropshipping/models/purchase.py
@@ -12,5 +12,5 @@ class PurchaseOrder(models.Model):
         super()._onchange_requisition_id()
         if self.requisition_id and self.requisition_id.procurement_group_id:
             self.group_id = self.requisition_id.procurement_group_id.id
-            if self.group_id.sale_id.partner_id:
-                self.dest_address_id = self.group_id.sale_id.partner_id.id
+            if self.group_id.sale_id.partner_shipping_id:
+                self.dest_address_id = self.group_id.sale_id.partner_shipping_id.id


### PR DESCRIPTION
When generating a request for quotation from a dropship purchase
agreement, the dropship address of the RFQ uses the customer address
instead of the delivery address

Steps to reproduce:
1. Install Sales and stock_dropshipping module
2. Go to Settings > General Settings > Users > Manage Users, open user
Mitchell Admin and in the Access Rights tab enable 'Manage Multiple
Stock Locations'
3. Go to Settings > Sales > Quotations & Orders and enable Customer
Addresses
4. Go to Settings > Purchase > Orders and enable Purchase Agreements
5. Go to Sales > Products > Products and edit a product (e.g. 'Acoustic
Bloc Screens')
- In the Purchase tab set Procurement to 'Propose a call for tenders'
- In the Inventory tab enable routes 'Buy' and 'Dropship'
6. Create a Sale Order for this product with a different Delivery
Address then the Customer and confirm it
7. Go to Purchase > Orders > Purchase Agreements and open the new
purchase agreement
8. Confirm it and create a new quotation
9. The Dropship Address is the address of the customer but it should be
the delivery address

Solution:
Use the delivery address instead of the customer address for dropship

opw-2880042