### PR TITLE
[FIX] pos_adyen: Remove the diagnosis from the polling

### DIFF
--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -82,18 +82,11 @@ class PosPaymentMethod(models.Model):
         _logger.info('get_latest_adyen_status\n%s', pos_config_name)
         self.ensure_one()
 
-        # Poll the status of the terminal if there's no new
-        # notification we received. This is done so we can quickly
-        # notify the user if the terminal is no longer reachable due
-        # to connectivity issues.
-        self.proxy_adyen_request(self._adyen_diagnosis_request_data(pos_config_name))
-
         latest_response = self.sudo().adyen_latest_response
         latest_response = json.loads(latest_response) if latest_response else False
 
         return {
             'latest_response': latest_response,
-            'last_received_diagnosis_id': self.sudo().adyen_latest_diagnosis,
         }
 
     def proxy_adyen_request(self, data, operation=False):


### PR DESCRIPTION
Actually we send request to check if the terminal is available when we poll
the status of a payment.

We remove it and need check the availablity before we start the session

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
