### PR TITLE
[FIX] mail: allow a normal user to view the mail template preview

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -69,11 +69,21 @@ class MailTemplate(models.Model):
                                         help="Sidebar action to make this template available on records "
                                              "of the related document model")
 
+    # access
+    can_write = fields.Boolean(compute='_compute_can_write',
+                               help='The current user can edit the template.')
+
     # Overrides of mail.render.mixin
     @api.depends('model')
     def _compute_render_model(self):
         for template in self:
             template.render_model = template.model
+
+    @api.depends_context('uid')
+    def _compute_can_write(self):
+        writable_templates = self._filter_access_rules('write')
+        for template in self:
+            template.can_write = template in writable_templates
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -46,7 +46,10 @@
                                 <div class="oe_title">
                                     <h2 style="display: inline-block;"><field name="subject" placeholder="Subject (placeholders may be used here)"/></h2>
                                 </div>
-                                <field name="body_html" widget="html" class="oe-bordered-editor" options="{'style-inline': true, 'codeview': true }"/>
+                                <field name="can_write" invisible="1"/>
+                                <field name="body_html" widget="html" class="oe-bordered-editor"
+                                    options="{'style-inline': true, 'codeview': true }"
+                                    attrs="{'readonly': [('can_write', '=', False)]}"/>
                                 <field name="attachment_ids" widget="many2many_binary"/>
                             </page>
                             <page string="Email Configuration" name="email_configuration">

--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -25,9 +25,10 @@ class MailTemplatePreview(models.TransientModel):
         if not result.get('mail_template_id') or 'resource_ref' not in fields:
             return result
         mail_template = self.env['mail.template'].browse(result['mail_template_id'])
-        res = self.env[mail_template.model_id.model].search([], limit=1)
+        model = mail_template.sudo().model
+        res = self.env[model].search([], limit=1)
         if res:
-            result['resource_ref'] = '%s,%s' % (mail_template.model_id.model, res.id)
+            result['resource_ref'] = '%s,%s' % (model, res.id)
         return result
 
     mail_template_id = fields.Many2one('mail.template', string='Related Mail Template', required=True)
@@ -53,7 +54,8 @@ class MailTemplatePreview(models.TransientModel):
     @api.depends('model_id')
     def _compute_no_record(self):
         for preview in self:
-            preview.no_record = (self.env[preview.model_id.model].search_count([]) == 0) if preview.model_id else True
+            model_id = preview.sudo().model_id
+            preview.no_record = (self.env[model_id.model].search_count([]) == 0) if model_id else True
 
     @api.depends('lang', 'resource_ref')
     def _compute_mail_template_fields(self):


### PR DESCRIPTION
Bug
===
A user without administration right can not preview a mail template
because on the ACl on the <ir.model>.

Task-2845877