### PR TITLE
[FIX] web: Remove CSS comment parsed as rule

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -190,7 +190,7 @@
         <t t-call-assets="web.tests_assets" t-js="False"/>
         <style>
             body {
-                position: relative; // bootstrap-datepicker needs this
+                position: relative; /* bootstrap-datepicker needs this */
             }
             body:not(.debug) .modal-backdrop, body:not(.debug) .modal, body:not(.debug) .ui-autocomplete {
                 opacity: 0 !important;


### PR DESCRIPTION
A CSS comment in webclient_templates was written as a JS comment and
appeared as an invalid CSS rule in the devtools. This commit converts
that comment to use the proper syntax.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
