### PR TITLE
[FIX] web: consistent capital letters in domain selector

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_root_node.xml
+++ b/addons/web/static/src/core/domain_selector/domain_selector_root_node.xml
@@ -8,7 +8,7 @@
             t-attf-class="{{ props.className }} {{ props.readonly ? 'o_read_mode' : 'o_edit_mode'}}"
         >
             <t t-if="!hasNode">
-                <span>Match <strong>All records</strong></span>
+                <span>Match <strong>all records</strong></span>
                 <t t-if="!props.readonly">
                     <button
                         class="btn btn-sm btn-primary o_domain_add_first_node_button"

--- a/addons/web/static/tests/views/fields/domain_field_tests.js
+++ b/addons/web/static/tests/views/fields/domain_field_tests.js
@@ -791,7 +791,7 @@ QUnit.module("Fields", (hooks) => {
             },
         });
 
-        assert.strictEqual(target.querySelector(".o_read_mode").textContent, "Match All records");
+        assert.strictEqual(target.querySelector(".o_read_mode").textContent, "Match all records");
 
         await click(target.querySelector(".o_domain_show_selection_button"));
         assert.containsOnce(


### PR DESCRIPTION
"All" is capitalized but not "records".
It should be consistent: either all capitalized, none, or only the first word

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
