### PR TITLE
Manual FW port of #81269

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -331,6 +331,14 @@ class AccountMove(models.Model):
             i -= 5
         return spaced_qrr_ref
 
+    @api.model
+    def space_scor_reference(self, iso11649_ref):
+        """ Makes the provided SCOR reference human-friendly, spacing its elements
+        by blocks of 5 from right to left.
+        """
+
+        return ' '.join(iso11649_ref[i:i + 4] for i in range(0, len(iso11649_ref), 4))
+
     def l10n_ch_action_print_qr(self):
         '''
         Checks that all invoices can be printed in the QR format.

--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -22,6 +22,9 @@
 
                 <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.amount_residual).replace(',','\xa0')"/>
 
+                <t t-set="is_qrr" t-value="o.partner_bank_id.l10n_ch_qr_iban"/>
+                <t t-set="is_scor" t-value="o.partner_bank_id._is_iso11649_reference(o.payment_reference)"/>
+
                 <div class="swissqr_page_title">
                     <h1>QR-bill for invoice <t t-esc="o.name"/></h1>
                 </div>
@@ -53,12 +56,20 @@
                                 <br/>
                             </div>
 
-                            <t t-if="o.partner_bank_id.l10n_ch_qr_iban">
+                            <t t-if="is_qrr or is_scor">
                                 <div class="swissqr_text title">
                                     <span>Reference</span>
                                 </div>
+                            </t>
+                            <t t-if="is_qrr">
                                 <div class="swissqr_text content">
                                     <span t-esc="o.space_qrr_reference(o.payment_reference)"/><br/>
+                                    <br/>
+                                </div>
+                            </t>
+                            <t t-if="is_scor">
+                                <div class="swissqr_text content">
+                                    <span t-esc="o.space_scor_reference(o.payment_reference)"/><br/>
                                     <br/>
                                 </div>
                             </t>
@@ -157,17 +168,25 @@
                                 <br/>
                             </div>
 
-                            <t t-if="o.partner_bank_id.l10n_ch_qr_iban">
+                            <t t-if="is_qrr or is_scor">
                                 <div class="swissqr_text title">
                                     <span class="title">Reference</span>
                                 </div>
+                            </t>
+                            <t t-if="is_qrr">
                                 <div class="swissqr_text content">
                                     <span t-esc="o.space_qrr_reference(o.payment_reference)"/><br/>
                                     <br/>
                                 </div>
                             </t>
+                            <t t-if="is_scor">
+                                <div class="swissqr_text content">
+                                    <span t-esc="o.space_scor_reference(o.payment_reference)"/><br/>
+                                    <br/>
+                                </div>
+                            </t>
 
-                            <t t-set="additional_info" t-value="(o.ref or o.name if o.partner_bank_id.l10n_ch_qr_iban else o.payment_reference or o.ref or o.name)"/>
+                            <t t-set="additional_info" t-value="(o.ref or o.name if is_qrr or is_scor else o.payment_reference or o.ref or o.name)"/>
                             <t t-if="additional_info">
                                 <div class="swissqr_text title">
                                     <span>Additional information</span>

--- a/doc/cla/individual/TeoGoddet.md
+++ b/doc/cla/individual/TeoGoddet.md
@@ -1,0 +1,9 @@
+Switzerland, 2021-12-11
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Téo Goddet teo.goddet@gmail.com https://github.com/TeoGoddet


### PR DESCRIPTION
Forward port of https://github.com/odoo/odoo/pull/93376 (which was a forward port of #81269)
superseed #93978

According to https://www.paymentstandards.ch/en/shared/know-how/faq/qr.html
The following types can be used:

QR-bill with QR IBAN and QR reference
QR-bill with IBAN and creditor reference (ISO 11649)
QR-bill with IBAN without reference
The difference lies in the use of IBAN and references.

Current behavior before PR:
QR-bill with IBAN and creditor reference (ISO 11649) is not supported yet and downgraded as "without reference".

Desired behavior after PR is merged:
QR-bill with IBAN and creditor reference (ISO 11649) are included in the qr code if they are present.