### PR TITLE
[FIX] l10n_es_edi_sii: allow any user to send invoices to the SII

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -46,7 +46,7 @@ class PatchedHTTPAdapter(requests.adapters.HTTPAdapter):
         context = conn.conn_kw['ssl_context']
 
         def patched_load_cert_chain(l10n_es_odoo_certificate, keyfile=None, password=None):
-            cert_file, key_file, dummy = l10n_es_odoo_certificate._decode_certificate()
+            cert_file, key_file, dummy = l10n_es_odoo_certificate.sudo()._decode_certificate()
             cert_obj = load_certificate(FILETYPE_PEM, cert_file)
             pkey_obj = load_privatekey(FILETYPE_PEM, key_file)
 


### PR DESCRIPTION
Only users with admin rights are able to confirm and send an invoice to
the SII

Steps to reproduce:
1. Install l10n_es_edi_sii module
2. Switch to company 'ES Company'
3. Go to Settings > Invoicing > Spain Localization > Registro de Libros
   connection SII and select 'Hacienda Foral de Gipuzkoa'
4. Go to Invoicing > Configuration > Accounting > Journals and open
   'Customer Invoices'. In the 'Advanced Settings' tab, enable EDI
   functionality 'SII IVA Llevanza de libros registro (ES)'
5. Go to Invoicing > Configuration > Spain > Certificate (ES) and import
   the certificate (file named sello_entidad_act.p12 in
   l10n_es_edi_sii/demo/certificates/) with password "IZDesa2021"
6. Connect as demo in 'ES Company'
7. Create an invoice with any customer and product and confirm it
8. Click on 'Send now', an access error is raised

Solution:
Call `_decode_certificate` with sudo to allow any user to send invoices
to the SII

opw-2767288