### PR TITLE
[FIX] web_editor: allow to convert a list element into a paragraph block

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -547,7 +547,7 @@ export const editorCommands = {
         const selectedBlocks = [...new Set(getTraversedNodes(editor.editable).map(closestBlock))];
         for (const block of selectedBlocks) {
             if (
-                ['P', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE'].includes(
+                ['P', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'BLOCKQUOTE'].includes(
                     block.nodeName,
                 )
             ) {
@@ -555,8 +555,13 @@ export const editorCommands = {
                 editor.historyPauseSteps();
                 editor.execCommand('removeFormat');
                 editor.historyUnpauseSteps();
-                setTagName(block, tagName);
-            } else {
+                const inLI = block.closest('li');
+                if (inLI && tagName === "P") {
+                    inLI.oToggleList(0);
+                } else {
+                    setTagName(block, tagName);
+                }
+            }  else {
                 // eg do not change a <div> into a h1: insert the h1
                 // into it instead.
                 const newBlock = editor.document.createElement(tagName);


### PR DESCRIPTION
**Current behavior before PR:**

Conversion of list element to paragraph block was not possible, as Text from
    command-list was only changing the tag of a selected element, not the list tag.

**Desired behavior after PR is merged:**

Now list element can be converted to a paragraph block when the Text block is
    selected.

Task-2826472


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
