### PR TITLE
[FIX] purchase_stock: propagate PO line sequence to stock moves

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -404,6 +404,7 @@ class PurchaseOrderLine(models.Model):
             'propagate_cancel': self.propagate_cancel,
             'route_ids': self.order_id.picking_type_id.warehouse_id and [(6, 0, [x.id for x in self.order_id.picking_type_id.warehouse_id.route_ids])] or [],
             'warehouse_id': self.order_id.picking_type_id.warehouse_id.id,
+            'sequence': self.sequence,
         }
         diff_quantity = self.product_qty - qty
         if float_compare(diff_quantity, 0.0,  precision_rounding=self.product_uom.rounding) > 0:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The default order of the picking moves generated from a purchase order should be the same order as the purchase order lines.

Steps to reproduce:
- Create a purchase order with several purchase lines.
- Change the order of the purchase lines.
- Confirm the purchase order.
  => The moves of the picking don't maintain same order as set before.

(purchase version of https://github.com/odoo/odoo/pull/94202)

**Current behavior before PR:**

**Desired behavior after PR is merged:**




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr