### PR TITLE
[FIX] auth_totp: remove outdated trusted devices

### DIFF
--- a/addons/auth_totp/models/auth_totp.py
+++ b/addons/auth_totp/models/auth_totp.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from odoo import models
+from odoo import api, models
+from odoo.addons.auth_totp.controllers.home import TRUSTED_DEVICE_AGE
+
+import logging
+_logger = logging.getLogger(__name__)
 
 
 class AuthTotpDevice(models.Model):
@@ -12,3 +16,11 @@ class AuthTotpDevice(models.Model):
     _inherit = "res.users.apikeys"
     _description = "Authentication Device"
     _auto = False
+
+    @api.autovacuum
+    def _gc_device(self):
+        self._cr.execute("""
+            DELETE FROM auth_totp_device
+            WHERE create_date < (NOW() AT TIME ZONE 'UTC' - INTERVAL '%s SECONDS')
+        """, [TRUSTED_DEVICE_AGE])
+        _logger.info("GC'd %d totp devices entries", self._cr.rowcount)


### PR DESCRIPTION
The trusted devices are valid for maximum 90 days (TRUSTED_DEVICE_AGE).
No need to keep them in the list of trusted device, it may even be
confusing.
