### PR TITLE
[14.0][FIX] hr_holidays: Add `res_id` to meetings of leaves to be able to archive them when refusing leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -909,6 +909,7 @@ class HolidaysRequest(models.Model):
                 meeting_name = _("%s on Time Off : %.2f day(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_days)
             meeting_values = {
                 'name': meeting_name,
+                'res_id': holiday.id,
                 'duration': holiday.number_of_days * (calendar.hours_per_day or HOURS_PER_DAY),
                 'description': holiday.notes,
                 'user_id': user.id,

--- a/doc/cla/individual/RachidAlassir.md
+++ b/doc/cla/individual/RachidAlassir.md
@@ -1,0 +1,9 @@
+Tunisia, 2020-11-05
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Rachid Al Assir rachidalassir@gmail.com https://github.com/RachidAlassir


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add `res_id` to meetings of leaves to be able to archive them when refusing leaves

Please check this  [line](https://github.com/odoo/odoo/blob/14.0/addons/hr_holidays/models/hr_leave.py#L898) this is how Odoo uses `res_id` of meetings to fetch the corresponding leaves

[Here](https://github.com/odoo/odoo/blob/14.0/addons/hr_holidays/models/hr_leave.py#L1116) is where Odoo archive meetings
 
Current behavior before PR:
Because meetings of leaves don't have `res_id`, they always exist and are `active` and they keep increasing once refusing and validating several times.
Desired behavior after PR is merged:
Add `res_id` to leaves meetings


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
