### PR TITLE
Update requirements.txt for mac m1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Pillow==9.0.1  # min version = 7.0.0 (Focal with security backports)
 polib==1.1.0
 psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
-psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
+psycopg2==2.9.2; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
 pyopenssl==19.0.0
 PyPDF2==1.26.0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

version of psycopg2 in requirment.txt

Current behavior before PR:

version of psycopg2 is not working

Desired behavior after PR is merged:

version of psycopg2 is updated
