### PR TITLE
[IMP] hr_timesheet,**: improve generic UX

### DIFF
--- a/addons/hr_timesheet/data/hr_timesheet_demo.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_demo.xml
@@ -104,6 +104,7 @@
         <field name="date" eval="(DateTime.now() + relativedelta(days=-1)).strftime('%Y-%m-%d')"/>
         <field name="unit_amount">2.00</field>
         <field name="project_id" ref='project.project_project_2'/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.00</field>
     </record>
 
@@ -131,6 +132,7 @@
         <field name="date" eval="(DateTime.now() + relativedelta(days=-1)).strftime('%Y-%m-%d')"/>
         <field name="unit_amount">1.00</field>
         <field name="project_id" ref='project.project_project_2'/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.00</field>
     </record>
 
@@ -150,6 +152,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_1"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -170,6 +173,7 @@
         <field name="unit_amount">3</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_1"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-90.0</field>
     </record>
 
@@ -200,6 +204,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_1"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -260,6 +265,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_1"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -320,6 +326,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_1"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -380,6 +387,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_1"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -470,6 +478,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -490,6 +499,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -520,6 +530,7 @@
         <field name="unit_amount">3</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-90.0</field>
     </record>
 
@@ -550,6 +561,7 @@
         <field name="unit_amount">3</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-90.0</field>
     </record>
 
@@ -570,6 +582,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -580,6 +593,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -620,6 +634,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_2"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -690,6 +705,7 @@
         <field name="unit_amount">3</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-90.0</field>
     </record>
 
@@ -710,6 +726,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -720,6 +737,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -750,6 +768,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -760,6 +779,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -770,6 +790,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -790,6 +811,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -810,6 +832,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -830,6 +853,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_5"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -950,6 +974,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -960,6 +985,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1010,6 +1036,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1050,6 +1077,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -1080,6 +1108,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1090,6 +1119,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1110,6 +1140,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1141,6 +1172,7 @@
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_6"/>
         <field name="amount">-60.0</field>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
     </record>
 
     <record id="project_1_task_6_account_analytic_line_21" model="account.analytic.line">
@@ -1220,6 +1252,7 @@
         <field name="unit_amount">3</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_7"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-90.0</field>
     </record>
 
@@ -1240,6 +1273,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_7"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -1250,6 +1284,7 @@
         <field name="unit_amount">3</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_7"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-90.0</field>
     </record>
 
@@ -1260,6 +1295,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_7"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1310,6 +1346,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_7"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_analysis'))]"/>
         <field name="amount">-60.0</field>
     </record>
 
@@ -1480,6 +1517,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_8"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1610,6 +1648,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_8"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1690,6 +1729,7 @@
         <field name="unit_amount">1</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_8"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-30.0</field>
     </record>
 
@@ -1730,6 +1770,7 @@
         <field name="unit_amount">2</field>
         <field name="project_id" ref="project.project_project_1"/>
         <field name="task_id" ref="project.project_1_task_8"/>
+        <field name="tag_ids" eval="[Command.link(ref('project.tag_training'))]"/>
         <field name="amount">-60.0</field>
     </record>
 

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -13,9 +13,13 @@ class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
     @api.model
-    def _get_favorite_project_id(self):
-        last_timesheet_ids = self.search([('user_id', '=', self._uid), ('project_id', '!=', False)], limit=5)
-        if len(last_timesheet_ids) == 5 and len(last_timesheet_ids.project_id) == 1:
+    def _get_favorite_project_id(self, employee_id=False):
+        employee_id = employee_id or self.env.user.employee_id.id
+        last_timesheet_ids = self.search([
+            ('employee_id', '=', employee_id),
+            ('project_id', '!=', False),
+        ], limit=5)
+        if len(last_timesheet_ids.project_id) == 1:
             return last_timesheet_ids.project_id.id
         return False
 
