### PR TITLE
[FIX] sale: split method _is_add_to_cart_possible for override

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -281,6 +281,12 @@ class ProductTemplate(models.Model):
             'has_discounted_price': has_discounted_price,
         }
 
+    def _can_be_added_to_cart(self):
+        """
+        Pre-check to `_is_add_to_cart_possible` to know if product can be sold.
+        """
+        return self.sale_ok
+
     def _is_add_to_cart_possible(self, parent_combination=None):
         """
         It's possible to add to cart (potentially after configuration) if
@@ -294,7 +300,7 @@ class ProductTemplate(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-        if not self.active or not self.sale_ok:
+        if not self.active or not self._can_be_added_to_cart():
             # for performance: avoid calling `_get_possible_combinations`
             return False
         return next(self._get_possible_combinations(parent_combination), False) is not False


### PR DESCRIPTION
This commit has as purpose to split the method `_is_add_to_cart_possible`
and put only the first part in another method so it can be overridden.

Issue:

The first part of the method _is_add_to_cart_possible check that the
product is active and can be sold.
The second part check if a combination is possible.

In sale_renting module, only the first part must be overridden since
second part is a common check to all product regardless if it
can or can't be sold or rent

opw-2879711