### PR TITLE
[IMP] l10n_es_edi_sii: clearer missing element TipoDesglose error

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -6,6 +6,7 @@ from OpenSSL.crypto import load_certificate, load_privatekey, FILETYPE_PEM
 from zeep.transports import Transport
 
 from odoo import fields
+from odoo.exceptions import UserError
 from odoo.tools import html_escape
 
 import math
@@ -351,6 +352,11 @@ class AccountEdiFormat(models.Model):
                         invoice_node.setdefault('TipoDesglose', {})
                         invoice_node['TipoDesglose'].setdefault('DesgloseTipoOperacion', {})
                         invoice_node['TipoDesglose']['DesgloseTipoOperacion']['Entrega'] = tax_details_info_consu_vals['tax_details_info']
+                    if not invoice_node.get('TipoDesglose'):
+                        raise UserError(_(
+                            "In case of a foreign customer, you need to configure the tax scope on taxes:\n%s",
+                            "\n".join(invoice.line_ids.tax_ids.mapped('name'))
+                        ))
 
                     invoice_node['ImporteTotal'] = round(sign * (
                         tax_details_info_service_vals['tax_details']['base_amount']


### PR DESCRIPTION
When sending an invoice to the SII edi, the field TipoDesglose is
required. In case we have a foreign customer outside of Spain, we are
filtering the taxes information based on the tax scope (services or
goods). In case the tax scope is not filled in, TipoDesglose is not
provided and this will cause the request to fail, with no clear reason
for the user. We should add an UserError message to make it clear enough
so the user can fix it himself.

Description of the issue/feature this PR addresses:
opw-2886985

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
