### PR TITLE
[FIX] hr_expense: remove taxes_id from product view

### DIFF
--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -9,14 +9,12 @@ class ProductTemplate(models.Model):
 
     can_be_expensed = fields.Boolean(string="Can be Expensed", help="Specify whether the product can be selected in an expense.")
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            # When creating an expense product on the fly, you don't expect to
-            # have taxes on it
-            if vals.get('can_be_expensed', False) and not self.env.context.get('import_file'):
-                vals.update({'supplier_taxes_id': False})
-        return super(ProductTemplate, self).create(vals_list)
+    @api.model
+    def default_get(self, fields):
+        result = super(ProductTemplate, self).default_get(fields)
+        if self.env.context.get('default_can_be_expensed'):
+            result['supplier_taxes_id'] = False
+        return result
 
     @api.onchange('type')
     def _onchange_type_for_expense(self):


### PR DESCRIPTION
Reproduction:
1. Install Expense in V15
2. Go to Expense->Configuration->Expense Products
3. Create a new product, after selecting a vendor tax, click save, the
selected vendor tax is erased and is not saved.

Reason: When creating a new expense product in the normal flow, it still
falls in the condition thus the vendor tax is not updated for the first
time.

Fix: This issue is fixed in the V15 and onwards. The new code just needs
to be backforwarded to V13 and V14.

opw-2852894

Related fix in V15: https://github.com/odoo-dev/odoo/commit/0937ed8d18e4b9ebcaeba6508bd6ffdf1d8e58b7#diff-b294a9786d016b2eda726753fbf75bf749227c2f102d154aa094b2c635334e7e

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
