### PR TITLE
[FIX] hr_holidays: fix undeterministic test

### DIFF
--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -28,8 +28,8 @@ class TestHrHolidaysAccessRightsCommon(TestHrHolidaysCommon):
             'holiday_status_id': cls.leave_type.id,
             'department_id': cls.employee_emp.department_id.id,
             'employee_id': cls.employee_emp.id,
-            'date_from': datetime.now(),
-            'date_to': datetime.now() + relativedelta(days=1),
+            'date_from': datetime.now() + relativedelta(days=30),
+            'date_to': datetime.now() + relativedelta(days=31),
             'number_of_days': 1,
         })
 


### PR DESCRIPTION
The test was randomly failing on nightly builds as the timeoff was
considered as started, thus preventing the user from modifying it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
