### PR TITLE
[FIX] account: allow billing user to register payment difference

### DIFF
--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -54,8 +54,7 @@
                                    attrs="{'invisible': ['|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}"/>
                         </group>
                         <group name="group3"
-                               attrs="{'invisible': ['|', ('payment_difference', '=', 0.0), '|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}"
-                               groups="account.group_account_readonly">
+                               attrs="{'invisible': ['|', ('payment_difference', '=', 0.0), '|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}">
                             <label for="payment_difference"/>
                             <div>
                                 <field name="payment_difference"/>


### PR DESCRIPTION
Currently, the register payment button in the invoice form view is
accessible to any Accounting/Billing user. But in the payment register
wizard, the payment difference related fields are only visible for an
Accounting/Auditor user. This does not make sense as the auditor access
level is a read-only role, and there is no dependency between auditor
and billing rights. We should modify the group in the wizard to allow
billing users to use the functionality without the need for accountant
access rights.

Description of the issue/feature this PR addresses:
opw-2865492

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
