### PR TITLE
[FIX] web: graph,pivot: favorite groupbys

### DIFF
--- a/addons/web/static/src/views/graph/graph_view.js
+++ b/addons/web/static/src/views/graph/graph_view.js
@@ -11,6 +11,7 @@ import { useModel } from "../helpers/model";
 import { GraphArchParser } from "./graph_arch_parser";
 import { GraphModel } from "./graph_model";
 import { GraphRenderer } from "./graph_renderer";
+import { SearchModel } from "@web/search/search_model";
 
 const viewRegistry = registry.category("views");
 
@@ -127,6 +128,24 @@ export class GraphView extends Component {
     }
 }
 
+class GraphSearchModel extends SearchModel {
+    _getIrFilterDescription() {
+        this.preparingIrFilterDescription = true;
+        const result = super._getIrFilterDescription(...arguments);
+        this.preparingIrFilterDescription = false;
+        return result;
+    }
+
+    _getSearchItemGroupBys(activeItem) {
+        const { searchItemId } = activeItem;
+        const { context, type } = this.searchItems[searchItemId];
+        if (!this.preparingIrFilterDescription && type === "favorite" && context.graph_groupbys) {
+            return context.graph_groupbys;
+        }
+        return super._getSearchItemGroupBys(...arguments);
+    }
+}
+
 GraphView.template = "web.GraphView";
 GraphView.buttonTemplate = "web.GraphView.Buttons";
 
@@ -152,6 +171,7 @@ GraphView.icon = "fa-bar-chart";
 GraphView.multiRecord = true;
 
 GraphView.Model = GraphModel;
+GraphView.SearchModel = GraphSearchModel;
 
 GraphView.ArchParser = GraphArchParser;
 

--- a/addons/web/static/src/views/pivot/pivot_view.js
+++ b/addons/web/static/src/views/pivot/pivot_view.js
@@ -11,6 +11,7 @@ import { Layout } from "@web/views/layout";
 import { PivotArchParser } from "@web/views/pivot/pivot_arch_parser";
 import { PivotModel } from "@web/views/pivot/pivot_model";
 import { PivotRenderer } from "@web/views/pivot/pivot_renderer";
+import { SearchModel } from "@web/search/search_model";
 
 const viewRegistry = registry.category("views");
 
@@ -155,6 +156,28 @@ export class PivotView extends Component {
     }
 }
 
+class PivotSearchModel extends SearchModel {
+    _getIrFilterDescription() {
+        this.preparingIrFilterDescription = true;
+        const result = super._getIrFilterDescription(...arguments);
+        this.preparingIrFilterDescription = false;
+        return result;
+    }
+
+    _getSearchItemGroupBys(activeItem) {
+        const { searchItemId } = activeItem;
+        const { context, type } = this.searchItems[searchItemId];
+        if (
+            !this.preparingIrFilterDescription &&
+            type === "favorite" &&
+            context.pivot_row_groupby
+        ) {
+            return context.pivot_row_groupby;
+        }
+        return super._getSearchItemGroupBys(...arguments);
+    }
+}
+
 PivotView.template = "web.PivotView";
 PivotView.buttonTemplate = "web.PivotView.Buttons";
 PivotView.components = { Renderer: PivotRenderer, Layout };
@@ -168,6 +191,7 @@ PivotView.defaultProps = {
 };
 
 PivotView.Model = PivotModel;
+PivotView.SearchModel = PivotSearchModel;
 
 PivotView.ArchParser = PivotArchParser;
 

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -3597,5 +3597,44 @@ QUnit.module("Views", (hooks) => {
             },
         });
         checkLabels(assert, graph, ["January 2016", "March 2016", "May 2016", "April 2016"]);
-    })
+    });
+
+    QUnit.test("graph_groupbys should be also used after first load", async function (assert) {
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            groupBy: ["date:quarter"],
+            arch: `<graph/>`,
+            irFilters: [
+                {
+                    user_id: [2, "Mitchell Admin"],
+                    name: "Favorite",
+                    id: 1,
+                    context: `{
+                        "group_by": [],
+                        "graph_measure": "revenue",
+                        "graph_mode": "bar",
+                        "graph_groupbys": ["color_id"],
+                    }`,
+                    sort: "[]",
+                    domain: "",
+                    is_default: false,
+                    model_id: "foo",
+                    action_id: false,
+                },
+            ],
+        });
+
+        checkModeIs(assert, graph, "bar");
+        checkLabels(assert, graph, ["Q1 2016", "Q2 2016", "Undefined"]);
+        checkLegend(assert, graph, "Count");
+
+        await toggleFavoriteMenu(graph);
+        await toggleMenuItem(graph, "Favorite");
+
+        checkModeIs(assert, graph, "bar");
+        checkLabels(assert, graph, ["Undefined", "red"]);
+        checkLegend(assert, graph, "Revenue");
+    });
 });

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -5391,4 +5391,164 @@ QUnit.module("Views", (hooks) => {
             assert.strictEqual(getCurrentValues(pivot), values.join());
         }
     );
