### PR TITLE
[FIX] core: upgrading module should not add XML id for custom fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1077,8 +1077,15 @@ class IrModelFields(models.Model):
                 )
             ):
                 xml_id = field_xmlid(module, field_model, field_name)
-                record = self.browse(field_id)
-                data_list.append({'xml_id': xml_id, 'record': record})
+                if field.manual:
+                    # the refactoring of this code introduced a bug that adds
+                    # xmlids to custom fields when upgrading the module;
+                    # pretend the xmlid has been loaded to avoid the field to
+                    # be deleted when upgrading the module
+                    self.env['ir.model.data']._load_xmlid(xml_id)
+                else:
+                    record = self.browse(field_id)
+                    data_list.append({'xml_id': xml_id, 'record': record})
         self.env['ir.model.data']._update_xmlids(data_list)
 
     @tools.ormcache()


### PR DESCRIPTION
This happens when upgrading the module that introduces a model: the
custom fields on the model are given an XML id for the module.

Because of the issue, some existing databases may have XML ids for
custom fields.  For those cases, the code must mark those XML ids as
"loaded", otherwise those custom fields could be deleted at the next
module upgrade (records with XML ids corresponding to a module are
deleted if their XML id hasn't been "loaded" during the module upgrade.)