### PR TITLE
[FIX] l10n_id_efaktur: fix price when tax is not included

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -209,9 +209,10 @@ class AccountMove(models.Model):
                     if tax.amount > 0:
                         tax_line += line.price_subtotal * (tax.amount / 100.0)
 
-                invoice_line_unit_price = line.price_unit
-
-                invoice_line_total_price = invoice_line_unit_price * line.quantity
+                discount = 1 - (line.discount / 100)
+                # guarantees price to be tax-excluded
+                invoice_line_total_price = line.price_subtotal / discount if discount else 0
+                invoice_line_unit_price = invoice_line_total_price / line.quantity if line.quantity else 0
 
                 line_dict = {
                     'KODE_OBJEK': line.product_id.default_code or '',

--- a/addons/l10n_id_efaktur/tests/__init__.py
+++ b/addons/l10n_id_efaktur/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_id_efaktur

--- a/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
+++ b/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
@@ -1,0 +1,91 @@
+from odoo.tests import tagged, common
+from odoo.addons.l10n_id_efaktur.models.account_move import FK_HEAD_LIST, LT_HEAD_LIST, OF_HEAD_LIST, _csv_row
+
+@tagged('post_install', '-at_install')
+class TestIndonesianEfaktur(common.TransactionCase):
+    def setUp(self):
+        """
+        1) contact with l10n_id_pkp=True, l10n_id_kode_transaksi="01"
+        2) tax: amount=10, type_tax_use=sale, price_include=True
+        3) invoice with partner_id=contact, journal=customer invoices,
+        """
+        super().setUp()
+
+        self.maxDiff = 1500
+        # change company info for csv detai later
+        self.env.company.country_id = self.env.ref('base.id')
+        self.env.company.street = "test"
+        self.env.company.phone = "12345"
+
+        self.partner_id = self.env['res.partner'].create({"name": "l10ntest", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "12345"})
+        self.tax_id = self.env['account.tax'].create({"name": "test tax", "type_tax_use": "sale", "amount": 10.0, "price_include": True})
+
+        self.efaktur = self.env['l10n_id_efaktur.efaktur.range'].create({'min': '0000000000001', 'max': '0000000000010'})
+        self.out_invoice_1 = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_id.id,
+            'invoice_date': '2019-05-01',
+            'date': '2019-05-01',
+            'invoice_line_ids': [
+                (0, 0, {'name': 'line1', 'price_unit': 110.0, 'tax_ids': self.tax_id.ids}),
+            ],
+            'l10n_id_kode_transaksi': "01",
+        })
+        self.out_invoice_1.post()
+
+        self.out_invoice_2 = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_id.id,
+            'invoice_date': '2019-05-01',
+            'date': '2019-05-01',
+            'invoice_line_ids': [
+                (0, 0, {'name': 'line1', 'price_unit': 110.11, 'quantity': 400, 'tax_ids': self.tax_id.ids})
+            ],
+            'l10n_id_kode_transaksi': '01'
+        })
+        self.out_invoice_2.post()
+
+    def test_efaktur_csv_output_1(self):
+        """
+        Test to ensure that the output csv data contains tax-excluded prices regardless of whether the tax configuration is tax-included or tax-excluded.
+        Current test is using price of 110 which is tax-included with tax of amount 10%. So the unit price listed has to be 100 whereas the original result would have 110 instead.
+        """
+        # to check the diff when test fails
+
+        efaktur_csv_output = self.out_invoice_1._generate_efaktur_invoice(',')
+        output_head = '%s%s%s' % (
+            _csv_row(FK_HEAD_LIST, ','),
+            _csv_row(LT_HEAD_LIST, ','),
+            _csv_row(OF_HEAD_LIST, ','),
+        )
+        # remaining lines
+        line_4 = '"FK","01","0","0000000000001","5","2019","1/5/2019","12345","l10ntest","","100","10","0","","0","110","0","0","INV/2019/0001 12345","0"\n'
+        line_5 = '"FAPR","000000000000000","YourCompany","test","","","","","","","","","","12345"\n'
+        line_6 = '"OF","","","100","1.0","100","0","100","10","0","0"\n'
+
+        efaktur_csv_expected = output_head + line_4 + line_5 + line_6
+
+        self.assertEqual(efaktur_csv_expected, efaktur_csv_output)
+
+    def test_efaktur_csv_output_decimal_place(self):
+        """
+        Test to ensure that decimal place conversion is only done when inputting to csv
+        This is to test original calculation of invoice_line_total_price: invoice_line_total_price = invoice_line_unit_price * line.quantity
+        as invoice_line_unit_price is already converted to be tax-excluded and set to the decimal place as configured on the currency, the calculation of total could be flawed.
+
+        In this test case, the tax-included price unit is 110.11, hence tax-excluded is 100.1,
+        invoice_line_unit_price will be 100, if we continue with the calculation of total price, it will be 100*400 = 40000
+        eventhough the total is supposed to be 100.1*400 = 40040, there is a 40 discrepancy
+        """
+        efaktur_csv_output = self.out_invoice_2._generate_efaktur_invoice(',')
+        output_head = '%s%s%s' % (
+            _csv_row(FK_HEAD_LIST, ','),
+            _csv_row(LT_HEAD_LIST, ','),
+            _csv_row(OF_HEAD_LIST, ','),
+        )
+        line_4 = '"FK","01","0","0000000000002","5","2019","1/5/2019","12345","l10ntest","","40040","4004","0","","0","44044","0","0","INV/2019/0002 12345","0"\n'
+        line_5 = '"FAPR","000000000000000","YourCompany","test","","","","","","","","","","12345"\n'
+        line_6 = '"OF","","","100","400.0","40040","0","40040","4004","0","0"\n'
+
+        efaktur_csv_expected = output_head + line_4 + line_5 + line_6
+        self.assertEqual(efaktur_csv_expected, efaktur_csv_output)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When tax is configured to be "Include in Price", the e-faktur document violates official regulation. Prices columns in e-faktur has to be declared without tax inclusion. Current code does not differentiate behaviour when "Include in Price" configuration in tax is True or False.

Current behavior before PR:
When tax is configured to be "Include in Price", the prices columns (unit price and the total) includes tax, which violated the e-faktur documentation rule. Consequently, the calculation for discount will be flawed since the current discount amount computation is (price_unit * quantity) - price_subtotal.

Desired behavior after PR is merged:
Price columns (unit price and total) should no longer include tax, and will result to correct discount amount calculation.

Task:
2889400

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
