### PR TITLE
[FIX] portal: allow words to be broken in portal messages

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -496,6 +496,8 @@ form label {
 
     .o_portal_chatter_messages {
         margin-bottom: 15px;
+        overflow-wrap: break-word;
+        word-break: break-word;
 
         .o_portal_chatter_message {
             div.media-body > p:not(.o_portal_chatter_puslished_date):last-of-type {


### PR DESCRIPTION
Steps to reproduce:
- Create a sale order
- Set a very long message in the chatter
- Clink on the customer preview

Current behavior:
There is a empty space in the top right corner

Expected behavior:
The preview is a usual

Explanation:
The very long word in the chatter created at the
bottom of the page a very long message that increased
the page width, modifying the usual view. To fix that
we allow long words to broken to keep the same width.

opw-2880050
