### PR TITLE
[ADD] missing_index: new module to control adding indexes to foreign …

### DIFF
--- a/addons/auto_index/__init__.py
+++ b/addons/auto_index/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/addons/auto_index/__manifest__.py
+++ b/addons/auto_index/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "auto_index",
+    'version': '0.1',
+    'summary': """
+Short (1 phrase/line) summary of the module's purpose, used as
+subtitle on modules listing or apps.openerp.com""",
+    'description': """
+        Long description of module's purpose
+    """,
+    'license': 'LGPL-3',
+    'category': 'Technical',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/missing_index_log_views.xml',
+        'views/missing_index_views.xml',
+        'views/index_statistics.xml',
+    ],
+}

--- a/addons/auto_index/models/__init__.py
+++ b/addons/auto_index/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import missing_indexes, index_change_log

--- a/addons/auto_index/models/index_change_log.py
+++ b/addons/auto_index/models/index_change_log.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class IndexChangeLog(models.Model):
+    _name = "missing.index_log"
+    _description = "actions taken on indexes"
+    _rec_name = "index_command"
+
+    index_command = fields.Char(string="Index command", required=True)
+    index_name = fields.Char(string="Index name", required=True)
+    action = fields.Selection([("created", "Created"), ("removed", "Removed")], required=True, string="Action taken")

