### PR TITLE
[FIX] website, web_editor: fix header and footer page options

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -6,6 +6,33 @@ const {ColorpickerWidget} = require('web.Colorpicker');
 let editableWindow = window;
 const _setEditableWindow = (ew) => editableWindow = ew;
 
+const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = ['primary', 'secondary', 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'success', 'info', 'warning', 'danger'];
+
+/**
+ * These constants are colors that can be edited by the user when using
+ * web_editor in a website context. We keep track of them so that color
+ * palettes and their preview elements can always have the right colors
+ * displayed even if website has redefined the colors during an editing
+ * session.
+ *
+ * @type {string[]}
+ */
+const EDITOR_COLOR_CSS_VARIABLES = [...COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES];
+// o-cc and o-colors
+for (let i = 1; i <= 5; i++) {
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-color-${i}`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-bg`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-h1`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-text`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-primary`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-secondary`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-primary-border`);
+    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-secondary-border`);
+}
+// Grays
+for (let i = 100; i <= 900; i += 100) {
+    EDITOR_COLOR_CSS_VARIABLES.push(`${i}`);
+}
 /**
  * window.getComputedStyle cannot work properly with CSS shortcuts (like
  * 'border-width' which is a shortcut for the top + right + bottom + left border
@@ -364,9 +391,11 @@ function _getColorClass(el, colorNames, prefix) {
 }
 
 return {
+    COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES: COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES,
     CSS_SHORTHANDS: CSS_SHORTHANDS,
     CSS_UNITS_CONVERSION: CSS_UNITS_CONVERSION,
     DEFAULT_PALETTE: DEFAULT_PALETTE,
+    EDITOR_COLOR_CSS_VARIABLES: EDITOR_COLOR_CSS_VARIABLES,
     computePxByRem: _computePxByRem,
     convertValueToUnit: _convertValueToUnit,
     convertNumericToUnit: _convertNumericToUnit,

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1492,7 +1492,11 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
             if (ColorpickerWidget.isCSSColor(this._value)) {
                 this.colorPreviewEl.style.backgroundColor = this._value;
             } else if (!weUtils.isColorGradient(this._value)) {
-                this.colorPreviewEl.style.backgroundColor = `var(--we-cp-${this._value}`;
+                if (weUtils.EDITOR_COLOR_CSS_VARIABLES.includes(this._value)) {
+                    this.colorPreviewEl.style.backgroundColor = `var(--we-cp-${this._value}`;
+                } else {
+                    this.colorPreviewEl.classList.add(`bg-${this._value}`);
+                }
             } else {
                 this.colorPreviewEl.style.backgroundImage = this._value;
             }

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -8,7 +8,6 @@ const {ColorpickerWidget} = require('web.Colorpicker');
 const Widget = require('web.Widget');
 const customColors = require('web_editor.custom_colors');
 const weUtils = require('web_editor.utils');
-const compatibilityColorNames = ['primary', 'secondary', 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'success', 'info', 'warning', 'danger'];
 
 const qweb = core.qweb;
 
@@ -248,7 +247,7 @@ const ColorPaletteWidget = Widget.extend({
 
         // Compute class colors
 
-        this.colorNames = [...compatibilityColorNames];
+        this.colorNames = [...weUtils.COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES];
         this.colorToColorNames = {};
         this.el.querySelectorAll('button[data-color]:not(.o_custom_gradient_btn)').forEach(elem => {
             const colorName = elem.dataset.color;
@@ -259,8 +258,10 @@ const ColorPaletteWidget = Widget.extend({
             const isCCName = weUtils.isColorCombinationName(colorName);
             if (isCCName) {
                 $color.find('.o_we_cc_preview_wrapper').addClass(`o_cc o_cc${colorName}`);
-            } else {
+            } else if (weUtils.EDITOR_COLOR_CSS_VARIABLES.includes(colorName)) {
                 elem.style.backgroundColor = `var(--we-cp-${colorName})`;
+            } else {
+                elem.classList.add(`bg-${colorName}`);
             }
             this.colorNames.push(colorName);
             if (!isCCName && !elem.classList.contains('d-none')) {
@@ -276,7 +277,7 @@ const ColorPaletteWidget = Widget.extend({
         }
         if (this.options.selectedColor) {
             let selectedColor = this.options.selectedColor;
-            if (compatibilityColorNames.includes(selectedColor)) {
+            if (weUtils.COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES.includes(selectedColor)) {
                 selectedColor = weUtils.getCSSVariableValue(selectedColor, this.style) || selectedColor;
             }
             selectedColor = ColorpickerWidget.normalizeCSSColor(selectedColor);
@@ -1028,6 +1029,5 @@ ColorPaletteWidget.loadDependencies = async function (rpcCapableObj) {
 
 return {
     ColorPaletteWidget: ColorPaletteWidget,
-    compatibilityColorNames: compatibilityColorNames,
 };
 });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -11,7 +11,6 @@ const Dialog = require('web.Dialog');
 const customColors = require('web_editor.custom_colors');
 const {ColorPaletteWidget} = require('web_editor.ColorPalette');
 const {ColorpickerWidget} = require('web.Colorpicker');
-const {compatibilityColorNames} = require('web_editor.ColorPalette');
 const concurrency = require('web.concurrency');
 const { device } = require('web.config');
 const { localization } = require('@web/core/l10n/localization');
@@ -1236,24 +1235,17 @@ const Wysiwyg = Widget.extend({
     },
     /**
      * Sets custom CSS Variables on the snippet menu element.
-     * Used for color previews and color palette.
+     * Used for color previews and color palette to get the color
+     * values of the editable. (e.g. if the editable is in an iframe
+     * with different SCSS color values as the top window.)
+     *
+     * @param {HTMLElement} element
      */
     setCSSVariables(element) {
-        for (let i = 1; i <= 5; i++) {
-            element.style.setProperty(`--we-cp-o-color-${i}`, weUtils.getCSSVariableValue(`o-color-${i}`));
-            element.style.setProperty(`--we-cp-o-cc${i}-bg`, weUtils.getCSSVariableValue(`o-cc${i}-bg`));
-            element.style.setProperty(`--we-cp-o-cc${i}-h1`, weUtils.getCSSVariableValue(`o-cc${i}-h1`));
-            element.style.setProperty(`--we-cp-o-cc${i}-text`, weUtils.getCSSVariableValue(`o-cc${i}-text`));
-            element.style.setProperty(`--we-cp-o-cc${i}-btn-primary`, weUtils.getCSSVariableValue(`o-cc${i}-btn-primary`));
-            element.style.setProperty(`--we-cp-o-cc${i}-btn-primary-border`, weUtils.getCSSVariableValue(`o-cc${i}-btn-primary-border`));
-            element.style.setProperty(`--we-cp-o-cc${i}-btn-secondary`, weUtils.getCSSVariableValue(`o-cc${i}-btn-secondary`));
-            element.style.setProperty(`--we-cp-o-cc${i}-btn-secondary-border`, weUtils.getCSSVariableValue(`o-cc${i}-btn-secondary-border`));
-        }
-        for (let i = 100; i <= 900; i += 100) {
-            element.style.setProperty(`--we-cp-${i}`, weUtils.getCSSVariableValue(`${i}`));
-        }
-        for (const name of compatibilityColorNames) {
-            element.style.setProperty(`--we-cp-${name}`, weUtils.getCSSVariableValue(name));
+        const stylesToCopy = weUtils.EDITOR_COLOR_CSS_VARIABLES;
+
+        for (const style of stylesToCopy) {
+            element.style.setProperty(`--we-cp-${style}`, weUtils.getCSSVariableValue(style));
         }
     },
     /**

--- a/addons/website/static/src/components/wysiwyg_adapter/page_options.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/page_options.js
@@ -18,7 +18,9 @@ export const pageOptionsCallbacks = {
         headerEl.classList.toggle('o_snippet_invisible', !value);
     },
     footer_visible: function (value) {
-        this.document.querySelector('#wrapwrap > footer').toggleClass('d-none o_snippet_invisible', !value);
+        const footerEl = this.document.querySelector('#wrapwrap > footer');
+        footerEl.classList.toggle('d-none', !value);
+        footerEl.classList.toggle('o_snippet_invisible', !value);
     },
 };
 export class PageOption {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -321,7 +321,8 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             case 'get_page_option':
                  return event.data.onSuccess(this.pageOptions[params[0]].value);
             case 'toggle_page_option':
-                return this._togglePageOption(...params);
+                this._togglePageOption(...params);
+                return event.data.onSuccess();
             case 'edit_menu':
                 return this.dialogs.add(EditMenuDialog, {
                     save: () => {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -509,6 +509,12 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             },
         ];
     }
+    /**
+     * @returns {boolean} true if the page has been altered.
+     */
+    _isDirty() {
+        return this.widget.isDirty() || Object.values(this.pageOptions).some(option => option.isDirty);
+    }
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -538,7 +544,6 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
      * @private
      */
     async _onSaveRequest(event) {
-        const isDirty = this.widget.isDirty();
         let callback = () => this.props.quitCallback();
         if (event.data.reload || event.data.reloadEditor) {
             this.widget.trigger_up('disable_loading_effects');
@@ -565,7 +570,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 this.action.doAction(event.data.action);
             };
         }
-        if (isDirty) {
+        if (this._isDirty()) {
             return this.save().then(callback);
         } else {
             return callback();
@@ -590,8 +595,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
      * @private
      */
     _onCancelRequest(event) {
-        const isDirty = this.widget.isDirty();
-        if (isDirty) {
+        if (this._isDirty()) {
             this.dialogs.add(WebsiteDialog, {
                 body: _t("If you discard the current edits, all unsaved changes will be lost. You can cancel to return to edit mode."),
                 primaryClick: () => this.props.quitCallback(),

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2175,7 +2175,8 @@ options.registry.TopMenuVisibility = VisibilityPageOptionUpdate.extend({
         // TODO this is hacky but changing the header visibility may have an
         // effect on features like FullScreenHeight which depend on viewport
         // size so we simulate a resize.
-        $(window).trigger('resize');
+        const targetWindow = this.$target[0].ownerDocument.defaultView;
+        targetWindow.dispatchEvent(new targetWindow.Event('resize'));
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -138,7 +138,7 @@ function clickOnSnippet(snippet, position = "bottom") {
     const snippetClass = snippet.id || snippet;
     return {
         trigger: `iframe #wrapwrap .${snippetClass}`,
-        extra_trigger: "iframe body.editor_enable",
+        extra_trigger: "body.editor_has_snippets",
         content: Markup(_t("<b>Click on a snippet</b> to access its options menu.")),
         position: position,
         run: "click",

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import wTourUtils from 'website.tour_utils';
+
+wTourUtils.registerEditionTour('website_page_options', {
+    test: true,
+    url: '/',
+    edition: true,
+}, [
+    wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-button[data-visibility="transparent"]'),
+    // It's important to test saving right after changing that option only as
+    // this is why this test was made in the first place: the page was not
+    // marked as dirty when that option was the only one that was changed.
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the header is transparent",
+        trigger: 'iframe #wrapwrap.o_header_overlay',
+        run: () => null, // it's a check
+    },
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption('topMenuColor', 'we-select.o_we_so_color_palette'),
+    wTourUtils.changeOption('topMenuColor', 'button[data-color="black-50"]', 'background color', 'bottom', true),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the header is in black-50",
+        trigger: 'iframe header#top.bg-black-50',
+        run: () => null, // it's a check
+    },
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-button[data-visibility="hidden"]'),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the header is hidden",
+        trigger: 'iframe #wrapwrap:has(header#top.d-none.o_snippet_invisible)',
+        run: () => null, // it's a check
+    },
+    wTourUtils.clickOnEdit(),
+    {
+        content: "Click on 'header' in the invisible elements list",
+        extra_trigger: '#oe_snippets.o_loaded',
+        trigger: '.o_we_invisible_el_panel .o_we_invisible_entry',
+    },
+    wTourUtils.clickOnSnippet({id: 'o_footer', name: 'Footer'}),
+    wTourUtils.changeOption('HideFooter', 'we-button[data-name="hide_footer_page_opt"] we-checkbox'),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the footer is hidden and the header is visible",
+        trigger: 'iframe #wrapwrap:has(.o_footer.d-none.o_snippet_invisible)',
+        extra_trigger: 'iframe #wrapwrap header#top:not(.d-none)',
+        run: () => null, // it's a check
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -302,3 +302,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_18_website_snippets_menu_tabs(self):
         self.start_tour("/?enable_editor=1", "website_snippets_menu_tabs", login="admin")
+
+    def test_19_website_page_options(self):
+        self.start_tour("/web", "website_page_options", login="admin")

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -171,7 +171,9 @@
     <xpath expr="//div[@id='wrapwrap']" position="before">
         <t groups="website.group_website_publisher">
             <t t-foreach="['header_overlay', 'header_color', 'header_visible', 'footer_visible']" t-as="optionName">
-                <input t-if="optionName in main_object" type="hidden" class="o_page_option_data" t-att-name="optionName" t-att-value="main_object[optionName]"/>
+                <!-- Firefox autocomplete is too aggressive and works on hidden inputs,
+                so we need to disable it (https://bugzilla.mozilla.org/show_bug.cgi?id=520561) -->
+                <input t-if="optionName in main_object" type="hidden" class="o_page_option_data" autocomplete="off" t-att-name="optionName" t-att-value="main_object[optionName]"/>
             </t>
         </t>
     </xpath>


### PR DESCRIPTION
Commit [1] moved the editor in the backend introducing changes to the
way some options interact with the website. This unfortunately broke
the header position option, the header background option and the footer
visibility option.

The header position option would loop indefinitely, the header
background color option would not display the correct preview colors and
the footer position would trigger a traceback.

This commit fix those bugs:

- The header position option had a callback that was never called, it is
  now called.
- The copy of styles introduced by [2] is now less implicit. Only styles
  that are defined in web_editor/common/utils [EDITABLE_CSS_VARIABLES]
  are copied on the snippet menu, and only those variables will be used
  as background colors for the preview elements. (Allowing for every
  other colors like black and white to be used with classes).
- The footer visibility option had a broken line of code that was copied
  from past code. It is now fixed and working.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b
[2]: https://github.com/odoo/odoo/commit/212a8bfdd21269b18054200b9e2585e1c95540d6

task-2687506