### PR TITLE
[FIX] web_editor: style qweb element in odoo editor

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -391,6 +391,7 @@ function classToStyle($editable, cssRules) {
  * @param {JQuery} [$iframe] the iframe containing the editable, if any
  */
 function toInline($editable, cssRules, $iframe) {
+    $editable.removeClass('odoo-editor-editable');
     const editable = $editable.get(0);
     const iframe = $iframe && $iframe.get(0);
     const doc = editable.ownerDocument;
@@ -448,6 +449,7 @@ function toInline($editable, cssRules, $iframe) {
     for (const [node, displayValue] of displaysToRestore) {
         node.style.setProperty('display', displayValue);
     }
+    $editable.addClass('odoo-editor-editable');
 }
 /**
  * Convert font icons to images.

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -877,7 +877,7 @@ section, .oe_img_bg, [data-oe-shape-data] {
 
 /* QWEB */
 
-.odoo-editor, .o_readonly {
+.odoo-editor-editable, .o_readonly {
     t,
     [t-if],
     [t-elif],


### PR DESCRIPTION
Before this commit, the styles for the qweb elements
(t, t-if, t-out, ...) were not applied.
This commit apply them except when converting html to inline
styling.

task-2892193




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
