### PR TITLE
[FIX] product_expiry: filter quants by expiration alert date

### DIFF
--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -48,7 +48,7 @@
             <xpath expr="//filter[@name='reserved']" position="after">
                 <separator/>
                 <filter string="Expiration Alerts" name="expiration_alerts"
-                    domain="[('removal_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"/>
+                    domain="[('lot_id.alert_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"/>
             </xpath>
         </field>
      </record>


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable “Expiration date” in inventory settings
- Create a Storable product “P1”
    - Tracking: by serial number
    - Enable the expiration date option
    - Update the quantity:
        - Create a new Lot “SN1”:
            - select today's date as the alert date

- Go to inventory > reporting > Inventory Report
- Try to filter by “Expiration Alerts”

Problem:
The product P1 is not selected, because the filter checks the removal
date instead of the alert date

Solution:
The filter should check if the alert date is less than or equal
to today's date to display products or not, as it is for lots:
https://github.com/odoo/odoo/blob/14.0/addons/product_expiry/views/production_lot_views.xml#L30-L39

opw-2889737




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
