### PR TITLE
[IMP] mail: Disable message, mail and notification duplication

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -5,7 +5,7 @@
             <field name="name">mail.mail.form</field>
             <field name="model">mail.mail</field>
             <field name="arch" type="xml">
-                <form string="Email message">
+                <form string="Email message" duplicate="0">
                     <header>
                         <button name="send" string="Send Now" type="object" states='outgoing' class="oe_highlight"/>
                         <button name="mark_outgoing" string="Retry" type="object" states='exception,cancel'/>

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -23,7 +23,7 @@
             <field name="model">mail.message</field>
             <field name="priority">20</field>
             <field name="arch" type="xml">
-                <form string="Message">
+                <form string="Message" duplicate="0">
                     <sheet>
                         <group>
                             <group>


### PR DESCRIPTION
Duplicating an email sent from Odoo would raise an error because some required fields could not be set. 
Setting those fields on duplication does not make sense, duplication is to be disabled on e-mails.

As this applies to some messages and no use-case could be found for the duplication of messages or notifications,
both also had duplication disabled.

Task-2857244
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
