### PR TITLE
[FIX] web_editor: correct link behaviors 

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -13,7 +13,9 @@ import {
     isMediaElement,
     getDeepRange,
     isUnbreakable,
-    isUnremovable
+    closestElement,
+    getUrlsInfosInString,
+    URL_REGEX,
 } from './utils.js';
 
 const NOT_A_NUMBER = /[^\d]/g;
@@ -107,9 +109,10 @@ class Sanitize {
                 node = nodeP;
             }
 
+            const anchor = this.root.ownerDocument.getSelection().anchorNode;
+            const anchorEl = anchor && closestElement(anchor);
             // Remove zero-width spaces added by `fillEmpty` when there is
             // content and the selection is not next to it.
-            const anchor = this.root.ownerDocument.getSelection().anchorNode;
             if (
                 node.nodeType === Node.TEXT_NODE &&
                 node.textContent.includes('\u200B') &&
@@ -174,7 +177,15 @@ class Sanitize {
             ) {
                 node.setAttribute('contenteditable', 'false');
             }
-
+            // update link URL if label is a new valid link
+            if (node.nodeName === 'A' && anchorEl === node) {
+                const linkLabel = node.textContent;
+                const match = linkLabel.match(URL_REGEX);
+                if (match && match[0] === node.textContent) {
+                    const urlInfo = getUrlsInfosInString(linkLabel)[0];
+                    node.setAttribute('href', urlInfo.url);
+                }
+            }
             if (node.firstChild) {
                 this._parse(node.firstChild);
             }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -23,11 +23,36 @@ export const CTGROUPS = {
     BLOCK: CTYPES.BLOCK_OUTSIDE | CTYPES.BLOCK_INSIDE,
     BR: CTYPES.BR,
 };
+const tldWhitelist = [
+    'com', 'net', 'org', 'ac', 'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'an',
+    'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'ax', 'az', 'ba', 'bb', 'bd',
+    'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bl', 'bm', 'bn', 'bo', 'br', 'bq',
+    'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch',
+    'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cs', 'cu', 'cv', 'cw', 'cx',
+    'cy', 'cz', 'dd', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg',
+    'eh', 'er', 'es', 'et', 'eu', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga',
+    'gb', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq',
+    'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu',
+    'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm',
+    'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky',
+    'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly',
+    'ma', 'mc', 'md', 'me', 'mf', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo',
+    'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na',
+    'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om',
+    'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt',
+    'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd',
+    'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'ss',
+    'st', 'su', 'sv', 'sx', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj',
+    'tk', 'tl', 'tm', 'tn', 'to', 'tp', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua',
+    'ug', 'uk', 'um', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn',
+    'vu', 'wf', 'ws', 'ye', 'yt', 'yu', 'za', 'zm', 'zr', 'zw', 'co\\.uk'];
 
-export const URL_REGEX =
-    /((?:(?:https?:\/\/)|(?:[-a-zA-Z0-9@:%._\+~#=]{1,64}\.))[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-zA-Z0-9()]{2,63}\b(?:(?!\.)[^\s]*))/gi;
-export const URL_REGEX_WITH_INFOS =
-    /((?:(https?:\/\/)|(?:[-a-zA-Z0-9@:%._\+~#=]{1,64}\.))[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-zA-Z0-9()]{2,63}\b(?:(?!\.)[^\s]*))/gi;
+const urlRegexBase = `|(?:[-a-zA-Z0-9@:%._\\+~#=]{1,64}\\.))[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-zA-Z][a-zA-Z0-9]{1,62}|(?:[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.(?:${tldWhitelist.join('|')})))\\b(?:(?!\\.)[^\\s]*`;
+const httpRegex = `(?:https?:\\/\\/)`;
+const httpCapturedRegex= `(https?:\\/\\/)`;
+
+export const URL_REGEX = new RegExp(`((?:(?:${httpRegex}${urlRegexBase}))`, 'gi');
+export const URL_REGEX_WITH_INFOS = new RegExp(`((?:(?:${httpCapturedRegex}${urlRegexBase}))`, 'gi');
 export const YOUTUBE_URL_GET_VIDEO_ID =
     /^(?:(?:https?:)?\/\/)?(?:(?:www|m)\.)?(?:youtube\.com|youtu\.be)(?:\/(?:[\w-]+\?v=|embed\/|v\/)?)([^\s?&#]+)(?:\S+)?$/i;
 

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -1260,6 +1260,29 @@ describe('Copy and paste', () => {
                     },
                     contentAfter: '<p>a<a href="http://existing.com">bhttp://www.xyz.com[]c</a>d</p>',
                 });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'random');
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">brandom[]c</a>d</p>',
+                });
+            });
+            it('should paste and transform an URL in a existing link if pasting valid url', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">[]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://www.xyz.xdc');
+                    },
+                    contentAfter: '<p>a<a href="https://www.xyz.xdcc">https://www.xyz.xdc[]c</a>d</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[].com</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'oom');
+                    },
+                    contentAfter: '<p>a<a href="https://boom.com">boom[].com</a>d</p>',
+                });
             });
         });
         describe('range not collapsed', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/urlRegex.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/urlRegex.test.js
@@ -1,20 +1,24 @@
-import { URL_REGEX } from '../../src/OdooEditor.js';
+import { URL_REGEX, URL_REGEX_WITH_INFOS } from '../../src/OdooEditor.js';
 
 describe('urlRegex', () => {
-    it('should not match foo.com', () => {
+    it('should match foo.com', () => {
         const url = 'foo.com';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+    it('should not match foo.else', () => {
+        const url = 'foo.else';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX);
         chai.expect(match).to.be.equal(null);
     });
-
     it('should match abc.abc.abc', () => {
         const url = 'abc.abc.abc';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX);
         chai.expect(match[0]).to.be.equal(url);
     });
-
     it('should match http://abc.abc.abc', () => {
         const url = 'http://abc.abc.abc';
         const text = `abc ${url} abc`;
@@ -27,7 +31,6 @@ describe('urlRegex', () => {
         const match = text.match(URL_REGEX);
         chai.expect(match[0]).to.be.equal(url);
     });
-
     it('should match 1234-abc.runbot007.odoo.com/web#id=3&menu_id=221', () => {
         const url = '1234-abc.runbot007.odoo.com/web#id=3&menu_id=221';
         const text = `abc ${url} abc`;
@@ -38,6 +41,51 @@ describe('urlRegex', () => {
         const url = 'https://1234-abc.runbot007.odoo.com/web#id=3&menu_id=221';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+});
+
+describe('urlRegex with infos', () => {
+    it('should match foo.com', () => {
+        const url = 'foo.com';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+    it('should not match foo.else', () => {
+        const url = 'foo.else';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
+        chai.expect(match).to.be.equal(null);
+    });
+    it('should match abc.abc.abc', () => {
+        const url = 'abc.abc.abc';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+    it('should match http://abc.abc.abc', () => {
+        const url = 'http://abc.abc.abc';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+    it('should match https://abc.abc.abc', () => {
+        const url = 'https://abc.abc.abc';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+    it('should match 1234-abc.runbot007.odoo.com/web#id=3&menu_id=221', () => {
+        const url = '1234-abc.runbot007.odoo.com/web#id=3&menu_id=221';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
+        chai.expect(match[0]).to.be.equal(url);
+    });
+    it('should match https://1234-abc.runbot007.odoo.com/web#id=3&menu_id=221', () => {
+        const url = 'https://1234-abc.runbot007.odoo.com/web#id=3&menu_id=221';
+        const text = `abc ${url} abc`;
+        const match = text.match(URL_REGEX_WITH_INFOS);
         chai.expect(match[0]).to.be.equal(url);
     });
 });


### PR DESCRIPTION
Change the unit test to reflect spec:

* Some TLD are white listed to not required a subdomain to be considered a valid URL.
 => .com, .net, .org + all ccTLD

* Change a link 'href' when we change the link label,
 if the new label is a valid URL.

task-2858621

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
