### PR TITLE
[FIX] web: CP: remove "o_promote" is no longer used

### DIFF
--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -50,12 +50,12 @@ class DefaultFooter extends Component {
 }
 DefaultFooter.template = xml`
 <span>
-    <span class="o_promote font-weight-bolder text-primary">TIP</span> — search for
+    <span class="font-weight-bolder text-primary">TIP</span> — search for
     <t t-foreach="elements" t-as="element" t-key="element.namespace">
         <t t-if="!(element_first || element_last)">, </t>
         <t t-if="element_last and !element_first"> and </t>
         <span class="o_namespace btn-link text-primary o_cursor_pointer" t-on-click="() => this.onClick(element.namespace)">
-            <span t-out="element.namespace" class="o_promote font-weight-bolder text-primary"/><t t-out="element.name"/>
+            <span t-out="element.namespace" class="font-weight-bolder text-primary"/><t t-out="element.name"/>
         </span>
     </t>
 </span>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
