### PR TITLE
[FIX] l10n_eu_service: ValueError on install

### DIFF
--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -117,7 +117,10 @@ class Company(models.Model):
         return self.env.ref(f'l10n_eu_service.oss_tax_account_company_{self.id}')
 
     def _get_oss_tags(self):
-        [chart_template_xml_id] = self.chart_template_id.get_xml_id().values()
+        try:
+            [chart_template_xml_id] = self.chart_template_id.get_xml_id().values()
+        except ValueError:
+            return {}
         tag_for_country = EU_TAG_MAP.get(chart_template_xml_id, {
             'invoice_base_tag': None,
             'invoice_tax_tag': None,


### PR DESCRIPTION
I'm getting this error on some CI builds:

```
2022-06-24 13:09:43,634 27 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`.
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 459, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 347, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 240, in load_module_graph
    getattr(py_module, post_init)(cr, registry)
  File "/opt/odoo/auto/addons/l10n_eu_service/__init__.py", line 10, in l10n_eu_service_post_init
    env['res.company']._map_all_eu_companies_taxes()
  File "/opt/odoo/auto/addons/l10n_eu_service/models/res_company.py", line 18, in _map_all_eu_companies_taxes
    companies._map_eu_taxes()
  File "/opt/odoo/auto/addons/l10n_eu_service/models/res_company.py", line 28, in _map_eu_taxes
    invoice_repartition_lines, refund_repartition_lines = company._get_repartition_lines_oss()
  File "/opt/odoo/auto/addons/l10n_eu_service/models/res_company.py", line 84, in _get_repartition_lines_oss
    oss_account, oss_tags = self._get_oss_account(), self._get_oss_tags()
  File "/opt/odoo/auto/addons/l10n_eu_service/models/res_company.py", line 120, in _get_oss_tags
    [chart_template_xml_id] = self.chart_template_id.get_xml_id().values()
ValueError: not enough values to unpack (expected 1, got 0)
```

This should fix it.

@moduon MT-960



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
