### PR TITLE
hr_expense: use all taxes as price_included

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -538,7 +538,7 @@
                             </group>
                             <group string="Accounting">
                                 <field name="property_account_expense_id" groups="account.group_account_readonly"/>
-                                <field name="supplier_taxes_id" domain="[('price_include', '=', True)]" widget="many2many_tags" 
+                                <field name="supplier_taxes_id" widget="many2many_tags" 
                                        context="{'default_type_tax_use':'purchase', 'default_price_include': 1}" 
                                        options="{'no_quick_create': True}"/>
                             </group>

--- a/addons/hr_expense/wizard/hr_expense_split.py
+++ b/addons/hr_expense/wizard/hr_expense_split.py
@@ -41,7 +41,7 @@ class HrExpenseSplit(models.TransientModel):
     @api.depends('total_amount', 'tax_ids')
     def _compute_amount_tax(self):
         for split in self:
-            taxes = split.tax_ids.compute_all(price_unit=split.total_amount, currency=split.currency_id, quantity=1, product=split.product_id)
+            taxes = split.tax_ids.with_context(force_price_include=True).compute_all(price_unit=split.total_amount, currency=split.currency_id, quantity=1, product=split.product_id)
             split.amount_tax = taxes['total_included'] - taxes['total_excluded']
 
     @api.depends('product_id')


### PR DESCRIPTION
In expense flow the taxes are calculated as included in price.
Prior, to guarantee it, we had domain - ('price_include', '=', True) on taxes.
That could be inconvenient from user's point of view, as they first needed to
define taxes with price_include = True. That led to users duplicating taxes
between included/excluded just so that they could use taxes in expense.

Now we force taxes to act like price_include = True. This way, user does not
need to define taxes just for expense's purposes and still taxes will be calculated
as it supposed to be - included in price.

task - 2850882

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
