### PR TITLE
[FIX] base: loading the public user avatar

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -390,7 +390,11 @@ class IrHttp(models.AbstractModel):
                 filehash = record['checksum']
 
         if not content:
-            content = record[field] or ''
+            try:
+                content = record[field] or ''
+            except AccessError:
+                # `record[field]` may not be readable for current user -> 404
+                content = ''
 
         # filename
         if not filename:

--- a/odoo/addons/base/tests/test_ir_http.py
+++ b/odoo/addons/base/tests/test_ir_http.py
@@ -149,3 +149,8 @@ class test_ir_http_mimetype(common.TransactionCase):
             attachment,
         )
         self.assertEqual(filename, 'image.gif')
+
+    def test_ir_http_public_user_image(self):
+        public_user = self.env.ref('base.public_user')
+        code, *_ = self.env['ir.http']._binary_record_content(public_user.with_user(public_user), 'image_128')
+        self.assertEqual(code, 404)


### PR DESCRIPTION
Access /web/content/res.users/4/image_128 without being logged in,
internal server error because you cannot access the public user (id=4)
image.

The permissions are validated inside of `_get_record_and_check` but that
function doesn't take related fields into account, it merely verifies
that the record is accessible, not the request record field.

The image_128 field is a related field, such fields are considered
"complicated" inside of the ir.http model thus there is no optimization
done beside just accessing the record which is "vulnerable" to access
rights. In this case while the public user record is accessible, its
image_128 field isn't. In such case we should return a 404-NotFound page
to the browser.

Closes #94258

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
