### PR TITLE
[FIX] core: replace empty images by placeholder

### DIFF
--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -192,6 +192,7 @@ class IrBinary(models.AbstractModel):
             image.
 
         """
+        stream = None
         try:
             stream = self._get_stream_from(
                 record, field_name, filename, filename_field, mimetype,
@@ -200,6 +201,8 @@ class IrBinary(models.AbstractModel):
         except UserError:
             if request.params.get('download'):
                 raise
+
+        if not stream or stream.size == 0:
             if not placeholder:
                 placeholder = record._get_placeholder_filename(field_name)
             stream = self._get_placeholder_stream(placeholder)


### PR DESCRIPTION
Create an empty image attachment and load it via an `<img>` html tag in
a document. Upon rendering the image is replaced by the default browser
placeholder instead of the pretty Odoo one.

Task: 2886028

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
