### PR TITLE
[MERGE][FIX] mail: allow normal users to view mail template preview

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -69,11 +69,21 @@ class MailTemplate(models.Model):
                                         help="Sidebar action to make this template available on records "
                                              "of the related document model")
 
+    # access
+    can_write = fields.Boolean(compute='_compute_can_write',
+                               help='The current user can edit the template.')
+
     # Overrides of mail.render.mixin
     @api.depends('model')
     def _compute_render_model(self):
         for template in self:
             template.render_model = template.model
+
+    @api.depends_context('uid')
+    def _compute_can_write(self):
+        writable_templates = self._filter_access_rules('write')
+        for template in self:
+            template.can_write = template in writable_templates
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/mail/static/src/scss/composer.scss
+++ b/addons/mail/static/src/scss/composer.scss
@@ -172,3 +172,10 @@
         background-color: rgba($white, 0.1);
     }
 }
+
+.o_mail_composer_form {
+    .oe-bordered-editor[name=body] .o_readonly {
+        border: 1px solid $o-gray-300;
+        padding: 4px;
+    }
+}

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -46,7 +46,10 @@
                                 <div class="oe_title">
                                     <h2 style="display: inline-block;"><field name="subject" placeholder="Subject (placeholders may be used here)"/></h2>
                                 </div>
-                                <field name="body_html" widget="html" class="oe-bordered-editor" options="{'style-inline': true, 'codeview': true }"/>
+                                <field name="can_write" invisible="1"/>
+                                <field name="body_html" widget="html" class="oe-bordered-editor"
+                                    options="{'style-inline': true, 'codeview': true }"
+                                    attrs="{'readonly': [('can_write', '=', False)]}"/>
                                 <field name="attachment_ids" widget="many2many_binary"/>
                             </page>
                             <page string="Email Configuration" name="email_configuration">

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -6,7 +6,7 @@
             <field name="model">mail.compose.message</field>
             <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
             <field name="arch" type="xml">
-                <form string="Compose Email">
+                <form string="Compose Email" class="o_mail_composer_form">
                     <group>
                         <!-- truly invisible fields for control and options -->
                         <field name="composition_mode" invisible="1"/>

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -5,7 +5,7 @@
             <field name="name">survey.invite.view.form</field>
             <field name="model">survey.invite</field>
             <field name="arch" type="xml">
-                <form string="Compose Email">
+                <form string="Compose Email" class="o_mail_composer_form">
                     <group col="1">
                         <group col="2">
                             <field name="survey_access_mode" invisible="1"/>

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -5,7 +5,7 @@
             <field name="name">slide.channel.invite.view.form</field>
             <field name="model">slide.channel.invite</field>
             <field name="arch" type="xml">
-                <form string="Compose Email">
+                <form string="Compose Email" class="o_mail_composer_form">
                     <group col="1">
                         <group col="2">
                             <field name="channel_id" invisible="1"/>


### PR DESCRIPTION
**Template Access Issue**

Followup of odoo/odoo@1a3e713c99474951cb5000c55a2382ba12074273

Bug
===

If the user doesn't have the template editor, he cannot open the template
preview.

Technical
=========

The reason for that is because the web editor moves some CSS properties,
and so when the user tries to open the preview, an access error is raised.

1. Ideally, the template form view should not be editable if the access
rules do not allow it. But in `_postprocess_tag_field`, we only check
for access right because we don't have the record. So a user without
write access rules, but having write access right can edit the template
in the UI, and gets an error when saving.

2. Also, the web editor should not save the HTML value if no change are
made on the field (like all other text / char field).

To mitigate the issue in stable, we add a computed field that check the
access rules and make the body readonly if he can not edit the template.
So the web editor is not loaded, the CSS properties are not moved. Other
possible solutions are way to complex technically speaking (editor internals
to update in frontend, complex comparison of html blobs in backend, cache
usage making fields_view_get override not working in all cases, ... )

As the HTML body look weird in readonly mode, add the same border as the web
editor.

**Ir.Model Issue**

A user without administration right can not preview a mail template because
of the ACl on the <ir.model>.

Task-2845877