### PR TITLE
[FIX] hr_recruitment_skills: remove unexisting js_class

### DIFF
--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -52,15 +52,4 @@
             </filter>
         </field>
     </record>
-
-    <record id="hr_applicant_view_kanban" model="ir.ui.view">
-        <field name="name">hr.applicant.view.kanban.inherit.skills</field>
-        <field name="model">hr.applicant</field>
-        <field name="inherit_id" ref="hr_recruitment.hr_kanban_view_applicant"/>
-        <field name="arch" type="xml">
-            <xpath expr="//kanban" position="attributes">
-                <attribute name="js_class">hr_applicant_kanban</attribute>
-            </xpath>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
The populate JS class has been removed in #94554 but was still
referenced in the view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
