### PR TITLE
Allow adding target to links in notifications

### DIFF
--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -15,7 +15,7 @@ export const displayNotificationAction = (env, action) => {
         type: params.type || "info",
     };
     let links = (params.links || []).map((link) => {
-        let target = '_blank'
+        let target = '_blank';
         if ('target' in link) {
             if (link.target == 'current') {
                 target = '_self';

--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -15,7 +15,13 @@ export const displayNotificationAction = (env, action) => {
         type: params.type || "info",
     };
     let links = (params.links || []).map((link) => {
-        return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
+        let target = '_blank'
+        if ('target' in link) {
+            if (link.target == 'current') {
+                target = '_self';
+            }
+        }
+        return `<a href="${escape(link.url)}" target="${target}">${escape(link.label)}</a>`;
     });
     const message = owl.markup(sprintf(escape(params.message), ...links));
     env.services.notification.add(message, options);


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
Adds an optional `target` param for use with links in notifications. Backwards compatible: behavior is unchanged if target is not specified.

_Current behavior before PR:_
Links in notifications (`displayNotificationAction`) always open in a new window (target is `_blank`).

_Desired behavior after PR is merged:_
Using the `target` parameter you can select if a link in a notification has to open in a new window or in the current one. 
If a target is not specified, the link opens in a new window (the old behavior).

The parameter uses the same keywords as similar parameters in other code of Odoo: `new` for `_blank` and `current` for `_self`

Example usage: 

```
return {
    'type': 'ir.actions.client',
    'tag': 'display_notification',
    'params': {
        'type': 'success',
        'title': 'My Title',
        'message': f'My message with a link at the end: %s',
        'links': [{
            'label': 'Click here',
            'url': 'https://example.com',
            'target': 'current' // <-- the new parameter
        }],
    }
}

```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