--- a/addons/auto_index/models/missing_indexes.py
+++ b/addons/auto_index/models/missing_indexes.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, tools
+from odoo.tools import OrderedSet
+
+
+class MissingIndexes(models.Model):
+    _name = "missing.index"
+    _description = "shows the indexes that are missing from the foreign key fields"
+    _table = "o_missing_indexes_fk"
+    _auto = False
+    _rec_name = "constraint"
+    _order = "size_raw desc"
+
+    banane = fields.Char(string="table name", readonly=True)
+    orange = fields.Char(string="column name", readonly=True)
+    size = fields.Char(string="table size", readonly=True)
+    size_raw = fields.Integer(string="table size bytes", readonly=True)
+
+    constraint = fields.Char(string="foreign key name", readonly=True)
+    referenced_table = fields.Char(string="reference table", readonly=True)
+    index_create_statement = fields.Char(readonly=True)
+
+    def init(self) -> None:
+        tools.drop_view_if_exists(self._cr, self._table)
+        self._cr.execute(f"""
+CREATE OR REPLACE VIEW {self._table} as
+SELECT 
+        row_number() OVER() AS id,
+        c.conrelid::regclass                                               AS "banane",
+    /* list of key column names in order */
+       string_agg(a.attname, ',' ORDER BY x.n)                            AS orange, 
+       pg_catalog.pg_size_pretty(pg_catalog.pg_relation_size(c.conrelid)) AS size,
+       pg_catalog.pg_relation_size(c.conrelid)                            as size_raw,
+       c.conname                                                          AS constraint,
+       c.confrelid::regclass                                              AS referenced_table,
+       'create index "' || c.conname || '_idx_fk_auto" on "' || c.conrelid::regclass || '" using btree ("' ||
+       string_agg(a.attname, ',' ORDER BY x.n) || '"); '                  as index_create_statement
+FROM pg_catalog.pg_constraint c
+         /* enumerated key column numbers per foreign key */
+         CROSS JOIN LATERAL unnest(c.conkey) WITH ORDINALITY AS x(attnum, n)
+    /* name for each key column */
+         JOIN pg_catalog.pg_attribute a ON a.attnum = x.attnum AND a.attrelid = c.conrelid
+WHERE NOT EXISTS
+    /* is there a matching index for the constraint? */
+    (SELECT 1
+     FROM pg_catalog.pg_index i
+     WHERE i.indrelid = c.conrelid
+         /* it must not be a partial index */
+       AND i.indpred IS NULL
+         /* the first index columns must be the same as the
+            key columns, but order doesn't matter */
+       AND (i.indkey::smallint[])[0:cardinality(c.conkey) - 1]
+         OPERATOR (pg_catalog.@>) c.conkey)
+  AND c.contype = 'f'
+  --AND pg_catalog.pg_relation_size(c.conrelid) > 1000000
+GROUP BY c.conrelid, c.conname, c.confrelid
+having string_agg(a.attname, ',' ORDER BY x.n) not in ('create_uid', 'write_uid')
+        """)
+
+    def create_index(self):
+        """
+        actually creates the index.
+        We might do this in a CRON immediately executed, because it might take some time to create large indexes
+        """
+        for index in self:
+            index_name = f"{index.constraint}_idx_fk_auto"
+            tools.create_index(self.env.cr, index_name, index.banane, [index.orange])
+            self.env["missing.index_log"].create(
+                {"index_command": index.index_create_statement, "action": "created", "index_name": index_name})
+
+    def create_all_large_indexes(self):
+        all_indexes = self.search(domain=[('size', '>', 1000000)], order="size")  # get all the indexes, small first
+        all_indexes.create_index()
+
+
+class IndexStatistics(models.Model):
+    _name = "index.statistics"
+    _description = "shows the usage statistics of any index in postgresql"
+    _table = "o_index_statistics"
+    _auto = False
+    _order = "index_size_raw desc"
+    _rec_name = "index_name"
+
+    table_name = fields.Char(string="Table name", readonly=True)
+    index_name = fields.Char(string="Index name", readonly=True)
+    idx_scan = fields.Integer(string="Number of scans", readonly=True)
+    idx_tup_read = fields.Integer(string="Number of tuple returned", readonly=True)
+    idx_tup_fetch = fields.Integer(string="Number of fetches", readonly=True)
+    index_definition = fields.Char(string="Index definition", readonly=True)
+    index_size = fields.Char(string="Index size on disk", readonly=True)
+    index_size_raw = fields.Integer(string="Index size on disk in bytes", readonly=True)
+    is_unique = fields.Boolean(string="Is unique", readonly=True)
+    is_clustered = fields.Boolean(string="Is clustered", readonly=True)
+    is_primary = fields.Boolean(string="Is Primary", readonly=True)
+
+    def init(self) -> None:
+        tools.drop_view_if_exists(self._cr, self._table)
+        self._cr.execute(f"""
+CREATE OR REPLACE VIEW {self._table} as
+SELECT
+        row_number() OVER() AS id,
+        relid                                                    as table_id,
+        pi2.indexrelid                                           as index_id,
+        relname                                                  as table_name,
+        indexrelname                                             as index_name,
+        idx_scan,
+        idx_tup_read,
+        idx_tup_fetch,
+        indexdef                                                 as index_definition,
+        pg_size_pretty(pg_table_size(stat_all_index.indexrelid)) as index_size,
+        pg_table_size(stat_all_index.indexrelid)                 as index_size_raw,
+        pi2.indisunique                                          as is_unique,
+        pi2.indisclustered                                       as is_clustered,
+        pi2.indisprimary                                         as is_primary
+FROM pg_catalog.pg_stat_all_indexes stat_all_index
+         INNER JOIN pg_catalog.pg_indexes pi ON stat_all_index.indexrelname = pi.indexname
+         INNER JOIN pg_catalog.pg_index pi2 ON pi2.indexrelid = stat_all_index.indexrelid
+WHERE pi.schemaname <> 'pg_catalog'
+        """)
+
+    def remove_index(self):
+        for index in self:
+            tools.drop_index(self.env.cr, index.index_name, index.table_name)
+            self.env["missing.index_log"].create(
+                {"index_command": index.index_definition, "action": "removed", "index_name": index.index_name})
+
+    def remove_all_unused_indexes(self):
+        all_unused_indexes = self.search(domain=[('idx_scan', '=', 0), ('idx_tup_read', '=', 0), ('idx_tup_fetch', '=', 0), ('is_unique', '=', False), ('is_primary', '=', False), ('is_clustered', '=', False)])
+
+        all_impacted_tables = OrderedSet(all_unused_indexes.mapped('table_name'))
+
+        all_unused_indexes.remove_index()
+
+        for impacted_table in all_impacted_tables:
+            # pylint: disable=sql-injection
+            # input doesn't come from the user
+            self.env.cr.execute(f'analyse {impacted_table};')

--- a/addons/auto_index/security/ir.model.access.csv
+++ b/addons/auto_index/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auto_index_auto_index,auto_index_missing_indexes,model_missing_index,base.group_system,1,0,0,0
+access_auto_index_statistics,auto_index_statistics,model_index_statistics,base.group_system,1,0,0,0
+access_auto_index_change_log,auto_index_index_change_log,model_missing_index_log,base.group_system,1,0,1,0
+access_auto_index_index_statistics,auto_index_index_statistics,model_index_statistics,base.group_system,1,0,0,0