@@ -27,7 +31,8 @@ class AccountAnalyticLine(models.Model):
         if not self.env.context.get('default_employee_id') and 'employee_id' in field_list and result.get('user_id'):
             result['employee_id'] = self.env['hr.employee'].search([('user_id', '=', result['user_id']), ('company_id', '=', result.get('company_id', self.env.company.id))], limit=1).id
         if not self._context.get('default_project_id') and 'project_id' in field_list:
-            favorite_project_id = self._get_favorite_project_id()
+            employee_id = result.get('employee_id', self.env.context.get('default_employee_id', False))
+            favorite_project_id = self._get_favorite_project_id(employee_id)
             if favorite_project_id:
                 result['project_id'] = favorite_project_id
         return result

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -13,12 +13,23 @@ class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
     @api.model
+    def _get_favorite_project_id(self):
+        last_timesheet_ids = self.search([('user_id', '=', self._uid), ('project_id', '!=', False)], limit=5)
+        if len(last_timesheet_ids) == 5 and len(last_timesheet_ids.project_id) == 1:
+            return last_timesheet_ids.project_id.id
+        return False
+
+    @api.model
     def default_get(self, field_list):
         result = super(AccountAnalyticLine, self).default_get(field_list)
         if 'encoding_uom_id' in field_list:
             result['encoding_uom_id'] = self.env.company.timesheet_encode_uom_id.id
         if not self.env.context.get('default_employee_id') and 'employee_id' in field_list and result.get('user_id'):
             result['employee_id'] = self.env['hr.employee'].search([('user_id', '=', result['user_id']), ('company_id', '=', result.get('company_id', self.env.company.id))], limit=1).id
+        if not self._context.get('default_project_id') and 'project_id' in field_list:
+            favorite_project_id = self._get_favorite_project_id()
+            if favorite_project_id:
+                result['project_id'] = favorite_project_id
         return result
 
     def _domain_project_id(self):

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -50,6 +50,42 @@
             <field name="name">Renovations</field>
         </record>
 
+        <!-- Analytic Tags -->
+        <record id="tag_analysis" model="account.analytic.tag">
+            <field name="name">Analysis</field>
+            <field name="color">1</field>
+        </record>
+
+        <record id="tag_design" model="account.analytic.tag">
+            <field name="name">Design</field>
+            <field name="color">2</field>
+        </record>
+
+        <record id="tag_training" model="account.analytic.tag">
+            <field name="name">Training</field>
+            <field name="color">3</field>
+        </record>
+
+        <record id="tag_research" model="account.analytic.tag">
+            <field name="name">Research</field>
+            <field name="color">4</field>
+        </record>
+
+        <record id="tag_development" model="account.analytic.tag">
+            <field name="name">Development</field>
+            <field name="color">5</field>
+        </record>
+
+        <record id="tag_modification" model="account.analytic.tag">
+            <field name="name">Modification</field>
+            <field name="color">6</field>
+        </record>
+
+        <record id="tag_decoration" model="account.analytic.tag">
+            <field name="name">Decoration</field>
+            <field name="color">7</field>
+        </record>
+
         <!-- Stage templates -->
         <record id="project.project_project_stage_2" model="project.project.stage">
             <field name="mail_template_id" ref="project.project_done_email_template"/>
@@ -93,6 +129,7 @@
             <field name="tag_ids" eval="[Command.link(ref('project.project_tags_05'))]"/>
             <field name="stage_id" ref="project.project_project_stage_1"/>
             <field name="analytic_account_id" ref="project.analytic_office_design"/>
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_design'))]"/>
         </record>
         <record id="project_1_follower_admin" model="mail.followers">
             <field name="res_model">project.project</field>
@@ -109,6 +146,7 @@
             <field name="tag_ids" eval="[Command.link(ref('project.project_tags_04'))]"/>
             <field name="stage_id" ref="project.project_project_stage_1"/>
             <field name="analytic_account_id" ref="project.analytic_research_development"/>
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_research')), Command.link(ref('tag_development'))]"/>
         </record>
         <record id="project_2_activity_1" model="mail.activity">
             <field name="res_id" ref="project_project_2"/>
