### PR TITLE
[FIX] account: format tax value with correct decimal separator

### DIFF
--- a/addons/account/static/src/js/tax_totals.js
+++ b/addons/account/static/src/js/tax_totals.js
@@ -30,8 +30,9 @@ class TaxGroupComponent extends Component {
 
     patched() {
         if (this.state.value === 'edit') {
+            const currency = session.get_currency(this.props.record.data.currency_id.data.id); // The records using this widget must have a currency_id field.
             this.inputTax.el.focus(); // Focus the input
-            this.inputTax.el.value = this.props.taxGroup.tax_group_amount;
+            this.inputTax.el.value = fieldUtils.format.float(this.props.taxGroup.tax_group_amount, null, {digits: currency.digits});
         }
     }
 


### PR DESCRIPTION
Editing the tax value of a vendor bill uses the wrong decimal separator

Steps to reproduce:
1. Install Invoicing
2. Switch to German / Deutsch language
3. Go to Invoicing > Vendors (Lieferanten) > Bills (Rechnungen)
4. Create a new bill with any product (if needed, edit the product price
   to have a tax with a decimal part)
5. Click on the tax value (as if you edit it), the decimal separator
   changes from a comma to a dot
6. Click anywhere on the form, the tax value isn't correctly parsed

Solution:
Format the tax value with the currency precision

opw-2889701