### PR TITLE
[FIX] mail: mail notification login always redirect to discuss

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -100,7 +100,17 @@ class MailController(http.Controller):
         else:
             record_action = record_sudo.get_access_action()
             if record_action['type'] == 'ir.actions.act_url' and record_action.get('target_type') != 'public':
-                return cls._redirect_to_messaging()
+                url_params = {
+                    'model': model,
+                    'id': res_id,
+                    'active_id': res_id,
+                    'action': record_action.get('id'),
+                }
+                view_id = record_sudo.get_formview_id()
+                if view_id:
+                    url_params['view_id'] = view_id
+                url = '/web/login?redirect=#%s' % url_encode(url_params)
+                return werkzeug.utils.redirect(url)
 
         record_action.pop('target_type', None)
         # the record has an URL redirection: use it directly


### PR DESCRIPTION
Steps to reproduce:

1- ping a user on any record
2- open the link in the email without being logged in
3- you are redirected to the login page
4- after login, you will be in discuss module

Bug:

the function `_redirect_to_messaging` is called instead of constructing
the proper redirect based on the model

Fix:
like:
https://github.com/odoo/odoo/blob/15.0/addons/mail/controllers/mail.py#L100-L110

back-port of 
https://github.com/odoo/odoo/commit/0b9d49f33713fc2d5a76f25523f2d4bb5ddb3b44

OPW-2885735