### PR TITLE
[FIX] stock: stock_production_lot

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -220,9 +220,10 @@ class ProductionLot(models.Model):
                     lot_path.add(lot.id)
                     next_lots = producing_move_lines.produce_line_ids.lot_id.filtered(lambda l: l.id not in lot_path)
                     next_lots_ids = set(next_lots.ids)
-                    # If some producing lots are in lot_path, it means that they have been previously processed.
-                    # Their results are therefore already in delivery_by_lot and we add them to delivery_ids directly.
-                    delivery_ids.update(*[set(delivery_by_lot.get(lot_id)) for lot_id in (producing_move_lines.produce_line_ids.lot_id - next_lots).ids])
+                    # If some producing lots are in lot_path, it can mean one of two things:
+                    #   - We encountered a cycle. In that case we simply return an empty list since the correct values will be computed later on.
+                    #   - We encountered an already processed lot. The lot picking_ids are already in delivery_by_lot so we add them directly to delivery_ids.
+                    delivery_ids.update(*[set(delivery_by_lot.get(lot_id, [])) for lot_id in (producing_move_lines.produce_line_ids.lot_id - next_lots).ids])
 
                     for lot_id, delivery_ids_set in next_lots._find_delivery_ids_by_lot(lot_path=lot_path, delivery_by_lot=delivery_by_lot).items():
                         if lot_id in next_lots_ids:


### PR DESCRIPTION
Fix issue introduced in commit 664451b0
When there is a cycle in the lot tree, the line
`delivery_by_lot.get(lot_id)` returns None which raises an Error
because the set() function needs an iterable. Such
a situation can happen when a product with a BOM
has a component with a BOM whose component is the first
product, i.e. a bom references another BOM which
references the first one.

Since encountering a cycle means that we are currently
in the process of computing this lot picking_ids, simply
add a default empty list. The correct picking_ids will be
set later on once the recursive calls return.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
