### PR TITLE
14.0 opw 2893036 calendar mail subject display wrong special character mafo

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -132,7 +132,7 @@ class Attendee(models.Model):
                         attendee.ids,
                         compute_lang=True,
                         post_process=True)[attendee.id]
-                subject = mail_template._render_field(
+                subject = mail_template.with_context(safe=True)._render_field(
                     'subject',
                     attendee.ids,
                     compute_lang=True)[attendee.id]


### PR DESCRIPTION
Steps to reproduce:
- Add an ampersand to the subject of the calendar subject
- Send an email reminder or update

Problem:
In the subject the amperstand is replaced by &amp;

Explanation:
The jinja engin needs the safe in the context to remove the
autoescape and to escape any HTML content submitted via template
variables.

opw-2893036
