### PR TITLE
[FIX] website: fix typo in snippets_all_drag_and_drop test

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -67,7 +67,7 @@ tour.register("snippets_all_drag_and_drop", {
             // safety check, otherwise the test might "break" one day and
             // receive no steps. The test would then not test anything anymore
             // without us noticing it.
-            if (steps.lenth < 280) {
+            if (steps.length < 280) {
                 console.error("This test is not behaving as it should.");
             }
         },


### PR DESCRIPTION
The test was introduced in [1] with a typo on the first step (which is
only there to ensure the test does contain steps).

[1]: https://github.com/odoo/odoo/commit/460d5ecb926c13a79ba363f8f86442433d91bf6f
