### PR TITLE
[FIX] calendar: event recurrence start date is not correctly computed

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -406,13 +406,14 @@ class Meeting(models.Model):
         defaults = self.env['calendar.recurrence'].default_get(recurrence_fields)
         for event in self:
             if event.recurrency:
+                event.update(defaults)  # default recurrence values are needed to correctly compute the recurrence params
                 event_values = event._get_recurrence_params()
                 rrule_values = {
                     field: event.recurrence_id[field]
                     for field in recurrence_fields
                     if event.recurrence_id[field]
                 }
-                event.update({**false_values, **defaults, **event_values, **rrule_values})
+                event.update({**false_values, **event_values, **rrule_values})
             else:
                 event.update(false_values)
 
@@ -603,8 +604,8 @@ class Meeting(models.Model):
         """
         if not self.start:
             return fields.Date.today()
-        if self.recurrence_id.event_tz:
-            tz = pytz.timezone(self.recurrence_id.event_tz)
+        if self.recurrency and self.event_tz:
+            tz = pytz.timezone(self.event_tz)
             return pytz.utc.localize(self.start).astimezone(tz).date()
         return self.start.date()
 

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -5,6 +5,7 @@ import datetime
 from datetime import datetime, timedelta, time
 
 from odoo import fields
+from odoo.tests import Form
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 import pytz
 import re
@@ -185,6 +186,14 @@ class TestCalendar(SavepointCaseWithUserDemo):
             else:
                 self.assertEqual(d.hour, 15)
             self.assertEqual(d.minute, 30)
+
+    def test_recurring_ny(self):
+        self.env.user.tz = 'US/Eastern'
+        f = Form(self.CalendarEvent.with_context(tz='US/Eastern'))
+        f.name = 'test'
+        f.start = '2022-07-07 01:00:00'  # This is in UTC. In NY, it corresponds to the 6th of july at 9pm.
+        f.recurrency = True
+        self.assertEqual(f.weekday, 'WE')
 
     def test_event_activity_timezone(self):
         activty_type = self.env['mail.activity.type'].create({


### PR DESCRIPTION
Steps to reproduce:

  - Set your timezone to New York
    In linux for example with: `timedatectl set-timezone America/New_York`
  - Verify that the user timezone is also set to NY
  - Create a reccurent event the 6 july 2022 (a wednesday)
  - In options, check the recurrent box
  - Set repeat to once every week
  - Thursday is the only day checked
  -> It should be Wednesday

Cause of the issue:

  When `_compute_recurrence` is called, `event.recurrence_id` has not
  yet been set
  -> `event.recurrence_id.event_tz` is False
  => Copy the defaults before computing the start date and check the
  timezone of the event itself

opw-2886253
