### PR TITLE
[FIX] mail: permission error when editing a mail.message

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -223,7 +223,7 @@ class DiscussController(http.Controller):
     def mail_message_update_content(self, message_id, body, attachment_ids):
         guest = request.env['mail.guest']._get_guest_from_request(request)
         message_sudo = guest.env['mail.message'].browse(message_id).sudo().exists()
-        if not message_sudo.is_current_user_or_guest_author and not guest.env.user.has_group('base.group_system'):
+        if not message_sudo.is_current_user_or_guest_author and not guest.env.user._is_admin():
             raise NotFound()
         message_sudo._update_content(body=body, attachment_ids=attachment_ids)
         return {


### PR DESCRIPTION
Steps to follow:

  On a runbot,
  - Login as Mitchell Admin
  - Set the Administration permission of Marc Demo to Access Rights
  - Login as Mark Demo
  - Go to the Discuss App
  - Edit a message from someone else by clicking on the pencil
  -> A Traceback occurs

Cause of the issue:

  - The pencil button is only displayed for another user if the logged in user
    is admin. This is done by checking if the user is superUser or if he
    has the group `base.group_erp_manager`
    This is the case here
  - When editing the message, the `base.group_system` is checked.
    In this case, it is not present.

Solution:

  Check the `base.group_erp_manager` in both cases

opw-2892740