### PR TITLE
[13.0][FIX] delivery: Set the correct value of shipping_weight from pickings

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -66,7 +66,8 @@ class StockPicking(models.Model):
     @api.depends('package_ids', 'weight_bulk')
     def _compute_shipping_weight(self):
         for picking in self:
-            picking.shipping_weight = picking.weight_bulk + sum([pack.shipping_weight for pack in picking.package_ids])
+            # if shipping weight is not assigned => default to calculated product weight
+            picking.shipping_weight = picking.weight_bulk + sum([pack.shipping_weight or pack.weight for pack in picking.package_ids])
 
     def _get_default_weight_uom(self):
         return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:

picking.shipping_weight calculation has been updated so if a pack.weight = 0 then calculation will default to the calculated
product weight. This prevents inconsistency between the "Total Weight" at the top of the Delivery Slip and the package sections' displayed weights. To distinguish which value is being used, package sections that use the total product weight rather than the pack.weight have "(estimated)" after it. (from https://github.com/odoo/odoo/commit/d20467bb6a2e1e6b07a2db86ee4be199eeeed0e2)

**Impacted versions**:
- 13.0

Related to: https://github.com/OCA/l10n-spain/pull/2372#issuecomment-1163096029

cc @Tecnativa TT37180

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
