### PR TITLE
[FIX] web: graph dropdown scrollable selector matches the ouside div

### DIFF
--- a/addons/web/static/src/scss/graph_view.scss
+++ b/addons/web/static/src/scss/graph_view.scss
@@ -80,7 +80,7 @@
     }
 }
 
-.o_graph_measures_list {
+.o_graph_measures_list .o_dropdown_menu {
     max-height: calc(100vh - #{$o-navbar-height} - 100px);
     overflow-y: auto;
 }


### PR DESCRIPTION
This is a followup of https://github.com/odoo/odoo/pull/92688

The graph view has been slightly changed in 14.0 causing the selector to match
The bounding div for the graph view

cf https://github.com/odoo/odoo/commit/b74a79515c7127fdb81dc2cd8c215b9fcc97053b#commitcomment-76743519