### PR TITLE
[FIX] point_of_sale: pos reports sum is wrong

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -44,8 +44,8 @@ class PosOrderReport(models.Model):
                 COUNT(*) AS nbr_lines,
                 s.date_order AS date,
                 SUM(l.qty) AS product_qty,
-                SUM(l.qty * l.price_unit / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS price_sub_total,
-                SUM(ROUND((l.qty * l.price_unit) * (100 - l.discount) / 100 / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,
+                SUM(l.price_subtotal_incl / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS price_sub_total,
+                SUM(ROUND((l.price_subtotal_incl) * (100 - l.discount) / 100 / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,
                 SUM((l.qty * l.price_unit) * (l.discount / 100) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS total_discount,
                 CASE
                     WHEN SUM(l.qty * u.factor) = 0 THEN NULL


### PR DESCRIPTION
Steps to reproduce:

1- install POS
2- create a pruduct c with price p and excluded tax t
3- make a POS order with c
4- go to Point of Sale > Reporting > Orders
5- switch to pivot view
6- Total price and Subtotal w/o discount fields are wrong

current values:
total price = qty * p
subtotal w/o discount =  ROUND((qty * p) * (100 - discount) / 100

correct values:
total price = qty * price_unit * (1 + t)
subtotal w/o discount =
 ROUND((qty * price_unit * (1 + t)) * (100 - discount) / 100

Bug:

the SQL query

Fix:
Use price_subtotal_incl which is already the total amount including
taxes and excluding discounts.

OPW-2885643

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
