### PR TITLE
[FIX] product: product weight/volume for intrastat

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -93,7 +93,7 @@
                                 <group string="Vendor Bills" name="bill"/>
                             </group>
                         </page>
-                        <page string="Inventory" name="inventory" groups="product.group_stock_packaging" attrs="{'invisible':[('type', '=', 'service')]}">
+                        <page string="Inventory" name="inventory" groups="product.group_stock_packaging,account_intrastat.group_intrastat_weight_volume" attrs="{'invisible':[('type', '=', 'service')]}">
                             <group name="inventory">
                                 <group name="group_lots_and_weight" string="Logistics" attrs="{'invisible': [('type', 'not in', ['product', 'consu'])]}">
                                     <label for="weight" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"/>


### PR DESCRIPTION
Intrastat measures the flow of goods between European nations. As such
weight and volume are required for intrastat purposes.

The associated PR contains the definition of the
account_intrastat.group_intrastat_weight_volume group:

task-id: 2884474