### PR TITLE
[IMP] payment(_*): allow dynamic token display name

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -1056,11 +1056,18 @@ class PaymentTransaction(models.Model):
                 "Refund transaction reference: %(ref)s (%(acq_name)s).",
                 amount=formatted_amount, ref=self.reference, acq_name=self.acquirer_id.name
             )
-        else:  # 'online_token'
+        elif self.operation in ('online_token', 'offline'):
             message = _(
                 "A transaction with reference %(ref)s has been initiated using the payment method "
                 "%(token_name)s (%(acq_name)s).",
                 ref=self.reference, token_name=self.token_id.name, acq_name=self.acquirer_id.name
+            )
+        else:  # 'validation'
+            message = _(
+                "A transaction with reference %(ref)s has been initiated to save a new payment "
+                "method (%(acq_name)s)",
+                ref=self.reference,
+                acq_name=self.acquirer_id.name,
             )
         return message
 

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -1059,8 +1059,10 @@ class PaymentTransaction(models.Model):
         elif self.operation in ('online_token', 'offline'):
             message = _(
                 "A transaction with reference %(ref)s has been initiated using the payment method "
-                "%(token_name)s (%(acq_name)s).",
-                ref=self.reference, token_name=self.token_id.name, acq_name=self.acquirer_id.name
+                "%(token)s (%(acq_name)s).",
+                ref=self.reference,
+                token=self.token_id._build_display_name(),
+                acq_name=self.acquirer_id.name
             )
         else:  # 'validation'
             message = _(

--- a/addons/payment/tests/__init__.py
+++ b/addons/payment/tests/__init__.py
@@ -6,4 +6,5 @@ from . import test_account_payment
 from . import test_flows
 from . import test_multicompany_flows
 from . import test_payment_acquirer
+from . import test_payment_token
 from . import test_payment_transaction

--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -188,7 +188,7 @@ class PaymentCommon(AccountTestInvoicingCommon):
 
     def _create_token(self, sudo=True, **values):
         default_values = {
-            'name': "XXXXXXXXXXXXXXX-2565 (TEST)",
+            'payment_details': "1234",
             'acquirer_id': self.acquirer.id,
             'partner_id': self.partner.id,
             'acquirer_ref': "Acquirer Ref (TEST)",

--- a/addons/payment/tests/test_payment_token.py
+++ b/addons/payment/tests/test_payment_token.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date
+
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 
@@ -14,3 +16,26 @@ class TestPaymentToken(PaymentCommon):
         token = self._create_token(active=False)
         with self.assertRaises(UserError):
             token.active = True
+
+    def test_display_name_is_padded(self):
+        """ Test that the display name is built by padding the payment details. """
+        token = self._create_token()
+        self.assertEqual(token._build_display_name(), '•••• 1234')
+
+    def test_display_name_for_empty_payment_details(self):
+        """ Test that the display name is still built for token without payment details. """
+        token = self._create_token(payment_details='')
+        self.assertEqual(
+            token._build_display_name(),
+            f"Payment details saved on {date.today().strftime('%Y/%m/%d')}",
+        )
+
+    def test_display_name_is_shortened_to_max_length(self):
+        """ Test that the display name is not fully padded when a `max_length` is passed. """
+        token = self._create_token()
+        self.assertEqual(token._build_display_name(max_length=6), '• 1234')
+
+    def test_display_name_is_not_padded(self):
+        """ Test that the display name is not padded when `should_pad` is `False`. """
+        token = self._create_token()
+        self.assertEqual(token._build_display_name(should_pad=False), '1234')

--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -115,20 +115,6 @@ def to_minor_currency_units(major_amount, currency, arbitrary_decimal_number=Non
     return int(float_round(major_amount * (10**decimal_number), precision_digits=0))
 
 
-# Token values formatting
-
-def build_token_name(payment_details_short=None, final_length=16):
-    """ Pad plain payment details with leading X's to build a token name of the desired length.
-
-    :param str payment_details_short: The plain part of the payment details (usually last 4 digits)
-    :param int final_length: The desired final length of the token name (16 for a bank card)
-    :return: The padded token name
-    :rtype: str
-    """
-    payment_details_short = payment_details_short or '????'
-    return f"{'X' * (final_length - len(payment_details_short))}{payment_details_short}"
-
-
 # Partner values formatting
 
 def format_partner_address(address1="", address2=""):

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -120,7 +120,7 @@
                                    t-att-data-provider="token.provider"
                                    data-payment-option-type="token"/>
                             <!-- === Token name === -->
-                            <span class="payment_option_name" t-esc="token.name"/>
+                            <span class="payment_option_name" t-esc="token.display_name"/>
                             <!-- === "V" check mark === -->
                             <t t-call="payment.verified_token_checkmark"/>
                             <!-- === "Unpublished" badge === -->
@@ -254,7 +254,7 @@
                                    t-att-data-provider="token.provider"
                                    data-payment-option-type="token"/>
                             <!-- === Token name === -->
-                            <span class="payment_option_name" t-esc="token.name"/>
+                            <span class="payment_option_name" t-esc="token.display_name"/>
                             <!-- === "V" check mark === -->
                             <t t-call="payment.verified_token_checkmark"/>
                             <!-- === "Unpublished" badge === -->

--- a/addons/payment/views/payment_token_views.xml
+++ b/addons/payment/views/payment_token_views.xml
@@ -16,7 +16,7 @@
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <group name="general_information">
-                        <field name="name"/>
+                        <field name="payment_details"/>
                         <field name="partner_id" />
                     </group>
                     <group name="technical_information">
@@ -34,7 +34,7 @@
         <field name="model">payment.token</field>
         <field name="arch" type="xml">
             <tree string="Payment Tokens">
-                <field name="name"/>
+                <field name="payment_details"/>
                 <field name="partner_id"/>
                 <field name="acquirer_id" readonly="1"/>
                 <field name="acquirer_ref" readonly="1"/>

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -415,7 +415,7 @@ class PaymentTransaction(models.Model):
         additional_data = notification_data['additionalData']
         token = self.env['payment.token'].create({
             'acquirer_id': self.acquirer_id.id,
-            'name': payment_utils.build_token_name(additional_data.get('cardSummary')),
+            'payment_details': additional_data.get('cardSummary'),
             'partner_id': self.partner_id.id,
             'acquirer_ref': additional_data['recurring.recurringDetailReference'],
             'adyen_shopper_reference': additional_data['recurring.shopperReference'],

--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -138,9 +138,10 @@ class AuthorizeAPI:
 
         payment = response.get('paymentProfile', {}).get('payment', {})
         if self.payment_method_type == 'credit_card':
-            res['name'] = payment.get('creditCard', {}).get('cardNumber')
+            # Authorize.net pads the card and account numbers with X's.
+            res['payment_details'] = payment.get('creditCard', {}).get('cardNumber')[-4:]
         else:
-            res['name'] = payment.get('bankAccount', {}).get('accountNumber')
+            res['payment_details'] = payment.get('bankAccount', {}).get('accountNumber')[-4:]
         return res
 
     def delete_customer_profile(self, profile_id):

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -293,7 +293,7 @@ class PaymentTransaction(models.Model):
         if cust_profile:
             token = self.env['payment.token'].create({
                 'acquirer_id': self.acquirer_id.id,
-                'name': cust_profile.get('name'),
+                'payment_details': cust_profile.get('payment_details'),
                 'partner_id': self.partner_id.id,
                 'acquirer_ref': cust_profile.get('payment_profile_id'),
                 'authorize_profile': cust_profile.get('profile_id'),

--- a/addons/payment_flutterwave/models/payment_transaction.py
+++ b/addons/payment_flutterwave/models/payment_transaction.py
@@ -178,7 +178,7 @@ class PaymentTransaction(models.Model):
 
         token = self.env['payment.token'].create({
             'acquirer_id': self.acquirer_id.id,
-            'name': payment_utils.build_token_name(notification_data['card']['last_4digits']),
+            'payment_details': notification_data['card']['last_4digits'],
             'partner_id': self.partner_id.id,
             'acquirer_ref': notification_data['card']['token'],
             'flutterwave_customer_email': notification_data['customer']['email'],

--- a/addons/payment_ogone/models/payment_transaction.py
+++ b/addons/payment_ogone/models/payment_transaction.py
@@ -228,10 +228,9 @@ class PaymentTransaction(models.Model):
         :param dict notification_data: The notification data sent by the provider
         :return: None
         """
-        token_name = notification_data.get('CARDNO') or payment_utils.build_token_name()
         token = self.env['payment.token'].create({
             'acquirer_id': self.acquirer_id.id,
-            'name': token_name,  # Already padded with 'X's
+            'payment_details': notification_data.get('CARDNO')[-4:],  # Ogone pads details with X's.
             'partner_id': self.partner_id.id,
             'acquirer_ref': notification_data['ALIAS'],
             'verified': True,  # The payment is authorized, so the payment method is valid

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -463,7 +463,7 @@ class PaymentTransaction(models.Model):
 
         token = self.env['payment.token'].create({
             'acquirer_id': self.acquirer_id.id,
-            'name': payment_utils.build_token_name(payment_method['card'].get('last4')),
+            'payment_details': payment_method['card'].get('last4'),
             'partner_id': self.partner_id.id,
             'acquirer_ref': customer_id,
             'verified': True,

--- a/addons/payment_test/models/payment_token.py
+++ b/addons/payment_test/models/payment_token.py
@@ -16,3 +16,18 @@ class PaymentToken(models.Model):
             ('error', "Error"),
         ],
     )
+
+    def _build_display_name(self, *args, should_pad=True, **kwargs):
+        """ Override of `payment` to build the display name without padding.
+
+        Note: self.ensure_one()
+
+        :param list args: The arguments passed by QWeb when calling this method.
+        :param bool should_pad: Whether the token should be padded or not.
+        :param dict kwargs: Optional data.
+        :return: The test token name.
+        :rtype: str
+        """
+        if self.provider != 'test':
+            return super()._build_display_name(*args, should_pad=should_pad, **kwargs)
+        return super()._build_display_name(*args, should_pad=False, **kwargs)

--- a/addons/payment_test/models/payment_transaction.py
+++ b/addons/payment_test/models/payment_transaction.py
@@ -202,11 +202,10 @@ class PaymentTransaction(models.Model):
         """
         self.ensure_one()
 
-        payment_details_short = notification_data['cc_summary']
         state = notification_data['simulated_state']
         token = self.env['payment.token'].create({
             'acquirer_id': self.acquirer_id.id,
-            'name': payment_utils.build_token_name(payment_details_short=payment_details_short),
+            'payment_details': notification_data['payment_details'],
             'partner_id': self.partner_id.id,
             'acquirer_ref': 'fake acquirer reference',
             'verified': True,

--- a/addons/payment_test/static/src/js/payment_form.js
+++ b/addons/payment_test/static/src/js/payment_form.js
@@ -31,7 +31,7 @@ odoo.define('payment_test.payment_form', require => {
                 route: '/payment/test/simulate_payment',
                 params: {
                     'reference': processingValues.reference,
-                    'cc_summary': customerInput.slice(-4),
+                    'payment_details': customerInput,
                     'simulated_state': simulatedPaymentState,
                 },
             }).then(() => {

--- a/addons/payment_test/tests/common.py
+++ b/addons/payment_test/tests/common.py
@@ -13,6 +13,6 @@ class PaymentTestCommon(PaymentCommon):
 
         cls.notification_data = {
             'reference': cls.reference,
-            'cc_summary': '1234',
+            'payment_details': '1234',
             'simulated_state': 'done',
         }


### PR DESCRIPTION
Before this commit, tokens were prefixed with usually 12 X’s. To improve
readability, modernity and to shorten the length, this commit changes
token prefixes to a standard format of •••• 1111. 

task-2832669

See also: 
- https://github.com/odoo/enterprise/pull/29190
- https://github.com/odoo/upgrade/pull/3738