### PR TITLE
[FIX] account: round analytic account line amount

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4287,7 +4287,8 @@ class AccountMoveLine(models.Model):
             analytic tags with analytic distribution.
         """
         self.ensure_one()
-        amount = -self.balance * distribution.percentage / 100.0
+        currency = self.currency_id or self.move_id.company_id.currency_id
+        amount = currency.round(-self.balance * distribution.percentage / 100.0)
         default_name = self.name or (self.ref or '/' + ' -- ' + (self.partner_id and self.partner_id.name or '/'))
         return {
             'name': default_name,


### PR DESCRIPTION
Activate analytic accounting ang tags
Create analytic account A, B and C
Create analytic tag T, with repartition into accounts:
- A, 33.33%
- B, 33.33%
- C, 33.34%
Create an invoice with a single line of 785.08 and the analytic tag T
Save and post the invoice
Go to Account>Analytic Items
Three items will display:

|Account|Amount|
|-------|------|
|      A|261.67|
|      B|261.67|
|      C|261.75|

Total is 785.08 (should be 785.09), because even if the system display the
amounts rounded, in the analytic lines they are stored not rounded.
Exporting the xlsl will show the unrounded amounts.

opw-2857640

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
