### PR TITLE
[FIX] web: allow scroll on from/to date picker on mobile

### DIFF
--- a/addons/web/static/src/legacy/js/libs/daterangepicker.js
+++ b/addons/web/static/src/legacy/js/libs/daterangepicker.js
@@ -1,5 +1,7 @@
-odoo.define('web.daterangepicker.extensions', function () {
+odoo.define('web.daterangepicker.extensions', function (require) {
 'use strict';
+
+var config = require('web.config');
 
 /**
  * Don't allow user to select off days(Dates which are out of current calendar).
@@ -19,6 +21,14 @@ daterangepicker.prototype.move = function () {
     const offset = this.element.offset();
     this.drops = this.container.height() < offset.top ? 'up' : 'down';
     moveFunction.apply(this, arguments);
+    if (config.device.isMobile) {
+        this.container.css('overflow-y', 'auto');
+        if (this.drops === 'down') {
+            this.container.css('max-height', `calc(100vh - ${this.container.css('top')}`);
+        } else {
+            this.container.css('max-height', `calc(100vh - ${this.container.css('bottom')}`);
+        }
+    }
 };
 
 });


### PR DESCRIPTION
Steps to reproduce (on mobile):

  - Install `hr_holidays` module
  - Go to `Time Off` app and click on `New Time Off`
  - Try to select From/to dates.

Issue:

  Can't click on button `Apply`.

Cause:

  The date picker element has an absolute position.

Solution:

  When the date picker is rendered, add overflow-y: auto to the
  container and set max-height to the size of screen - top or
  bottom offset size.

opw-2803227