### PR TITLE
[IMP] mail, website_slides: replace createChatterContainer during tests

### DIFF
--- a/addons/mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/mail/static/tests/helpers/model_definitions_setup.js
@@ -21,6 +21,7 @@ addModelNamesToFetch([
 ]);
 
 addFakeModel('res.fake', {
+    message_ids: { string: 'Messages', type: 'one2many', relation: 'mail.message' },
     activity_ids: { string: "Activities", type: 'one2many', relation: 'mail.activity' },
     email_cc: { type: 'char' },
     partner_ids: { relation: 'res.partner', string: "Related partners", type: 'one2many' },

--- a/addons/mail/static/tests/helpers/view_definitions_setup.js
+++ b/addons/mail/static/tests/helpers/view_definitions_setup.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+const viewArchsRegistry = registry.category('mail.view.archs');
+const activityArchsRegistry = viewArchsRegistry.category('activity');
+const formArchsRegistry = viewArchsRegistry.category('form');
+const kanbanArchsRegistry = viewArchsRegistry.category('kanban');
+const listArchsRegistry = viewArchsRegistry.category('list');
+const searchArchsRegistry = viewArchsRegistry.category('search');
+
+activityArchsRegistry.add('default', '<activity><templates></templates></activity>');
+formArchsRegistry.add('default', '<form/>');
+kanbanArchsRegistry.add('default', '<kanban><templates></templates>');
+listArchsRegistry.add('default', '<tree/>');
+searchArchsRegistry.add('default', '<search/>');
+
+formArchsRegistry.add(
+    'res.partner',
+    `<form>
+        <sheet>
+            <field name="name"/>
+        </sheet>
+        <div class="oe_chatter">
+            <field name="activity_ids"/>
+            <field name="message_follower_ids"/>
+            <field name="message_ids"/>
+        </div>
+    </form>`
+);
+formArchsRegistry.add(
+    'res.fake',
+    `<form>
+        <div class="oe_chatter">
+            <field name="message_ids"/>
+        </div>
+    </form>`
+);

--- a/addons/mail/static/tests/qunit_suite_tests/components/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/activity_mark_done_popover_tests.js
@@ -19,10 +19,11 @@ QUnit.test('activity mark done popover simplest layout', async function (assert)
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     await click('.o_Activity_markDoneButton');
 
@@ -70,10 +71,11 @@ QUnit.test('activity with force next mark done popover simplest layout', async f
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     await click('.o_Activity_markDoneButton');
 
@@ -120,7 +122,7 @@ QUnit.test('activity mark done popover mark done without feedback', async functi
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args) {
             if (route === '/web/dataset/call_kw/mail.activity/action_feedback') {
                 assert.step('action_feedback');
@@ -138,9 +140,10 @@ QUnit.test('activity mark done popover mark done without feedback', async functi
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     await click('.o_Activity_markDoneButton');
     await click('.o_ActivityMarkDonePopoverContent_doneButton');
@@ -161,7 +164,7 @@ QUnit.test('activity mark done popover mark done with feedback', async function 
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args) {
             if (route === '/web/dataset/call_kw/mail.activity/action_feedback') {
                 assert.step('action_feedback');
@@ -179,9 +182,10 @@ QUnit.test('activity mark done popover mark done with feedback', async function 
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     await click('.o_Activity_markDoneButton');
 
@@ -206,7 +210,7 @@ QUnit.test('activity mark done popover mark done and schedule next', async funct
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, env, createChatterContainerComponent } = await start({
+    const { click, env, openView } = await start({
         async mockRPC(route, args) {
             if (route === '/web/dataset/call_kw/mail.activity/action_feedback_schedule_next') {
                 assert.step('action_feedback_schedule_next');
@@ -222,15 +226,16 @@ QUnit.test('activity mark done popover mark done and schedule next', async funct
             }
         },
     });
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction() {
             assert.step('activity_action');
             throw new Error("The do-action event should not be triggered when the route doesn't return an action");
         },
-    });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
     });
     await click('.o_Activity_markDoneButton');
 
@@ -255,12 +260,17 @@ QUnit.test('[technical] activity mark done & schedule next with new action', asy
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent, env } = await start({
+    const { click, env, openView } = await start({
         async mockRPC(route, args) {
             if (route === '/web/dataset/call_kw/mail.activity/action_feedback_schedule_next') {
                 return { type: 'ir.actions.act_window' };
             }
         },
+    });
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     patchWithCleanup(env.services.action, {
         doAction(action) {
@@ -271,10 +281,6 @@ QUnit.test('[technical] activity mark done & schedule next with new action', asy
                 "The content of the action should be correct"
             );
         },
-    });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
     });
     await click('.o_Activity_markDoneButton');
 

--- a/addons/mail/static/tests/qunit_suite_tests/components/activity_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/activity_tests.js
@@ -18,10 +18,11 @@ QUnit.test('activity simplest layout', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -95,10 +96,11 @@ QUnit.test('activity with note layout', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -131,10 +133,11 @@ QUnit.test('activity info layout when planned after tomorrow', async function (a
         res_model: 'res.partner',
         state: 'planned',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -171,10 +174,11 @@ QUnit.test('activity info layout when planned tomorrow', async function (assert)
         res_model: 'res.partner',
         state: 'planned',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -208,10 +212,11 @@ QUnit.test('activity info layout when planned today', async function (assert) {
         res_model: 'res.partner',
         state: 'today',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -248,10 +253,11 @@ QUnit.test('activity info layout when planned yesterday', async function (assert
         res_model: 'res.partner',
         state: 'overdue',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -288,10 +294,11 @@ QUnit.test('activity info layout when planned before yesterday', async function 
         res_model: 'res.partner',
         state: 'overdue',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -324,10 +331,11 @@ QUnit.test('activity with a summary layout', async function (assert) {
         res_model: 'res.partner',
         summary: 'test summary',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -361,10 +369,11 @@ QUnit.test('activity without summary layout', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -409,10 +418,11 @@ QUnit.test('activity details toggle', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -465,10 +475,11 @@ QUnit.test('activity details layout', async function (assert) {
         state: 'planned',
         user_id: resUsersId1,
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -542,10 +553,11 @@ QUnit.test('activity with mail template layout', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -602,7 +614,12 @@ QUnit.test('activity with mail template: preview mail', async function (assert) 
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent, env } = await start();
+    const { env, openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction(action) {
             assert.step('do_action');
@@ -637,10 +654,6 @@ QUnit.test('activity with mail template: preview mail', async function (assert) 
             );
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
-    });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
         1,
@@ -672,7 +685,7 @@ QUnit.test('activity with mail template: send mail', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent } = await start({
+    const { openView } = await start({
         async mockRPC(route, args) {
             if (args.method === 'activity_send_mail') {
                 assert.step('activity_send_mail');
@@ -684,9 +697,10 @@ QUnit.test('activity with mail template: send mail', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_model: 'res.partner',
+        res_id: resPartnerId1,
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -719,10 +733,11 @@ QUnit.test('activity upload document is available', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent } = await start();
-    const chatterContainerComponent = await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { messaging, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -735,7 +750,7 @@ QUnit.test('activity upload document is available', async function (assert) {
         "should have activity upload button"
     );
     assert.ok(
-        chatterContainerComponent.chatter.activityBoxView.activityViews[0].fileUploader,
+        messaging.models['Chatter'].all()[0].activityBoxView.activityViews[0].fileUploader,
         "should have a file uploader"
     );
 });
@@ -753,10 +768,11 @@ QUnit.test('activity click on mark as done', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -797,10 +813,11 @@ QUnit.test('activity mark as done popover should focus feedback input on open [R
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -835,7 +852,12 @@ QUnit.test('activity click on edit', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent, env } = await start();
+    const { click, env, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction(action) {
             assert.step('do_action');
@@ -867,10 +889,6 @@ QUnit.test('activity click on edit', async function (assert) {
             return this._super(...arguments);
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
-    });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
         1,
@@ -900,7 +918,12 @@ QUnit.test('activity edition', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent, env } = await start();
+    const { click, env, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction(action, options) {
             assert.step('do_action');
@@ -932,10 +955,6 @@ QUnit.test('activity edition', async function (assert) {
             pyEnv['mail.activity'].write([mailActivityId1], { icon: 'fa-check' });
             options.onClose();
         },
-    });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
     });
     assert.containsOnce(
         document.body,
@@ -992,7 +1011,7 @@ QUnit.test('activity click on cancel', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args) {
             if (route === '/web/dataset/call_kw/mail.activity/unlink') {
                 assert.step('unlink');
@@ -1001,9 +1020,10 @@ QUnit.test('activity click on cancel', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Activity').length,
@@ -1042,10 +1062,11 @@ QUnit.test('activity mark done popover close on ESCAPE', async function (assert)
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     await click('.o_Activity_markDoneButton');
@@ -1081,10 +1102,11 @@ QUnit.test('activity mark done popover click on discard', async function (assert
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     await click('.o_Activity_markDoneButton');
@@ -1120,7 +1142,12 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent, env } = await start();
+    const { env, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction(action) {
             assert.strictEqual(
@@ -1140,10 +1167,6 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
             );
             assert.step('do-action:openFormView_some.model_250');
         },
-    });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
     });
     assert.containsOnce(
         document.body,
@@ -1177,10 +1200,11 @@ QUnit.test('button related to file uploading is replaced when updating activity 
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { createChatterContainerComponent, messaging } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { messaging, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     // Update the record server side then fetch updated data in order to

--- a/addons/mail/static/tests/qunit_suite_tests/components/attachment_box_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/attachment_box_tests.js
@@ -11,11 +11,19 @@ QUnit.test('base empty rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { createChatterContainerComponent } = await start();
-    const chatterContainerComponent = await createChatterContainerComponent({
-        isAttachmentBoxVisibleInitially: true,
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const views = {
+        'res.partner,false,form':
+            `<form>
+                <div class="oe_chatter">
+                    <field name="message_ids"  options="{'open_attachments': True}"/>
+                </div>
+            </form>`,
+    };
+    const { messaging, openView } = await start({ serverData: { views } });
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_AttachmentBox`).length,
@@ -28,7 +36,7 @@ QUnit.test('base empty rendering', async function (assert) {
         "should have a button add"
     );
     assert.ok(
-        chatterContainerComponent.chatter.attachmentBoxView.fileUploader,
+        messaging.models['Chatter'].all()[0].attachmentBoxView.fileUploader,
         "should have a file uploader"
     );
     assert.strictEqual(
@@ -57,11 +65,19 @@ QUnit.test('base non-empty rendering', async function (assert) {
             res_model: 'res.partner',
         },
     ]);
-    const { createChatterContainerComponent } = await start();
-    const chatterContainerComponent = await createChatterContainerComponent({
-        isAttachmentBoxVisibleInitially: true,
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const views = {
+        'res.partner,false,form':
+            `<form>
+                <div class="oe_chatter">
+                    <field name="message_ids"  options="{'open_attachments': True}"/>
+                </div>
+            </form>`,
+    };
+    const { messaging, openView } = await start({ serverData: { views } });
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_AttachmentBox`).length,
@@ -74,7 +90,7 @@ QUnit.test('base non-empty rendering', async function (assert) {
         "should have a button add"
     );
     assert.ok(
-        chatterContainerComponent.chatter.attachmentBoxView.fileUploader,
+        messaging.models['Chatter'].all()[0].attachmentBoxView.fileUploader,
         "should have a file uploader"
     );
     assert.strictEqual(
@@ -103,11 +119,19 @@ QUnit.test('view attachments', async function (assert) {
             res_model: 'res.partner',
         },
     ]);
-    const { click, createChatterContainerComponent, messaging } = await start();
-    await createChatterContainerComponent({
-        isAttachmentBoxVisibleInitially: true,
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const views = {
+        'res.partner,false,form':
+            `<form>
+                <div class="oe_chatter">
+                    <field name="message_ids"  options="{'open_attachments': True}"/>
+                </div>
+            </form>`,
+    };
+    const { click, messaging, openView } = await start({ serverData: { views } });
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     const firstAttachment = messaging.models['Attachment'].findFromIdentifyingData({ id: irAttachmentId1 });
 
@@ -167,11 +191,19 @@ QUnit.test('remove attachment should ask for confirmation', async function (asse
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        isAttachmentBoxVisibleInitially: true,
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const views = {
+        'res.partner,false,form':
+            `<form>
+                <div class="oe_chatter">
+                    <field name="message_ids"  options="{'open_attachments': True}"/>
+                </div>
+            </form>`,
+    };
+    const { click, openView } = await start({ serverData: { views } });
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_suggested_recipient_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_suggested_recipient_tests.js
@@ -12,10 +12,11 @@ QUnit.test("suggest recipient on 'Send message' composer", async function (asser
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: "John Jane", email: "john@jane.be" });
     const resFakeId1 = pyEnv['res.fake'].create({ email_cc: "john@test.be", partner_ids: [resPartnerId1] });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
     await click(`.o_ChatterTopbar_buttonSendMessage`);
     assert.containsOnce(
@@ -31,10 +32,11 @@ QUnit.test("with 3 or less suggested recipients: no 'show more' button", async f
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: "John Jane", email: "john@jane.be" });
     const resFakeId1 = pyEnv['res.fake'].create({ email_cc: "john@test.be", partner_ids: [resPartnerId1] });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
     await click(`.o_ChatterTopbar_buttonSendMessage`);
     assert.containsNone(
@@ -50,10 +52,11 @@ QUnit.test("display reason for suggested recipient on mouse over", async functio
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: "John Jane", email: "john@jane.be" });
     const resFakeId1 = pyEnv['res.fake'].create({ partner_ids: [resPartnerId1] });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
     await click(`.o_ChatterTopbar_buttonSendMessage`);
     const partnerTitle = document.querySelector(`.o_ComposerSuggestedRecipient[data-partner-id="${resPartnerId1}"]`).getAttribute('title');
@@ -69,10 +72,11 @@ QUnit.test("suggested recipient without partner are unchecked by default", async
 
     const pyEnv = await startServer();
     const resFakeId1 = pyEnv['res.fake'].create({ email_cc: "john@test.be" });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
     await click(`.o_ChatterTopbar_buttonSendMessage`);
     const checkboxUnchecked = document.querySelector('.o_ComposerSuggestedRecipient:not([data-partner-id]) input[type=checkbox]');
@@ -88,10 +92,11 @@ QUnit.test("suggested recipient with partner are checked by default", async func
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: "John Jane", email: "john@jane.be" });
     const resFakeId1 = pyEnv['res.fake'].create({ partner_ids: [resPartnerId1] });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
     await click(`.o_ChatterTopbar_buttonSendMessage`);
     const checkboxChecked = document.querySelector(`.o_ComposerSuggestedRecipient[data-partner-id="${resPartnerId1}"] input[type=checkbox]`);
@@ -114,10 +119,11 @@ QUnit.test("more than 3 suggested recipients: display only 3 and 'show more' but
     const resFakeId1 = pyEnv['res.fake'].create({
         partner_ids: [resPartnerId1, resPartnerId2, resPartnerId3, resPartnerId4],
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
 
     await click(`.o_ChatterTopbar_buttonSendMessage`);
@@ -141,10 +147,11 @@ QUnit.test("more than 3 suggested recipients: show all of them on click 'show mo
     const resFakeId1 = pyEnv['res.fake'].create({
         partner_ids: [resPartnerId1, resPartnerId2, resPartnerId3, resPartnerId4],
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
 
     await click(`.o_ChatterTopbar_buttonSendMessage`);
@@ -170,10 +177,11 @@ QUnit.test("more than 3 suggested recipients -> click 'show more' -> 'show less'
     const resFakeId1 = pyEnv['res.fake'].create({
         partner_ids: [resPartnerId1, resPartnerId2, resPartnerId3, resPartnerId4],
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
 
     await click(`.o_ChatterTopbar_buttonSendMessage`);
@@ -198,10 +206,11 @@ QUnit.test("suggested recipients list display 3 suggested recipient and 'show mo
     const resFakeId1 = pyEnv['res.fake'].create({
         partner_ids: [resPartnerId1, resPartnerId2, resPartnerId3, resPartnerId4],
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
 
     await click(`.o_ChatterTopbar_buttonSendMessage`);
@@ -226,7 +235,7 @@ QUnit.test("suggested recipients should not be notified when posting an internal
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: "John Jane", email: "john@jane.be" });
     const resFakeId1 = pyEnv['res.fake'].create({ partner_ids: [resPartnerId1] });
-    const { click, createChatterContainerComponent, insertText } = await start({
+    const { click, insertText, openView } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/message/post') {
                 assert.strictEqual(
@@ -237,9 +246,10 @@ QUnit.test("suggested recipients should not be notified when posting an internal
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resFakeId1,
-        threadModel: 'res.fake',
+    await openView({
+        res_id: resFakeId1,
+        res_model: 'res.fake',
+        views: [[false, 'form']],
     });
     await click(`.o_ChatterTopbar_buttonLogNote`);
     await insertText('.o_ComposerTextInput_textarea', "Dummy Message");

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
@@ -30,10 +30,11 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
             res_id: resPartnerId1,
         });
     }
-    const { createChatterContainerComponent, messaging } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { messaging, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_Chatter`).length,
@@ -71,12 +72,13 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
 });
 
 QUnit.test('base rendering when chatter has no record', async function (assert) {
-    assert.expect(10);
+    assert.expect(9);
 
-    const { click, createChatterContainerComponent } = await start();
-    const chatterContainerComponent = await createChatterContainerComponent({
-        threadModel: 'res.partner',
-    }, { waitUntilMessagesLoaded: false });
+    const { click, openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     assert.strictEqual(
         document.querySelectorAll(`.o_Chatter`).length,
         1,
@@ -96,10 +98,6 @@ QUnit.test('base rendering when chatter has no record', async function (assert) 
         document.querySelectorAll(`.o_Chatter_thread`).length,
         1,
         "should have a thread in the chatter"
-    );
-    assert.ok(
-        chatterContainerComponent.chatter.thread.isTemporary,
-        "thread should have a temporary thread linked to chatter"
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Message`).length,
@@ -149,10 +147,11 @@ QUnit.test('base rendering when chatter has attachments', async function (assert
             res_model: 'res.partner',
         },
     ]);
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_Chatter`).length,
@@ -190,10 +189,11 @@ QUnit.test('show attachment box', async function (assert) {
             res_model: 'res.partner',
         },
     ]);
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_Chatter`).length,
@@ -234,10 +234,11 @@ QUnit.test('chatter: drop attachments', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     const files = [
         await createFile({
@@ -296,10 +297,11 @@ QUnit.test('composer show/hide on log note/send message [REQUIRE FOCUS]', async 
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatterTopbar_buttonSendMessage`).length,
@@ -374,10 +376,11 @@ QUnit.test('should display subject when subject is not the same as the thread na
         res_id: resPartnerId1,
         subject: "Salutations, voyageur",
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.containsOnce(
@@ -403,10 +406,11 @@ QUnit.test('should not display subject when subject is the same as the thread na
         res_id: resPartnerId1,
         subject: "Salutations, voyageur",
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.containsNone(
@@ -426,10 +430,11 @@ QUnit.test('should not display user notification messages in chatter', async fun
         model: 'res.partner',
         res_id: resPartnerId1,
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.containsNone(
@@ -444,10 +449,11 @@ QUnit.test('post message with "CTRL-Enter" keyboard shortcut', async function (a
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent, insertText } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, insertText, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsNone(
         document.body,
@@ -473,10 +479,11 @@ QUnit.test('post message with "META-Enter" keyboard shortcut', async function (a
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent, insertText } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, insertText, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsNone(
         document.body,
@@ -505,10 +512,11 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async function 
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent, insertText } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, insertText, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsNone(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_topbar_tests.js
@@ -13,10 +13,11 @@ QUnit.test('base rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.strictEqual(
@@ -64,10 +65,11 @@ QUnit.test('base rendering', async function (assert) {
 QUnit.test('base disabled rendering', async function (assert) {
     assert.expect(8);
 
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadModel: 'res.partner',
-    }, { waitUntilMessagesLoaded: false });
+    const { openView } = await start();
+    await openView({
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatterTopbar`).length,
         1,
@@ -111,18 +113,19 @@ QUnit.test('attachment loading is delayed', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { advanceTime, createChatterContainerComponent } = await start({
+    const { advanceTime, openView } = await start({
         hasTimeControl: true,
         loadingBaseDelayDuration: 100,
         async mockRPC(route) {
             if (route.includes('/mail/thread/data')) {
                 await makeTestPromise(); // simulate long loading
             }
-        }
+        },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.strictEqual(
@@ -154,16 +157,17 @@ QUnit.test('attachment counter while loading attachments', async function (asser
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { createChatterContainerComponent } = await start({
+    const { openView } = await start({
         async mockRPC(route) {
             if (route.includes('/mail/thread/data')) {
                 await makeTestPromise(); // simulate long loading
             }
         }
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.strictEqual(
@@ -194,16 +198,17 @@ QUnit.test('attachment counter transition when attachments become loaded)', asyn
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
     const attachmentPromise = makeTestPromise();
-    const { createChatterContainerComponent } = await start({
+    const { openView } = await start({
         async mockRPC(route) {
             if (route.includes('/mail/thread/data')) {
                 await attachmentPromise;
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.strictEqual(
@@ -250,10 +255,11 @@ QUnit.test('attachment counter without attachments', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.strictEqual(
@@ -297,10 +303,11 @@ QUnit.test('attachment counter with attachments', async function (assert) {
             res_model: 'res.partner',
         },
     ]);
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.strictEqual(
@@ -330,10 +337,11 @@ QUnit.test('composer state conserved when clicking on another topbar button', as
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.containsOnce(
@@ -406,10 +414,11 @@ QUnit.test('rendering with multiple partner followers', async function (assert) 
             res_model: 'res.partner',
         },
     ]);
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId3,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId3,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.containsOnce(
@@ -458,10 +467,11 @@ QUnit.test('log note/send message switching', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -514,10 +524,11 @@ QUnit.test('log note toggling', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -550,10 +561,11 @@ QUnit.test('send message toggling', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -1438,21 +1438,7 @@ QUnit.test("Show a default status in the recipient status text when the thread d
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="message_ids"/>
-                </div>
-            </form>`,
-    };
-    const { click, openView } = await start({
-        serverData: { views },
-    });
+    const { click, openView } = await start();
     await openView({
         res_model: 'res.partner',
         res_id: resPartnerId1,
@@ -1471,21 +1457,7 @@ QUnit.test("Show a thread name in the recipient status text.", async function (a
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ name: "test name" });
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="message_ids"/>
-                </div>
-            </form>`,
-    };
-    const { click, messaging, openView } = await start({
-        serverData: { views },
-    });
+    const { click, messaging, openView } = await start();
     await openView({
         res_model: 'res.partner',
         res_id: resPartnerId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/follow_button_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follow_button_tests.js
@@ -13,21 +13,7 @@ QUnit.module('follow_button_tests.js');
 QUnit.test('base rendering not editable', async function (assert) {
     assert.expect(2);
 
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
-    const { openView, pyEnv } = await start({
-        serverData: { views },
-    });
+    const { openView, pyEnv } = await start();
     await openView({
         res_id: pyEnv.currentPartnerId,
         res_model: 'res.partner',
@@ -59,21 +45,7 @@ QUnit.test('hover following button', async function (assert) {
     pyEnv['res.partner'].write([pyEnv.currentPartnerId], {
         message_follower_ids: [followerId],
     });
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
-    const { openView } = await start({
-        serverData: { views },
-    });
+    const { openView } = await start();
     await openView({
         res_id: threadId,
         res_model: 'res.partner',
@@ -131,21 +103,7 @@ QUnit.test('hover following button', async function (assert) {
 QUnit.test('click on "follow" button', async function (assert) {
     assert.expect(4);
 
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
-    const { click, openView, pyEnv } = await start({
-        serverData: { views },
-    });
+    const { click, openView, pyEnv } = await start();
     await openView({
         res_id: pyEnv.currentPartnerId,
         res_model: 'res.partner',
@@ -189,21 +147,7 @@ QUnit.test('click on "unfollow" button', async function (assert) {
     pyEnv['res.partner'].write([pyEnv.currentPartnerId], {
         message_follower_ids: [followerId],
     });
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
-    const { click, openView } = await start({
-        serverData: { views },
-    });
+    const { click, openView } = await start();
     await openView({
         res_id: threadId,
         res_model: 'res.partner',

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
@@ -15,21 +15,7 @@ QUnit.module('follower_list_menu_tests.js');
 QUnit.test('base rendering not editable', async function (assert) {
     assert.expect(5);
 
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="message_ids"/>
-                </div>
-            </form>`,
-    };
-    const { openView } = await start({
-        serverData: { views },
-    });
+    const { openView } = await start();
     await openView(
         {
             res_model: 'res.partner',
@@ -72,7 +58,7 @@ QUnit.test('base rendering editable', async function (assert) {
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
 
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
                 // mimic user with write access
@@ -82,9 +68,10 @@ QUnit.test('base rendering editable', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     assert.containsOnce(
@@ -133,7 +120,7 @@ QUnit.test('click on "add followers" button', async function (assert) {
         res_model: 'res.partner',
     });
 
-    const { click, createChatterContainerComponent, env } = await start({
+    const { click, env, openView } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
                 // mimic user with write access
@@ -142,6 +129,11 @@ QUnit.test('click on "add followers" button', async function (assert) {
                 return res;
             }
         },
+    });
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     patchWithCleanup(env.services.action, {
         doAction(action, options) {
@@ -176,10 +168,6 @@ QUnit.test('click on "add followers" button', async function (assert) {
             });
             options.onClose();
         },
-    });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
     });
 
     assert.containsOnce(
@@ -255,7 +243,7 @@ QUnit.test('click on remove follower', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
                 // mimic user with write access
@@ -273,9 +261,10 @@ QUnit.test('click on remove follower', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     await click('.o_FollowerListMenu_buttonFollowers');
@@ -323,7 +312,7 @@ QUnit.test('Hide "Add follower" and subtypes edition/removal buttons except own 
             res_model: 'res.partner',
         },
     ]);
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
                 // mimic user with no write access
@@ -333,9 +322,10 @@ QUnit.test('Hide "Add follower" and subtypes edition/removal buttons except own 
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     await click('.o_FollowerListMenu_buttonFollowers');
@@ -388,7 +378,7 @@ QUnit.test('Show "Add follower" and subtypes edition/removal buttons on all foll
             res_model: 'res.partner',
         },
     ]);
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
                 // mimic user with write access
@@ -398,9 +388,10 @@ QUnit.test('Show "Add follower" and subtypes edition/removal buttons on all foll
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     await click('.o_FollowerListMenu_buttonFollowers');
@@ -438,7 +429,7 @@ QUnit.test('Show "No Followers" dropdown-item if there are no followers and user
     const pyEnv = await startServer();
 
     const resPartnerId1 = pyEnv['res.partner'].create({});
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
                 // mimic user without write access
@@ -448,9 +439,10 @@ QUnit.test('Show "No Followers" dropdown-item if there are no followers and user
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
 
     await click('.o_FollowerListMenu_buttonFollowers');

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
@@ -27,18 +27,6 @@ QUnit.test('simplest layout of a followed subtype', async function (assert) {
     pyEnv['res.partner'].write([pyEnv.currentPartnerId], {
         message_follower_ids: [followerId],
     });
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
     const { click, openView } = await start({
         // FIXME: should adapt mock server code to provide `hasWriteAccess`
         async mockRPC(route, args, performRPC) {
@@ -49,7 +37,6 @@ QUnit.test('simplest layout of a followed subtype', async function (assert) {
                 return res;
             }
         },
-        serverData: { views },
     });
     await openView({
         res_model: 'res.partner',
@@ -101,18 +88,6 @@ QUnit.test('simplest layout of a not followed subtype', async function (assert) 
     pyEnv['res.partner'].write([pyEnv.currentPartnerId], {
         message_follower_ids: [followerId],
     });
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
     const { click, openView } = await start({
         // FIXME: should adapt mock server code to provide `hasWriteAccess`
         async mockRPC(route, args, performRPC) {
@@ -123,7 +98,6 @@ QUnit.test('simplest layout of a not followed subtype', async function (assert) 
                 return res;
             }
         },
-        serverData: { views },
     });
     await openView({
         res_model: 'res.partner',
@@ -155,18 +129,6 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
     pyEnv['res.partner'].write([pyEnv.currentPartnerId], {
         message_follower_ids: [followerId],
     });
-    const views = {
-        'res.partner,false,form':
-            `<form string="Partners">
-                <sheet>
-                    <field name="name"/>
-                </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids"/>
-                    <field name="activity_ids"/>
-                </div>
-            </form>`,
-    };
     const { click, messaging, openView } = await start({
         // FIXME: should adapt mock server code to provide `hasWriteAccess`
         async mockRPC(route, args, performRPC) {
@@ -177,7 +139,6 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
                 return res;
             }
         },
-        serverData: { views },
     });
     await openView({
         res_model: 'res.partner',

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
@@ -20,7 +20,7 @@ QUnit.test('base rendering not editable', async function (assert) {
         res_id: threadId,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args, performRpc) {
             if (route === '/mail/thread/data') {
                 // mimic user without write access
@@ -30,9 +30,10 @@ QUnit.test('base rendering not editable', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     await click('.o_FollowerListMenu_buttonFollowers');
     assert.containsOnce(
@@ -73,10 +74,11 @@ QUnit.test('base rendering editable', async function (assert) {
         res_id: threadId,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     await click('.o_FollowerListMenu_buttonFollowers');
     assert.containsOnce(
@@ -123,10 +125,11 @@ QUnit.test('click on partner follower details', async function (assert) {
         res_model: 'res.partner',
     });
     const openFormDef = makeDeferred();
-    const { click, createChatterContainerComponent, env } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { click, env, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     patchWithCleanup(env.services.action, {
         doAction(action) {
@@ -180,21 +183,27 @@ QUnit.test('click on edit follower', async function (assert) {
         res_id: threadId,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent, messaging } = await start({
+    const { click, messaging, openView } = await start({
         async mockRPC(route, args) {
             if (route.includes('/mail/read_subscription_data')) {
                 assert.step('fetch_subtypes');
             }
         },
     });
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     const thread = messaging.models['Thread'].create({
         id: threadId,
         model: 'res.partner',
     });
     await thread.fetchData(['followers']);
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     await click('.o_FollowerListMenu_buttonFollowers');
     assert.containsOnce(
@@ -231,7 +240,7 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
         res_id: threadId,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({
+    const { click, openView } = await start({
         async mockRPC(route, args) {
             if (route.includes('/mail/read_subscription_data')) {
                 assert.step('fetch_subtypes');
@@ -246,9 +255,10 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     await click('.o_FollowerListMenu_buttonFollowers');
     assert.containsOnce(

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -25,10 +25,11 @@ QUnit.test('basic rendering', async function (assert) {
         model: 'res.partner',
         res_id: threadId,
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.strictEqual(
         document.querySelectorAll('.o_Message').length,
@@ -111,10 +112,11 @@ QUnit.test('Notification Sent', async function (assert) {
         notification_type: 'email',
         res_partner_id: resPartnerId,
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -183,7 +185,12 @@ QUnit.test('Notification Error', async function (assert) {
         res_partner_id: resPartnerId,
     });
     const openResendActionDef = makeDeferred();
-    const { createChatterContainerComponent, env } = await start();
+    const { env, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction(action, options) {
             assert.step('do_action');
@@ -199,10 +206,6 @@ QUnit.test('Notification Error', async function (assert) {
             );
             openResendActionDef.resolve();
         },
-    });
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
     });
 
     assert.containsOnce(
@@ -695,10 +698,11 @@ QUnit.test('subtype description should be displayed if it is different than body
         res_id: threadId,
         subtype_id: subtypeId,
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -724,10 +728,11 @@ QUnit.test('subtype description should not be displayed if it is similar to body
         res_id: threadId,
         subtype_id: subtypeId,
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -751,7 +756,12 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
         model: 'res.partner',
         res_id: threadId,
     });
-    const { createChatterContainerComponent, env } = await start();
+    const { env, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         doAction(action) {
             assert.strictEqual(
@@ -771,10 +781,6 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
             );
             assert.step('do-action:openFormView_some.model_250');
         },
-    });
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
     });
     assert.containsOnce(
         document.body,
@@ -806,10 +812,11 @@ QUnit.test('chat with author should be opened after clicking on their avatar', a
         model: 'res.partner',
         res_id: threadId,
     });
-    const { click, createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { click, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     assert.containsOnce(
         document.body,
@@ -850,10 +857,13 @@ QUnit.test('chat with author should be opened after clicking on their im status 
         model: 'res.partner',
         res_id: threadId,
     });
-    const { advanceTime, click, createChatterContainerComponent } = await start({ hasTimeControl: true });
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { advanceTime, click, openView } = await start({
+        hasTimeControl: true,
+    });
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     await afterNextRender(() => advanceTime(50 * 1000)); // next fetch of im_status
     assert.containsOnce(
@@ -928,31 +938,6 @@ QUnit.test('open chat with author on avatar click should be disabled when curren
     );
 });
 
-QUnit.test('message should not be considered as "clicked" after clicking on its author name', async function (assert) {
-    assert.expect(1);
-
-    const pyEnv = await startServer();
-    const [threadId, partnerId] = pyEnv['res.partner'].create([{}, {}]);
-    pyEnv['mail.message'].create({
-        author_id: partnerId,
-        body: "<p>Test</p>",
-        model: 'res.partner',
-        res_id: threadId,
-    });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
-    });
-    document.querySelector(`.o_Message_authorName`).click();
-    await nextAnimationFrame();
-    assert.doesNotHaveClass(
-        document.querySelector(`.o_Message`),
-        'o-clicked',
-        "message should not be considered as 'clicked' after clicking on its author name"
-    );
-});
-
 QUnit.test('message should not be considered as "clicked" after clicking on its author avatar', async function (assert) {
     assert.expect(1);
 
@@ -964,10 +949,11 @@ QUnit.test('message should not be considered as "clicked" after clicking on its 
         model: 'res.partner',
         res_id: threadId,
     });
-    const { createChatterContainerComponent } = await start();
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
+    const { openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
     });
     document.querySelector(`.o_Message_authorAvatar`).click();
     await nextAnimationFrame();
@@ -993,14 +979,15 @@ QUnit.test('message should not be considered as "clicked" after clicking on noti
         notification_status: 'exception',
         notification_type: 'email',
     });
-    const { createChatterContainerComponent, env } = await start();
+    const { env, openView } = await start();
+    await openView({
+        res_id: threadId,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     patchWithCleanup(env.services.action, {
         // intercept the action: this action is not relevant in the context of this test.
         doAction() {},
-    });
-    await createChatterContainerComponent({
-        threadId,
-        threadModel: 'res.partner',
     });
     document.querySelector('.o_Message_notificationIconClickable.o-error').click();
     await nextAnimationFrame();

--- a/addons/mail/static/tests/qunit_suite_tests/models/file_uploader_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/file_uploader_tests.js
@@ -1,10 +1,9 @@
 /** @odoo-module **/
 
-import { start, startServer } from '@mail/../tests/helpers/test_utils';
+import { start, startServer, dropFiles, dragenterFiles } from '@mail/../tests/helpers/test_utils';
+import { dom, file } from 'web.test_utils';
 
-import { file } from 'web.test_utils';
-
-const { createFile, inputFiles } = file;
+const { createFile } = file;
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('file_uploader', {}, function () {
@@ -14,45 +13,70 @@ QUnit.test('no conflicts between file uploaders', async function (assert) {
     assert.expect(2);
 
     const pyEnv = await startServer();
-    const [resPartnerId1, resPartnerId2] = pyEnv['res.partner'].create([{}, {}]);
-    const { afterNextRender, createChatterContainerComponent, messaging } = await start();
-    const firstChatterContainerComponent = await createChatterContainerComponent({
-        threadId: resPartnerId1,
-        threadModel: 'res.partner',
+    const resPartnerId1 = pyEnv['res.partner'].create({});
+    const channelId =  pyEnv['mail.channel'].create({});
+    pyEnv['mail.message'].create({
+        body: 'not empty',
+        model: 'mail.channel',
+        res_id: channelId,
     });
-    const secondChatterContainerComponent = await createChatterContainerComponent({
-        threadId: resPartnerId2,
-        threadModel: 'res.partner',
-    });
+    const { afterNextRender, click, messaging, openView } = await start();
 
+    // Uploading file in the first thread: res.partner chatter.
+    await openView({
+        res_id: resPartnerId1,
+        res_model: 'res.partner',
+        views: [[false, 'form']],
+    });
     const file1 = await createFile({
         name: 'text1.txt',
         content: 'hello, world',
         contentType: 'text/plain',
     });
-    await afterNextRender(() => inputFiles(
-        firstChatterContainerComponent.chatter.fileUploader.fileInput,
-        [file1]
-    ));
-    assert.strictEqual(
-        messaging.models['Attachment'].all().length,
-        1,
-        'Uploaded file should be the only attachment created'
+    await afterNextRender(() =>
+        dragenterFiles(document.querySelector('.o_Chatter'))
+    );
+    await afterNextRender(() =>
+        dropFiles(document.querySelector('.o_Chatter_dropZone'), [file1])
     );
 
+    // Uploading file in the second thread: mail.channel in chatWindow.
+    await click(`.o_MessagingMenu_toggler`);
+    await click(`.o_NotificationListItem[data-thread-local-id="${
+        messaging.models['Thread'].findFromIdentifyingData({
+            id: channelId,
+            model: 'mail.channel',
+        }).localId
+    }"]`);
     const file2 = await createFile({
         name: 'text2.txt',
         content: 'hello, world',
         contentType: 'text/plain',
     });
-    await afterNextRender(() => inputFiles(
-        secondChatterContainerComponent.chatter.fileUploader.fileInput,
-        [file2]
-    ));
+    await afterNextRender(() =>
+        dragenterFiles(document.querySelector('.o_ChatWindow'))
+    );
+    await afterNextRender(() =>
+        dropFiles(document.querySelector('.o_ChatWindow .o_DropZone'), [file2])
+    );
+    await afterNextRender(() =>
+        dom.triggerEvent(
+            document.querySelector('.o_ChatWindow .o_ComposerTextInput_textarea'),
+            'keydown',
+            { key: 'Enter' },
+        )
+    );
+    const channelThread = messaging.models['Thread'].findFromIdentifyingData({ id: channelId, model: 'mail.channel' });
+    const chatterThread = messaging.models['Thread'].findFromIdentifyingData({ id: resPartnerId1, model: 'res.partner' });
     assert.strictEqual(
-        messaging.models['Attachment'].all().length,
-        2,
-        'Uploaded file should be the only attachment added'
+        chatterThread.allAttachments.length,
+        1,
+        'Chatter thread should only have one attachment'
+    );
+    assert.strictEqual(
+        channelThread.allAttachments.length,
+        1,
+        'Channel thread should only have one attachment'
     );
 });
 

--- a/addons/website_slides/static/tests/helpers/view_definitions_setup.js
+++ b/addons/website_slides/static/tests/helpers/view_definitions_setup.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+const viewArchsRegistry = registry.category('mail.view.archs');
+
+viewArchsRegistry.category('form').add(
+    'slide.channel',
+    `<form>
+        <div class="oe_chatter">
+            <field name="activity_ids"/>
+        </div>
+    </form>`
+);

--- a/addons/website_slides/static/tests/qunit_suite_tests/components/activity_tests.js
+++ b/addons/website_slides/static/tests/qunit_suite_tests/components/activity_tests.js
@@ -18,7 +18,7 @@ QUnit.test('grant course access', async function (assert) {
         request_partner_id: resPartnerId1,
         res_model: 'slide.channel',
     });
-    const { createChatterContainerComponent } = await start({
+    const { openView } = await start({
         async mockRPC(route, args) {
             if (args.method === 'action_grant_access') {
                 assert.strictEqual(args.args.length, 1);
@@ -31,9 +31,10 @@ QUnit.test('grant course access', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: slideChannelId1,
-        threadModel: 'slide.channel',
+    await openView({
+        res_id: slideChannelId1,
+        res_model: 'slide.channel',
+        views: [[false, 'form']],
     });
 
     assert.containsOnce(document.body, '.o_Activity', "should have activity component");
@@ -55,7 +56,7 @@ QUnit.test('refuse course access', async function (assert) {
         request_partner_id: resPartnerId1,
         res_model: 'slide.channel',
     });
-    const { createChatterContainerComponent } = await start({
+    const { openView } = await start({
         async mockRPC(route, args) {
             if (args.method === 'action_refuse_access') {
                 assert.strictEqual(args.args.length, 1);
@@ -68,9 +69,10 @@ QUnit.test('refuse course access', async function (assert) {
             }
         },
     });
-    await createChatterContainerComponent({
-        threadId: slideChannelId1,
-        threadModel: 'slide.channel',
+    await openView({
+        res_id: slideChannelId1,
+        res_model: 'slide.channel',
+        views: [[false, 'form']],
     });
 
     assert.containsOnce(document.body, '.o_Activity', "should have activity component");


### PR DESCRIPTION
The createChatterContainer helper was used during tests to mount
a chatter container and test it. However, this approach is not
very realistic and blocks some waiting PRs. In order to get closer
from the reality, let's mount a webClient and open a form view
containing a chatter.

enterprise: https://github.com/odoo/enterprise/pull/28684