### PR TITLE
[IMP] test_mail: add a test case for tracked computed field performances

### DIFF
--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import warnings
+
 from odoo import fields, models
 
 
@@ -25,6 +27,9 @@ class IrModelField(models.Model):
         elif tracking is False:
             tracking = None
         vals['tracking'] = tracking
+
+        if not field.store and tracking:
+            warnings.warn(f"{field.name} is not stored and cannot be tracked")
         return vals
 
     def _instanciate_attrs(self, field_data):

--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -18,7 +18,9 @@ class IrModelField(models.Model):
         set to 100. """
         vals = super(IrModelField, self)._reflect_field_params(field, model_id)
         tracking = getattr(field, 'tracking', None)
-        if tracking is True:
+        if field.related and not field.store:
+            tracking = None  # disable tracking attribute coming from non-stored related field
+        elif tracking is True:
             tracking = 100
         elif tracking is False:
             tracking = None

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -296,7 +296,15 @@ class MailThread(models.AbstractModel):
             return super(MailThread, self).write(values)
 
         if not self._context.get('mail_notrack'):
-            self._track_prepare(self._fields)
+            # only prepare tracking of modified fields
+            # indirectly modified fields to track (such as stored compute)
+            # are handled by '_compute_field_value'
+            computed_stored_fields = {
+                field.name
+                for field in self._fields.values()
+                if field.store and field.compute
+            }
+            self._track_prepare(values.keys() | computed_stored_fields)
 
         # Perform write
         result = super(MailThread, self).write(values)

--- a/addons/test_mail/models/__init__.py
+++ b/addons/test_mail/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_model_fields
 from . import test_mail_corner_case_models
 from . import test_mail_models
 from . import test_mail_thread_models

--- a/addons/test_mail/models/ir_model_fields.py
+++ b/addons/test_mail/models/ir_model_fields.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.tools import mute_logger
+
+
+class IrModelField(models.Model):
+    _inherit = 'ir.model.fields'
+
+    def _reflect_field_params(self, field, model_id):
+        """ Disable the warnings for our specific test model. """
+        if model_id == self.env['ir.model']._get_id('mail.test.track.compute'):
+            with mute_logger('py.warnings'):
+                return super(IrModelField, self)._reflect_field_params(field, model_id)
+        else:
+            return super(IrModelField, self)._reflect_field_params(field, model_id)

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -118,7 +118,8 @@ class MailTestTrackMonetary(models.Model):
     _inherit = ['mail.thread']
 
     company_id = fields.Many2one('res.company')
-    company_currency = fields.Many2one("res.currency", string='Currency', related='company_id.currency_id', readonly=True, tracking=True)
+    company_currency = fields.Many2one("res.currency", string='Currency', related='company_id.currency_id',
+        readonly=True, tracking=True, store=True)
     revenue = fields.Monetary('Revenue', currency_field='company_currency', tracking=True)
 
 

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -89,10 +89,27 @@ class MailTestTrackCompute(models.Model):
     _description = "Test tracking with computed fields"
     _inherit = ['mail.thread']
 
+    description = fields.Char('Description')
     partner_id = fields.Many2one('res.partner', tracking=True)
     partner_name = fields.Char(related='partner_id.name', store=True, tracking=True)
     partner_email = fields.Char(related='partner_id.email', store=True, tracking=True)
     partner_phone = fields.Char(related='partner_id.phone', tracking=True)
+    partner_title_name = fields.Char(compute='_compute_partner_title_name', tracking=True)
+    partner_title_name_stored = fields.Char(compute='_compute_partner_title_name_stored', tracking=True, store=True)
+
+    @api.depends('partner_id')
+    def _compute_partner_title_name(self):
+        # make it purposefully "bad" and go through relationship every time
+        # this will be useful for future query counters
+        for record in self:
+            record.partner_title_name = record.partner_id.title.name
+
+    @api.depends('partner_id')
+    def _compute_partner_title_name_stored(self):
+        # make it purposefully "bad" and go through relationship every time
+        # this will be useful for future query counters
+        for record in self:
+            record.partner_title_name_stored = record.partner_id.title.name
 
 
 class MailTestTrackMonetary(models.Model):

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -248,12 +248,11 @@ class TestTracking(TestMailCommon):
         record.partner_id = partner
         self.flush_tracking()
         self.assertEqual(len(record.message_ids), 2)
-        self.assertEqual(len(record.message_ids[0].tracking_value_ids), 4)
+        self.assertEqual(len(record.message_ids[0].tracking_value_ids), 3)
         self.assertTracking(record.message_ids[0], [
             ('partner_id', 'many2one', False, partner),
             ('partner_name', 'char', False, 'Foo'),
             ('partner_email', 'char', False, 'foo@example.com'),
-            ('partner_phone', 'char', False, '1234567890'),
         ])
 
         # modify partner: one tracking message for the only recomputed field

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -842,20 +842,21 @@ class TestMailComplexPerformance(BaseMailPerformance):
         )
 
         self.env.invalidate_all()
-        with self.assertQueryCount(employee=10):
+        with self.assertQueryCount(employee=9):
             rec.write({'partner_id': self.partners[0].id})
             self.flush_tracking()
 
-        # should properly create a tracking message for 'partner_title_name' and
-        # 'partner_title_name_stored' even if changed indirectly through a computed field
-        self.assertIn('partner_title_name', rec.sudo().message_ids.tracking_value_ids.mapped('field.name'))
+        # should properly create a tracking message for 'partner_title_name_stored'
+        # even if changed indirectly through a computed field
         self.assertIn('partner_title_name_stored', rec.sudo().message_ids.tracking_value_ids.mapped('field.name'))
+        # 'partner_title_name' however should NOT be tracked as it is not stored
+        self.assertNotIn('partner_title_name', rec.sudo().message_ids.tracking_value_ids.mapped('field.name'))
 
         # unlink tracking values to be able to easily test next case
         rec.sudo().message_ids.tracking_value_ids.unlink()
 
         self.env.invalidate_all()
-        with self.assertQueryCount(employee=4):
+        with self.assertQueryCount(employee=2):
             rec.write({'description': 'Updated Description'})
             self.flush_tracking()
 


### PR DESCRIPTION
This commit adds a test case that asserts the query counters when tracking
computed fields through regular write operations.

It is used as a preliminary work for an upcoming optimization.

Task-2801515
