### PR TITLE
Update de.po

### DIFF
--- a/addons/l10n_ch/i18n/de.po
+++ b/addons/l10n_ch/i18n/de.po
@@ -691,7 +691,7 @@ msgstr "<span>Währung</span>"
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
 msgid "<span>Payable by</span>"
-msgstr "<span>Zahlbar bis</span>"
+msgstr "<span>Zu bezahlen von</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template


### PR DESCRIPTION
"Zu bezahlen von" corresponds better to "Payable by" than "Zahlbar bis"

Description of the issue/feature this PR addresses:

Not a perfect translation

Desired behavior after PR is merged:

Better translation


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
