### PR TITLE
[FIX] l10n_latam_invoice_document: fix account tour

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -48,7 +48,7 @@ class AccountMove(models.Model):
     l10n_latam_document_number = fields.Char(
         compute='_compute_l10n_latam_document_number', inverse='_inverse_l10n_latam_document_number',
         string='Document Number', readonly=True, states={'draft': [('readonly', False)]})
-    l10n_latam_use_documents = fields.Boolean(related='journal_id.l10n_latam_use_documents')
+    l10n_latam_use_documents = fields.Boolean(compute='_compute_l10n_latam_use_documents')
     l10n_latam_manual_document_number = fields.Boolean(compute='_compute_l10n_latam_manual_document_number', string='Manual Number')
     l10n_latam_document_type_id_code = fields.Char(related='l10n_latam_document_type_id.code', string='Doc Type')
 
@@ -68,6 +68,11 @@ class AccountMove(models.Model):
             lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_document_type_id
             and not x.l10n_latam_manual_document_number and x.state == 'draft' and not x.posted_before).name = '/'
         super(AccountMove, self - without_doc_type - manual_documents)._compute_name()
+
+    @api.depends('journal_id', 'journal_id.type', 'journal_id.company_id.country_id', 'journal_id.l10n_latam_company_use_documents', 'journal_id.l10n_latam_use_documents')
+    def _compute_l10n_latam_use_documents(self):
+        for rec in self:
+            rec.l10n_latam_use_documents = rec.journal_id.type in ['sale', 'purchase'] and rec.journal_id.l10n_latam_company_use_documents
 
     @api.depends('l10n_latam_document_type_id', 'journal_id')
     def _compute_l10n_latam_manual_document_number(self):


### PR DESCRIPTION
Steps to reproduce:

  - Install l10n_ar module
  - Switch to `Your Company` Company
  - Edit company and set no country on it.
  - Activate debug mode (with test assets)
  - Launch `account_tour` tour (test mode)

Issue:

  Tour fails.

Cause:

    Tour fails because a required field is empty.

Solution

  The field `Document Type` should not be required but is; when removing
  the country of the company for the test, there is no re-trigger of the
  `_onchange_company` (for the field `l10n_latam_use_documents`) on the
  journal because it's a simple compute field NOT stored.

opw-2899629