### PR TITLE
[FIX] account_accountant: allow billing user to access tax report

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -92,6 +92,7 @@ access_account_tax_repartition_line_manager,account.tax repartition.line.manager
 access_account_tax_report_line_readonly,account.tax.report.line.invoice,model_account_tax_report_line,account.group_account_readonly,1,0,0,0
 access_account_tax_report_line_ac_user,account.tax.report.line.ac.user,model_account_tax_report_line,account.group_account_manager,1,1,1,1
 access_account_tax_report_invoice,account.tax.report.invoice,model_account_tax_report,account.group_account_readonly,1,0,0,0
+access_account_tax_report_billing,account.tax.report.billing,model_account_tax_report,account.group_account_invoice,1,0,0,0
 access_account_tax_report_ac_user,account.tax.report.ac.user,model_account_tax_report,account.group_account_manager,1,1,1,1
 access_account_tax_group_internal_user,account.tax.group internal user,model_account_tax_group,base.group_user,1,0,0,0
 access_account_tax_group_readonly,account.tax.group,model_account_tax_group,account.group_account_readonly,1,0,0,0


### PR DESCRIPTION
Currently, an Accounting/Billing user can access Tax report from the
menu, but he cannot read model account.tax.report, which logically
raises an access right error. We should allow him to normally access
this report instead.

Description of the issue/feature this PR addresses:
opw-2865492

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
