### PR TITLE
[FIX] im_livechat: remove compute of fields with legacy widgets

### DIFF
--- a/addons/im_livechat/static/src/models/public_livechat.js
+++ b/addons/im_livechat/static/src/models/public_livechat.js
@@ -4,31 +4,28 @@ import PublicLivechat from '@im_livechat/legacy/models/public_livechat';
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'PublicLivechat',
     identifyingFields: ['livechatButtonOwner'],
-    recordMethods: {
-        /**
-         * @private
-         * @returns {FieldCommand|im_livechat/legacy/models/public_livechat}
-         */
-        _computeLegacyPublicLivechat() {
-            if (!this.data) {
-                return clear();
-            }
-            return new PublicLivechat({
-                parent: this.livechatButtonOwner.widget,
-                data: this.data,
+    lifecycleHooks: {
+        _created() {
+            this.update({
+                legacyPublicLivechat: new PublicLivechat({
+                    parent: this.livechatButtonOwner.widget,
+                    data: this.data,
+                }),
             });
         },
+        _willDelete() {
+            this.legacyPublicLivechat.destroy();
+        },
+    },
+    recordMethods: {
     },
     fields: {
         data: attr(),
-        legacyPublicLivechat: attr({
-            compute: '_computeLegacyPublicLivechat',
-        }),
+        legacyPublicLivechat: attr(),
         livechatButtonOwner: one('LivechatButtonView', {
             inverse: 'publicLivechat',
             readonly: true,

--- a/addons/im_livechat/static/src/models/public_livechat_window.js
+++ b/addons/im_livechat/static/src/models/public_livechat_window.js
@@ -4,43 +4,31 @@ import PublicLivechatWindow from '@im_livechat/legacy/widgets/public_livechat_wi
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'PublicLivechatWindow',
     identifyingFields: ['livechatButtonViewOwner'],
     lifecycleHooks: {
-        _willDelete() {
-            if (this.legacyChatWindow) {
-                this.legacyChatWindow.destroy();
-            }
+        _created() {
+            this.update({
+                legacyChatWindow: new PublicLivechatWindow(
+                    this.livechatButtonViewOwner.widget,
+                    this.messaging.livechatButtonView.publicLivechat.legacyPublicLivechat,
+                    {
+                        displayStars: false,
+                        headerBackgroundColor: this.livechatButtonViewOwner.headerBackgroundColor,
+                        placeholder: this.livechatButtonViewOwner.inputPlaceholder,
+                        titleColor: this.livechatButtonViewOwner.titleColor,
+                    },
+                ),
+            });
         },
-    },
-    recordMethods: {
-        /**
-         * @private
-         * @returns {im_livechat/legacy/widgets/public_chat_window|FieldCommand}
-         */
-        _computeLegacyChatWindow() {
-            if (!this.livechatButtonViewOwner.widget && this.legacyChatWindow) {
-                this.legacyChatWindow.destroy();
-                return clear();
-            }
-            return new PublicLivechatWindow(
-                this.livechatButtonViewOwner.widget,
-                this.messaging.livechatButtonView.publicLivechat.legacyPublicLivechat,
-                {
-                    displayStars: false,
-                    headerBackgroundColor: this.livechatButtonViewOwner.headerBackgroundColor,
-                    placeholder: this.livechatButtonViewOwner.inputPlaceholder,
-                    titleColor: this.livechatButtonViewOwner.titleColor,
-                },
-            );
+        _willDelete() {
+            this.legacyChatWindow.destroy();
         },
     },
     fields: {
         legacyChatWindow: attr({
-            compute: '_computeLegacyChatWindow',
             default: null,
         }),
         livechatButtonViewOwner: one('LivechatButtonView', {


### PR DESCRIPTION
These fields should not be declarative with compute, because
these widgets need to manager existence by hand (i.e. manually
`new` or `.destroy()`).

Task-2900003
