### PR TITLE
[FIX] crm: sale user should be able to convert and merge lead

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -390,6 +390,40 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         convert.action_apply()
         self.assertEqual(self.lead_1.type, 'opportunity')
 
+    @users('user_sales_salesman')
+    def test_lead_merge_user(self):
+        """ Test convert wizard working in merge mode with sales user """
+        date = Datetime.from_string('2020-01-20 16:00:00')
+        self.crm_lead_dt_mock.now.return_value = date
+
+        leads = self.env['crm.lead']
+        for x in range(2):
+            leads |= self.env['crm.lead'].create({
+                'name': 'Dup-%02d-%s' % (x+1, self.lead_1.name),
+                'type': 'lead', 'user_id': False, 'team_id': self.lead_1.team_id.id,
+                'contact_name': 'Duplicate %02d of %s' % (x+1, self.lead_1.contact_name),
+                'email_from': self.lead_1.email_from,
+                'probability': 10,
+            })
+
+        convert = self.env['crm.lead2opportunity.partner'].with_context({
+            'active_model': 'crm.lead',
+            'active_id': leads[0].id,
+            'active_ids': leads[0].ids,
+        }).create({})
+
+        # test internals of convert wizard
+        self.assertEqual(convert.duplicated_lead_ids, leads)
+        self.assertEqual(convert.name, 'merge')
+        self.assertEqual(convert.action, 'create')
+
+        convert.write({'user_id': self.user_sales_salesman.id})
+        self.assertEqual(convert.user_id, self.user_sales_salesman)
+        self.assertEqual(convert.team_id, self.sales_team_convert)
+
+        convert.action_apply()
+        self.assertEqual(leads[0].type, 'opportunity')
+
     @users('user_sales_manager')
     def test_lead_merge_duplicates(self):
         """ Test Lead._get_lead_duplicates() and check: partner / email fallbacks """

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -135,7 +135,7 @@ class Lead2OpportunityPartner(models.TransientModel):
                     'user_id': self.user_id.id,
                     'team_id': self.team_id.id,
                 })
-        (to_merge - result_opportunity).unlink()
+        (to_merge - result_opportunity).sudo().unlink()
         return result_opportunity
 
     def _action_convert(self):


### PR DESCRIPTION
Use case
--------

A sale user convert a lead to an opportunity, this lead has duplicates.

The wizard will convert and merge the lead. At the end of the process
the duplicated lead are delete.

Issue
-----

Before this commit the user get an access error because he cannot delete
leads

Since they can merge lead using the action "Merge" it's not consistent
and sales user should be able to merge lead during the conversion
as well



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
