### PR TITLE
[FIX] web_editor, web_unsplash: fix unsplash on the frontend

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -23,8 +23,8 @@ Odoo Web Editor widget.
         #----------------------------------------------------------------------
 
         'web.assets_qweb': [
+            ('include', 'web_editor.assets_media_dialog_templates'),
             'web_editor/static/src/xml/*.xml',
-            'web_editor/static/src/components/**/*.xml',
         ],
         'web_editor.assets_wysiwyg': [
             # lib
@@ -84,13 +84,17 @@ Odoo Web Editor widget.
             'web_editor/static/src/js/wysiwyg/wysiwyg.js',
             'web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js',
         ],
+        # TODO: Move those dialog assets in assets_common and make the public
+        # root fetch templates from the common assets
+        'web_editor.assets_media_dialog_templates': [
+            'web_editor/static/src/components/media_dialog/*.xml',
+            'web_editor/static/src/components/upload_progress_toast/*.xml',
+        ],
         'web_editor.assets_media_dialog': [
             'web_editor/static/src/components/media_dialog/*.js',
             'web_editor/static/src/components/media_dialog/*.scss',
-            'web_editor/static/src/components/media_dialog/*.xml',
             'web_editor/static/src/components/upload_progress_toast/*.js',
             'web_editor/static/src/components/upload_progress_toast/*.scss',
-            'web_editor/static/src/components/upload_progress_toast/*.xml',
         ],
         'web.assets_common': [
             'web_editor/static/lib/odoo-editor/src/base_style.css',
@@ -113,6 +117,7 @@ Odoo Web Editor widget.
             'web_editor/static/src/js/frontend/loader_loading.js',
         ],
         'web.assets_frontend': [
+            ('include', 'web_editor.assets_media_dialog_templates'),
             ('include', 'web_editor.assets_media_dialog'),
 
             'web_editor/static/src/scss/web_editor.common.scss',

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.xml
@@ -40,7 +40,7 @@
                         onImageClick="() => this.onClickAttachment(attachment)"/>
                 </t>
             </t>
-            <t t-if="['all', 'media-library'].includes(state.searchService)">
+            <t id="o_we_media_library_images" t-if="['all', 'media-library'].includes(state.searchService)">
                 <t t-foreach="state.libraryMedia" t-as="media" t-key="media.id">
                     <AutoResizeImage author="media.author"
                         src="media.thumbnail_url"

--- a/addons/web_unsplash/__manifest__.py
+++ b/addons/web_unsplash/__manifest__.py
@@ -15,12 +15,12 @@
         'web.assets_frontend': [
             'web_unsplash/static/src/js/unsplash_beacon.js',
         ],
+        'web_editor.assets_media_dialog_templates': [
+            'web_unsplash/static/src/components/media_dialog/*.xml',
+        ],
         'web_editor.assets_media_dialog': [
             'web_unsplash/static/src/components/media_dialog/*.js',
             'web_unsplash/static/src/services/unsplash_service.js',
-        ],
-        'web.assets_qweb': [
-            'web_unsplash/static/src/components/*/*.xml',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
@@ -98,6 +98,10 @@ patch(ImageSelector.prototype, 'image_selector_unsplash', {
         return this.props.selectedMedia[this.props.id].filter(media => media.mediaType === 'unsplashRecord').map(({ id }) => id);
     },
 
+    get isFetching() {
+        return this._super() || this.state.isFetchingUnsplash;
+    },
+
     // It seems that setters are mandatory when patching a component that
     // extends another component.
     set canLoadMore(_) {},

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.xml
@@ -40,18 +40,20 @@
     </div>
 </t>
 
-<t t-inherit="web_editor.ImagesListTemplate" t-inherit-mode="extension">
-    <xpath expr="//t[@t-foreach='state.libraryMedia']" position="after">
-        <t t-if="['all', 'unsplash'].includes(state.searchService)" t-foreach="state.unsplashRecords" t-as="record" t-key="record.id">
-            <AutoResizeImage src="record.url"
-                author="record.user.name"
-                authorLink="record.user.links.html"
-                name="record.user.name"
-                title="record.user.name"
-                altDescription="record.alt_description"
-                selected="this.selectedRecordIds.includes(record.id)"
-                onImageClick="() => this.onClickRecord(record)"
-                minRowHeight="MIN_ROW_HEIGHT"/>
+<t t-name="web_unsplash.ImagesListTemplate" t-inherit="web_editor.ImagesListTemplate" t-inherit-mode="extension">
+    <xpath expr="//t[@id='o_we_media_library_images']" position="after">
+        <t t-if="['all', 'unsplash'].includes(state.searchService)">
+            <t t-foreach="state.unsplashRecords" t-as="record" t-key="record.id">
+                <AutoResizeImage src="record.url"
+                    author="record.user.name"
+                    authorLink="record.user.links.html"
+                    name="record.user.name"
+                    title="record.user.name"
+                    altDescription="record.alt_description"
+                    selected="this.selectedRecordIds.includes(record.id)"
+                    onImageClick="() => this.onClickRecord(record)"
+                    minRowHeight="MIN_ROW_HEIGHT"/>
+            </t>
         </t>
     </xpath>
 </t>


### PR DESCRIPTION
Before this commit, when the admin had set his unsplash credentials in
the media dialog, he could search for unsplash images in the backend
(website builder, optimize SEO, html fields), but not on the frontend
(from the website_forum reply section for example). This was caused by a
wrong assets management for the media dialog views.

This commit reworks the assets_media_dialog introduced in [1], that were
not correctly defined. Until now, a web_editor.assets_media_dialog
bundle including js, scss and xml files was included in both the
web.assets_frontend and web.assets_backend bundles. It was built that
way, because the frontend only takes the views defined in the
web.assets_frontend bundle.
Two mistakes were made with that approach:
- The views defined in web.assets_backend are not added to the
webclient's templates list. Only the ones defined in web.assets_qweb
are. It was only working because web.assets_qweb was globally taking
every component view, defined as /component/*/*.xml.
- The qweb extensions templates for web_unsplash were defined in
web.assets_qweb (therefore, not included in web.assets_frontend and not
added to the frontend's template list).

To change that and include the web_editor and web_unsplash media dialog
views both for the frontend and the backend, a
web_editor.assets_media_dialog_templates is added, with the xml files
from the web_editor.assets_media_dialog bundle. But this time, this new
views-only bundle is included in web.assets_frontend and
web.assets_qweb.
When the public root's assets management is reworked and when it fetches
the templates from assets_common, these bundles should move to
assets_common, as discussed in [2].

Also, the extension template that adds the unsplash records is reworked:
the t-if is separated from the t-foreach, and set using an id instead of
the qweb instruction that it was using before, as it is more robust.

Finally, the isFetching getter was not set on the unsplash ImageSelector
patch, leading to a visual glitch ("No images found" was displayed while
querying unsplash). It is added in this commit.

task-2687506

[1]: https://github.com/odoo/odoo/commit/a154ee7ad6fd3ebdd38943e1439badae11c3151d
[2]: https://github.com/odoo/odoo/pull/89223#discussion_r895627061

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
