### PR TITLE
[FIX] website: lower the step safety check amount

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -67,7 +67,7 @@ tour.register("snippets_all_drag_and_drop", {
             // safety check, otherwise the test might "break" one day and
             // receive no steps. The test would then not test anything anymore
             // without us noticing it.
-            if (steps.length < 280) {
+            if (steps.length < 220) {
                 console.error("This test is not behaving as it should.");
             }
         },


### PR DESCRIPTION
The drag and drop mega test is quite simple: the python gets the list of
all the snippets (by rendering a view + etree), then it just starts a JS
tour by passing all those snippets in the tour URL.

From there, the JS tour is in charged of building its own steps based on
the list of snippets it received from the python.

The MOST important part is to be 100% sure that the built steps are as
expected: ~5 steps / snippets: ~220 steps with website only and ~280
steps with all modules.
If we don't have that check, the tour could suddenly not test anything
because the step list would be empty, but the test wouldn't fail.

Thus, we don't want to programmatically try to compute that step amount
but want it to remain an hardcoded number, which is lowered in this
commit as if we have 220 (it could be 200, 150..) steps, it means that
the steps were built as expected.

Note that since the test is run on post_install, 280 was fine since all
modules were installed.
But the nightly build is also testing this test with only the website
module, ultimately failing.

Note that this check was actually not working at all since [1] as there
was a typo on `length`.

[1]: https://github.com/odoo/odoo/commit/61b19dafd1fb79120f701b94038bbe859aa2e271
