### PR TITLE
[FIX] knowledge: do not set member permission as none when removing self member

### DIFF
--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -985,8 +985,6 @@ class Article(models.Model):
             share_partner_ids = partners.filtered(lambda partner: partner.partner_share)
             self._add_members(share_partner_ids, 'read')
             self._add_members(partners - share_partner_ids, permission)
-
-        if permission != 'none':
             self._send_invite_mail(partners)
 
         return True
@@ -1061,18 +1059,8 @@ class Article(models.Model):
 
         # belongs to current article members
         current_membership = self.article_member_ids.filtered(lambda m: m == member)
-
-        current_user_partner = self.env.user.partner_id
-        remove_self = member.partner_id == current_user_partner
-        # If remove self member, set member permission to 'none' (= leave article) to hide the article for the user.
-        if remove_self:
-            if current_membership:
-                members_command = [(1, current_membership.id, {'permission': 'none'})]
-            else:
-                members_command = [(0, 0, {'partner_id': current_user_partner.id, 'permission': 'none'})]
-            self.sudo().write({'article_member_ids': members_command})
         # member to remove is on the article itself. Simply remove the member.
-        elif current_membership:
+        if current_membership:
             if not self.env.su and not self.user_has_write_access:
                 raise AccessError(
                     _("You cannot remove the member %(member_name)s from article %(article_name)s",

--- a/addons/knowledge/static/src/components/permission_panel/permission_panel.xml
+++ b/addons/knowledge/static/src/components/permission_panel/permission_panel.xml
@@ -55,7 +55,7 @@
                     <div class="flex-shrink-0">
                         <div class="input-group">
                             <div t-if="!(member.based_on &amp;&amp; member.permission === 'none') &amp;&amp; !member.is_unique_writer
-                                        &amp;&amp; (state.user_is_admin || props.user_permission === 'write' || state.partner_id === member.partner_id)"
+                                        &amp;&amp; (state.user_is_admin || props.user_permission === 'write')"
                                  class="d-flex align-items-center mr-2">
                                 <i class="fa fa-w fa-times o_delete text-danger" title="Remove Member"
                                    t-on-click="event => this._onRemoveMember(event, member)" type="button">

--- a/addons/knowledge/tests/test_knowledge_article_permissions.py
+++ b/addons/knowledge/tests/test_knowledge_article_permissions.py
@@ -417,10 +417,23 @@ class TestKnowledgeArticlePermissionsTools(KnowledgeArticlePermissionsCase):
 
         # cannot gain privilege: setting none if I remove myself to ensure no gain is performed
         my_member = readonly.article_member_ids.filtered(lambda m: m.partner_id == self.env.user.partner_id)
+        with self.assertRaises(exceptions.AccessError,
+                               msg='Permission: do not allow to remove self members when having only read access'):
+            readonly._remove_member(my_member)
+        self.assertMembers(readonly, 'write',
+                           {self.env.user.partner_id: 'read',
+                            self.partner_portal: 'read'})
+
+        # can remove self member if write access
+        my_member.sudo().permission = 'write'
+        self.assertMembers(readonly, 'write',
+                           {self.env.user.partner_id: 'write',
+                            self.partner_portal: 'read'})
         readonly._remove_member(my_member)
         self.assertMembers(readonly, 'write',
-                           {self.env.user.partner_id: 'none',
-                            self.partner_portal: 'read'})
+                           {self.partner_portal: 'read'})
+
+        # more tests on _remove_member: see test_article_remove_member in test_knowledge_article_business.py
 
 
 @tagged('knowledge_acl')


### PR DESCRIPTION
Purpose
=======

Avoid creating a "None" member when someone leaves an article as:
- This is mostly noise
- It could potentially trigger an unsync on the article
- It will exclude you from working on the article FOREVER
- People could try to delete this newly created member too

Specifications
============

When a member is removed, do not create a new member with right "None",
just remove it
=> Read member should not be able to leave an article
(to avoid an escalation by then enjoying the internal rights)

Task-2896684