### PR TITLE
[FIX] stock_account: correctly compute price_unit for return

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -41,7 +41,7 @@ class StockMove(models.Model):
         if self.origin_returned_move_id and self.origin_returned_move_id.sudo().stock_valuation_layer_ids:
             layers = self.origin_returned_move_id.sudo().stock_valuation_layer_ids
             quantity = sum(layers.mapped("quantity"))
-            return layers.currency_id.round(sum(layers.mapped("value")) / quantity) if not float_is_zero(quantity, layers.uom_id.rounding) else 0
+            return layers.currency_id.round(sum(layers.mapped("value")) / quantity) if not float_is_zero(quantity, precision_rounding=layers.uom_id.rounding) else 0
         return price_unit if not float_is_zero(price_unit, precision) or self._should_force_price_unit() else self.product_id.standard_price
 
     @api.model


### PR DESCRIPTION
Current behavior:
When returning a delivery that had a quanity lower than 1
the inventory valuation showed a value of 0 for the return

Steps to reproduce:
- Create a product that use "m" (meters) as UoM
- Change the configuration of the product Category
  and set Costing method to FIFO and Inventory valuation to Automated
- Create a SO for this product with a quantity of 0.15
- Validate the order and validate the delivery with full quantity
- Now click on return and make a return for the delivery
- Validate the return and go in the inventory valuation
- Show the inventory valuation for the created product
- The return has a value of 0 when it should have the same value
  as the delivery

opw-2880153
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