--- a/addons/auto_index/views/index_statistics.xml
+++ b/addons/auto_index/views/index_statistics.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- list view of missing index actions log -->
+    <record model="ir.ui.view" id="auto_index_statistics_list">
+        <field name="name">Index statistics</field>
+        <field name="model">index.statistics</field>
+        <field name="arch" type="xml">
+            <tree string="some title">
+                <field name="table_name"/>
+                <field name="index_name"/>
+                <field name="idx_scan"/>
+                <field name="idx_tup_read"/>
+                <field name="idx_tup_fetch"/>
+                <field name="index_definition" optional="hidden"/>
+                <field name="index_size"/>
+                <field name="index_size_raw" optional="hidden"/>
+                <field name="is_unique"/>
+                <field name="is_primary"/>
+                <field name="is_clustered" optional=""/>
+                <button name="remove_index" string="Remove index" type="object"/>
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="auto_index_statistics_search">
+        <field name="name">auto_index_statistics_search</field>
+        <field name="model">index.statistics</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="table_name"/>
+                <field name="index_name"/>
+                <field name="idx_scan"/>
+                <field name="idx_tup_read"/>
+                <field name="idx_tup_fetch"/>
+                <filter name="unused_index" string="Unused Index" domain="[('idx_scan','=',0),('idx_tup_read','=',0),('idx_tup_fetch','=',0),]" />
+                <filter name="large_unused_index" string="Large unused Index" domain="[('index_size_raw','>=',1000000),('idx_scan','=',0),('idx_tup_read','=',0),('idx_tup_fetch','=',0),]" />
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="auto_index_statistics">
+        <field name="name">Index statistics</field>
+        <field name="res_model">index.statistics</field>
+        <field name="context">{'search_default_unused_index': True}</field>
+    </record>
+
+    <menuitem parent="base.next_id_9" id="auto_index_statistics_menu" action="auto_index_statistics"/>
+<!--    <menuitem id="auto_index_statistics_menu" action="auto_index_statistics"/>-->
+
+     <record model="ir.actions.server" id="action_remove_unused_index">
+        <field name="name">Remove all unused indexes</field>
+        <field name="model_id" ref="model_index_statistics"/>
+        <field name="binding_model_id" ref="model_index_statistics" />
+        <field name="state">code</field>
+        <field name="groups_id" eval="[(4,ref('base.group_user'))]"/>
+        <field name="code">
+records.remove_all_unused_indexes()
+        </field>
+    </record>
+</odoo>

--- a/addons/auto_index/views/missing_index_log_views.xml
+++ b/addons/auto_index/views/missing_index_log_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- list view of missing index actions log -->
+    <record model="ir.ui.view" id="auto_index_missing_index_log_list">
+        <field name="name">Missing index log</field>
+        <field name="model">missing.index_log</field>
+        <field name="arch" type="xml">
+            <tree string="some title">
+                <field name="index_command"/>
+                <field name="action"/>
+                <field name="create_date"/>
+                <field name="create_uid"/>
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="auto_index_missing_index_log">
+        <field name="name">Missing index log</field>
+        <field name="res_model">missing.index_log</field>
+    </record>
+
+    <menuitem parent="base.next_id_9" id="auto_index_missing_index_log_menu" action="auto_index_missing_index_log"/>
+</odoo>

--- a/addons/auto_index/views/missing_index_views.xml
+++ b/addons/auto_index/views/missing_index_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- list view of missing indexes -->
+    <record model="ir.ui.view" id="auto_index_missing_index_list">
+        <field name="name">Missing index</field>
+        <field name="model">missing.index</field>
+        <field name="arch" type="xml">
+            <tree string="some title">
+                <field name="banane"/>
+                <field name="orange"/>
+                <field name="size_raw"/>
+                <field name="size" optional="hidden"/>
+                <field name="constraint" optional="hidden"/>
+                <field name="referenced_table" optional="hidden"/>
+                <button name="create_index" string="create index" type="object"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- actions opening views on models -->
+    <record model="ir.actions.act_window" id="auto_index_missing_index">
+        <field name="name">Missing index</field>
+        <field name="res_model">missing.index</field>
+    </record>
+
+    <!-- Top menu item -->
+    <menuitem parent="base.next_id_9" id="auto_index_missing_index_menu" action="auto_index_missing_index"/>
+<!--    <menuitem  id="auto_index_missing_index_menu" action="auto_index_missing_index"/>-->
+
+     <record model="ir.actions.server" id="action_create_all_large_index">
+        <field name="name">All large (>1Mb) FK indexes</field>
+        <field name="model_id" ref="model_missing_index"/>
+        <field name="binding_model_id" ref="model_missing_index" />
+        <field name="state">code</field>
+        <field name="groups_id" eval="[(4,ref('base.group_user'))]"/>
+        <field name="code">
+records.create_all_large_indexes()
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
…keys

On a normal database, adding index to foreign keys is a good way to avoid systematic table scans in joins.
In odoo we do not create indexes on foreign key columns by default because of the size of those indexes.
Adding an index on all foreign keys, except 'create_uid' and 'write_uid' doesn't take more than 20% of database space.
Furthermore, keeping track of which index is used and removing the unused index is a good way to keep performance good and database size under control.

This module allows both to add indexes on foreign keys and to remove unused indexes (and re-add them if needed)
