### PR TITLE
[FIX] stock: traceback when there is no delveries for a lot

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -222,7 +222,7 @@ class ProductionLot(models.Model):
                     next_lots_ids = set(next_lots.ids)
                     # If some producing lots are in lot_path, it means that they have been previously processed.
                     # Their results are therefore already in delivery_by_lot and we add them to delivery_ids directly.
-                    delivery_ids.update(*[set(delivery_by_lot.get(lot_id)) for lot_id in (producing_move_lines.produce_line_ids.lot_id - next_lots).ids])
+                    delivery_ids.update(*(delivery_by_lot.get(lot_id, []) for lot_id in (producing_move_lines.produce_line_ids.lot_id - next_lots).ids))
 
                     for lot_id, delivery_ids_set in next_lots._find_delivery_ids_by_lot(lot_path=lot_path, delivery_by_lot=delivery_by_lot).items():
                         if lot_id in next_lots_ids:


### PR DESCRIPTION
Fixes 38bfbed
We cannot create a `set` from `None`
```
   File "/home/odoo/src/odoo/15.0/addons/stock/models/stock_production_lot.py", line 225, in <listcomp>
    delivery_ids.update(*[set(delivery_by_lot.get(lot_id)) for lot_id in (producing_move_lines.produce_line_ids.lot_id - next_lots).ids])
 TypeError: 'NoneType' object is not iterable
```
Small optimization: no need to create a list that's immediately unpacked.

This error was detected during upgrades.
upg-360084

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
