### PR TITLE
[FIX] web: fix timing issue in owl_compatibility

### DIFF
--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -436,20 +436,17 @@ odoo.define('web.OwlCompatibility', function (require) {
     function setToRemount(node, updateAndRender) {
         let toRemount = true;
 
-        node.mounted.push(() => {
-            toRemount = false;
-        });
         if (!node.isPatched) {
             node.isPatched = true;
-            const renderFn = node.renderFn;
-            node.renderFn = () => {
-                const res = renderFn.call(node, ...arguments);
+            node.mounted.push(() => {
+                toRemount = false;
+            });
+            node.willUpdateProps.push(() => {
                 const rootMounted = node.fiber.root.mounted;
                 if (toRemount && !rootMounted.includes(node.fiber)) {
                     rootMounted.push(node.fiber);
                 }
-                return res;
-            }
+            });
         }
         return () => toRemount = true;
     }


### PR DESCRIPTION
A recent update in owl required a change in the owl compatibility layer.
(see commit 3c7e2cb5a2224ff624e0899ca392be8b3828b43a)

Sadly, even though the change seems correct to me, it slightly changes
the timing of the owl compatibility code, which causes issues in the
forward ported code.  With this commit, we update the owl compatibility
code to be closer to the previous behaviour

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
