### PR TITLE
[REV] pos_restaurant: stop closing paymentscreen while paying

### DIFF
--- a/addons/pos_restaurant/static/src/js/Chrome.js
+++ b/addons/pos_restaurant/static/src/js/Chrome.js
@@ -76,8 +76,7 @@ odoo.define('pos_restaurant.chrome', function (require) {
                 this.showScreen('FloorScreen', { floor: table ? table.floor : null });
             }
             _shouldResetIdleTimer() {
-                const stayPaymentScreen = this.mainScreen.name === 'PaymentScreen' && this.env.pos.get_order().paymentlines.length > 0;
-                return super._shouldResetIdleTimer() && !stayPaymentScreen && this.mainScreen.name !== 'FloorScreen';
+                return super._shouldResetIdleTimer() && this.env.pos.config.iface_floorplan && this.mainScreen.name !== 'FloorScreen';
             }
             __showScreen() {
                 super.__showScreen(...arguments);


### PR DESCRIPTION
Revert of
https://github.com/odoo/odoo/pull/92794

If you install pos_restaurant and open a PoS sale session, issue will start to appear after a certain time (about 1 minute):

For V15:
Javascript console logs will log errors:
`TypeError: Cannot read properties of undefined (reading 'id') Chrome.js:97`

For V15.2:
The products button will become unresponsive (so the PoS is unusable).
With error in the JS console as well:
`TypeError: Cannot read properties of undefined (reading '0') Chrome.js`

OPW-2889985

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
