### PR TITLE
[FIX] website: race condition on snippet_version tour.

### DIFF
--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -31,10 +31,8 @@ wTourUtils.registerEditionTour("snippet_version", {
             console.error("error Dropped a s_test_snip snippet but missing s_share template name in it");
         }
     },
-}, {
-    content: "Click on save button",
-    trigger: 'button[data-action="save"]',
 },
+    ...wTourUtils.clickOnSave(),
     wTourUtils.clickOnEdit(),
 {
     content: "Modify the version of snippets",


### PR DESCRIPTION
Commit [1] moved the edition of the website in the backend and
introduced an iframe as the editable. In doing so, some tour
actions became unstable.

The issue is that previously, when an action reloaded the page, the tour
service would reload as well. This is no longer the case and the tour
service stays active when the page is reloaded (e.g. when saving a
page). This can lead to a tour clicking on an item before it is ready to
be clicked.

Specifically in this case, the tour saved and clicked on edit as the
next step.
Clicking on edit before the page is properly reloaded leads to the click
being ignored.

This commit uses the util function `clickOnSave` which ensures we're out
of edit mode and the page is reloaded before doing anything else.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

runbot-4074