### PR TITLE
[FIX] mrp: add read access on BOM to the purchase users

### DIFF
--- a/addons/purchase_mrp/__manifest__.py
+++ b/addons/purchase_mrp/__manifest__.py
@@ -15,7 +15,8 @@ from purchase order.
     """,
     'data': [
         'views/purchase_order_views.xml',
-        'views/mrp_production_views.xml'
+        'views/mrp_production_views.xml',
+        'security/ir.model.access.csv',
     ],
     'depends': ['mrp', 'purchase_stock'],
     'installable': True,

--- a/addons/purchase_mrp/security/ir.model.access.csv
+++ b/addons/purchase_mrp/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mrp_bom_purchase_user,mrp.bom,mrp.model_mrp_bom,purchase.group_purchase_user,1,0,0,0
+access_mrp_bom_line_purchase_user,mrp.bom.line,mrp.model_mrp_bom_line,purchase.group_purchase_user,1,0,0,0


### PR DESCRIPTION
Steps to reproduce the bug:
- Install mrp and purchase
- Create a new user “U1” > give him only the “purchase” user access
- Log in as “U1”
- Go to purchase app > create a new PO
- Try to select any product

Problem:
A user error is triggered because we check if the product has a BOM
but since the user does not have access to MRP, an error is raised

opw-2885982




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
