### PR TITLE
[FIX] Inventory: prevent crash when printing package report if uom ro…

### DIFF
--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -5,7 +5,7 @@
     <t t-call="web.basic_layout">
         <!-- quantity patterns are always 3 digit codes + 1 digit for number of digits (excluding units) -->
         <t t-set="uom_unit_id" t-value="env.ref('uom.product_uom_unit').id"/>
-        <t t-set="gs1_uom_patterns" t-value="{rule.associated_uom_id.id: rule.pattern[1:4] + str(len(str(rule.associated_uom_id.rounding).split('.')[1])) for rule in env['barcode.rule'].search([('associated_uom_id', '!=', False), ('associated_uom_id.id', '!=', uom_unit_id), ('is_gs1_nomenclature', '=', True)])}"/>
+        <t t-set="gs1_uom_patterns" t-value="{rule.associated_uom_id.id: rule.pattern[1:4] + str(len(str('{:.10f}'.format(rule.associated_uom_id.rounding).rstrip('0')).split('.')[1])) for rule in env['barcode.rule'].search([('associated_uom_id', '!=', False), ('associated_uom_id.id', '!=', uom_unit_id), ('is_gs1_nomenclature', '=', True)])}"/>
         <t t-foreach="docs" t-as="o">
             <t>
                 <div class="page">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- If you have a UoM (ex: kg) with rounding of more than 4 digits it will be seen as 1e-5 instead of 0.00001 (in case of 5 digits) for example and cause a crash when you try to print the package barcode (Inventory -> products -> packages -> choose any one -> print "Package Barcode with Content")

Current behavior before PR:

- Traceback when you want to print the package barcode

Desired behavior after PR is merged:

- Be able to print the package barcode



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
