### PR TITLE
[FIX] website_forum: fix tag click event not found records

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -16,6 +16,8 @@ from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
 from odoo.exceptions import UserError
 from odoo.http import request
+from odoo.osv import expression
+
 
 _logger = logging.getLogger(__name__)
 
@@ -163,8 +165,14 @@ class WebsiteForum(WebsiteProfile):
 
     @http.route('/forum/get_tags', type='http', auth="public", methods=['GET'], website=True, sitemap=False)
     def tag_read(self, query='', limit=25, **post):
+        # TODO: In master always check the forum_id domain part and add forum_id
+        #       as required method param, not in **post
+        forum_id = post.get('forum_id')
+        domain = [('name', '=ilike', (query or '') + "%")]
+        if forum_id:
+            domain = expression.AND([domain, [('forum_id', '=', int(forum_id))]])
         data = request.env['forum.tag'].search_read(
-            domain=[('name', '=ilike', (query or '') + "%")],
+            domain=domain,
             fields=['id', 'name'],
             limit=int(limit),
         )

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -159,7 +159,7 @@ class Forum(models.Model):
             self.env['forum.post'].with_context(active_test=False).search([('forum_id', 'in', self.ids)]).write({'active': vals['active']})
         return res
 
-    @api.model
+    @api.model  # TODO: Remove me, this is not an `api.model` method
     def _tag_to_write_vals(self, tags=''):
         Tag = self.env['forum.tag']
         post_tags = []
@@ -168,7 +168,7 @@ class Forum(models.Model):
         for tag in (tag for tag in tags.split(',') if tag):
             if tag.startswith('_'):  # it's a new tag
                 # check that not already created meanwhile or maybe excluded by the limit on the search
-                tag_ids = Tag.search([('name', '=', tag[1:])])
+                tag_ids = Tag.search([('name', '=', tag[1:]), ('forum_id', '=', self.id)])
                 if tag_ids:
                     existing_keep.append(int(tag_ids[0]))
                 else:

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -86,6 +86,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     return {
                         query: term,
                         limit: 50,
+                        forum_id: $('#wrapwrap').data('forum_id'),
                     };
                 },
                 results: function (data) {

--- a/addons/website_forum/tests/test_forum.py
+++ b/addons/website_forum/tests/test_forum.py
@@ -436,3 +436,25 @@ class TestForum(TestForumCommon):
             not discussions_post.uid_has_answered or discussions_post.forum_id.mode == 'discussions', True)
         self.assertEqual(
             discussions_post.uid_has_answered and discussions_post.forum_id.mode == 'questions', False)
+
+    def test_tag_creation_multi_forum(self):
+        Post = self.env['forum.post']
+        forum_1 = self.forum
+        forum_2 = forum_1.copy({
+            'name': 'Questions Forum'
+        })
+        self.user_portal.karma = KARMA['tag_create']
+        Post.with_user(self.user_portal).create({
+            'name': "Post Forum 1",
+            'forum_id': forum_1.id,
+            'tag_ids': forum_1._tag_to_write_vals('_Food'),
+        })
+        Post.with_user(self.user_portal).create({
+            'name': "Post Forum 2",
+            'forum_id': forum_2.id,
+            'tag_ids': forum_2._tag_to_write_vals('_Food'),
+        })
+        food_tags = self.env['forum.tag'].search([('name', '=', 'Food')])
+        self.assertEqual(len(food_tags), 2, "One Food tag should have been created in each forum.")
+        self.assertIn(forum_1, food_tags.forum_id, "One Food tag should have been created for forum 1.")
+        self.assertIn(forum_2, food_tags.forum_id, "One Food tag should have been created for forum 2.")


### PR DESCRIPTION
A forum tag is always linked to a forum.
But some flows are not considering that part and are returning/using
tags from other forum too.

Step to reproduce, having 2 forum `Cats` and `Dogs`:
- Create a `Food` tag on the `Dogs` forum
- On the `Cats` forum, type `Food` in the tag input
- First error: the `Food` from `Dogs` incorrectly shows up
  It means that the user can't create a new one from the `Cats` forum
  but will actually have to select (without know it) the one from the
  `Dogs` forum.
- Select that tag anyway
- Second error: The tags displayed on the post is redirecting to the
  wrong other forum, ultimately not showing the post from all forums
  (and the one you just came from).
- Third error: The /tags page won't list the `Food` tag on the `Cats`
  forum.

Note that there is probably some access traceback involved in a multi
website and/or multi company setup.

After this commit:
- only the tags from the current forum will show up and be selectable
  when creating a post.
- it will be possible to create a new tag for a forum is another forum
  already has a tag of that name
- the tag on the post (next to its title) will not redirect to the
  incorrect (and possibly not accessible) forum

Co-authored-by: hoangtiendung <hoangtiendung070797@gmail.com>
