### PR TITLE
[IMP] tests: common.Form, can't write on invisible fields

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -849,6 +849,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         })
 
     def test_in_invoice_line_onchange_cash_rounding_1(self):
+        # Required for `invoice_cash_rounding_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('account.group_cash_rounding')
         # Test 'add_invoice_line' rounding
         move_form = Form(self.invoice)
         # Add a cash rounding having 'add_invoice_line'.
@@ -1193,6 +1195,12 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         })
 
     def test_in_invoice_onchange_past_invoice_1(self):
+        if self.env.ref('purchase.group_purchase_manager', raise_if_not_found=False):
+            # `purchase` adds a view which makes `invoice_vendor_bill_id` invisible
+            # for purchase users
+            # https://github.com/odoo/odoo/blob/385884afd31f25d61e99d139ecd4c574d99a1863/addons/purchase/views/account_move_views.xml#L26
+            self.env.user.groups_id -= self.env.ref('purchase.group_purchase_manager')
+            self.env.user.groups_id -= self.env.ref('purchase.group_purchase_user')
         copy_invoice = self.invoice.copy()
 
         move_form = Form(self.invoice)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1453,6 +1453,8 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         ])
 
     def test_out_invoice_line_onchange_cash_rounding_1(self):
+        # Required for `invoice_cash_rounding_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('account.group_cash_rounding')
         # Test 'add_invoice_line' rounding
         move_form = Form(self.invoice)
         # Add a cash rounding having 'add_invoice_line'.
