### PR TITLE
[FIX] base_import: fix fallback for selection fields

### DIFF
--- a/addons/base_import/static/src/legacy/js/import_action.js
+++ b/addons/base_import/static/src/legacy/js/import_action.js
@@ -341,12 +341,10 @@ var DataImport = AbstractAction.extend({
             if (field) {
                 if (['boolean', 'many2one', 'many2many', 'selection'].includes(type) && this.value === 'skip_record') {
                     options.import_skip_records.push(field);
-                } else if (['many2one', "many2many", "selection"].includes(type)) {
-                    if (this.value === 'set_empty') {
-                        options.import_set_empty_fields.push(field);
-                    } else {
-                        options.name_create_enabled_fields[field] = this.value === 'create';
-                    }
+                } else if (this.value === 'set_empty') {
+                    options.import_set_empty_fields.push(field);
+                } else if (['many2one', "many2many"].includes(type)) {
+                    options.name_create_enabled_fields[field] = this.value === 'create';
                 // for selection, include also 'skip' that will be interpreted as 'None' in backend.
                 } else if (['boolean','selection'].includes(type) && this.value !== 'prevent') {
                     options.fallback_values[field] = {


### PR DESCRIPTION
Import wizard provides a fallback mechanism for some types of fields. It didn't
work for selection fields, "Set to" value was ignored.

Here is a review of the available fallback options depending on field type (see
code references below):

Boolean fields:
* Prevent import
* Skip record *(optional)*
* Set to: False
* Set to: True

Relational fields:
* Prevent import
* Set value as empty *(optional)*
* Skip record *(optional)*
* -- Create new values

Selection fields:
* Prevent import
* Set value as empty *(optional)*
* Skip record *(optional)*
* -- Set to: value1
* -- Set to: value2
* -- Set to: ...

Previous implementation combined selection fields and relational fields, but
those are different. So, fix it by making a proper if-else blocks.

opw-2791809

https://github.com/odoo/odoo/blob/59c3b7b09023316012b5b63e859d713033ee2b4e/addons/base_import/static/src/legacy/js/import_action.js#L528-L540

https://github.com/odoo/odoo/blob/59c3b7b09023316012b5b63e859d713033ee2b4e/addons/base_import/static/src/legacy/xml/base_import.xml#L46-L56