@@ -356,6 +394,7 @@
             <field name="tag_ids" eval="[Command.set([ref('project_tags_00')])]"/>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="milestone_id" ref="project.project_1_milestone_2" />
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_modification'))]"/>
         </record>
         <record id="project_1_task_4_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -449,6 +488,7 @@
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="color">11</field>
             <field name="milestone_id" ref="project.project_1_milestone_3" />
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_modification'))]"/>
         </record>
         <record id="project_1_task_6_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -489,6 +529,7 @@
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=6)"/>
             <field name="color">9</field>
             <field name="milestone_id" ref="project.project_1_milestone_3" />
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_modification'))]"/>
         </record>
         <record id="project_1_task_7_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -660,6 +701,7 @@
             <field name="parent_id" ref="project.project_1_task_12"/>
             <field name="name">Preparation</field>
             <field name="stage_id" ref="project_stage_1"/>
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_analysis'))]"/>
         </record>
         <record id="project_1_task_15" model="project.task">
             <field name="sequence">30</field>
@@ -683,6 +725,7 @@
             <field name="name">Customer analysis + Architecture</field>
             <field name="color">7</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+            <field name="analytic_tag_ids" eval="[Command.link(ref('tag_analysis')), Command.link(ref('tag_design'))]"/>
         </record>
         <record id="project_2_task_1_mail_message_1" model="mail.message">
             <field name="model">project.task</field>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1819,8 +1819,9 @@ class Task(models.Model):
                 )
                 if partner_id:
                     vals['partner_id'] = partner_id
-        if vals.get('project_id'):
-            project = self.env['project.project'].browse(vals.get('project_id'))
+        project_id = vals.get('project_id', self.env.context.get('default_project_id'))
+        if project_id:
+            project = self.env['project.project'].browse(project_id)
             if project.analytic_account_id:
                 vals['analytic_account_id'] = project.analytic_account_id.id
             if project.analytic_tag_ids:
@@ -1902,6 +1903,9 @@ class Task(models.Model):
                 else:
                     for field_name in self._get_recurrence_fields() + ['recurring_task']:
                         vals.pop(field_name, None)
+            project_id = vals.get('project_id')
+            if project_id:
+                self = self.with_context(default_project_id=project_id)
         return super()._load_records_create(vals_list)
 
     @api.model_create_multi

--- a/addons/sale_timesheet/report/timesheets_analysis_views.xml
+++ b/addons/sale_timesheet/report/timesheets_analysis_views.xml
@@ -60,18 +60,27 @@
                 <field name="so_line" groups="sales_team.group_sale_salesman"/>
             </xpath>
             <xpath expr="//filter[@name='month']" position="before">
-                <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"/>
-                <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"/>
-                <filter name="billable_milestones" string="Billed on Milestones" domain="[('timesheet_invoice_type', '=', 'billable_milestones')]"/>
-                <filter name="billable_manual" string="Billed Manually" domain="[('timesheet_invoice_type', '=', 'billable_manual')]"/>
-                <filter name="non_billable" string="Non-Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"/>
+                <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="billable_milestones" string="Billed on Milestones" domain="[('timesheet_invoice_type', '=', 'billable_milestones')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="billable_manual" string="Billed Manually" domain="[('timesheet_invoice_type', '=', 'billable_manual')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="non_billable" string="Non-Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"
+                    groups="sales_team.group_sale_salesman"/>
                 <separator/>
             </xpath>
             <xpath expr="//filter[@name='groupby_employee']" position="after">
-                <filter string="Sales Order" name="groupby_sale_order" domain="[]" context="{'group_by': 'order_id'}" groups="sales_team.group_sale_salesman"/>
-                <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]" context="{'group_by': 'so_line'}" groups="sales_team.group_sale_salesman"/>
-                <filter string="Invoice" name="groupby_invoice" domain="[]" context="{'group_by': 'timesheet_invoice_id'}"/>
-                <filter string="Billable Type" name="groupby_timesheet_invoice_type" domain="[]" context="{'group_by': 'timesheet_invoice_type'}"/>
+                <filter string="Sales Order" name="groupby_sale_order" domain="[]"
+                    context="{'group_by': 'order_id'}" groups="sales_team.group_sale_salesman"/>
+                <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]"
+                    context="{'group_by': 'so_line'}" groups="sales_team.group_sale_salesman"/>
+                <filter string="Invoice" name="groupby_invoice" domain="[]"
+                    context="{'group_by': 'timesheet_invoice_id'}" groups="sales_team.group_sale_salesman"/>
+                <filter string="Billable Type" name="groupby_timesheet_invoice_type" domain="[]"
+                    context="{'group_by': 'timesheet_invoice_type'}" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -11,18 +11,27 @@
                     <field name="so_line" groups="sales_team.group_sale_salesman"/>
                 </xpath>
                 <xpath expr="//filter[@name='month']" position="before">
