### PR TITLE
[FIX] point_of_sale: close popup buttons hidden on mobile

### DIFF
--- a/addons/point_of_sale/static/src/css/popups/closing_pos_popup.css
+++ b/addons/point_of_sale/static/src/css/popups/closing_pos_popup.css
@@ -127,6 +127,28 @@
     font-style: italic;
 }
 
+@media screen and (max-width: 768px) {
+    .pos .close-pos-popup {
+        overflow-y: auto;
+    }
+
+    .pos .close-pos-popup .footer {
+        display: flex;
+        flex-direction: column;
+        height: unset;
+    }
+
+    .pos .close-pos-popup .footer .button {
+        width: 90% !important;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .pos .close-pos-popup .footer .button:last-of-type {
+        margin-bottom: 10px;
+    }
+}
+
 .pos .close-pos-popup .footer .button {
     width: 150px;
 }


### PR DESCRIPTION
## Steps to follow:

  - Use a mobile view in the browser dev tools
  - Open the POS app
  - Perform a Sale
  - Close the session
  
### Before the fix:
![image](https://user-images.githubusercontent.com/48759451/175322455-16ebf016-693c-46a7-849a-12dc7eab0aa8.png)

### With the fix:
![image](https://user-images.githubusercontent.com/48759451/175322304-1cc060b1-b8dc-4fa9-9ce1-bc956ccbe29e.png)

I tested it and it works correctly on
- Firefox Android
- Chrome Android
- Safari IOS

opw-2788751