### PR TITLE
[FIX] point_of_sale: add warning when entering not existing SN/lot_id

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -802,6 +802,8 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/js/Popups/SelectionPopup.js:0
 #: code:addons/point_of_sale/static/src/js/Popups/TextAreaPopup.js:0
 #: code:addons/point_of_sale/static/src/js/Popups/TextInputPopup.js:0
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js:0
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Popups/EditListPopup.xml:0
 #: code:addons/point_of_sale/static/src/xml/Popups/ProductConfiguratorPopup.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenElectronicPayment.xml:0
@@ -1711,6 +1713,8 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js:0
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml:0
@@ -1921,6 +1925,15 @@ msgstr ""
 #, python-format
 msgid "Do not have access, skip this data for user's digest email"
 msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js:0
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js:0
+#, python-format
+msgid "Do you want to delete them?"
+msgstr ""
+
 
 #. module: point_of_sale
 #. openerp-web
@@ -5160,6 +5173,15 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js:0
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js:0
+#, python-format
+msgid "Serial Number(s) Doesn't Exist"
+msgstr ""
+
+
+#. module: point_of_sale
+#. openerp-web
 #: code:addons/point_of_sale/static/src/xml/Popups/EditListInput.xml:0
 #, python-format
 msgid "Serial/Lot Number"
@@ -5738,6 +5760,14 @@ msgstr ""
 #, python-format
 msgid ""
 "The fiscal data module encountered an error while receiving your order."
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderWidget.js:0
+#: code:addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js:0
+#, python-format
+msgid "The following serial numbers do not exists: "
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -100,6 +100,15 @@ class StockPicking(models.Model):
         pickings = self.filtered(lambda p: p.picking_type_id != p.picking_type_id.warehouse_id.pos_type_id)
         return super(StockPicking, pickings)._send_confirmation_email()
 
+class ProductionLot(models.Model):
+    _inherit = 'stock.production.lot'
+
+    @api.model
+    def check_lots_exist(self, lots, product_id):
+        """returns the list of serial numbers that do not exist"""
+        existing_sn = self.env['stock.production.lot'].search([('name', 'in', [lot['name'] for lot in lots]), ('product_id', '=', product_id)])
+        return list(set(map(lambda x: x['name'], lots)) - set(existing_sn.mapped('name')))
+
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'
 


### PR DESCRIPTION
Current behavior:
If the operation type of the PoS is configured to not create SN/lot_id
and you use an unexisting lot/SN in the PoS you receive no warning.

Steps to reproduce:
- Make sure that the "Create New Lots/Serial Numbers" is not checked
  in the PoS orders operation type
- Create a product tracked by SN
- Start a PoS session and add this product to the order
- Enter a wrong SN
- You get no warning that the SN is wrong

opw-2884883
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
