### PR TITLE
[FIX] sale_mrp: show correct MO count on smart button

### DIFF
--- a/addons/sale_mrp/models/sale.py
+++ b/addons/sale_mrp/models/sale.py
@@ -20,7 +20,7 @@ class SaleOrder(models.Model):
         for item in data:
             procurement_groups = self.env['procurement.group'].browse(item['ids'])
             mrp_count[item['sale_id'][0]] = len(
-                set(procurement_groups.stock_move_ids.created_production_id.ids) |
+                set(procurement_groups.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids.ids) |
                 set(procurement_groups.mrp_production_ids.ids))
         for sale in self:
             sale.mrp_production_count = mrp_count.get(sale.id)
@@ -28,7 +28,7 @@ class SaleOrder(models.Model):
     def action_view_mrp_production(self):
         self.ensure_one()
         procurement_groups = self.env['procurement.group'].search([('sale_id', 'in', self.ids)])
-        mrp_production_ids = set(procurement_groups.stock_move_ids.created_production_id.ids) |\
+        mrp_production_ids = set(procurement_groups.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids.ids) |\
             set(procurement_groups.mrp_production_ids.ids)
         action = {
             'res_model': 'mrp.production',


### PR DESCRIPTION
Current behavior:
When creating a backorder for a MO the smart buttons showing
the MO counts had the wrong value

Steps to reproduce:
- Have a product that has MTO and Manufacture in his routes
- Create a quotation for 5 of this product
- Validate the order and click the manufacturing smart button
- Set the quantity to 3 and validate
- Create backorder
- Go back to the quotation, the manufacturing count is still 1
  but should be 2

partial backport of: #79627
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
