### PR TITLE
[FIX] mail: fix error caused by useComponentToModel

### DIFF
--- a/addons/mail/static/src/component_hooks/use_component_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_component_to_model.js
@@ -2,7 +2,7 @@
 
 import { clear } from '@mail/model/model_field_command';
 
-const { onWillDestroy, onWillUpdateProps, useComponent } = owl;
+const { onWillDestroy, onWillRender, onWillUpdateProps, useComponent } = owl;
 
 /**
  * This hook provides support for saving the reference of the component directly
@@ -28,6 +28,16 @@ export function useComponentToModel({ fieldName, modelName }) {
         }
         if (nextRecord) {
             nextRecord.update({ [fieldName]: component });
+        }
+    });
+    onWillRender(() => {
+        const record = modelManager.models[modelName].get(component.props.localId);
+        if (record && !record[fieldName]) {
+            // When the record is deleted then created again, its
+            // localId can be the same. In this scenario, the Component
+            // would not call setup neither willUpdateprops. Therefore,
+            // we need to set the component for this new record.
+            record.update({ [fieldName]: component });
         }
     });
     onWillDestroy(() => {


### PR DESCRIPTION
Some components use the `useComponentToModel` hook to set the component
field on their related record. When a record is deleted then created
again, its localId can remain the same. This means the Component won't
trigger the `setup` method neither the `willUpdateprops`. Therefore,
the second record's component field would be undefined. In order to
solve this issue, let's check that the record's field is properly set
when the component is rendered.