### PR TITLE
[IMP] mail: Show trigger message before automatic tracking template response, notify on response to template

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -110,6 +110,7 @@ class Message(models.Model):
         ('email', 'Email'),
         ('comment', 'Comment'),
         ('notification', 'System notification'),
+        ('auto_comment', 'Automated Targeted Notification'),
         ('user_notification', 'User Specific Notification')],
         'Type', required=True, default='email',
         help="Message type: email for email message, notification for system "

--- a/addons/mail/static/src/core/message_model.js
+++ b/addons/mail/static/src/core/message_model.js
@@ -113,6 +113,10 @@ export class Message {
         return this.datetime.toLocaleString(DateTime.DATETIME_SHORT);
     }
 
+    get isAutomatedMessage() {
+        return this.type === "auto_comment";
+    }
+
     get isSelfMentioned() {
         return this.recipients.some((recipient) => recipient === this._store.self);
     }

--- a/addons/mail/static/src/core_ui/message.js
+++ b/addons/mail/static/src/core_ui/message.js
@@ -190,6 +190,9 @@ export class Message extends Component {
         if (this.props.message.type === "notification") {
             return _t("System notification");
         }
+        if (this.props.message.type === "auto_comment") {
+            return _t("Automated message");
+        }
         if (!this.props.message.isDiscussion && this.props.message.type !== "user_notification") {
             return _t("Note");
         }

--- a/addons/mail/static/src/core_ui/message.xml
+++ b/addons/mail/static/src/core_ui/message.xml
@@ -132,9 +132,9 @@
                                     'position-absolute top-0': !env.inDiscussApp,
                                     'start-0 ms-3': isAlignedRight,
                                     'end-0 me-3': env.inChatWindow and !isAlignedRight or env.inChatter,
-                                    'mt-n4': env.inChatter and (message.isDiscussion or message.isNotification),
-                                    'mt-n5': env.inChatter and !(message.isDiscussion or message.isNotification),
-                                    'mt-2': env.inDiscussApp and (message.isDiscussion or message.isNotification),
+                                    'mt-n4': env.inChatter and (message.isDiscussion or message.isNotification or message.isAutomatedMessage),
+                                    'mt-n5': env.inChatter and !(message.isDiscussion or message.isNotification or message.isAutomatedMessage),
+                                    'mt-2': env.inDiscussApp and (message.isDiscussion or message.isNotification or message.isAutomatedMessage),
                                     'mt-n3': env.inChatWindow,
                                     'ms-2': env.inDiscussApp,
                                     'invisible': !isActive,
@@ -142,7 +142,7 @@
                                 }"
                             >
                                 <div class="d-flex rounded-1 shadow-sm overflow-hidden alignedRight" t-att-class="{
-                                        'mt-3': env.inChatter and !(message.isDiscussion or message.isNotification),
+                                        'mt-3': env.inChatter and !(message.isDiscussion or message.isNotification or message.isAutomatedMessage),
                                         'flex-row-reverse': env.inChatWindow and isAlignedRight,
                                     }"
                                 >

--- a/addons/mail/static/src/core_ui/message_reactions.xml
+++ b/addons/mail/static/src/core_ui/message_reactions.xml
@@ -4,9 +4,9 @@
     <div class="position-relative d-flex flex-wrap"
         t-att-class="{
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
-            'ms-3': !(env.inChatWindow and env.alignedRight) and props.message.isDiscussion,
+            'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.isDiscussion or props.message.isAutomatedMessage),
         }"
