### PR TITLE
[FIX] sale: Salesperson always set to current user

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -517,7 +517,7 @@ class SaleOrder(models.Model):
     @api.depends('partner_id')
     def _compute_user_id(self):
         for order in self:
-            if not order.user_id:
+            if order.partner_id and not order.user_id:
                 order.user_id = order.partner_id.user_id or order.partner_id.commercial_partner_id.user_id or self.env.user
 
     @api.depends('partner_id', 'user_id')


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two internal users U1 and U2 both in group group_sale_salesman
- Let's consider a customer C with default salesperson set to U2
- Log with U1 and create a SO for C

Bug:

The salesperson set on the SO was U1 instead of U2

PS: When creating the SO, the user_id is directly set to self.env.user

opw:2863205