### PR TITLE
[FIX] point_of_sale: res.partner doesn't belong to a specific company

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
@@ -56,6 +56,9 @@ odoo.define('point_of_sale.ClientDetailsEdit', function(require) {
                 });
             }
             processedChanges.id = this.props.partner.id || false;
+            if (!this.props.partner.id) {
+                processedChanges.company_id = this.env.pos.company.id;
+            }
             this.trigger('save-changes', { processedChanges });
         }
         async uploadImage(event) {


### PR DESCRIPTION
Steps to reproduce:

1- install POS in multicompany env
2- create a customer c from POS UI
3- c doesn't belong to the active company

Bug:
the company_id is not set when the customer is created

Fix:
set comapny_id to current active company

OPW-2881551

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
