### PR TITLE
[FIX] sale_,(project): set default analytic account and analytic tags in task

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1645,8 +1645,9 @@ class Task(models.Model):
                 )
                 if partner_id:
                     vals['partner_id'] = partner_id
-        if vals.get('project_id'):
-            project = self.env['project.project'].browse(vals.get('project_id'))
+        project_id = vals.get('project_id', self.env.context.get('default_project_id'))
+        if project_id:
+            project = self.env['project.project'].browse(project_id)
             if project.analytic_account_id:
                 vals['analytic_account_id'] = project.analytic_account_id.id
             if project.analytic_tag_ids:

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -253,6 +253,8 @@ class SaleOrderLine(models.Model):
         description = '<br/>'.join(sale_line_name_parts[1:])
         return {
             'name': title if project.sale_line_id else '%s - %s' % (self.order_id.name or '', title),
+            'analytic_account_id': project.analytic_account_id.id,
+            'analytic_tag_ids': [Command.set(project.analytic_tag_ids.ids)],
             'planned_hours': planned_hours,
             'partner_id': self.order_id.partner_id.id,
             'email_from': self.order_id.partner_id.email,


### PR DESCRIPTION
Currently, the project's analytic account and analytic tags are not set by
default in the task. Now it will be fixed.

 Steps to reproduce:
    1. Install project
    2. Activate the analytic account and analytic tags in the user setting
    3. Create a project with analytic account and analytic tags
    4. Create a task from the kanban view
    5. Check the analytic account and analytic tags in the task

 Steps to reproduce:
    1. Install sale_project
    2. Activate the analytic account and analytic tags in the user setting
    3. Create a project with analytic account and analytic tags
    4. Create a product (Create on Order = task)
    5. Create a sale order and confirm
    6. Check the analytic account and analytic tags in the task

task-2930761