### PR TITLE
[FIX] website_sale: fix website_sale `test_customize` tests

### DIFF
--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -53,6 +53,11 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             else:
                 ptav.price_extra = 50.4
 
+        # Update the pricelist currency regarding env.company_id currency_id in case company has changed currency with COA installation.
+        website = self.env['website'].get_current_website()
+        pricelist = website.get_current_pricelist()
+        pricelist.write({'currency_id': self.env.company.currency_id.id})
+
     def test_01_admin_shop_customize_tour(self):
         # Enable Variant Group
         self.env.ref('product.group_product_variant').write({'users': [(4, self.env.ref('base.user_admin').id)]})


### PR DESCRIPTION
Cause:

  The tests fails because the expected price is not the right one.
  It is because that when installing the l10n module, it changed
  the current company currency (if no localization set) but not the
  pricelist.

Solution:

  For the tests, change pricelist currency of the main website
  with company currency.

opw-2899730