### PR TITLE
[IMP] project,sale_project,hr_timesheet: improve generic UX for project

### DIFF
--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -38,6 +38,7 @@ up a management by affair.
         'data/hr_timesheet_data.xml',
         'views/project_sharing_views.xml',
         'views/rating_views.xml',
+        'views/project_update_views.xml',
     ],
     'demo': [
         'data/hr_timesheet_demo.xml',

--- a/addons/hr_timesheet/views/project_update_views.xml
+++ b/addons/hr_timesheet/views/project_update_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="project_update_view_search_inherit" model="ir.ui.view">
+            <field name="name">project.update.view.search.inherit</field>
+            <field name="model">project.update</field>
+            <field name="inherit_id" ref="project.project_update_view_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='my_updates']" position='after'>
+                    <filter string="My Team's Updates" name="my_team_updates" domain="[('user_id.employee_parent_id.user_id', '=', uid)]"/>
+                    <filter string="My Department's Updates" name="my_department_updates" domain="[('user_id.employee_id.member_of_department', '=', True)]"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/project/views/project_update_templates.xml
+++ b/addons/project/views/project_update_templates.xml
@@ -32,6 +32,7 @@
 <li t-attf-class="{{milestone['is_reached'] and 'o_checked' or ''}}">
 <t t-esc="milestone['name']"/>
 <span t-if="milestone['is_deadline_future'] and not milestone['is_reached'] and not milestone['can_be_marked_as_done']"><font style="color: rgb(190, 190, 190);"><t t-set="color_level" t-value="64"/><t t-call="project.milestone_deadline"/></font></span>
+<span t-elif="milestone['is_deadline_exceeded']"><font style="color: rgb(255, 0, 0);"><t t-call="project.milestone_deadline"/></font></span>
 <span t-else=""><t t-set="color_level" t-value="128"/><t t-call="project.milestone_deadline"/></span>
 </li>
 </t>
@@ -39,8 +40,8 @@
 
 <t t-if="milestones['updated']">
 <t t-if="milestones['last_update_date']">Since <t t-esc="milestones['last_update_date']" t-options='{"widget": "date"}'/> (last project update), </t>
-<t t-if="len(milestones['updated']) > 1">the deadline of the following milestones has been updated:</t>
-<t t-else="">the deadline of the following milestone has been updated:</t>
+<t t-if="len(milestones['updated']) > 1">the deadline for the following milestones has been updated:</t>
+<t t-else="">the deadline for the following milestone has been updated:</t>
 <ul>
 <t t-foreach="milestones['updated']" t-as="milestone">
 <li>

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -7,6 +7,15 @@
             <search string="Search Update">
                 <field name="name"/>
                 <field name="project_id" invisible="1"/>
+                <filter string="My Updates" name="my_updates" domain="[('user_id', '=', uid)]"/>
+                <filter string="Followed Updates" name="followed_updates" domain="[('message_is_follower', '=', True)]"/>
+                <separator/>
+                <filter string="On Track" name="on_track" domain="[('status', '=', 'on_track')]"/>
+                <filter string="At Risk" name="at_risk" domain="[('status', '=', 'at_risk')]"/>
+                <filter string="Off Track" name="off_track" domain="[('status', '=', 'off_track')]"/>
+                <filter string="On Hold" name="on_hold" domain="[('status', '=', 'on_hold')]"/>
+                <separator/>
+                <filter name="date" string="Date" date="date"/>
             </search>
         </field>
     </record>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -776,7 +776,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//group" position="after">
                     <footer>
-                        <button string="Create" name="action_view_tasks" type="object" class="btn-primary o_open_tasks" data-hotkey="q"/>
+                        <button string="Create Project" name="action_view_tasks" type="object" class="btn-primary o_open_tasks" data-hotkey="q"/>
                         <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z"/>
                     </footer>
                 </xpath>
@@ -972,7 +972,7 @@
                     No projects found. Let's create one!
                 </p>
                 <p>
-                    Create projects to organize your tasks and define a different workflow for each project.
+                    Create projects to organize your tasks. Define a different workflow for each project.
                 </p>
             </field>
         </record>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -187,6 +187,21 @@
         </field>
     </record>
 
+    <record id="sale_project_milestone_view_tree" model="ir.ui.view">
+        <field name="name">project.milestone.view.tree.inherit</field>
+        <field name="model">project.milestone</field>
+        <field name="inherit_id" ref="sale_project.project_milestone_view_tree"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="sale_line_id" position="attributes">
+                <attribute name="optional">show</attribute>
+            </field>
+            <field name="quantity_percentage" position="attributes">
+                <attribute name="optional">show</attribute>
+            </field>
+        </field>
+    </record>
+
     <record id="project_milestone_view_tree_salesman" model="ir.ui.view">
         <field name="name">project.milestone.view.tree.inherit.salesman</field>
         <field name="model">project.milestone</field>

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -12,6 +12,10 @@
                     <field name="project_ids" invisible="1"/>
                     <field name="project_count" widget="statinfo" string="Projects"/>
                 </button>
+                <field name="is_product_milestone" invisible="1"/>
+                <button class="oe_stat_button" name="action_view_milestone" type="object" icon="fa-check-square-o"  attrs="{'invisible': ['|', ('is_product_milestone', '=', False), ('project_ids', '=', [])]}" groups="project.group_project_milestone">
+                    <field name="milestone_count" widget="statinfo" string="Milestones"/>
+                </button>
                 <button type="object" name="action_view_task" class="oe_stat_button" icon="fa-tasks" attrs="{'invisible': [('tasks_count', '=', 0)]}" groups="project.group_project_user">
                     <field name="tasks_count" widget="statinfo" string="Tasks"/>
                 </button>


### PR DESCRIPTION
Purpose of this commit to improve generic usage of project app.

So in this commit done following changes:
 - add the following filters for project.update search view
 - display 'due mm/dd/yyyy' in red if the deadline is in the
   past and the milestone hasn't been reached yet for milestone section
 - add an 'x Milestones' stat button that should open a list view of all of
   the Milestones that are linked to an SOL of this SO for sale.order form view
 - add an 'unread messages' filter with separated from other filter
 - rename 'create' into 'create project for project wizard
 - change to "Create projects to organise your tasks. Define a different workflow
   for each project." for project.project action helper

task-2864875

