### PR TITLE
[FIX] website_sale: Use company bank instead of acquirer to generate qr code

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1849,7 +1849,7 @@
                         <b>Communication: </b><span t-esc='order.reference'/>
                     </div>
                     <div t-if="payment_tx_id.acquirer_id.sudo().qr_code">
-                        <t t-set="qr_code" t-value="payment_tx_id.acquirer_id.sudo().journal_id.bank_account_id.build_qr_code_base64(order.amount_total,payment_tx_id.reference, None, payment_tx_id.currency_id, payment_tx_id.partner_id)"/>
+                        <t t-set="qr_code" t-value="payment_tx_id.company_id.partner_id.bank_ids[:1].build_qr_code_base64(order.amount_total,payment_tx_id.reference, None, payment_tx_id.currency_id, payment_tx_id.partner_id)"/>
                         <div class="card-body" t-if="qr_code">
                             <h3>Or scan me with your banking app.</h3>
                             <img class="border border-dark rounded" t-att-src="qr_code"/>


### PR DESCRIPTION
Before this commit wire transfer was using this line to generate qr code
`payment_tx_id.acquirer_id.sudo().journal_id.bank_account_id.build_qr_code_base64`
But this is a problem has transfert doesn't use `journal_id`.

Instead we can use the bank_id of the company's partner_id.

opw-2855065