### PR TITLE
[FIX] resource: use resource tz in attendances for common calendars.

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -387,6 +387,7 @@ class ResourceCalendar(models.Model):
         assert start_dt.tzinfo and end_dt.tzinfo
         self.ensure_one()
         combine = datetime.combine
+        required_tz = tz
 
         resources_list = list(resources) + [self.env['resource.resource']]
         resource_ids = [r.id for r in resources_list]
@@ -404,7 +405,7 @@ class ResourceCalendar(models.Model):
         for attendance in self.env['resource.calendar.attendance'].search(domain):
             for resource in resources_list:
                 # express all dates and times in specified tz or in the resource's timezone
-                tz = tz if tz else timezone((resource or self).tz)
+                tz = required_tz if required_tz else timezone((resource or self).tz)
                 if (tz, start_dt) in cache_dates:
                     start = cache_dates[(tz, start_dt)]
                 else:

--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -531,6 +531,35 @@ class TestCalendar(TestResourceCommon):
         calendar_dt = self.calendar_john._get_closest_work_time(dt, resource=self.john.resource_id)
         self.assertEqual(calendar_dt, start, "It should have found the attendance on the 3rd April")
 
+    def test_attendance_intervals_batch_tz(self):
+        # Calendar for Jean and Pierre:
+        # Europe/Brussels, Monday to Friday, 8->16
+        # resource TZ : Pierre in UTC, Jean in Europe/Brussels (from calendar)
+        pierre = self.env['resource.test'].create({
+            'name': 'Pierre',
+            'resource_calendar_id': self.calendar_jean.id,
+            'tz': 'UTC'
+        })
+        # Friday (summer): 7->15 UTC / 9->17 Europe/Brussels
+        start_dt = datetime_tz(2020, 4, 3, 7, 0, 0, tzinfo='UTC')
+        end_dt = datetime_tz(2020, 4, 3, 15, 0, 0, tzinfo='UTC')
+        resources = [self.jean.resource_id, pierre.resource_id]
+
+        common_calendar = pierre.resource_calendar_id
+        attendance_intervals = common_calendar._attendance_intervals_batch(start_dt, end_dt, resources)
+        jean_intervals = list(attendance_intervals[self.jean.resource_id.id])
+        pierre_intervals = list(attendance_intervals[pierre.resource_id.id])
+
+        # Intervals should take each resource tz into account separately
+        self.assertEqual(len(jean_intervals), 1)
+        self.assertEqual(jean_intervals[0][0], datetime_tz(2020, 4, 3, 9, 0, 0, tzinfo=self.jean.tz))
+        self.assertEqual(jean_intervals[0][1], datetime_tz(2020, 4, 3, 16, 0, 0, tzinfo=self.jean.tz))
+
+        self.assertEqual(len(pierre_intervals), 1)
+        self.assertEqual(pierre_intervals[0][0], datetime_tz(2020, 4, 3, 8, 0, 0, tzinfo=pierre.tz))
+        self.assertEqual(pierre_intervals[0][1], datetime_tz(2020, 4, 3, 15, 0, 0, tzinfo=pierre.tz))
+
+
 class TestResMixin(TestResourceCommon):
 
     def test_adjust_calendar(self):


### PR DESCRIPTION
FIXED ISSUE
In the resource.calendar method _attendance_intervals_batch, the tz
variable used to compute the intervals was set only once per attendance,
using the first resource, then never updated for the next ones. This is
corrected. This was an issue when calling the method on common calendar
with different resources as parameter.

TEST
A test is added in TestCalendar to check that when calling the method
with resources (and no requested tz), each tz is correctly used.

(See task for the original issue seen in appointment module)
Task-2867652

**Note: to do only in 15.0 since code has been updated in task Task-2674527 from 15.1 on.**