### PR TITLE
[FIX] mail: fix useComponentToModel/useRefToModel

### DIFF
--- a/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js
@@ -32,6 +32,18 @@ export function useComponentToModel({ fieldName, modelName, propNameAsRecordLoca
             nextRecord.update({ [fieldName]: component });
         }
     });
+    const __render = component.__render;
+    component.__render = fiber => {
+        const record = modelManager.models[modelName].get(component.props[propNameAsRecordLocalId]);
+        if (record && !record[fieldName]) {
+            // When the record is deleted then created again, its
+            // localId can be the same. In this scenario, the Component
+            // would not call setup neither willUpdateprops. Therefore,
+            // we need to set the component for this new record.
+            record.update({ [fieldName]: component });
+        }
+        __render.call(component, fiber);
+    };
     const __destroy = component.__destroy;
     component.__destroy = parent => {
         const record = modelManager.models[modelName].get(component.props[propNameAsRecordLocalId]);

--- a/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
+++ b/addons/mail/static/src/component_hooks/use_ref_to_model/use_ref_to_model.js
@@ -34,6 +34,18 @@ export function useRefToModel({ fieldName, modelName, propNameAsRecordLocalId, r
             nextRecord.update({ [fieldName]: ref });
         }
     });
+    const __render = component.__render;
+    component.__render = fiber => {
+        const record = modelManager.models[modelName].get(component.props[propNameAsRecordLocalId]);
+        if (record && !record[fieldName]) {
+            // When the record is deleted then created again, its
+            // localId can be the same. In this scenario, the Component
+            // would not call setup neither willUpdateprops. Therefore,
+            // we need to set the ref for this new record.
+            record.update({ [fieldName]: ref });
+        }
+        __render.call(component, fiber);
+    };
     const __destroy = component.__destroy;
     component.__destroy = parent => {
         const record = modelManager.models[modelName].get(component.props[propNameAsRecordLocalId]);


### PR DESCRIPTION
Some components use the `useComponentToModel`/`useRefToModel` hooks
to set a field on their related record. When a record is deleted then
created again, its localId can remain the same. This means the Component
won't trigger the `setup` method neither the `willUpdateprops`. Therefore,
the second record's field would be undefined. In order to solve this issue,
let's check that the record's field is properly set when the component is
rendered.