### PR TITLE
[FIX] mail: don't subscribe existing channels members

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -262,6 +262,7 @@ class Channel(models.Model):
     # ------------------------------------------------------------
 
     def _subscribe_users_automatically(self):
+        self = self.with_context(active_test=False)
         new_members = self._subscribe_users_automatically_get_members()
         if new_members:
             to_create = [


### PR DESCRIPTION
Currently, the auto-subscription system may attempt to subscribe members that are already present, if the corresponding contact is archived.

This did not occur before 15.0 because we used to rely on the m2m relationship `channel_partner_ids`, and the LINK(4) command never creates duplicates.

As of #62859, we're unconditionally creating `mail.channel.partner` entries for contacts returned by `_subscribe_users_automatically_get_members()`, which may include archived members.

Forcing `active_test=False` on the upstream method helps ensure that all downstream code takes archived entries into account when computing the members to add.

How to reproduce a crash before this patch:
- Configure a channel to auto-subscribe a department
- Add an employee to that department (A)
- Archive the user and contact for that employee, but not the employee
- Add another employee (B) to that department
- -> Traceback, constraint violation for `mail_channel_partner_partner_unique`, because  `_subscribe_users_automatically()` tries to add employee (A) who is already a member of the channel.

opw-2895716