### PR TITLE
[FIX] l10n_ch : generate ref payement

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3530,6 +3530,9 @@ class AccountMove(models.Model):
 
         return groups
 
+    def l10n_ch_hook_get_isr_number(self, pa):
+        pass
+
 class AccountMoveLine(models.Model):
     _name = "account.move.line"
     _description = "Journal Item"

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -22,7 +22,10 @@ class PaymentTransaction(models.Model):
 
     def _compute_sale_order_reference(self, order):
         self.ensure_one()
-        if self.acquirer_id.so_reference_type == 'so_name':
+        reference = self.env['account.move'].l10n_ch_hook_get_isr_number(self)
+        if reference:
+            return reference
+        elif self.acquirer_id.so_reference_type == 'so_name':
             return order.name
         else:
             # self.acquirer_id.so_reference_type == 'partner'


### PR DESCRIPTION
Steps to reproduce:
	- Runbot 15.0 localized in Switzerland
	- Install website, sale, contact, l10n_ch
	- add a IBAN, QR-Iban and bank name and BIC
	- add an address in Switzerland to the company
	- make an order from the website and use an address in Switzerland
	- go to the generated sale order and try to generate an invoice
Issue:
	- The payment reference in the Invoice will not be QR-compatible
Workaround:
	- Remove the payment ref and let the invoice app regenerate the
	number. This is not the right way to do it because the client might
	have already paid his order using the previous reference as
	communication.

For this fix to work, we need a way to generate the QR ref and the
reference for payment as early as the cart validation on the website.
Since the l10n_ch module does not depend on website, website_sales, sales, or
payment. It is impossible to inherit one of their class to add this behavior.
The only way I found was to use a hook function in accounting.

This is not optimal and probably should not be merged.

This might be a limitation, and therefore should be done the right way
in master

Test database dump : https://drive.google.com/file/d/1ftjWwSQt-rxA6wQsvKAj53KlNQPLau9T/view?usp=sharing