### PR TITLE
[FIX] hr_recruitment: hired employees field in Job Positions not reca…

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -44,6 +44,12 @@ class Job(models.Model):
     color = fields.Integer("Color Index")
     is_favorite = fields.Boolean(compute='_compute_is_favorite', inverse='_inverse_is_favorite')
     favorite_user_ids = fields.Many2many('res.users', 'job_favorite_user_rel', 'job_id', 'user_id', default=_get_default_favorite_user_ids)
+    no_of_hired_employee = fields.Integer(compute='_compute_no_of_hired_employee', store=True)
+
+    @api.depends('application_ids.date_closed')
+    def _compute_no_of_hired_employee(self):
+        for job in self:
+            job.no_of_hired_employee = len(job.application_ids.filtered(lambda applicant: applicant.date_closed))
 
     def _compute_is_favorite(self):
         for job in self:


### PR DESCRIPTION
…lculating

Step to reproduce issue
1. Go to Recruitment
2. Open a job that is actively recruiting
3. Move an applicant to the contract signed stage

Expected Behavior
When applicant is hired the number of "hired employees" remained
unchanged in the Job Positions view

Solution
`
    @api.depends('application_ids.date_closed')
    def _compute_no_of_hired_employee(self):

        for job in self:
            hired_count = 0
            for applicant in job.application_ids:
                if applicant.date_closed:
                    hired_count += 1
            job.no_of_hired_employee = hired_count
`
This code snippet recalculate the of hired employees whenever am
applicant is hired

opw-2881105

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
