### PR TITLE
[FIX] mail: broken email scheduled date

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7468,6 +7468,11 @@ msgid "Wrong operation name (%s)"
 msgstr ""
 
 #. module: mail
+#: model_terms:ir.ui.view,arch_db:mail.view_mail_form
+msgid "YYYY-MM-DD HH:MM:SS"
+msgstr ""
+
+#. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/js/activity.js:0
 #: code:addons/mail/static/src/models/message/message.js:0

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -9,8 +9,10 @@ import psycopg2
 import smtplib
 import threading
 import re
+import pytz
 
 from collections import defaultdict
+from dateutil.parser import parse
 
 from odoo import _, api, fields, models
 from odoo import tools
@@ -87,7 +89,12 @@ class MailMail(models.Model):
         for values in values_list:
             if 'is_notification' not in values and values.get('mail_message_id'):
                 values['is_notification'] = True
-
+            if values.get('scheduled_date'):
+                parsed_datetime = self._parse_scheduled_datetime(values['scheduled_date'])
+                if parsed_datetime:
+                    values['scheduled_date'] = parsed_datetime.strftime(tools.DEFAULT_SERVER_DATETIME_FORMAT)
+                else:
+                    values['scheduled_date'] = False
         new_mails = super(MailMail, self).create(values_list)
 
         new_mails_w_attach = self
@@ -100,6 +107,12 @@ class MailMail(models.Model):
         return new_mails
 
     def write(self, vals):
+        if vals.get('scheduled_date'):
+            parsed_datetime = self._parse_scheduled_datetime(vals['scheduled_date'])
+            if parsed_datetime:
+                vals['scheduled_date'] = parsed_datetime.strftime(tools.DEFAULT_SERVER_DATETIME_FORMAT)
+            else:
+                vals['scheduled_date'] = False
         res = super(MailMail, self).write(vals)
         if vals.get('attachment_ids'):
             for mail in self:
@@ -138,11 +151,13 @@ class MailMail(models.Model):
                                 messages to send (by default all 'outgoing'
                                 messages are sent).
         """
-        filters = ['&',
-                   ('state', '=', 'outgoing'),
-                   '|',
-                   ('scheduled_date', '<', datetime.datetime.now()),
-                   ('scheduled_date', '=', False)]
+        filters = [
+            '&',
+                ('state', '=', 'outgoing'),
+                '|',
+                   ('scheduled_date', '=', False),
+                   ('scheduled_date', '<=', datetime.datetime.utcnow()),
+        ]
         if 'filters' in self._context:
             filters.extend(self._context['filters'])
         # TODO: make limit configurable
@@ -200,6 +215,42 @@ class MailMail(models.Model):
             mail_to_delete_ids = [mail.id for mail in self if mail.auto_delete]
             self.browse(mail_to_delete_ids).sudo().unlink()
         return True
+
+    def _parse_scheduled_datetime(self, scheduled_datetime):
+        """ Taking an arbitrary datetime (either as a date, a datetime or a string)
+        try to parse it and return a datetime timezoned to UTC.
+
+        If no specific timezone information is given, we consider it as being
+        given in UTC, as all datetime values given to the server. Trying to
+        guess its timezone based on user or flow would be strange as this is
+        not standard. When manually creating datetimes for mail.mail scheduled
+        date, business code should ensure either a timezone info is set, either
+        it is converted into UTC.
+
+        Using yearfirst when parsing str datetimes eases parser's job when
+        dealing with the hard-to-parse trio (01/04/09 -> ?). In most use cases
+        year will be given first as this is the expected default formatting.
+
+        :return datetime: parsed datetime (or False if parser failed)
+        """
+        if isinstance(scheduled_datetime, datetime.datetime):
+            parsed_datetime = scheduled_datetime
+        elif isinstance(scheduled_datetime, datetime.date):
+            parsed_datetime = datetime.combine(scheduled_datetime, datetime.time.min)
+        else:
+            try:
+                parsed_datetime = parse(scheduled_datetime, yearfirst=True)
+            except (ValueError, TypeError):
+                parsed_datetime = False
+        if parsed_datetime:
+            if not parsed_datetime.tzinfo:
+                parsed_datetime = pytz.utc.localize(parsed_datetime)
+            else:
+                try:
+                    parsed_datetime = parsed_datetime.astimezone(pytz.utc)
+                except Exception:
+                    pass
+        return parsed_datetime
 
     # ------------------------------------------------------
     # mail_mail formatting, tools and send mechanism

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -27,7 +27,7 @@
                             <field name="recipient_ids" widget="many2many_tags"/>
                             <field name="email_cc"/>
                             <field name="reply_to"/>
-                            <field name="scheduled_date"/>
+                            <field name="scheduled_date" placeholder="YYYY-MM-DD HH:MM:SS"/>
                         </group>
                         <notebook>
                             <page string="Body" name="body">


### PR DESCRIPTION
Step to reproduce:
	activate the developer mode
	go to settings - technical - emails
	create a new email and set the Scheduled Send Date in the future
	run the scheduled action Mail: Email Queue Manager

Current behavior:
the email is sent and the action does not consider the filter

Expected behavior:
the email is not sent and will only be sent when the scheduler detects
that scheduled_date exceeds the current time.

Issue description:
The scheduled_date field of the mail is of type char and contains
the time in local time. We need to set "now" with the right format and
timezone for the filter to compare the two correctly.

opw-2823106
