### PR TITLE
[FIX] website: keep margin when link is applied in images wall

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/001.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/001.scss
@@ -22,25 +22,25 @@
     &.o_masonry {
         &.o_spc-none div.o_masonry_col {
             padding: 0;
-            > img {
+            > img, > a > img {
                 margin: 0 !important;
             }
         }
         &.o_spc-small div.o_masonry_col {
             padding: 0 ($spacer * .5);
-            > img {
+            > img, > a > img {
                 margin-bottom: $spacer !important;
             }
         }
         &.o_spc-medium div.o_masonry_col {
             padding: 0 $spacer;
-            > img {
+            > img, > a > img {
                 margin-bottom: $spacer * 2 !important;
             }
         }
         &.o_spc-big div.o_masonry_col {
             padding: 0 ($spacer * 1.5);
-            > img {
+            > img, > a > img {
                 margin-bottom: $spacer * 3 !important;
             }
         }

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -85,6 +85,11 @@ options.registry.gallery = options.Class.extend({
      * @see this.selectClass for parameters
      */
     addImages: function (previewMode) {
+        // Prevent opening dialog twice.
+        if (this.__imageDialogOpened) {
+            return Promise.resolve();
+        }
+        this.__imageDialogOpened = true;
         const $images = this.$('img');
         var $container = this.$('> .container, > .container-fluid, > .o_container_small');
         var dialog = new weWidgets.MediaDialog(this, {multiImages: true, onlyImages: true, mediaWidth: 1920});
@@ -107,7 +112,10 @@ options.registry.gallery = options.Class.extend({
                     this.trigger_up('cover_update');
                 }
             });
-            dialog.on('closed', this, () => resolve());
+            dialog.on('closed', this, () => {
+                this.__imageDialogOpened = false;
+                return resolve();
+            });
             dialog.open();
         });
     },


### PR DESCRIPTION
The vertical spacing between images of an images wall was lost when a
link was added to an image.

This commit applies the bottom margin to images even if they are
within a link.

Steps to reproduce:
- Drop an "Images Wall" block.
- Add 4 images to the wall.
- Add a link to the first image.
=> The gap between the two images of the first column disappeared.

task-2818919

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
