### PR TITLE
[FIX] portal: fix the chatter message visibility buttons

### DIFF
--- a/addons/project/static/src/scss/project_sharing/chatter.scss
+++ b/addons/project/static/src/scss/project_sharing/chatter.scss
@@ -26,6 +26,18 @@
             width: 45px;
             height: 45px;
         }
+
+        .o_portal_message_internal_off {
+            .btn-danger {
+                display: none;
+            }
+        }
+
+        .o_portal_message_internal_on {
+            .btn-success {
+                display: none;
+            }
+        }
     }
 
     &.o-aside {


### PR DESCRIPTION
before this commit: the portal chatter message visibility toggle buttons not
working properly based on requirements "It show all two button together" when
click on any of this two button there is no reflection.

after this commit: the chatter message visibility toggle button works like"when
click on 'Employee only' it shows 'visible' and when we click on visible the
 things are vise-versa" based on requirements.

task-2858336

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
