### PR TITLE
[FIX] purchase_mrp: set anglo_saxon flag in the test

### DIFF
--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -27,6 +27,8 @@ class TestAngloSaxonValuationPurchaseMRP(SavepointCase):
             'property_stock_valuation_account_id': cls.stock_valuation_account.id,
         })
 
+        cls.env.company.anglo_saxon_accounting = True
+
     def test_kit_anglo_saxo_price_diff(self):
         """
         Suppose an automated-AVCO configuration and a Price Difference Account defined on


### PR DESCRIPTION
If the module `l10n_de` is installed, the test
`test_kit_anglo_saxo_price_diff` will fail. This is because the flag
`use_anglo_saxon` is not enabled by default in the chart template of
German companies. Therefore, when posting the invoice, we skip the
anglo-saxon lines generation:
https://github.com/odoo/odoo/blob/f3ae759f2d54829f91badd32cacf70e8a8211288/addons/purchase_stock/models/account_invoice.py#L40-L42
This explains why the test fails.

OPW-2843861