@@ -1977,7 +1979,8 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         a custom reversal date.
         '''
         move_form = Form(self.invoice)
-        move_form.date = '2016-01-01'
+        # `date` is invisible in the view, the date of the invoice should be set using `invoice_date` instead
+        move_form.invoice_date = '2016-01-01'
         move_form.currency_id = self.currency_data['currency']
         move_form.save()
 
@@ -3459,6 +3462,8 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         move_form.partner_id = self.partner_a
 
         # Quick edit total amount not activated yet
+        # As quick edit total is not yet activated, it's invisible by default in the view
+        move_form._view['modifiers']['quick_edit_total_amount']['invisible'] = False
         move_form.quick_edit_total_amount = 100.0
         invoice = move_form.save()
         self.assertEqual(invoice.amount_total, 0.0)

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -532,6 +532,8 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
         })
 
     def test_out_refund_line_onchange_cash_rounding_1(self):
+        # Required for `invoice_cash_rounding_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('account.group_cash_rounding')
         # Test 'add_invoice_line' rounding
         move_form = Form(self.invoice)
         # Add a cash rounding having 'add_invoice_line'.

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -3536,6 +3536,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         """ Test the CABA entries generated from an invoice with almost
         equal lines, different only on analytic accounting
         """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         # Make the tax account reconcilable
         self.tax_account_1.reconcile = True
 

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -200,10 +200,14 @@ class TestAccountPayment(AccountTestInvoicingCommon):
 
     def test_payment_move_sync_onchange(self):
 
-        pay_form = Form(self.env['account.payment'].with_context(default_journal_id=self.company_data['default_journal_bank'].id))
+        pay_form = Form(self.env['account.payment'].with_context(
+            default_journal_id=self.company_data['default_journal_bank'].id,
+            # The `partner_type` is set through the window action context in the web client
+            # the field is otherwise invisible in the form.
+            default_partner_type='customer',
+        ))
         pay_form.amount = 50.0
         pay_form.payment_type = 'inbound'
-        pay_form.partner_type = 'customer'
         pay_form.partner_id = self.partner_a
         payment = pay_form.save()
 
@@ -246,8 +250,12 @@ class TestAccountPayment(AccountTestInvoicingCommon):
 
         # ==== Check editing the account.payment ====
 
+        # `partner_type` on payment is always invisible. It's supposed to be set through a context `default_` key
+        # In this case the goal of the test is to take an existing customer payment and change it to a supplier payment,
+        # which is not supposed to be possible through the web interface.
+        # So, change the payment partner_type beforehand rather than in the form view.
+        payment.partner_type = 'supplier'
         pay_form = Form(payment)
-        pay_form.partner_type = 'supplier'
         pay_form.currency_id = self.currency_data['currency']
         pay_form.partner_id = self.partner_a
         payment = pay_form.save()

--- a/addons/account/tests/test_payment_term.py
+++ b/addons/account/tests/test_payment_term.py
@@ -73,7 +73,6 @@ class TestAccountInvoiceRounding(AccountTestInvoicingCommon):
         with Form(self.invoice) as move_form:
             move_form.invoice_payment_term_id = pay_term
             move_form.invoice_date = invoice_date
-            move_form.date = invoice_date
         self.assertEqual(
             self.invoice.line_ids.filtered(
                 lambda l: l.account_id == self.company_data['default_account_receivable']

--- a/addons/crm/tests/test_res_partner.py
+++ b/addons/crm/tests/test_res_partner.py
@@ -46,6 +46,20 @@ class TestPartner(TestCrmCommon):
 
         # test form tool
         partner_form = Form(self.env['res.partner'], 'base.view_partner_form')
+        # `parent_id` is invisible when `is_company` is True (`company_type == 'company'`)
+        # and parent_id is not set
+        # So, set a temporary `parent_id` before setting the contact as company
+        # to make `parent_id` visible in the interface while being a company
+        # <field name="parent_id"
+        #     attrs="{
+        #         'invisible': [
+        #             '|',
+        #             '&amp;', ('is_company','=', True),('parent_id', '=', False),
+        #             ('company_name', '!=', False),('company_name', '!=', '')
+        #         ]
+        #     }"
+        # />
+        partner_form.parent_id = contact_company_1
         partner_form.company_type = 'company'
         partner_form.parent_id = contact_company
         partner_form.name = 'Mom Corp'

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -16,6 +16,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             'name': 'Automatic Test',
             'time_type': 'leave',
             'requires_allocation': 'no',
+            # Required for `request_unit_half` to be visible in the view
+            'request_unit': 'half_day',
         })
 
     def test_no_attendances(self):

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -271,6 +271,18 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_form.holiday_status_id = self.holidays_type_1
         leave_form.request_date_from = date(2019, 5, 6)
         leave_form.request_date_to = date(2019, 5, 6)
+        # TODO: The test is wrong by modifying `date_from` and `date_to`, which are invisible
+        # It should edit only `request_date_from` and `request_date_to` instead
+        # And there is really a bug. Using the web client, when you put your PC in Auckland timezone,
+        # and the admin preferences in Auckland Timezone
+        # and create a time off for the current day, the computation is completely wrong
+        # and compute the date to before the date from *-)
+        # For instance, for a time-off from 06/16/2022 to 06/16/2022 (1 day) it computes
+        # 06/16/2022 08:00:00 as date_from and 06/15/2022 17:00:00 as date_to
+        # Bug reported to the rd-fun-vidange channel to the dev who introduced the bug
+        # https://discord.com/channels/678381219515465750/687337760452902925/986918361768263710
+        leave_form._view['modifiers']['date_from']['invisible'] = False
+        leave_form._view['modifiers']['date_to']['invisible'] = False
         leave_form.date_from = datetime(2019, 5, 6, 0, 0, 0)
         leave_form.date_to = datetime(2019, 5, 6, 23, 59, 59)
         leave = leave_form.save()

--- a/addons/hr_holidays/tests/test_stress_days.py
+++ b/addons/hr_holidays/tests/test_stress_days.py
@@ -111,9 +111,9 @@ class TestHrLeaveStressDays(TransactionCase):
 
         with self.assertRaises(ValidationError), Form(self.env['hr.leave'].with_user(self.employee_user.id).with_context(default_employee_id=self.employee_emp.id)) as leave_form:
             leave_form.holiday_status_id = self.leave_type
-            leave_form.date_from = datetime(2021, 11, 1)
-            leave_form.date_to = datetime(2021, 11, 1)
+            leave_form.request_date_from = datetime(2021, 11, 1)
+            leave_form.request_date_to = datetime(2021, 11, 1)
             self.assertFalse(leave_form.has_stress_day)
 
-            leave_form.date_to = datetime(2021, 11, 5)
+            leave_form.request_date_to = datetime(2021, 11, 5)
             self.assertTrue(leave_form.has_stress_day)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/common.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/common.py
@@ -17,6 +17,9 @@ class TestUBLCommon(AccountEdiTestCommon):
     def setUpClass(cls, chart_template_ref=None, edi_format_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref, edi_format_ref=edi_format_ref)
 
+        # Required for `product_uom_id` to be visible in the form views
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
+
         # Ensure the testing currency is using a valid ISO code.
         real_usd = cls.env.ref('base.USD')
         real_usd.name = 'FUSD'

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -122,8 +122,10 @@ class TestMailingListMerge(MassMailCommon):
             active_model='mailing.list'
         ))
         merge_form.new_list_name = False
-        merge_form.dest_list_id = self.mailing_list_3
         merge_form.merge_options = 'existing'
+        # Need to set `merge_options` before `dest_lid_id` so `dest_list_id` is visible
+        # `'invisible': [('merge_options', '=', 'new')]`
+        merge_form.dest_list_id = self.mailing_list_3
         merge_form.archive_src_lists = False
         result_list = merge_form.save().action_mailing_lists_merge()
 

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -66,7 +66,7 @@ class TestMrpCommon(common2.TestStockCommon):
             login='hilda',
             email='h.h@example.com',
             notification_type='inbox',
-            groups='mrp.group_mrp_user, stock.group_stock_user, mrp.group_mrp_byproducts',
+            groups='mrp.group_mrp_user, stock.group_stock_user, mrp.group_mrp_byproducts, uom.group_uom',
         )
         cls.user_mrp_manager = mail_new_test_user(
             cls.env,
@@ -74,8 +74,11 @@ class TestMrpCommon(common2.TestStockCommon):
             login='gary',
             email='g.g@example.com',
             notification_type='inbox',
-            groups='mrp.group_mrp_manager, stock.group_stock_user, mrp.group_mrp_byproducts',
+            groups='mrp.group_mrp_manager, stock.group_stock_user, mrp.group_mrp_byproducts, uom.group_uom',
         )
+        # Required for `product_uom_id` to be visible in the view
+        # This class is used by a lot of tests which sets `product_uom_id` on `mrp.production`
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
 
         cls.workcenter_1 = cls.env['mrp.workcenter'].create({
             'name': 'Nuclear Workcenter',

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -85,6 +85,8 @@ class TestMrpProductionBackorder(TestMrpCommon):
         should be MO/001-02.
         Check that all MO are reachable through the procurement group.
         """
+        # Required for `manufacture_steps` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_adv_location")
         with Form(self.warehouse) as warehouse:
             warehouse.manufacture_steps = 'pbm'
 
@@ -128,6 +130,8 @@ class TestMrpProductionBackorder(TestMrpCommon):
         should be MO/001-02.
         Check that all MO are reachable through the procurement group.
         """
+        # Required for `manufacture_steps` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_adv_location")
         with Form(self.warehouse) as warehouse:
             warehouse.manufacture_steps = 'pbm_sam'
         production, _, product_to_build, product_to_use_1, product_to_use_2 = self.generate_mo(qty_base_1=4, qty_final=4, picking_type_id=self.warehouse.manu_type_id)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -496,6 +496,8 @@ class TestBoM(TestMrpCommon):
             'name': 'Deserts Table'
         })
 
+        # Required to display `operation_ids` in the form view
+        self.env.user.groups_id += self.env.ref("mrp.group_mrp_routings")
         with Form(bom_crumble) as bom:
             with bom.bom_line_ids.new() as line:
                 line.product_id = butter
@@ -660,6 +662,8 @@ class TestBoM(TestMrpCommon):
             'name': 'Deserts Table'
         })
 
+        # Required to display `operation_ids` in the form view
+        self.env.user.groups_id += self.env.ref("mrp.group_mrp_routings")
         with Form(bom_drawer) as bom:
             with bom.bom_line_ids.new() as line:
                 line.product_id = screw

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -134,6 +134,11 @@ class TestMrpMulticompany(common.TransactionCase):
         })
         mo_form = Form(self.env['mrp.production'].with_user(self.user_a))
         mo_form.product_id = product
+        # The mo must be confirmed, no longer in draft, in order for `lot_producing_id` to be visible in the view
+        # <div class="o_row" attrs="{'invisible': ['|', ('state', '=', 'draft'), ('product_tracking', 'in', ('none', False))]}">
+        mo = mo_form.save()
+        mo.action_confirm()
+        mo_form = Form(mo)
         mo_form.lot_producing_id = lot_b
         mo = mo_form.save()
         with self.assertRaises(UserError):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -339,6 +339,8 @@ class TestMrpOrder(TestMrpCommon):
 
     def test_update_quantity_4(self):
         """ Workcenter 1 has 10' start time and 5' stop time """
+        # Required for `workerorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         bom = self.env['mrp.bom'].create({
             'product_id': self.product_6.id,
             'product_tmpl_id': self.product_6.product_tmpl_id.id,
@@ -517,6 +519,11 @@ class TestMrpOrder(TestMrpCommon):
 
         self.assertEqual(production.move_raw_ids.mapped('manual_consumption'), [False, True, True])
 
+        # <field name="qty_producing" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+        production.action_confirm()
+        production.action_assign()
+        production.is_locked = False
+
         # test no updating
         production_form = Form(production)
         production_form.qty_producing = 5
@@ -689,6 +696,11 @@ class TestMrpOrder(TestMrpCommon):
 
         self.stock_shelf_2 = self.stock_location_14
         mo, _, p_final, p1, p2 = self.generate_mo(tracking_base_1='lot', qty_base_1=10, qty_final=1)
+
+        # Required for `lot_producing_id` to be visible in the view
+        # <field name="lot_producing_id" attrs="{'invisible': [('product_tracking', 'in', ('none', False))]}"/>
+        p_final.tracking = 'lot'
+
         self.assertEqual(len(mo), 1, 'MO should have been created')
 
         first_lot_for_p1 = self.env['stock.lot'].create({
@@ -999,6 +1011,8 @@ class TestMrpOrder(TestMrpCommon):
         byproduct3 none   1.0 dozen
         Check qty producing update and moves finished values.
         """
+        # Required for `byproduct_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_byproducts')
         dozen = self.env.ref('uom.product_uom_dozen')
         self.byproduct1 = self.env['product.product'].create({
             'name': 'Byproduct 1',
@@ -2368,6 +2382,8 @@ class TestMrpOrder(TestMrpCommon):
         Create a second one in 10 minutes (expected should NOT go from 15 to 12.5, it should go from 15 to 10)
         """
         # First production, the default is 60 and there is 0 productions of that operation
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         production_form = Form(self.env['mrp.production'])
         production_form.bom_id = self.bom_4
         production = production_form.save()
@@ -2375,6 +2391,8 @@ class TestMrpOrder(TestMrpCommon):
         production.action_confirm()
         production.button_plan()
         # Production planned, time to start, I produce all the 1 product
+        # 'invisible': [('state', '=', 'draft')]
+        production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
             wo.duration = 15 # in 15 minutes
@@ -2390,6 +2408,8 @@ class TestMrpOrder(TestMrpCommon):
         production.action_confirm()
         production.button_plan()
         # Production planned, time to start, I produce all the 1 product
+        # 'invisible': [('state', '=', 'draft')]
+        production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
             wo.duration = 10  # In 10 minutes this time
@@ -2410,6 +2430,8 @@ class TestMrpOrder(TestMrpCommon):
         Test that when tracking the 2 last production, if we make one with under capacity, and one with normal capacity,
         the two are equivalent (1 done with capacity 2 in 10mn = 2 done with capacity 2 in 10mn)
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         production_form = Form(self.env['mrp.production'])
         production_form.bom_id = self.bom_5
         production = production_form.save()
@@ -2417,6 +2439,8 @@ class TestMrpOrder(TestMrpCommon):
         production.button_plan()
 
         # Production planned, time to start, I produce all the 1 product
+        # 'invisible': [('state', '=', 'draft')]
+        production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
             wo.duration = 10  # in 10 minutes
@@ -2434,6 +2458,8 @@ class TestMrpOrder(TestMrpCommon):
         production.action_confirm()
         production.button_plan()
         # Production planned, time to start, I produce all the 2 product
+        # 'invisible': [('state', '=', 'draft')]
+        production_form = Form(production)
         production_form.qty_producing = 2
         with production_form.workorder_ids.edit(0) as wo:
             wo.duration = 10  # In 10 minutes this time
@@ -2457,6 +2483,8 @@ class TestMrpOrder(TestMrpCommon):
         5 -> 30mn
         ...
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         production_form = Form(self.env['mrp.production'])
         production_form.bom_id = self.bom_6
         production = production_form.save()
@@ -2464,6 +2492,8 @@ class TestMrpOrder(TestMrpCommon):
         production.button_plan()
 
         # Production planned, time to start, I produce all the 1 product
+        # 'invisible': [('state', '=', 'draft')]
+        production_form = Form(production)
         production_form.qty_producing = 1
         with production_form.workorder_ids.edit(0) as wo:
             wo.duration = 10  # in 10 minutes
@@ -2760,6 +2790,8 @@ class TestMrpOrder(TestMrpCommon):
         """
             Check that the work order is started only once when clicking the start button several times.
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         production_form = Form(self.env['mrp.production'])
         production_form.bom_id = self.bom_2
         production_form.product_qty = 1
@@ -2869,6 +2901,8 @@ class TestMrpOrder(TestMrpCommon):
         -> The user replans one of the WO: the warnings should disappear and the
         WO should be postponed.
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         mos = self.env['mrp.production']
         for _ in range(2):
             mo_form = Form(self.env['mrp.production'])
@@ -2899,6 +2933,8 @@ class TestMrpOrder(TestMrpCommon):
         -> The user replans one of the WO: the warnings should disappear and the
         WO should be postponed.
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         mos = self.env['mrp.production']
         for _ in range(2):
             mo_form = Form(self.env['mrp.production'])

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -681,6 +681,8 @@ class TestProcurement(TestMrpCommon):
         This test ensures that, when running the scheduler, the generated MOs are based
         on the correct BoMs
         """
+        # Required for `picking_type_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
         warehouse = self.env.ref('stock.warehouse0')
 
         stock_location01 = warehouse.lot_stock_id

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -11,6 +11,10 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Required for `uom_id` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
+        # Required for `manufacture_steps` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('stock.group_adv_location')
         # Create warehouse
         cls.customer_location = cls.env['ir.model.data']._xmlid_to_res_id('stock.stock_location_customers')
         warehouse_form = Form(cls.env['stock.warehouse'])

--- a/addons/mrp_account/tests/test_analytic_account.py
+++ b/addons/mrp_account/tests/test_analytic_account.py
@@ -107,6 +107,8 @@ class TestAnalyticAccount(TransactionCase):
         """Test when workcenter and MO are using the same analytic account, no
         duplicated lines will be post.
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         # set wc analytic account to be the same of the one on the bom
         self.workcenter.costs_hour_account_id = self.analytic_account
 
@@ -147,6 +149,8 @@ class TestAnalyticAccount(TransactionCase):
         """Test when workcenter and MO are using the same analytic account, no
         duplicated lines will be post.
         """
+        # Required for `workorder_ids` to be visible in the view
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         # set wc analytic account to be different from the one on the bom
         wc_analytic_account = self.env['account.analytic.account'].create({'name': 'wc_analytic_account'})
         self.workcenter.costs_hour_account_id = wc_analytic_account

--- a/addons/mrp_account/tests/test_bom_price.py
+++ b/addons/mrp_account/tests/test_bom_price.py
@@ -19,6 +19,8 @@ class TestBomPrice(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Required for `product_uom_id ` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
         cls.Product = cls.env['product.product']
         cls.Bom = cls.env['mrp.bom']
 

--- a/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
+++ b/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
@@ -160,6 +160,9 @@ class TestStockLandedCostsMrp(ValuationReconciliationTestCommon):
         man_order = man_order_form.save()
         man_order.action_confirm()
         # produce product
+        # To edit `qty_producing`, the mo must no be draft. It's not thanks to the above `action_confirm()`
+        # but the values of the form do not update automatically, it must be reloaded.
+        man_order_form = Form(man_order)
         man_order_form.qty_producing = 1
         man_order_form.save()
         man_order.button_mark_done()

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -237,6 +237,8 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking. Checks that the delivery and MO for its components are
         automatically created.
         """
+        # Required for `location_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         # Tick "manufacture" and MTO on self.comp2
         mto_route = self.env.ref('stock.route_warehouse0_mto')
         mto_route.active = True

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -1008,6 +1008,8 @@ class TestVariantsArchive(common.TestProductCommon):
     def test_uom_update_variant(self):
         """ Changing the uom on the template do not behave the same
         as changing on the product product."""
+        # Required for `uom_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref("uom.group_uom")
         units = self.env.ref('uom.product_uom_unit')
         cm = self.env.ref('uom.product_uom_cm')
         template = self.env['product.template'].create({

--- a/addons/project/tests/test_project_recurrence.py
+++ b/addons/project/tests/test_project_recurrence.py
@@ -465,6 +465,9 @@ class TestProjectrecurrence(TransactionCase):
             tasks = self.env['project.task'].search(domain)
             return tasks, len(tasks), len(tasks.filtered('parent_id'))
 
+        # Required for `child_ids` to be visible in the view
+        # {'invisible': [('allow_subtasks', '=', False)]}
+        self.project_recurring.allow_subtasks = True
         parent_task = self.env['project.task'].create({
             'name': 'Parent Task',
             'project_id': self.project_recurring.id
@@ -558,6 +561,9 @@ class TestProjectrecurrence(TransactionCase):
             return len(tasks), len(tasks.filtered('parent_id'))
 
         # Phase 0 : Initialize test case
+        # Required for `child_ids` to be visible in the view
+        # {'invisible': [('allow_subtasks', '=', False)]}
+        self.project_recurring.allow_subtasks = True
         parent_task = self.env['project.task'].create({
             'name': 'Parent Task',
             'project_id': self.project_recurring.id

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -144,6 +144,10 @@ class TestProjectSharing(TestProjectSharingCommon):
             3.2) Create a sub-task
             3.3) Create a second sub-task
         """
+        # 0) Allow to create subtasks in the project tasks
+        # Required for `child_ids` to be visible in the view
+        # {'invisible': [('allow_subtasks', '=', False)]}
+        self.project_cows.allow_subtasks = True
         # 1) Give the 'read' access mode to a portal user in a project and try to create task with this user.
         with self.assertRaises(AccessError, msg="Should not accept the portal user create a task in the project when he has not the edit access right."):
             with self.get_project_sharing_form_view(self.task_cow.with_context({'tracking_disable': True, 'default_project_id': self.project_cows.id}), self.user_portal) as form:

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -179,6 +179,8 @@ class TestPurchase(AccountTestInvoicingCommon):
         according to the product_qty. Also check product_qty or product_packaging
         are correctly calculated when one of them changed.
         """
+        # Required for `product_packaging_qty` to be visible in the view
+        self.env.user.groups_id += self.env.ref('product.group_stock_packaging')
         packaging_single = self.env['product.packaging'].create({
             'name': "I'm a packaging",
             'product_id': self.product_a.id,

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -304,6 +304,8 @@ class TestPurchaseToInvoice(AccountTestInvoicingCommon):
         """ Tests whether, when an analytic account rule is set, and user changes manually the analytic account on
         the po, it is the same that is mentioned in the bill.
         """
+        # Required for `analytic.group_analytic_accounting` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         analytic_account_default = self.env['account.analytic.account'].create({'name': 'default'})
         analytic_account_manual = self.env['account.analytic.account'].create({'name': 'manual'})
 

--- a/addons/purchase/tests/test_purchase_order_report.py
+++ b/addons/purchase/tests/test_purchase_order_report.py
@@ -41,7 +41,39 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
         f = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         f.invoice_date = f.date
         f.partner_id = po.partner_id
-        f.purchase_id = po
+        # <field name="invoice_vendor_bill_id" position="after">
+        #     <field name="purchase_id" invisible="1"/>
+        #     <label for="purchase_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
+        #             attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}" />
+        #     <field name="purchase_vendor_bill_id" nolabel="1"
+        #             attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
+        #             class="oe_edit_only"
+        #             domain="partner_id and [('company_id', '=', company_id), ('partner_id.commercial_partner_id', '=', commercial_partner_id)] or [('company_id', '=', company_id)]"
+        #             placeholder="Select a purchase order or an old bill"
+        #             context="{'show_total_amount': True}"
+        #             options="{'no_create': True, 'no_open': True}"/>
+        # </field>
+        # @api.onchange('purchase_vendor_bill_id', 'purchase_id')
+        # def _onchange_purchase_auto_complete(self):
+        #     ...
+        #     elif self.purchase_vendor_bill_id.purchase_order_id:
+        #         self.purchase_id = self.purchase_vendor_bill_id.purchase_order_id
+        #     self.purchase_vendor_bill_id = False
+        # purchase_vendor_bill_id = fields.Many2one('purchase.bill.union'
+        # class PurchaseBillUnion(models.Model):
+        #     _name = 'purchase.bill.union'
+        #     ...
+        #     def init(self):
+        #         self.env.cr.execute("""
+        #                 ...
+        #                 SELECT
+        #                     -id, name, ...
+        #                     id as purchase_order_id
+        #                 FROM purchase_order
+        #                 ...
+        #             )""")
+        #     ...
+        f.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po.id)
         invoice = f.save()
         invoice.action_post()
         po.flush_model()

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -53,7 +53,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
         move_form.invoice_date = date
         move_form.partner_id = self.partner_a
         move_form.currency_id = self.currency_data['currency']
-        move_form.purchase_id = purchase_order
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-purchase_order.id)
         return move_form.save()
 
     def test_shipment_invoice(self):

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -449,6 +449,8 @@ class TestCreatePicking(common.TestProductCommon):
             'Delivery deadline date should be changed.')
 
     def test_07_differed_schedule_date(self):
+        # Required for `reception_steps` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
         warehouse = self.env['stock.warehouse'].search([], limit=1)
 
         with Form(warehouse) as w:

--- a/addons/purchase_stock/tests/test_onchange_product.py
+++ b/addons/purchase_stock/tests/test_onchange_product.py
@@ -27,6 +27,8 @@ class TestOnchangeProductId(TransactionCase):
         cls.supplierinfo_model = cls.env["product.supplierinfo"]
 
     def test_onchange_product_id(self):
+        # Required for `product_uom` to be visible in the view
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
 
         uom_id = self.product_uom_model.search([('name', '=', 'Units')])[0]
 

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -77,7 +77,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
 
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.partner_id = self.partner_a
-        move_form.purchase_id = self.po
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-self.po.id)
         self.invoice = move_form.save()
 
         self.assertEqual(self.po.order_line.mapped('qty_invoiced'), [5.0, 5.0], 'Purchase: all products should be invoiced"')
@@ -110,7 +110,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = self.partner_a
-        move_form.purchase_id = self.po
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-self.po.id)
         self.invoice = move_form.save()
         self.invoice.action_post()
 
@@ -141,6 +141,13 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_refund'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = self.partner_a
+        # Not supposed to see/change the purchase order of a refund invoice by default
+        # <field name="purchase_id" invisible="1"/>
+        # <label for="purchase_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
+        #         attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}" />
+        # <field name="purchase_vendor_bill_id" nolabel="1"
+        #         attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
+        move_form._view['modifiers']['purchase_id']['invisible'] = False
         move_form.purchase_id = self.po
         self.invoice = move_form.save()
         move_form = Form(self.invoice)

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -106,6 +106,8 @@ class TestReorderingRule(TransactionCase):
             - Increase the quantity on the PO, the extra quantity should follow the push rules and
               thus go to stock
         """
+        # Required for `warehouse_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
         subloc_1 = self.env['stock.location'].create({'name': 'subloc_1', 'location_id': warehouse_1.lot_stock_id.id})
         subloc_2 = self.env['stock.location'].create({'name': 'subloc_2', 'location_id': warehouse_1.lot_stock_id.id})
@@ -216,6 +218,8 @@ class TestReorderingRule(TransactionCase):
         })
 
         # create reordering rules
+        # Required for `warehouse_id` to be visible in the view
+        self.env['res.users'].browse(2).groups_id += self.env.ref('stock.group_stock_multi_locations')
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'].with_user(2))
         orderpoint_form.warehouse_id = warehouse_1
         orderpoint_form.location_id = outside_loc
@@ -617,6 +621,8 @@ class TestReorderingRule(TransactionCase):
         If the user triggers each orderpoint separately, it should still produce two
         different purchase order lines (one for each orderpoint)
         """
+        # Required for `warehouse_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
         stock_location = warehouse.lot_stock_id
         sub_location = self.env['stock.location'].create({'name': 'subloc_1', 'location_id': stock_location.id})

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -382,7 +382,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = self.partner_id
-        move_form.purchase_id = po1
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po1.id)
         invoice_po1 = move_form.save()
         invoice_po1.action_post()
 
@@ -408,7 +408,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = self.partner_id
-        move_form.purchase_id = po2
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po2.id)
         invoice_po2 = move_form.save()
         invoice_po2.action_post()
 
@@ -433,6 +433,14 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_refund'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = self.partner_id
+
+        # Not supposed to see/change the purchase order of a refund invoice by default
+        # <field name="purchase_id" invisible="1"/>
+        # <label for="purchase_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
+        #         attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}" />
+        # <field name="purchase_vendor_bill_id" nolabel="1"
+        #         attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
+        move_form._view['modifiers']['purchase_id']['invisible'] = False
         move_form.purchase_id = po2
         with move_form.invoice_line_ids.edit(0) as line_form:
             line_form.quantity = 10
@@ -468,7 +476,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = order.partner_id
-        move_form.purchase_id = order
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-order.id)
         with move_form.invoice_line_ids.edit(0) as line_form:
             line_form.price_unit = 15.0
         invoice = move_form.save()
@@ -1164,7 +1172,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         # Create an invoice with a different price and a discount
         invoice_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         invoice_form.invoice_date = invoice_form.date
-        invoice_form.purchase_id = order
+        invoice_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-order.id)
         with invoice_form.invoice_line_ids.edit(0) as line_form:
             line_form.price_unit = 100.0
             line_form.discount = 10.0
@@ -1211,7 +1219,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         # Create an invoice with a different price and a discount
         invoice_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         invoice_form.invoice_date = invoice_form.date
-        invoice_form.purchase_id = order
+        invoice_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-order.id)
         with invoice_form.invoice_line_ids.edit(0) as line_form:
             line_form.tax_ids.clear()
             line_form.discount = 10.0
@@ -1258,7 +1266,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         # Create an invoice with a different price and a discount
         invoice_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         invoice_form.invoice_date = invoice_form.date
-        invoice_form.purchase_id = order
+        invoice_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-order.id)
         with invoice_form.invoice_line_ids.edit(0) as line_form:
             line_form.price_unit = 100.0
             line_form.discount = 10.0

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -326,6 +326,8 @@ class TestRepair(AccountTestInvoicingCommon):
         """Tests functionality of creating a repair directly from a return picking,
         i.e. repair can be made and defaults to appropriate return values. """
         # test return
+        # Required for `location_dest_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         picking_form = Form(self.env['stock.picking'])
         picking_form.picking_type_id = self.stock_warehouse.return_type_id
         picking_form.partner_id = self.res_partner_1

--- a/addons/sale/tests/test_reinvoice.py
+++ b/addons/sale/tests/test_reinvoice.py
@@ -35,6 +35,8 @@ class TestReInvoice(TestSaleCommon):
         )
 
     def test_at_cost(self):
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         """ Test vendor bill at cost for product based on ordered and delivered quantities. """
         # create SO line and confirm SO (with only one line)
         sale_order_line1 = self.env['sale.order.line'].create({
@@ -146,6 +148,8 @@ class TestReInvoice(TestSaleCommon):
         """ Test invoicing vendor bill at sales price for products based on delivered and ordered quantities. Check no existing SO line is incremented, but when invoicing a
             second time, increment only the delivered so line.
         """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         # create SO line and confirm SO (with only one line)
         sale_order_line1 = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_delivery_sales_price'].id,
@@ -216,6 +220,8 @@ class TestReInvoice(TestSaleCommon):
 
     def test_no_expense(self):
         """ Test invoicing vendor bill with no policy. Check nothing happen. """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         # confirm SO
         sale_order_line = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_delivery_no'].id,

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -583,6 +583,8 @@ class TestSaleOrder(TestSaleCommon):
         according to the product_qty. Also check product_qty or product_packaging
         are correctly calculated when one of them changed.
         """
+        # Required for `product_packaging_qty` to be visible in the view
+        self.env.user.groups_id += self.env.ref('product.group_stock_packaging')
         partner = self.env['res.partner'].create({'name': "I'm a partner"})
         product_tmpl = self.env['product.template'].create({'name': "I'm a product"})
         product = product_tmpl.product_variant_id
@@ -768,6 +770,8 @@ class TestSaleOrder(TestSaleCommon):
         self.assertEqual(line.untaxed_amount_to_invoice, line.price_subtotal)
 
     def test_discount_and_amount_undiscounted(self):
+        # Required for `discount` to be visible in the view
+        self.env.user.groups_id += self.env.ref('product.group_discount_per_so_line')
         """When adding a discount on a SO line, this test ensures that amount undiscounted is
         consistent with the used tax"""
         sale_order = self.env['sale.order'].create({

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -444,6 +444,8 @@ class TestSaleToInvoice(TestSaleCommon):
         """ Tests whether, when an analytic account rule is set and the so has an analytic account,
         the default analytic acount doesn't replace the one from the so in the invoice.
         """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         analytic_account_default = self.env['account.analytic.account'].create({'name': 'default'})
         analytic_account_so = self.env['account.analytic.account'].create({'name': 'so'})
 

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -11,6 +11,11 @@ class TestMultistepManufacturing(TestMrpCommon):
     def setUpClass(cls):
         super().setUpClass()
 
+        # Required for `uom_id ` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
+        # Required for `manufacture_steps` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('stock.group_adv_location')
+
         cls.env.ref('stock.route_warehouse0_mto').active = True
         cls.MrpProduction = cls.env['mrp.production']
         # Create warehouse

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -15,6 +15,8 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
+        # Required for `uom_id` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
         cls.env.ref('stock.route_warehouse0_mto').active = True
 
         # Useful models
@@ -213,7 +215,7 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         """
         for comp in components:
             f = Form(self.env['stock.move'])
-            f.name = 'Test Receipt Components'
+            # <field name="name" invisible="1"/>
             f.location_id = self.env.ref('stock.stock_location_suppliers')
             f.location_dest_id = warehouse.lot_stock_id
             f.product_id = comp

--- a/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
@@ -17,7 +17,9 @@ class TestSaleMrpLeadTime(TestStockCommon):
         cls.env.ref('stock.route_warehouse0_mto').active = True
         # Update the product_1 with type, route, Manufacturing Lead Time and Customer Lead Time
         with Form(cls.product_1) as p1:
-            p1.type = 'product'
+            # `type` is invisible in the view,
+            # and it's a compute field based on `detailed_type` which is the field visible in the view
+            p1.detailed_type = 'product'
             p1.produce_delay = 5.0
             p1.sale_delay = 5.0
             p1.route_ids.clear()
@@ -26,7 +28,9 @@ class TestSaleMrpLeadTime(TestStockCommon):
 
         # Update the product_2 with type
         with Form(cls.product_2) as p2:
-            p2.type = 'consu'
+            # `type` is invisible in the view,
+            # and it's a compute field based on `detailed_type` which is the field visible in the view
+            p2.detailed_type = 'consu'
 
         # Create Bill of materials for product_1
         with Form(cls.env['mrp.bom']) as bom:

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -10,6 +10,8 @@ from odoo.tools import mute_logger
 class TestSaleMrpProcurement(TransactionCase):
 
     def test_sale_mrp(self):
+        # Required for `uom_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
         self.env.ref('stock.route_warehouse0_mto').active = True
         warehouse0 = self.env.ref('stock.warehouse0')
         # In order to test the sale_mrp module in OpenERP, I start by creating a new product 'Slider Mobile'
@@ -77,6 +79,10 @@ class TestSaleMrpProcurement(TransactionCase):
         to avoid generating multiple deliveries
         to the customer location
         """
+        # Required for `uom_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
+        # Required for `manufacture_step` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
         self.env.ref('stock.route_warehouse0_mto').active = True
         # Create warehouse
         self.customer_location = self.env['ir.model.data']._xmlid_to_res_id('stock.stock_location_customers')

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -436,6 +436,12 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         with Form(self.env['project.project'].with_context({'tracking_disable': True})) as project_form:
             project_form.name = 'Test Billable Project'
             project_form.allow_billable = True
+            # `sale_line_employee_ids` is not visible if `partner_id` is not set
+            # As the behavior of the test is to check the partner on the project
+            # is set to the partner of the order line, temporary make the field visible
+            # even if it's not the case in the reality, in the web client
+            # {'invisible': ['|', ('allow_billable', '=', False), ('partner_id', '=', False)]}
+            project_form._view['modifiers']['sale_line_employee_ids']['invisible'] = False
             with project_form.sale_line_employee_ids.new() as mapping_form:
                 mapping_form.employee_id = self.employee_manager
                 mapping_form.sale_line_id = self.so.order_line[:1]

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -52,6 +52,8 @@ class TestReInvoice(TestCommonSaleTimesheet):
 
     def test_at_cost(self):
         """ Test vendor bill at cost for product based on ordered and delivered quantities. """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         # create SO line and confirm SO (with only one line)
         sale_order_line1 = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_order_cost'].id,
@@ -144,6 +146,8 @@ class TestReInvoice(TestCommonSaleTimesheet):
         """ Test invoicing vendor bill at sales price for products based on delivered and ordered quantities. Check no existing SO line is incremented, but when invoicing a
             second time, increment only the delivered so line.
         """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         # create SO line and confirm SO (with only one line)
         sale_order_line1 = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_delivery_sales_price'].id,
@@ -231,6 +235,8 @@ class TestReInvoice(TestCommonSaleTimesheet):
 
     def test_no_expense(self):
         """ Test invoicing vendor bill with no policy. Check nothing happen. """
+        # Required for `analytic_account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
         # confirm SO
         sale_order_line = self.env['sale.order.line'].create({
             'product_id': self.company_data['product_order_no'].id,

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -1176,6 +1176,8 @@ class StockMove(TransactionCase):
         """Receive a package. Test the package will be move to a child location
         with correct storage category.
         """
+        # Required for `result_package_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_tracking_lot")
         # storage category
         storage_category = self.env['stock.storage.category'].create({
             'name': "storage category"
@@ -1240,6 +1242,8 @@ class StockMove(TransactionCase):
         """Receive package with same package type twice. Check putaway rule can
         be applied on the first one but not the second one due to no space.
         """
+        # Required for `result_package_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_tracking_lot")
         # storage category
         storage_category = self.env['stock.storage.category'].create({
             'name': "storage category"
@@ -1341,6 +1345,8 @@ class StockMove(TransactionCase):
         only accept new product when empty. Check putaway rule can be applied on
         the first one but not the second one.
         """
+        # Required for `result_package_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_tracking_lot")
         # storage category
         storage_category = self.env['stock.storage.category'].create({
             'name': "storage category",
@@ -1443,6 +1449,8 @@ class StockMove(TransactionCase):
         accept same product. Check putaway rule can be applied on the first one
         but not the second one.
         """
+        # Required for `result_package_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_tracking_lot")
         # storage category
         storage_category = self.env['stock.storage.category'].create({
             'name': "storage category",

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2102,6 +2102,8 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(delivery_order.show_mark_as_todo, False)
 
     def test_owner_1(self):
+        # Required for `owner_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref("stock.group_tracking_owner")
         """Make a receipt, set an owner and validate"""
         owner1 = self.env['res.partner'].create({'name': 'owner'})
         receipt = self.env['stock.picking'].create({
@@ -2169,7 +2171,7 @@ class TestSinglePicking(TestStockCommon):
         ), view='stock.view_picking_form')
         receipt_form.partner_id = partner
         receipt_form.picking_type_id = picking_type
-        receipt_form.location_id = supplier_location
+        # <field name="location_id" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}"
         receipt_form.location_dest_id = stock_location
         receipt = receipt_form.save()
         with receipt_form.move_line_nosuggest_ids.new() as move_line:

--- a/addons/stock/tests/test_multicompany.py
+++ b/addons/stock/tests/test_multicompany.py
@@ -22,14 +22,20 @@ class TestMultiCompany(TransactionCase):
         cls.user_a = cls.env['res.users'].create({
             'name': 'user company a with access to company b',
             'login': 'user a',
-            'groups_id': [(6, 0, [group_user.id, group_stock_manager.id])],
+            'groups_id': [(6, 0, [
+                group_user.id,
+                group_stock_manager.id,
+            ])],
             'company_id': cls.company_a.id,
             'company_ids': [(6, 0, [cls.company_a.id, cls.company_b.id])]
         })
         cls.user_b = cls.env['res.users'].create({
             'name': 'user company b with access to company a',
             'login': 'user b',
-            'groups_id': [(6, 0, [group_user.id, group_stock_manager.id])],
+            'groups_id': [(6, 0, [
+                group_user.id,
+                group_stock_manager.id,
+            ])],
             'company_id': cls.company_b.id,
             'company_ids': [(6, 0, [cls.company_a.id, cls.company_b.id])]
         })
@@ -218,6 +224,8 @@ class TestMultiCompany(TransactionCase):
     def test_orderpoint_1(self):
         """As a user of company A, create an orderpoint for company B. Check itsn't possible to
         use a warehouse of companny A"""
+        # Required for `warehouse_id` and `location_id` to be visible in the view
+        self.user_a.groups_id += self.env.ref("stock.group_stock_multi_locations")
         product = self.env['product.product'].create({
             'type': 'product',
             'name': 'shared product',
@@ -237,6 +245,8 @@ class TestMultiCompany(TransactionCase):
         """As a user of Company A, check it is not possible to change the company on an existing
         orderpoint to Company B.
         """
+        # Required for `warehouse_id` and `location_id` to be visible in the view
+        self.user_a.groups_id += self.env.ref("stock.group_stock_multi_locations")
         product = self.env['product.product'].create({
             'type': 'product',
             'name': 'shared product',

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -110,6 +110,8 @@ class TestProcRule(TransactionCase):
         self.assertEqual(move_dest.date_deadline, new_deadline, msg='deadline date should be unchanged')
 
     def test_reordering_rule_1(self):
+        # Required for `location_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         warehouse = self.env['stock.warehouse'].search([], limit=1)
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
         orderpoint_form.product_id = self.product
@@ -156,6 +158,9 @@ class TestProcRule(TransactionCase):
         reordering rule (RR). Add extra product to already confirmed picking => automatically
         run another RR
         """
+        # Required for `location_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
+
         self.productA = self.env['product.product'].create({
             'name': 'Desk Combination',
             'type': 'product',

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1181,10 +1181,14 @@ class TestReports(TestReportsCommon):
         delivery_form.partner_id = self.partner
         delivery_form.picking_type_id = picking_type_by_date
         delivery_form.scheduled_date = datetime.now() + timedelta(days=5)
-        delivery_form.priority = '1'
         with delivery_form.move_ids_without_package.new() as move_line:
             move_line.product_id = self.product
             move_line.product_uom_qty = 3
+        delivery_by_date_priority = delivery_form.save()
+        # <field name="priority" attrs="{'invisible': [('name','=','/')]}"/>
+        # The priority field is not visible until the name is set,
+        # which is done after a first save / the `create`
+        delivery_form.priority = '1'
         delivery_by_date_priority = delivery_form.save()
         delivery_by_date_priority.action_confirm()
 

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -536,6 +536,8 @@ class TestWarehouse(TestStockCommon):
         self.assertFalse(warehouse.pack_type_id.active)
 
     def test_toggle_active_warehouse_2(self):
+        # Required for `delivery_steps` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
         wh = Form(self.env['stock.warehouse'])
         wh.name = "The attic of Willy"
         wh.code = "WIL"

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -1011,6 +1011,8 @@ class TestAngloSaxonAccounting(TestStockValuationCommon):
         """
         When reversing an invoice that contains some anglo-saxo AML, the new anglo-saxo AML should have the same value
         """
+        # Required for `account_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('account.group_account_readonly')
         self.product1.categ_id.property_cost_method = 'average'
 
         self._make_in_move(self.product1, 2, unit_cost=10)

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -67,6 +67,8 @@ class TestDropship(common.TransactionCase):
         self.assertAlmostEqual(pol2.product_qty, sol2.product_uom_qty)
 
     def test_00_dropship(self):
+        # Required for `route_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
 
         # Create a vendor
         supplier_dropship = self.env['res.partner'].create({'name': 'Vendor of Dropshipping test'})

--- a/addons/stock_dropshipping/tests/test_procurement_exception.py
+++ b/addons/stock_dropshipping/tests/test_procurement_exception.py
@@ -7,6 +7,10 @@ from odoo.tests import common, Form
 class TestProcurementException(common.TransactionCase):
 
     def test_00_procurement_exception(self):
+        # Required for `partner_invoice_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('account.group_delivery_invoice_address')
+        # Required for `route_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
 
         res_partner_2 = self.env['res.partner'].create({'name': 'My Test Partner'})
         res_partner_address = self.env['res.partner'].create({
@@ -17,7 +21,18 @@ class TestProcurementException(common.TransactionCase):
         # I create a product with no supplier define for it.
         product_form = Form(self.env['product.product'])
         product_form.name = 'product with no seller'
-        product_form.list_price = 20.00
+        # <field name="list_price" position="attributes">
+        #     <attribute name="attrs">{'readonly': [('product_variant_count', '&gt;', 1)]}</attribute>
+        #     <attribute name="invisible">1</attribute>
+        # </field>
+        # <field name="list_price" position="after">
+        #     <field name="lst_price" class="oe_inline" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}"/>
+        # </field>
+        # @api.onchange('lst_price')
+        # def _set_product_lst_price(self):
+        #     ...
+        #         product.write({'list_price': value})
+        product_form.lst_price = 20.00
         product_form.categ_id = self.env.ref('product.product_category_1')
         product_with_no_seller = product_form.save()
 

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -68,7 +68,7 @@ class TestStockValuation(ValuationReconciliationTestCommon):
         # create the vendor bill
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.partner_id = vendor1
-        move_form.purchase_id = self.purchase_order1
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-self.purchase_order1.id)
         move_form.invoice_date = move_form.date
         for i in range(len(self.purchase_order1.order_line)):
             with move_form.invoice_line_ids.edit(i) as line_form:

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -409,7 +409,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.invoice_date = move_form.date
         move_form.partner_id = order.partner_id
-        move_form.purchase_id = order
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-order.id)
         move = move_form.save()
         move.action_post()
 

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -91,9 +91,12 @@ class TestCrmPerformance(CrmPerformanceCase):
         """ Test a single lead creation using Form with a partner """
         with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=189):  # tcf only: 180 - com runbot: 172
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
-            with Form(self.env['crm.lead']) as lead_form:
-                lead_form.partner_id = self.partners[0]
-                lead_form.name = 'Test Lead'
+            with self.debug_mode():
+                # {'invisible': ['|', ('type', '=', 'opportunity'), ('is_partner_visible', '=', False)]}
+                # lead.is_partner_visible = bool(lead.type == 'opportunity' or lead.partner_id or is_debug_mode)
+                with Form(self.env['crm.lead']) as lead_form:
+                    lead_form.partner_id = self.partners[0]
+                    lead_form.name = 'Test Lead'
 
             _lead = lead_form.save()
 

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -109,14 +109,17 @@ class TestEventPerformance(EventPerformanceCase):
         # no type, no website
         with freeze_time(self.reference_now), self.assertQueryCount(event_user=206):  # tef only: 179? - com runbot: 160
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
-            with Form(self.env['event.event']) as event_form:
-                event_form.name = 'Test Event'
-                event_form.date_begin = self.reference_now + timedelta(days=1)
-                event_form.date_end = self.reference_now + timedelta(days=5)
-                event_form.website_menu = False
-                if has_social:
-                    event_form.social_menu = False
-            _event = event_form.save()
+            # Require for `website_menu` to be visible
+            # <div name="event_menu_configuration" groups="base.group_no_one">
+            with self.debug_mode():
+                with Form(self.env['event.event']) as event_form:
+                    event_form.name = 'Test Event'
+                    event_form.date_begin = self.reference_now + timedelta(days=1)
+                    event_form.date_end = self.reference_now + timedelta(days=5)
+                    event_form.website_menu = False
+                    if has_social:
+                        event_form.social_menu = False
+                _event = event_form.save()
 
     @users('event_user')
     @warmup
@@ -127,14 +130,17 @@ class TestEventPerformance(EventPerformanceCase):
         # no type, website
         with freeze_time(self.reference_now), self.assertQueryCount(event_user=671):  # tef only: 638? - com runbot: 571 - ent runbot: 671
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
-            with Form(self.env['event.event']) as event_form:
-                event_form.name = 'Test Event'
-                event_form.date_begin = self.reference_now + timedelta(days=1)
-                event_form.date_end = self.reference_now + timedelta(days=5)
-                event_form.website_menu = True
-                if has_social:
-                    event_form.social_menu = False
-            _event = event_form.save()
+            # Require for `website_menu` to be visible
+            # <div name="event_menu_configuration" groups="base.group_no_one">
+            with self.debug_mode():
+                with Form(self.env['event.event']) as event_form:
+                    event_form.name = 'Test Event'
+                    event_form.date_begin = self.reference_now + timedelta(days=1)
+                    event_form.date_end = self.reference_now + timedelta(days=5)
+                    event_form.website_menu = True
+                    if has_social:
+                        event_form.social_menu = False
+                _event = event_form.save()
 
     @users('event_user')
     @warmup
@@ -146,13 +152,16 @@ class TestEventPerformance(EventPerformanceCase):
         # type and website
         with freeze_time(self.reference_now), self.assertQueryCount(event_user=700):  # tef only: 601 - com runbot: 604 - ent runbot: 700
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
-            with Form(self.env['event.event']) as event_form:
-                event_form.name = 'Test Event'
-                event_form.date_begin = self.reference_now + timedelta(days=1)
-                event_form.date_end = self.reference_now + timedelta(days=5)
-                event_form.event_type_id = event_type
-                if has_social:
-                    event_form.social_menu = False
+            # Require for `website_menu` to be visible
+            # <div name="event_menu_configuration" groups="base.group_no_one">
+            with self.debug_mode():
+                with Form(self.env['event.event']) as event_form:
+                    event_form.name = 'Test Event'
+                    event_form.date_begin = self.reference_now + timedelta(days=1)
+                    event_form.date_end = self.reference_now + timedelta(days=5)
+                    event_form.event_type_id = event_type
+                    if has_social:
+                        event_form.social_menu = False
 
     @users('event_user')
     @warmup

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -208,10 +208,9 @@ class TestActivityFlow(TestActivityCommon):
             'summary': 'Email Summary',
         })
         call_activity_type = ActivityType.create({'name': 'call'})
-        with Form(self.env['mail.activity'].with_context(default_res_model_id=self.env['ir.model']._get_id('mail.test.activity'))) as ActivityForm:
-            ActivityForm.res_model_id = self.env['ir.model']._get('mail.test.activity')
-            ActivityForm.res_id = self.test_record.id
-
+        with Form(self.env['mail.activity'].with_context(default_res_model_id=self.env['ir.model']._get_id('mail.test.activity'), default_res_id=self.test_record.id)) as ActivityForm:
+            # `res_model_id` and `res_id` are invisible, see view `mail.mail_activity_view_form_popup`
+            # they must be set using defaults, see `action_feedback_schedule_next`
             ActivityForm.activity_type_id = call_activity_type
             # activity summary should be empty
             self.assertEqual(ActivityForm.summary, False)

--- a/odoo/addons/base/tests/test_form_create.py
+++ b/odoo/addons/base/tests/test_form_create.py
@@ -12,6 +12,8 @@ class TestFormCreate(TransactionCase):
     """
 
     def test_create_res_partner(self):
+        # Required for `property_account_payable_id`, `property_account_receivable_id` to be visible in the view
+        self.env.user.groups_id += self.env.ref('account.group_account_readonly')
         partner_form = Form(self.env['res.partner'])
         partner_form.name = 'a partner'
         # YTI: Clean that brol

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -121,7 +121,12 @@ class TestPartner(TransactionCase):
             self.env['res.partner'].with_context(default_lang='de_DE'),
             'base.view_partner_form'
         )
-        partner_form.is_company = True
+        # <field name="is_company" invisible="1"/>
+        # <field name="company_type" widget="radio" options="{'horizontal': true}"/>
+        # @api.onchange('company_type')
+        # def onchange_company_type(self):
+        #     self.is_company = (self.company_type == 'company')
+        partner_form.company_type = 'company'
         partner_form.name = "Test Company"
         self.assertEqual(partner_form.lang, 'de_DE', "New partner's lang should take default from context")
         with partner_form.child_ids.new() as child:

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -277,7 +277,9 @@ class TestUsers2(TransactionCase):
         user_groups_ids = [str(group_id) for group_id in sorted(user_groups.ids)]
         group_field_name = f"sel_groups_{'_'.join(user_groups_ids)}"
 
-        user_form = Form(self.env['res.users'], view='base.view_users_form')
+        # <group col="4" attrs="{'invisible': [('sel_groups_1_9_10', '!=', 1)]}" groups="base.group_no_one" class="o_label_nowrap">
+        with self.debug_mode():
+            user_form = Form(self.env['res.users'], view='base.view_users_form')
         user_form.name = "Test"
         user_form.login = "Test"
         self.assertFalse(user_form.share)


### PR DESCRIPTION
In the web client, in a real use case, it's not possible
to write on fields which are invisible,
as it's not possible to write on fields which are readonly.

This is a first step in the goal to change the behavior
of the `groups=` attribute in the back-end views,
to remove them for the view instead of making them invisible.

This is mainly to reduce the diff of the revision that will introduce
the mentioned above behavior change.

As nodes with `groups=` will be removed from the view
when the user doesn't have the group, it's no longer possible
to set a value on a field having a `groups=` the user doesn't have
in the `Form` test class, as the field will no longer be at all in the
view.
However, these unit tests shouldn't have been able to set values
on invisible fields in the first place.
This revision therefore aims to correct the unit tests setting value
on fields which were invisible because the user executing the
test was not part of the required group(s) for these fields
to be visible in the view.

Linked enterprise PR: odoo/enterprise#28936