### PR TITLE
[IMP] web: update owl from 2.0.0-beta-8 to 2.0.0-beta-10

### DIFF
--- a/addons/web/static/src/core/datepicker/datepicker.xml
+++ b/addons/web/static/src/core/datepicker/datepicker.xml
@@ -8,7 +8,7 @@
                 class="o_datepicker_input o_input datetimepicker-input"
                 t-att-name="props.name"
                 t-att-placeholder="props.placeholder"
-                t-attf-data-target="#{{ datePickerId }}"
+                t-attf-data-target="#{ '#' + datePickerId }"
                 t-att-readonly="props.readonly"
                 t-ref="input"
                 t-on-change="() => this.onDateChange()"

--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -153,7 +153,7 @@ odoo.define('web.OwlCompatibility', function (require) {
         onWillStart() {
             if (!(this.props.Component.prototype instanceof Component)) {
                 this.widget = new this.props.Component(this, ...this.widgetArgs);
-                return this.widget._widgetRenderAndInsert(() => {});
+                return this.widget._widgetRenderAndInsert(() => { });
             }
         }
 
@@ -290,7 +290,7 @@ odoo.define('web.OwlCompatibility', function (require) {
     }
 
     const bodyRef = { get el() { return document.body } };
-    function standaloneAdapter(props = {}, ref=bodyRef) {
+    function standaloneAdapter(props = {}, ref = bodyRef) {
         const env = owl.Component.env;
         const app = new App(null, {
             templates: window.__OWL_TEMPLATES__,
@@ -413,7 +413,7 @@ odoo.define('web.OwlCompatibility', function (require) {
     function prepareForFinish(node) {
         const fiber = node.fiber;
         const complete = fiber.complete;
-        fiber.complete = function() {
+        fiber.complete = function () {
             // if target is not in dom
             // just trigger mounted hooks on the Proxy, not on any other node
             if (!this.target.ownerDocument.contains(this.target)) {
@@ -436,18 +436,18 @@ odoo.define('web.OwlCompatibility', function (require) {
     function setToRemount(node, updateAndRender) {
         let toRemount = true;
 
-        node.mounted.push(() => {
-            toRemount = false;
-        });
-        node.updateAndRender = function (props, parentFiber) {
-            const res = updateAndRender.call(this, ...arguments);
-            const rootMounted = parentFiber.root.mounted;
-            if (toRemount && !rootMounted.includes(this.fiber)) {
-                rootMounted.push(this.fiber);
-            }
-            return res;
-        };
-
+        if (!node.isPatched) {
+            node.isPatched = true;
+            node.mounted.push(() => {
+                toRemount = false;
+            });
+            node.willUpdateProps.push(() => {
+                const rootMounted = node.fiber.root.mounted;
+                if (toRemount && !rootMounted.includes(node.fiber)) {
+                    rootMounted.push(node.fiber);
+                }
+            });
+        }
         return () => toRemount = true;
     }
     /**
@@ -586,7 +586,7 @@ odoo.define('web.OwlCompatibility', function (require) {
             return this.app.makeNode(ProxyComponent, props);
         }
 
-        setup() {}
+        setup() { }
 
         get el() {
             return this.node.component.el;
@@ -685,7 +685,7 @@ odoo.define('web.OwlCompatibility', function (require) {
                 return;
             }
             recursiveCall(this.node, true, (node) => {
-               for (const cb of node.mounted) {
+                for (const cb of node.mounted) {
                     cb();
                 }
             });

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -127,7 +127,7 @@
         <input type="text" class="o_datepicker_input o_input datetimepicker-input"
             t-att-name="props.name"
             t-att-placeholder="props.placeholder"
-            t-attf-data-target="#{{ datePickerId }}"
+            t-attf-data-target="#{ '#' + datePickerId }"
             t-att-readonly="props.readonly"
             t-ref="autofocus"
             t-on-change="_onInputChange"


### PR DESCRIPTION
Note: this PR is a manual forward port. The original PR are:
- in saas-15.3 => https://github.com/odoo/odoo/pull/94249
- in saas-15.4 => https://github.com/odoo/odoo/pull/94407

Release notes:
https://github.com/odoo/owl/releases/tag/v2.0.0-beta-9
https://github.com/odoo/owl/releases/tag/v2.0.0-beta-10

Details:

Fix: event: no crash when using t-on + modifier on slots/components
Fix: component: fix props comparison code
Fix: component: fix wrong behaviour when using t-on on t-component
Fix: component: props values are own property of props object
Fix: t-out: allow expressions evaluating as number
Fix: compiler: add support for #{...} in string interpolation
Fix: compiler: escape backticks in attributes
Fix: crash when dynamic class have leading space
Imp: slots: add support for t-props on slots props
Imp: tooling: add another d.ts file
Imp: app: small scale perf improvement
Imp: app: add fast path for when component has no prop
Imp: validation: add support for value types
Imp: add support for t-call-context
Ref: compiler: remove useless ; in compiled output
Ref: move some code around
X-original-commit: 3c7e2cb5a2224ff624e0899ca392be8b3828b43a

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
