### PR TITLE
[FIX] web_editor: crash on pasting from website

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.js
+++ b/addons/web_editor/static/src/js/editor/rte.js
@@ -11,6 +11,8 @@ var summernoteCustomColors = require('web_editor.rte.summernote_custom_colors');
 
 var _t = core._t;
 
+const { browser } = owl;
+
 // Summernote Lib (neek change to make accessible: method and object)
 var dom = summernote.core.dom;
 var range = summernote.core.range;


### PR DESCRIPTION
Current behavior before PR:

When pasting content on a web page with a web editor, a `browser is not defined`
 error occurs. This error seems to commit [1] import missing `browser`
 while calling `browser.setTimeout`.

So we imported `browser` from owl to handle this error.

[1]: https://github.com/odoo/odoo/commit/3e8259bba04dc4f1a3e35fb10ff6c885a1c65ac5


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
