### PR TITLE
[WIP][IMP] base: multi-languages usability

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -206,7 +206,6 @@ class Lead(models.Model):
         'res.lang', string='Language',
         compute='_compute_lang_id', readonly=False, store=True)
     lang_code = fields.Char(related='lang_id.code')
-    lang_active_count = fields.Integer(compute='_compute_lang_active_count')
     # Address fields
     street = fields.Char('Street', compute='_compute_partner_address_values', readonly=False, store=True)
     street2 = fields.Char('Street2', compute='_compute_partner_address_values', readonly=False, store=True)
@@ -416,10 +415,6 @@ class Lead(models.Model):
             lang_id_by_code = {}
         for lead in self.filtered('partner_id'):
             lead.lang_id = lang_id_by_code.get(lead.partner_id.lang, False)
-
-    @api.depends('lang_id')
-    def _compute_lang_active_count(self):
-        self.lang_active_count = len(self.env['res.lang'].get_installed())
 
     @api.depends('partner_id')
     def _compute_partner_address_values(self):

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -30,6 +30,7 @@ class Partner(models.Model):
                     state_id=lead.state_id.id,
                     country_id=lead.country_id.id,
                     zip=lead.zip,
+                    lang=lead.lang_code,
                 )
         return rec
 

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -247,7 +247,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
 
     @users('user_sales_manager')
     def test_lead_convert_no_lang(self):
-        """ Ensure converting a lead with an archived language correctly falls back on the default partner language. """
+        """ Ensure converting a lead with a disable language is correctly propagated """
         inactive_lang = self.env["res.lang"].sudo().create({
             'code': 'en_ZZ',
             'name': 'Inactive Lang',
@@ -264,7 +264,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         }).create({'action': 'create'})
         convert.action_apply()
         self.assertTrue(lead.partner_id)
-        self.assertEqual(lead.partner_id.lang, 'en_US')
+        self.assertEqual(lead.partner_id.lang, 'en_ZZ')
 
     @users('user_sales_manager')
     def test_lead_convert_internals(self):

--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -169,8 +169,7 @@ class NewLeadNotification(TestCrmCommon):
     @users('user_sales_manager')
     def test_lead_message_get_suggested_recipients_langs(self):
         """This test checks that creating a contact from a lead with an inactive
-        language will ignore the language while creating a contact from a lead
-        with an active language will take it into account """
+        or active language will take it into account """
         leads = self.env['crm.lead'].create([
             {
                 'email_from': self.test_email,
@@ -188,7 +187,7 @@ class NewLeadNotification(TestCrmCommon):
                 'email': 'test.email@example.com',
                 'lang': None,
                 'reason': 'Customer Email',
-                'create_values': {'lang': None},
+                'create_values': {'lang': 'fr_FR'},
             }, {
                 'name': 'Test Email',
                 'email': 'test.email@example.com',

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -119,9 +119,8 @@
                                     <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                 </div>
                                 <field name="website" widget="url" placeholder="e.g. https://www.odoo.com"/>
-                                <field name="lang_active_count" invisible="1"/>
                                 <field name="lang_code" invisible="1"/>
-                                <field name="lang_id" invisible="lang_active_count &lt;= 1"
+                                <field name="lang_id"
                                     options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
                             </group>
 
@@ -292,8 +291,7 @@
                                             <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                         </div>
                                         <field name="website" widget="url" placeholder="e.g. https://www.odoo.com"/>
-                                        <field name="lang_active_count" invisible="1"/>
-                                        <field name="lang_id" invisible="lang_active_count &lt;= 1"
+                                        <field name="lang_id"
                                             options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
                                     </group>
                                     <group class="mt48">

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -121,7 +121,8 @@
                                 <field name="website" widget="url" placeholder="e.g. https://www.odoo.com"/>
                                 <field name="lang_code" invisible="1"/>
                                 <field name="lang_id"
-                                    options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                                    options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"
+                                    context="{'active_test': False, 'lang_installed': True}"/>
                             </group>
 
                             <group name="opportunity_partner" invisible="type == 'lead'">
@@ -292,7 +293,8 @@
                                         </div>
                                         <field name="website" widget="url" placeholder="e.g. https://www.odoo.com"/>
                                         <field name="lang_id"
-                                            options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                                            options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"
+                                            context="{'active_test': False, 'lang_installed': True}"/>
                                     </group>
                                     <group class="mt48">
                                         <label for="contact_name_page_lead"/>

--- a/addons/spreadsheet/models/res_lang.py
+++ b/addons/spreadsheet/models/res_lang.py
@@ -6,6 +6,7 @@ from odoo.addons.spreadsheet.utils.formatting import (
     strftime_format_to_spreadsheet_date_format,
     strftime_format_to_spreadsheet_time_format,
 )
+from odoo.tools import get_lang
 
 
 class Lang(models.Model):
@@ -22,7 +23,7 @@ class Lang(models.Model):
     @api.model
     def _get_user_spreadsheet_locale(self):
         """Convert the odoo lang to a spreadsheet locale."""
-        lang = self._lang_get(self.env.user.lang)
+        lang = self._lang_get(get_lang(self.env, lang_code=self.env.user.lang).get('code'))
         return lang._odoo_lang_to_spreadsheet_locale()
 
     def _odoo_lang_to_spreadsheet_locale(self):

--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -12,6 +12,8 @@ from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, MissingError
 
 from odoo.addons.spreadsheet.utils.validate_data import fields_in_spreadsheet, menus_xml_ids_in_spreadsheet
+from odoo.tools import get_lang
+
 
 class SpreadsheetMixin(models.AbstractModel):
     _name = "spreadsheet.mixin"
@@ -111,7 +113,7 @@ class SpreadsheetMixin(models.AbstractModel):
         The sheet name should be the same for all users to allow consistent references
         in formulas. It is translated for the user creating the spreadsheet.
         """
