### PR TITLE
[IMP] mail: replace createMessageComponent during tests

### DIFF
--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -400,19 +400,6 @@ function getCreateComposerSuggestionComponent({ env, target }) {
     };
 }
 
-function getCreateMessageComponent({ env, target }) {
-    return async function createMessageComponent(message) {
-        const messageView = env.services.messaging.modelManager.messaging.models['MessageView'].create({
-            message: replace(message),
-            qunitTest: insertAndReplace(),
-        });
-        await createRootMessagingComponent(env, "Message", {
-            props: { record: messageView },
-            target,
-        });
-    };
-}
-
 function getCreateNotificationListComponent({ env, target }) {
     return async function createNotificationListComponent({ filter = 'all' } = {}) {
         const notificationListView = env.services.messaging.modelManager.messaging.models['NotificationListView'].create({
@@ -590,7 +577,6 @@ async function start(param0 = {}) {
         click: getClick({ afterNextRender }),
         createComposerComponent: getCreateComposerComponent({ env: webClient.env, target }),
         createComposerSuggestionComponent: getCreateComposerSuggestionComponent({ env: webClient.env, target }),
-        createMessageComponent: getCreateMessageComponent({ env: webClient.env, target }),
         createNotificationListComponent: getCreateNotificationListComponent({ env: webClient.env, target }),
         createRootMessagingComponent: (componentName, props) => createRootMessagingComponent(webClient.env, componentName, { props, target }),
         createThreadViewComponent: getCreateThreadViewComponent({ afterEvent, env: webClient.env, target }),


### PR DESCRIPTION
The createMessageComponent  helper was used during tests to mount
a message component  and test it. However, this approach is not
very realistic and blocks some waiting PRs. In order to get closer
from the reality, let's mount a webClient so that the message component
can be mounted in its real environment.

enterprise: https://github.com/odoo/enterprise/pull/28720