### PR TITLE
[FIX] project: hide the "Recurrent" option in the form view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -945,7 +945,7 @@
                             <field name="partner_phone" widget="phone" attrs="{'invisible': True}"/>
                             <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
-                            <field name="recurring_task" attrs="{'invisible': [('allow_recurring_tasks', '=', False), ('active', '=', False)]}" />
+                            <field name="recurring_task" attrs="{'invisible': ['|', ('allow_recurring_tasks', '=', False), ('active', '=', False)]}"/>
                             <field name="legend_blocked" invisible="1"/>
                             <field name="legend_normal" invisible="1"/>
                             <field name="legend_done" invisible="1"/>


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/85176, following a conflict resolution in a forward-bot, the domain used to show the "Recurrent" option in the form view of tasks is wrong, and the option is shown for all unarchived tasks, regardless of whether the setting is enabled.

This PR fixes this domain.