-        lang = self.env["res.lang"]._lang_get(self.env.user.lang)
+        lang = self.env["res.lang"]._lang_get(get_lang(self.env, lang_code=self.env.user.lang).get('code'))
         locale = lang._odoo_lang_to_spreadsheet_locale()
         return {
             "version": 1,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -524,7 +524,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=34, employee=34):  # tm 23/23 / com 33/33
+        with self.assertQueryCount(admin=35, employee=35):  # tm 24/24 / com 34/34
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -554,7 +554,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=34, employee=34):  # tm 23/23 / com 32/32
+        with self.assertQueryCount(admin=35, employee=35):  # tm 24/24 / com 33/33
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -84,7 +84,7 @@ class WebsiteEventMeetController(EventCommunityController):
         max_capacity = post.get("capacity")
 
         # get the record to be sure they really exist
-        lang = request.env["res.lang"].search([("code", "=", lang_code)], limit=1)
+        lang = request.env["res.lang"].with_context(active_test=False).search([("code", "=", lang_code)], limit=1)
 
         if not lang or max_capacity == "no_limit":
             raise Forbidden()
@@ -105,7 +105,7 @@ class WebsiteEventMeetController(EventCommunityController):
 
     @http.route(["/event/active_langs"], type="json", auth="public")
     def active_langs(self):
-        return request.env["res.lang"].sudo().get_installed()
+        return request.env["res.lang"].with_context(lang_installed=False).sudo()._get_available_lang()
 
     # ------------------------------------------------------------
     # ROOM PAGE VIEW

--- a/addons/website_event_meet/views/event_meeting_room_views.xml
+++ b/addons/website_event_meet/views/event_meeting_room_views.xml
@@ -45,7 +45,8 @@
                         </group>
                         <group>
                             <field name="room_max_capacity" widget="radio" options="{'horizontal': true}"/>
-                            <field name="room_lang_id" options="{'no_create': True}"/>
+                            <field name="room_lang_id" options="{'no_create': True}"
+                                context="{'active_test': False, 'lang_installed': True}"/>
                             <field name="chat_room_id" required="0" invisible="not id"/>
                             <field name="room_participant_count" readonly="1" invisible="not id"/>
                         </group>

