### PR TITLE
[FIX] website: (re)properly stop widgets before when removing snippet

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -701,6 +701,7 @@ WysiwygAdapterComponent.prototype.events = {
     'widgets_start_request': '_onRootEventRequest',
     'widgets_stop_request': '_onRootEventRequest',
     'ready_to_clean_for_save': '_onRootEventRequest',
+    'will_remove_snippet': '_onRootEventRequest',
     'gmap_api_request': '_onRootEventRequest',
     'gmap_api_key_request': '_onRootEventRequest',
     'request_save': '_onSaveRequest',


### PR DESCRIPTION
Commit [1] introduced an event that stops the public widgets of a
snippet prior to removing it from the DOM.
Commit [2] moved the edition to the backend and forgot to bind that
event to the website_root

This commit fixes that.

[1]: https://github.com/odoo/odoo/commit/b66409cad4a9a3d040820c3935f9a64b09ba25d3
[2]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506
[1]: https://github.com/odoo/odoo/commit/b66409cad4a9a3d040820c3935f9a64b09ba25d3
[2]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506
