### PR TITLE
[FIX] purchase: Avoid errors for user without purchase order rights.

### DIFF
--- a/addons/purchase/models/analytic_account.py
+++ b/addons/purchase/models/analytic_account.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models, _
 class AccountAnalyticAccount(models.Model):
     _inherit = 'account.analytic.account'
 
-    purchase_order_count = fields.Integer("Purchase Order Count", compute='_compute_purchase_order_count')
+    purchase_order_count = fields.Integer("Purchase Order Count", compute='_compute_purchase_order_count', compute_sudo=True)
 
     @api.depends('line_ids')
     def _compute_purchase_order_count(self):


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
This issue is cause becease this field read POs and for an user that not have any rights to access to purchase Order, this user cannot access to analytic account.

Desired behavior after PR is merged:


After this change no matter if the user have or not access to Purchas order, alaways see the analytic account.
Current behavior before PR:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
