### PR TITLE
[FIX] website, web_unsplash: allow Restricted editor to use Unsplash

### DIFF
--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class Web_Unsplash(http.Controller):
 
     def _get_access_key(self):
-        if request.env.user._has_unsplash_key_rights():
+        if request.env.user._has_unsplash_key_rights(mode='read'):
             return request.env['ir.config_parameter'].sudo().get_param('unsplash.access_key')
         raise werkzeug.exceptions.NotFound()
 
@@ -141,7 +141,7 @@ class Web_Unsplash(http.Controller):
 
     @http.route("/web_unsplash/save_unsplash", type='json', auth="user")
     def save_unsplash(self, **post):
-        if request.env.user._has_unsplash_key_rights():
+        if request.env.user._has_unsplash_key_rights(mode='write'):
             request.env['ir.config_parameter'].sudo().set_param('unsplash.app_id', post.get('appId'))
             request.env['ir.config_parameter'].sudo().set_param('unsplash.access_key', post.get('key'))
             return True

--- a/addons/web_unsplash/models/res_users.py
+++ b/addons/web_unsplash/models/res_users.py
@@ -6,10 +6,12 @@ from odoo import models
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
-    def _has_unsplash_key_rights(self):
+    def _has_unsplash_key_rights(self, mode='write'):
         self.ensure_one()
         # Website has no dependency to web_unsplash, we cannot warranty the order of the execution
         # of the overwrite done in 5ef8300.
         # So to avoid to create a new module bridge, with a lot of code, we prefer to make a check
         # here for website's user.
-        return self.has_group('base.group_erp_manager') or self.has_group('website.group_website_designer')
+        assert mode in ('read', 'write')
+        website_group_required = (mode == 'write') and 'website.group_website_designer' or 'website.group_website_publisher'
+        return self.has_group('base.group_erp_manager') or self.has_group(website_group_required)


### PR DESCRIPTION
Before this commit, when a restricted editor search for an image, he
will have an error 404 not found, when he try to access to the unsplash
key. Now he can search for image on Unsplash.
