### PR TITLE
[FIX] account: fix tax computation on change in currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4078,8 +4078,8 @@ class AccountMoveLine(models.Model):
         for line in self:
             if not line.move_id.is_invoice(include_receipts=True):
                 continue
-
-            line.update(line._get_price_total_and_subtotal())
+            price_unit = abs(line.amount_currency) if (not line.display_type and line.tax_repartition_line_id) else None
+            line.update(line._get_price_total_and_subtotal(price_unit=price_unit))
             line.update(line._get_fields_onchange_subtotal())
 
     @api.onchange('currency_id')


### PR DESCRIPTION
Task 2870871

When currency changes/date changes to a date with a different currency rate, the tax amount resets to 0. 
Recompute taxes when currency changes.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
