### PR TITLE
[FIX] payment: unexpected test behavior

### DIFF
--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -31,6 +31,8 @@ class TestFlows(PaymentHttpCommon):
             if key in route_values:
                 self.assertEqual(val, route_values[key])
 
+        self.assertIn(self.acquirer.id, tx_context['acquirer_ids'])
+
         # Route values are taken from tx_context result of /pay route to correctly simulate the flow
         route_values = {
             k: tx_context[k]
@@ -94,6 +96,9 @@ class TestFlows(PaymentHttpCommon):
     def test_10_direct_checkout_public(self):
         # No authentication needed, automatic fallback on public user
         self.user = self.public_user
+        # Make sure the company considered in payment/pay
+        # doesn't fall back on the public user main company (not the test one)
+        self.partner.company_id = self.env.company.id
         self._test_flow('direct')
 
     def test_11_direct_checkout_portal(self):
@@ -109,8 +114,10 @@ class TestFlows(PaymentHttpCommon):
         self._test_flow('direct')
 
     def test_20_redirect_checkout_public(self):
-        self.partner = self.default_partner
-        self.user = self.env.ref('base.public_user')
+        self.user = self.public_user
+        # Make sure the company considered in payment/pay
+        # doesn't fall back on the public user main company (not the test one)
+        self.partner.company_id = self.env.company.id
         self._test_flow('redirect')
 
     def test_21_redirect_checkout_portal(self):


### PR DESCRIPTION
Some payment tests were unexpectedly relying on the 'transfer' payment acquirer
to work because of a multi-company issue in the core payment tests setup.

This commit fixes the problem and adds an additional check in the tests to
make sure they rely correctly on the 'dummy' acquirer created in the payment
tests common.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
