### PR TITLE
[FIX] l10n_it_edi: <ImportoTotaleDocumento> field

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -145,6 +145,7 @@
                                 <BolloVirtuale>SI</BolloVirtuale>
                                 <ImportoBollo t-esc="format_numbers(record.l10n_it_stamp_duty)"/>
                             </DatiBollo>
+                            <ImportoTotaleDocumento t-esc="format_monetary(record.amount_total, currency)"/>
                         </DatiGeneraliDocumento>
                         <DatiOrdineAcquisto t-if="record.ref">
                             <IdDocumento t-esc="format_alphanumeric(record.ref[:20])"/>

--- a/addons/l10n_it_edi_sdicoop/tests/expected_xmls/IT00470550013_basis.xml
+++ b/addons/l10n_it_edi_sdicoop/tests/expected_xmls/IT00470550013_basis.xml
@@ -55,6 +55,7 @@
         <Divisa>EUR</Divisa>
         <Data>2022-03-24</Data>
         <Numero>___ignore___</Numero>
+        <ImportoTotaleDocumento></ImportoTotaleDocumento>
       </DatiGeneraliDocumento>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
@@ -285,7 +285,6 @@ class TestItEdi(AccountEdiTestCommon):
             equal to taxable base * tax rate (there is a constraint in the edi where taxable base * tax rate = tax amount, but also
             taxable base = sum(subtotals) + rounding amount)
         """
-
         # In this case, the first two lines use a price_include tax the
         # subtotals should be 800.40 / (100 + 22.0) * 100 = 656.065564..,
         # where 22.0 is the tax rate.
@@ -350,6 +349,9 @@ class TestItEdi(AccountEdiTestCommon):
                 <xpath expr="//DettaglioPagamento//ImportoPagamento" position="inside">
                     2577.29
                 </xpath>
+                <xpath expr="//DatiGeneraliDocumento//ImportoTotaleDocumento" position="inside">
+                    2577.29
+                </xpath>
             ''')
         invoice_etree = etree.fromstring(self.price_included_invoice._export_as_xml())
         # Remove the attachment and its details
@@ -409,6 +411,9 @@ class TestItEdi(AccountEdiTestCommon):
                 <xpath expr="//DettaglioPagamento//ImportoPagamento" position="inside">
                     1464.73
                 </xpath>
+                <xpath expr="//DatiGeneraliDocumento//ImportoTotaleDocumento" position="inside">
+                    1464.73
+                </xpath>
             ''')
         invoice_etree = self.with_applied_xpath(invoice_etree, "<xpath expr='.//Allegati' position='replace'/>")
         self.assertXmlTreeEqual(invoice_etree, expected_etree)
@@ -441,6 +446,9 @@ class TestItEdi(AccountEdiTestCommon):
             </DatiBeniServizi>
             </xpath>
             <xpath expr="//DettaglioPagamento//ImportoPagamento" position="inside">
+                0.00
+            </xpath>
+            <xpath expr="//DatiGeneraliDocumento//ImportoTotaleDocumento" position="inside">
                 0.00
             </xpath>
             ''')
@@ -487,6 +495,9 @@ class TestItEdi(AccountEdiTestCommon):
             </DatiBeniServizi>
             </xpath>
             <xpath expr="//DettaglioPagamento//ImportoPagamento" position="inside">
+              2929.47
+            </xpath>
+            <xpath expr="//DatiGeneraliDocumento//ImportoTotaleDocumento" position="inside">
               2929.47
             </xpath>
             ''')


### PR DESCRIPTION
The total value of the invoice can be reported in the edi using the
field <ImportoTotaleDocumento>. This commit uses the amount_total of the
invoice to occupy this field.

task-id: 2894623
