### PR TITLE
[FIX] web_editor: changing header style keep its text alignment

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -568,7 +568,12 @@ export const editorCommands = {
             ) {
                 setSelection(block, 0, block, nodeSize(block));
                 editor.historyPauseSteps();
+                // Keep the alignment and remove rest of the applied styles.
+                const textAlign = block.style.textAlign;
                 editor.execCommand('removeFormat');
+                if (textAlign) {
+                    block.style.textAlign = textAlign;
+                }
                 editor.historyUnpauseSteps();
                 const inLI = block.closest('li');
                 if (inLI && tagName === "P") {


### PR DESCRIPTION
**Current behavior before PR:**

On editing the card title with a triple click selection and when we select
a header causes the change on the title as well as on the body.

**Desired behavior after PR is merged:**

Now after selection(triple click) changes just the title or the selection only

Task-2641462

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
