### PR TITLE
[FIX] website: add the email of when a user fill the website form

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -170,6 +170,15 @@ class WebsiteForm(http.Controller):
                 except ValueError:
                     error_fields.append(field_name)
 
+                if dest_model._name == 'mail.mail' and field_name == 'email_from':
+                    # As the "email_from" is used to populate the email_from of the
+                    # sent mail.mail, it could be filtered out at sending time if no
+                    # outgoing mail server "from_filter" match the sender email.
+                    # To make sure the email contains that (important) information
+                    # we also add it to the "custom message" that will be included
+                    # in the body of the email sent.
+                    custom_fields.append((_('email'), field_value))
+
             # If it's a custom field
             elif field_name != 'context':
                 custom_fields.append((field_name, field_value))

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -10966,6 +10966,12 @@ msgid "eLearning"
 msgstr ""
 
 #. module: website
+#: code:addons/website/controllers/form.py:0
+#, python-format
+msgid "email"
+msgstr ""
+
+#. module: website
 #. openerp-web
 #: code:addons/website/static/src/xml/website.xml:0
 #, python-format


### PR DESCRIPTION
Purpose
=======
When a public user fill a form on Website (e.g. /contactus), an email
will be sent. The email filled in the form will be used as the "email
from", but if no mail server match this email address it will be
encapsulated into "`notifications@mycompany.com`" (see https://github.com/odoo/odoo/pull/61853).

Even though the email is still present in the "Reply-To" header, we
want to add it at the end of the email, so the receiver has this
information easily.

Task-2833093