+
+    QUnit.test("pivot_row_groupby should be also used after first load", async function (assert) {
+        const ids = [1, 2];
+        const expectedContexts = [
+            {
+                group_by: ["bar"],
+                pivot_column_groupby: [],
+                pivot_measures: ["__count"],
+                pivot_row_groupby: ["product_id"],
+            },
+            {
+                group_by: ["bar", "customer"],
+                pivot_column_groupby: [],
+                pivot_measures: ["__count"],
+                pivot_row_groupby: ["customer"],
+            },
+        ];
+
+        const pivot = await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `<pivot/>`,
+            searchViewArch: `
+                <search>
+                    <filter name='product_id' string="Product" context="{'group_by':'product_id'}"/>
+                    <filter name='customer' string="Customer" context="{'group_by':'customer'}"/>
+                </search>
+            `,
+            groupBy: ["bar"],
+            mockRPC(route, args) {
+                if (args.method === "create_or_replace") {
+                    assert.deepEqual(args.args[0].context, expectedContexts.shift());
+                    return ids.shift();
+                }
+            },
+        });
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "true", "Undefined"],
+            "The row headers should be as expected"
+        );
+
+        await click(pivot.el.querySelector("tbody th")); // click on row header "Total"
+        await click(pivot.el.querySelector("tbody th")); // click on row header "Total"
+        await click(pivot.el.querySelector("tbody .o_group_by_menu .o_menu_item")); // select "Product"
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "xphone", "xpad"],
+            "The row headers should be as expected"
+        );
+
+        await toggleFavoriteMenu(pivot);
+        await toggleSaveFavorite(pivot);
+        await editFavoriteName(pivot, "Favorite");
+        await saveFavorite(pivot);
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "xphone", "xpad"],
+            "The row headers should be as expected"
+        );
+
+        await removeFacet(pivot);
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "true", "Undefined"],
+            "The row headers should be as expected"
+        );
+
+        await toggleFavoriteMenu(pivot);
+        await toggleMenuItem(pivot, "Favorite");
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "xphone", "xpad"],
+            "The row headers should be as expected"
+        );
+
+        await toggleGroupByMenu(pivot);
+        await toggleMenuItem(pivot, "Customer");
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "xphone", "First", "xpad", "Second", "First"],
+            "The row headers should be as expected"
+        );
+
+        await click(pivot.el.querySelector("tbody th")); // click on row header "Total"
+        await click(pivot.el.querySelector("tbody th")); // click on row header "Total"
+        await click(pivot.el.querySelectorAll("tbody .o_group_by_menu .o_menu_item")[1]); // select "Customer"
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "First", "Second"],
+            "The row headers should be as expected"
+        );
+
+        await toggleFavoriteMenu(pivot);
+        await toggleSaveFavorite(pivot);
+        await editFavoriteName(pivot, "Favorite 2");
+        await saveFavorite(pivot);
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+            ["Total", "First", "Second"],
+            "The row headers should be as expected"
+        );
+    });
+
+    QUnit.test(
+        "pivot_row_groupby should be also used after first load (2)",
+        async function (assert) {
+            const pivot = await makeView({
+                serverData,
+                type: "pivot",
+                resModel: "partner",
+                groupBy: ["product_id"],
+                arch: `<pivot/>`,
+                irFilters: [
+                    {
+                        user_id: [2, "Mitchell Admin"],
+                        name: "Favorite",
+                        id: 1,
+                        context: `
+                            {
+                                "group_by": [],
+                                "pivot_row_groupby": ["customer"],
+                                "pivot_col_groupby": [],
+                                "pivot_measures": ["foo"],
+                            }
+                        `,
+                        sort: "[]",
+                        domain: "",
+                        is_default: false,
+                        model_id: "foo",
+                        action_id: false,
+                    },
+                ],
+            });
+
+            assert.deepEqual(
+                [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+                ["Total", "xphone", "xpad"],
+                "The row headers should be as expected"
+            );
+
+            await toggleFavoriteMenu(pivot);
+            await toggleMenuItem(pivot, "Favorite");
+
+            assert.deepEqual(
+                [...pivot.el.querySelectorAll("th")].slice(3).map((el) => el.innerText),
+                ["Total", "First", "Second"],
+                "The row headers should be as expected"
+            );
+        }
+    );
 });


### PR DESCRIPTION
Problem:

Have a pivot view in some state. Toggle a favorite with a context in which a key "pivot_row_groupby" is defined. The pivot view should be grouped (on rows) by that pivot_row_groupby but it is not always the case.
The basic problem is that the key "pivot_row_groupby" is never considered after the first load (see method load in pivot_model.js).

Solution:

We make the search model used by the pivot view send as groupby for the favorite its pivot_row_groupby instead of its groupBy (which can be different).  We do something similar for the graph view that presents a similar problem.

OPW: 2837428