### PR TITLE
[CHG] l10n_fr: check restrict_mode_hash_table on all accounting journals

### DIFF
--- a/addons/l10n_fr/models/account_chart_template.py
+++ b/addons/l10n_fr/models/account_chart_template.py
@@ -15,6 +15,7 @@ class AccountChartTemplate(models.Model):
             return journal_data
 
         for journal in journal_data:
+            journal.update({'restrict_mode_hash_table': True})
             if journal['type'] in ('sale', 'purchase'):
                 journal.update({'refund_sequence': True})
         return journal_data

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

In french software accounting the reset to draft button is not allowed according https://bofip.impots.gouv.fr/bofip/2899-PGP.html/identifiant%3DBOI-BIC-DECLA-30-10-20-40-20131213#-Apres_la_validation_compta_62   

### TO REPRODUCE

* in debug mode add admin user in `Show Full Accounting Features` group
* create new test company using euros as currency
* switch to that freshly created company
* go to invoicing configuration  and setup fr accounting using the *l10n_fr* module

* go to invoicing > Configuration > journals and make sure `Lock Posted Entries with Hash` is checked (or not) in the "Advanced settings" tab
* go to a posted invoice or posted one and make sure there is not the "reset to draft" button !  

## Current behavior before PR:

Journal created from FR template do not comes with the `restrict_mode_hash_table` allowing to reset to draft account entries.

## Desired behavior after PR is merged:

Journal prohibe changed on posted entries.

**I'm wondering if such change could be included in other active branches (13.0, 14.0, 15.0) or should I created a dedicated module to get that behavior by default ?**


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
