### PR TITLE
[MERGE][IMP] web: allow commands to be middle-clickable

### DIFF
--- a/addons/web/static/src/core/commands/command_items.xml
+++ b/addons/web/static/src/core/commands/command_items.xml
@@ -4,6 +4,7 @@
   <t t-name="web.DefaultCommandItem" owl="1">
     <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2 cursor-pointer">
       <t t-slot="name"/>
+      <t t-slot="focusMessage"/>
     </div>
   </t>
 

--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -24,6 +24,10 @@
                     top: 0.4em;
                 }
             }
+            a {
+                text-decoration: none;
+                color: inherit;
+            }
         }
 
     }
@@ -42,6 +46,10 @@
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;
+        }
+        .o_command_focus {
+            white-space: nowrap;
+            opacity: 0.9;
         }
     }
 }

--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -16,9 +16,6 @@
             &_hotkey {
                 align-items: center;
                 justify-content: space-between;
-            }
-
-            &_hotkey, &_left {
                 background-color: inherit;
                 padding: 0.5rem 1.3em;
                 display: flex;
@@ -41,7 +38,7 @@
     }
     .o_command{
         cursor: pointer;
-        .test-ellipsis {
+        .text-ellipsis {
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -18,17 +18,26 @@
             <div class="o_command_category px-0">
               <t t-foreach="category.commands" t-as="command" t-key="command.keyId">
                 <t t-set="commandIndex" t-value="state.commands.indexOf(command)"/>
-                <div t-attf-id="o_command_{{commandIndex}}" class="o_command" t-att-class="{ focused: state.selectedCommand === command }" t-on-click="() => this.onCommandClicked(commandIndex)" t-on-mouseenter="() => this.onCommandMouseEnter(commandIndex)" t-on-close="() => this.props.closeMe()">
-                  <t t-component="command.Component || DefaultCommandItem" name="command.name" searchValue="state.searchValue" t-props="command.props" executeCommand="() => this.executeCommand(command)">
-                    <t t-set-slot="name">
-                      <span class="o_command_name">
-                        <t t-foreach="command.splitName" t-as="name" t-key="name_index">
-                          <b t-if="name_index % 2" t-out="name" class="text-primary"/>
-                          <t t-else="" t-out="name"/>
-                        </t>
-                      </span>
+                <div t-attf-id="o_command_{{commandIndex}}" class="o_command"
+                  t-att-class="{ focused: state.selectedCommand === command }"
+                  t-on-click="(event) => this.onCommandClicked(event, commandIndex)"
+                  t-on-mouseenter="() => this.onCommandMouseEnter(commandIndex)"
+                  t-on-close="() => this.props.closeMe()">
+                  <a t-att-href="command.href">
+                    <t t-component="command.Component || DefaultCommandItem" name="command.name" searchValue="state.searchValue" t-props="command.props" executeCommand="() => this.executeCommand(command)">
+                      <t t-set-slot="name">
+                        <span class="o_command_name text-ellipsis" t-att-title="command.name">
+                          <t t-foreach="command.splitName" t-as="name" t-key="name_index">
+                            <b t-if="name_index % 2" t-out="name" class="text-primary"/>
+                            <t t-else="" t-out="name"/>
+                          </t>
+                        </span>
+                      </t>
+                      <t t-set-slot="focusMessage">
+                          <small t-if="!isMobileOS and command.href and state.selectedCommand === command" class="o_command_focus text-muted"><kbd>⏎</kbd> to open, <kbd><t t-if="isMacOS">CMD</t><t t-else="">CTRL</t></kbd>+<kbd>⏎</kbd> to open in new tab</small>
+                      </t>
                     </t>
-                  </t>
+                  </a>
                 </div>
               </t>
             </div>

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -14,6 +14,7 @@ const { Component, xml, EventBus } = owl;
  *  name: string;
  *  action: ()=>(void | CommandPaletteConfig);
  *  category?: string;
+ *  href?: string;
  * }} Command
  */
 

--- a/addons/web/static/src/webclient/menus/menu_command_item.xml
+++ b/addons/web/static/src/webclient/menus/menu_command_item.xml
@@ -2,12 +2,15 @@
 <templates xml:space="preserve">
 
   <t t-name="web.AppIconCommand" owl="1">
-    <div class="o_command_default position-relative d-flex align-items-center justify-content-between px-4 py-2 cursor-pointer">
-      <t t-slot="name"/>
-      <img t-if="props.webIconData" class="o_app_icon position-relative rounded-1" t-attf-src="{{props.webIconData}}"/>
-      <div t-else="" class="o_app_icon d-flex align-items-center justify-content-center" t-attf-style="background-color:{{props.webIcon.backgroundColor}}" >
+    <div class="o_command_default position-relative d-flex align-items-center px-4 py-2 cursor-pointer">
+      <img t-if="props.webIconData" class="me-2 o_app_icon position-relative rounded-1" t-attf-src="{{props.webIconData}}"/>
+      <div t-else="" class="me-2 o_app_icon d-flex align-items-center justify-content-center" t-attf-style="background-color:{{props.webIcon.backgroundColor}}" >
         <i t-att-class="props.webIcon.iconClass" t-attf-style="color:{{props.webIcon.color}}"></i>
       </div>
+      <t t-slot="name"/>
+      <span class="ms-auto flex-shrink-0">
+        <t t-slot="focusMessage"/>
+      </span>
     </div>
   </t>
 

--- a/addons/web/static/src/webclient/menus/menu_providers.js
+++ b/addons/web/static/src/webclient/menus/menu_providers.js
@@ -40,6 +40,7 @@ commandProviderRegistry.add("menu", {
                     },
                     category: "menu_items",
                     name: menu.parents + " / " + menu.label,
+                    href: menu.href || `#menu_id=${menu.id}&amp;action_id=${menu.actionID}`,
                 });
             });
         }
