### PR TITLE
[IMP] payment: Standardize validation transaction reference

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -206,7 +206,7 @@ class PaymentPortal(portal.CustomerPortal):
         rendering_context = {
             'acquirers': acquirers_sudo,
             'tokens': tokens_sudo,
-            'reference_prefix': payment_utils.singularize_reference_prefix(prefix='validation'),
+            'reference_prefix': payment_utils.singularize_reference_prefix(prefix='V'),
             'partner_id': partner_sudo.id,
             'access_token': access_token,
             'transaction_route': '/payment/transaction',

--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -158,7 +158,7 @@ class TestFlows(PaymentHttpCommon):
     @freeze_time("2011-11-02 12:00:21")
     def _test_validation(self, flow):
         # Fixed with freezegun
-        expected_reference = 'validation-20111102120021'
+        expected_reference = 'V-20111102120021'
 
         validation_amount = self.acquirer._get_validation_amount()
         validation_currency = self.acquirer._get_validation_currency()


### PR DESCRIPTION
Before this commit, the reference of a validation transaction followed
this format: “validation-20220222072710”, which did not match the
standard format for refund transactions (”R-S000001”). Moreover, some
providers limit the length of transaction references which forced us to
truncate the quite long reference.

With this commit, future validation transactions will have a reference of
the format: “V-20220222072710”.

See also:
- Enterprise PR: https://github.com/odoo/enterprise/pull/29076

task-2830826