### PR TITLE
[FIX] base: only show salesperson that have access to partner company

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -213,7 +213,7 @@ class Partner(models.Model):
     company_type = fields.Selection(string='Company Type',
         selection=[('person', 'Individual'), ('company', 'Company')],
         compute='_compute_company_type', inverse='_write_company_type')
-    company_id = fields.Many2one('res.company', 'Company', index=True)
+    company_id = fields.Many2one('res.company', 'Company', index=True, domain=lambda self: [('id', 'in', self.env.companies.ids)])
     color = fields.Integer(string='Color Index', default=0)
     user_ids = fields.One2many('res.users', 'partner_id', string='Users', auto_join=True)
     partner_share = fields.Boolean(
@@ -374,6 +374,8 @@ class Partner(models.Model):
     def _onchange_company_id(self):
         if self.parent_id:
             self.company_id = self.parent_id.company_id.id
+        if self.user_id and self.company_id and self.company_id not in self.user_id.company_ids:
+            self.user_id = False
 
     @api.depends('name', 'email')
     def _compute_email_formatted(self):

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -336,7 +336,7 @@
                         <page name='sales_purchases' string="Sales &amp; Purchase">
                             <group name="container_row_2">
                                 <group string="Sales" name="sale" priority="1">
-                                    <field name="user_id" domain="[('share', '=', False)]"/>
+                                    <field name="user_id" domain="[('share', '=', False), '|', ('company_id', '=?', company_id), ('company_ids', '=', company_id)]"/>
                                 </group>
                                 <group string="Purchase" name="purchase" priority="2">
                                 </group>


### PR DESCRIPTION
Current behavior:
If a user only has access to company A, and you set company B as
a partner company. The user could still be selected as the partner
sales person
Before this fix you were also able to select companies that you are
not part of.

Steps to reproduce:
- Have at least 2 companies
- Edit User A so that he only has access to company B
- Edit any partner and set his company to company A
- You can still select User A as salesperson even if he doesn't have
  access to company A

opw-2884151
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
