### PR TITLE
[FIX] mail: Update legacy arguments for services.action.doAction

### DIFF
--- a/addons/mail/static/src/models/discuss.js
+++ b/addons/mail/static/src/models/discuss.js
@@ -166,7 +166,7 @@ registerModel({
                     'mail.action_discuss',
                     {
                         active_id: this.threadToActiveId(this),
-                        clear_breadcrumbs: false,
+                        clearBreadcrumbs: false,
                         on_reverse_breadcrumb: () => this.close(), // this is useless, close is called by destroy anyway
                     },
                 );

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -233,7 +233,7 @@ registerModel({
             this.env.services.action.doAction(
                 'mail.mail_resend_message_action',
                 {
-                    additional_context: {
+                    additionalContext: {
                         mail_message_to_resend: this.id,
                     },
                 }

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -193,7 +193,7 @@ QUnit.test('Notification Error', async function (assert) {
                 "action should be the one to resend email"
             );
             assert.strictEqual(
-                options.additional_context.mail_message_to_resend,
+                options.additionalContext.mail_message_to_resend,
                 mailMessageId,
                 "action should have correct message id"
             );

--- a/addons/sms/static/src/models/message.js
+++ b/addons/sms/static/src/models/message.js
@@ -13,7 +13,7 @@ patchRecordMethods('Message', {
             this.env.services.action.doAction(
                 'sms.sms_resend_action',
                 {
-                    additional_context: {
+                    additionalContext: {
                         default_mail_message_id: this.id,
                     },
                 },

--- a/addons/sms/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/sms/static/tests/qunit_suite_tests/components/message_tests.js
@@ -123,7 +123,7 @@ QUnit.test('Notification Error', async function (assert) {
                 "action should be the one to resend sms"
             );
             assert.strictEqual(
-                options.additional_context.default_mail_message_id,
+                options.additionalContext.default_mail_message_id,
                 mailMessageId1,
                 "action should have correct message id"
             );

--- a/addons/snailmail/static/src/models/message.js
+++ b/addons/snailmail/static/src/models/message.js
@@ -25,7 +25,7 @@ addRecordMethods('Message', {
         this.env.services.action.doAction(
             'snailmail.snailmail_letter_format_error_action',
             {
-                additional_context: {
+                additionalContext: {
                     message_id: this.id,
                 },
             },
@@ -43,7 +43,7 @@ addRecordMethods('Message', {
         this.env.services.action.doAction(
             'snailmail.snailmail_letter_missing_required_fields_action',
             {
-                additional_context: {
+                additionalContext: {
                     default_letter_id: letterIds[0],
                 },
             }

--- a/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -568,7 +568,7 @@ QUnit.test('Format Error', async function (assert) {
                 "action should be the one for format error"
             );
             assert.strictEqual(
-                options.additional_context.message_id,
+                options.additionalContext.message_id,
                 mailMessageId1,
                 "action should have correct message id"
             );
@@ -645,7 +645,7 @@ QUnit.test('Missing Required Fields', async function (assert) {
                 "action should be the one for missing fields"
             );
             assert.strictEqual(
-                options.additional_context.default_letter_id,
+                options.additionalContext.default_letter_id,
                 snailMailLetterId1,
                 "action should have correct letter id"
             );


### PR DESCRIPTION
Emails could not be resent from the chatter after failing to be sent.
This was due to parts of the code not being updated after the refactoring of OWL.

Multiple other instances of non-updated code are updated here.

Task-2887153
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
