### PR TITLE
[FIX] mail: Momentary _mail_track error on model having no company_id

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -54,8 +54,12 @@ class BaseModel(models.AbstractModel):
                 tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, new_value, col_name, col_info, tracking_sequence, self._name)
                 if tracking:
                     if tracking['field_type'] == 'monetary':
-                        tracking['currency_id'] = getattr(self, col_info.get('currency_field', ''), self.company_id.currency_id).id
-                    tracking_value_ids.append([0, 0, tracking])
+                        currency_field = col_info['currency_field'] if col_info.get('currency_field') and col_info.get('currency_field') in self else None
+                        if currency_field:
+                            currency_id = self[currency_field].id
+                        else:
+                            currency_id = self.company_id.currency_id if 'company_id' in self else self.env.company.currency_id
+                        tracking['currency_id'] = currency_id
                 changes.add(col_name)
 
         return changes, tracking_value_ids


### PR DESCRIPTION
Implementing a monetary field on a model that has no `company_id` field definition would raise AttributeError although currency_id was there or even currency_field is declared for the field. The problem causes by this code https://github.com/odoo/odoo/blob/3287d4ef30c78d8b64abf3f923ee6c04f1984ab3/addons/mail/models/models.py#L56-L57

It means that if we want to track that monetary field, the corresponding model must come with company_id field.

This PR fixes the issue by checking if the model has `company_id` first to take its currency before falling to the current company's currency



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
