### PR TITLE
[FIX] base: fix link to non-existing documentation page

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -468,7 +468,7 @@
                                 </div>
                             </group>
                             <group string="Developer API Keys" help="test">
-                                <a href="https://www.odoo.com/documentation/14.0/developer/webservices/odoo.html#api-keys" target="_blank">
+                                <a href="https://www.odoo.com/documentation/14.0/developer/misc/api/external_api.html#api-keys" target="_blank">
                                     <i class="fa fa-fw o_button_icon fa-arrow-right"></i>
                                     <span>Documentation</span>
                                 </a>


### PR DESCRIPTION
The documentation page for the external API was moved elsewhere with PR
odoo/documentation#2026.

See also:
- https://github.com/odoo/documentation/pull/2251