### PR TITLE
[IMP] survey: add tooltip for presenter on live survey

### DIFF
--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -28,6 +28,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
     start: function () {
         var self = this;
         this.fadeInOutTime = 500;
+        this.$('[data-toggle="tooltip"]').tooltip({ delay: 0 });
         return this._super.apply(this, arguments).then(function () {
             if (self.$el.data('isSessionClosed')) {
                 self._displaySessionClosedPage();
@@ -68,6 +69,9 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             setupPromises.push(self._setupLeaderboard());
 
             self.$el.removeClass('invisible');
+            if (!self.isStartScreen) {
+                self._updateNextPageTooltip();
+            }
             return Promise.all(setupPromises);
         });
     },
@@ -178,6 +182,9 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         }
 
         this.currentScreen = screenToDisplay;
+        if (['userInputs', 'results', 'leaderboard', 'leaderboardFinal'].includes(screenToDisplay)) {
+            this._updateNextPageTooltip();
+        }
     },
 
     /**
@@ -213,6 +220,9 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         }
 
         this.currentScreen = screenToDisplay;
+        if (['question', 'userInputs', 'results'].includes(screenToDisplay)) {
+            this._updateNextPageTooltip();
+        }
     },
 
     /**
@@ -413,6 +423,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             $('div.o_survey_background').css("background-image", "url(" + this.nextQuestion.background_image_url + ")");
             $('div.o_survey_background').removeClass('o_survey_background_transition');
         }
+        this._updateNextPageTooltip();
     },
 
     /**
@@ -656,6 +667,25 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             this.resultsChart.setShowAnswers(showAnswers);
             this.resultsChart.updateChart();
         }
+    },
+
+    /**
+     * Updates the tooltip for current page (on right arrow icon for 'Next' content).
+     * this method will be called on Clicking of Next and Previous Arrow to fetch the
+     * tooltip for the Next Content.
+     */
+    _updateNextPageTooltip: function() {
+        this._rpc({
+            route: _.str.sprintf('/survey/session/tooltip/%s', this.surveyAccessToken),
+            params: {
+                current_screen: this.currentScreen
+            }
+        }).then((tooltip) => {
+            const sessionNavigationNextEl = this.el.querySelector('.o_survey_session_navigation_next');
+            if (sessionNavigationNextEl && tooltip) {
+                sessionNavigationNextEl.dataset.originalTitle = tooltip;
+            }
+        });
     }
 });
 

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -46,7 +46,7 @@
                         </h2>
                     </div>
                     <a role="button"
-                        class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
+                        class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" data-toggle="tooltip" data-placement="left" title="Start"/>
                 </div>
             </div>
         </t>
@@ -109,7 +109,7 @@
                     <div t-field="survey.description_done"/>
                 </div>
                 <a role="button"
-                    class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
+                    class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" data-toggle="tooltip" data-placement="left"/>
                 <a role="button"
                     class="font-weight-bold fa fa-chevron-left o_survey_session_navigation o_survey_session_navigation_previous p-3" />
                 <div class="o_survey_session_results flex-column flex-grow-1 mx-5">


### PR DESCRIPTION
Current behavior before PR:

While filling out the survey user don't have any idea about the upcoming
Section/Question.

Desired behavior after PR is merged:

Ease the job of the live speaker by letting them know in advance
what the next slide will be about.
Added a label next to the arrow icon based on what the next slide will be.

Task: https://www.odoo.com/web#id=2791000&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
