### PR TITLE
[FIX] http_routing: add missing space in qweb template

### DIFF
--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -43,7 +43,7 @@
                             <pre t-esc="exception"/>
                         </p>
                         <p>
-                            The error occurred while rendering the template <code t-esc="qweb_exception.name"/>
+                            The error occurred while rendering the template <code t-esc="qweb_exception.name"/> 
                             <t t-if="qweb_exception.html">and evaluating the following expression: <code t-esc="qweb_exception.html"/></t>
                         </p>
                     </div>


### PR DESCRIPTION
Since last refactoring of qweb to replace postprocessing cleaning by
oneval cleaning, the space between xml node are now ignored.

It's not a bug, but a tradeoff of the new implementation to avoid empty
line with code like
```xml
    <t t-if="condition">
        <div>...</div>
    </t>
```






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
