### PR TITLE
[FIX] account_edi_ubl_cii: hide Factur-X warnings

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -127,6 +127,11 @@ class AccountEdiFormat(models.Model):
                 'success': True,
                 'attachment': attachment,
             }
+
+            # We only want to display warnings/errors for Factur-X for German and French companies
+            if self.code == 'facturx_1_0_05' and invoice.company_id.country_id.code not in ['FR', 'DE']:
+                errors = []
+
             if errors:
                 res[invoice].update({
                     'success': False,

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -15,7 +15,7 @@ DEFAULT_FACTURX_DATE_FORMAT = '%Y%m%d'
 class AccountEdiXmlCII(models.AbstractModel):
     _name = "account.edi.xml.cii"
     _inherit = 'account.edi.common'
-    _description = "Factur-x/XRechnung CII 2.2.0"
+    _description = "Factur-X/XRechnung CII 2.2.0"
 
     def _export_invoice_filename(self, invoice):
         return "factur-x.xml"


### PR DESCRIPTION
Only show the Factur-X warnings for German/French companies because it
might only be useful for them.