### PR TITLE
[FIX] event_booth: mark data as non updatable

### DIFF
--- a/addons/event_booth/data/event_booth_category_data.xml
+++ b/addons/event_booth/data/event_booth_category_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<odoo><data>
+<odoo><data noupdate="1">
 
     <record id="event_booth_category_standard" model="event.booth.category">
         <field name="name">Standard Booth</field>


### PR DESCRIPTION
Start with 'demo' data is important for good onboarding.

But once we use the module in production, we don't want to reset price
with default one on each upgrade.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
