### PR TITLE
[FIX] im_livechat: make external livechat work with only im_livechat

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -93,7 +93,7 @@
                 window.addEventListener('load', function () {
                     odoo.define('im_livechat.loaderData', function() {
                         return {
-                            isAvailable: <t t-out="info['available']"/>,
+                            isAvailable: <t t-out="'true' if info['available'] else 'false'"/>,
                             serverUrl: "<t t-out="info['server_url']"/>",
                             options: <t t-out="json.dumps(info.get('options', {}))"/>,
                         };


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/92786

Commit above make external livechat not working due to
`info['available']` being `True`, and `True` is not
a valid javascript keyword. The correct value is `true`,
starting with a smaller case.