### PR TITLE
[FIX] website, web_tour: fix edit_megamenu/edit_menus inconsistent tours

### DIFF
--- a/addons/web_tour/static/src/js/tour_manager.js
+++ b/addons/web_tour/static/src/js/tour_manager.js
@@ -238,8 +238,6 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
     update: function (tour_name) {
         if (this.paused) return;
 
-        this.$modal_displayed = $('.modal:visible').last();
-
         tour_name = this.running_tour || tour_name;
         if (tour_name) {
             var tour = this.tours[tour_name];
@@ -280,6 +278,7 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
             this._log.push("blockUI is preventing the tip to be consumed");
             return false;
         }
+        this.$modal_displayed = $('.modal:visible').last();
 
         var $trigger;
         if (tip.in_modal !== false && this.$modal_displayed.length) {

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -251,7 +251,7 @@ function getClientActionUrl(path, edition) {
 function clickOnExtraMenuItem(stepOptions, backend = false) {
     return Object.assign({}, {
         content: "Click on the extra menu dropdown toggle if it is there",
-        trigger: `${backend ? "iframe" : ""} #top_menu:not(.o_loading)`,
+        trigger: `${backend ? "iframe" : ""} #top_menu`,
         run: function () {
             const extraMenuButton = this.$anchor[0].querySelector('.o_extra_menu_items a.nav-link');
             if (extraMenuButton) {

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -41,14 +41,13 @@ wTourUtils.registerEditionTour('edit_megamenu', {
         run: 'text Megaaaaa!'
     },
     {
-        content: "Save the new menu item",
-        trigger: '.o_website_dialog .btn-primary',
-        run: 'click',
+        content: "Confirm the mega menu label",
+        trigger: '.modal-footer .btn-primary',
     },
     {
-        content: "Save the changes to the menu",
+        content: "Save the website menu with a new mega menu",
         trigger: '.modal-footer .btn-primary',
-        run: 'click',
+        extra_trigger: '.oe_menu_editor [data-is-mega-menu="true"] .js_menu_label:contains("Megaaaaa!")',
     },
     // Edit a menu item
     wTourUtils.clickOnExtraMenuItem({extra_trigger: '#oe_snippets.o_loaded'}, true),

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -2,11 +2,6 @@
 
 import wTourUtils from 'website.tour_utils';
 
-const clickOnSave = {
-   content: "Clicks on the menu edition dialog save button",
-   trigger: '.modal-dialog .btn-primary:contains("Ok"), .modal-dialog .btn-primary:contains("Save")',
-};
-
 wTourUtils.registerEditionTour('edit_menus', {
     test: true,
     url: '/',
@@ -31,8 +26,15 @@ wTourUtils.registerEditionTour('edit_menus', {
         trigger: '.modal-dialog .o_website_dialog input',
         run: 'text Megaaaaa!'
     },
-    clickOnSave,
-    Object.assign({}, clickOnSave, {extra_trigger: '.o_dialog_container:not(:has(.o_inactive_modal))'}),
+    {
+        content: "Confirm the mega menu label",
+        trigger: '.modal-footer .btn-primary',
+    },
+    {
+        content: "Save the new menu",
+        trigger: '.modal-footer .btn-primary',
+        extra_trigger: '.oe_menu_editor [data-is-mega-menu="true"] .js_menu_label:contains("Megaaaaa!")',
+    },
     wTourUtils.clickOnExtraMenuItem({extra_trigger: 'body:not(:has(.oe_menu_editor))'}, true),
     {
         content: "There should be a new megamenu item.",
@@ -55,21 +57,34 @@ wTourUtils.registerEditionTour('edit_menus', {
         extra_trigger: '.o_website_dialog:visible',
         trigger: '.modal-body a:eq(0)',
     },
-    clickOnSave,
+    {
+        content: "Confirm the new menu entry without a label",
+        trigger: '.modal-footer .btn-primary',
+    },
     {
         content: "It didn't save without a label. Fill label input.",
         extra_trigger: '.o_website_dialog:eq(1):visible',
         trigger: '.modal-dialog .o_website_dialog input:eq(0)',
         run: 'text Random!',
     },
-    clickOnSave,
+    {
+        content: "Confirm the new menu entry without a url",
+        trigger: '.modal-footer .btn-primary',
+    },
     {
         content: "It didn't save without a url. Fill url input.",
         trigger: '.modal-dialog .o_website_dialog input:eq(1)',
         run: 'text #',
     },
-    clickOnSave,
-    Object.assign({}, clickOnSave, {extra_trigger: '.o_dialog_container:not(:has(.o_inactive_modal))'}),
+    {
+        content: "Confirm the new menu entry",
+        trigger: '.modal-footer .btn-primary',
+    },
+    {
+        content: "Save the website menu with the new entry",
+        trigger: '.modal-footer .btn-primary',
+        extra_trigger: '.oe_menu_editor .js_menu_label:contains("Random!")',
+    },
     // Edit the new menu item from the "edit link" popover button
     wTourUtils.clickOnExtraMenuItem({extra_trigger: '#oe_snippets.o_loaded'}, true),
     {
@@ -85,7 +100,10 @@ wTourUtils.registerEditionTour('edit_menus', {
         trigger: '.modal-dialog .o_website_dialog input:eq(0)',
         run: 'text Modnar',
     },
-    clickOnSave,
+    {
+        content: "Confirm the new label",
+        trigger: '.modal-footer .btn-primary',
+    },
     ...wTourUtils.clickOnSave(),
     wTourUtils.clickOnExtraMenuItem({extra_trigger: 'iframe body:not(.editor_enable)'}, true),
     {
@@ -118,8 +136,15 @@ wTourUtils.registerEditionTour('edit_menus', {
         trigger: '.modal-dialog .o_website_dialog input:eq(0)',
         run: 'text Modnar !!',
     },
-    clickOnSave,
-    Object.assign({}, clickOnSave, {extra_trigger: '.o_dialog_container:not(:has(.o_inactive_modal))'}),
+    {
+        content: "Confirm the new menu label",
+        trigger: '.modal-footer .btn-primary',
+    },
+    {
+        content: "Save the website menu with the new menu label",
+        trigger: '.modal-footer .btn-primary',
+        extra_trigger: '.oe_menu_editor .js_menu_label:contains("Modnar !!")',
+    },
     ...wTourUtils.clickOnSave(),
     wTourUtils.clickOnExtraMenuItem({extra_trigger: 'iframe body:not(.editor_enable)'}, true),
     {
@@ -147,7 +172,10 @@ wTourUtils.registerEditionTour('edit_menus', {
         trigger: '.oe_menu_editor li:contains("Home") ul li:contains("Contact us")',
         run: () => {}, // It's a check.
     },
-    clickOnSave,
+    {
+        content: "Save the website menu with new nested menus",
+        trigger: '.modal-footer .btn-primary',
+    },
     {
         content: "Menu item should have a child",
         trigger: 'iframe #top_menu .nav-item a.dropdown-toggle:contains("Home")',


### PR DESCRIPTION
This commit fixes an inconsistent behaviour in tours using the website's
"Edit Menu" dialogs.
When adding a mega menu, two dialogs are displayed:
- The main "Edit Menu" dialog, from which you can open
- The "Menu" dialog with the mega menu label input

When these two dialogs were opened, and closed successively (click on
"Ok" to confirm the menu label, then click on "Save" to save the new
website menu), the tour was sometimes triggering the primary button of
the wrong dialog.

Two issues were leading to this inconsistent behaviour:
1/ Sometimes, the tour would click twice on the same primary button,
and would not wait for the current dialog to close.
To prevent that, extra_triggers are added to the steps to check that the
first click was correctly taken into account (and so, that the upper
dialog, that was the active dialog, was closed).

2/ Other times, the tour would click on the wrong dialog primary button
(it would click on the inactive dialog's button that would save the menu
without validating the label first).
This was coming from the web_tour.TourManager inaccurate
$modal_displayed property, which was defined and used in two different
javascript threads of execution. It could reference modals that were
not the actual modals from the DOM, when used in _check_for_tooltip.
To prevent that, that property is set inside the method it is used in.
It could be defined as a const and not a property, but this way the
commit history is left untouched.

runbot-4000
runbot-4001
runbot-4004
runbot-4005


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
