### PR TITLE
[FIX] mail: update record after activity edit

### DIFF
--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -174,8 +174,9 @@ class Activity extends Component {
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickEdit(ev) {
-        this.activity.edit();
+    async _onClickEdit(ev) {
+        await this.activity.edit();
+        this.trigger('reload', { keepChanges: true });
     }
 
     /**

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -133,6 +133,8 @@ function factory(dependencies) {
         /**
          * Opens (legacy) form view dialog to edit current activity and updates
          * the activity when dialog is closed.
+         *
+         * @return {Promise} promise that is fulfilled when the form has been closed
          */
         edit() {
             const action = {
@@ -148,9 +150,16 @@ function factory(dependencies) {
                 },
                 res_id: this.id,
             };
-            this.env.bus.trigger('do-action', {
-                action,
-                options: { on_close: () => this.fetchAndUpdate() },
+            return new Promise(resolve => {
+                this.env.bus.trigger('do-action', {
+                    action,
+                    options: {
+                        on_close: () => {
+                            resolve();
+                            this.fetchAndUpdate();
+                        },
+                    },
+                });
             });
         }
 


### PR DESCRIPTION
Steps to follow:

  - Go to a crm.lead
  - Schedule an activity
  - Click on edit
  - Click on mark as done in the popup
  - Move the lead to a new stage
  -> A missing record error is displayed for the activity

Cause of the issue:

  Once the activity has been mark as done (deleted),
  The crm.lead record is not updated. The old activity is then
  passed to the server where an error is thrown

Solution:

  Update the main view after editing an activity

opw-2878984