### PR TITLE
[FIX] mrp: fix duration expected

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1562,9 +1562,9 @@ class MrpProduction(models.Model):
             production.name = self._get_name_backorder(production.name, production.backorder_sequence)
             (production.move_raw_ids | production.move_finished_ids).name = production.name
             (production.move_raw_ids | production.move_finished_ids).origin = production._get_origin()
-            production.product_qty = amounts[production][0]
             backorder_vals = production.copy_data(default=production._get_backorder_mo_vals())[0]
             backorder_qtys = amounts[production][1:]
+            production.product_qty = amounts[production][0]
 
             next_seq = max(production.procurement_group_id.mrp_production_ids.mapped("backorder_sequence"), default=1)
 
@@ -1716,7 +1716,7 @@ class MrpProduction(models.Model):
             bo = production_to_backorders[production]
 
             # Adapt duration
-            for workorder in (production | bo).workorder_ids:
+            for workorder in bo.workorder_ids:
                 workorder.duration_expected = workorder.duration_expected * workorder.production_id.product_qty / initial_qty
 
             # Adapt quantities produced

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2588,6 +2588,7 @@ class TestMrpOrder(TestMrpCommon):
         wo_1, wo_2, wo_3 = mo.workorder_ids
         self.assertEqual(mo.state, 'confirmed')
         self.assertEqual(wo_1.state, 'ready')
+        self.assertEqual(wo_1.duration_expected, 20 * 60)
 
         # produce 20 / 10 / 5 on workorders, create backorder
 
@@ -2620,6 +2621,7 @@ class TestMrpOrder(TestMrpCommon):
         wo_4, wo_5, wo_6 = mo_2.workorder_ids
 
         self.assertEqual(wo_4.state, 'cancel')
+        self.assertEqual(wo_5.duration_expected, 15 * 60)
 
         # produce 10 / 5, create backorder
 
@@ -2649,6 +2651,7 @@ class TestMrpOrder(TestMrpCommon):
 
         self.assertEqual(wo_7.state, 'cancel')
         self.assertEqual(wo_8.state, 'cancel')
+        self.assertEqual(wo_9.duration_expected, 10 * 60)
 
         # produce 10 and finish work
 


### PR DESCRIPTION
_split_productions wrongly compute duration expected for backorders.

Setting quantity on production adapt many things including workorders,
so adapt original production after copy_data for backorders.

task: 2884562

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
