### PR TITLE
[ADD] web_editor, mass_mailing: add signature command to PowerBox

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -313,9 +313,8 @@ var MassMailingFieldHtml = FieldHtml.extend({
         const options = this._super.apply(this, arguments);
         options.resizable = false;
         options.defaultDataForLinkTools = { isNewWindow: true };
-        if (this._wysiwygSnippetsActive) {
-            options.wysiwygAlias = 'mass_mailing.wysiwyg';
-        } else {
+        options.wysiwygAlias = 'mass_mailing.wysiwyg';
+        if (!this._wysiwygSnippetsActive) {
             delete options.snippets;
         }
         return options;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1874,6 +1874,22 @@ const Wysiwyg = Widget.extend({
                     this.odooEditor.execCommand('setTag', 'pre');
                 },
             },
+            {
+                groupName: 'Basic blocks',
+                title: 'Signature',
+                description: 'Insert your signature.',
+                fontawesome: 'fa-pencil-square-o',
+                callback: async () => {
+                    const res = await this._rpc({
+                        model: 'res.users',
+                        method: 'read',
+                        args: [this.getSession().uid, ['signature']],
+                    });
+                    if (res && res[0] && res[0].signature) {
+                        this.odooEditor.execCommand('insertHTML', res[0].signature);
+                    }
+                },
+            },
         ];
         if (options.allowCommandLink) {
             commands.push(


### PR DESCRIPTION
This adds a command to the PowerBox to insert a signature into the editable document.

Implementing a first iteration of this revealed an issue with mass_mailing that is fixed here: the "plain text" template instantiated the regular web_editor.wysiwyg rather than its specific override for mass_mailing, with the consequence that it didn't include certain customizations like commands that should be overridden for mass_mailing.

task-2715295

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
