### PR TITLE
[FIX] hr_recruitment: Hiring employee must be counted

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -44,6 +44,12 @@ class Job(models.Model):
     color = fields.Integer("Color Index")
     is_favorite = fields.Boolean(compute='_compute_is_favorite', inverse='_inverse_is_favorite')
     favorite_user_ids = fields.Many2many('res.users', 'job_favorite_user_rel', 'job_id', 'user_id', default=_get_default_favorite_user_ids)
+    no_of_hired_employee = fields.Integer(compute='_compute_no_of_hired_employee', store=True)
+
+    @api.depends('application_ids.emp_id', 'application_ids.date_closed')
+    def _compute_no_of_hired_employee(self):
+        for job in self:
+            job.no_of_hired_employee = len(job.application_ids.filtered(lambda app: app.emp_id and app.date_closed))
 
     def _compute_is_favorite(self):
         for job in self:


### PR DESCRIPTION
The field no_of_hired_employee was not used when hiring employee

opw:2881105




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
