### PR TITLE
[FIX] hr_timesheet: ensure UoM is defined on timesheets

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -179,7 +179,7 @@ class AccountAnalyticLine(models.Model):
             if partner_id:
                 vals['partner_id'] = partner_id
         # set timesheet UoM from the AA company (AA implies uom)
-        if 'product_uom_id' not in vals and all(v in vals for v in ['account_id', 'project_id']):  # project_id required to check this is timesheet flow
+        if not vals.get('product_uom_id') and all(v in vals for v in ['account_id', 'project_id']):  # project_id required to check this is timesheet flow
             analytic_account = self.env['account.analytic.account'].sudo().browse(vals['account_id'])
             vals['product_uom_id'] = analytic_account.company_id.project_time_mode_id.id
         return vals

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -367,3 +367,29 @@ class TestTimesheet(TestCommonTimesheet):
         })
 
         self.assertEqual(timesheet.project_id, second_project, 'The project_id of timesheet should be second_project')
+
+    def test_ensure_product_uom_set_in_timesheet(self):
+        self.assertFalse(self.project_customer.timesheet_ids, 'No timesheet should be recorded in this project')
+        self.assertFalse(self.project_customer.total_timesheet_time, 'The total time recorded should be equal to 0 since no timesheet is recorded.')
+
+        timesheet1, timesheet2 = self.env['account.analytic.line'].create([
+            {'unit_amount': 1.0, 'project_id': self.project_customer.id},
+            {'unit_amount': 3.0, 'project_id': self.project_customer.id, 'product_uom_id': False},
+        ])
+        self.assertEqual(
+            timesheet1.product_uom_id,
+            self.project_customer.analytic_account_id.company_id.timesheet_encode_uom_id,
+            'The default UoM set on the timesheet should be the one set on the company of AA.'
+        )
+        self.assertEqual(
+            timesheet2.product_uom_id,
+            self.project_customer.analytic_account_id.company_id.timesheet_encode_uom_id,
+            'Even if the product_uom_id field is empty in the vals, the product_uom_id should have a UoM by default,'
+            ' otherwise the `total_timesheet_time` in project should not included the timesheet.'
+        )
+        self.assertEqual(self.project_customer.timesheet_ids, timesheet1 + timesheet2)
+        self.assertEqual(
+            self.project_customer.total_timesheet_time,
+            timesheet1.unit_amount + timesheet2.unit_amount,
+            'The total timesheet time of this project should be equal to 4.'
+        )


### PR DESCRIPTION
Before this commit, if the user uses Studio app to customize the form
view of timesheet and adds `product_uom_id` field in that view, then if
for instance that field is invisible, it will be in in the vals when the
user will create a timesheet. In that case, the value given to that
field will be False since the field has no default value. Since in the
compute of `total_timesheet_time` defined in project used that field to
convert the `unit_amount` of each timesheet linked to this project in
the right UoM, the `product_uom_id` field has to be defined if the AAL
is a timesheet, otherwise, the timesheets without any UoM set on
`product_uom_id` will be excluded in the compute.

This commit fixes the issue by setting a UoM if the UoM is not in vals
or if the value is False for a timesheet.

opw-2884148