### PR TITLE
[REF] hr_contract, web: give tooltip info as t-call-context

### DIFF
--- a/addons/hr_contract/static/src/xml/hr_contract_templates.xml
+++ b/addons/hr_contract/static/src/xml/hr_contract_templates.xml
@@ -3,7 +3,7 @@
     <t t-name="hr_contract.CalendarMismatch" owl="1">
         <div class="o-tooltip px-1 py-2">
             <p style="font-size: 12px;" class="text-danger"
-                t-esc="info.text"/>
+                t-esc="text"/>
         </div>
     </t>
 </templates>

--- a/addons/web/static/src/core/tooltip/tooltip.xml
+++ b/addons/web/static/src/core/tooltip/tooltip.xml
@@ -3,9 +3,7 @@
 
     <t t-name="web.Tooltip" owl="1">
         <div class="o-tooltip px-2 py-1">
-            <t t-if="props.template" t-call="{{props.template}}">
-                 <t t-set="info" t-value="props.info"/>
-            </t>
+            <t t-if="props.template" t-call="{{props.template}}" t-call-context="props.info"/>
             <small t-else="" t-esc="props.tooltip"/>
         </div>
     </t>

--- a/addons/web/static/tests/core/tooltip/tooltip_service_tests.js
+++ b/addons/web/static/tests/core/tooltip/tooltip_service_tests.js
@@ -149,7 +149,7 @@ QUnit.module("Tooltip service", (hooks) => {
         await makeParent(MyComponent, { mockSetTimeout, mockSetInterval });
 
         assert.containsNone(target, ".o_popover_container .o_popover");
-        let [outerSpan, innerSpan] = target.querySelectorAll("span.our_span");
+        const [outerSpan, innerSpan] = target.querySelectorAll("span.our_span");
         outerSpan.dispatchEvent(new Event("mouseenter"));
         innerSpan.dispatchEvent(new Event("mouseenter"));
         await nextTick();
@@ -325,8 +325,8 @@ QUnit.module("Tooltip service", (hooks) => {
         const templates = {
             my_tooltip_template: `
                 <ul>
-                    <li>X: <t t-esc="info.x"/></li>
-                    <li>Y: <t t-esc="info.y"/></li>
+                    <li>X: <t t-esc="x"/></li>
+                    <li>Y: <t t-esc="y"/></li>
                 </ul>
             `,
         };


### PR DESCRIPTION
Previously, we would use t-set to add the tooltip info under the key
"info" in the rendering context, while this works fine, it was mostly
just a workaround for the lack of support in owl for passing a rendering
context to be used by the t-call directly. Since this is now supported
in owl, the commit uses this feature for the tooltips and adapts the
call sites.

enterprise: https://github.com/odoo/enterprise/pull/28882
