### PR TITLE
[FIX] hr_expense: remove taxes_id from product view

### DIFF
--- a/addons/sale_expense/views/product_view.xml
+++ b/addons/sale_expense/views/product_view.xml
@@ -15,8 +15,8 @@
             <xpath expr="//field[@name='standard_price']" position="before">
                 <field name="list_price" attrs="{'invisible':[('expense_policy', '!=', 'sales_price')]}"/>
             </xpath>
-            <xpath expr="//field[@name='supplier_taxes_id']" position="after">
-                <field name="taxes_id" widget="many2many_tags" attrs="{'invisible':[('expense_policy', '=', 'no')]}"/>
+            <xpath expr="//field[@name='taxes_id']" position="attributes">
+                <attribute name="invisible">0</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Reproduction:
1. Install Expense in V15
2. Go to Expense->Configuration->Expense Products
3. Create a new product, after selecting a few Customer Taxes, click
save, the selected taxes are not shown on the saved page

Reason: The taxes_id is defined twice. One is in the hr_view, another is
in the product_view of the module sale_expense. This causes the taxes
are not shown on the saved page after choosing and saving the customer
taxes. But when you Edit the product and choose another customer tax,
the chosen taxes appear again.

Fix: This fix changes the inherited view in sale_expense, to make sure
the selected customer taxes are not erased in the view. It's a safer fix
as it avoids potentially broken customization

opw-2852894

related change: https://github.com/odoo-dev/odoo/commit/26a5653f48016d20f4bf050051a0844a760e4470#diff-35ce298bc166ce5f8a1fb1a73ae7f7c7730e12925d518dedfab92ce63e6bb83dL527-L529

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
