### PR TITLE
[FIX] hr_timesheet: avoid setting an archived employee to a timesheet in the form view

### DIFF
--- a/addons/hr_timesheet/i18n/hr_timesheet.pot
+++ b/addons/hr_timesheet/i18n/hr_timesheet.pot
@@ -1138,6 +1138,12 @@ msgid "Timesheets can be logged on this task."
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/hr_timesheet.py:0
+#, python-format
+msgid "Timesheets must be created with an active employee."
+msgstr ""
+
+#. module: hr_timesheet
 #: model:digest.tip,name:hr_timesheet.digest_tip_hr_timesheet_0
 msgid "Tip: Record your Timesheets faster"
 msgstr ""
@@ -1280,6 +1286,12 @@ msgid ""
 "You cannot log timesheets on this project since it is linked to an inactive "
 "analytic account. Please change this account, or reactivate the current one "
 "to timesheet on the project."
+msgstr ""
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/hr_timesheet.py:0
+#, python-format
+msgid "You cannot set an archived employee to the existing timesheets."
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -120,11 +120,12 @@ class AccountAnalyticLine(models.Model):
 
         # Although this make a second loop on the vals, we need to wait the preprocess as it could change the company_id in the vals
         # TODO To be refactored in master
-        employees = self.env['hr.employee'].sudo().with_context(active_test=False).search([('user_id', 'in', user_ids)])
+        employees = self.env['hr.employee'].sudo().search([('user_id', 'in', user_ids)])
         employee_for_user_company = defaultdict(dict)
         for employee in employees:
             employee_for_user_company[employee.user_id.id][employee.company_id.id] = employee.id
 
+        employee_ids = set()
         for vals in vals_list:
             # compute employee only for timesheet lines, makes no sense for other lines
             if not vals.get('employee_id') and vals.get('project_id'):
@@ -133,7 +134,10 @@ class AccountAnalyticLine(models.Model):
                     continue
                 company_id = list(employee_for_company)[0] if len(employee_for_company) == 1 else vals.get('company_id', self.env.company.id)
                 vals['employee_id'] = employee_for_company.get(company_id, False)
-
+            elif vals.get('employee_id'):
+                employee_ids.add(vals['employee_id'])
+        if any(not emp.active for emp in self.env['hr.employee'].browse(list(employee_ids))):
+            raise UserError(_('Timesheets must be created with an active employee.'))
         lines = super(AccountAnalyticLine, self).create(vals_list)
         for line, values in zip(lines, vals_list):
             if line.project_id:  # applied only for timesheet
@@ -146,6 +150,10 @@ class AccountAnalyticLine(models.Model):
             raise AccessError(_("You cannot access timesheets that are not yours."))
 
         values = self._timesheet_preprocess(values)
+        if values.get('employee_id'):
+            employee = self.env['hr.employee'].browse(values['employee_id'])
+            if not employee.active:
+                raise UserError(_('You cannot set an archived employee to the existing timesheets.'))
         if 'name' in values and not values.get('name'):
             values['name'] = '/'
         result = super(AccountAnalyticLine, self).write(values)

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -419,3 +419,22 @@ class TestTimesheet(TestCommonTimesheet):
             timesheet1.unit_amount + timesheet2.unit_amount,
             'The total timesheet time of this project should be equal to 4.'
         )
+    def test_create_timesheet_with_archived_employee(self):
+        ''' the timesheet can be created or edited only with an active employee
+        '''
+        self.empl_employee2.active = False
+        batch_vals = {
+            'project_id': self.project_customer.id,
+            'task_id': self.task1.id,
+            'name': 'archived employee timesheet',
+            'unit_amount': 3,
+            'employee_id': self.empl_employee2.id
+        }
+
+        self.assertRaises(UserError, self.env['account.analytic.line'].create, batch_vals)
+
+        batch_vals["employee_id"] = self.empl_employee.id
+        timesheet = self.env['account.analytic.line'].create(batch_vals)
+
+        with self.assertRaises(UserError):
+            timesheet.employee_id = self.empl_employee2

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -46,6 +46,7 @@
                     <attribute name="invisible">0</attribute>
                     <attribute name="required">1</attribute>
                     <attribute name="widget">many2one_avatar_employee</attribute>
+                    <attribute name="context">{'active_test': True}</attribute>
                 </xpath>
             </field>
         </record>
@@ -151,7 +152,7 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='date']" position="before">
-                    <field name="employee_id" required="1"/>
+                    <field name="employee_id" required="1" context="{'active_test': True}"/>
                     <field name="user_id" invisible="1"/>
                 </xpath>
             </field>

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -112,7 +112,7 @@
                         <tree editable="bottom" string="Timesheet Activities" default_order="date">
                             <field name="date"/>
                             <field name="user_id" invisible="1"/>
-                            <field name="employee_id" required="1" widget="many2one_avatar_employee"/>
+                            <field name="employee_id" required="1" widget="many2one_avatar_employee" context="{'active_test': True}"/>
                             <field name="name" required="0"/>
                             <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                             <field name="project_id" invisible="1"/>
@@ -122,7 +122,7 @@
                         <kanban class="o_kanban_mobile">
                             <field name="date"/>
                             <field name="user_id"/>
-                            <field name="employee_id" widget="many2one_avatar_employee"/>
+                            <field name="employee_id" widget="many2one_avatar_employee" context="{'active_test': True}"/>
                             <field name="name"/>
                             <field name="unit_amount" decoration-danger="unit_amount &gt; 24"/>
                             <field name="project_id"/>
@@ -157,7 +157,7 @@
                                  <group>
                                     <field name="date"/>
                                     <field name="user_id" invisible="1"/>
-                                    <field name="employee_id" required="1" widget="many2one_avatar_employee"/>
+                                    <field name="employee_id" required="1" widget="many2one_avatar_employee" context="{'active_test': True}"/>
                                     <field name="name" required="0"/>
                                     <field name="unit_amount" string="Duration" widget="float_time" decoration-danger="unit_amount &gt; 24"/>
                                     <field name="project_id" invisible="1"/>


### PR DESCRIPTION
Steps to reproduce:
- Install timesheet
- Archive an employee
- Create a timesheet

Current behavior:
You can select the archived employee

Expected behavior:
You can not select the archived employee

Explanation:
In commit 17b2b07e76121ebb0be16637bf4082e457c2ac63 the employee_id
field of the timesheet was set to have context active_test to false.
To fix this issue we reset the context for this field in every
timesheet form. 

A task exist to fix the issue on master id 2884736

opw-2887727
opw-2870739

