### PR TITLE
[FIX] account: do not copy paired internal transfer reference

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -52,7 +52,7 @@ class AccountPayment(models.Model):
         help="QR-code report URL to use to generate the QR-code to scan with a banking app to perform this payment.")
     paired_internal_transfer_payment_id = fields.Many2one('account.payment',
         help="When an internal transfer is posted, a paired payment is created. "
-        "They are cross referenced trough this field")
+        "They are cross referenced trough this field", copy=False)
 
     # == Payment methods fields ==
     payment_method_line_id = fields.Many2one('account.payment.method.line', string='Payment Method',


### PR DESCRIPTION
Create an internal transfer and post it
The system will automatically create the paired payment
Now duplicate the transfer and post it
No paired payment will be created

This occurs because the field paired_internal_transfer_payment_id is
copied to the new record, linking the new intenal transfer to the old
paired payment, so the system will not create a new one

opw-2870995

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
