### PR TITLE
[IMP] hr_recruitment: Improve kanban view for long job titles

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -31,7 +31,7 @@
                             <div class="o_kanban_card_header">
                                 <div class="o_kanban_card_header_title">
                                     <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
-                                    <div class="o_primary col-12">
+                                    <div class="o_primary col-11">
                                         <t t-esc="record.name.value"/>
                                     </div>
                                     <div class="col-12 text-muted">


### PR DESCRIPTION
There is an overlap with the ribbon for long titles

TaskID: 2888621

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
