### PR TITLE
[13.0][FIX] purchase_stock lines date propagation

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -274,12 +274,11 @@ class PurchaseOrderLine(models.Model):
                             total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                 line.qty_received = total
 
-    @api.model
-    def create(self, values):
-        line = super(PurchaseOrderLine, self).create(values)
-        if line.order_id.state == 'purchase':
-            line._create_or_update_picking()
-        return line
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super(PurchaseOrderLine, self).create(vals_list)
+        lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
+        return lines
 
     def write(self, values):
         for line in self.filtered(lambda l: not l.display_type):

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -277,6 +277,24 @@ class PurchaseOrderLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         lines = super(PurchaseOrderLine, self).create(vals_list)
+
+        # when no "propagate_date", find if the product has a route with a buy rule,
+        # if yes, use the setting on the rule, if no, set "True" as default.
+        for line, vals in zip(lines, vals_list):
+            if 'propagate_date' not in vals:
+                buy_rules = line.product_id.route_ids.rule_ids.filtered(lambda r: r.action == "buy")
+                if buy_rules:
+                    rule = min(buy_rules, key=lambda r: (r.route_id.sequence, r.sequence))
+                    line.write({
+                        'propagate_date': rule.propagate_date,
+                        'propagate_date_minimum_delta': rule.propagate_date_minimum_delta,
+                    })
+                else:
+                    line.write({
+                        'propagate_date': True,
+                        'propagate_date_minimum_delta': 0,
+                    })
+
         lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
         return lines
 


### PR DESCRIPTION
This fix landed in [saas-13.4](https://github.com/odoo/odoo/tree/saas-13.4) and it was later discarded as in [14.0](https://github.com/odoo/odoo/tree/14.0) all the propagate_date stuff was discarded. Anyway, the bug still exists in [13.0](https://github.com/odoo/odoo/tree/13.0).

From the rationale of the commit:

Before this commit, when we manually create a PO line, the propagate_date will always be `False`. So the change on scheduled date will never pass to corresponding move.

After this commit, when create a PO line, if no propagate_date for it, we find if the product has a route with a buy rule. If yes, use the setting on its first buy rule, if no, set the default to be true.


cc @Tecnativa TT37567

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
