### PR TITLE
[FIX] hr: fix access error on language change

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -8,8 +8,13 @@ from odoo.exceptions import AccessError
 class User(models.Model):
     _inherit = ['res.users']
 
+    def _employee_ids_domain(self):
+        # employee_ids is considered a safe field and as such will be fetched as sudo.
+        # So try to enforce the security rules on the field to make sure we do not load employees outside of active companies
+        return [('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
+
     # note: a user can only be linked to one employee per company (see sql constraint in ´hr.employee´)
-    employee_ids = fields.One2many('hr.employee', 'user_id', string='Related employee')
+    employee_ids = fields.One2many('hr.employee', 'user_id', string='Related employee', domain=_employee_ids_domain)
     employee_id = fields.Many2one('hr.employee', string="Company employee",
         compute='_compute_company_employee', search='_search_company_employee', store=False)
 

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -41,7 +41,7 @@
     <record id="hr_employee_public_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee_public"/>
-        <field name="domain_force">['|','|',('user_id', '=', user.id),('company_id', '=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">['|',('company_id', '=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="hr_job_comp_rule" model="ir.rule">


### PR DESCRIPTION
Backport of odoo/odoo#81474
Before odoo/odoo#86889 a regular user with employees in multiple
companies was not able to change his own language due to a chain of
event calling onchange on all the employee_ids and employee_ids on
res.users being read as sudo.
The fix does work but was wrong because it gave access to the user's
public employee regardless of the active company_id
A domain was added to employee_ids to make force the security rules even
in sudo.
