### PR TITLE
[FIX] point_of_sale: load archived payment methods

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1921,7 +1921,7 @@ class PosSession(models.Model):
     def _loader_params_pos_payment_method(self):
         return {
             'search_params': {
-                'domain': [],
+                'domain': ['|', ('active', '=', False), ('active', '=', True)],
                 'fields': ['name', 'is_cash_count', 'use_payment_terminal', 'split_transactions', 'type'],
                 'order': 'is_cash_count desc, id',
             },


### PR DESCRIPTION
Before this commit, if one of the used payment methods was archived,
it would raise an error when loading the paid orders.

The solution is to load archived payment methods.

opw-2892321

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
