### PR TITLE
[FIX] l10n_ch_website_sale : creation of bridge module

### DIFF
--- a/addons/l10n_ch_website_sale/__init__.py
+++ b/addons/l10n_ch_website_sale/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_ch_website_sale/__manifest__.py
+++ b/addons/l10n_ch_website_sale/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+# Main contributor: Nicolas Bessi. Camptocamp SA
+# Financial contributors: Hasa SA, Open Net SA,
+#                         Prisme Solutions Informatique SA, Quod SA
+# Translation contributors: brain-tec AG, Agile Business Group
+{
+    'name': "Switzerland - Website Sale",
+    'description': """
+Swiss localization
+==================
+
+Bridge module with l10n_ch localisation module and website_sale. 
+
+This module modify the behaviour of the website_sale when it generate the reference payement. This allows the reference to be 
+QR-Bill friendly. 
+
+    """,
+    'version': '1.0',
+    'depends': ['l10n_ch', 'sale_management'],
+    'license': 'LGPL-3',
+    'auto_install': True,
+}

--- a/addons/l10n_ch_website_sale/models/__init__.py
+++ b/addons/l10n_ch_website_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import payment

--- a/addons/l10n_ch_website_sale/models/payment.py
+++ b/addons/l10n_ch_website_sale/models/payment.py
@@ -1,0 +1,27 @@
+from odoo import models
+
+from odoo.tools.misc import mod10r
+
+l10n_ch_ISR_NUMBER_LENGTH = 27
+l10n_ch_ISR_ID_NUM_LENGTH = 6
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    def _compute_sale_order_reference(self, order):
+        self.ensure_one()
+        if self.company_id.bank_ids.l10n_ch_qr_iban and self.sale_order_ids.name:
+            id_number = self.company_id.bank_ids.l10n_ch_postal or ''
+            if id_number:
+                id_number = id_number.zfill(l10n_ch_ISR_ID_NUM_LENGTH)
+            # Gets an unique number based on the sale order name. A letter will get converted to its base10 value
+            invoice_ref = "".join([[str(ord(a)), a][a.isdigit()] for a in self.sale_order_ids.name])
+            full_len = len(id_number) + len(invoice_ref)
+            ref_payload_len = l10n_ch_ISR_NUMBER_LENGTH - 1
+            extra = full_len - ref_payload_len
+            if extra > 0:
+                invoice_ref = invoice_ref[extra:]
+            internal_ref = invoice_ref.zfill(ref_payload_len - len(id_number))
+            return mod10r(id_number + internal_ref)
+        else:
+            return super()._compute_sale_order_reference(order)

--- a/addons/l10n_ch_website_sale/tests/__init__.py
+++ b/addons/l10n_ch_website_sale/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_swissqr

--- a/addons/l10n_ch_website_sale/tests/test_swissqr.py
+++ b/addons/l10n_ch_website_sale/tests/test_swissqr.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+from odoo.tools.misc import mod10r
+
+CH_IBAN = 'CH15 3881 5158 3845 3843 7'
+QR_IBAN = 'CH21 3080 8001 2345 6782 7'
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestSwissQRWebsit(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='l10n_ch.l10nch_chart_template'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+    def setUp(self):
+        super(TestSwissQRWebsit, self).setUp()
+        # Activate SwissQR in Swiss invoices
+        self.env['ir.config_parameter'].create(
+            {'key': 'l10n_ch.print_qrcode', 'value': '1'}
+        )
+        self.customer = self.env['res.partner'].create(
+            {
+                "name": "Partner",
+                "street": "Route de Berne 41",
+                "street2": "",
+                "zip": "1000",
+                "city": "Lausanne",
+                "country_id": self.env.ref("base.ch").id,
+            }
+        )
+        self.env.user.company_id.partner_id.write(
+            {
+                "street": "Route de Berne 88",
+                "street2": "",
+                "zip": "2000",
+                "city": "Neuchâtel",
+                "country_id": self.env.ref('base.ch').id,
+            }
+        )
+        self.product = self.env['product.product'].create({
+            'name': 'Customizable Desk',
+        })
+
+
+    def create_account(self, number):
+        """ Generates a test res.partner.bank. """
+        return self.env['res.partner.bank'].create(
+            {
+                'acc_number': number,
+                'partner_id': self.env.user.company_id.partner_id.id,
+            }
+        )
+
+    def test_qq(self):
+        qriban_account = self.create_account(QR_IBAN)
+        self.assertTrue(qriban_account.l10n_ch_qr_iban)
+        order = self.env['sale.order'].create(
+            {
+            'name' : "S00001",
+            'partner_id': self.env['res.partner'].search([("name", '=', 'Partner')])[0].id
+
+            }
+        )
+        self.env['sale.order.line'].create(
+            {
+            'order_id' : order.id,
+            'product_id': self.env['product.product'].search([('name', '=', 'Customizable Desk')])[0].id,
+            'price_unit': 100,
+            }
+        )
+        acquirer = self.env['payment.acquirer'].create({
+            'name': 'Test',
+        })
+        pt = self.env['payment.transaction'].create(
+            {
+                'acquirer_id': acquirer.id,
+                'sale_order_ids' : [order.id],
+                'partner_id': self.env['res.partner'].search([("name", '=', 'Partner')])[0].id,
+                'amount': 100,
+                'currency_id': self.env.company.currency_id.id,
+            }
+        )
+        pt._set_pending()
+        if re.match(r'^(\d{2,27})$', order.reference):
+            assert(order.reference == mod10r(order.reference[:-1]))
+        else:
+            assert(False)


### PR DESCRIPTION
Steps to reproduce:
	- Runbot 15.0 localized in Switzerland
	- Install website, sale, contact, l10n_ch
	- add a IBAN, QR-Iban and bank name and BIC
	- add an address in Switzerland to the company
	- make an order from the website and use an address in Switzerland
	- go to the generated sale order and try to generate an invoice
Issue:
	- The payment reference in the Invoice will not be QR-compatible
Solution:
	- Build a bridge module between website_sale and l10n_ch
	- This module does generate a QR-bill friendly reference to the sale order


opw-2846247