### PR TITLE
[PRF] payment_adyen: only load the SDK on pages with a payment form

### DIFF
--- a/addons/payment_adyen/__manifest__.py
+++ b/addons/payment_adyen/__manifest__.py
@@ -11,14 +11,13 @@
     'data': [
         'views/payment_adyen_templates.xml',
         'views/payment_views.xml',
+        'views/payment_templates.xml',  # Only load the SDK on pages with a payment form.
         'data/payment_acquirer_data.xml',  # Depends on views/payment_adyen_templates.xml
     ],
     'application': True,
     'uninstall_hook': 'uninstall_hook',
     'assets': {
         'web.assets_frontend': [
-            'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.css',
-            'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.js',
             'payment_adyen/static/src/js/payment_form.js',
             'payment_adyen/static/src/scss/dropin.scss',
         ],

--- a/addons/payment_adyen/views/payment_templates.xml
+++ b/addons/payment_adyen/views/payment_templates.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="checkout" inherit_id="payment.checkout">
+        <xpath expr="." position="inside">
+            <t t-call="payment_adyen.sdk_assets"/>
+        </xpath>
+    </template>
+
+    <template id="manage" inherit_id="payment.manage">
+        <xpath expr="." position="inside">
+            <t t-call="payment_adyen.sdk_assets"/>
+        </xpath>
+    </template>
+
+    <template id="sdk_assets">
+        <script src="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.js"
+                integrity="sha384-YiT4BfPwbplFwUnpDjm2rmWCvpzdi6+l+1E+J9JKTB3CYyKbbwJ8ghkUheQf79X9"
+                crossorigin="anonymous">
+        </script>
+        <link rel="stylesheet"
+              href="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.css"
+              integrity="sha384-X1zQUhO5NGWdMQmDcuv2kyQK65QR7/VJtNthEImZm7jOvOEicQrnVijI0n9DcHkF"
+              crossorigin="anonymous">
+        </link>
+    </template>
+
+</odoo>


### PR DESCRIPTION
The SDK of Adyen Checkout is quite large (≲ 1MB) and was always loaded
on all frontend pages before this commit, which hurt the loading
performances.

This commit restricts the loading of the SDK to pages that include one
of the payment forms (either 'checkout' or 'manage').

task-2899271