### PR TITLE
[IMP] mail, auth_totp: notify user about important security modi…

### DIFF
--- a/addons/auth_totp_mail/__manifest__.py
+++ b/addons/auth_totp_mail/__manifest__.py
@@ -14,6 +14,7 @@ by sending an email to the target user. This email redirect them to :
     'data': [
         'data/ir_action_data.xml',
         'data/mail_template_data.xml',
+        'data/security_notifications_template.xml',
         'views/res_users_views.xml',
     ],
     'assets': {

--- a/addons/auth_totp_mail/data/security_notifications_template.xml
+++ b/addons/auth_totp_mail/data/security_notifications_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Extend the security update template to include 2fa suggestion -->
+        <template id="account_security_setting_update" inherit_id="mail.account_security_setting_update">
+            <xpath expr="//ul[hasclass('o_mail_account_security_suggestions')]/li[1]" position="after">
+                <li t-if="suggest_2fa">
+                    <span>Consider</span>
+                    <a href="https://www.odoo.com/documentation/master/applications/general/auth/2fa.html">
+                        activating Two-factor Authentication
+                    </a>
+                </li>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/auth_totp_mail/models/__init__.py
+++ b/addons/auth_totp_mail/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import auth_totp_device
 from . import res_users

--- a/addons/auth_totp_mail/models/auth_totp_device.py
+++ b/addons/auth_totp_mail/models/auth_totp_device.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, models
+from collections import defaultdict
+
+
+class AuthTotpDevice(models.Model):
+    _inherit = "auth_totp.device"
+
+    def unlink(self):
+        """ Notify users when trusted devices are removed from their account. """
+        removed_devices_by_user = self._classify_by_user()
+        for user, removed_devices in removed_devices_by_user.items():
+            user._notify_security_setting_update(
+                _("Security Update: Device Removed"),
+                _(
+                    "A trusted device has just been removed from your account: %(device_names)s",
+                    device_names=', '.join([device.name for device in removed_devices])
+                ),
+            )
+
+        return super().unlink()
+
+    def _generate(self, scope, name):
+        """ Notify users when trusted devices are added onto their account.
+        We override this method instead of 'create' as those records are inserted directly into the
+        database using raw SQL. """
+
+        res = super()._generate(scope, name)
+
+        self.env.user._notify_security_setting_update(
+            _("Security Update: Device Added"),
+            _(
+                "A trusted device has just been added to your account: %(device_name)s",
+                device_name=name
+            ),
+        )
+
+        return res
+
+    def _classify_by_user(self):
+        devices_by_user = defaultdict(lambda: self.env['auth_totp.device'])
+        for device in self:
+            devices_by_user[device.user_id] |= device
+
+        return devices_by_user

--- a/addons/auth_totp_mail/tests/__init__.py
+++ b/addons/auth_totp_mail/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_notify_security_update_totp
 from . import test_totp

--- a/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
+++ b/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.test_notify_security_update import TestNotifySecurityUpdate
+from odoo.tests import users
+
+
+class TestNotifySecurityUpdateTotp(TestNotifySecurityUpdate):
+    @users('employee')
+    def test_security_update_totp_enabled_disabled(self):
+        recipients = [self.env.user.email_formatted]
+        with self.mock_mail_gateway():
+            self.env.user.write({'totp_secret': 'test'})
+
+        self.assertMailMailWEmails(recipients, 'outgoing', fields_values={
+            'subject': 'Security Update: 2FA Activated',
+        })
+
+        with self.mock_mail_gateway():
+            self.env.user.write({'totp_secret': False})
+
+        self.assertMailMailWEmails(recipients, 'outgoing', fields_values={
+            'subject': 'Security Update: 2FA Deactivated',
+        })
+
+    @users('employee')
+    def test_security_update_trusted_device_added_removed(self):
+        """ Make sure we notify the user when TOTP trusted devices are added/removed on his account. """
+        recipients = [self.env.user.email_formatted]
+        with self.mock_mail_gateway():
+            self.env['auth_totp.device']._generate('trusted_device_chrome', 'Chrome on Windows')
+
+        self.assertMailMailWEmails(recipients, 'outgoing', fields_values={
+            'subject': 'Security Update: Device Added',
+        })
+
+        # generating a key outside of the 'auth_totp.device' model should however not notify
+        with self.mock_mail_gateway():
+            self.env['res.users.apikeys']._generate('new_api_key', 'New Key')
+        self.assertNotSentEmail(recipients)
+
+        # now remove the key using the user's relationship
+        with self.mock_mail_gateway():
+            self.env['auth_totp.device'].flush_model()
+            self.env.user.write({'totp_trusted_device_ids': [(5, 0)]})
+
+        self.assertMailMailWEmails(recipients, 'outgoing', fields_values={
+            'subject': 'Security Update: Device Removed',
+        })

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -91,6 +91,7 @@ For more specific needs, you may also assign custom-defined actions
         'data/mail_templates_mailgateway.xml',
         'data/mail_channel_data.xml',
         'data/mail_activity_data.xml',
+        'data/security_notifications_templates.xml',
         'data/ir_cron_data.xml',
         'security/mail_security.xml',
         'security/ir.model.access.csv',

--- a/addons/mail/data/security_notifications_templates.xml
+++ b/addons/mail/data/security_notifications_templates.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Template for security update notification (password/login/mail changed, ...) -->
+        <template id="account_security_setting_update">
+<p>
+    <span>Dear <t t-out="user.name"/>,</span>
+</p>
+<p>
+    <span t-out="security_update_text"/>
+    <span>(<t
+        t-out="update_datetime"
+        t-options='{"widget": "datetime", "hide_seconds": True}'/>).</span>
+</p>
+<p>
+    <span>If this was done by you:</span><br/>
+    <ul>
+        <li>You can safely ignore this message</li>
+    </ul>
+</p>
+<p>
+    <span>If this was not done by you:</span>
+</p>
+<ul class="o_mail_account_security_suggestions">
+    <li t-if="suggest_password_reset">
+        <span>We suggest you start by</span>
+        <a t-att-href="password_reset_url">
+            Resetting Your Password
+        </a>
+    </li>
+    <li>
+        Contact your administrator
+    </li>
+</ul>
+        </template>
+    </data>
+</odoo>

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -10,6 +10,7 @@ from . import test_mail_full_composer
 from . import test_mail_render
 from . import test_mail_template
 from . import test_mail_tools
+from . import test_notify_security_update
 from . import test_res_partner
 from . import test_res_users
 from . import test_res_users_settings

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -18,6 +18,7 @@ from odoo.addons.bus.models.bus import ImBus, json_dump
 from odoo.addons.mail.models.mail_mail import MailMail
 from odoo.addons.mail.models.mail_message import Message
 from odoo.addons.mail.models.mail_notification import MailNotification
+from odoo.addons.mail.models.res_users import Users
 from odoo.tests import common, new_test_user
 from odoo.tools import formataddr, mute_logger, pycompat
 from odoo.tools.translate import code_translations
@@ -1028,11 +1029,13 @@ class MailCommon(common.TransactionCase, MailCase):
         cls._init_outgoing_gateway()
         # ensure admin configuration
         cls.user_admin = cls.env.ref('base.user_admin')
-        cls.user_admin.write({
-            'country_id': cls.env.ref('base.be').id,
-            'email': 'test.admin@test.example.com',
-            'notification_type': 'inbox',
-        })
+
+        with patch.object(Users, '_notify_security_setting_update', side_effect=lambda *args, **kwargs: None):
+            cls.user_admin.write({
+                'country_id': cls.env.ref('base.be').id,
+                'email': 'test.admin@test.example.com',
+                'notification_type': 'inbox',
+            })
         cls.partner_admin = cls.env.ref('base.partner_admin')
         cls.company_admin = cls.user_admin.company_id
         cls.company_admin.write({'email': 'company@example.com'})

--- a/addons/mail/tests/test_notify_security_update.py
+++ b/addons/mail/tests/test_notify_security_update.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests import users
+
+
+class TestNotifySecurityUpdate(MailCommon):
+
+    @users('employee')
+    def test_security_update_email(self):
+        """ User should be notified on old email address when the email changes """
+        with self.mock_mail_gateway():
+            self.env.user.write({'email': 'new@example.com'})
+
+        self.assertMailMailWEmails(['e.e@example.com'], 'outgoing', fields_values={
+            'subject': 'Security Update: Email Changed',
+        })
+
+    @users('employee')
+    def test_security_update_login(self):
+        with self.mock_mail_gateway():
+            self.env.user.write({'login': 'newlogin'})
+
+        self.assertMailMailWEmails([self.env.user.email_formatted], 'outgoing', fields_values={
+            'subject': 'Security Update: Login Changed',
+        })
+
+    @users('employee')
+    def test_security_update_password(self):
+        with self.mock_mail_gateway():
+            self.env.user.write({'password': 'newpassword'})
+
+        self.assertMailMailWEmails([self.env.user.email_formatted], 'outgoing', fields_values={
+            'subject': 'Security Update: Password Changed',
+        })


### PR DESCRIPTION
…fications

This commit aims to notify the user (currently through an email) that some
important security parameter of his account has changed.

Here is a list of what is currently notified:
- password change
- login change
- email change
- 2FA enabled/disabled
- trusted device (for 2FA) added/removed

This email is rather simple and only invites the end-user to take actions if
that change was not done by him (reset password, contact administrator, ...).

Task-2639168
