### PR TITLE
[FIX] website_sale_stock: avoid unnecessary qty computation

### DIFF
--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -17,7 +17,7 @@ class SaleOrder(models.Model):
         for line in self.order_line:
             if line.product_id.type == 'product' and line.product_id.inventory_availability in ['always', 'threshold']:
                 cart_qty = sum(self.order_line.filtered(lambda p: p.product_id.id == line.product_id.id).mapped('product_uom_qty'))
-                if cart_qty > line.product_id.with_context(warehouse=self.warehouse_id.id).virtual_available and (line_id == line.id):
+                if (line_id == line.id) and cart_qty > line.product_id.with_context(warehouse=self.warehouse_id.id).virtual_available:
                     qty = line.product_id.with_context(warehouse=self.warehouse_id.id).virtual_available - cart_qty
                     new_val = super(SaleOrder, self)._cart_update(line.product_id.id, line.id, qty, 0, **kwargs)
                     values.update(new_val)


### PR DESCRIPTION
Module `website_sale_stock` extends method `_cart_update` to check if current
product is out-of-stock and not available for sale. However, the method may be
also used to update pricelist [2]. Particularly, on checkout process the method
is called against each line [1]. It makes N^2 complexity and might lead to
timeout error [3].

Fix it by checking line's id before computing `virtual_available` qty.

[1]:
https://github.com/odoo/odoo/blob/9af913f9f321c54faaac59be1ca0e2e1b586b06c/addons/website_sale/controllers/main.py#L761

[2]: https://github.com/odoo/odoo/blob/9af913f9f321c54faaac59be1ca0e2e1b586b06c/addons/website_sale/models/website.py#L362-L364

[3] opw-2810543

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
