### PR TITLE
[FIX] payment: amount can be negative

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -677,7 +677,7 @@ class PaymentTransaction(models.Model):
         self.ensure_one()
 
         payment_vals = {
-            'amount': self.amount,
+            'amount': abs(self.amount),
             'payment_type': 'inbound' if self.amount > 0 else 'outbound',
             'currency_id': self.currency_id.id,
             'partner_id': self.partner_id.commercial_partner_id.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
the amount of payment cannot be negative.
the negative amount is manage by payment_type.


@oco-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
