### PR TITLE
[FIX] im_livechat: no unamed attachment on public livechat messages

### DIFF
--- a/addons/im_livechat/static/src/legacy/models/abstract_message.js
+++ b/addons/im_livechat/static/src/legacy/models/abstract_message.js
@@ -36,7 +36,10 @@ const AbstractMessage = Class.extend({
      * @param {string} [data.message_type = undefined]
      */
     init(parent, data) {
-        this._attachmentIDs = data.attachment_ids || [];
+        // Attachments are not supported in (public) livechat.
+        // We ignore data from server, otherwise field commands
+        // will be wrongly considered as unamed attachments.
+        this._attachmentIDs = [];
         this._body = data.body || "";
         // by default: current datetime
         this._date = data.date ? moment(time.str_to_datetime(data.date)) : moment();


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/commit/0c30945d364a8b986f0b48db28e42c7b355471e3
Commit above changed the message formatter in python,
so that `attachment_ids` now always return a list of field commands.

This work fine in backend code of discuss, but in public livechat,
it still uses legacy code. The legacy code do not support field
commands, so instead it thinks the command is data of an attachment,
thus showing an "unamed" attachment.

Actually attachments are not supported in livechat. Code had some
handling of attachments just because this was shared with the
backend in the past.

This commit fixes the issues by simply enforcing showing no
attachment in any message in public livechat.
