### PR TITLE
[FIX] mrp: allow selecting only the SNs linked to the MO

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -3873,6 +3873,14 @@ msgid ""
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/models/mrp_unbuild.py:0
+#, python-format
+msgid ""
+"The selected serial number does not correspond to the one used in the "
+"manufacturing order, please select another one."
+msgstr ""
+
+#. module: mrp
 #: code:addons/mrp/models/mrp_bom.py:0
 #, python-format
 msgid ""

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -88,6 +88,19 @@ class MrpUnbuild(models.Model):
             self.product_qty = self.mo_id.product_qty
             self.product_uom_id = self.mo_id.product_uom_id
             self.bom_id = self.mo_id.bom_id
+            if self.lot_id and self.lot_id not in self.mo_id.move_finished_ids.move_line_ids.lot_id:
+                return {'warning': {
+                    'title': _("Warning"),
+                    'message': _("The selected serial number does not correspond to the one used in the manufacturing order, please select another one.")
+                }}
+
+    @api.onchange('lot_id')
+    def _onchange_lot_id(self):
+        if self.mo_id and self.lot_id and self.lot_id not in self.mo_id.move_finished_ids.move_line_ids.lot_id:
+            return {'warning': {
+                'title': _("Warning"),
+                'message': _("The selected serial number does not correspond to the one used in the manufacturing order, please select another one.")
+            }}
 
     @api.onchange('product_id')
     def _onchange_product_id(self):


### PR DESCRIPTION
Stpes to reproduce the bug:
- Create a storable product “P1”:
    - tracking: Serial number
    - BOM: 1 unit of C1

- Create the MO 1:
    - produce 1 unit of P1:
        - Create the SN1

- Create the MO 2:
    - produce 1 unit of P1:
        - Create the SN2

- Create an Unbuild order:
   - Select the MO1

Problem:
You have the possibility to select any Serial number linked to the product “P1”, whereas only SNs created in this MO can be selected

opw-2834529




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
