### PR TITLE
[FIX] web: ignore allowed company from session storage

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -297,6 +297,12 @@ function makeActionManager(env) {
                 const storedAction = browser.sessionStorage.getItem("current_action");
                 const lastAction = JSON.parse(storedAction || "{}");
                 if (lastAction.res_model === state.model) {
+                    if (lastAction.context) {
+                        // If this method is called because of a company switch, the
+                        // stored allowed_company_ids is incorrect.
+                        // (Fix will be improved in master)
+                        delete lastAction.context.allowed_company_ids;
+                    }
                     actionRequest = lastAction;
                     options.viewType = state.view_type;
                 }


### PR DESCRIPTION
When switching the company, if the displayed action hasn't any
identifier, the RPC will be based on the previous company.

To reproduce the issue:
(Need stock. Use demo data)
1. Inventory > Operations > Inventory Adjustments
2. Enable the column 'Company'
3. Switch the company to "My Company (Chicago)"

Error: The quants of "My Company (San Fransisco)" are listed -> this
does not respect the selected company

On step 1, when clicking on Inventory Adjustment, it loads a Server
Action that returns another action:
https://github.com/odoo/odoo/blob/68657a85eb09dd306feab91d805b8c21eb75010f/addons/stock/views/stock_quant_views.xml#L356-L364
The returned action is a Window Action built on PY-side:
https://github.com/odoo/odoo/blob/b5d16141dc48d4379452ea40e167f3b00f956c20/addons/stock/models/stock_quant.py#L283-L300
So this Window Action hasn't any identifier (there isn't any
`action=...` in the URL)

Later on, when reloading the page (because of the company switch), we
try to load the action. To do so, we first call `_getActionParams`. In
this method, we take the current state and try to extract some
information. Because there isn't any action defined on the state (as
explained in the previous paragraph), we use the `current_action` stored
in the session storage (i.e., the window action returned by the server):
https://github.com/odoo/odoo/blob/590fa18cafe2c7bbd109692f564c2175ca6d820c/addons/web/static/src/webclient/actions/action_service.js#L294-L302
And here is the issue: the stored action contains its context and this
context contains the `allowed_company_ids` key (-> with the previous
company)

As a result, when performing the search_read to get all the quants of
the view:
https://github.com/odoo/odoo/blob/f5ba34e45b66e0fccc2559bf434e255d38a0faa0/addons/web/static/src/legacy/js/views/basic/basic_model.js#L5016-L5025
And when getting the context, it leads to `_getEvalContext`
https://github.com/odoo/odoo/blob/f5ba34e45b66e0fccc2559bf434e255d38a0faa0/addons/web/static/src/legacy/js/views/basic/basic_model.js#L3716-L3728
We apply the user context (which contains the correct value for the
company) and then apply the element context (which contains the
incorrect one, as explained above)

This explains why it will display the quants of the previously-selected
company.

OPW-2871086