### PR TITLE
[14.0][FIX] account_edi_ubl_cii: Prevent error when zip is not set

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -131,7 +131,7 @@ class AccountEdiCommon(models.AbstractModel):
         # add Norway, Iceland, Liechtenstein
         european_economic_area = self.env.ref('base.europe').country_ids.mapped('code') + ['NO', 'IS', 'LI']
 
-        if customer.country_id.code == 'ES':
+        if customer.country_id.code == 'ES' and customer.zip:
             if customer.zip[:2] in ('35', '38'):  # Canary
                 # [BR-IG-10]-A VAT breakdown (BG-23) with VAT Category code (BT-118) "IGIC" shall not have a VAT
                 # exemption reason code (BT-121) or VAT exemption reason text (BT-120).


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:

Prevent error when zip is not set (since https://github.com/odoo/odoo/commit/b467c2c6536d291ac9b4d426f964fb1d9e309e3f).

**Impacted versions**:
- 14.0
- 15.0
 - master

Related to: https://github.com/OCA/l10n-spain/pull/2370

cc @Tecnativa TT36147

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
