### PR TITLE
[FIX] core: upgrading module should not add XML id for custom fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1067,7 +1067,7 @@ class IrModelFields(models.Model):
         for (field_model, field_name), field_id in field_ids.items():
             model = self.env[field_model]
             field = model._fields.get(field_name)
-            if field and (
+            if field and not field.manual and (
                 module == model._original_module
                 or module in field._modules
                 or any(


### PR DESCRIPTION
This happens when upgrading the module that introduces a model: the
custom fields on the model are given an XML id for the module.