-                    <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"/>
-                    <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"/>
-                    <filter name="billable_milestones" string="Billed on Milestones" domain="[('timesheet_invoice_type', '=', 'billable_milestones')]"/>
-                    <filter name="billable_manual" string="Billed Manually" domain="[('timesheet_invoice_type', '=', 'billable_manual')]"/>
-                    <filter name="non_billable" string="Non-Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"/>
+                    <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter name="billable_milestones" string="Billed on Milestones" domain="[('timesheet_invoice_type', '=', 'billable_milestones')]"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter name="billable_manual" string="Billed Manually" domain="[('timesheet_invoice_type', '=', 'billable_manual')]"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter name="non_billable" string="Non-Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"
+                        groups="sales_team.group_sale_salesman"/>
                     <separator/>
                 </xpath>
                 <xpath expr="//filter[@name='groupby_employee']" position="after">
-                    <filter string="Sales Order" name="groupby_sale_order" domain="[]" context="{'group_by': 'order_id'}" groups="sales_team.group_sale_salesman"/>
-                    <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]" context="{'group_by': 'so_line'}" groups="sales_team.group_sale_salesman"/>
-                    <filter string="Invoice" name="groupby_invoice" domain="[]" context="{'group_by': 'timesheet_invoice_id'}"/>
-                    <filter string="Billing Type" name="groupby_timesheet_invoice_type" domain="[]" context="{'group_by': 'timesheet_invoice_type'}"/>
+                    <filter string="Sales Order" name="groupby_sale_order" domain="[]" context="{'group_by': 'order_id'}"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]" context="{'group_by': 'so_line'}"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter string="Invoice" name="groupby_invoice" domain="[]" context="{'group_by': 'timesheet_invoice_id'}"
+                        groups="sales_team.group_sale_salesman"/>
+                    <filter string="Billing Type" name="groupby_timesheet_invoice_type" domain="[]"
+                        context="{'group_by': 'timesheet_invoice_type'}" groups="sales_team.group_sale_salesman"/>
                 </xpath>
             </field>
     </record>


### PR DESCRIPTION
** = project, sale_timesheet
In this PR the following improvements:
1) If the last five timesheets belong to the same project then that project is
considered a favorite project. Currently, this feature is only in the timesheet's
 grid. Now done in all view.
2) If the user does not have access to the salesman then the billing type filters
will not appear.
3) Currently, the analytic tag is not added to the project, task, and timesheet.
In this commit, we have inserted analytic tags in some projects, tasks, and
timesheets. If an analytic tag is inserted in the project, it will be automatically
added to the task and timesheet.
4) Currently, the project's analytic account and analytic tags are not set by
default in the task.
Technical: In this task, we have added a demo of analytic tags in the project.
  -> The default_get() method does not call when the demo data is loaded, so
    the analytic account and analytic tags are not set. So we called
    default_get() from _load_records_create().



task-2861376
