### PR TITLE
[FIX] hr_recruitment: don't send chatter to Recruitment Interviewers

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -424,12 +424,12 @@ class Applicant(models.Model):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
         return super().fields_view_get(view_id, view_type, toolbar, submenu)
 
-    def _notify_compute_recipients(self, message, msg_vals):
+    def _notify_get_recipients(self, message, msg_vals):
         """
             Do not notify members of the Recruitment Interviewer group, as this
             might leak some data they shouldn't have access to.
         """
-        recipients = super()._notify_compute_recipients(message, msg_vals)
+        recipients = super()._notify_get_recipients(message, msg_vals)
         interviewer_group = self.env.ref('hr_recruitment.group_hr_recruitment_interviewer').id
         return [recipient for recipient in recipients if interviewer_group not in recipient['groups']]
 

--- a/addons/hr_recruitment/tests/test_recruitment_interviewer.py
+++ b/addons/hr_recruitment/tests/test_recruitment_interviewer.py
@@ -114,6 +114,8 @@ class TestRecruitmentInterviewer(MailCommon):
             'interviewer_id': self.interviewer_user.id,
         })
 
+        applicant.message_subscribe(partner_ids=[self.interviewer_user.partner_id.id])
+
         with self.mock_mail_gateway():
             message = applicant.message_post(body='A super secret message', message_type='comment', subtype_xmlid='mail.mt_comment')
 
@@ -121,7 +123,7 @@ class TestRecruitmentInterviewer(MailCommon):
             message.with_user(self.interviewer_user).read()
 
         try:
-            self._find_mail_mail_wpartners(self.interviewer_user.partner_id, False)
+            self._find_mail_mail_wpartners(self.interviewer_user.partner_id, None)
         except AssertionError:
             pass
         else:


### PR DESCRIPTION
1f7c83cc3e97c7c81 renamed _notify_compute_recipients to
_notify_get_recipients. This function was not renamed with it so
members of the hr_recruitment.group_hr_recruitment_interviewer group
were receiving chatter they shouldn't be receiving.

The test didn't catch this because:

- the interviewer was not subscribed and thus never received email,
- MockEmail._filter_mail got passed status=False instead of None,
  which always made it return an empty mail.mail recordset.

opw-2898730