### PR TITLE
[FIX] hr_expense: bank account permission

### DIFF
--- a/addons/hr_expense/wizard/account_payment_register.py
+++ b/addons/hr_expense/wizard/account_payment_register.py
@@ -14,7 +14,7 @@ class AccountPaymentRegister(models.TransientModel):
     def _get_line_batch_key(self, line):
         # OVERRIDE to set the bank account defined on the employee
         res = super()._get_line_batch_key(line)
-        expense_sheet = self.env['hr.expense.sheet'].search([('payment_mode', '=', 'own_account'), ('account_move_id', 'in', line.move_id.ids)])
+        expense_sheet = self.env['hr.expense.sheet'].search([('payment_mode', '=', 'own_account'), ('account_move_id', 'in', line.move_id.ids)]).sudo()
         if expense_sheet and not line.move_id.partner_bank_id:
             res['partner_bank_id'] = expense_sheet.employee_id.bank_account_id.id or line.partner_id.bank_ids and line.partner_id.bank_ids.ids[0]
         return res


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Accountant can't register payment on expense. if employee has data bank account in partner.
Accountant not necessary has permission employee/officer

Step to error:
1. Create new user with accountant (no Employee)
![Selection_002](https://user-images.githubusercontent.com/20896369/176587640-06bb650c-e956-49e2-a2a3-55133850784e.png)
2. Add bank account in partner
![Selection_003](https://user-images.githubusercontent.com/20896369/176587703-69e8ee56-befd-4fff-8251-b33a6eff1692.png)
3. Create expense and normal process, until register payment. it will throw error permission
![Selection_001](https://user-images.githubusercontent.com/20896369/176587789-cab434a7-a8ee-4e4c-852a-60719eb5094a.png)

**Desired behavior after PR is merged:**

Accountant can register payment with not need Employee permission


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
