### PR TITLE
[FIX] tests: look for google-chrome-stable executable

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -909,7 +909,7 @@ class ChromeBrowser:
     def executable(self):
         system = platform.system()
         if system == 'Linux':
-            for bin_ in ['google-chrome', 'chromium', 'chromium-browser']:
+            for bin_ in ['google-chrome', 'chromium', 'chromium-browser', 'google-chrome-stable']:
                 try:
                     return find_in_path(bin_)
                 except IOError:


### PR DESCRIPTION
On archlinux, when installing the AUR package [1] through yay, the
executable name is `google-chrome-stable`

[1]: https://aur.archlinux.org/packages/google-chrome



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
