### PR TITLE
[FIX] base: partner demo data should be noupdate = 1

### DIFF
--- a/odoo/addons/base/data/res_partner_demo.xml
+++ b/odoo/addons/base/data/res_partner_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data noupdate="0">
+    <data noupdate="1">
         <!--
         Resource: res.partner.category
         -->


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Steps to reproduce (1):

- A new production database is created from scratch using demo data, that later is customized.
- Time later, in ir_module_module, you manually set demo = False.
- Do update/migrate.
  => The partners from the demo, already customized, will be deleted.

Steps to reproduce (2):

- A new production database is created from scratch using demo data, that later is customized.
- Do update/migrate.
  => The customized demo partners are reseted to their default.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr