### PR TITLE
[FIX] website, website_links: fix click everywhere test

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -83,7 +83,6 @@ export class WebsitePreview extends Component {
                 this.websiteService.currentWebsiteId = null;
                 this.websiteService.websiteRootInstance = undefined;
                 this.websiteService.pageDocument = null;
-                this.websiteService.contentWindow = null;
             };
         }, () => [this.props.action.context.params]);
 
@@ -191,7 +190,6 @@ export class WebsitePreview extends Component {
         this.title.setParts({ action: this.currentTitle });
 
         this.websiteService.pageDocument = this.iframe.el.contentDocument;
-        this.websiteService.contentWindow = this.iframe.el.contentWindow;
 
         // This is needed for the registerThemeHomepageTour tours
         const { editable, viewXmlid } = this.websiteService.currentWebsite.metadata;

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -86,6 +86,7 @@ export const websiteService = {
             set pageDocument(document) {
                 pageDocument = document;
                 if (!document) {
+                    contentWindow = null;
                     return;
                 }
                 // Not all files have a dataset. (e.g. XML)
@@ -112,13 +113,11 @@ export const websiteService = {
                         viewXmlid: viewXmlid,
                     };
                 }
+                contentWindow = document.defaultView;
                 websiteSystrayRegistry.trigger('CONTENT-UPDATED');
             },
             get pageDocument() {
                 return pageDocument;
-            },
-            set contentWindow(window) {
-                contentWindow = window;
             },
             get contentWindow() {
                 return contentWindow;

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -86,6 +86,7 @@ export const websiteService = {
             set pageDocument(document) {
                 pageDocument = document;
                 if (!document) {
+                    currentMetadata = {};
                     contentWindow = null;
                     return;
                 }

--- a/addons/website_links/static/src/components/navbar/navbar.js
+++ b/addons/website_links/static/src/components/navbar/navbar.js
@@ -12,8 +12,7 @@ patch(NavBar.prototype, 'website_links_navbar', {
         onWillStart(() => {
             this.websiteEditingMenus['website_links.menu_link_tracker'] = {
                 openWidget: () => this.websiteService.goToWebsite({ path: `/r?u=${encodeURIComponent(this.websiteService.contentWindow.location.href)}` }),
-                isDisplayed: () => this.websiteService.currentWebsite,
-                options: () => {},
+                isDisplayed: () => this.websiteService.currentWebsite && this.websiteService.contentWindow,
             };
         });
     },


### PR DESCRIPTION
This commit fixes a race condition happening when clicking on the "Link
Tracker" menu of the website, when the website_preview client action's
iframe is not loaded yet.

That menu uses the iframe's contentWindow.location (taking it from the
website service), which was not set before the "load" event of the
iframe.

With this commit, the contentWindow is set at the website service level
when setting the pageDocument, as it can be taken from it
(document.defaultView), and the link tracker is displayed only when
there is a contentWindow at the website service level.

task-2687506


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
