### PR TITLE
[FIX] website: fix page properties auto save

### DIFF
--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -115,6 +115,7 @@ FormViewDialog.props = {
     preventCreate: { type: Boolean, optional: true },
     preventEdit: { type: Boolean, optional: true },
     isToMany: { type: Boolean, optional: true },
+    size: { type: String, optional: true },
 };
 FormViewDialog.defaultProps = {
     onRecordSaved: () => {},

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.FormViewDialog" owl="1">
-    <Dialog title="props.title" contentClass="'o_form_view_dialog'" modalRef="modalRef" t-if="!state.error">
+    <Dialog size="props.size" title="props.title" contentClass="'o_form_view_dialog'" modalRef="modalRef" t-if="!state.error">
       <View t-props="viewProps"/>
       <t t-set-slot="footer">
         <t t-if="props.preventEdit and props.preventCreate">

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -4,7 +4,6 @@ import { registry } from '@web/core/registry';
 import { useService } from '@web/core/utils/hooks';
 import core from 'web.core';
 import { AceEditorAdapterComponent } from '../../components/ace_editor/ace_editor';
-import { PagePropertiesDialogWrapper } from '../../components/dialog/page_properties';
 import { WebsiteEditorComponent } from '../../components/editor/editor';
 import { WebsiteTranslator } from '../../components/translator/translator';
 import {OptimizeSEODialog} from '@website/components/dialog/seo';
@@ -293,7 +292,6 @@ WebsitePreview.components = {
     BlockIframe,
     WebsiteTranslator,
     AceEditorAdapterComponent,
-    PagePropertiesDialogWrapper,
 };
 
 registry.category('actions').add('website_preview', WebsitePreview);

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -33,7 +33,6 @@
             reloadIframe.bind="this.reloadIframe"
             removeWelcomeMessage.bind="this.removeWelcomeMessage"/>
         <AceEditorAdapterComponent t-if="websiteContext.showAceEditor"/>
-        <PagePropertiesDialogWrapper t-if="websiteContext.showPageProperties"/>
     </div>
 </t>
 

--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -162,6 +162,7 @@ DuplicatePageDialog.props = {
 export const pagePropertiesProps = {
     title: _t('Page Properties'),
     resModel: 'website.page',
+    size: 'md',
     context: {
         form_view_ref: 'website.website_page_properties_view_form',
     },

--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -4,11 +4,10 @@ import {CheckBox} from '@web/core/checkbox/checkbox';
 import {useService, useAutofocus} from "@web/core/utils/hooks";
 import {useWowlService} from '@web/legacy/utils';
 import {WebsiteDialog} from './dialog';
-import {FormViewDialog} from 'web.view_dialogs';
-import {standaloneAdapter} from 'web.OwlCompatibility';
-import {qweb} from 'web.core';
+import {FormViewDialog} from "@web/views/view_dialogs/form_view_dialog";
+import {qweb, _t} from 'web.core';
 
-const {Component, onWillStart, useState, xml, useRef, markup, onRendered} = owl;
+const {Component, onWillStart, onMounted, onWillUnmount, onRendered, useState, xml, useRef, markup} = owl;
 
 export class PageDependencies extends Component {
     setup() {
@@ -101,9 +100,9 @@ export class DeletePageDialog extends Component {
         await this.orm.unlink("website.page", [
             this.props.pageId,
         ]);
-        this.website.goToWebsite();
+        this.website.goToWebsite({path: '/'});
         this.props.close();
-        this.props.onClose();
+        this.props.onDelete();
     }
 }
 DeletePageDialog.components = {
@@ -113,8 +112,8 @@ DeletePageDialog.components = {
 };
 DeletePageDialog.template = 'website.DeletePageDialog';
 DeletePageDialog.props = {
+    onDelete: {type: Function, optional: true},
     pageId: Number,
-    onClose: Function,
     close: Function,
 };
 
@@ -138,7 +137,7 @@ export class DuplicatePageDialog extends Component {
             );
             this.website.goToWebsite({path: res, edition: true});
         }
-        this.props.onClose();
+        this.props.onDuplicate();
     }
 }
 DuplicatePageDialog.components = {WebsiteDialog};
@@ -155,108 +154,122 @@ DuplicatePageDialog.template = xml`
 </WebsiteDialog>
 `;
 DuplicatePageDialog.props = {
-    onClose: Function,
-    close: Function,
+    onDuplicate: {type: Function, optional: true},
     pageId: Number,
+    close: Function,
 };
 
-export class PagePropertiesDialogWrapper extends Component {
-    setup() {
-        try {
-            this.websiteService = useService('website');
-            this.dialogService = useService('dialog');
-            this.orm = useService('orm');
-        } catch {
-            // Use services in legacy environment.
-            this.websiteService = useWowlService('website');
-            this.dialogService = useWowlService('dialog');
-            this.orm = useWowlService('orm');
-        }
+export const pagePropertiesProps = {
+    title: _t('Page Properties'),
+    resModel: 'website.page',
+    context: {
+        form_view_ref: 'website.website_page_properties_view_form',
+    },
+};
 
+export class PagePropertiesDialog extends FormViewDialog {
+    setup() {
+        super.setup();
+        this.dialog = useService('dialog');
+        this.website = useService('website');
+
+        this.viewProps.resId = this.resId;
+        this.viewProps.buttonTemplate = 'website.PagePropertiesDialog.Buttons';
+
+        onMounted(() => {
+            this.actionClone = this.modalRef.el.querySelector('.o_page_properties_clone');
+            this.actionDelete = this.modalRef.el.querySelector('.o_page_properties_delete');
+            this.actionClone.addEventListener('click', this.clonePage.bind(this));
+            this.actionDelete.addEventListener('click', this.deletePage.bind(this));
+        });
+
+        onWillUnmount(() => {
+            this.actionClone.removeEventListener('click', this.clonePage.bind(this));
+            this.actionDelete.removeEventListener('click', this.deletePage.bind(this));
+        });
+    }
+
+    get resId() {
+        return this.props.resId || (this.website.currentWebsite && this.website.currentWebsite.metadata.mainObject.id);
+    }
+
+    clonePage() {
+        this.dialog.add(DuplicatePageDialog, {
+            pageId: this.resId,
+            onDuplicate: () => {
+                this.props.close();
+                this.props.onClose();
+            },
+        });
+    }
+
+    deletePage() {
+        this.dialog.add(DeletePageDialog, {
+            pageId: this.resId,
+            onDelete: () => {
+                this.props.close();
+                this.props.onClose();
+            },
+        });
+    }
+}
+PagePropertiesDialog.props = {
+    ...FormViewDialog.props,
+    onClose: {type: Function, optional: true},
+};
+
+PagePropertiesDialog.defaultProps = {
+    onClose: () => {},
+};
+
+// TODO remove this once the 'website.page' listView is adapted to OWL.
+export class PagePropertiesDialogManager extends Component {
+    setup() {
+        this.dialog = useService('dialog');
         onRendered(this.createDialog);
     }
 
     createDialog() {
-        if (this.props.mode === 'clone') {
-            this.dialogService.add(DuplicatePageDialog, {
-                pageId: this.pageId,
-                onClose: this.props.onClose,
-            });
-        } else if (this.props.mode === 'delete') {
-            this.dialogService.add(DeletePageDialog, {
-                pageId: this.pageId,
-                onClose: this.props.onClose,
-            });
-        } else {
-            const parent = standaloneAdapter({Component});
-            const formViewDialog = new FormViewDialog(parent, this.dialogOptions);
-            formViewDialog.buttons = [...formViewDialog.buttons, ...this.extraButtons];
-            formViewDialog.on('form_dialog_discarded', parent, () => this.websiteService.context.showPageProperties = false);
-            formViewDialog.open();
+        switch (this.props.mode) {
+            case 'clone':
+                this.dialog.add(DuplicatePageDialog, {
+                    pageId: this.props.resId,
+                    onDuplicate: this.props.onClose,
+                });
+                break;
+            case 'delete':
+                this.dialog.add(DeletePageDialog, {
+                    pageId: this.props.resId,
+                    onDelete: this.props.onClose,
+                });
+                break;
+            default:
+                this.dialog.add(PagePropertiesDialog, {
+                    ...pagePropertiesProps,
+                    resId: this.props.resId,
+                    onClose: this.props.onClose,
+                    onRecordSaved: this.props.onRecordSaved,
+                });
+                break;
         }
     }
-
-    get pageId() {
-        return this.props.currentPage || (this.websiteService.currentWebsite && this.websiteService.currentWebsite.metadata.mainObject.id);
-    }
-
-    get dialogOptions() {
-        return {
-            res_model: "website.page",
-            res_id: this.pageId,
-            context: {
-                form_view_ref: 'website.website_page_properties_view_form'
-            },
-            title: this.env._t("Page Properties"),
-            size: 'medium',
-            on_saved: (record, changed) => {
-                if (changed) {
-                    return this.orm.read("website.page", [this.pageId], ['url']).then(res => {
-                        this.websiteService.goToWebsite({websiteId: record.data.website_id.res_id, path: res[0]['url']});
-                    });
-                }
-            },
-        };
-    }
-
-    get extraButtons() {
-        const wrapper = this;
-        return [{
-            text: this.env._t("Duplicate Page"),
-            icon: 'fa-clone',
-            classes: 'btn-link ms-auto',
-            click: function () {
-                wrapper.dialogService.add(DuplicatePageDialog, {
-                    pageId: wrapper.pageId,
-                    onClose: this.close.bind(this),
-                });
-            },
-        },
-        {
-            text: this.env._t("Delete Page"),
-            icon: 'fa-trash',
-            classes: 'btn-link',
-            click: function () {
-                wrapper.dialogService.add(DeletePageDialog, {
-                    pageId: wrapper.pageId,
-                    onClose: this.close.bind(this),
-                });
-            },
-        }];
-    }
 }
-PagePropertiesDialogWrapper.template = xml``;
-PagePropertiesDialogWrapper.props = {
+PagePropertiesDialogManager.template = xml``;
+PagePropertiesDialogManager.props = {
     onClose: {
         type: Function,
-        optional: true,
-    },
-    currentPage: {
-        type: Number,
         optional: true,
     },
     mode: {
         type: String,
         optional: true,
     },
+    resId: {
+        type: [Number, Boolean],
+        optional: true,
+    },
+    onRecordSaved: {
+        type: Function,
+        optional: true,
+    }
 };

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -8,14 +8,14 @@
                 <t t-call="{{ constructor.popoverTemplate }}"/>
             </t>
             <t t-if="props.type === 'key'">
-                <div t-att-data-template="depTemplate" data-html="true" title="Dependencies" t-ref="action">
+                <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
                     It looks like your file is being called by
                     <a href="#" t-on-click="showDependencies"><t t-esc="depText" /></a>.
                     Changing its name will break these calls.
                 </div>
             </t>
             <t t-else="">
-                <div t-att-data-template="depTemplate" data-html="true" title="Dependencies" t-ref="action">
+                <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
                     (could be used in <a href="#" t-on-click="showDependencies"><t t-esc="depText" /></a>)
                 </div>
             </t>
@@ -60,7 +60,7 @@
         <p>Are you sure you want to delete this page ?</p>
         <p class="text-warning">Don't forget to update all links referring to this page.</p>
         <PageDependencies pageId="props.pageId" mode="'collapse'"/>
-        <CheckBox onChange.bind="onConfirmCheckboxChange">
+        <CheckBox value="state.confirm" onChange.bind="onConfirmCheckboxChange">
             <p class="text-warning">I am sure about this.</p>
         </CheckBox>
 
@@ -73,6 +73,13 @@
             </button>
         </t>
     </WebsiteDialog>
+</t>
+
+<t t-name="website.PagePropertiesDialog.Buttons" t-inherit="web.FormView.Buttons" owl="1">
+    <xpath expr="//div[hasclass('o_cp_buttons')]" position="after">
+        <button class="btn btn-link ms-auto o_page_properties_clone"><i class="fa fa-fw fa-clone"/>Duplicate Page</button>
+        <button class="btn btn-link o_page_properties_delete"><i class="fa fa-fw fa-trash"/>Delete Page</button>
+    </xpath>
 </t>
 
 </templates>

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -33,7 +33,7 @@
                 <div t-attf-id="collapseDependencies{{ dependency_index }}" class="collapse" aria-expanded="false">
                     <ul>
                         <li t-foreach="dependency_value" t-as="item" t-key="item">
-                            <a t-att-href="item.link" t-out="item.contentToDisplay"/>
+                            <a t-att-href="item.link" t-out="item.contentToDisplay" target="_blank"/>
                         </li>
                     </ul>
                 </div>
@@ -47,7 +47,7 @@
         <b><t t-esc="dependency"/></b>
         <ul>
             <li t-foreach="dependency_value" t-as="item" t-key="item">
-                <a t-att-href="item_value['link']" t-att-title="item_value['item']" class="o_text_overflow">
+                <a t-att-href="item_value['link']" t-att-title="item_value['item']" class="o_text_overflow" target="_blank">
                     <t t-esc="item_value['item']"/>
                 </a>
             </li>

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -1,35 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
 
-<t t-name="website.FieldPageUrl" owl="1">
-    <div>
+<t t-name="website.PageUrlField" owl="1">
+    <t t-if="props.readonly">
+        <a class="o_form_uri o_text_overflow" t-att-href="props.value" t-esc="props.value || ''"/>
+    </t>
+    <t t-else="">
         <div class="d-flex">
-            <div class="input-group-text rounded-start text-lowercase border-0" t-esc="serverUrl.length > 30 ? serverUrl.slice(0,14) + '..' + serverUrl.slice(-14) : serverUrl"/>
-            <input t-model="state.url" type="text" class="o_input"/>
+            <div
+                class="input-group-text rounded-start text-lowercase border-0"
+                t-esc="serverUrl.length > 30 ? serverUrl.slice(0,14) + '..' + serverUrl.slice(-14) : serverUrl"
+            />
+            <input
+                class="o_input"
+                type="text"
+                t-att-placeholder="props.placeholder"
+                t-att-required="props.required"
+                t-att-id="props.id"
+                t-model="state.url"
+                t-ref="input"
+            />
         </div>
         <div t-if="enableRedirect">
             <div class="d-flex mt-4">
-                <Switch extraClasses="'me-auto'" label="'Redirect Old URL'" value="state.redirect_old_url" onChange="(value) => this.onChangeRedirectOldUrl(value)"/>
-                <PageDependencies pageId="resId" mode="'popover'"/>
+                <Switch
+                    extraClasses="'me-auto'"
+                    label="'Redirect Old URL'"
+                    value="state.redirect_old_url"
+                    onChange="(value) => this.onChangeRedirectOldUrl(value)"
+                />
+                <PageDependencies pageId="props.record.resId" mode="'popover'"/>
             </div>
             <div t-if="state.redirect_old_url" class="d-flex mt-4">
                 <label class="my-0 me-4 fw-bold" for="redirect_type">Type</label>
-                <select class="o_input w-50" id="redirect_type" t-model="state.redirect_type">
+                <select class="o_input w-50" id="redirect_type" t-model="state.redirect_type" t-on-change="updateValues">
                     <option value="301">301 Moved permanently</option>
                     <option value="302">302 Moved temporarily</option>
                 </select>
             </div>
         </div>
-    </div>
+    </t>
 </t>
 
-<t t-name="website.FieldPageName" owl="1">
-    <div>
-        <input t-model="state.name" type="text" class="o_input"/>
+<t t-name="website.PageNameField" owl="1">
+    <t t-if="props.readonly">
+        <span t-esc="formattedPageName"/>
+    </t>
+    <t t-else="">
+        <input
+            class="o_input"
+            type="text"
+            t-att-placeholder="props.placeholder"
+            t-att-required="props.required"
+            t-att-id="props.id"
+            t-model="state.name"
+            t-ref="input"
+        />
         <div t-if="warnAboutCall" class="mt-4">
-            <PageDependencies pageId="resId" mode="'popover'" type="'key'"/>
+            <PageDependencies pageId="props.record.resId" mode="'popover'" type="'key'"/>
         </div>
-    </div>
+    </t>
 </t>
 
 <t t-name="website.FieldFaPrefix" owl="1">

--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -6,6 +6,7 @@ import { registry } from "@web/core/registry";
 import { patch } from 'web.utils';
 import { EditMenuDialog } from '@website/components/dialog/edit_menu';
 import { OptimizeSEODialog } from '@website/components/dialog/seo';
+import {PagePropertiesDialog, pagePropertiesProps} from '@website/components/dialog/page_properties';
 
 const websiteSystrayRegistry = registry.category('website_systray');
 const { useState } = owl;
@@ -13,6 +14,7 @@ const { useState } = owl;
 patch(NavBar.prototype, 'website_navbar', {
     setup() {
         this._super();
+        this.orm = useService('orm');
         this.websiteService = useService('website');
         this.websiteContext = useState(this.websiteService.context);
 
@@ -41,8 +43,16 @@ patch(NavBar.prototype, 'website_navbar', {
                 isDisplayed: () => this.canShowAceEditor(),
             },
             'website.menu_page_properties': {
-                openWidget: () => this.websiteContext.showPageProperties = true,
+                Component: PagePropertiesDialog,
                 isDisplayed: () => this.canShowPageProperties(),
+                getProps: () => ({
+                    ...pagePropertiesProps,
+                    onRecordSaved: (record) => {
+                        return this.orm.read('website.page', [record.resId], ['url']).then(res => {
+                            this.websiteService.goToWebsite({websiteId: record.data.website_id[0], path: res[0]['url']});
+                        });
+                    },
+                })
             },
         };
     },

--- a/addons/website/static/src/js/website_page_list.js
+++ b/addons/website/static/src/js/website_page_list.js
@@ -4,7 +4,7 @@ import ListController from 'web.ListController';
 import viewRegistry from 'web.view_registry';
 import ListView from 'web.ListView';
 import {ComponentWrapper} from 'web.OwlCompatibility';
-import {PagePropertiesDialogWrapper} from '@website/components/dialog/page_properties';
+import {PagePropertiesDialogManager} from '@website/components/dialog/page_properties';
 import {qweb} from 'web.core';
 
 const WebsitePageListController = ListController.extend({
@@ -86,9 +86,10 @@ const WebsitePageListController = ListController.extend({
      * @private
      */
     async _addDialog(record, mode = '') {
-        this._pagePropertiesDialog = new ComponentWrapper(this, PagePropertiesDialogWrapper, {
-            currentPage: record.data.id,
+        this._pagePropertiesDialog = new ComponentWrapper(this, PagePropertiesDialogManager, {
+            resId: record.data.id,
             onClose: this._onCloseDialog.bind(this),
+            onRecordSaved: this.reload.bind(this),
             mode: mode,
         });
         await this._pagePropertiesDialog.mount(this.el);

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -45,7 +45,6 @@ export const websiteService = {
             isPublicRootReady: false,
             snippetsLoaded: false,
             isMobile: false,
-            showPageProperties: false,
         });
         const bus = new EventBus();
 

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -136,7 +136,7 @@
                     <notebook>
                         <page string="Name">
                             <group class="mt-4">
-                                <field name="name" string="Page Name" widget="page_name"/>
+                                <field name="name" string="Page Name" widget="page_name" placeholder="e.g. Home Page"/>
                             </group>
                             <group>
                                 <field name="website_id" invisible="1"/>


### PR DESCRIPTION
1- Go to page properties > change the URL of a page.
2- A list of dependencies appears on a popover.
3- Click on a dependency > you are redirected to the related object
but the URL change for your page was "saved".

The changes on form views are automatically saved when the view is left
using a "beforeunload" handler.

The goal of this PR is to fix this behaviour by making the form view
dialog auto save optional.

task-2687506