### PR TITLE
[FIX] l10n_id_efaktur: use shipping address for Column "ALAMAT LENGKAP"

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -155,7 +155,8 @@ class AccountMove(models.Model):
             else:
                 number_ref = str(move.name) + " " + nik
 
-            street = ', '.join([x for x in (move.partner_id.street, move.partner_id.street2) if x])
+            shipping_partner = self.env['res.partner'].browse(self._get_invoice_delivery_partner_id())
+            street = ', '.join([x for x in (shipping_partner.street, shipping_partner.street2) if x])
 
             invoice_npwp = '000000000000000'
             if move.partner_id.vat and len(move.partner_id.vat) >= 12:
@@ -173,7 +174,7 @@ class AccountMove(models.Model):
             eTax['TANGGAL_FAKTUR'] = '{0}/{1}/{2}'.format(move.invoice_date.day, move.invoice_date.month, move.invoice_date.year)
             eTax['NPWP'] = invoice_npwp
             eTax['NAMA'] = move.partner_id.name if eTax['NPWP'] == '000000000000000' else move.partner_id.l10n_id_tax_name or move.partner_id.name
-            eTax['ALAMAT_LENGKAP'] = move.partner_id.contact_address.replace('\n', '') if eTax['NPWP'] == '000000000000000' else move.partner_id.l10n_id_tax_address or street
+            eTax['ALAMAT_LENGKAP'] = move.partner_id.contact_address.replace('\n', '') if eTax['NPWP'] == '000000000000000' else shipping_partner.l10n_id_tax_address or street
             eTax['JUMLAH_DPP'] = int(float_round(move.amount_untaxed, 0)) # currency rounded to the unit
             eTax['JUMLAH_PPN'] = int(float_round(move.amount_tax, 0))
             eTax['ID_KETERANGAN_TAMBAHAN'] = '1' if move.l10n_id_kode_transaksi == '07' else ''


### PR DESCRIPTION
To generate an e-faktur

1. Settings > Users & Companies/Compagnies:
- Create a new company ‘ID Indonesia’:
- Set the state (e.g Yogyakarta (ID))
- Set the country ‘Indonesia’

Accounting:
2. > Customers > e-Faktur
- Set a range of numbers (which are supposed to be assigned by the
Indonesian government);

3. > Configuration > Settings
- Fiscal Localization: select the Indonesian package

4. > Customers > Customers
- Create a new res.partner:
- Set the country ‘Indonesia’
- Check ‘ID PKP’ field
- Fill Tax Address field
- Fill NIK field
- Under ‘Accounting tab’: set both accounting entries (Receivable +
  Payable)
- Create a delivery address

5. > Customers > Invoices
- Create a random invoice with the res.partner set in point 5. as the
Customer
- Confirm the invoice
- Action > Download e-Faktur

Under column ALAMAT LENGKAP the tax Address will be used, but the
delivery address should be used
Follows the official documentation with translation
https://www.pajakku.com/tax-guide/12490/PER_DIRJEN_PJK/PER - 03/PJ/2022
(Article 6, paragraph 6)

Translation:
Paragraph 2 : The identity of the Buyer of Taxable Goods and Services or
the Recipient of Taxable Goods and Services which includes name,
address, NPWP, NIK, and passport number as referred to in Article 5
letter b must be filled in accordance with the actual or actual name,
address, NPWP, NIK, and passport number.

Paragraph 6 : In the event that the delivery of Taxable Goods and/or
Taxable Service is made to the Buyer of Taxable Goods and/or Receiver of
Taxable Service which is the place where the VAT or VAT and STLG payable
is concentrated, but the Taxable Goods and/or Taxable Service is sent or
delivered to the place where the VAT or VAT and STLG payable is
centralized, the following provisions shall apply:
a. the name and NPWP as referred to in paragraph (2) shall be the name
and NPWP of PKP where the VAT or VAT and STLG payable is centralized;
and

b. the address as referred to in paragraph (2) shall be the address of
the place where the VAT or VAT and STLG payable that is centralized
receives the Taxable Goods and/or Services.

opw-2878096

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
