### PR TITLE
[FIX] website: split s_countdown templates into specific files

### DIFF
--- a/addons/website/static/src/snippets/s_countdown/000.xml
+++ b/addons/website/static/src/snippets/s_countdown/000.xml
@@ -3,24 +3,4 @@
     <t t-name="website.s_countdown.end_redirect_message">
         <p class="text-center s_countdown_end_redirect_message">Time's up! You can now visit <a class="s_countdown_end_redirect_url" t-attf-href="#{redirectUrl}">this page</a>.</p>
     </t>
-    <t t-name="website.s_countdown.end_message">
-        <div class="s_countdown_end_message d-none">
-            <div class="oe_structure">
-                <section class="s_picture pt48 pb24" data-snippet="s_picture">
-                    <div class="container">
-                        <h2 style="text-align: center;">Happy Odoo Anniversary!</h2>
-                        <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
-                        <p><br/></p>
-                        <div class="row s_nb_column_fixed">
-                            <div class="col-lg-12 pb24">
-                                <figure class="figure">
-                                    <img src="/web/image/website.library_image_18" class="figure-img img-thumbnail mx-auto padding-large" style="width: 50%;" alt="Countdown is over - Firework"/>
-                                </figure>
-                            </div>
-                        </div>
-                    </div>
-                </section>
-            </div>
-        </div>
-    </t>
 </templates>

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -8,6 +8,7 @@ const CountdownWidget = require('website.s_countdown');
 const qweb = core.qweb;
 
 options.registry.countdown = options.Class.extend({
+    xmlDependencies: ['/website/static/src/snippets/s_countdown/options.xml'],
     events: _.extend({}, options.Class.prototype.events || {}, {
         'click .toggle-edit-message': '_onToggleEndMessageClick',
     }),

--- a/addons/website/static/src/snippets/s_countdown/options.xml
+++ b/addons/website/static/src/snippets/s_countdown/options.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-name="website.s_countdown.end_message">
+    <div class="s_countdown_end_message d-none">
+        <div class="oe_structure">
+            <section class="s_picture pt48 pb24" data-snippet="s_picture">
+                <div class="container">
+                    <h2 style="text-align: center;">Happy Odoo Anniversary!</h2>
+                    <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
+                    <p><br/></p>
+                    <div class="row s_nb_column_fixed">
+                        <div class="col-lg-12 pb24">
+                            <figure class="figure">
+                                <img src="/web/image/website.library_image_18" class="figure-img img-thumbnail mx-auto padding-large" style="width: 50%;" alt="Countdown is over - Firework"/>
+                            </figure>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</t>
+
+</templates>


### PR DESCRIPTION
The s_countdown snippet had 2 templates defined into one file (000.xml):
- One for showing a redirect message which is rendered in the
  public widget flow.
- Another for showing an end message which is rendered and
  appended to the snippet in the option flow.

The templates were loaded by the public widget, which means that even
if no end message was shown, the template would be loaded into memory
for a visitor.

This commit fixes that by splitting the file into 2 templates, one for
the options and one for the public widget, insuring that the option will
load what it needs.

(This necessary for the task linked, which moves the edition to the
backend, preventing the option from relying on a public widget template.
Since it can slightly benefit stable as well, it is done here.)

task-2687506