### PR TITLE
[FIX] hr_holidays: negative allocation in accrual plan

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -328,12 +328,13 @@ class HolidaysAllocation(models.Model):
 
     def _end_of_year_accrual(self):
         # to override in payroll
-        today = fields.Date.today()
+        first_day_this_year = fields.Date.today() + relativedelta(month=1, day=1)
         for allocation in self:
-            current_level = allocation._get_current_accrual_plan_level_id(today)[0]
+            current_level = allocation._get_current_accrual_plan_level_id(first_day_this_year)[0]
+            nextcall = current_level._get_next_date(first_day_this_year)
             if current_level and current_level.action_with_unused_accruals == 'lost':
                 # Allocations are lost but number_of_days should not be lower than leaves_taken
-                allocation.write({'number_of_days': allocation.leaves_taken, 'lastcall': today, 'nextcall': False})
+                allocation.write({'number_of_days': allocation.leaves_taken, 'lastcall': first_day_this_year, 'nextcall': nextcall})
 
     def _get_current_accrual_plan_level_id(self, date, level_ids=False):
         """


### PR DESCRIPTION
Steps to reproduce:

- Create an accrual plan with two levels, the first should have
its action_with_unused_accruals set as lost. The second should
start one year after the first level.
- Use this plan on a employee and make it start the first day of
the previous year.

Current behavior:
The number of allocated day is wrong and can even be negative

Expected behavior:
The days of the first level are lost and there is the right amount
of allocated days,

Explanation:
The _end_of_the_year function was first designed to be only called
on the first day of the year but the it changed since then without
updating it's content and it can be called any day of the year now. In
this case the use of today() does not make sense and it should be
replaced by the first day of the current year.

opw-2868297