### PR TITLE
[IMP] web: update owl from 2.0.0-beta-8 to 2.0.0-beta-10

### DIFF
--- a/addons/web/static/src/core/datepicker/datepicker.xml
+++ b/addons/web/static/src/core/datepicker/datepicker.xml
@@ -8,7 +8,7 @@
                 class="o_datepicker_input o_input datetimepicker-input"
                 t-att-name="props.name"
                 t-att-placeholder="props.placeholder"
-                t-attf-data-target="#{{ datePickerId }}"
+                t-attf-data-target="#{ '#' + datePickerId }"
                 t-att-readonly="props.readonly"
                 t-ref="input"
                 t-on-change="() => this.onDateChange()"

--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -153,7 +153,7 @@ odoo.define('web.OwlCompatibility', function (require) {
         onWillStart() {
             if (!(this.props.Component.prototype instanceof Component)) {
                 this.widget = new this.props.Component(this, ...this.widgetArgs);
-                return this.widget._widgetRenderAndInsert(() => {});
+                return this.widget._widgetRenderAndInsert(() => { });
             }
         }
 
@@ -290,7 +290,7 @@ odoo.define('web.OwlCompatibility', function (require) {
     }
 
     const bodyRef = { get el() { return document.body } };
-    function standaloneAdapter(props = {}, ref=bodyRef) {
+    function standaloneAdapter(props = {}, ref = bodyRef) {
         const env = owl.Component.env;
         const app = new App(null, {
             templates: window.__OWL_TEMPLATES__,
@@ -413,7 +413,7 @@ odoo.define('web.OwlCompatibility', function (require) {
     function prepareForFinish(node) {
         const fiber = node.fiber;
         const complete = fiber.complete;
-        fiber.complete = function() {
+        fiber.complete = function () {
             // if target is not in dom
             // just trigger mounted hooks on the Proxy, not on any other node
             if (!document.contains(this.target)) {
@@ -439,15 +439,18 @@ odoo.define('web.OwlCompatibility', function (require) {
         node.mounted.push(() => {
             toRemount = false;
         });
-        node.updateAndRender = function (props, parentFiber) {
-            const res = updateAndRender.call(this, ...arguments);
-            const rootMounted = parentFiber.root.mounted;
-            if (toRemount && !rootMounted.includes(this.fiber)) {
-                rootMounted.push(this.fiber);
+        if (!node.isPatched) {
+            node.isPatched = true;
+            const renderFn = node.renderFn;
+            node.renderFn = () => {
+                const res = renderFn.call(node, ...arguments);
+                const rootMounted = node.fiber.root.mounted;
+                if (toRemount && !rootMounted.includes(node.fiber)) {
+                    rootMounted.push(node.fiber);
+                }
+                return res;
             }
-            return res;
-        };
-
+        }
         return () => toRemount = true;
     }
     /**
@@ -586,7 +589,7 @@ odoo.define('web.OwlCompatibility', function (require) {
             return this.app.makeNode(ProxyComponent, props);
         }
 
-        setup() {}
+        setup() { }
 
         get el() {
             return this.node.component.el;
@@ -685,7 +688,7 @@ odoo.define('web.OwlCompatibility', function (require) {
                 return;
             }
             recursiveCall(this.node, true, (node) => {
-               for (const cb of node.mounted) {
+                for (const cb of node.mounted) {
                     cb();
                 }
             });

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -127,7 +127,7 @@
         <input type="text" class="o_datepicker_input o_input datetimepicker-input"
             t-att-name="props.name"
             t-att-placeholder="props.placeholder"
-            t-attf-data-target="#{{ datePickerId }}"
+            t-attf-data-target="#{ '#' + datePickerId }"
             t-att-readonly="props.readonly"
             t-ref="autofocus"
             t-on-change="_onInputChange"


### PR DESCRIPTION
Release notes:
https://github.com/odoo/owl/releases/tag/v2.0.0-beta-9
https://github.com/odoo/owl/releases/tag/v2.0.0-beta-10

Details:

fix: event: no crash when using t-on + modifier on slots/components
fix: component: fix props comparison code
fix: component: fix wrong behaviour when using t-on on t-component
fix: component: props values are own property of props object
fix: t-out: allow expressions evaluating as number
fix: compiler: add support for #{...} in string interpolation
imp: slots: add support for t-props on slots props
imp: tooling: add another d.ts file
ref: compiler: remove useless ; in compiled output
ref: move some code around
imp: app: small scale perf improvement
imp: app: add fast path for when component has no prop
imp: validation: add support for value types
fix: compiler: escape backticks in attributes

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
