### PR TITLE
[FIX] hr_timesheet: specify alias name for column progress

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -14,7 +14,7 @@ class ReportProjectTaskUser(models.Model):
 
     def _select(self):
         return super(ReportProjectTaskUser, self)._select() + """,
-            progress as progress,
+            t.progress as progress,
             t.effective_hours as hours_effective,
             t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
             planned_hours as hours_planned"""
@@ -23,6 +23,6 @@ class ReportProjectTaskUser(models.Model):
         return super(ReportProjectTaskUser, self)._group_by() + """,
             remaining_hours,
             t.effective_hours,
-            progress,
+            t.progress,
             planned_hours
             """


### PR DESCRIPTION
Alias 't' is ignored when column 'progress' is used. Error occurs in enterprice version when two tables: project_task and project_project are joined (they both have column progress).
https://github.com/odoo/enterprise/blob/4629bba1db2eee7c1d25c4334454763a1116ab22/industry_fsm/report/project_report.py#L18

Impacted versions:
 - error occurs in v14, but I suspect that v13 should also be affected.

Steps to reproduce:
 1. add alias name to colum progress: 'progress' changes to 't.progress'

Current behaviour:
Gives error during upgrade:
```
            CREATE view report_project_task_user_fsm as

             SELECT
                    (select 1 ) AS nbr,
                    t.id as id,
                    t.date_assign as date_assign,
                    t.date_end as date_end,
                    t.date_last_stage_update as date_last_stage_update,
                    t.date_deadline as date_deadline,
                    t.user_id,
                    t.project_id,
                    t.priority,
                    t.name as name,
                    t.company_id,
                    t.partner_id,
                    t.stage_id as stage_id,
                    t.kanban_state as state,
                    t.working_days_close as working_days_close,
                    t.working_days_open  as working_days_open,
                    (extract('epoch' from (t.date_deadline-(now() at time zone 'UTC'))))/(3600*24)  as delay_endings_days
        ,
            progress as progress,
            t.effective_hours as hours_effective,
            t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
            planned_hours as hours_planned,
            t.planned_date_begin as planned_date_begin,
            t.planned_date_end as planned_date_end

            FROM project_task t
            INNER JOIN project_project p ON t.project_id = p.id AND p.is_fsm = 't'
            WHERE t.active = 'true'

                GROUP BY
                    t.id,
                    t.create_date,
                    t.write_date,
                    t.date_assign,
                    t.date_end,
                    t.date_deadline,
                    t.date_last_stage_update,
                    t.user_id,
                    t.project_id,
                    t.priority,
                    t.name,
                    t.company_id,
                    t.partner_id,
                    t.stage_id
        ,
            remaining_hours,
            t.effective_hours,
            progress,
            planned_hours
            ,
            planned_date_begin,
            planned_date_end

ERROR: column reference "progress" is ambiguous
LINE 23:             progress as progress,
                     ^

2022-06-23 09:05:22,698 29 WARNING db_359432 odoo.modules.loading: Transient module states were reset
2022-06-23 09:05:22,698 29 ERROR db_359432 odoo.modules.registry: Failed to load registry
2022-06-23 09:05:22,698 29 CRITICAL db_359432 odoo.service.server: Failed to initialize database `db_359432`.
Traceback (most recent call last):
  File "/home/odoo/src/odoo/14.0/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 457, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 349, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 199, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/src/odoo/14.0/odoo/modules/registry.py", line 406, in init_models
    model.init()
  File "/home/odoo/src/enterprise/14.0/industry_fsm/report/project_report.py", line 21, in init
    """ % (self._table, self._select(), self._group_by()))
  File "<decorator-gen-3>", line 2, in execute
  File "/home/odoo/src/odoo/14.0/odoo/sql_db.py", line 101, in check
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/14.0/odoo/sql_db.py", line 298, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.AmbiguousColumn: column reference "progress" is ambiguous
LINE 23:             progress as progress,
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
