### PR TITLE
[MERGE][FIX] various: display full name/title in form views

### DIFF
--- a/addons/coupon/views/coupon_program_views.xml
+++ b/addons/coupon/views/coupon_program_views.xml
@@ -192,7 +192,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='title']" position="inside">
                 <label for="name" string="Program Name"/>
-                <h1><field name="name" class="oe_title o_text_overflow" placeholder="e.g. 10% Discount" height="20px"/></h1>
+                <h1><field name="name" class="oe_title text-break" placeholder="e.g. 10% Discount" height="20px"/></h1>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" type="action" icon="fa-ticket" name="%(coupon.coupon_action)d" attrs="{'invisible': [('promo_applicability', '=', 'on_current_order')]}">

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -50,7 +50,7 @@
                         <div class="oe_title">
                             <label for="name" string="Lead" attrs="{'invisible': [('type', '=', 'opportunity')]}"/>
                             <label for="name" attrs="{'invisible': [('type', '=', 'lead')]}"/>
-                            <h1><field class="o_text_overflow" name="name" placeholder="e.g. Product Pricing"/></h1>
+                            <h1><field class="text-break" name="name" placeholder="e.g. Product Pricing"/></h1>
                             <h2 class="o_row no-gutters align-items-end">
                                 <div class="col" attrs="{'invisible': [('type', '=', 'lead')]}">
                                     <label for="expected_revenue" class="oe_edit_only" />

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -189,7 +189,7 @@
                         <field name="kanban_state" widget="state_selection" class="ml-auto float-right"/>
                         <div class="oe_title">
                             <label for="name" string="Event Name"/>
-                            <h1><field class="o_text_overflow" name="name" placeholder="e.g. Conference for Architects"/></h1>
+                            <h1><field class="text-break" name="name" placeholder="e.g. Conference for Architects"/></h1>
                         </div>
                         <group>
                             <group>

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -55,7 +55,7 @@
     // For large devices, limit the width of subject and adjust the emoji widget accordingly
     @include media-breakpoint-up(md) {
         input.o_field_char.o_field_widget {
-            min-width: 86%;
+            max-width: 86%;
         }
         .o_mail_add_emoji {
             right: 14%;

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -161,7 +161,7 @@
                     <div class="oe_title">
                         <label for="name" string="Contact Name"/>
                         <h1>
-                            <field class="o_text_overflow" name="name" placeholder="e.g. John Smith"/>
+                            <field class="text-break" name="name" placeholder="e.g. John Smith"/>
                         </h1>
                         <div>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%%"/>

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -90,7 +90,7 @@
                     <div class="oe_title">
                         <label for="name"/>
                         <h1>
-                            <field name="name" class="o_text_overflow" placeholder="e.g. Consumer Newsletter"/>
+                            <field name="name" class="text-break" placeholder="e.g. Consumer Newsletter"/>
                         </h1>
                     </div>
                     <group>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -167,7 +167,7 @@
                             <field name="active" invisible="1"/>
                             <field name="mailing_type" widget="radio" options="{'horizontal': true}" invisible="1"
                                 attrs="{'readonly': [('state', '!=', 'draft')]}" force_save="1"/>
-                            <field class="o_text_overflow" name="subject" string="Subject" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
+                            <field class="text-break" name="subject" string="Subject" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
                             <label for="mailing_model_id" string="Recipients"/>
                             <div name="mailing_model_id_container">
                                 <div class="row">

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -102,7 +102,7 @@
                     For an SMS Text Message, internal Title of the Message.</attribute>
             </xpath>
             <xpath expr="//field[@name='subject']" position="after">
-                <field class="o_text_overflow" name="sms_subject" string="Title" placeholder="e.g. Black Friday SMS coupon" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))], 'required': [('mailing_type', '=', 'sms')]}"/>
+                <field class="text-break" name="sms_subject" string="Title" placeholder="e.g. Black Friday SMS coupon" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))], 'required': [('mailing_type', '=', 'sms')]}"/>
             </xpath>
             <xpath expr="//field[@name='preview']" position="attributes">
                 <attribute name="attrs">{'readonly': [('state', 'in', ('sending', 'done'))], 'invisible': [('mailing_type', '!=', 'mail')]}</attribute>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -43,7 +43,7 @@
                         <h1>
                             <div class="d-flex">
                                 <field name="priority" widget="priority" class="mr-3"/>
-                                <field class="o_text_overflow" name="name" placeholder="e.g. Cheese Burger"/>
+                                <field class="text-break" name="name" placeholder="e.g. Cheese Burger"/>
                             </div>
                         </h1>
                     </div>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -365,7 +365,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
                         <h1>
-                            <field name="name" class="o_text_overflow" placeholder="Project Name"/>
+                            <field name="name" class="text-break" placeholder="Project Name"/>
                         </h1>
                     </div>
                     <group>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -32,7 +32,7 @@
                     <div class="oe_title">
                         <label for="name" string="Sales Team"/>
                         <h1>
-                            <field class="o_text_overflow" name="name" placeholder="e.g. North America"/>
+                            <field class="text-break" name="name" placeholder="e.g. North America"/>
                         </h1>
                         <div name="options_active"/>
                     </div>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -31,7 +31,7 @@
                     <div class="oe_button_box d-flex justify-content-end" name="button_box">
                     </div>
                     <group id="top-group">
-                        <field class="o_text_overflow" name="name" string="Campaign Name" placeholder="e.g. Black Friday"/>
+                        <field class="text-break" name="name" string="Campaign Name" placeholder="e.g. Black Friday"/>
                         <field name="user_id" domain="[('share', '=', False)]"/>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                     </group>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -168,8 +168,8 @@
                         <field name="country_code" invisible="1"/>
                         <field name="company_type" widget="radio" options="{'horizontal': true}"/>
                         <h1>
-                            <field id="company" class="o_text_overflow" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact'),('is_company', '=', True)], 'invisible': [('is_company','=', False)]}"/>
-                            <field id="individual" class="o_text_overflow" name="name" default_focus="1" placeholder="e.g. Brandom Freeman" attrs="{'required' : [('type', '=', 'contact'), ('is_company', '=', False)], 'invisible': [('is_company','=', True)]}"/>
+                            <field id="company" class="text-break" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact'),('is_company', '=', True)], 'invisible': [('is_company','=', False)]}"/>
+                            <field id="individual" class="text-break" name="name" default_focus="1" placeholder="e.g. Brandom Freeman" attrs="{'required' : [('type', '=', 'contact'), ('is_company', '=', False)], 'invisible': [('is_company','=', True)]}"/>
                         </h1>
                         <div class="o_row">
                             <field name="parent_id"


### PR DESCRIPTION
With commit[1], we added `o_text_overflow` classes at several places to avoid
long names going out of the boxes. However, for the name/title fields in the
form views, we should always show the full name.

So this commit replaces `o_text_overflow` class with `text-break` from
name/title fields in the form views to display full string in the read
only mode, but also keep them from going outside of the form view.

Below are the modules affected:
 - base
 - coupon
 - crm
 - event
 - mass_mailing
 - mass_mailing_sms
 - project
 - sales_team

commit[1] - https://github.com/odoo/odoo/commit/a0ebb4609848a65f9b6a14a94030ad3144a95038

task-2889845