### PR TITLE
[FIX] mrp: set identifiers in action response

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1067,7 +1067,7 @@ class MrpProduction(models.Model):
 
     def action_view_mrp_production_childs(self):
         self.ensure_one()
-        mrp_production_ids = self._get_children()
+        mrp_production_ids = self._get_children().ids
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',
@@ -1087,7 +1087,7 @@ class MrpProduction(models.Model):
 
     def action_view_mrp_production_sources(self):
         self.ensure_one()
-        mrp_production_ids = self._get_sources()
+        mrp_production_ids = self._get_sources().ids
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -428,8 +428,8 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.assertEqual(subproduction.mrp_production_source_count, 1)
         child_action = production.action_view_mrp_production_childs()
         source_action = subproduction.action_view_mrp_production_sources()
-        self.assertEqual(child_action.get('res_id'), subproduction)
-        self.assertEqual(source_action.get('res_id'), production)
+        self.assertEqual(child_action.get('res_id'), subproduction.id)
+        self.assertEqual(source_action.get('res_id'), production.id)
 
     def test_3_steps_and_byproduct(self):
         """ Suppose a warehouse with Manufacture option set to '3 setps' and a product P01 with a reordering rule.


### PR DESCRIPTION
The actions need to return the identifiers, not the records
(See before the fix: 4870606b00a758e63713e6e82c0cba9b1e7dd4aa)
