### PR TITLE
[FIX] base: correctly apply implied groups

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1098,16 +1098,18 @@ class GroupsImplied(models.Model):
         """ Add the given group to the groups implied by the current group
         :param implied_group: the implied group to add
         """
-        if implied_group not in self.implied_ids:
-            self.write({'implied_ids': [Command.link(implied_group.id)]})
+        groups = self.filtered(lambda g: implied_group not in g.implied_ids)
+        groups.write({'implied_ids': [Command.link(implied_group.id)]})
 
     def _remove_group(self, implied_group):
         """ Remove the given group from the implied groups of the current group
         :param implied_group: the implied group to remove
         """
-        if implied_group in self.implied_ids:
-            self.write({'implied_ids': [Command.unlink(implied_group.id)]})
-            implied_group.write({'users': [Command.unlink(user.id) for user in self.users]})
+        groups = self.filtered(lambda g: implied_group in g.implied_ids)
+        if groups:
+            groups.write({'implied_ids': [Command.unlink(implied_group.id)]})
+            if groups.users:
+                implied_group.write({'users': [Command.unlink(user.id) for user in groups.users]})
 
 class UsersImplied(models.Model):
     _inherit = 'res.users'


### PR DESCRIPTION
If one of the groups in `self` implies the group `implied_group` then
the rest won't be updated.

This also contradicts the way the settings are later checked (which is
correct) on
https://github.com/odoo/odoo/blob/f2c214e227db7c9ec2340ef87644f2f7c2e370c5/odoo/addons/base/models/res_config.py#L508

See 4f19f29

opw-2832741
upg-356843

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