@@ -63,6 +64,7 @@ commandProviderRegistry.add("menu", {
                 },
                 category: "apps",
                 name: menu.label,
+                href: menu.href || `#menu_id=${menu.id}&amp;action_id=${menu.actionID}`,
                 props,
             });
         });

--- a/addons/web/static/tests/core/commands/command_service_tests.js
+++ b/addons/web/static/tests/core/commands/command_service_tests.js
@@ -913,7 +913,7 @@ QUnit.test("data-command-category", async (assert) => {
     assert.deepEqual(
         [
             ...target.querySelectorAll(
-                ".o_command_category:nth-of-type(1) .o_command > div > span:first-child"
+                ".o_command_category:nth-of-type(1) .o_command > a > div > span:first-child"
             ),
         ].map((el) => el.textContent),
         ["Robert baratheon", "Joffrey baratheon"]
@@ -921,7 +921,7 @@ QUnit.test("data-command-category", async (assert) => {
     assert.deepEqual(
         [
             ...target.querySelectorAll(
-                ".o_command_category:nth-of-type(2) .o_command > div > span:first-child"
+                ".o_command_category:nth-of-type(2) .o_command > a > div > span:first-child"
             ),
         ].map((el) => el.textContent),
         ["Aria stark", "Bran stark"]

--- a/addons/web/static/tests/core/commands/menu_provider_tests.js
+++ b/addons/web/static/tests/core/commands/menu_provider_tests.js
@@ -80,7 +80,7 @@ QUnit.test("displays only apps if the search value is '/'", async (assert) => {
     assert.containsOnce(target, ".o_command_category");
     assert.containsN(target, ".o_command", 2);
     assert.deepEqual(
-        [...target.querySelectorAll(".o_command")].map((el) => el.textContent),
+        [...target.querySelectorAll(".o_command_name")].map((el) => el.textContent),
         ["Contact", "Sales"]
     );
 });
@@ -94,7 +94,7 @@ QUnit.test("displays apps and menu items if the search value is not only '/'", a
     assert.containsOnce(target, ".o_command_palette");
     assert.containsN(target, ".o_command", 3);
     assert.deepEqual(
-        [...target.querySelectorAll(".o_command")].map((el) => el.textContent),
+        [...target.querySelectorAll(".o_command_name")].map((el) => el.textContent),
         ["Sales", "Sales / Info", "Sales / Report"]
     );
 });


### PR DESCRIPTION
Purpose
=======
Allow commands in the command palette to be opened in a new tab by
either CTRL+clicking on the command, CTRL+ENTER or right clicking and
copying the link/opening in new tab.

Specifications
=============
Add new slot `focusMessage` that displays the message (if device is not
a mobile device). The `href` value has then to be defined in the
registry.

Task-2710445