### PR TITLE
[FIX] account: remove tags of deleted taxes

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -751,6 +751,8 @@ var StatementModel = BasicModel.extend({
                         prop.tax_ids = _.filter(prop.tax_ids, function (val) {
                             return val.id !== id;
                         });
+                        // Remove all tax tags, they will be recomputed in case of remaining taxes
+                        prop.tag_ids = [];
                         break;
                 }
             }


### PR DESCRIPTION
Have a tax with tax tags
Create a bank statement line
Reconcile creating a manual operation, add the tax, then remove it and
validate
Check journal entry

The tax tags will be present on the base line even if the tax was
removed

opw-2867395

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
