### PR TITLE
[FIX] pos_restaurant: SubmitOrder bug

### DIFF
--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -509,7 +509,7 @@ var PosDB = core.Class.extend({
     },
     /**
      * Return the orders with requested ids if they are unpaid.
-     * @param {array<number>} ids order_ids.
+     * @param {array<string>} ids order_ids (uid).
      * @return {array<object>} list of orders.
      */
     get_unpaid_orders_to_sync: function(ids){

--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -154,6 +154,13 @@ models.Order = models.Order.extend({
             line.set_dirty(false);
         });
         this.trigger('change',this);
+        // We sync if the caller is not the current order.
+        // Otherwise, cached "changes" fields (mp_dirty, saved_resume)
+        // will be invalidated without reaching the server
+        const isTheCurrentOrder = this.pos.get_order() && this.pos.get_order().uid === this.uid;
+        if (!isTheCurrentOrder && this.server_id) {
+            this.pos.sync_from_server(null, [this], [this.uid]);
+        }
     },
     computeChanges: function(categories){
         var current_res = this.build_line_resume();


### PR DESCRIPTION
Prior to this fix,
Order.saveChanges() could run when the
user is in the floor view (did not wait for printing to finish)
==> printing changes are not synced correctly

Fix,
Check if the current order matches the order from
PosModel.get_order() and has a server_id
if it does, call this.pos.sync_from_server on the current order




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
