### PR TITLE
[FIX] sale: Partial payment link with invoice policy based on deliverd qty

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -113,10 +113,10 @@ class PaymentTransaction(models.Model):
         # invoice the sale orders if needed
         self._invoice_sale_orders()
         res = super(PaymentTransaction, self)._reconcile_after_transaction_done()
-        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
+        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice') and any(so.state in ('sale', 'done') for so in self.sale_order_ids):
             default_template = self.env['ir.config_parameter'].sudo().get_param('sale.default_email_template')
             if default_template:
-                for trans in self.filtered(lambda t: t.sale_order_ids):
+                for trans in self.filtered(lambda t: t.sale_order_ids.filtered(lambda so: so.state in ('sale', 'done'))):
                     ctx_company = {'company_id': trans.acquirer_id.company_id.id,
                                    'force_company': trans.acquirer_id.company_id.id,
                                    'mark_invoice_as_sent': True,
@@ -132,9 +132,11 @@ class PaymentTransaction(models.Model):
                 ctx_company = {'company_id': trans.acquirer_id.company_id.id,
                                'force_company': trans.acquirer_id.company_id.id}
                 trans = trans.with_context(**ctx_company)
-                trans.sale_order_ids._force_lines_to_invoice_policy_order()
-                invoices = trans.sale_order_ids._create_invoices()
-                trans.invoice_ids = [(6, 0, invoices.ids)]
+                confirmed_orders = trans.sale_order_ids.filtered(lambda so: so.state in ('sale', 'done'))
+                if confirmed_orders:
+                    confirmed_orders._force_lines_to_invoice_policy_order()
+                    invoices = confirmed_orders._create_invoices()
+                    trans.invoice_ids = [(6, 0, invoices.ids)]
 
     @api.model
     def _compute_reference_prefix(self, values):

--- a/addons/sale/tests/test_sale_transaction.py
+++ b/addons/sale/tests/test_sale_transaction.py
@@ -55,3 +55,17 @@ class TestSaleTransaction(AccountingTestCase):
         with mute_logger('odoo.addons.sale.models.payment'):
             self.transaction._post_process_after_done()
         self.assertEqual(self.order.state, 'draft', 'a transaction for an incorrect amount should not validate a quote')
+
+    def test_sale_transaction_partial_delivery(self):
+        """Test that with automatic invoice and invoicing policy based on delivered quantity, a transaction for the partial
+        amount does not validate the SO."""
+        # set automatic invoice
+        self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', 'True')
+        # modify order total
+        self.order.order_line[0].price_unit = 200.0
+        # invoicing policy is based on delivered quantity
+        self.product.invoice_policy = 'delivery'
+        self.transaction._set_transaction_done()
+        with mute_logger('odoo.addons.sale.models.payment'):
+            self.transaction.sudo()._post_process_after_done()
+        self.assertEqual(self.order.state, 'draft', 'a partial transaction with automatic invoice and invoice_policy = delivery should not validate a quote')


### PR DESCRIPTION
- Configure payment stripe to be available on the web shop
- Let's consider a product with P (sales price = 100€) invoice policy based on delivered qty
- Set in the config parameter sale.automatic_invoice to True
- Create a SO with P and generate a payment link PL for 50€
- Go to PL and pay it

Bug:

An error was raised because there was no invoicable line when computing the
invoice of SO

opw:2635175

Backport of dee53d8aecd3d1eedd37bfa93c07ca28a3441fbe

This backport is needed to fix the error `There is nothing to invoice` raise on the payment processing page for the new integration of Adyen PayByLink.

See: 
- https://github.com/odoo/odoo/pull/87041
