### PR TITLE
[FIX] l10n_fr : 0% tax in wrong category for repport

### DIFF
--- a/addons/l10n_fr/data/account_tax_data.xml
+++ b/addons/l10n_fr/data/account_tax_data.xml
@@ -1947,7 +1947,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'plus_report_line_ids': [ref('l10n_fr.tax_report_02')],
+                'plus_report_line_ids': [ref('l10n_fr.tax_report_05')],
             }),
             (0,0, {
                 'factor_percent': 100,
@@ -1958,7 +1958,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-                'minus_report_line_ids': [ref('l10n_fr.tax_report_02')],
+                'minus_report_line_ids': [ref('l10n_fr.tax_report_05')],
             }),
             (0,0, {
                 'factor_percent': 100,


### PR DESCRIPTION
Steps to reproduce:
	- install l10n_fr, account_accountant
	- generate an invoice with tax "TVA 0% autres opérations non imposables (vente)"
	- Got to Accounting > Reporting > Tax Report
Issue:
	The last invoice would appear in the 02 "Autres opérations imposables" meanwhile it should appear
	in the Autres opérations non imposables

Solution:
	Change the base data to fit

opw-2882543




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
