### PR TITLE
[FIX] web: fix space symbol in monetary field's title

### DIFF
--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -23,6 +23,8 @@ var utils = require('web.utils');
 
 var _t = core._t;
 
+const NBSP = "\u00a0";
+
 //------------------------------------------------------------------------------
 // Formatting
 //------------------------------------------------------------------------------
@@ -353,9 +355,9 @@ function formatMonetary(value, field, options) {
         return formatted_value;
     }
     if (currency.position === "after") {
-        return formatted_value += '&nbsp;' + currency.symbol;
+        return formatted_value += NBSP + currency.symbol;
     } else {
-        return currency.symbol + '&nbsp;' + formatted_value;
+        return currency.symbol + NBSP + formatted_value;
     }
 }
 /**
@@ -552,6 +554,9 @@ function parseFloat(value) {
  */
 function parseMonetary(value, field, options) {
     var values = value.split('&nbsp;');
+    if (values.length === 1) {
+        values = value.split(NBSP);
+    }
     if (values.length === 1) {
         return parseFloat(value);
     }

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -34,6 +34,7 @@ QUnit.module('basic_fields', {
                     txt: {string: "txt", type: "text", default: "My little txt Value\nHo-ho-hoooo Merry Christmas"},
                     int_field: {string: "int_field", type: "integer", sortable: true, searchable: true},
                     qux: {string: "Qux", type: "float", digits: [16,1], searchable: true},
+                    monetary: {string: "MMM", type: "monetary", digits: [16,1], searchable: true},
                     p: {string: "one2many field", type: "one2many", relation: 'partner', searchable: true},
                     trululu: {string: "Trululu", type: "many2one", relation: 'partner', searchable: true},
                     timmy: {string: "pokemon", type: "many2many", relation: 'partner_type', searchable: true},
@@ -83,7 +84,17 @@ QUnit.module('basic_fields', {
                     selection: 'done',
                 },
                 {id: 3, bar: true, foo: "gnap", int_field: 80, qux: -3.89859, m2o: 1, m2m: []},
-                {id: 5, bar: false, foo: "blop", int_field: -4, qux: 9.1, m2o: 1, m2m: [1], currency_id: 1}],
+                {id: 5, bar: false, foo: "blop", int_field: -4, qux: 9.1, m2o: 1, m2m: [1], currency_id: 1, monetary: 99.9}],
+                onchanges: {},
+            },
+            team: {
+                fields: {
+                    partner_ids: { string: "Partner", type: "one2many", relation: 'partner' },
+                },
+                records: [{
+                    id: 1,
+                    partner_ids: [5],
+                }],
                 onchanges: {},
             },
             product: {
@@ -4357,6 +4368,46 @@ QUnit.module('basic_fields', {
         // Non-breaking space between the currency and the amount
         assert.strictEqual(form.$('.o_field_widget').first().text(), '$\u00a0108.25',
             'The new value should be rounded properly.');
+
+        form.destroy();
+    });
+
+    QUnit.test('monetary field in the lines of a form view', async function (assert) {
+        assert.expect(4);
+
+        var form = await createView({
+            View: FormView,
+            model: 'team',
+            data: this.data,
+            arch:'<form>' +
+                    '<sheet>' +
+                      '<field name="partner_ids">' +
+                        '<tree editable="bottom">' +
+                          '<field name="monetary"/>' +
+                          '<field name="currency_id" invisible="1"/>' +
+                        '</tree>' +
+                      '</field>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+            session: {
+                currencies: _.indexBy(this.data.currency.records, 'id'),
+            },
+        });
+
+        // Non-breaking space between the currency and the amount
+        assert.strictEqual(form.$('.o_list_table .o_list_number').first().text(), '$\u00a099.9',
+                           'The value should be displayed properly.');
+        assert.hasAttrValue(form.$('.o_list_table .o_list_number').first(), 'title', '$\u00a099.9',
+                           'The title value should be displayed properly.');
+
+        await testUtils.form.clickEdit(form);
+
+        // Non-breaking space between the currency and the amount
+        assert.strictEqual(form.$('.o_list_table .o_list_number').first().text(), '$\u00a099.9',
+                           'The value should be displayed properly.');
+        assert.hasAttrValue(form.$('.o_list_table .o_list_number').first(), 'title', '$\u00a099.9',
+                            'The title value should be displayed properly.');
 
         form.destroy();
     });


### PR DESCRIPTION
Browsers don't render html entity in the "title" attribute and we cannot use
them. Otherwise we may get values like "$&nbsp;100".

Fix it by using special character and not html entity. It works both in html
strings and attributues

The problem was reported here:
https://github.com/odoo/odoo/pull/90191#issuecomment-1156034355

STEPS: open invoice and put pointer over monetary field in the list.

Note, that to reproduce the problem, the widget should not be specifed
explicitly. See
https://github.com/odoo/odoo/blob/5b9fada39913cd456a3659faef1160f84ae19860/addons/web/static/src/js/views/list/list_renderer.js#L436-L439
https://github.com/odoo/odoo/blob/5b9fada39913cd456a3659faef1160f84ae19860/addons/web/static/src/js/views/list/list_renderer.js#L452-L456
