### PR TITLE
[FIX] website_hr_recruitment: job positions w/o address are not shown

### DIFF
--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -45,8 +45,8 @@ class WebsiteHrRecruitment(http.Controller):
 
         # Filter job / office for country
         if country and not kwargs.get('all_countries'):
-            jobs = [j for j in jobs if j.address_id is None or j.address_id.country_id and j.address_id.country_id.id == country.id]
-            offices = set(j.address_id for j in jobs if j.address_id is None or j.address_id.country_id and j.address_id.country_id.id == country.id)
+            jobs = [j for j in jobs if not j.address_id or j.address_id.country_id.id == country.id]
+            offices = set(j.address_id for j in jobs if not j.address_id or j.address_id.country_id.id == country.id)
         else:
             offices = set(j.address_id for j in jobs if j.address_id)
 


### PR DESCRIPTION
When accessing the job positions page, country is detected automatically
to filter only those jobs whose country match current one + the ones
available in any country. However, when job positions have no specific
country, they're being excluded due to the usage of an old API
(expecting relational fields as `None` when they're empty), so only
positions with country are being taken into account.

This commit fixes the above by expecting the correct value (an empty
recordset) when an address is not set.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
