### PR TITLE
[FIX] hr_holidays: fix multicompany issue

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_model.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_model.js
@@ -3,11 +3,6 @@
 import CalendarModel from "web.CalendarModel";
 
 export const TimeOffCalendarModel = CalendarModel.extend({
-    _getFilterDomain: function() {
-        const company_domain = [['user_id.company_id', 'in', this.data.context.allowed_company_ids]];
-        return this._super().concat(company_domain);
-    },
-
     calendarEventToRecord(event) {
         const data = this._super(...arguments);
         if (event.allDay) {

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -623,7 +623,7 @@
         <field name="name">Dashboard</field>
         <field name="res_model">hr.leave</field>
         <field name="view_mode">calendar,tree,form,activity</field>
-        <field name="domain">[('user_id', '=', uid)]</field>
+        <field name="domain">[('user_id', '=', uid), ('employee_company_id', 'in', allowed_company_ids)]</field>
         <field name="context">{'short_name': 1, 'search_default_active_time_off': 1}</field>
         <field name="search_view_id" ref="hr_holidays.hr_leave_view_search_my"/>
         <field name="help" type="html">
@@ -715,7 +715,7 @@
             'hide_employee_name': 1,
             'holiday_status_name_get': False}
         </field>
-        <field name="domain">[('employee_id.company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain">[('employee_company_id', 'in', allowed_company_ids)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Meet the time off dashboard.


### PR DESCRIPTION
Before this commit, if you are on the time off dashboard calendar of a company
that is not set as your user's default company, no time off is displayed.

Also, if you try to consult your time offs on the dashboard tree view and if
you have one leave with a leave_type without company on a company that is not
the one you're logged in, you'll get a access error.

This commit fixes both issues.

taskID 2893659