### PR TITLE
[FIX] web_editor: traceback while removing the link

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -83,7 +83,7 @@ class Sanitize {
 
     parse(node) {
         node = closestBlock(node);
-        if (['UL', 'OL'].includes(node.tagName)) {
+        if (node && ['UL', 'OL'].includes(node.tagName)) {
             node = node.parentElement;
         }
         this._parse(node);


### PR DESCRIPTION
**Current behavior before PR:**

After inserting the 'calendar' or 'appointment' link in an article through the
'/appointment ' or '/calendar' command, removing the link shows the error.

**Desired behavior after PR is merged:**

Removing the link through the link editor will remove the link and only keep the
text.

**Task**-2894489