### PR TITLE
[FIX] project_timesheet_holidays: reset timesheets when global holiday has calendar edited

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -151,15 +151,16 @@ class ResourceCalendarLeaves(models.Model):
         return results
 
     def write(self, vals):
-        start_dates = self.mapped('date_from')
-        end_dates = self.mapped('date_to')
+        date_from, date_to, calendar_id = vals.get('date_from'), vals.get('date_to'), vals.get('calendar_id')
+        global_time_off_updated = self.env['resource.calendar.leaves']
+        if date_from or date_to or 'calendar_id' in vals:
+            global_time_off_updated = self.filtered(lambda r: (date_from is not None and r.date_from != date_from) or (date_to is not None and r.date_to != date_to) or (calendar_id is not None and r.calendar_id.id != calendar_id))
+            timesheets = global_time_off_updated.sudo().timesheet_ids
+            if timesheets:
+                timesheets.write({'global_leave_id': False})
+                timesheets.unlink()
         result = super(ResourceCalendarLeaves, self).write(vals)
-        date_from, date_to = vals.get('date_from'), vals.get('date_to')
-        if date_from or date_to:
-            if any(start_date != date_from or end_date != date_to for start_date, end_date in zip(start_dates, end_dates)):
-                timesheets = self.mapped('timesheet_ids')
-                if timesheets:
-                    timesheets.write({'global_leave_id': False})
-                    timesheets.unlink()
-                    self._timesheet_create_lines()
+        if global_time_off_updated:
+            global_time_offs_with_leave_timesheet = global_time_off_updated.filtered(lambda r: not r.resource_id and r.calendar_id.company_id.internal_project_id and r.calendar_id.company_id.leave_timesheet_task_id)
+            global_time_offs_with_leave_timesheet._timesheet_create_lines()
         return result


### PR DESCRIPTION
Steps to reproduce:
- Install Time off and timesheet modules
- Create a public holiday with no "working hours"
- Then edit it and add it with working hours used by some employees

Expected behavior:
Adding the working hours makes that the global time off meets the
requirements to create timesheets. Then the employee related to the
new "working hours" is going to have timesheets created for this
holiday.

Current behavior:
No timesheet is created.

Explanation:
The write function of the global time off only updated timesheets
when the dates where modified. We add the update in the calendar_id
modification case and with it the new conditions to create the
timesheets.

opw-2879882
