### PR TITLE
[FIX] base: retrieve last rates only from current company

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -356,7 +356,7 @@ class CurrencyRate(models.Model):
         return super().create([self._sanitize_vals(vals) for vals in vals_list])
 
     def _get_latest_rate(self):
-        return self.currency_id.rate_ids.filtered(lambda x: (
+        return self.currency_id.rate_ids.sudo().filtered(lambda x: (
             x.rate
             and x.company_id == (self.company_id or self.env.company)
             and x.name < (self.name or fields.Date.today())
@@ -364,7 +364,7 @@ class CurrencyRate(models.Model):
 
     def _get_last_rates_for_companies(self, companies):
         return {
-            company: company.currency_id.rate_ids.filtered(lambda x: (
+            company: company.currency_id.rate_ids.sudo().filtered(lambda x: (
                 x.rate
                 and x.company_id == company or not x.company_id
             )).sorted('name')[-1:].rate or 1


### PR DESCRIPTION
Steps to reproduce:

  - Install accounting module
  - Ensure there is 2 companies
  - Activate both companies (with company switcher)
  - Go to Accounting -> Configuration -> Currencies
  - Select currency `EUR`
  - Add a rate and set second company as company
  - Disable second company (with company switcher)
  - Click on `Show Currency Rates` in action menu
  - Click on create

Issue:

  Access Error

Cause:

  Currency Rate model have a compute field `rate`.
  This last one calls `_get_latest_rate` that will retrieve the last
  rate for the currency. To do so, it will first retrieve all rates for
  the currency (that might include rates with company not the same as the
  current one) before filtering regarding company.

Solution:

  Use sudo().  Same issue/fix for `_get_last_rates_for_companies`.

opw-2832708