### PR TITLE
[FIX] stock: order stock.production.lot by name

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -11,6 +11,7 @@ class ProductionLot(models.Model):
     _inherit = ['mail.thread','mail.activity.mixin']
     _description = 'Lot/Serial'
     _check_company_auto = True
+    _order = 'name, id'
 
     name = fields.Char(
         'Lot/Serial Number', default=lambda self: self.env['ir.sequence'].next_by_code('stock.lot.serial'),


### PR DESCRIPTION
Sorting the `stock.quant` by lot_id didn't work correctly

Steps to reproduce:
1. Install Inventory
2. Edit a product tracking to 'By Unique Serial Number' (e.g. Acoustic
Bloc Screens)
3. Go to Inventory > Overview > Receipts, create a receipt for 3
Acoustic Bloc Screens with serial number '05', '01' and '03' and
validate
4. Go to Inventory > Reporting > Inventory Report, remove the
'Group By' filters and sort the entries by Lot/Serial Number
5. The serial numbers are not properly ordered ('01' is between '03'
and '05')

Solution:
Order the `stock.production.lot` by name

Problem:
Sorting the `stock.quant` by lot_id used the id of
`stock.production.lot`

opw-2879464