### PR TITLE
[FIX] web: ProgressBarField behavior and allow edition in kanban

### DIFF
--- a/addons/web/static/src/views/fields/progress_bar/kanban_progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/kanban_progress_bar_field.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { ProgressBarField } from "./progress_bar_field";
+
+class KanbanProgressBarField extends ProgressBarField {
+    onClick() {
+        if (this.props.isEditable && !this.props.record.isReadonly(this.props.name)) {
+            this.state.isEditing = true;
+        }
+    }
+}
+
+registry.category("fields").add("kanban.progressbar", KanbanProgressBarField);

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ProgressBarField" owl="1">
-        <t t-if="props.readonly">
-            <div class="o_progressbar">
+        <t t-if="!state.isEditing">
+            <div class="o_progressbar" t-on-click="onClick">
                 <div class="o_progress" aria-valuemin="0" t-att-aria-valuemax="state.maxValue" t-att-aria-valuenow="state.currentValue">
                     <div class="o_progressbar_complete" t-att-style="'width: min(' + 100 * state.currentValue / state.maxValue + '%, 100%)'"></div>
                 </div>
@@ -16,7 +16,7 @@
             </div>
         </t>
         <t t-else="">
-            <div class="o_progressbar d-flex" t-ref="numpadDecimal">
+            <div class="o_progressbar d-flex" t-ref="numpadDecimal" t-on-click="onClick">
                 <div class="o_progress" aria-valuemin="0" t-att-aria-valuemax="state.maxValue" t-att-aria-valuenow="state.currentValue">
                     <div class="o_progressbar_complete" t-att-style="'width: min(' + 100 * state.currentValue / state.maxValue + '%, 100%)'"></div>
                 </div>
@@ -30,38 +30,33 @@
                             t-att-required="props.required"
                             t-on-change="(ev) => this.onChangeValue(ev.target.value, 'currentValue')"
                             t-on-input="(ev) => this.onInput(ev, 'currentValue')"
+                            t-on-blur="(ev) => this.onBlur(ev.target.value, 'currentValue')"
                         />
                         <span>%</span>
                     </div>
                 </t>
                 <t t-else="">
-                <t t-if="props.isCurrentValueEditable">
-                        <input
-                            class="o_progressbar_value o_input"
-                            type="text"
-                            inputmode="numeric"
-                            t-att-value="getFormattedValue('currentValue')"
-                            t-on-change="(ev) => this.onChangeValue(ev.target.value, 'currentValue')"
-                            t-on-input="(ev) => this.onInput(ev, 'currentValue')"
-                        />
-                    </t>
-                    <t t-else="">
-                        <span class="o_progressbar_value" t-esc="state.currentValue"/>
-                    </t>
-                    <span>/</span>
-                    <t t-if="props.isMaxValueEditable">
-                        <input
-                            class="o_progressbar_value o_input"
-                            type="text"
-                            inputmode="numeric"
-                            t-att-value="getFormattedValue('maxValue')"
-                            t-on-change="(ev) => this.onChangeValue(ev.target.value, 'maxValue')"
-                            t-on-input="(ev) => this.onInput(ev, 'maxValue')"
-                        />
-                    </t>
-                    <t t-else="">
-                        <span class="o_progressbar_value" t-esc="state.maxValue"/>
-                    </t>
+                    <input
+                        t-if="props.isCurrentValueEditable"
+                        class="o_progressbar_value o_input"
+                        type="text"
+                        inputmode="numeric"
+                        t-att-value="getFormattedValue('currentValue')"
+                        t-on-change="(ev) => this.onChangeValue(ev.target.value, 'currentValue')"
+                        t-on-input="(ev) => this.onInput(ev, 'currentValue')"
+                        t-on-blur="(ev) => this.onBlur(ev.target.value, 'currentValue')"
+                    />
+                    <span t-if="props.isCurrentValueEditable and props.isMaxValueEditable" t-esc="'/'" />
+                    <input
+                        t-if="props.isMaxValueEditable"
+                        class="o_progressbar_value o_input"
+                        type="text"
+                        inputmode="numeric"
+                        t-att-value="getFormattedValue('maxValue')"
+                        t-on-change="(ev) => this.onChangeValue(ev.target.value, 'maxValue')"
+                        t-on-input="(ev) => this.onInput(ev, 'maxValue')"
+                        t-on-blur="onBlur"
+                    />
                 </t>
             </div>
         </t>

--- a/addons/web/static/tests/views/fields/numeric_fields_tests.js
+++ b/addons/web/static/tests/views/fields/numeric_fields_tests.js
@@ -114,7 +114,6 @@ QUnit.module("Fields", (hooks) => {
             const integerInput = target.querySelector(".o_field_integer input");
             const monetaryInput = target.querySelector(".o_field_monetary input");
             const percentageInput = target.querySelector(".o_field_percentage input");
-            const progressbarInputs = target.querySelectorAll(".o_field_progressbar input");
 
             // Dispatch numpad "dot" and numpad "comma" keydown events to all inputs and check
             // Numpad "comma" is specific to some countries (Brazil...)
@@ -163,6 +162,8 @@ QUnit.module("Fields", (hooks) => {
             await nextTick();
             assert.strictEqual(percentageInput.value, "99🇧🇪🇧🇪");
 
+            await click(target.querySelector(".o_progress"));
+            const progressbarInputs = target.querySelectorAll(".o_field_progressbar input");
             progressbarInputs[0].dispatchEvent(
                 new KeyboardEvent("keydown", { code: "NumpadDecimal", key: "." })
             );


### PR DESCRIPTION
This commit fixes some inconsistencies of the progressbar
field widget since it was converted to Owl. Some behaviors
were wrongly adapted and edition was not enabled in kanban
views. It was also missing an option to allow editing the
field value in readonly mode.