### PR TITLE
[IMP] mail, *: remove createMessagingMenu during tests

### DIFF
--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -30,8 +30,7 @@ QUnit.test('closing a chat window with no message from admin side unpins it', as
             uuid: 'channel-10-uuid',
         },
     );
-    const { createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { messaging } = await start();
 
     await afterNextRender(() => document.querySelector(`.o_MessagingMenu_toggler`).click());
     await afterNextRender(() => document.querySelector(`.o_NotificationList_preview`).click());

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -23,8 +23,7 @@ QUnit.test('livechats should be in "chat" filter', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { messaging } = await start();
     assert.containsOnce(
         document.body,
         '.o_MessagingMenu',

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { ChatterContainer } from '@mail/components/chatter_container/chatter_container';
-import { MessagingMenuContainer } from '@mail/components/messaging_menu_container/messaging_menu_container';
 import { insertAndReplace, replace } from '@mail/model/model_field_command';
 import { getMessagingComponent } from '@mail/utils/messaging_component';
 import { nextTick } from '@mail/utils/utils';
@@ -451,12 +450,6 @@ function getCreateMessageComponent({ env, target }) {
     };
 }
 
-function getCreateMessagingMenuComponent({ env, target }) {
-    return async function createMessagingMenuComponent() {
-        return await createRootComponent(env, MessagingMenuContainer, { target });
-    };
-}
-
 function getCreateNotificationListComponent({ env, target }) {
     return async function createNotificationListComponent({ filter = 'all' } = {}) {
         const notificationListView = env.services.messaging.modelManager.messaging.models['NotificationListView'].create({
@@ -636,7 +629,6 @@ async function start(param0 = {}) {
         createComposerComponent: getCreateComposerComponent({ env: webClient.env, target }),
         createComposerSuggestionComponent: getCreateComposerSuggestionComponent({ env: webClient.env, target }),
         createMessageComponent: getCreateMessageComponent({ env: webClient.env, target }),
-        createMessagingMenuComponent: getCreateMessagingMenuComponent({ env: webClient.env, target }),
         createNotificationListComponent: getCreateNotificationListComponent({ env: webClient.env, target }),
         createRootMessagingComponent: (componentName, props) => createRootMessagingComponent(webClient.env, componentName, { props, target }),
         createThreadViewComponent: getCreateThreadViewComponent({ afterEvent, env: webClient.env, target }),

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -9,6 +9,7 @@ import { DialogManagerContainer } from '@mail/components/dialog_manager_containe
 import { DiscussContainer } from '@mail/components/discuss_container/discuss_container';
 import { PopoverManagerContainer } from '@mail/components/popover_manager_container/popover_manager_container';
 import { messagingService } from '@mail/services/messaging_service';
+import { systrayService } from '@mail/services/systray_service';
 import { makeMessagingToLegacyEnv } from '@mail/utils/make_messaging_to_legacy_env';
 
 import { registry } from '@web/core/registry';
@@ -109,6 +110,7 @@ function setupMessagingServiceRegistries({
         const { key, operation } = ev.detail;
         if (key === 'legacy_bus_service' && operation === 'add') {
             serviceRegistry.add('messaging', messagingService);
+            serviceRegistry.add('systray_service', systrayService);
             serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));
             serviceRegistry.removeEventListener('UPDATE', addMessagingToRegistryFn);
         }

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -59,8 +59,7 @@ QUnit.test('initial mount', async function (assert) {
 QUnit.test('chat window new message: basic rendering', async function (assert) {
     assert.expect(10);
 
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
     assert.strictEqual(
@@ -118,8 +117,7 @@ QUnit.test('chat window new message: basic rendering', async function (assert) {
 QUnit.test('chat window new message: focused on open [REQUIRE FOCUS]', async function (assert) {
     assert.expect(2);
 
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
     assert.ok(
@@ -136,8 +134,7 @@ QUnit.test('chat window new message: focused on open [REQUIRE FOCUS]', async fun
 QUnit.test('chat window new message: close', async function (assert) {
     assert.expect(1);
 
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
     await click(`.o_ChatWindow_header .o_ChatWindowHeader_commandClose`);
@@ -151,8 +148,7 @@ QUnit.test('chat window new message: close', async function (assert) {
 QUnit.test('chat window new message: fold', async function (assert) {
     assert.expect(6);
 
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
     assert.doesNotHaveClass(
@@ -232,14 +228,13 @@ QUnit.test('open chat from "new message" chat window should open chat in place o
     ]);
     const imSearchDef = makeDeferred();
     patchUiSize({ width: 1920 });
-    const { click, createMessagingMenuComponent, insertText, messaging } = await start({
+    const { click, insertText, messaging } = await start({
         mockRPC(route, args) {
             if (args.method === 'im_search') {
                 imSearchDef.resolve();
             }
         }
     });
-    await createMessagingMenuComponent();
     assert.containsN(
         document.body,
         '.o_ChatWindow',
@@ -347,8 +342,7 @@ QUnit.test('new message chat window should close on selecting the user if chat w
         name: "Partner 131",
         public: 'private',
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent, click } = await start();
 
     // open "new message" chat window
     await click(`.o_MessagingMenu_toggler`);
@@ -389,14 +383,13 @@ QUnit.test('new message autocomplete should automatically select first result', 
     const resPartnerId1 = pyEnv['res.partner'].create({ name: "Partner 131" });
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
     const imSearchDef = makeDeferred();
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         mockRPC(route, args) {
             if (args.method === 'im_search') {
                 imSearchDef.resolve();
             }
         },
     });
-    await createMessagingMenuComponent();
 
     // open "new message" chat window
     await click(`.o_MessagingMenu_toggler`);
@@ -425,8 +418,7 @@ QUnit.test('chat window: basic rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_NotificationList_preview`);
@@ -511,14 +503,13 @@ QUnit.test('chat window: fold', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create({});
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         mockRPC(route, args) {
             if (args.method === 'channel_fold') {
                 assert.step(`rpc:${args.method}/${args.kwargs.state}`);
             }
         },
     });
-    await createMessagingMenuComponent();
     // Open Thread
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_dropdownMenu .o_NotificationList_preview`);
@@ -562,14 +553,13 @@ QUnit.test('chat window: open / close', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create({});
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         mockRPC(route, args) {
             if (args.method === 'channel_fold') {
                 assert.step(`rpc:channel_fold/${args.kwargs.state}`);
             }
         },
     });
-    await createMessagingMenuComponent();
     assert.containsNone(
         document.body,
         '.o_ChatWindow',
@@ -626,8 +616,7 @@ QUnit.test('Mobile: opening a chat window should not update channel state on the
         ],
     });
     patchUiSize({ size: SIZES.SM });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_NotificationList_preview`);
     assert.containsOnce(
@@ -656,8 +645,7 @@ QUnit.test('Mobile: closing a chat window should not update channel state on the
         ],
     });
     patchUiSize({ size: SIZES.SM });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_NotificationList_preview`);
     assert.containsOnce(
@@ -873,8 +861,7 @@ QUnit.test('chat window: composer state conservation on toggle discuss', async f
 
     const pyEnv = await startServer();
     const mailChannelId = pyEnv['mail.channel'].create({});
-    const { click, createMessagingMenuComponent, insertText, openDiscuss, openView } = await start();
-    const messagingMenuComponent = await createMessagingMenuComponent();
+    const { click, insertText, messaging, openDiscuss, openView } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_dropdownMenu .o_NotificationList_preview`);
     // Set content of the composer of the chat window
@@ -899,7 +886,7 @@ QUnit.test('chat window: composer state conservation on toggle discuss', async f
     ];
     await afterNextRender(() =>
         inputFiles(
-            messagingMenuComponent.messaging.chatWindowManager.chatWindows[0].threadView.composerView.fileUploader.fileInput,
+            messaging.chatWindowManager.chatWindows[0].threadView.composerView.fileUploader.fileInput,
             files
         )
     );
@@ -948,8 +935,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, openDiscuss, openView } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent, click, openDiscuss, openView } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
@@ -1028,8 +1014,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'mailChannel1' }, { name: 'mailChannel2' }]);
     patchUiSize({ width: 1920 }); // enough to fit at least 2 chat windows
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
@@ -1158,8 +1143,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         { name: 'mailChannel3' },
     ]);
     patchUiSize({ width: 900 }); // enough to fit 2 chat windows but not 3
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
 
     // open, from systray menu, chat windows of channels with Id 1, 2, then 3
     await click(`.o_MessagingMenu_toggler`);
@@ -1281,8 +1265,7 @@ QUnit.test('chat window: switch on TAB', async function (assert) {
 
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'channel1' }, { name: 'channel2' }]);
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     await click(`
@@ -1486,8 +1469,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent, click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
@@ -1606,8 +1588,7 @@ QUnit.test('chat window: post message on non-mailing channel with "CTRL-Enter" k
         ],
     });
     patchUiSize({ size: SIZES.SM });
-    const { click, createMessagingMenuComponent, insertText } = await start();
-    await createMessagingMenuComponent();
+    const { click, insertText } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_dropdownMenu .o_NotificationList_preview`);
@@ -1636,8 +1617,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, openDiscuss, openView } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent, click, openDiscuss, openView } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
@@ -2063,8 +2043,7 @@ QUnit.test('should not have chat window hidden menu in mobile (transition from 2
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'mailChannel1' }, { name: 'mailChannel1' }]);
     patchUiSize({ width: 600 }); // enough to fit 1 chat window + hidden menu
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
     // open, from systray menu, chat windows of channels with id 1, 2
     await click('.o_MessagingMenu_toggler');
     await click(`

--- a/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -28,11 +28,10 @@ QUnit.test('[technical] messaging not created then becomes created', async funct
     assert.expect(2);
 
     const messagingBeforeCreationDeferred = makeTestPromise();
-    const { createMessagingMenuComponent } = await start({
+    await start({
         messagingBeforeCreationDeferred,
         waitUntilMessagingCondition: 'none',
     });
-    await createMessagingMenuComponent();
     assert.containsOnce(
         document.body,
         '.o_MessagingMenuContainer_spinner',
@@ -51,7 +50,7 @@ QUnit.test('[technical] messaging not created then becomes created', async funct
 QUnit.test('messaging not initialized', async function (assert) {
     assert.expect(2);
 
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         async mockRPC(route) {
             if (route === '/mail/init_messaging') {
                 // simulate messaging never initialized
@@ -60,7 +59,6 @@ QUnit.test('messaging not initialized', async function (assert) {
         },
         waitUntilMessagingCondition: 'created',
     });
-    await createMessagingMenuComponent();
     assert.strictEqual(
         document.querySelectorAll('.o_MessagingMenu_loading').length,
         1,
@@ -80,7 +78,7 @@ QUnit.test('messaging becomes initialized', async function (assert) {
 
     const messagingInitializedProm = makeTestPromise();
 
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         async mockRPC(route) {
             if (route === '/mail/init_messaging') {
                 await messagingInitializedProm;
@@ -88,7 +86,6 @@ QUnit.test('messaging becomes initialized', async function (assert) {
         },
         waitUntilMessagingCondition: 'created',
     });
-    await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
 
     // simulate messaging becomes initialized
@@ -113,8 +110,7 @@ QUnit.test('basic rendering', async function (assert) {
             permission: 'denied',
         },
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     assert.strictEqual(
         document.querySelectorAll('.o_MessagingMenu').length,
         1,
@@ -258,8 +254,7 @@ QUnit.test('counter is taking into account failure notification', async function
         notification_status: 'exception', // necessary value to have a failure
         notification_type: 'email',
     });
-    const { createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    await start();
 
     assert.containsOnce(
         document.body,
@@ -276,8 +271,7 @@ QUnit.test('counter is taking into account failure notification', async function
 QUnit.test('switch tab', async function (assert) {
     assert.expect(15);
 
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.strictEqual(
@@ -378,8 +372,7 @@ QUnit.test('switch tab', async function (assert) {
 QUnit.test('new message', async function (assert) {
     assert.expect(3);
 
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
 
@@ -401,10 +394,9 @@ QUnit.test('new message', async function (assert) {
 QUnit.test('no new message when discuss is open', async function (assert) {
     assert.expect(3);
 
-    const { click, createMessagingMenuComponent, openDiscuss, openView } = await start({
+    const { click, openDiscuss, openView } = await start({
         autoOpenDiscuss: true,
     });
-    await createMessagingMenuComponent();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.strictEqual(
@@ -444,8 +436,7 @@ QUnit.test('channel preview: basic rendering', async function (assert) {
         model: 'mail.channel', // necessary to link message to channel
         res_id: mailChannelId1, // id of related channel
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.strictEqual(
@@ -542,8 +533,7 @@ QUnit.test('filtered previews', async function (assert) {
             res_id: mailChannelId2, // id of related channel
         },
     ]);
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.strictEqual(
@@ -686,8 +676,7 @@ QUnit.test('open chat window from preview', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create({});
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_dropdownMenu .o_ThreadPreview`);
@@ -708,8 +697,7 @@ QUnit.test('no code injection in message body preview', async function (assert) 
         model: "mail.channel",
         res_id: mailChannelId1,
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.containsOnce(
@@ -750,8 +738,7 @@ QUnit.test('no code injection in message body preview from sanitized message', a
         model: "mail.channel",
         res_id: mailChannelId1,
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.containsOnce(
@@ -792,8 +779,7 @@ QUnit.test('<br/> tags in message body preview are transformed in spaces', async
         model: "mail.channel",
         res_id: mailChannelId1,
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.containsOnce(
@@ -827,8 +813,7 @@ QUnit.test('rendering with OdooBot has a request (default)', async function (ass
             permission: 'default',
         },
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     assert.ok(
         document.querySelector('.o_MessagingMenu_counter'),
@@ -861,8 +846,7 @@ QUnit.test('rendering without OdooBot has a request (denied)', async function (a
             permission: 'denied',
         },
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     assert.containsNone(
         document.body,
@@ -886,8 +870,7 @@ QUnit.test('rendering without OdooBot has a request (accepted)', async function 
             permission: 'granted',
         },
     });
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
 
     assert.containsNone(
         document.body,
@@ -915,7 +898,7 @@ QUnit.test('respond to notification prompt (denied)', async function (assert) {
             },
         },
     });
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         services: {
             notification: makeFakeNotificationService(() => {
                 assert.step(
@@ -924,7 +907,6 @@ QUnit.test('respond to notification prompt (denied)', async function (assert) {
             }),
         },
     });
-    await createMessagingMenuComponent();
 
     await click('.o_MessagingMenu_toggler');
     await click('.o_NotificationRequest');
@@ -953,8 +935,7 @@ QUnit.test('Group chat should be displayed inside the chat section of the messag
     const mailChannelId1 = pyEnv['mail.channel'].create({
         channel_type: 'group',
     });
-    const { click, createMessagingMenuComponent, messaging } = await start();
-    await createMessagingMenuComponent();
+    const { click, messaging } = await start();
 
     await click('.o_MessagingMenu_toggler');
     await click(`.o_MessagingMenuTab[data-tab-id="chat"]`);

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
@@ -25,7 +25,7 @@ QUnit.test('mark as read', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await start({
+    const { afterEvent, click } = await start({
         async mockRPC(route, args) {
             if (route.includes('mark_all_as_read')) {
                 assert.step('mark_all_as_read');
@@ -40,7 +40,6 @@ QUnit.test('mark as read', async function (assert) {
             }
         },
     });
-    await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),
@@ -84,7 +83,7 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await start({
+    const { afterEvent, click } = await start({
         async mockRPC(route, args) {
             if (route.includes('mark_all_as_read')) {
                 assert.step('mark_all_as_read');
@@ -99,7 +98,6 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
             }
         },
     });
-    await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),
@@ -148,7 +146,7 @@ QUnit.test('click on expand from chat window should close the chat window and op
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click, createMessagingMenuComponent, env } = await start();
+    const { afterEvent, click, env } = await start();
     patchWithCleanup(env.services.action, {
         doAction(action) {
             assert.step('do_action');
@@ -164,7 +162,6 @@ QUnit.test('click on expand from chat window should close the chat window and op
             );
         },
     });
-    await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),
@@ -222,7 +219,7 @@ QUnit.test('[technical] opening a non-channel chat window should not call channe
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await start({
+    const { afterEvent, click } = await start({
         async mockRPC(route, args) {
             if (route.includes('channel_fold')) {
                 const message = "should not call channel_fold when opening a non-channel chat window";
@@ -232,7 +229,6 @@ QUnit.test('[technical] opening a non-channel chat window should not call channe
             }
         },
     });
-    await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),
@@ -287,8 +283,7 @@ QUnit.test('preview should display last needaction message preview even if there
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent } = await start();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),
@@ -328,8 +323,7 @@ QUnit.test('chat window header should not have unread counter for non-channel th
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent, click } = await start();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_preview_tests.js
@@ -29,14 +29,13 @@ QUnit.test('mark as read', async function (assert) {
     const [mailChannelPartnerId] = pyEnv['mail.channel.partner'].search([['channel_id', '=', mailChannelId1], ['partner_id', '=', pyEnv.currentPartnerId]]);
     pyEnv['mail.channel.partner'].write([mailChannelPartnerId], { seen_message_id: mailMessageId1 });
 
-    const { click, createMessagingMenuComponent } = await start({
+    const { click } = await start({
         async mockRPC(route, args) {
             if (route.includes('set_last_seen_message')) {
                 assert.step('set_last_seen_message');
             }
         },
     });
-    await createMessagingMenuComponent();
     await click('.o_MessagingMenu_toggler');
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -769,12 +769,11 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, messaging } = await start();
+    const { afterEvent, click, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel'
     });
-    await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
@@ -834,13 +833,12 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, messaging } = await start();
+    const { afterEvent, click, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel'
     });
 
-    await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',

--- a/addons/test_mail/static/tests/systray_activity_menu_tests.js
+++ b/addons/test_mail/static/tests/systray_activity_menu_tests.js
@@ -162,8 +162,7 @@ QUnit.test('activity menu widget: close on messaging menu click', async function
 
     legacySystrayItems.push(ActivityMenu);
     registerCleanup(() => legacySystrayItems.pop());
-    const { click, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { click } = await start();
     await testUtils.nextTick();
 
     await testUtils.dom.click(document.querySelector('.dropdown-toggle[title="Activities"]'));

--- a/addons/test_mail_full/static/tests/qunit_suite_tests/thread_needaction_preview_tests.js
+++ b/addons/test_mail_full/static/tests/qunit_suite_tests/thread_needaction_preview_tests.js
@@ -30,8 +30,7 @@ QUnit.test('rating value displayed on the thread needaction preview', async func
         rating_image_url: "/rating/static/src/img/rating_5.png",
         rating_text: "top",
     }]);
-    const { afterEvent, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent } = await start();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),

--- a/addons/test_mail_full/static/tests/qunit_suite_tests/thread_preview_tests.js
+++ b/addons/test_mail_full/static/tests/qunit_suite_tests/thread_preview_tests.js
@@ -21,8 +21,7 @@ QUnit.test('rating value displayed on the thread preview', async function (asser
         rating_image_url: "/rating/static/src/img/rating_5.png",
         rating_text: "top",
     });
-    const { afterEvent, createMessagingMenuComponent } = await start();
-    await createMessagingMenuComponent();
+    const { afterEvent } = await start();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),


### PR DESCRIPTION
*: im_livechat, test_mail, test_mail_full.

The createMessagingMenu helper was used during tests to mount
a messaging menu and test it. However, this approach is not
very realistic and blocks some waiting PRs. In order to get closer
from the reality, let's instanciate a webClient and a systrayService
for the messagingMenu to be present at all time.

enterprise: https://github.com/odoo/enterprise/pull/28747