### PR TITLE
[FIX] website_sale: no tax included in snipets products

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -283,7 +283,7 @@
         </template>
 
         <template id="price_dynamic_filter_template_product_product" name="Dynamic Product Filter Price">
-            <span t-esc="record._get_contextual_price()" class="font-weight-bold"
+            <span t-esc="record._get_contextual_price_tax_selection()" class="font-weight-bold"
                   t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
             <del t-if="data.get('has_discounted_price')" class="text-danger ml-1 h6" style="white-space: nowrap;"
                  t-esc="data['list_price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -90,3 +90,11 @@ class Product(models.Model):
     def _is_add_to_cart_allowed(self):
         self.ensure_one()
         return self.user_has_groups('base.group_system') or (self.sale_ok and self.website_published)
+
+    def _get_contextual_price_tax_selection(self):
+        self.ensure_one()
+        price = self._get_contextual_price()
+        line_tax_type = self.env['ir.config_parameter'].sudo().get_param('account.show_line_subtotals_tax_selection')
+        if line_tax_type == "tax_included" and self.taxes_id:
+            price = self.taxes_id.compute_all(price, product=self, partner=self.env['res.partner'])['total_included']
+        return price


### PR DESCRIPTION
Steps to reproduce:
- Take a product sold on the e-commerce and add taxes
- In the Website settings chose the product prices to be
 shown tax-included
- Add the snippet "Products"

Problem:
The price shown on the snippet is tax-excluded while the
price shown on the product page is tax-included. The
price on the snippet should also be tax-included.

Explanation
Bug introduced by commit 9e99a9df464d97a74ca320d200599f7dce2d3050
using the _get_contextual_price ignored the option where the taxes
needed to be computed. To solve the issue we create a new function
that calls _get_contextual_price but also add the taxes if
necessary.

opw-2894461