### PR TITLE
[FIX] website: display the flag image of the language selector

### DIFF
--- a/addons/test_website/tests/test_is_multilang.py
+++ b/addons/test_website/tests/test_is_multilang.py
@@ -71,3 +71,22 @@ class TestIsMultiLang(odoo.tests.HttpCase):
         self.assertEqual(urlparse(it_href).path, f'/{it.url_code}/test_lang_url/my-super-country-italia-{country1.id}')
         self.assertEqual(urlparse(fr_href).path, f'/{be.url_code}/test_lang_url/my-super-country-belgium-{country1.id}')
         self.assertEqual(urlparse(en_href).path, f'/test_lang_url/my-super-country-{country1.id}')
+
+    def test_03_head_alternate_href(self):
+        website = self.env['website'].search([], limit=1)
+        be = self.env.ref('base.lang_fr_BE').sudo()
+        en = self.env.ref('base.lang_en').sudo()
+
+        be.active = True
+        be_prefix = "/" + be.iso_code
+
+        website.default_lang_id = en
+        website.language_ids = en + be
+
+        # alternate href should be use the current url.
+        self.url_open(be_prefix)
+        self.url_open(be_prefix + '/contactus')
+        r = self.url_open(be_prefix)
+        self.assertRegex(r.text, r'<link rel="alternate" hreflang="en" href="http://[^"]+/"/>')
+        r = self.url_open(be_prefix + '/contactus')
+        self.assertRegex(r.text, r'<link rel="alternate" hreflang="en" href="http://[^"]+/contactus"/>')

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -309,7 +309,7 @@
     </template>
 
     <template id="debug_icon" name="Debug Icon">
-        <t t-if="debug">
+        <t t-if="debug" t-nocache="The query strings and debug mode can change for the same page and the same rendering.">
             <t t-set="debug_mode_help" t-value="' (%s)' % debug if debug != '1' else ''"/>
             <a t-attf-href="?#{keep_query('*', debug='')}" t-attf-title="Debug mode is activated#{debug_mode_help}. Click here to exit debug mode."
                class="o_debug_mode"><span class="fa fa-bug"/></a>

--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -47,6 +47,7 @@ tour.register('automatic_editor_on_new_website', {
     },
     {
         content: "Select parseltongue",
+        extra_trigger: 'a.js_change_lang .o_lang_flag',
         trigger: 'a.js_change_lang[data-url_code=pa_GB]',
     },
     {

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -310,5 +310,5 @@ class WithContext(HttpCase):
         self.url_open('/contactus')
         r = self.url_open('/?debug=1')
         self.assertIn('<a class="o_debug_mode" href="?debug="', r.text)
-        r = self.url_open('/contactus?debug=1')
-        self.assertIn('<a class="o_debug_mode" href="?debug="', r.text)
+        r = self.url_open('/contactus?name=MyName')  # don't force debug here, already done on previous step
+        self.assertIn('<a class="o_debug_mode" href="?debug=&amp;name=MyName"', r.text)

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -303,3 +303,12 @@ class WithContext(HttpCase):
         root_html = html.fromstring(r.content)
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
         self.assertEqual(canonical_url, website.domain + "/")
+
+    def test_t_cache_footer_debug_link(self):
+        # Debug link (flag) should be use the current url.
+        self.url_open('/')
+        self.url_open('/contactus')
+        r = self.url_open('/?debug=1')
+        self.assertIn('<a class="o_debug_mode" href="?debug="', r.text)
+        r = self.url_open('/contactus?debug=1')
+        self.assertIn('<a class="o_debug_mode" href="?debug="', r.text)

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -110,11 +110,9 @@
         </t>
         <!-- `alternate`/`canonical` mainly useful to crawlers/bots/SEO tools, which test the website as public user -->
         <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
-            <t t-cache="website,canonical_params">
-                <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
-                <t t-foreach="alternate_languages" t-as="lg">
+            <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
+            <t t-foreach="alternate_languages" t-as="lg">
         <link rel="alternate" t-att-hreflang="lg['hreflang']" t-att-href="lg['href']"/>
-                </t>
             </t>
         </t>
         <link t-if="request and website and website.is_public_user()" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1889,6 +1889,10 @@
 </template>
 
 <template id="language_selector" inherit_id="portal.language_selector">
+    <xpath expr="//t[@t-nocache]" position="attributes">
+        <attribute name="t-nocache-flags">flags</attribute>
+    </xpath>
+
     <xpath expr="//t[@t-set='active_lang']" position="before">
         <t t-if="lang not in (lg[0] for lg in languages)">
             <t t-set="lang" t-value="website.default_lang_id.code"/>


### PR DESCRIPTION
Issue introduced by commit b0a2a41
The template's "flags" value was not in the t-nocache values to use when rendering languages.
Debug icon consistency according to the mode and the url.
Fref form link alternate depends on the current url.