### PR TITLE
[FIX] domain for mrp child mos action

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1080,7 +1080,7 @@ class MrpProduction(models.Model):
         else:
             action.update({
                 'name': _("%s Child MO's") % self.name,
-                'domain': [('id', 'in', mrp_production_ids)],
+                'domain': [('id', 'in', mrp_production_ids.ids)],
                 'view_mode': 'tree,form',
             })
         return action


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Since we change this method in order to use the _get_children() that returns the record, we need to use the .ids in order to get the list to the domain

Current behavior before PR:
we got an error because we are using "id in mrp.production(ID1, ID2)

Desired behavior after PR is merged:
We want to use "id in [ID1, ID2]




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
