### PR TITLE
[IMP] knowledge: improve article tree in sidebar

### DIFF
--- a/addons/knowledge/controllers/main.py
+++ b/addons/knowledge/controllers/main.py
@@ -153,12 +153,17 @@ class KnowledgeController(http.Controller):
         )
 
     @http.route('/knowledge/tree_panel/children', type='json', auth='user')
-    def get_tree_panel_children(self, parent_id):
+    def get_tree_panel_children(self, parent_id, loaded_ids=None):
         parent = self._fetch_article(parent_id)
         if not parent:
             return werkzeug.exceptions.NotFound()
+
+        articles = parent.child_ids
+        if loaded_ids:
+            articles = articles.filtered(lambda article: article.id not in loaded_ids)
+
         return request.env['ir.qweb']._render('knowledge.articles_template', {
-            'articles': parent.child_ids,
+            'articles': articles.sorted("sequence"),
             'portal_readonly_mode': not request.env.user.has_group('base.group_user'),  # used to bypass access check (to speed up loading)
         })
 

--- a/addons/knowledge/static/src/js/knowledge_controller.js
+++ b/addons/knowledge/static/src/js/knowledge_controller.js
@@ -372,12 +372,13 @@ const KnowledgeArticleFormController = FormController.extend({
         if (!articleId) {
             return;
         }
-        this.do_action('knowledge.ir_actions_server_knowledge_home_page', {
+        await this.do_action('knowledge.ir_actions_server_knowledge_home_page', {
             stackPosition: 'replaceCurrentAction',
             additional_context: {
                 res_id: articleId
             }
         });
+        document.getElementById(`article_${articleId}`).scrollIntoView(false);
     },
     /**
      * @returns {Array[String]}

--- a/addons/knowledge/static/src/js/knowledge_renderers.js
+++ b/addons/knowledge/static/src/js/knowledge_renderers.js
@@ -89,10 +89,11 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
      */
     _onBtnArticleCreateClick: function (event) {
         const $target = $(event.currentTarget);
-        const $li = $target.closest('li');
+        const parentId = $target.closest('li').data('article-id');
         this.trigger_up('create', {
-            target_parent_id: $li.data('article-id')
+            target_parent_id: parentId
         });
+        this._addUnfolded(parentId.toString());
     },
     /**
      * @param {Event} event
@@ -355,20 +356,48 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
                 $li.siblings('.o_knowledge_empty_info').addClass('d-none');
                 this.$('.o_knowledge_empty_info:only-child').removeClass('d-none');
                 this.trigger_up('move', {...data,
-                    onSuccess: () => {
+                    onSuccess: async () => {
                         const id = $li.data('parent-id');
                         if (typeof id !== 'undefined') {
                             const $parent = this.$(`.o_article[data-article-id="${id}"]`);
                             if (!$parent.children('ul').is(':parent')) {
                                 const $caret = $parent.find('> .o_article_handle > .o_article_caret');
                                 $caret.remove();
+                                this._removeUnfolded(id.toString());
                             }
                         }
                         if ($parent.length > 0) {
-                            const $handle = $parent.children('.o_article_handle:first');
-                            if ($handle.children('.o_article_caret').length === 0) {
+                            const $first_parent = $parent.first();
+                            const $caret = $first_parent.find('> .o_article_handle > .o_article_caret');
+                            // Show other children if parent already had any
+                            if ($caret.length > 0) {
+                                const $icon = $caret.find("> i");
+                                if ($icon.hasClass("fa-caret-right")) {
+                                    const $ul = $first_parent.find('> div > ul');
+                                    if ($ul.length) {
+                                        // Show children content stored in sibling
+                                        $first_parent.find('> ul').prepend($ul.find('> li'));
+                                        $ul.remove();
+                                    } else {
+                                        // Call the children content
+                                        const children = await this._rpc({
+                                            route: '/knowledge/tree_panel/children',
+                                            params: {
+                                                parent_id: $first_parent.data('article-id'),
+                                                loaded_ids: [$li.data('article-id')],
+                                            }
+                                        });
+                                        $first_parent.find('> ul').prepend(children);
+                                    }
+                                    this._addUnfolded($first_parent.data('article-id').toString());
+                                    $icon.removeClass('fa-caret-right');
+                                    $icon.addClass('fa-caret-down');
+                                }
+                            } else {
+                                const $handle = $parent.children('.o_article_handle:first');
                                 const $caret = $(QWeb.render('knowledge.knowledge_article_caret', {}));
                                 $handle.prepend($caret);
+                                this._addUnfolded($first_parent.data('article-id').toString());
                             }
                         }
                         $li.data('parent-id', $parent.data('article-id'));

--- a/addons/website_knowledge/controllers/main.py
+++ b/addons/website_knowledge/controllers/main.py
@@ -17,5 +17,5 @@ class KnowledgeWebsiteController(KnowledgeController):
         return super().access_knowledge_home()
 
     @http.route('/knowledge/tree_panel/children', type='json', auth='public', website=True, sitemap=False)
-    def get_tree_panel_children(self, parent_id):
-        return super().get_tree_panel_children(parent_id)
+    def get_tree_panel_children(self, parent_id, loaded_ids=None):
+        return super().get_tree_panel_children(parent_id, loaded_ids)


### PR DESCRIPTION
Purpose:
========

- Fix unfolded articles caching: previously, articles where added
or removed from the list of unfodled articles in the cache only when
clicking on the caret that folds or unfolds an article. Therefore,
when a child article was created or when an article was moved under
a parent article, these new parent articles were not added to the
cache and were folded when selecting another article.
Article ids are now also added/removed from the list of unfolded
articles when an article has been (un)folded without clicking on a
caret.

- Fix moving articles under folded articles: previously, moving an
article under a folded article was either not possible if the article
had been unfolded and refolded before, or it overwrote the other
existing children if it had not been unfolded before.
The former issue arises because when one folds an article, the "ul"
containing the children articles was simply hidden, which is not
compatible with NestedSortable. Therefore, instead of only hiding the
"ul", it is moved to one of its siblings, so that one can move it
back when one unfolds the parent again, or when an article is moved
under it. This trick also allows to always place the moved article as
the last child of it's parent, which was not the case with other
approaches tried.
To solve the latter issue, an RPC is now done to fetch the other
children of the parent when an article is moved under this parent and
when the children have not been fetched yet.

- Fix ordering of articles fetched through a RPC: previously, the
order of the articles fetched when unfolding an article was not the
same as the one when these articles were loaded on page load, causing
articles to change position when unfolding then selecting an article.
The order is now the same in both cases.

- Scroll to articles in the sidebar when created: when one creates an
article, it spawns at the bottom of its section/group of children in
the sidebar. Now, the sideview is scrolled in order to have the
handle of the newly created article in the view.

Task-2858704