### PR TITLE
[FIX] account_edi_ubl_cii: fix edi options on journal

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -105,6 +105,15 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         return journal.type == 'sale'
 
+    def _is_enabled_by_default_on_journal(self, journal):
+        """ Indicate if the EDI format should be selected by default on the journal passed as parameter.
+        If True, this EDI format will be selected by default on the journal.
+
+        :param journal: The journal.
+        :returns: True if this format should be enabled by default on the journal, False otherwise.
+        """
+        return True
+
     def _is_embedding_to_invoice_pdf_needed(self):
         """ Indicate if the EDI must be embedded inside the PDF report.
 

--- a/addons/account_edi/models/account_journal.py
+++ b/addons/account_edi/models/account_journal.py
@@ -4,6 +4,8 @@
 from odoo import api, models, fields, _
 from odoo.exceptions import UserError
 
+from collections import defaultdict
+
 
 class AccountJournal(models.Model):
     _inherit = 'account.journal'
@@ -47,11 +49,34 @@ class AccountJournal(models.Model):
 
         for journal in self:
             compatible_edis = edi_formats.filtered(lambda e: e._is_compatible_with_journal(journal))
-            journal.compatible_edi_ids += compatible_edis
+            journal.compatible_edi_ids = compatible_edis
 
     @api.depends('type', 'company_id', 'company_id.country_id')
     def _compute_edi_format_ids(self):
         edi_formats = self.env['account.edi.format'].search([])
+        journal_ids = self.ids
+
+        if journal_ids:
+            self._cr.execute('''
+                SELECT
+                    move.journal_id,
+                    ARRAY_AGG(doc.edi_format_id) AS edi_format_ids
+                FROM account_edi_document doc
+                JOIN account_move move ON move.id = doc.move_id
+                WHERE doc.state IN ('to_cancel', 'to_send')
+                AND move.journal_id IN %s
+                GROUP BY move.journal_id
+            ''', [tuple(journal_ids)])
+            protected_edi_formats_per_journal = {r[0]: set(r[1]) for r in self._cr.fetchall()}
+        else:
+            protected_edi_formats_per_journal = defaultdict(set)
 
         for journal in self:
-            journal.edi_format_ids += edi_formats.filtered(lambda e: e._is_compatible_with_journal(journal))
+            enabled_edi_formats = edi_formats.filtered(lambda e: e._is_compatible_with_journal(journal) and
+                                                                 e._is_enabled_by_default_on_journal(journal))
+
+            # The existing edi formats that are already in use so we can't remove it.
+            protected_edi_format_ids = protected_edi_formats_per_journal.get(journal.id, set())
+            protected_edi_formats = journal.edi_format_ids.filtered(lambda e: e.id in protected_edi_format_ids)
+
+            journal.edi_format_ids = enabled_edi_formats + protected_edi_formats

--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -87,7 +87,7 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         if self.code not in FORMAT_CODES:
             return super()._is_compatible_with_journal(journal)
-        return self._is_ubl_cii_available(journal.company_id)
+        return self._is_ubl_cii_available(journal.company_id) and journal.type == 'sale'
 
     def _is_enabled_by_default_on_journal(self, journal):
         # EXTENDS account_edi
@@ -107,6 +107,7 @@ class AccountEdiFormat(models.Model):
         res = {}
         for invoice in invoices:
             builder = self._get_xml_builder(invoice.company_id)
+            # For now, the errors are not displayed anywhere, don't want to annoy the user
             xml_content, errors = builder._export_invoice(invoice)
 
             # DEBUG: send directly to the test platform (the one used by ecosio)
@@ -127,14 +128,6 @@ class AccountEdiFormat(models.Model):
                 'success': True,
                 'attachment': attachment,
             }
-            if errors:
-                res[invoice].update({
-                    'success': False,
-                    'error': _("Errors occured while creating the EDI document (format: %s). The receiver "
-                               "might refuse it.", builder._description)
-                             + '<p> <li>' + "</li> <li>".join(errors) + '</li> </p>',
-                    'blocking_level': 'info',
-                })
 
         return res
 


### PR DESCRIPTION
In 14.0, `_is_enabled_by_default_on_journal` does not exist, thus
every edi.format is enabled by default. This commit allows to only
have facturx enabled by default.

In addition, we only want the edi.format options to appear
on the sale journals (out_invoice, out_refund).

Finally, the warnings are no longer displayed on top of the invoice.