--- a/addons/website_jitsi/models/chat_room.py
+++ b/addons/website_jitsi/models/chat_room.py
@@ -30,7 +30,7 @@ class ChatRoom(models.Model):
         'Jitsi Server Domain', compute='_compute_jitsi_server_domain',
         help='The Jitsi server domain can be customized through the settings to use a different server than the default "meet.jit.si"')
     lang_id = fields.Many2one(
-        "res.lang", "Language",
+        "res.lang", "Language", domain=lambda self: [('code', 'in', self.env['res.lang']._get_enabled_lang_code())],
         default=lambda self: self.env["res.lang"].search([("code", "=", self.env.user.lang)], limit=1))
     max_capacity = fields.Selection(
         [("4", "4"), ("8", "8"), ("12", "12"), ("16", "16"),

--- a/addons/website_jitsi/views/chat_room_views.xml
+++ b/addons/website_jitsi/views/chat_room_views.xml
@@ -23,7 +23,8 @@
                     <group>
                         <group>
                             <field name="is_full"/>
-                            <field name="lang_id" options="{'no_create': True}"/>
+                            <field name="lang_id" options="{'no_create': True}"
+                                context="{'active_test': False, 'lang_installed': True}"/>
                             <field name="participant_count"/>
                             <field name="max_capacity"/>
                         </group>

--- a/odoo/addons/base/data/res.lang.csv
+++ b/odoo/addons/base/data/res.lang.csv
@@ -1,5 +1,5 @@
 "id","name","code","iso_code","direction","grouping","decimal_point","thousands_sep","date_format","time_format","week_start"
-"base.lang_en","English (US)","en_US","en","Left-to-Right","[3,0]",".",",","%m/%d/%Y","%H:%M:%S","7"
+"base.lang_en","English","en_US","en","Left-to-Right","[3,0]",".",",","%m/%d/%Y","%H:%M:%S","7"
 "base.lang_am_ET","Amharic / አምሃርኛ","am_ET","am_ET","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%I:%M:%S","7"
 "base.lang_ar","Arabic / الْعَرَبيّة","ar_001","ar","Right-to-Left","[3,0]",".",",","%d %b, %Y","%I:%M:%S","6"
 "base.lang_ar_SY","Arabic (Syria) / الْعَرَبيّة","ar_SY","ar_SY","Right-to-Left","[3,0]",".",",","%d %b, %Y","%I:%M:%S","6"

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -29,7 +29,7 @@ WARNING_HELP = 'Selecting the "Warning" option will notify user with the message
 ADDRESS_FIELDS = ('street', 'street2', 'zip', 'city', 'state_id', 'country_id')
 @api.model
 def _lang_get(self):
-    return self.env['res.lang'].get_installed()
+    return self.env['res.lang'].with_context(lang_installed=True)._get_available_lang()
 
 
 # put POSIX 'Etc/*' entries at the end to avoid confusing users - see bug 1086728

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -197,7 +197,6 @@ class Partner(models.Model):
     ref = fields.Char(string='Reference', index=True)
     lang = fields.Selection(_lang_get, string='Language',
                             help="All the emails and documents sent to this contact will be translated in this language.")
-    active_lang_count = fields.Integer(compute='_compute_active_lang_count')
     tz = fields.Selection(_tz_get, string='Timezone', default=lambda self: self._context.get('tz'),
                           help="When printing documents and exporting/importing data, time values are computed according to this timezone.\n"
                                "If the timezone is not set, UTC (Coordinated Universal Time) is used.\n"
@@ -341,12 +340,6 @@ class Partner(models.Model):
                     name = f"{partner.commercial_company_name or partner.sudo().parent_id.name}, {name}"
 
             partner.complete_name = name.strip()
-
-    @api.depends('lang')
-    def _compute_active_lang_count(self):
-        lang_count = len(self.env['res.lang'].get_installed())
-        for partner in self:
-            partner.active_lang_count = lang_count
 
     @api.depends('tz')
     def _compute_tz_offset(self):

--- a/odoo/addons/base/tests/test_res_lang.py
+++ b/odoo/addons/base/tests/test_res_lang.py
@@ -117,3 +117,17 @@ class test_res_lang(TransactionCase):
         with self.assertRaises(AttributeError):
             # raise error for querying a not cached field of the dummy language
             ResLang._get_data(code='dummy').flag_image
+
+    def test_available_lang(self):
+        available_langs_code = self.env["res.lang"]._get_enabled_lang_code()
+        installed_langs_code = [lang[0] for lang in self.env["res.lang"].get_installed()]
+        self.assertTrue(len(available_langs_code) >= len(installed_langs_code))
+
+        for lang in installed_langs_code:
+            # Check that all installed languages are in the enabled languages
+            self.assertIn(lang, available_langs_code)
+            available_langs_code.remove(lang)
+
+        default_langs = self.env["res.lang"].search([("code", "in", available_langs_code)])
+
+        self.assertTrue(all(not lang.active for lang in default_langs))

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -517,7 +517,7 @@ class TestTranslation(TransactionCase):
     def test_110_search_es(self):
         self.env['res.lang']._activate_lang('es_ES')
         langs = self.env['res.lang'].get_installed()
-        self.assertEqual([('en_US', 'English (US)'), ('fr_FR', 'French / Français'), ('es_ES', 'Spanish / Español')],
+        self.assertEqual([('en_US', 'English'), ('fr_FR', 'French / Français'), ('es_ES', 'Spanish / Español')],
                          langs, "Test did not start with the expected languages")
         CategoryEs = self.env['res.partner.category'].with_context(lang='es_ES')
         category_equal = CategoryEs.search([('name', '=', 'Customers')])
@@ -581,7 +581,7 @@ class TestTranslationWrite(TransactionCase):
         self.env['res.lang']._activate_lang('fr_FR')
 
         langs = self.env['res.lang'].get_installed()
-        self.assertEqual([('en_US', 'English (US)'), ('fr_FR', 'French / Français')], langs,
+        self.assertEqual([('en_US', 'English'), ('fr_FR', 'French / Français')], langs,
                          "Test did not started with expected languages")
 
         category = self.env['res.partner.category'].with_context(lang='en_US').create({'name': 'English'})
@@ -648,7 +648,7 @@ class TestTranslationWrite(TransactionCase):
         self.env['res.lang']._activate_lang('fr_FR')
 
         langs = self.env['res.lang'].get_installed()
-        self.assertEqual([('en_US', 'English (US)'), ('fr_FR', 'French / Français')], langs,
+        self.assertEqual([('en_US', 'English'), ('fr_FR', 'French / Français')], langs,
             "Test did not started with expected languages")
 
         po_string = '''
@@ -713,7 +713,7 @@ class TestTranslationWrite(TransactionCase):
         self.env['res.lang']._activate_lang('fr_FR')
 
         langs = self.env['res.lang'].get_installed()
-        self.assertEqual([('en_US', 'English (US)'), ('fr_FR', 'French / Français')], langs,
+        self.assertEqual([('en_US', 'English'), ('fr_FR', 'French / Français')], langs,
             "Test did not started with expected languages")
 
         belgium = self.env.ref('base.be')
@@ -766,7 +766,7 @@ class TestTranslationWrite(TransactionCase):
         self.env['res.lang']._activate_lang('nl_NL')
 
         langs = self.env['res.lang'].get_installed()
-        self.assertEqual([('nl_NL', 'Dutch / Nederlands'), ('en_US', 'English (US)'), ('fr_FR', 'French / Français')], langs,
+        self.assertEqual([('nl_NL', 'Dutch / Nederlands'), ('en_US', 'English'), ('fr_FR', 'French / Français')], langs,
                          "Test did not started with expected languages")
 
         belgium = self.env.ref('base.be')
@@ -797,7 +797,7 @@ class TestTranslationWrite(TransactionCase):
     def _test_create_empty(self, empty_value):
         self.env['res.lang']._activate_lang('fr_FR')
         langs = self.env['res.lang'].get_installed()
-        self.assertEqual([('en_US', 'English (US)'), ('fr_FR', 'French / Français')], langs,
+        self.assertEqual([('en_US', 'English'), ('fr_FR', 'French / Français')], langs,
                          "Test did not started with expected languages")
 
         group = self.env['res.groups'].create({'name': 'test_group', 'comment': empty_value})

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -235,8 +235,7 @@
                             <field name="website" string="Website" widget="url" placeholder="e.g. https://www.odoo.com"/>
                             <field name="title" options='{"no_open": True}' placeholder="e.g. Mister"
                                 invisible="is_company"/>
-                            <field name="active_lang_count" invisible="1"/>
-                            <field name="lang" invisible="active_lang_count &lt;= 1"/>
+                            <field name="lang"/>
                             <field name="category_id" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"
                                    placeholder='e.g. "B2B", "VIP", "Consulting", ...'/>
                         </group>

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -694,6 +694,8 @@ class Environment(Mapping):
         """
         lang = self.context.get('lang')
         if lang and lang != 'en_US' and not self['res.lang']._get_data(code=lang):
+            if not self['res.lang']._get_all_data(code=lang):
+                raise UserError(_('Invalid language code: %s', lang))
             # Fallback on the first lang active or en_US
             lang = get_lang(self, lang_code=lang).get('code', 'en_US')
         return lang or None

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -31,6 +31,7 @@ except ImportError:
 
 from .exceptions import AccessError, UserError, CacheMiss
 from .tools import clean_context, frozendict, lazy_property, OrderedSet, Query, SQL, StackMap
+from .tools.misc import get_lang
 from .tools.translate import _
 
 if TYPE_CHECKING:
@@ -693,7 +694,8 @@ class Environment(Mapping):
         """
         lang = self.context.get('lang')
         if lang and lang != 'en_US' and not self['res.lang']._get_data(code=lang):
-            raise UserError(_('Invalid language code: %s', lang))
+            # Fallback on the first lang active or en_US
+            lang = get_lang(self, lang_code=lang).get('code', 'en_US')
         return lang or None
 
     @lazy_property


### PR DESCRIPTION
- Before only languages installed (aka active) are displayed to the
user. This prevents the selection of a language that does not
require translations. For example, you could specify the language
of a contact without needing the translation/multi-lang feature.

Now we have a way to display languages installed and the default
languages. The default languages refer to all languages with
an iso code of 2 letters (en, fr, es, ...)

- Replace selection field by many2one (wip)


task-2839020
