### PR TITLE
[FIX] account_edi{,_facturx}: properly retrieve product/description

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -625,6 +625,9 @@ class AccountEdiFormat(models.Model):
         :param barcode:         The barcode of the product.
         :returns:               A product or an empty recordset if not found.
         '''
+        if name and '\n' in name:
+            # cut Sales Description from the name
+            name = name.split('\n')[0]
         domains = []
         for value, domain in (
             (name, ('name', 'ilike', name)),

--- a/addons/account_edi_facturx/data/facturx_templates.xml
+++ b/addons/account_edi_facturx/data/facturx_templates.xml
@@ -21,6 +21,10 @@
                         <ram:SellerAssignedID
                             t-if="line.product_id and line.product_id.default_code"
                             t-esc="line.product_id.default_code"/>
+                        <!-- TODO:
+                        <ram:Name t-esc="line.product_id.name or line.name"/>
+                        <ram:Description t-esc="line.name" t-if="line.name != line.product_id.name"/>
+                        -->
                         <ram:Name t-esc="line.name"/>
                     </ram:SpecifiedTradeProduct>
 

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -324,13 +324,14 @@ class AccountEdiFormat(models.Model):
 
                         # Product.
                         name = _find_value('.//ram:SpecifiedTradeProduct/ram:Name', element)
-                        if name:
-                            invoice_line_form.name = name
                         invoice_line_form.product_id = self_ctx._retrieve_product(
                             default_code=_find_value('.//ram:SpecifiedTradeProduct/ram:SellerAssignedID', element),
                             name=_find_value('.//ram:SpecifiedTradeProduct/ram:Name', element),
                             barcode=_find_value('.//ram:SpecifiedTradeProduct/ram:GlobalID', element)
                         )
+                        # force original line description instead of the one copied from product's Sales Description
+                        if name:
+                            invoice_line_form.name = name
 
                         # Quantity.
                         line_elements = element.xpath('.//ram:SpecifiedLineTradeDelivery/ram:BilledQuantity', namespaces=tree.nsmap)

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -310,13 +310,14 @@ class AccountEdiXmlCII(models.AbstractModel):
 
         # Product.
         name = _find_value('.//ram:SpecifiedTradeProduct/ram:Name', tree)
-        if name:
-            invoice_line_form.name = name
         invoice_line_form.product_id = self.env['account.edi.format']._retrieve_product(
             default_code=_find_value('.//ram:SpecifiedTradeProduct/ram:SellerAssignedID', tree),
             name=_find_value('.//ram:SpecifiedTradeProduct/ram:Name', tree),
             barcode=_find_value('.//ram:SpecifiedTradeProduct/ram:GlobalID', tree)
         )
+        # force original line description instead of the one copied from product's Sales Description
+        if name:
+            invoice_line_form.name = name
 
         xpath_dict = {
             'basis_qty': [


### PR DESCRIPTION
Odoo attaches factur-x doc to every invoice pdf. That data can be used to upload
invoice to another Odoo instance.

On uploading such an invoice, Odoo tries to find product in its DB. But it
doesn't work if original product has Sales Description which is by default
copied to line's Description (field `name`).

Fix it by searching by first line in the name value of factur-x. Product name
doesn't contain \n symbol in most cases anyway.

This commit doesn't fix factur-x doc generation because of stable version
policy. In next Odoo release we should use separate factur-x attributes for
product name and invoice line description.

opw-2878530

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
