### PR TITLE
[FIX] l10n_in : mandatory state_id for no country

### DIFF
--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -13,7 +13,7 @@
                 <field name="l10n_in_country_code" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='state_id']" position="attributes">
-                <attribute name="attrs">{'required': ['|', ('l10n_in_country_code','=', 'IN'), ('l10n_in_country_code','=', False)]}</attribute>
+                <attribute name="attrs">{'required': [('l10n_in_country_code','=', 'IN')]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce:
	- Install contact,l10n_in
	- Create a new contact with no country
Issue:
	- The state ID is now mandatory when there is no country
Solution:
	- Modify the xml to remove the condition for no country

opw-2882164