### PR TITLE
[FIX] profiler: make profiler work with freezegun

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -27,6 +27,7 @@ from werkzeug import urls
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
 _logger = logging.getLogger(__name__)
+real_time = time.time.__call__  # ensure we have a non patched time for query times when using freezegun
 
 def unbuffer(symb, cr):
     if symb is None:
@@ -306,7 +307,7 @@ class Cursor(BaseCursor):
 
         if self.sql_log:
             _logger.debug("query: %s", self._format(query, params))
-        start = time.time()
+        start = real_time()
         try:
             params = params or None
             res = self._obj.execute(query, params)
@@ -317,7 +318,7 @@ class Cursor(BaseCursor):
 
         # simple query count is always computed
         self.sql_log_count += 1
-        delay = (time.time() - start)
+        delay = (real_time() - start)
         current_thread = threading.current_thread()
         if hasattr(current_thread, 'query_count'):
             current_thread.query_count += 1

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import datetime
+from datetime import datetime
 import gc
 import json
 import logging
@@ -17,6 +17,9 @@ from odoo import tools
 
 _logger = logging.getLogger(__name__)
 
+# ensure we have a non patched time for profiling times when using freezegun
+real_datetime_now = datetime.now
+real_time = time.time.__call__
 
 def _format_frame(frame):
     code = frame.f_code
@@ -57,7 +60,7 @@ def stack_size():
 
 
 def make_session(name=''):
-    return f'{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {name}'
+    return f'{real_datetime_now():%Y-%m-%d %H:%M:%S} {name}'
 
 
 def force_hook():
@@ -114,7 +117,7 @@ class Collector:
         self._entries.append({
             'stack': self._get_stack_trace(frame),
             'exec_context': getattr(self.profiler.init_thread, 'exec_context', ()),
-            'start': time.time(),
+            'start': real_time(),
             **(entry or {}),
         })
 
@@ -178,9 +181,9 @@ class PeriodicCollector(Collector):
 
     def run(self):
         self.active = True
-        last_time = time.time()
+        last_time = real_time()
         while self.active:  # maybe add a check on parent_thread state?
-            duration = time.time() - last_time
+            duration = real_time() - last_time
             if duration > self.frame_interval * 10 and self.last_frame:
                 # The profiler has unexpectedly slept for more than 10 frame intervals. This may
                 # happen when calling a C library without releasing the GIL. In that case, the
@@ -190,10 +193,10 @@ class PeriodicCollector(Collector):
                 self._entries[-1]['stack'].append(('profiling', 0, '⚠ Profiler freezed for %s s' % duration, ''))
                 self.last_frame = None  # skip duplicate detection for the next frame.
             self.add()
-            last_time = time.time()
+            last_time = real_time()
             time.sleep(self.frame_interval)
 
-        self._entries.append({'stack': [], 'start': time.time()})  # add final end frame
+        self._entries.append({'stack': [], 'start': real_time()})  # add final end frame
 
     def start(self):
         interval = self.profiler.params.get('traces_async_interval')
@@ -361,7 +364,7 @@ class QwebCollector(Collector):
         self.events = []
 
         def hook(event, sql_log_count, **kwargs):
-            self.events.append((event, kwargs, sql_log_count, time.time()))
+            self.events.append((event, kwargs, sql_log_count, real_time()))
         self.hook = hook
 
     def _get_directive_profiling_name(self, directive, attrib):
@@ -476,6 +479,7 @@ class Profiler:
         self.disable_gc = disable_gc
         self.filecache = {}
         self.params = params or {}  # custom parameters usable by collectors
+        self.profile_id = None
 
         if db is ...:
             # determine database from current thread
@@ -511,7 +515,7 @@ class Profiler:
             self.init_thread.profiler_params = self.params
         if self.disable_gc and gc.isenabled():
             gc.disable()
-        self.start_time = time.time()
+        self.start_time = real_time()
         for collector in self.collectors:
             collector.start()
         return self
@@ -520,7 +524,7 @@ class Profiler:
         try:
             for collector in self.collectors:
                 collector.stop()
-            self.duration = time.time() - self.start_time
+            self.duration = real_time() - self.start_time
             self._add_file_lines(self.init_stack_trace)
 
             if self.db:
@@ -530,7 +534,7 @@ class Profiler:
                     values = {
                         "name": self.description,
                         "session": self.profile_session,
-                        "create_date": datetime.datetime.now(),
+                        "create_date": real_datetime_now(),
                         "init_stack_trace": json.dumps(_format_stack(self.init_stack_trace)),
                         "duration": self.duration,
                         "entry_count": self.entry_count(),
@@ -543,8 +547,8 @@ class Profiler:
                         sql.SQL(",").join(map(sql.Identifier, values)),
                     )
                     cr.execute(query, [tuple(values.values())])
-                    profile_id = cr.fetchone()[0]
-                    _logger.info('ir_profile %s (%s) created', profile_id, self.profile_session)
+                    self.profile_id = cr.fetchone()[0]
+                    _logger.info('ir_profile %s (%s) created', self.profile_id, self.profile_session)
         finally:
             if self.disable_gc:
                 gc.enable()
@@ -581,7 +585,7 @@ class Profiler:
         This is mainly useful to uniquify a path between executions.
         """
         return path.format(
-            time=datetime.datetime.now().strftime("%Y%m%d-%H%M%S"),
+            time=real_datetime_now.strftime("%Y%m%d-%H%M%S"),
             len=self.entry_count(),
             desc=re.sub("[^0-9a-zA-Z-]+", "_", self.description)
         )
@@ -601,7 +605,7 @@ class Profiler:
         return json.dumps({
             "name": self.description,
             "session": self.profile_session,
-            "create_date": datetime.datetime.now().strftime("%Y%m%d-%H%M%S"),
+            "create_date": real_datetime_now.strftime("%Y%m%d-%H%M%S"),
             "init_stack_trace": _format_stack(self.init_stack_trace),
             "duration": self.duration,
             "collectors": {collector.name: collector.entries for collector in self.collectors},


### PR DESCRIPTION
When freezegun is used, the profiler and sql_db time are freezed,
Making the profile and sql perf counters invalids.

A possible solution would be to black list some modules in freezegun but
this doens't look possible in the pinned version (0.3.x).

Saving the builtin time.time is not enough, it looks like freezegun will
find all occurences and replace them.
We need to get the __call__ instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
