### PR TITLE
[15.0] [FIX] Fix compute rounding to_minor_currency_units method.

### DIFF
--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -95,7 +95,7 @@ def to_minor_currency_units(major_amount, currency, arbitrary_decimal_number=Non
 
     The conversion is done by multiplying the amount by 10^k where k is the number of decimals of
     the currency as per the ISO 4217 norm.
-    To force a different number of decimals, set it as the value of the `decimal_number` argument.
+    To force a different number of decimals, set it as the value of the `arbitrary_decimal_number` argument.
 
     Note: currency.ensure_one() if arbitrary_decimal_number is not provided
 
@@ -110,7 +110,7 @@ def to_minor_currency_units(major_amount, currency, arbitrary_decimal_number=Non
     else:
         currency.ensure_one()
         decimal_number = currency.decimal_places
-    return int(float_round(major_amount, decimal_number) * (10**decimal_number))
+    return int(float_round(major_amount * (10**decimal_number), precision_digits=0))
 
 
 # Token values formatting


### PR DESCRIPTION
eg : if we have a major_amount to 2.04999 and arbitrary_decimal_number to 2.
Before this commit, we had a result to 204 instead of 205.


Description of the issue/feature this PR addresses:
The rounding is wrong if we have a major_amount to 2.04999 and arbitrary_decimal_number to 2.

Current behavior before PR:
We had a result to 204 instead of 205.

Desired behavior after PR is merged:
We have a result to 205.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
