### PR TITLE
[FIX] sale_stock: propagate SO line sequence to stock moves

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -435,6 +435,7 @@ class SaleOrderLine(models.Model):
             'warehouse_id': self.order_id.warehouse_id or False,
             'partner_id': self.order_id.partner_shipping_id.id,
             'company_id': self.order_id.company_id,
+            'sequence': self.sequence,
         })
         for line in self.filtered("order_id.commitment_date"):
             date_planned = fields.Datetime.from_string(line.order_id.commitment_date) - timedelta(days=line.order_id.company_id.security_lead)

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -62,7 +62,7 @@ class StockRule(models.Model):
 
     def _get_custom_move_fields(self):
         fields = super(StockRule, self)._get_custom_move_fields()
-        fields += ['sale_line_id', 'partner_id']
+        fields += ['sale_line_id', 'partner_id', 'sequence']
         return fields
 
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The default order of the picking moves generated from a sale order should be the same order as the sale order lines.

Steps to reproduce:
- Create a sale order with several sale lines.
- Change the order of the sale lines.
- Confirm the sale order.
  => The moves of the picking don't maintain same order as set before.



**Current behavior before PR:**

**Desired behavior after PR is merged:**




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr