### PR TITLE
 [FIX] base: internal server error by binary_record_content

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -390,7 +390,11 @@ class IrHttp(models.AbstractModel):
                 filehash = record['checksum']
 
         if not content:
-            content = record[field] or ''
+            try:
+                content = record[field] or ''
+            except AccessError:
+                # `record[field]` may not be readable for current user -> 404
+                content = ''
 
         # filename
         if not filename:


### PR DESCRIPTION
Steps to reproduce the bug:

- Access website forum by public user, the image avatar of public user was broken.
[Image error]  
(In this case, i changed karma related right of forum for comment all post so form comment for public user was displayed).
![Selection_015](https://user-images.githubusercontent.com/12383306/174980102-76c3465f-caa8-41a1-856d-7a61e669780a.png)
- You also check this error in live instance of Odoo by follow link (go to this link by public user)
https://odoocdn.com/web/image/res.users/208196/avatar_128/40x40?unique=e351129

![Selection_017](https://user-images.githubusercontent.com/12383306/174981186-27e9e1fb-495d-4041-9710-a7cfcc95597e.png)


Problem:

By default, public user and relative partner of this user have status `active=False` (they were archived). And when display avatar of public user the binary_content raise access exception and return internal server error to user.

Solution:
Use try/ except in `_binary_record_content` and return friendly content when exception occur.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

