### PR TITLE
[IMP] project,sale_timesheet: generic improvement for the project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -743,10 +743,14 @@ class Project(models.Model):
         favorite_projects.write({'favorite_user_ids': [(3, self.env.uid)]})
 
     def action_view_tasks(self):
-        action = self.with_context(active_id=self.id, active_ids=self.ids) \
-            .env.ref('project.act_project_project_2_project_task_all') \
-            .sudo().read()[0]
+        action = self.env['ir.actions.act_window']._for_xml_id('project.act_project_project_2_project_task_all')
         action['display_name'] = _("%(name)s", name=self.name)
+        context = action['context'].replace('active_id', str(self.id))
+        context = ast.literal_eval(context)
+        context.update({
+            'create': self.active,
+            })
+        action['context'] = context
         return action
 
     def action_view_all_rating(self):

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -59,10 +59,10 @@ class SaleOrder(models.Model):
         if field.name != 'invoice_status' or self.env.context.get('mail_activity_automation_skip'):
             return
 
-        # Get SOs which their state is not equal to upselling or invoied and if at least a SOL has warning prepaid service upsell set to True and the warning has not already been displayed
+        # Get SOs which their state is not equal to upselling and if at least a SOL has warning prepaid service upsell set to True and the warning has not already been displayed
         upsellable_orders = self.filtered(lambda so:
             so.state == 'sale'
-            and so.invoice_status not in ('upselling', 'invoiced')
+            and so.invoice_status != 'upselling'
             and (so.user_id or so.partner_id.user_id)  # salesperson needed to assign upsell activity
         )
         for order in upsellable_orders:

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -116,8 +116,7 @@
                         <t t-if="invoice_line.id in invoices_accessible">
                             <a t-attf-href="/my/invoices/{{ invoice_line.id }}">
                                 <i t-if="invoice_line.state == 'draft'">Draft Invoice</i>
-                                <t t-else="" t-esc="invoice_line.name"/>
-                            </a>
+                                <t t-else="" t-esc="invoice_line.name"/></a>
                             <span t-if="not invoice_line_last">,</span>
                         </t>
                         <t t-else=""><span t-esc="invoice_line.name"></span><span t-if="not invoice_line_last">,</span></t>


### PR DESCRIPTION
The purpose of the commit is to do the generic improvements for the project.

So in this commit did the following changes:
 - the 'upsell opportunity' activity should be generated even
   if the service has already been invoiced
 - project. task hide the 'create' button if the project in the
   context is archived
 - project.task portal form view: only the ref of the invoice
   should be underlined on hover, not the empty space.

task-2857924