### PR TITLE
[FIX] mail: Momentary _mail_track error on model having no company_id

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -54,8 +54,12 @@ class BaseModel(models.AbstractModel):
                 tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, new_value, col_name, col_info, tracking_sequence, self._name)
                 if tracking:
                     if tracking['field_type'] == 'monetary':
-                        tracking['currency_id'] = getattr(self, col_info.get('currency_field', ''), self.company_id.currency_id).id
-                    tracking_value_ids.append([0, 0, tracking])
+                        currency_field = col_info['currency_field'] if col_info.get('currency_field') and col_info.get('currency_field') in self else None
+                        if currency_field:
+                            currency_id = self[currency_field].id
+                        else:
+                            currency_id = self.company_id.currency_id if 'company_id' in self else self.env.company.currency_id
+                        tracking['currency_id'] = currency_id
                 changes.add(col_name)
 
         return changes, tracking_value_ids

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -60,6 +60,7 @@ class BaseModel(models.AbstractModel):
                         else:
                             currency_id = self.company_id.currency_id if 'company_id' in self else self.env.company.currency_id
                         tracking['currency_id'] = currency_id
+                    tracking_value_ids.append([0, 0, tracking])
                 changes.add(col_name)
 
         return changes, tracking_value_ids

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -86,6 +86,14 @@ class MailTestTrackMonetary(models.Model):
     company_currency = fields.Many2one("res.currency", string='Currency', related='company_id.currency_id', readonly=True, tracking=True)
     revenue = fields.Monetary('Revenue', currency_field='company_currency', tracking=True)
 
+class MailTestTrackMonetaryNoCompany(models.Model):
+    _name = 'mail.test.track.monetary.no_company'
+    _description = "Test Email Track Monetary No Company"
+    _inherit = ['mail.thread']
+
+    currency_id = fields.Many2one('res.currency', 'Currency', readonly=True, ondelete='set null',
+                                  help="Used to display the currency when tracking monetary values")
+    amount = fields.Monetary('Monetary Value', tracking=True)
 
 class MailTestSelectionTracking(models.Model):
     """ Test tracking for selection fields """

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -29,3 +29,4 @@ access_mail_test_track_compute,mail.test.track.compute,model_mail_test_track_com
 access_mail_test_track_monetary,mail.test.track.monetary,model_mail_test_track_monetary,base.group_user,1,1,1,1
 access_mail_test_track_selection_portal,mail.test.track.selection.portal,model_mail_test_track_selection,base.group_portal,0,0,0,0
 access_mail_test_track_selection_user,mail.test.track.selection.user,model_mail_test_track_selection,base.group_user,1,1,1,1
+access_mail_test_track_monetary_no_company,mail.test.track.monetary.no_company,model_mail_test_track_monetary_no_company,base.group_user,1,1,1,1

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -323,8 +323,14 @@ class TestTrackingMonetary(TestMailMultiCompanyCommon):
         record = self.env['mail.test.track.monetary'].with_user(self.user_employee).with_context(self._test_context).create({
             'company_id': self.user_employee.company_id.id,
         })
+        currency = self.env.ref('base.USD').id
+        record_no_company = self.env['mail.test.track.monetary.no_company'].with_user(self.user_employee).with_context(self._test_context).create({
+            'currency_id': currency,
+            'amount': 200
+        })
         self.flush_tracking()
         self.record = record.with_context(mail_notrack=False)
+        self.record_no_company = record_no_company
 
     def test_message_track_monetary(self):
         """ Update a record with a tracked monetary field """
@@ -352,6 +358,12 @@ class TestTrackingMonetary(TestMailMultiCompanyCommon):
             ('revenue', 'monetary', 100, 200),
             ('company_currency', 'many2one', self.user_employee.company_id.currency_id, self.company_2.currency_id)
         ])
+
+    def test_message_track_monetary_no_company(self):
+        try:
+            self.record_no_company.write({'amount': 300})
+        except AttributeError:
+            self.fail('AttributeError should not be raised when modifying tracked monetary fields')
 
 @tagged('mail_track')
 class TestTrackingInternals(TestMailCommon):


### PR DESCRIPTION
Implementing a monetary field on a model that has no company_id field definition would raise AttributeError although currency_id was there or even currency_field is declared for the field. The problem causes by this code

https://github.com/odoo/odoo/blob/3287d4ef30c78d8b64abf3f923ee6c04f1984ab3/addons/mail/models/models.py#L56-L57

It means that if we want to track that monetary field, the corresponding model must come with company_id field.

This PR fixes the issue by checking if the model has company_id first to take its currency before falling to the current company's currency




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
