### PR TITLE
[IMP] mail: move oncomponentupdate from discuss_view to thread

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -1,17 +1,9 @@
 /** @odoo-module **/
 
-import { useUpdateToModel } from '@mail/component_hooks/use_update_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { LegacyComponent } from '@web/legacy/legacy_component';
 
 export class Discuss extends LegacyComponent {
-
-    /**
-     * @override
-     */
-    setup() {
-        useUpdateToModel({ methodName: 'onComponentUpdate' });
-    }
 
     //--------------------------------------------------------------------------
     // Public

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1621,6 +1621,23 @@ registerModel({
         /**
          * @private
          */
+        _onChangeCounter() {
+            if (this === this.messaging.inbox) {
+                if (
+                    this.threadViews.length > 0 &&
+                    this.lastCounter > 0 && this.counter === 0
+                ) {
+                    this.env.services.effect.add({
+                        message: this.env._t("Congratulations, your inbox is empty!"),
+                        type: 'rainbow_man',
+                    });
+                }
+                this.update({ lastCounter: this.counter });
+            }
+        },
+        /**
+         * @private
+         */
         _onChangeLastSeenByCurrentPartnerMessageId() {
             this.messaging.messagingBus.trigger('o-thread-last-seen-by-current-partner-message-id-changed', {
                 thread: this,
@@ -2061,6 +2078,10 @@ registerModel({
             default: 0,
         }),
         /**
+         * Useful to display rainbow man on inbox.
+         */
+        lastCounter: attr(),
+        /**
          * Local value of message unread counter, that means it is based on initial server value and
          * updated with interface updates.
          */
@@ -2370,6 +2391,10 @@ registerModel({
         new OnChange({
             dependencies: ['lastSeenByCurrentPartnerMessageId'],
             methodName: '_onChangeLastSeenByCurrentPartnerMessageId',
+        }),
+        new OnChange({
+            dependencies: ['counter'],
+            methodName: '_onChangeCounter',
         }),
         new OnChange({
             dependencies: ['isServerPinned'],


### PR DESCRIPTION
**Current behavior before PR:**

The whole process depends on `thread_view` render, not `discuss`. So, it's
unnecessarily making `discuss_view` observe and rerender on a lot of useless
values.

**Desired behavior after PR is merged:**

Remove method from `discuss_view`. Make some `onChange` methods for handling
the functionality.

Task-2869417

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
