### PR TITLE
[FIX] crm_lead: crm.lead created from smart button

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -57,7 +57,7 @@ class Partner(models.Model):
         This function returns an action that displays the opportunities from partner.
         '''
         action = self.env['ir.actions.act_window']._for_xml_id('crm.crm_lead_opportunities')
-        action['context'] = {'active_test': False}
+        action['context'] = {'active_test': False, 'default_type':'opportunity'}
         if self.is_company:
             action['domain'] = [('partner_id.commercial_partner_id.id', '=', self.id)]
         else:

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -10,7 +10,7 @@
                             type="object" class="oe_highlight" data-hotkey="w" title="Mark as won"
                             attrs="{'invisible': ['|','|', ('active','=',False), ('probability', '=', 100), ('type', '=', 'lead')]}"/>
                         <button name="%(crm.crm_lead_lost_action)d" string="Lost" data-hotkey="l" title="Mark as lost"
-                            type="action" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'),('active', '=', False),('probability', '&lt;', 100)]}"/>
+                            type="action" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'),'&amp;',('active', '=', False),('probability', '&lt;', 100)]}"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action" help="Convert to Opportunity"
                             class="oe_highlight" attrs="{'invisible': ['|', ('type', '=', 'opportunity'), ('active', '=', False)]}" data-hotkey="v"/>
                         <button name="toggle_active" string="Restore" type="object" data-hotkey="z"

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -34,7 +34,7 @@
                             name="action_view_opportunity"
                             icon="fa-star"
                             groups="sales_team.group_sale_salesman"
-                            context="{'default_partner_id': active_id}">
+                            context="{'default_partner_id': active_id, 'default_type':'opportunity'}">
                             <field string="Opportunities" name="opportunity_count" widget="statinfo"/>
                         </button>
                     </div>


### PR DESCRIPTION
steps to reproduce issue
- go to contacts and create a contact for an individual
- after creating the contact click on opportunity, to create an crm.lead
for that contact
- after creating the crm.lead move it to the won stage
- [Video of steps to reproduce bug](https://drive.google.com/file/d/1IbiwONBJbCjsCwOJ3TOPygaE1fJeZ0Iq/view)

Expected Behavior
- there should not be two *LOST* buttons on the lead won stage
- the lead created under a contact should be automatically converted to
an opportunity

Solution
to fix the issue of two *LOST* buttons on lead won stage, the following
code snippet was used in the crm_lead_views.xml file
`attrs="{'invisible': ['|', ('type', '=', 'lead'),'&amp;',('active',
'=', False),('probability', '&lt;', 100)]}"`

to fix the issue with the crm.lead creation, the type field default was
changed to *opportunity*

opw-2886623

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
