### PR TITLE
[IMP] account: make account creation easier

### DIFF
--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -153,3 +153,35 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         group.code_prefix_end = 401000
 
         self.assertRecordValues(account_1 + account_2, [{'group_id': group.id}, {'group_id': False}])
+
+    def test_name_create(self):
+        """name_create should only be possible when importing
+           Code and Name should be split
+        """
+        with self.assertRaises(ValueError):
+            self.env['account.account'].name_create('550003 Existing Account')
+        account_id = self.env['account.account'].with_context(import_file=True).name_create('550003 Existing Account')[0]
+        account = self.env['account.account'].browse(account_id)
+        self.assertEqual(account.code, "550003")
+        self.assertEqual(account.name, "Existing Account")
+
+    def test_compute_account_type(self):
+        existing_account = self.env['account.account'].search([], limit=1)
+        # account_type should be computed
+        new_account_code = self.env['account.account']._search_new_account_code(
+            company=existing_account.company_id,
+            digits=len(existing_account.code),
+            prefix=existing_account.code[:-1])
+        new_account = self.env['account.account'].create({
+            'code': new_account_code,
+            'name': 'A new account'
+        })
+        self.assertEqual(new_account.account_type, existing_account.account_type)
+        # account_type should not be altered
+        alternate_account = self.env['account.account'].search([('account_type', '!=', existing_account.account_type)], limit=1)
+        alternate_code = self.env['account.account']._search_new_account_code(
+            company=alternate_account.company_id,
+            digits=len(alternate_account.code),
+            prefix=alternate_account.code[:-1])
+        new_account.code = alternate_code
+        self.assertEqual(new_account.account_type, existing_account.account_type)

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -56,24 +56,29 @@
                                         <!-- Bank -->
                                         <field name="default_account_id" string="Bank Account"
                                                attrs="{'required': [('id', '!=', False), ('type', '=', 'bank')], 'invisible': [('type', '!=', 'bank')]}"
+                                               options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <!-- Cash -->
                                         <field name="default_account_id" string="Cash Account"
                                                attrs="{'required': [('id', '!=', False), ('type', '=', 'cash')], 'invisible': [('type', '!=', 'cash')]}"
+                                               options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
 
                                         <field name="suspense_account_id"
                                                attrs="{'required': [('type', 'in', ('bank', 'cash'))], 'invisible': [('type', 'not in', ('bank', 'cash'))]}"
+                                               options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <field name="profit_account_id" attrs="{'invisible': ['!', ('type', 'in', ('cash', 'bank'))]}"/>
                                         <field name="loss_account_id" attrs="{'invisible': ['!', ('type', 'in', ('cash', 'bank'))]}"/>
                                         <!-- Sales -->
                                         <field name="default_account_id" string="Default Income Account"
                                                attrs="{'required': [('type', '=', 'sale')], 'invisible': [('type', '!=', 'sale')]}"
+                                               options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <!-- Purchase -->
                                         <field name="default_account_id" string="Default Expense Account"
                                                attrs="{'required': [('type', '=', 'purchase')], 'invisible': [('type', '!=', 'purchase')]}"
+                                               options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <field name="refund_sequence" attrs="{'invisible': [('type', 'not in', ['sale', 'purchase'])]}"/>
                                         <field name="code" placeholder="e.g. INV"/>


### PR DESCRIPTION
Task 2888204

- Name is automatically split into code and name
- account_type is computed based on the closest parent of the code prefix (and can be changed)
- _onchange_name is needed to split the name into code and name when creating from a related model's form

Taking the relevant code from odoo/odoo#90474


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
