### PR TITLE
[FIX] web : error when filter has empty selection

### DIFF
--- a/addons/web/static/src/js/control_panel/custom_filter_item.js
+++ b/addons/web/static/src/js/control_panel/custom_filter_item.js
@@ -124,8 +124,13 @@ odoo.define('web.CustomFilterItem', function (require) {
                     }
                     break;
                 case 'selection':
-                    const [firstValue] = this.fields[condition.field].selection[0];
-                    condition.value = firstValue;
+                    if (this.fields[condition.field].selection.length) {
+                        const [firstValue] = this.fields[condition.field].selection[0];
+                        condition.value = firstValue;
+                    }
+                    else {
+                        condition.value = "";
+                    }
                     break;
                 default:
                     condition.value = "";

--- a/addons/web/static/tests/control_panel/custom_filter_item_tests.js
+++ b/addons/web/static/tests/control_panel/custom_filter_item_tests.js
@@ -156,6 +156,38 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
 
             cfi.destroy();
         });
+        QUnit.test('selection field: no value', async function (assert) {
+            assert.expect(2);
+
+            this.fields.color.selection = [];
+            let expectedFilters;
+            class MockedSearchModel extends ActionModel {
+                dispatch(method, ...args) {
+                    assert.strictEqual(method, 'createNewFilters');
+                    const preFilters = args[0];
+                    assert.deepEqual(preFilters, expectedFilters);
+                }
+            }
+            const searchModel = new MockedSearchModel();
+            const cfi = await createComponent(CustomFilterItem, {
+                props: {
+                    fields: this.fields,
+                },
+                env: { searchModel },
+            });
+
+            // Default value
+            expectedFilters = [{
+                description: 'Color is ""',
+                domain: '[["color","=",""]]',
+                type: 'filter',
+            }];
+            await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'color');
+            await cpHelpers.applyFilter(cfi);
+
+            cfi.destroy();
+        })
 
         QUnit.test('adding a simple filter works', async function (assert) {
             assert.expect(6);


### PR DESCRIPTION
Steps to reproduce:
	- install approvals
	- in the approvals app go to filters>add custome filter> approval type
Issue:
	- traceback
Cause:
	- When no other module is installed, there is nothing to display under
	the approval type filter. Even if the field is not required,
	the javascript tries to access the first element of the selection array
	to auto-fill the menu.
Solution:
	Add a check, if empty and not required, do not display it and leave the
	field empty

opw-2895516