### PR TITLE
[FIX] auth_totp: show trusted devices in user prefs

### DIFF
--- a/addons/auth_totp/i18n/auth_totp.pot
+++ b/addons/auth_totp/i18n/auth_totp.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~14.5\n"
+"Project-Id-Version: Odoo Server saas~15.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 10:28+0000\n"
-"PO-Revision-Date: 2021-09-14 10:28+0000\n"
+"POT-Creation-Date: 2022-06-21 13:22+0000\n"
+"PO-Revision-Date: 2022-06-21 13:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,8 +33,14 @@ msgid "2-Factor authentication is now enabled."
 msgstr ""
 
 #. module: auth_totp
-#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
+msgid ""
+"<span attrs=\"{'invisible': [('totp_enabled', '=', False)]}\" class=\"text-"
+"muted\">This account is protected!</span>"
+msgstr ""
+
+#. module: auth_totp
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 msgid ""
 "<span attrs=\"{'invisible': [('totp_enabled', '=', False)]}\" class=\"text-"
 "muted\">Your account is protected!</span>"
@@ -72,6 +78,7 @@ msgid "Activate"
 msgstr ""
 
 #. module: auth_totp
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
 msgid "Added On"
 msgstr ""
@@ -79,7 +86,14 @@ msgstr ""
 #. module: auth_totp
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
 msgid ""
-"Are you sure? Two-factor authentication will be required again on all your "
+"Are you sure? The user may be asked to enter two-factor codes again on those"
+" devices"
+msgstr ""
+
+#. module: auth_totp
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
+msgid ""
+"Are you sure? You may be asked to enter two-factor codes again on those "
 "devices"
 msgstr ""
 
@@ -100,7 +114,6 @@ msgstr ""
 
 #. module: auth_totp
 #: model_terms:ir.ui.view,arch_db:auth_totp.auth_totp_form
-#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_wizard
 msgid "Cancel"
 msgstr ""
@@ -136,8 +149,9 @@ msgid "Description"
 msgstr ""
 
 #. module: auth_totp
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
-msgid "Device Name"
+msgid "Device"
 msgstr ""
 
 #. module: auth_totp
@@ -239,11 +253,13 @@ msgid "Qrcode"
 msgstr ""
 
 #. module: auth_totp
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
 msgid "Revoke"
 msgstr ""
 
 #. module: auth_totp
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
 msgid "Revoke All"
 msgstr ""
@@ -277,12 +293,8 @@ msgid "Totp Secret"
 msgstr ""
 
 #. module: auth_totp
-#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
-msgid "Trusted Device"
-msgstr ""
-
-#. module: auth_totp
 #: model:ir.model.fields,field_description:auth_totp.field_res_users__totp_trusted_device_ids
+#: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_field
 #: model_terms:ir.ui.view,arch_db:auth_totp.view_totp_form
 msgid "Trusted Devices"
 msgstr ""

--- a/addons/auth_totp/views/res_users_views.xml
+++ b/addons/auth_totp/views/res_users_views.xml
@@ -34,32 +34,6 @@
                                 <button attrs="{'invisible': [('totp_enabled', '=', False)]}" name="action_totp_disable" type="object"
                                         class="fa fa-toggle-on o_auth_2fa_btn text-primary enabled" aria-label="Disable 2FA"></button>
                             </div>
-                            <div colspan="2" attrs="{'invisible': [('totp_trusted_device_ids', '=', [])]}">
-                                <field name="totp_trusted_device_ids" nolabel="1" colspan="4" readonly="1">
-
-                                    <tree create="false" delete="false">
-                                        <field name="name" string="Trusted Devices"/>
-                                        <field name="create_date" string="Added On"/>
-                                        <button type="object" name="remove"
-                                                title="Revoke" icon="fa-trash"/>
-                                    </tree>
-                                    <form string="Trusted Device">
-                                        <group>
-                                            <group>
-                                                <field name="name" string="Device Name"/>
-                                                <field name="create_date" string="Added On"/>
-                                            </group>
-                                        </group>
-                                        <footer>
-                                            <button name="remove" string="Revoke" type="object" icon="fa-trash"/>
-                                            <button name="preference_cancel" string="Cancel" special="cancel" class="btn-secondary"/>
-                                        </footer>
-                                    </form>
-
-                                </field>
-                                <button name="revoke_all_devices" string="Revoke All" type="object" class="btn btn-secondary"
-                                        confirm="Are you sure? Two-factor authentication will be required again on all your devices"/>
-                            </div>
                             <span attrs="{'invisible': [('totp_enabled', '!=', False)]}" class="text-muted">
                                 Two-factor Authentication ("2FA") is a system of double authentication.
                                 The first one is done with your password and the second one with a code you get from a dedicated mobile app.