-        t-attf-class="{{ props.message.isDiscussion ? 'mt-n2' : 'mt-1' }}">
+        t-attf-class="{{ (props.message.isDiscussion or props.message.isAutomatedMessage) ? 'mt-n2' : 'mt-1' }}">
         <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
             t-on-click="() => this.onClickReaction(reaction)"
             t-on-contextmenu="onContextMenu"

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -130,6 +130,7 @@ class MailComposer(models.TransientModel):
         compute='_compute_record_name', readonly=False, store=True)  # useful only in monorecord comment mode
     # characteristics
     message_type = fields.Selection([
+        ('auto_comment', 'Automated Targeted Notification'),
         ('comment', 'Comment'),
         ('notification', 'System notification')],
         'Type', required=True, default='comment',

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1170,6 +1170,48 @@ class TestMailgateway(MailCommon):
     # Thread formation
     # --------------------------------------------------
 
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
+    def test_message_process_external_notification_reply(self):
+        """Ensure responses bot messages are discussions."""
+        bot_notification_message = self._create_gateway_message(
+            self.test_record,
+            'bot_notif_message',
+            author_id=self.env.ref('base.partner_root').id,
+            message_type='auto_comment',
+            is_internal=True,
+            subtype_id=self.env.ref('mail.mt_note').id,
+        )
+
+        self.format_and_process(
+            MAIL_TEMPLATE, self.email_from, '',
+            subject='Reply to bot notif',
+            extra=f'References: {bot_notification_message.message_id}'
+        )
+        new_msg = self.test_record.message_ids[0]
+        self.assertFalse(new_msg.is_internal, "Responses to messages sent by odoobot should always be public.")
+        self.assertEqual(new_msg.parent_id, bot_notification_message)
+        self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_comment'))
+
+        # Also check the regular case
+        some_notification_message = self._create_gateway_message(
+            self.test_record,
+            'some_notif_message',
+            message_type='notification',
+            is_internal=True,
+            subtype_id=self.env.ref('mail.mt_note').id,
+        )
+
+        self.format_and_process(
+            MAIL_TEMPLATE, self.email_from, '',
+            subject='Reply to some notif',
+            extra=f'References: {some_notification_message.message_id}'
+        )
+        new_msg = self.test_record.message_ids[0]
+        self.assertTrue(new_msg.is_internal, "Responses to messages sent by anyone but odoobot should keep"
+                        "the 'is_internal' value of the parent.")
+        self.assertEqual(new_msg.parent_id, some_notification_message)
+        self.assertEqual(new_msg.subtype_id, self.env.ref('mail.mt_note'))
+
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_in_reply_to(self):
         """ Incoming email using in-rely-to should go into the right destination even with a wrong destination """

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -35,6 +35,51 @@ class TestTracking(MailCommon):
 
         self.assertEqual(self.record.message_ids.author_id, self.partner_admin)
 
+    def test_message_track_message_type(self):
+        """Check that the right message type is applied for track templates."""
+        self.record.message_subscribe(
+            partner_ids=[self.user_admin.partner_id.id],
+            subtype_ids=[self.env.ref('mail.mt_comment').id]
+        )
+        mail_templates = self.env['mail.template'].create([{
+            'name': f'Template {n}',
+            'subject': f'Template {n}',
+            'model_id': self.env.ref('test_mail.model_mail_test_ticket').id,
+            'body_html': f'<p>Template {n}</p>',
+        } for n in range(2)])
+
+        def _track_subtype(self, init_values):
+            return self.env.ref('mail.mt_note')
+        self.patch(self.registry('mail.test.ticket'), '_track_subtype', _track_subtype)
+
+        def _track_template(self, changes):
+            if 'email_from' in changes:
+                return {'email_from': (mail_templates[0], {})}
+            elif 'container_id' in changes:
+                return {'container_id': (mail_templates[1], {'message_type': 'notification'})}
+            return {}
+        self.patch(self.registry('mail.test.ticket'), '_track_template', _track_template)
+
+        container = self.env['mail.test.container'].create({'name': 'Container'})
+
+        # default is auto_comment
+        with self.mock_mail_gateway():
+            self.record.email_from = 'test@test.lan'
+            self.flush_tracking()
+
+        first_message = self.record.message_ids.filtered(lambda message: message.subject == 'Template 0')
+        self.assertEqual(len(self.record.message_ids), 2, 'Should be one change message and one automated template')
+        self.assertEqual(first_message.message_type, 'auto_comment')
+
+        # auto_comment can be overriden by _track_template
+        with self.mock_mail_gateway(mail_unlink_sent=False):
+            self.record.container_id = container
+            self.flush_tracking()
+
+        second_message = self.record.message_ids.filtered(lambda message: message.subject == 'Template 1')
+        self.assertEqual(len(self.record.message_ids), 4, 'Should have added one change message and one automated template')
+        self.assertEqual(second_message.message_type, 'notification')
+
     def test_message_track_no_tracking(self):
         """ Update a set of non tracked fields -> no message, no tracking """
         self.record.write({

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -500,7 +500,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=37, employee=37):  # tm 27/27 / com 35/35
+        with self.assertQueryCount(admin=38, employee=38):  # tm 28/28 / com 36/36
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -530,7 +530,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=36, employee=36):  # tm 26/26 / com 34/34
+        with self.assertQueryCount(admin=37, employee=37):  # tm 27/27 / com 35/35
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',


### PR DESCRIPTION
When setting up an alias, if a tracked value was set to send a mail template on creation of a record, the template would be marked as sent before the original message was received.
This commit puts them back into order by processing the reception of the original message within the method of creation of the record.

Responding to that template with an e-mail would not notify the followers of that record.
This template is now marked as mt_comment.

Task-2834304
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
