### PR TITLE
[FIX] web: company currency missing from session if inactive

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -84,5 +84,9 @@ class Http(models.AbstractModel):
 
     def get_currencies(self):
         Currency = request.env['res.currency']
-        currencies = Currency.search([]).read(['symbol', 'position', 'decimal_places'])
+        currencies = Currency.search([
+            '|',
+            ('active', '=', True),
+            ('id', '=', self.env.company.currency_id.id)
+        ]).read(['symbol', 'position', 'decimal_places'])
         return {c['id']: {'symbol': c['symbol'], 'position': c['position'], 'digits': [69,c['decimal_places']]} for c in currencies}


### PR DESCRIPTION
Steps to follow:

  - In 15.0, use a clean database with crm only
  - Create a crm.lead
  - The expected revenue currency symbol is missing

In 15.0, USD and EUR are disabled by default
https://github.com/odoo/odoo/pull/74396/files#diff-4514e06704dabbd113ef9a9e219e2f8bcd172734d2966bfc53890c6e767d6abcR1264

opw-2878490