### PR TITLE
[FIX] google_drive: deprecate module

### DIFF
--- a/addons/google_drive/i18n/google_drive.pot
+++ b/addons/google_drive/i18n/google_drive.pot
@@ -320,8 +320,18 @@ msgid ""
 msgstr ""
 
 #. module: google_drive
+#: model_terms:ir.ui.view,arch_db:google_drive.res_config_settings_view_form
+msgid "This module will stop working after the 3rd October 2022 due to"
+msgstr ""
+
+#. module: google_drive
 #: model:ir.model.fields,field_description:google_drive.field_res_config_settings__google_drive_uri
 msgid "URI"
+msgstr ""
+
+#. module: google_drive
+#: model_terms:ir.ui.view,arch_db:google_drive.res_config_settings_view_form
+msgid "changes in Google Authentication API"
 msgstr ""
 
 #. module: google_drive

--- a/addons/google_drive/models/google_drive.py
+++ b/addons/google_drive/models/google_drive.py
@@ -15,7 +15,15 @@ from odoo.tools.translate import _
 
 from odoo.addons.google_account.models.google_service import GOOGLE_TOKEN_ENDPOINT, TIMEOUT
 
+from datetime import date
+
 _logger = logging.getLogger(__name__)
+
+# Google is depreciating their OOB Auth Flow on 3rd October 2022, the Google Drive
+# integration thus become irrelevant after that date.
+
+# https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob
+GOOGLE_AUTH_DEPRECATION_DATE = date(2022, 10, 3)
 
 
 class GoogleDrive(models.Model):
@@ -23,7 +31,13 @@ class GoogleDrive(models.Model):
     _name = 'google.drive.config'
     _description = "Google Drive templates config"
 
+    def _module_deprecated(self):
+        return GOOGLE_AUTH_DEPRECATION_DATE > fields.Date.today()
+
     def get_google_drive_url(self, res_id, template_id):
+        if self._module_deprecated():
+            return
+
         self.ensure_one()
         self = self.sudo()
 
@@ -50,6 +64,9 @@ class GoogleDrive(models.Model):
 
     @api.model
     def get_access_token(self, scope=None):
+        if self._module_deprecated():
+            return
+
         Config = self.env['ir.config_parameter'].sudo()
         google_drive_refresh_token = Config.get_param('google_drive_refresh_token')
         user_is_admin = self.env.is_admin()
@@ -85,6 +102,9 @@ class GoogleDrive(models.Model):
 
     @api.model
     def copy_doc(self, res_id, template_id, name_gdocs, res_model):
+        if self._module_deprecated():
+            return
+
         google_web_base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         access_token = self.get_access_token()
         # Copy template in to drive with help of new access token

--- a/addons/google_drive/models/res_config_settings.py
+++ b/addons/google_drive/models/res_config_settings.py
@@ -36,6 +36,9 @@ class ResConfigSettings(models.TransientModel):
 
     def action_setup_token(self):
         self.ensure_one()
+        if self.env['google.drive.config']._module_deprecated():
+            return
+
         template = self.env.ref('google_drive.google_drive_auth_code_wizard')
         return {
             'name': _('Set up refresh token'),

--- a/addons/google_drive/views/res_config_settings_views.xml
+++ b/addons/google_drive/views/res_config_settings_views.xml
@@ -9,6 +9,10 @@
             <div id="msg_module_google_drive" position="replace">
                 <div class="content-group"
                      attrs="{'invisible': [('module_google_drive','=',False)]}">
+                    <div class="mt8 mb8 text-warning font-weight-bold">
+                        This module will stop working after the 3rd October 2022 due to
+                        <a href="https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob">changes in Google Authentication API</a>.
+                    </div>
                     <div class="mt8 row">
                         <div class="col-sm">
                             <field name="is_google_drive_token_generated" invisible="1"/>


### PR DESCRIPTION
The module will stop working after the 3rd October 2022, as Google is
disabling their OOB Oauth Flow on that date[1].

The module will not do anything after that date and a warning message is
shown on the settings page to warn users.

[1]: https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob

task-2867215