### PR TITLE
[FIX] web_editor: properly paste lists and at beginning of editable

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -105,17 +105,34 @@ function insert(editor, data, isText = true) {
     let lastChildNode = false;
     if (fakeElLastChild.hasChildNodes()) {
         let tempCurrentNode = currentNode;
-        for (const n of [...fakeElLastChild.childNodes]) {
-            tempCurrentNode.after(n);
-            tempCurrentNode = n;
+        const children = [...fakeElLastChild.childNodes];
+        if (insertBefore) {
+            children.reverse();
         }
-        lastChildNode = tempCurrentNode;
+        for (const child of children) {
+            tempCurrentNode[insertBefore ? 'before' : 'after'](child);
+            tempCurrentNode = child;
+        }
+        if (insertBefore) {
+            currentNode = tempCurrentNode;
+            lastChildNode = children[0];
+        } else {
+            lastChildNode = tempCurrentNode;
+        }
     }
 
     if (fakeElFirstChild.hasChildNodes()) {
-        for (const n of [...fakeElFirstChild.childNodes]) {
-            currentNode.after(n);
+        const children = [...fakeElFirstChild.childNodes];
+        if (insertBefore) {
+            children.reverse();
+        }
+        for (const n of children) {
+            currentNode[insertBefore ? 'before' : 'after'](n);
             currentNode = n;
+        }
+        if (insertBefore) {
+            currentNode = children[0];
+            insertBefore = false;
         }
     }
 

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -51,25 +51,16 @@ function insert(editor, data, isText = true) {
     }
     const selection = editor.document.getSelection();
     const range = selection.getRangeAt(0);
-    let currentNode;
+    let startNode;
     let insertBefore = false;
     if (selection.isCollapsed) {
         if (range.startContainer.nodeType === Node.TEXT_NODE) {
             insertBefore = !range.startOffset;
             splitTextNode(range.startContainer, range.startOffset, DIRECTIONS.LEFT);
-            currentNode = range.startContainer;
+            startNode = range.startContainer;
         }
     } else {
         editor.deleteRange(selection);
-    }
-    currentNode = currentNode || editor.document.getSelection().anchorNode;
-    if (currentNode.nodeType === Node.ELEMENT_NODE) {
-        if (selection.anchorOffset === 0) {
-            currentNode.prepend(editor.document.createTextNode(''));
-            currentNode = currentNode.firstChild;
-        } else {
-            currentNode = currentNode.childNodes[selection.anchorOffset - 1];
-        }
     }
 
     const fakeEl = document.createElement('fake-element');
@@ -99,41 +90,38 @@ function insert(editor, data, isText = true) {
         }
     }
 
-    // if we have isolated block content,
-    // first we split the current focus element if it's a block
-    // then we insert the content in the right places
-    let lastChildNode = false;
-    if (fakeElLastChild.hasChildNodes()) {
-        let tempCurrentNode = currentNode;
-        const children = [...fakeElLastChild.childNodes];
-        if (insertBefore) {
-            children.reverse();
-        }
-        for (const child of children) {
-            tempCurrentNode[insertBefore ? 'before' : 'after'](child);
-            tempCurrentNode = child;
-        }
-        if (insertBefore) {
-            currentNode = tempCurrentNode;
-            lastChildNode = children[0];
+    startNode = startNode || editor.document.getSelection().anchorNode;
+    if (startNode.nodeType === Node.ELEMENT_NODE) {
+        if (selection.anchorOffset === 0) {
+            const textNode = editor.document.createTextNode('');
+            startNode.prepend(textNode);
+            startNode = textNode;
         } else {
-            lastChildNode = tempCurrentNode;
+            startNode = startNode.childNodes[selection.anchorOffset - 1];
         }
     }
 
+    // If we have isolated block content, first we split the current focus
+    // element if it's a block then we insert the content in the right places.
+    let currentNode = startNode;
+    let lastChildNode = false;
+    const _insertAt = (reference, nodes, insertBefore) => {
+        for (const child of (insertBefore ? nodes.reverse() : nodes)) {
+            reference[insertBefore ? 'before' : 'after'](child);
+            reference = child;
+        }
+    }
+    if (fakeElLastChild.hasChildNodes()) {
+        const toInsert = [...fakeElLastChild.childNodes]; // Prevent mutation
+        _insertAt(currentNode, [...toInsert], insertBefore);
+        currentNode = insertBefore ? toInsert[0] : currentNode;
+        lastChildNode = toInsert[toInsert.length - 1];
+    }
     if (fakeElFirstChild.hasChildNodes()) {
-        const children = [...fakeElFirstChild.childNodes];
-        if (insertBefore) {
-            children.reverse();
-        }
-        for (const n of children) {
-            currentNode[insertBefore ? 'before' : 'after'](n);
-            currentNode = n;
-        }
-        if (insertBefore) {
-            currentNode = children[0];
-            insertBefore = false;
-        }
+        const toInsert = [...fakeElFirstChild.childNodes]; // Prevent mutation
+        _insertAt(currentNode, [...toInsert], insertBefore);
+        currentNode = toInsert[toInsert.length - 1];
+        insertBefore = false;
     }
 
     // If all the Html have been isolated, We force a split of the parent element

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -96,6 +96,15 @@ describe('Copy and paste', () => {
     });
     describe('Simple text', () => {
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, 'x');
+                    },
+                    contentAfter: '<p>x[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -231,6 +240,15 @@ describe('Copy and paste', () => {
     describe('Simple html span', () => {
         const simpleHtmlCharX = '<span style="color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">x</span>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>x[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -345,6 +363,15 @@ describe('Copy and paste', () => {
     describe('Simple html p', () => {
         const simpleHtmlCharX = '<p>x</p>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>x[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -459,6 +486,15 @@ describe('Copy and paste', () => {
     describe('Complex html span', () => {
         const complexHtmlData = '<span style="color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">1</span><b style="box-sizing: border-box; font-weight: bolder; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">23</b><span style="color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"><span> </span>4</span>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1<b>23</b>&nbsp;4[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -573,6 +609,15 @@ describe('Copy and paste', () => {
     describe('Complex html p', () => {
         const complexHtmlData = '<p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">12</p><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">34</p>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>12</p><p>34[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -700,9 +745,18 @@ describe('Copy and paste', () => {
             });
         });
     });
-     describe('Complex html 3 p', () => {
+    describe('Complex html 3 p', () => {
         const complexHtmlData = '<p>1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6</p>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -830,6 +884,15 @@ describe('Copy and paste', () => {
     describe('Complex html p+i', () => {
         const complexHtmlData = '<p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">12</p><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><i style="box-sizing: border-box;">ii</i></p>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>12</p><p><i>ii</i>[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',
@@ -955,6 +1018,15 @@ describe('Copy and paste', () => {
     describe('Complex html 3p+b', () => {
         const complexHtmlData = '<p>1<b>23</b></p><p>zzz</p><p>45<b>6</b>7</p>';
         describe('range collapsed', async () => {
+            it('should paste a text at the beginning of a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]abcd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1<b>23</b></p><p>zzz</p><p>45<b>6</b>7[]abcd</p>',
+                });
+            });
             it('should paste a text in a p', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[]cd</p>',

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -1144,6 +1144,51 @@ describe('Copy and paste', () => {
                     contentAfter: '<p>12</p><ul><li>abc</li><li>def</li><li>ghi</li></ul>[]<p>34</p>',
                 });
             });
+            it('should paste the text of an li into another li', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>abc</li><li>de[]f</li><li>ghi</li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>123</li></ul>');
+                    },
+                    contentAfter: '<ul><li>abc</li><li>de123[]f</li><li>ghi</li></ul>',
+                });
+            });
+            it('should paste the text of an li into another li, and the text of another li into the next li', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>abc</li><li>de[]f</li><li>ghi</li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>123</li><li>456</li></ul>');
+                    },
+                    contentAfter: '<ul><li>abc</li><li>de123</li><li>456[]f</li><li>ghi</li></ul>',
+                });
+            });
+            it('should paste the text of an li into another li, insert a new li, and paste the text of a third li into the next li', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>abc</li><li>de[]f</li><li>ghi</li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>123</li><li>456</li><li>789</li></ul>');
+                    },
+                    contentAfter: '<ul><li>abc</li><li>de123</li><li>456</li><li>789[]f</li><li>ghi</li></ul>',
+                });
+            });
+            it('should paste the text of an li into another li and insert a new li at the end of a list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>abc</li><li>def</li><li>ghi[]</li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>123</li><li>456</li></ul>');
+                    },
+                    contentAfter: '<ul><li>abc</li><li>def</li><li>ghi123</li><li>456[]</li></ul>',
+                });
+            });
+            it('should insert a new li at the beginning of a list and paste the text of another li into the next li', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>[]abc</li><li>def</li><li>ghi</li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>123</li><li>456</li></ul>');
+                    },
+                    contentAfter: '<ul><li>123</li><li>456[]abc</li><li>def</li><li>ghi</li></ul>',
+                });
+            });
         });
     });
 


### PR DESCRIPTION
- Pasting blocks at the beginning of the editable pasted the content in the wrong place (after the first node instead of before it).
- Pasting a list within a list resulted in wrongly nested li elements (`<li><li>text</li></li>`). This applies the same principles for pasting lists within lists as were already applied for blocks within paragraphs.

task-2879892

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
