### PR TITLE
[FIX] base: Fix PDF generation

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -717,15 +717,12 @@ class IrActionsReport(models.Model):
 
             # Split the pdf for each record using the PDF outlines.
 
-            html_ids_wo_none = [x for x in html_ids if x]
-            if len(res_ids_wo_stream) == 1:
+            if not self.attachment:
+                # Splitting the pdf is not needed since we don't have any attachment to generate.
+                collected_streams[False] = {'stream': pdf_content_stream}
+            elif len(res_ids_wo_stream) == 1:
                 # Only one record: append the whole PDF.
                 collected_streams[res_ids_wo_stream[0]]['stream'] = pdf_content_stream
-            elif not html_ids_wo_none:
-                # When rendering some html without a one to one match between each res_id and a document
-                # 'html_ids' contains some 'None' values. In that case, there is nothing to split and the content
-                # can be returned directly.
-                collected_streams[False] = {'stream': pdf_content_stream}
             else:
                 # In case of multiple docs, we need to split the pdf according the records.
                 # To do so, we split the pdf based on top outlines computed by wkhtmltopdf.


### PR DESCRIPTION
Suppose we are printing a PDF on multiple records but having some of them excluded during the _prepare_html.
So, suppose these records are [20, 21].
If [21] is excluded during the rendering because nothing to render, the resulting html will contains only [20].
That is leading to a traceback when checking the outlines because of

assert len(outlines_pages) == len(res_ids)

This commit avoids to check the outlines if all records are not providing content.

Note: This doesn't work with the 'attachment_use' feature but it can't be since wkhtmltopdf don't provide enough data to say which outline corresponds to which id.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
