### PR TITLE
[IMP] core: count(*) instead of count(1)

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1144,7 +1144,7 @@ class TestQueries(TransactionCase):
         Model.search([('name', 'like', 'foo')])
 
         with self.assertQueries(['''
-            SELECT count(1)
+            SELECT count(*)
             FROM "res_partner"
             WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
         ''']):
@@ -1170,7 +1170,7 @@ class TestQueries(TransactionCase):
             Model.search([('name', 'like', 'foo')])
 
         with self.assertQueries(['''
-            SELECT COUNT(1)
+            SELECT COUNT(*)
             FROM "res_partner_title"
             WHERE ("res_partner_title"."id" = %s)
         ''']):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4879,7 +4879,7 @@ class BaseModel(metaclass=MetaModel):
         if count:
             # Ignore order, limit and offset when just counting, they don't make sense and could
             # hurt performance
-            query_str, params = query.select("count(1)")
+            query_str, params = query.select("count(*)")
             self._cr.execute(query_str, params)
             res = self._cr.fetchone()
             return res[0]


### PR DESCRIPTION
Some article supports that count(*) is more efficient than count(1):
- https://blog.jooq.org/whats-faster-count-or-count1/
- https://www.citusdata.com/blog/2016/10/12/count-performance/ (sub menu Exact Counts)

In my own test (https://github.com/ryv-odoo/odoo_scripts/blob/master/test_count.py): indeed, we can see a small performance gain with `count(*)`
(between 2% to 4% depending the number of row). Which isn't a big improvement but the change is
small and now, it reflects more the documentation of postgresql (https://www.postgresql.org/docs/14/functions-aggregate.html).