### PR TITLE
[FIX] website_partner: allow customization of a partner description

### DIFF
--- a/addons/website_partner/models/res_partner.py
+++ b/addons/website_partner/models/res_partner.py
@@ -9,7 +9,7 @@ class WebsiteResPartner(models.Model):
     _name = 'res.partner'
     _inherit = ['res.partner', 'website.seo.metadata']
 
-    website_description = fields.Html('Website Partner Full Description', strip_style=True, translate=html_translate)
+    website_description = fields.Html('Website Partner Full Description', sanitize=False, translate=html_translate)
     website_short_description = fields.Text('Website Partner Short Description', translate=True)
 
     def _compute_website_url(self):

--- a/addons/website_partner/tests/__init__.py
+++ b/addons/website_partner/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_website_description

--- a/addons/website_partner/tests/test_website_description.py
+++ b/addons/website_partner/tests/test_website_description.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestWebsiteDescription(TransactionCase):
+
+    def test_text_alteration(self):
+        website_description = '''
+            <span style="text-decoration-line: line-through;">
+                <font style="color: rgb(255, 0, 0);">Crossed</font>
+            </span>
+        '''
+        test_partner = self.env['res.partner'].create({
+            'name': 'Partner with text alteration',
+            'website_description': website_description,
+        })
+        self.assertEqual(test_partner.website_description, website_description)
+
+    def test_custom_code(self):
+        website_description = '''
+            <iframe
+                title="The way of the developer"
+                src="https://www.youtube.com/embed/dQw4w9WgXcQ">
+            </iframe>
+        '''
+        test_partner = self.env['res.partner'].create({
+            'name': 'Partner with an iframe',
+            'website_description': website_description,
+        })
+        self.assertEqual(test_partner.website_description, website_description)
+
+    def test_conditional_visibility_code(self):
+        website_description = '''
+            <section class="o_snippet_invisible o_conditional_hidden"
+                data-visibility="conditional"
+                data-visibility-value-logged=\'[{"value":"true","id":1}]\'
+                data-visibility-selectors=\'html:not([data-logged="true" ]) body:not(.editor_enable) [data-visibility-id="logged_o_1" ]\'
+                data-visibility-id="logged_o_1">
+            </section>
+        '''
+        test_partner = self.env['res.partner'].create({
+            'name': 'Partner with a conditional display',
+            'website_description': website_description,
+        })
+        self.assertEqual(test_partner.website_description, website_description)


### PR DESCRIPTION
Currently, when editing the description of a partner via the website, some
elements are not properly rendered (e.g.: code for an iframe, bold text,
conditional visiblity elements, etc.).

Step to reproduce the issue:
1) Install the website_partner module
2) Go to the page of a partner (e.g.: via the backend)
3) Edit the page and put some part of the text as bold. Save !
The content previously put in bold has now disappeared.

Solution: The issue is that since OWL migration, the way custom information are
saved in the website has changed (e.g.: from <b> to <span style="..."></span>
for bold characters). Furthermore, the `website_description` field inside our
model is sanitizing attributes, classes, styles and so on (and the fields used
in customization are not within the whitelist for sanization). This cause the
customization to fail in every cases.
On a security point of view, sanitizing can prevent injection but in this case,
only privileged users can edit the website so we don't need to protect this
from their edition.

opw-2881824
