### PR TITLE
[IMP] mail: remove deprecated autoOpenDiscuss parameter

### DIFF
--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -7,15 +7,7 @@ import {
 
 QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('discuss_sidebar_category_item_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('discuss_sidebar_category_item_tests.js');
 
 QUnit.test('livechat - avatar: should have a smiley face avatar for an anonymous livechat item', async function (assert) {
     assert.expect(2);
@@ -30,7 +22,8 @@ QUnit.test('livechat - avatar: should have a smiley face avatar for an anonymous
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const livechatItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
@@ -67,7 +60,8 @@ QUnit.test('livechat - avatar: should have a partner profile picture for a livec
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const livechatItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -8,15 +8,7 @@ import {
 
 QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('discuss_sidebar_category_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('discuss_sidebar_category_tests.js');
 
 QUnit.test('livechat - counter: should not have a counter if the category is unfolded and without unread messages', async function (assert) {
     assert.expect(1);
@@ -31,7 +23,8 @@ QUnit.test('livechat - counter: should not have a counter if the category is unf
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.containsNone(
         document.body,
         `.o_DiscussSidebar_categoryLivechat .o_DiscussSidebarCategory_counter`,
@@ -55,7 +48,8 @@ QUnit.test('livechat - counter: should not have a counter if the category is unf
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.containsNone(
         document.body,
         `.o_DiscussSidebar_categoryLivechat .o_DiscussSidebarCategory_counter`,
@@ -80,7 +74,8 @@ QUnit.test('livechat - counter: should not have a counter if category is folded 
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsNone(
         document.body,
@@ -109,7 +104,8 @@ QUnit.test('livechat - counter: should have correct value of unread threads if c
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelector(`.o_DiscussSidebar_categoryLivechat .o_DiscussSidebarCategory_counter`).textContent,
@@ -135,7 +131,8 @@ QUnit.test('livechat - states: close manually by clicking the title', async func
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: true,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,
@@ -183,7 +180,8 @@ QUnit.test('livechat - states: open manually by clicking the title', async funct
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsNone(
         document.body,
@@ -232,7 +230,8 @@ QUnit.test('livechat - states: close should update the value on the server', asy
         is_discuss_sidebar_category_livechat_open: true,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
@@ -281,7 +280,8 @@ QUnit.test('livechat - states: open should update the value on the server', asyn
         is_discuss_sidebar_category_livechat_open: false,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
@@ -329,7 +329,8 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: true,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,
@@ -376,7 +377,8 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsNone(
         document.body,
@@ -420,7 +422,8 @@ QUnit.test('livechat - states: category item should be invisible if the catgory 
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,
@@ -464,7 +467,8 @@ QUnit.test('livechat - states: the active category item should be visble even if
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -11,15 +11,7 @@ import { datetime_to_str } from 'web.time';
 
 QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('discuss_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('discuss_tests.js');
 
 QUnit.test('livechat in the sidebar: basic rendering', async function (assert) {
     assert.expect(5);
@@ -34,9 +26,9 @@ QUnit.test('livechat in the sidebar: basic rendering', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
+
     assert.containsOnce(document.body, '.o_Discuss_sidebar',
         "should have a sidebar section"
     );
@@ -89,9 +81,9 @@ QUnit.test('livechat in the sidebar: existing user with country', async function
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    await start({
-        autoOpenDiscuss: true,
-    });
+    const { openDiscuss } = await start();
+    await openDiscuss();
+
     assert.containsOnce(
         document.body,
         '.o_DiscussSidebar_categoryLivechat',
@@ -117,9 +109,9 @@ QUnit.test('do not add livechat in the sidebar on visitor opening his chat', asy
     const imLivechatChannelId1 = pyEnv['im_livechat.channel'].create({
         user_ids: [pyEnv.currentUserId],
     });
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
+
     assert.containsNone(
         document.body,
         '.o_DiscussSidebar_categoryLivechat',
@@ -164,9 +156,9 @@ QUnit.test('do not add livechat in the sidebar on visitor typing', async functio
         livechat_channel_id: imLivechatChannelId1,
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
+
     assert.containsNone(
         document.body,
         '.o_DiscussSidebar_categoryLivechat',
@@ -219,9 +211,8 @@ QUnit.test('add livechat in the sidebar on visitor sending first message', async
         livechat_channel_id: imLivechatChannelId1,
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.containsNone(
         document.body,
         '.o_DiscussSidebar_categoryLivechat',
@@ -287,9 +278,8 @@ QUnit.test('livechats are sorted by last activity time in the sidebar: most rece
             livechat_operator_id: pyEnv.currentPartnerId,
         },
     ]);
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     const livechat11 = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -353,14 +343,14 @@ QUnit.test('invite button should be present on livechat', async function (assert
             livechat_operator_id: pyEnv.currentPartnerId,
         },
     );
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_ThreadViewTopbar_inviteButton',
@@ -383,14 +373,14 @@ QUnit.test('call buttons should not be present on livechat', async function (ass
             livechat_operator_id: pyEnv.currentPartnerId,
         },
     );
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsNone(
         document.body,
         '.o_ThreadViewTopbar_callButton',
@@ -408,13 +398,14 @@ QUnit.test('reaction button should not be present on livechat', async function (
         livechat_operator_id: pyEnv.currentPartnerId,
         channel_partner_ids: [pyEnv.currentPartnerId, pyEnv.publicPartnerId],
     });
-    const { click, insertText } = await this.start({
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "Test");
     await click('.o_Composer_buttonSend');
     await click('.o_Message');
@@ -435,13 +426,14 @@ QUnit.test('reply button should not be present on livechat', async function (ass
         livechat_operator_id: pyEnv.currentPartnerId,
         channel_partner_ids: [pyEnv.currentPartnerId, pyEnv.publicPartnerId],
     });
-    const { click, insertText } = await this.start({
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "Test");
     await click('.o_Composer_buttonSend');
     await click('.o_Message');

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -472,8 +472,6 @@ function getOpenDiscuss(webClient, { context, params, ...props } = {}) {
  * Main function used to make a mocked environment with mocked messaging env.
  *
  * @param {Object} [param0={}]
- * @param {boolean} [param0.autoOpenDiscuss=false] determine if discuss should be
- *   open initially. Deprecated, call openDiscuss() instead.
  * @param {Object} [param0.serverData] The data to pass to the webClient
  * @param {Object} [param0.discuss={}] provide data that is passed to the discuss action.
  * @param {Object} [param0.legacyServices]
@@ -513,7 +511,6 @@ async function start(param0 = {}) {
         throttle: func => func,
     });
     const {
-        autoOpenDiscuss,
         discuss = {},
         hasTimeControl,
         waitUntilEvent,
@@ -559,10 +556,6 @@ async function start(param0 = {}) {
         await webClient.env.services.messaging.modelManager.messagingCreatedPromise;
         await webClient.env.services.messaging.modelManager.messagingInitializedPromise;
     }
-    const openDiscuss = getOpenDiscuss(webClient, discuss);
-    if (autoOpenDiscuss) {
-        await openDiscuss();
-    }
     // link the pyEnv to the actual mockServer after execution of createWebClient.
     pyEnv.mockServer = MockServer.currentMockServer;
     const openView = async (action, options) => {
@@ -583,7 +576,7 @@ async function start(param0 = {}) {
         env: webClient.env,
         insertText,
         messaging: webClient.env.services.messaging.modelManager.messaging,
-        openDiscuss,
+        openDiscuss: getOpenDiscuss(webClient, discuss),
         openView,
         pyEnv,
         webClient,

--- a/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
+++ b/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
@@ -15,9 +15,8 @@ QUnit.test('select another mailbox', async function (assert) {
     assert.expect(7);
 
     patchUiSize({ height: 360, width: 640 });
-    const { click, messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_Discuss',
@@ -68,14 +67,14 @@ QUnit.test('auto-select "Inbox" when discuss had channel as active thread', asyn
     const mailChannelId1 = pyEnv['mail.channel'].create({});
 
     patchUiSize({ height: 360, width: 640 });
-    const { click, messaging } = await start({
-        autoOpenDiscuss: true,
+    const { click, messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
             },
         },
     });
+    await openDiscuss();
     assert.hasClass(
         document.querySelector('.o_MobileMessagingNavbar_tab[data-tab-id="channel"]'),
         'o-active',

--- a/addons/mail/static/tests/qunit_suite_tests/components/channel_invitation_form_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/channel_invitation_form_tests.js
@@ -26,14 +26,14 @@ QUnit.test('should display the channel invitation form after clicking on the inv
         channel_type: 'chat',
         public: 'private',
     });
-    const { click } = await start({
-        autoOpenDiscuss: true,
+    const { click, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
             },
         },
     });
+    await openDiscuss();
     await click(`.o_ThreadViewTopbar_inviteButton`);
     assert.containsOnce(
         document.body,
@@ -64,14 +64,14 @@ QUnit.test('should be able to search for a new user to invite from an existing c
         channel_type: 'chat',
         public: 'private',
     });
-    const { click, insertText } = await start({
-        autoOpenDiscuss: true,
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
             },
         },
     });
+    await openDiscuss();
     await click(`.o_ThreadViewTopbar_inviteButton`);
     await insertText('.o_ChannelInvitationForm_searchInput', "TestPartner2");
     assert.strictEqual(
@@ -103,14 +103,14 @@ QUnit.test('should be able to create a new group chat from an existing chat', as
         channel_type: 'chat',
         public: 'private',
     });
-    const { click, insertText } = await start({
-        autoOpenDiscuss: true,
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
             },
         },
     });
+    await openDiscuss();
 
     await click(`.o_ThreadViewTopbar_inviteButton`);
     await insertText('.o_ChannelInvitationForm_searchInput', "TestPartner2");

--- a/addons/mail/static/tests/qunit_suite_tests/components/channel_member_list_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/channel_member_list_tests.js
@@ -7,15 +7,7 @@ import {
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('channel_member_list_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('channel_member_list_tests.js');
 
 QUnit.test('there should be a button to show member list in the thread view topbar initially', async function (assert) {
     assert.expect(1);
@@ -30,13 +22,14 @@ QUnit.test('there should be a button to show member list in the thread view topb
         channel_type: 'group',
         public: 'private',
     });
-    await this.start({
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_ThreadViewTopbar_showMemberListButton',
@@ -57,13 +50,14 @@ QUnit.test('should show member list when clicking on show member list button in 
         channel_type: 'group',
         public: 'private',
     });
-    const { click } = await this.start({
+    const { click, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     await click('.o_ThreadViewTopbar_showMemberListButton');
     assert.containsOnce(
         document.body,
@@ -85,13 +79,14 @@ QUnit.test('should have correct members in member list', async function (assert)
         channel_type: 'group',
         public: 'private',
     });
-    const { click, messaging } = await this.start({
+    const { click, messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     await click('.o_ThreadViewTopbar_showMemberListButton');
     assert.containsN(
         document.body,
@@ -128,13 +123,14 @@ QUnit.test('there should be a button to hide member list in the thread view topb
         channel_type: 'group',
         public: 'private',
      });
-    const { click } = await this.start({
+    const { click, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     await click('.o_ThreadViewTopbar_showMemberListButton');
     assert.containsOnce(
         document.body,
@@ -157,13 +153,14 @@ QUnit.test('should show a button to load more members if they are not all loaded
         channel_type: 'group',
         public: 'private',
     });
-    const { click } = await this.start({
+    const { click, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId}`,
             },
         },
     });
+    await openDiscuss();
     await click('.o_ThreadViewTopbar_showMemberListButton');
     assert.containsOnce(
         document.body,
@@ -187,13 +184,14 @@ QUnit.test('Load more button should load more members', async function (assert) 
         channel_type: 'group',
         public: 'private',
     });
-    const { click } = await this.start({
+    const { click, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId}`,
             },
         },
     });
+    await openDiscuss();
     await click('.o_ThreadViewTopbar_showMemberListButton');
     await click('.o_ChannelMemberList_loadMoreButton');
     assert.containsN(

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -940,7 +940,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => document.querySelector('.o_NotificationList_preview').click(),
-        message: "should wait until channel 20 scrolled to its last message after opening it from the messaging menu",
+        message: "should wait until channel scrolled to its last message after opening it from the messaging menu",
         predicate: ({ scrollTop, thread }) => {
             const messageList = document.querySelector('.o_ThreadView_messageList');
             return (
@@ -957,7 +957,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
         func: () => {
             document.querySelector(`.o_ThreadView_messageList`).scrollTop = 142;
         },
-        message: "should wait until channel 20 scrolled to 142 after setting this value manually",
+        message: "should wait until channel scrolled to 142 after setting this value manually",
         predicate: ({ scrollTop, thread }) => {
             return (
                 thread &&
@@ -978,7 +978,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
             res_model: 'mail.channel',
             views: [[false, 'form']],
         }),
-        message: "should wait until channel 20 restored its scroll to 142 after closing discuss",
+        message: "should wait until channel restored its scroll to 142 after closing discuss",
         predicate: ({ scrollTop, thread }) => {
             return (
                 thread &&
@@ -1474,7 +1474,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => document.querySelector('.o_NotificationList_preview').click(),
-        message: "should wait until channel 20 scrolled to its last message after opening it from the messaging menu",
+        message: "should wait until channel scrolled to its last message after opening it from the messaging menu",
         predicate: ({ scrollTop, thread }) => {
             const messageList = document.querySelector('.o_ThreadView_messageList');
             return (
@@ -1491,7 +1491,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
         func: () => {
             document.querySelector(`.o_ThreadView_messageList`).scrollTop = 142;
         },
-        message: "should wait until channel 20 scrolled to 142 after setting this value manually",
+        message: "should wait until channel scrolled to 142 after setting this value manually",
         predicate: ({ scrollTop, thread }) => {
             return (
                 thread &&
@@ -1519,7 +1519,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
     await afterNextRender(() => afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => document.querySelector('.o_ChatWindow_header').click(),
-        message: "should wait until channel 20 restored its scroll position to 142",
+        message: "should wait until channel restored its scroll position to 142",
         predicate: ({ scrollTop, thread }) => {
             return (
                 thread &&
@@ -1622,7 +1622,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => document.querySelector('.o_NotificationList_preview').click(),
-        message: "should wait until channel 20 scrolled to its last message after opening it from the messaging menu",
+        message: "should wait until channel scrolled to its last message after opening it from the messaging menu",
         predicate: ({ scrollTop, thread }) => {
             const messageList = document.querySelector('.o_ThreadView_messageList');
             return (
@@ -1637,7 +1637,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => document.querySelector(`.o_ThreadView_messageList`).scrollTop = 142,
-        message: "should wait until channel 20 scrolled to 142 after setting this value manually",
+        message: "should wait until channel scrolled to 142 after setting this value manually",
         predicate: ({ scrollTop, thread }) => {
             return (
                 thread &&
@@ -1661,7 +1661,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => document.querySelector('.o_ChatWindow_header').click(),
-        message: "should wait until channel 20 restored its scroll position to the last saved value (142)",
+        message: "should wait until channel restored its scroll position to the last saved value (142)",
         predicate: ({ scrollTop, thread }) => {
             return (
                 thread &&

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -576,8 +576,7 @@ QUnit.test('do not send typing notification on typing "/" command', async functi
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { insertText } = await start({
-        autoOpenDiscuss: true,
+    const { insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -589,6 +588,7 @@ QUnit.test('do not send typing notification on typing "/" command', async functi
             }
         },
     });
+    await openDiscuss();
 
     await insertText('.o_ComposerTextInput_textarea', "/");
     assert.verifySteps([], "No rpc done");
@@ -599,8 +599,7 @@ QUnit.test('do not send typing notification on typing after selecting suggestion
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, insertText } = await start({
-        autoOpenDiscuss: true,
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -612,6 +611,7 @@ QUnit.test('do not send typing notification on typing after selecting suggestion
             }
         },
     });
+    await openDiscuss();
 
     await insertText('.o_ComposerTextInput_textarea', "/");
     await click('.o_ComposerSuggestion');
@@ -1054,14 +1054,14 @@ QUnit.test('composer with thread typing notification status', async function (as
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,
@@ -1082,8 +1082,7 @@ QUnit.test('current partner notify is typing to other thread members', async fun
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { insertText } = await start({
-        autoOpenDiscuss: true,
+    const { insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1095,6 +1094,7 @@ QUnit.test('current partner notify is typing to other thread members', async fun
             }
         },
     });
+    await openDiscuss();
 
     await insertText('.o_ComposerTextInput_textarea', 'a');
     assert.verifySteps(
@@ -1110,8 +1110,7 @@ QUnit.test('current partner is typing should not translate on textual typing sta
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { insertText } = await start({
-        autoOpenDiscuss: true,
+    const { insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1124,6 +1123,7 @@ QUnit.test('current partner is typing should not translate on textual typing sta
             }
         },
     });
+    await openDiscuss();
 
     await insertText('.o_ComposerTextInput_textarea', 'a');
 
@@ -1147,8 +1147,7 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { advanceTime, insertText } = await start({
-        autoOpenDiscuss: true,
+    const { advanceTime, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1161,6 +1160,7 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
             }
         },
     });
+    await openDiscuss();
 
     await insertText('.o_ComposerTextInput_textarea', 'a');
 
@@ -1183,8 +1183,7 @@ QUnit.test('current partner notify is typing again to other members every 50s of
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { advanceTime, insertText } = await start({
-        autoOpenDiscuss: true,
+    const { advanceTime, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1197,6 +1196,7 @@ QUnit.test('current partner notify is typing again to other members every 50s of
             }
         },
     });
+    await openDiscuss();
 
     await insertText('.o_ComposerTextInput_textarea', "a");
     assert.verifySteps(

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
@@ -11,15 +11,7 @@ import { patchWithCleanup } from '@web/../tests/helpers/utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('discuss_inbox_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('discuss_inbox_tests.js');
 
 QUnit.test('reply: discard on pressing escape', async function (assert) {
     assert.expect(9);
@@ -43,17 +35,17 @@ QUnit.test('reply: discard on pressing escape', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { click, insertText } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, click, insertText, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -142,17 +134,17 @@ QUnit.test('reply: discard on discard button click', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { click } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, click, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -200,17 +192,17 @@ QUnit.test('reply: discard on reply button toggle', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { click } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, click, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -252,17 +244,17 @@ QUnit.test('reply: discard on click away', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { click } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, click, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -333,7 +325,7 @@ QUnit.test('"reply to" composer should log note if message replied to is a note'
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { click, insertText } = await this.start({
+    const { afterEvent, click, insertText, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/message/post') {
                 assert.step('/mail/message/post');
@@ -349,16 +341,17 @@ QUnit.test('"reply to" composer should log note if message replied to is a note'
                 );
             }
         },
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -399,7 +392,7 @@ QUnit.test('"reply to" composer should send message if message replied to is not
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { click, insertText } = await this.start({
+    const { afterEvent, click, insertText, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/message/post') {
                 assert.step('/mail/message/post');
@@ -415,16 +408,17 @@ QUnit.test('"reply to" composer should send message if message replied to is not
                 );
             }
         },
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -464,7 +458,8 @@ QUnit.test('error notifications should not be shown in Inbox', async function (a
         notification_type: 'email',
         res_partner_id: pyEnv.currentPartnerId, // must be for current partner
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_Message',
@@ -499,17 +494,17 @@ QUnit.test('show subject of message in Inbox', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -546,22 +541,23 @@ QUnit.test('show subject of message in history', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
+    const { afterEvent, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: 'mail.box_history',
             },
         },
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until history displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'history'
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until history displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'history'
+            );
         },
     });
     assert.containsOnce(
@@ -599,17 +595,17 @@ QUnit.test('click on (non-channel/non-partner) origin thread link should redirec
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { env } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, env, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     patchWithCleanup(env.services.action, {
@@ -679,17 +675,17 @@ QUnit.test('subject should not be shown when subject is the same as the thread n
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsNone(
@@ -717,17 +713,17 @@ QUnit.test('subject should not be shown when subject is the same as the thread n
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsNone(
@@ -755,17 +751,17 @@ QUnit.test('subject should not be shown when subject differs from thread name on
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsNone(
@@ -793,17 +789,17 @@ QUnit.test('subject should not be shown when subject differs from thread name on
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsNone(
@@ -831,17 +827,17 @@ QUnit.test('subject should be shown when the thread name has an extra prefix com
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsOnce(
@@ -869,17 +865,17 @@ QUnit.test('subject should not be shown when subject differs from thread name on
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsNone(
@@ -907,17 +903,17 @@ QUnit.test('subject should not be shown when subject differs from thread name on
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.containsNone(

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
@@ -15,9 +15,8 @@ QUnit.test('sidebar: pinned channel 1: init with one pinned channel', async func
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         `.o_Discuss_thread[data-thread-local-id="${messaging.inbox.localId}"]`,
@@ -40,9 +39,8 @@ QUnit.test('sidebar: pinned channel 2: open pinned channel', async function (ass
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -69,8 +67,7 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
             partner_id: pyEnv.currentPartnerId,
         }]],
     });
-    const { click, messaging } = await start({
-        autoOpenDiscuss: true,
+    const { click, messaging, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (args.method === 'action_unfollow') {
                 assert.step('action_unfollow');
@@ -80,6 +77,7 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
             }
         },
     });
+    await openDiscuss();
 
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -114,9 +112,8 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -181,9 +178,8 @@ QUnit.test('[technical] sidebar: channel group_based_subscription: mandatorily p
         }]],
         group_based_subscription: true,
     });
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -18,9 +18,8 @@ QUnit.test('channel - avatar: should have correct avatar', async function (asser
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ avatarCacheKey: '100111' });
 
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const channelItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
@@ -49,9 +48,8 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ avatarCacheKey: '101010' });
 
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const channelLocalId = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -98,9 +96,8 @@ QUnit.test('chat - avatar: should have correct avatar', async function (assert) 
         channel_type: 'chat',
         public: 'private',
     });
-    const { messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const chatItem = document.querySelector(`
         .o_DiscussSidebarCategoryItem[data-thread-local-id="${
@@ -145,9 +142,8 @@ QUnit.test('chat - sorting: should be sorted by last activity time', async funct
             public: 'private',
         },
     ]);
-    const { click, messaging } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const chat1 = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -8,15 +8,7 @@ import {
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('discuss_sidebar_category_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('discuss_sidebar_category_tests.js');
 
 QUnit.test('channel - counter: should not have a counter if the category is unfolded and without needaction messages', async function (assert) {
     assert.expect(1);
@@ -24,7 +16,8 @@ QUnit.test('channel - counter: should not have a counter if the category is unfo
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create({});
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_counter`).length,
         0,
@@ -61,7 +54,8 @@ QUnit.test('channel - counter: should not have a counter if the category is unfo
             res_partner_id: pyEnv.currentPartnerId,
         },
     ]);
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_counter`).length,
         0,
@@ -79,7 +73,8 @@ QUnit.test('channel - counter: should not have a counter if category is folded a
         is_discuss_sidebar_category_channel_open: false,
     });
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_counter`).length,
@@ -121,7 +116,8 @@ QUnit.test('channel - counter: should have correct value of needaction threads i
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelector(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_counter`).textContent,
@@ -133,7 +129,8 @@ QUnit.test('channel - counter: should have correct value of needaction threads i
 QUnit.test('channel - command: should have view command when category is unfolded', async function (assert) {
     assert.expect(1);
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_header .o_DiscussSidebarCategory_commandView`).length,
@@ -150,7 +147,8 @@ QUnit.test('channel - command: should have view command when category is folded'
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    const { click } = await this.start();
+    const { click, openDiscuss } = await start();
+    await openDiscuss();
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
     assert.strictEqual(
@@ -163,7 +161,8 @@ QUnit.test('channel - command: should have view command when category is folded'
 QUnit.test('channel - command: should have add command when category is unfolded', async function (assert) {
     assert.expect(1);
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_header .o_DiscussSidebarCategory_commandAdd`).length,
@@ -180,7 +179,8 @@ QUnit.test('channel - command: should not have add command when category is fold
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_header .o_DiscussSidebarCategory_commandAdd`).length,
@@ -198,7 +198,8 @@ QUnit.test('channel - states: close manually by clicking the title', async funct
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
     });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
     assert.containsNone(
@@ -222,7 +223,8 @@ QUnit.test('channel - states: open manually by clicking the title', async functi
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
     assert.containsOnce(
@@ -247,7 +249,8 @@ QUnit.test('channel - states: close should update the value on the server', asyn
         is_discuss_sidebar_category_channel_open: true,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
@@ -283,7 +286,8 @@ QUnit.test('channel - states: open should update the value on the server', async
         is_discuss_sidebar_category_channel_open: false,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
@@ -318,7 +322,8 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     await afterNextRender(() => {
         pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
@@ -347,7 +352,8 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     await afterNextRender(() => {
         pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
@@ -372,7 +378,8 @@ QUnit.test('channel - states: the active category item should be visble even if 
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,
@@ -437,7 +444,8 @@ QUnit.test('chat - counter: should not have a counter if the category is unfolde
         public: 'private',
     });
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_counter`).length,
         0,
@@ -459,7 +467,8 @@ QUnit.test('chat - counter: should not have a counter if the category is unfolde
         channel_type: 'chat',
         public: 'private',
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_counter`).length,
         0,
@@ -481,7 +490,8 @@ QUnit.test('chat - counter: should not have a counter if category is folded and 
         channel_type: 'chat',
         public: 'private',
     });
-    const { click } = await this.start();
+    const { click, openDiscuss } = await start();
+    await openDiscuss();
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_counter`).length,
@@ -516,7 +526,8 @@ QUnit.test('chat - counter: should have correct value of unread threads if categ
             public: 'private',
         },
     ]);
-    const { click } = await this.start();
+    const { click, openDiscuss } = await start();
+    await openDiscuss();
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.strictEqual(
         document.querySelector(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_counter`).textContent,
@@ -528,7 +539,8 @@ QUnit.test('chat - counter: should have correct value of unread threads if categ
 QUnit.test('chat - command: should have add command when category is unfolded', async function (assert) {
     assert.expect(1);
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_header .o_DiscussSidebarCategory_commandAdd`).length,
         1,
@@ -544,7 +556,8 @@ QUnit.test('chat - command: should not have add command when category is folded'
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
 
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_header .o_DiscussSidebarCategory_commandAdd`).length,
@@ -565,7 +578,8 @@ QUnit.test('chat - states: close manually by clicking the title', async function
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
     });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.containsNone(
         document.body,
@@ -591,7 +605,8 @@ QUnit.test('chat - states: open manually by clicking the title', async function 
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.containsOnce(
         document.body,
@@ -615,7 +630,8 @@ QUnit.test('chat - states: close should call update server data', async function
         is_discuss_sidebar_category_chat_open: true,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
@@ -650,7 +666,8 @@ QUnit.test('chat - states: open should call update server data', async function 
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
@@ -688,7 +705,8 @@ QUnit.test('chat - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     await afterNextRender(() => {
         pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
@@ -720,7 +738,8 @@ QUnit.test('chat - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     await afterNextRender(() => {
         pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
@@ -748,7 +767,8 @@ QUnit.test('chat - states: the active category item should be visble even if the
         channel_type: 'chat',
         public: 'private',
     });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
 
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_tests.js
@@ -22,14 +22,14 @@ QUnit.test('sidebar find shows channels matching search term', async function (a
         public: 'public',
     });
     const searchReadDef = makeDeferred();
-    const { click } = await start({
-        autoOpenDiscuss: true,
+    const { click, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (args.method === 'search_read') {
                 searchReadDef.resolve();
             }
         },
     });
+    await openDiscuss();
     await click(`.o_DiscussSidebarCategory_commandAdd`);
     document.querySelector(`.o_DiscussSidebarCategory_addingItem`).focus();
     document.execCommand('insertText', false, "test");
@@ -73,14 +73,14 @@ QUnit.test('sidebar find shows channels matching search term even when user is m
         public: 'public',
     });
     const searchReadDef = makeDeferred();
-    const { click } = await start({
-        autoOpenDiscuss: true,
+    const { click, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (args.method === 'search_read') {
                 searchReadDef.resolve();
             }
         },
     });
+    await openDiscuss();
     await click(`.o_DiscussSidebarCategory_commandAdd`);
     document.querySelector(`.o_DiscussSidebarCategory_addingItem`).focus();
     document.execCommand('insertText', false, "test");
@@ -121,9 +121,8 @@ QUnit.test('sidebar channels should be ordered case insensitive alphabetically',
         { name: "Abc" },
         { name: "Xyz" },
     ]);
-    await start({
-        autoOpenDiscuss: true,
-    });
+    const { openDiscuss } = await start();
+    await openDiscuss();
     const results = document.querySelectorAll('.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategoryItem_name');
     assert.deepEqual(
         [results[0].textContent, results[1].textContent, results[2].textContent, results[3].textContent],

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -19,24 +19,17 @@ const { createFile, inputFiles } = file;
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('discuss_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign({}, params, {
-                autoOpenDiscuss: true,
-            }));
-        };
-    },
-});
+QUnit.module('discuss_tests.js');
 
 QUnit.test('messaging not created', async function (assert) {
     assert.expect(1);
 
     const messagingBeforeCreationDeferred = makeTestPromise();
-    await this.start({
+    const { openDiscuss } = await start({
         messagingBeforeCreationDeferred,
         waitUntilMessagingCondition: 'none'
     });
+    await openDiscuss();
     assert.containsOnce(document.body, '.o_DiscussContainer_spinner', "should display messaging not initialized");
     messagingBeforeCreationDeferred.resolve();
 });
@@ -45,10 +38,11 @@ QUnit.test('discuss should be marked as opened if the component is already rende
     assert.expect(1);
 
     const messagingBeforeCreationDeferred = makeTestPromise();
-    const { env } = await this.start({
+    const { env, openDiscuss } = await start({
         messagingBeforeCreationDeferred,
         waitUntilMessagingCondition: 'none',
     });
+    await openDiscuss();
 
     await afterNextRender(() => messagingBeforeCreationDeferred.resolve());
     const { messaging } = env.services.messaging.modelManager;
@@ -61,7 +55,8 @@ QUnit.test('discuss should be marked as opened if the component is already rende
 QUnit.test('discuss should be marked as closed when the component is unmounted', async function (assert) {
     assert.expect(1);
 
-    const { messaging, webClient } = await this.start();
+    const { messaging, openDiscuss, webClient } = await start();
+    await openDiscuss();
 
     await afterNextRender(() => destroy(webClient));
     assert.notOk(
@@ -73,7 +68,7 @@ QUnit.test('discuss should be marked as closed when the component is unmounted',
 QUnit.test('messaging not initialized', async function (assert) {
     assert.expect(1);
 
-    await this.start({
+    const { openDiscuss } = await start({
         async mockRPC(route) {
             if (route === '/mail/init_messaging') {
                 await makeTestPromise(); // simulate messaging never initialized
@@ -81,6 +76,7 @@ QUnit.test('messaging not initialized', async function (assert) {
         },
         waitUntilMessagingCondition: 'created',
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll('.o_DiscussContainer_spinner').length,
         1,
@@ -93,7 +89,7 @@ QUnit.test('messaging becomes initialized', async function (assert) {
 
     const messagingInitializedProm = makeTestPromise();
 
-    await this.start({
+    const { openDiscuss } = await start({
         async mockRPC(route) {
             if (route === '/mail/init_messaging') {
                 await messagingInitializedProm;
@@ -101,6 +97,7 @@ QUnit.test('messaging becomes initialized', async function (assert) {
         },
         waitUntilMessagingCondition: 'created',
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll('.o_DiscussContainer_spinner').length,
         1,
@@ -118,7 +115,8 @@ QUnit.test('messaging becomes initialized', async function (assert) {
 QUnit.test('basic rendering', async function (assert) {
     assert.expect(4);
 
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll('.o_Discuss_sidebar').length,
         1,
@@ -143,7 +141,8 @@ QUnit.test('basic rendering', async function (assert) {
 QUnit.test('basic rendering: sidebar', async function (assert) {
     assert.expect(18);
 
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_category`).length,
         3,
@@ -260,7 +259,8 @@ QUnit.test('basic rendering: sidebar', async function (assert) {
 QUnit.test('sidebar: basic mailbox rendering', async function (assert) {
     assert.expect(5);
 
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     const inbox = document.querySelector(`
         .o_DiscussSidebar_categoryMailbox
         .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -302,7 +302,8 @@ QUnit.test('sidebar: basic mailbox rendering', async function (assert) {
 QUnit.test('sidebar: default active inbox', async function (assert) {
     assert.expect(1);
 
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     const inbox = document.querySelector(`
         .o_DiscussSidebar_categoryMailbox
         .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -318,7 +319,8 @@ QUnit.test('sidebar: default active inbox', async function (assert) {
 QUnit.test('sidebar: change item', async function (assert) {
     assert.expect(4);
 
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -363,7 +365,8 @@ QUnit.test('sidebar: inbox with counter', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.notification'].create({ notification_type: 'inbox', res_partner_id: pyEnv.currentPartnerId });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -389,7 +392,8 @@ QUnit.test('sidebar: inbox with counter', async function (assert) {
 QUnit.test('sidebar: add channel', async function (assert) {
     assert.expect(3);
 
-    const { click } = await this.start();
+    const { click, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChannel
@@ -418,7 +422,8 @@ QUnit.test('sidebar: basic channel rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`).length,
         1,
@@ -504,7 +509,8 @@ QUnit.test('sidebar: channel rendering with needaction counter', async function 
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId, // must be for current partner
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     const channel = document.querySelector(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`);
     assert.strictEqual(
         channel.querySelectorAll(`:scope .o_DiscussSidebarCategoryItem_counter`).length,
@@ -541,7 +547,8 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
         { name: "channel1", public: 'public' },
         { name: "channel2", public: 'private' },
     ]);
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`).length,
         2,
@@ -615,7 +622,8 @@ QUnit.test('sidebar: basic chat rendering', async function (assert) {
         channel_type: 'chat', // testing a chat is the goal of the test
         public: 'private', // expected value for testing a chat
     });
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`).length,
         1,
@@ -681,7 +689,8 @@ QUnit.test('sidebar: chat rendering with unread counter', async function (assert
         channel_type: 'chat',
         public: 'private',
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     const chat = document.querySelector(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`);
     assert.strictEqual(
         chat.querySelectorAll(`:scope .o_DiscussSidebarCategoryItem_counter`).length,
@@ -740,7 +749,8 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
             public: 'private',
         }
     ]);
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`).length,
         3,
@@ -845,7 +855,8 @@ QUnit.test('sidebar: chat custom name', async function (assert) {
         channel_type: 'chat',
         public: 'private',
     });
-    await this.start();
+    const { openDiscuss } = await start();
+    await openDiscuss();
     const chat = document.querySelector(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`);
     assert.strictEqual(
         chat.querySelector(`:scope .o_DiscussSidebarCategoryItem_name`).textContent,
@@ -859,7 +870,8 @@ QUnit.test('default thread rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -1010,7 +1022,7 @@ QUnit.test('default thread rendering', async function (assert) {
 QUnit.test('initially load messages from inbox', async function (assert) {
     assert.expect(3);
 
-    await this.start({
+    const { openDiscuss } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/inbox/messages') {
                 assert.step('/mail/channel/messages');
@@ -1022,19 +1034,21 @@ QUnit.test('initially load messages from inbox', async function (assert) {
             }
         },
     });
+    await openDiscuss();
     assert.verifySteps(['/mail/channel/messages']);
 });
 
 QUnit.test('default select thread in discuss params', async function (assert) {
     assert.expect(1);
 
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: 'mail.box_starred',
             },
         }
     });
+    await openDiscuss();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -1048,13 +1062,14 @@ QUnit.test('default select thread in discuss params', async function (assert) {
 QUnit.test('auto-select thread in discuss context', async function (assert) {
     assert.expect(1);
 
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: 'mail.box_starred',
             },
         },
     });
+    await openDiscuss();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -1076,7 +1091,7 @@ QUnit.test('load single message from channel initially', async function (assert)
         model: 'mail.channel',
         res_id: mailChannelId1
     });
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1092,6 +1107,7 @@ QUnit.test('load single message from channel initially', async function (assert)
             }
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_Discuss_thread .o_ThreadView_messageList`).length,
         1,
@@ -1129,13 +1145,14 @@ QUnit.test('open channel from active_id as channel id', async function (assert) 
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
             },
         }
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         `
@@ -1161,13 +1178,14 @@ QUnit.test('basic rendering of message', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId1
     });
-    const { click, messaging } = await this.start({
+    const { click, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     const message = document.querySelector(`
         .o_Discuss_thread
         .o_ThreadView_messageList
@@ -1259,13 +1277,14 @@ QUnit.test('should not be able to reply to temporary/transient messages', async 
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, insertText } = await this.start({
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     // these user interactions is to forge a transient message response from channel command "/who"
     await insertText('.o_ComposerTextInput_textarea', "/who");
     await click('.o_Composer_buttonSend');
@@ -1306,13 +1325,14 @@ QUnit.test('basic rendering of squashed message', async function (assert) {
             res_id: mailChannelId1, // id of related channel
         }
     ]);
-    const { click, messaging } = await this.start({
+    const { click, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_Discuss_thread .o_ThreadView_messageList .o_MessageList_message
@@ -1430,17 +1450,17 @@ QUnit.test('inbox messages are never squashed', async function (assert) {
             res_partner_id: pyEnv.currentPartnerId,
         },
     ]);
-    const { messaging } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, messaging, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
 
@@ -1492,7 +1512,7 @@ QUnit.test('load all messages from channel initially, less than fetch limit (29 
             res_id: mailChannelId1,
         });
     }
-    await this.start({
+    const { openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1504,6 +1524,7 @@ QUnit.test('load all messages from channel initially, less than fetch limit (29 
             }
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_Discuss_thread .o_ThreadView_messageList .o_MessageList_separatorDate
@@ -1551,13 +1572,14 @@ QUnit.test('load more messages from channel', async function (assert) {
             res_id: mailChannelId1,
         });
     }
-    const { click } = await this.start({
+    const { click, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_Discuss_thread .o_ThreadView_messageList .o_MessageList_separatorDate
@@ -1617,24 +1639,25 @@ QUnit.test('auto-scroll to bottom of thread', async function (assert) {
             res_id: mailChannelId1,
         });
     }
-    await this.start({
+    const { afterEvent, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        waitUntilEvent: {
-            eventName: 'o-component-message-list-scrolled',
-            message: "should wait until channel scrolled to its last message initially",
-            predicate: ({ scrollTop, thread }) => {
-                const messageList = document.querySelector('.o_ThreadView_messageList');
-                return (
-                    thread &&
-                    thread.model === 'mail.channel' &&
-                    thread.id === mailChannelId1 &&
-                    isScrolledToBottom(messageList)
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-component-message-list-scrolled',
+        func: openDiscuss,
+        message: "should wait until channel scrolled to its last message initially",
+        predicate: ({ scrollTop, thread }) => {
+            const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
+            return (
+                thread &&
+                thread.model === 'mail.channel' &&
+                thread.id === mailChannelId1 &&
+                isScrolledToBottom(messageList)
+            );
         },
     });
     assert.strictEqual(
@@ -1664,24 +1687,25 @@ QUnit.test('load more messages from channel (auto-load on scroll)', async functi
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent } = await this.start({
+    const { afterEvent, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        waitUntilEvent: {
-            eventName: 'o-component-message-list-scrolled',
-            message: "should wait until channel 20 scrolled to its last message initially",
-            predicate: ({ scrollTop, thread }) => {
-                const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
-                return (
-                    thread &&
-                    thread.model === 'mail.channel' &&
-                    thread.id === mailChannelId1 &&
-                    isScrolledToBottom(messageList)
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-component-message-list-scrolled',
+        func: openDiscuss,
+        message: "should wait until channel scrolled to its last message initially",
+        predicate: ({ scrollTop, thread }) => {
+            const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
+            return (
+                thread &&
+                thread.model === 'mail.channel' &&
+                thread.id === mailChannelId1 &&
+                isScrolledToBottom(messageList)
+            );
         },
     });
     assert.strictEqual(
@@ -1695,7 +1719,7 @@ QUnit.test('load more messages from channel (auto-load on scroll)', async functi
     await afterEvent({
         eventName: 'o-thread-view-hint-processed',
         func: () => document.querySelector('.o_ThreadView_messageList').scrollTop = 0,
-        message: "should wait until channel 20 loaded more messages after scrolling to top",
+        message: "should wait until channel loaded more messages after scrolling to top",
         predicate: ({ hint, threadViewer }) => {
             return (
                 hint.type === 'more-messages-loaded' &&
@@ -1744,24 +1768,25 @@ QUnit.test('new messages separator [REQUIRE FOCUS]', async function (assert) {
     }
     const [mailChannelPartnerId] = pyEnv['mail.channel.partner'].search([['channel_id', '=', mailChannelId1], ['partner_id', '=', pyEnv.currentPartnerId]]);
     pyEnv['mail.channel.partner'].write([mailChannelPartnerId], { seen_message_id: lastMessageId });
-    const { afterEvent, messaging } = await this.start({
+    const { afterEvent, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        waitUntilEvent: {
-            eventName: 'o-component-message-list-scrolled',
-            message: "should wait until channel 20 scrolled to its last message initially",
-            predicate: ({ scrollTop, thread }) => {
-                const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
-                return (
-                    thread &&
-                    thread.model === 'mail.channel' &&
-                    thread.id === mailChannelId1 &&
-                    isScrolledToBottom(messageList)
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-component-message-list-scrolled',
+        func: openDiscuss,
+        message: "should wait until channel scrolled to its last message initially",
+        predicate: ({ scrollTop, thread }) => {
+            const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
+            return (
+                thread &&
+                thread.model === 'mail.channel' &&
+                thread.id === mailChannelId1 &&
+                isScrolledToBottom(messageList)
+            );
         },
     });
     assert.containsN(
@@ -1868,18 +1893,19 @@ QUnit.test('restore thread scroll position', async function (assert) {
             res_id: mailChannelId2,
         });
     }
-    const { afterEvent, messaging } = await this.start({
+    const { afterEvent, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        waitUntilEvent: {
-            eventName: 'o-component-message-list-scrolled',
-            message: "should wait until channel 1 scrolled to its last message",
-            predicate: ({ thread }) => {
-                return thread && thread.model === 'mail.channel' && thread.id === mailChannelId1;
-            },
+    });
+    await afterEvent({
+        eventName: 'o-component-message-list-scrolled',
+        func: openDiscuss,
+        message: "should wait until channel 1 scrolled to its last message",
+        predicate: ({ thread }) => {
+            return thread && thread.model === 'mail.channel' && thread.id === mailChannelId1;
         },
     });
     assert.strictEqual(
@@ -2036,13 +2062,14 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
             res_id: mailChannelId1,
         }
     );
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebar_categoryChannel
@@ -2125,7 +2152,8 @@ QUnit.test('sidebar quick search', async function (assert) {
     for (let id = 1; id <= 20; id++) {
         pyEnv['mail.channel'].create({ name: `channel${id}` });
     }
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`).length,
         20,
@@ -2189,7 +2217,8 @@ QUnit.test('basic top bar rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    const { click, messaging } = await this.start();
+    const { click, messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelector(`
             .o_ThreadViewTopbar_threadName
@@ -2282,7 +2311,8 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
             res_partner_id: pyEnv.currentPartnerId, // must be for current partner
         }
     ]);
-    const { messaging } = await this.start();
+    const { messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -2361,13 +2391,14 @@ QUnit.test('starred: unstar all', async function (assert) {
         { body: "not empty", starred_partner_ids: [pyEnv.currentPartnerId] },
         { body: "not empty", starred_partner_ids: [pyEnv.currentPartnerId] }
     ]);
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: 'mail.box_starred',
             },
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -2422,7 +2453,7 @@ QUnit.test('toggle_star message', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -2439,6 +2470,7 @@ QUnit.test('toggle_star message', async function (assert) {
             }
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -2521,13 +2553,14 @@ QUnit.test('composer state: text save and restore', async function (assert) {
         { name: "General" },
         { name: "Special" },
     ]);
-    const { click, insertText } = await this.start({
+    const { click, insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     // Write text in composer for #general
     await insertText('.o_ComposerTextInput_textarea', "A message");
     await click(`.o_DiscussSidebarCategoryItem[data-thread-name="Special"]`);
@@ -2556,13 +2589,14 @@ QUnit.test('composer state: attachments save and restore', async function (asser
         { name: "General" },
         { name: "Special" },
     ]);
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     const channels = document.querySelectorAll(`
         .o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item
     `);
@@ -2648,7 +2682,7 @@ QUnit.test('post a simple message', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, insertText, messaging } = await this.start({
+    const { click, insertText, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -2685,6 +2719,7 @@ QUnit.test('post a simple message', async function (assert) {
             }
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_MessageList_empty`).length,
         1,
@@ -2745,13 +2780,14 @@ QUnit.test('post message on channel with "Enter" keyboard shortcut', async funct
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { insertText } = await this.start({
+    const { insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsNone(
         document.body,
         '.o_Message',
@@ -2779,13 +2815,14 @@ QUnit.test('do not post message on channel with "SHIFT-Enter" keyboard shortcut'
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { insertText } = await this.start({
+    const { insertText, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsNone(
         document.body,
         '.o_Message',
@@ -2822,17 +2859,17 @@ QUnit.test('rendering of inbox message', async function (assert) {
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    await this.start({
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until inbox displayed its messages",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    hint.type === 'messages-loaded' &&
-                    threadViewer.thread.model === 'mail.box' &&
-                    threadViewer.thread.id === 'inbox'
-                );
-            },
+    const { afterEvent, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until inbox displayed its messages",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                hint.type === 'messages-loaded' &&
+                threadViewer.thread.model === 'mail.box' &&
+                threadViewer.thread.id === 'inbox'
+            );
         },
     });
     assert.strictEqual(
@@ -2896,7 +2933,8 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { afterEvent, messaging } = await this.start();
+    const { afterEvent, messaging, openDiscuss } = await start();
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         `.o_DiscussSidebarCategory_item[data-thread-local-id="${
@@ -2958,7 +2996,8 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
 QUnit.test('receive new needaction messages', async function (assert) {
     assert.expect(12);
 
-    const { messaging, pyEnv } = await this.start();
+    const { messaging, openDiscuss, pyEnv } = await start();
+    await openDiscuss();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -3093,7 +3132,7 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId, // must be for current partner
     });
-    const { click, insertText, messaging } = await this.start({
+    const { click, insertText, messaging, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (route === '/mail/message/post') {
                 assert.step('message_post');
@@ -3133,6 +3172,7 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
             }),
         },
     });
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll('.o_Message').length,
         1,
@@ -3224,13 +3264,14 @@ QUnit.test('messages marked as read move to "History" mailbox', async function (
             res_partner_id: pyEnv.currentPartnerId, // must be for current partner
         }
     ]);
-    const { click, messaging } = await this.start({
+    const { click, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: 'mail.box_history',
             },
         },
     });
+    await openDiscuss();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -3337,13 +3378,14 @@ QUnit.test('mark a single message as read should only move this message to "Hist
             res_partner_id: pyEnv.currentPartnerId,
         }
     ]);
-    const { click, messaging } = await this.start({
+    const { click, messaging, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: 'mail.box_history',
             },
         },
     });
+    await openDiscuss();
     assert.hasClass(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -3447,20 +3489,20 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
         });
 
     }
-    const { afterEvent, click, messaging } = await this.start({
-        waitUntilEvent: {
-            eventName: 'o-component-message-list-scrolled',
-            message: "should wait until inbox scrolled to its last message initially",
-            predicate: ({ orderedMessages, scrollTop, thread }) => {
-                const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
-                return (
-                    thread &&
-                    thread.model === 'mail.box' &&
-                    thread.id === 'inbox' &&
-                    orderedMessages.length === 30 &&
-                    isScrolledToBottom(messageList)
-                );
-            },
+    const { afterEvent, click, messaging, openDiscuss } = await start();
+    await afterEvent({
+        eventName: 'o-component-message-list-scrolled',
+        func: openDiscuss,
+        message: "should wait until inbox scrolled to its last message initially",
+        predicate: ({ orderedMessages, scrollTop, thread }) => {
+            const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
+            return (
+                thread &&
+                thread.model === 'mail.box' &&
+                thread.id === 'inbox' &&
+                orderedMessages.length === 30 &&
+                isScrolledToBottom(messageList)
+            );
         },
     });
 
@@ -3519,7 +3561,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, channel)'
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ channel_type: 'chat' });
-    const { env } = await this.start({
+    const { env, openDiscuss } = await start({
         legacyServices: {
             bus_service: BusService.extend({
                 _beep() {}, // Do nothing
@@ -3530,6 +3572,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, channel)'
             }),
         },
     });
+    await openDiscuss();
     env.bus.on('set_title_part', null, payload => {
         assert.step('set_title_part');
         assert.strictEqual(payload.part, '_chat');
@@ -3556,7 +3599,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, chat)', a
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ channel_type: "chat" });
-    const { env } = await this.start({
+    const { env, openDiscuss } = await start({
         legacyServices: {
             bus_service: BusService.extend({
                 _beep() {}, // Do nothing
@@ -3567,6 +3610,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, chat)', a
             }),
         },
     });
+    await openDiscuss();
     env.bus.on('set_title_part', null, payload => {
         assert.step('set_title_part');
         assert.strictEqual(payload.part, '_chat');
@@ -3597,7 +3641,7 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
         { channel_type: 'chat', public: 'private' },
         { channel_type: 'chat', public: 'private' },
     ]);
-    const { env } = await this.start({
+    const { env, openDiscuss } = await start({
         legacyServices: {
             bus_service: BusService.extend({
                 _beep() {}, // Do nothing
@@ -3608,6 +3652,7 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
             }),
         },
     });
+    await openDiscuss();
     env.bus.on('set_title_part', null, payload => {
         step++;
         assert.step('set_title_part');
@@ -3681,7 +3726,8 @@ QUnit.test('auto-focus composer on opening thread', async function (assert) {
             public: 'private',
         }
     ]);
-    const { click } = await this.start();
+    const { click, openDiscuss } = await start();
+    await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebarMailbox[data-thread-name="Inbox"]
@@ -3803,22 +3849,23 @@ QUnit.test('mark channel as seen if last message is visible when switching chann
         model: "mail.channel",
         res_id: mailChannelId2,
     }]);
-    const { afterEvent, messaging } = await this.start({
+    const { afterEvent, messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId2}`,
             },
         },
-        waitUntilEvent: {
-            eventName: 'o-thread-view-hint-processed',
-            message: "should wait until channel 2 loaded its messages initially",
-            predicate: ({ hint, threadViewer }) => {
-                return (
-                    threadViewer.thread.model === 'mail.channel' &&
-                    threadViewer.thread.id === mailChannelId2 &&
-                    hint.type === 'messages-loaded'
-                );
-            },
+    });
+    await afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: openDiscuss,
+        message: "should wait until channel 2 loaded its messages initially",
+        predicate: ({ hint, threadViewer }) => {
+            return (
+                threadViewer.thread.model === 'mail.channel' &&
+                threadViewer.thread.id === mailChannelId2 &&
+                hint.type === 'messages-loaded'
+            );
         },
     });
     await afterNextRender(() => afterEvent({
@@ -3861,7 +3908,7 @@ QUnit.test('warning on send with shortcut when attempting to post message with s
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
@@ -3889,6 +3936,7 @@ QUnit.test('warning on send with shortcut when attempting to post message with s
             }),
         },
     });
+    await openDiscuss();
     const file = await createFile({
         content: 'hello, world',
         contentType: 'text/plain',
@@ -3931,7 +3979,7 @@ QUnit.test('send message only once when enter is pressed twice quickly', async f
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { insertText } = await this.start({
+    const { insertText, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
@@ -3943,6 +3991,7 @@ QUnit.test('send message only once when enter is pressed twice quickly', async f
             }
         },
     });
+    await openDiscuss();
     // Type message
     await insertText('.o_ComposerTextInput_textarea', "test message");
     await afterNextRender(() => {
@@ -3974,13 +4023,14 @@ QUnit.test('message being a replied to another message should show message being
         parent_id: mailMessageId1,
         res_id: mailChannelId1,
     });
-    const { messaging } = await this.start({
+    const { messaging, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.querySelector(`.o_Message[data-message-local-id="${
             messaging.models['Message'].findFromIdentifyingData({ id: mailMessageId2 }).localId

--- a/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -394,9 +394,8 @@ QUnit.test('new message', async function (assert) {
 QUnit.test('no new message when discuss is open', async function (assert) {
     assert.expect(3);
 
-    const { click, openDiscuss, openView } = await start({
-        autoOpenDiscuss: true,
-    });
+    const { click, openDiscuss, openView } = await start();
+    await openDiscuss();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.strictEqual(

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -1775,7 +1775,7 @@ QUnit.test('Retry loading more messages on failed load more messages should load
     await afterEvent({
         eventName: 'o-thread-view-hint-processed',
         func: () => document.querySelector('.o_MessageList_alertLoadingFailedRetryButton').click(),
-        message: "should wait until channel 20 loaded more messages after clicked on load more",
+        message: "should wait until channel loaded more messages after clicked on load more",
         predicate: ({ hint, threadViewer }) => {
             return (
                 hint.type === 'more-messages-loaded' &&

--- a/addons/website_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/website_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -33,14 +33,14 @@ QUnit.test('rendering of visitor banner', async function (assert) {
         livechat_operator_id: pyEnv.currentPartnerId,
         livechat_visitor_id: websiteVisitorId1,
     });
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_VisitorBanner',
@@ -132,14 +132,14 @@ QUnit.test('livechat with non-logged visitor should show visitor banner', async 
         livechat_operator_id: pyEnv.currentPartnerId,
         livechat_visitor_id: websiteVisitorId1,
     });
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_VisitorBanner',
@@ -175,14 +175,14 @@ QUnit.test('livechat with logged visitor should show visitor banner', async func
         livechat_operator_id: pyEnv.currentPartnerId,
         livechat_visitor_id: websiteVisitorId1,
     });
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_VisitorBanner',
@@ -208,14 +208,14 @@ QUnit.test('livechat without visitor should not show visitor banner', async func
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_MessageList',
@@ -233,14 +233,14 @@ QUnit.test('non-livechat channel should not show visitor banner', async function
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    await start({
-        autoOpenDiscuss: true,
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
     });
+    await openDiscuss();
     assert.containsOnce(
         document.body,
         '.o_MessageList',


### PR DESCRIPTION
The autoOpenDiscuss parameter was used but is deprecated for a while now.
This PR removes it.