@@ -67,7 +41,21 @@
                                 <a href="https://www.odoo.com/documentation/saas-15.3/applications/general/auth/2fa.html"
                                    title="Learn More" target="_blank">Learn More</a>
                             </span>
-                            <span attrs="{'invisible': [('totp_enabled', '=', False)]}" class="text-muted">Your account is protected!</span>
+                            <span attrs="{'invisible': [('totp_enabled', '=', False)]}" class="text-muted">This account is protected!</span>
+                            <group name="auth_devices" string="Trusted Devices" attrs="{'invisible': [('totp_trusted_device_ids', '=', [])]}">
+                                <div colspan="2">
+                                    <field name="totp_trusted_device_ids" nolabel="1" colspan="4" readonly="1">
+                                        <tree create="false" delete="false">
+                                            <field name="name" string="Device"/>
+                                            <field name="create_date" string="Added On"/>
+                                            <button type="object" name="remove"
+                                                    title="Revoke" icon="fa-trash"/>
+                                        </tree>
+                                    </field>
+                                    <button name="revoke_all_devices" string="Revoke All" type="object" class="btn btn-secondary"
+                                            confirm="Are you sure? The user may be asked to enter two-factor codes again on those devices"/>
+                                </div>
+                            </group>
                         </div>
                     </group>
                 </page>
@@ -90,6 +78,7 @@
                             <button attrs="{'invisible': [('totp_enabled', '=', False)]}" name="action_totp_disable"
                                type="object" class="fa fa-toggle-on o_auth_2fa_btn text-primary" aria-label="Disable 2FA"/>
                         </div>
+                        <span attrs="{'invisible': [('totp_enabled', '=', False)]}" class="text-muted">Your account is protected!</span>
                         <span attrs="{'invisible': [('totp_enabled', '!=', False)]}" class="text-muted">
                             Two-factor Authentication ("2FA") is a system of double authentication.
                             The first one is done with your password and the second one with a code you get from a dedicated mobile app.
@@ -97,7 +86,20 @@
                             <a href="https://www.odoo.com/documentation/saas-15.3/applications/general/auth/2fa.html"
                                title="Learn More" target="_blank">Learn More</a>
                         </span>
-                        <span attrs="{'invisible': [('totp_enabled', '=', False)]}" class="text-muted">Your account is protected!</span>
+                        <group name="auth_devices" string="Trusted Devices" attrs="{'invisible': [('totp_trusted_device_ids', '=', [])]}">
+                            <div colspan="2">
+                                <field name="totp_trusted_device_ids" nolabel="1" colspan="4" readonly="1">
+                                    <tree create="false" delete="false">
+                                        <field name="name" string="Device"/>
+                                        <field name="create_date" string="Added On"/>
+                                        <button type="object" name="remove"
+                                                title="Revoke" icon="fa-trash"/>
+                                    </tree>
+                                </field>
+                                <button name="revoke_all_devices" string="Revoke All" type="object" class="btn btn-secondary"
+                                        confirm="Are you sure? You may be asked to enter two-factor codes again on those devices"/>
+                            </div>
+                        </group>
                     </div>
                 </group>
             </group>


### PR DESCRIPTION
PR #75535 introduced trusted devices, but only made them visible in the main user form (for admins) and in the portal.

It's quite useful for users to be able to view and manage their trusteddevices in their own user preferences as well.

This commit add them in the "Account Security" of the user profile.

In addition:
- improve the layout of the trusted devices by wrapping them in a `<group>` to have them stand out from the surrounding prefs
- move the "Account is protected" label about the trusted devices, and under main the 2FA toggle button, where it's supposed to be.
- removed the custom form view for trusted devices inside the one2many. The point was to hide the extra `scope` field, but it's not worth it, and the Cancel button wasn't even working, the default form view is better.
- improve the confirmation message of the "Revoke All" button when it's located on the user management form (for admins) to clarify that it's not the admin's devices that will be revoked.
- change the 2FA label from "Your Account is protected" to "This account is protected" when located on the user management form for admins.

Note: this is a manual partial fwd-port of #94111, as this part was mistakenly dropped in the fwd-port chain at #94193, my bad 🤦