### PR TITLE
[IMP] stock_picking_batch: order wave pickings by location

### DIFF
--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -26,7 +26,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr t-foreach="o.picking_ids" t-as="pick">
+                                    <tr t-foreach="o.picking_ids.sorted(lambda l: l.location_id.display_name)" t-as="pick">
                                         <td>
                                             <span t-field="pick.name"/>
                                         </td>
@@ -43,7 +43,7 @@
                                 </tbody>
                             </table>
                             <p style="page-break-after: always;"/>
-                            <t t-foreach="locations" t-as="location">
+                            <t t-foreach="locations.sorted(lambda l: l.display_name)" t-as="location">
                                 <t t-set="loc_move_line" t-value="move_line_ids.filtered(lambda x: x.location_id==location)"/>
                                 <t t-set="products" t-value="loc_move_line.mapped('product_id')"/>
                                 <h3><span t-field="o.name"/></h3>


### PR DESCRIPTION
As of this commit the printed wave picking report will order the stock pickings and the grouped stock moves by source location.

opw-2812900