### PR TITLE
[REM] web: `o_kanban_counter_label` dead code removal

### DIFF
--- a/addons/web/static/src/legacy/scss/kanban_column_progressbar.scss
+++ b/addons/web/static/src/legacy/scss/kanban_column_progressbar.scss
@@ -73,11 +73,6 @@
             box-shadow: none;
             cursor: pointer;
         }
-
-        .o_kanban_counter_label {
-            font-size: 10px;
-            user-select: none;
-        }
     }
 
     > .o_kanban_counter_side {

--- a/addons/web/static/src/views/kanban/kanban_column_progressbar.scss
+++ b/addons/web/static/src/views/kanban/kanban_column_progressbar.scss
@@ -73,11 +73,6 @@
             box-shadow: none;
             cursor: pointer;
         }
-
-        .o_kanban_counter_label {
-            font-size: 10px;
-            user-select: none;
-        }
     }
 
     > .o_kanban_counter_side {


### PR DESCRIPTION
[REM] web: `o_kanban_counter_label` dead code removal

This commit removes the css class `.o_kanban_counter_label` which is no 
longer being used in Odoo.

The class above is supposed to add styles to text labels inside progress
bars in kanban view mode. However, this feature is no longer used, since
contextual information is already given either by tooltips 
(`progress-bar o_bar_has_records`) or by text on a side 
(`o_kanban_counter_side`).

Task-2898427

--

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
