### PR TITLE
[FIX] crm : set default value to company_currency

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -154,7 +154,7 @@ class Lead(models.Model):
     recurring_revenue_monthly_prorated = fields.Monetary('Prorated MRR', currency_field='company_currency', store=True,
                                                compute="_compute_recurring_revenue_monthly_prorated",
                                                groups="crm.group_use_recurring_revenues")
-    company_currency = fields.Many2one("res.currency", string='Currency', related='company_id.currency_id', readonly=True)
+    company_currency = fields.Many2one("res.currency", string='Currency', compute="_compute_company_currency", readonly=True)
     # Dates
     date_closed = fields.Datetime('Closed Date', readonly=True, copy=False)
     date_action_last = fields.Datetime('Last Action', readonly=True)
@@ -252,6 +252,14 @@ class Lead(models.Model):
                 lead.user_company_ids = all_companies
             else:
                 lead.user_company_ids = lead.company_id
+
+    @api.depends('company_id')
+    def _compute_company_currency(self):
+        for lead in self:
+            if not lead.company_id:
+                lead.company_currency = self.env.company.currency_id
+            else:
+                lead.company_currency = lead.company_id.currency_id
 
     @api.depends('user_id', 'type')
     def _compute_team_id(self):

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -232,6 +232,20 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.stage_id, self.stage_team1_1)
 
     @users('user_sales_manager')
+    def test_crm_lead_currency_sync(self):
+        lead = self.env['crm.lead'].create({
+            'name': 'Lead 1',
+            'company_id': self.company_main.id
+        })
+        self.assertEqual(lead.company_currency, self.env.ref('base.EUR'))
+
+        self.company_main.currency_id = self.env.ref('base.CHF')
+        lead.with_company(self.company_main).update({'company_id': False})
+        self.assertEqual(lead.company_currency, self.env.ref('base.CHF'))
+        #set back original currency
+        self.company_main.currency_id = self.env.ref('base.EUR')
+
+    @users('user_sales_manager')
     def test_crm_lead_partner_sync(self):
         lead, partner = self.lead_1.with_user(self.env.user), self.contact_2
         partner_email, partner_phone = self.contact_2.email, self.contact_2.phone


### PR DESCRIPTION
To reproduce
============

Have two companies with different currencies,
Create a lead in the first compnay => the expected revenue has the company's currency
Create a lead in the second company => the expected revenue doesn't have the currency

Purpose
=======

in v15 the `company_id` has became computed, but the compute method in some scenarios
doesn't set the `company_id`.
`company_currency` is related to `company_id`, so when `company_id` is not set `company_currency`
is also not set which occures this issue.

Specification
=============
To solve the issue, the field `company_currency` is computed now, and we give it the value of the active
company if `company_id` is not set.

opw-2862410