### PR TITLE
[REV] mail: Don't hide activity dropdown when clicking on feedback form

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -713,10 +713,6 @@ var KanbanActivity = BasicActivity.extend({
      */
     _renderDropdown: function () {
         var self = this;
-        this.$el.dropdown({
-            boundary: 'viewport',
-            flip: false,
-        });
         this.$('.o_activity')
             .toggleClass('dropdown-menu-right', config.device.isMobile)
             .html(QWeb.render('mail.KanbanActivityLoading'));

--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -1,6 +1,5 @@
 .o_activity_view {
     height: 100%;
-    overflow: auto;
     > table {
         background-color: white;
         thead > tr > th:first-of-type {

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.KanbanActivity">
     <div class="o_kanban_inline_block dropdown o_mail_activity">
         <!-- Dropdowns are created in JS to avoid some bugs, that's why the <a/> contains no args for the dropdown creation -->
-        <a class="dropdown-toggle o-no-caret o_activity_btn" data-toggle="dropdown" role="button">
+        <a class="dropdown-toggle o-no-caret o_activity_btn" data-boundary="viewport" data-flip="false" data-toggle="dropdown" role="button">
             <!-- span classes are generated dynamically (see _render) -->
             <span t-att-title="widget.selection[widget.activityState]" role="img" t-att-aria-label="widget.selection[widget.activity_state]"/>
        </a>


### PR DESCRIPTION
revert of https://github.com/odoo/odoo/pull/91209

Steps:
    - Go to CRM, kanban view
    - click on "Planned" button
    - click on "Mark as done" button
    - click on "Write Feedback" textarea

The activity dropdown disappears immediatly

opw-2884875