### PR TITLE
[FIX] core: maintain record lines ordered by _order after write

### DIFF
--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -218,8 +218,8 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.rule_1.match_text_location_note = False
         self._check_statement_matching(self.rule_1, {
             self.bank_line_3.id: {'aml_ids': [self.invoice_line_5.id], 'model': self.rule_1, 'partner': self.bank_line_3.partner_id},
-            self.bank_line_4.id: {'aml_ids': [self.invoice_line_7.id], 'model': self.rule_1, 'partner': self.bank_line_4.partner_id},
-            self.bank_line_5.id: {'aml_ids': [self.invoice_line_6.id], 'model': self.rule_1, 'partner': self.bank_line_5.partner_id},
+            self.bank_line_4.id: {'aml_ids': [self.invoice_line_6.id], 'model': self.rule_1, 'partner': self.bank_line_4.partner_id},
+            self.bank_line_5.id: {'aml_ids': [self.invoice_line_7.id], 'model': self.rule_1, 'partner': self.bank_line_5.partner_id},
         }, statements=self.bank_st_2)
 
         self.rule_1.match_text_location_label = True
@@ -227,8 +227,8 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.rule_1.match_text_location_note = True
         self._check_statement_matching(self.rule_1, {
             self.bank_line_3.id: {'aml_ids': [self.invoice_line_6.id], 'model': self.rule_1, 'partner': self.bank_line_3.partner_id},
-            self.bank_line_4.id: {'aml_ids': [self.invoice_line_7.id], 'model': self.rule_1, 'partner': self.bank_line_4.partner_id},
-            self.bank_line_5.id: {'aml_ids': [self.invoice_line_5.id], 'model': self.rule_1, 'partner': self.bank_line_5.partner_id},
+            self.bank_line_4.id: {'aml_ids': [self.invoice_line_5.id], 'model': self.rule_1, 'partner': self.bank_line_4.partner_id},
+            self.bank_line_5.id: {'aml_ids': [self.invoice_line_7.id], 'model': self.rule_1, 'partner': self.bank_line_5.partner_id},
         }, statements=self.bank_st_2)
 
         self.rule_1.match_text_location_label = True
@@ -254,8 +254,8 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.rule_1.match_text_location_note = False
         self._check_statement_matching(self.rule_1, {
             self.bank_line_3.id: {'aml_ids': [self.invoice_line_5.id], 'model': self.rule_1, 'partner': self.bank_line_3.partner_id},
-            self.bank_line_4.id: {'aml_ids': [self.invoice_line_5.id], 'model': self.rule_1, 'partner': self.bank_line_4.partner_id},
-            self.bank_line_5.id: {'aml_ids': [self.invoice_line_6.id], 'model': self.rule_1, 'partner': self.bank_line_5.partner_id},
+            self.bank_line_4.id: {'aml_ids': [self.invoice_line_6.id], 'model': self.rule_1, 'partner': self.bank_line_4.partner_id},
+            self.bank_line_5.id: {'aml_ids': [self.invoice_line_5.id], 'model': self.rule_1, 'partner': self.bank_line_5.partner_id},
         }, statements=self.bank_st_2)
 
     def test_matching_fields_match_text_location_no_partner(self):

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -107,7 +107,7 @@ class MicrosoftSync(models.AbstractModel):
 
         records_to_sync = records.filtered(lambda r: r.need_sync_m and r.active)
         for record in records_to_sync:
-            record._microsoft_insert(record._microsoft_values(self._get_microsoft_synced_fields()), timeout=3)
+            record._microsoft_insert(record.sudo()._microsoft_values(self._get_microsoft_synced_fields()), timeout=3)
         return records
 
     @api.depends('microsoft_id')

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -352,7 +352,7 @@ class TestPurchaseToInvoice(AccountTestInvoicingCommon):
             'company_id': company_b.id,
             'acc_type': 'bank'
         })
-        partner.bank_ids = [partner_bank_a.id, partner_bank_b.id]
+        assert len(partner.bank_ids) == 2
 
         PurchaseOrder = self.env['purchase.order'].with_context(tracking_disable=True)
         po_a = PurchaseOrder.with_company(company_a).create({

--- a/addons/sale_expense/tests/test_reinvoice.py
+++ b/addons/sale_expense/tests/test_reinvoice.py
@@ -99,7 +99,12 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
                 'is_expense': True,
             },
             {
-                'qty_delivered': 3.0,
+                'qty_delivered': 2.0,
+                'product_uom_qty': 1.0,
+                'is_expense': True,
+            },
+            {
+                'qty_delivered': 1.0,
                 'product_uom_qty': 1.0,
                 'is_expense': True,
             },
@@ -111,6 +116,7 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
         ])
 
         self.assertRecordValues(sale_order.order_line[1:], [
+            {'qty_delivered_method': 'analytic'},
             {'qty_delivered_method': 'analytic'},
             {'qty_delivered_method': 'analytic'},
             {'qty_delivered_method': 'analytic'},

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -61,7 +61,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1718, marketing=1720):  # test_mass_mailing_only: 1665 - 1666
+        with self.assertQueryCount(__system__=1768, marketing=1770):  # test_mass_mailing_only: 1665 - 1666
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -101,7 +101,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +63 compared to local
-        with self.assertQueryCount(__system__=1995, marketing=1997):  # test_mass_mailing only: 1931 - 1932
+        with self.assertQueryCount(__system__=2058, marketing=2060):  # test_mass_mailing only: 1931 - 1932
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -126,8 +126,10 @@ class Discussion(models.Model):
 class Message(models.Model):
     _name = 'test_new_api.message'
     _description = 'Test New API Message'
+    _order = 'sequence, id'
 
     discussion = fields.Many2one('test_new_api.discussion', ondelete='cascade')
+    sequence = fields.Integer(string='Sequence', default=10)
     body = fields.Text()
     author = fields.Many2one('res.users', default=lambda self: self.env.user)
     name = fields.Char(string='Title', compute='_compute_name', store=True)

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -373,7 +373,7 @@ odoo.define('web.test.x2many', function (require) {
         run: 'click'
     }, {
         content: "test one2many's line onchange",
-        trigger: '.o_list_view .o_selected_row td:nth(3):contains(3)',
+        trigger: '.o_list_view .o_selected_row td:nth(4):contains(3)',
         run: function () {}, // don't blur the many2one
     }, {
         content: "open the many2one to select an other user",

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -120,7 +120,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertEqual(field_onchange.get('messages'), '1')
         self.assertItemsEqual(
             strip_prefix('messages.', field_onchange),
-            ['author', 'body', 'name', 'size', 'important'],
+            ['author', 'body', 'name', 'size', 'important', 'sequence'],
         )
 
         # modify discussion name
@@ -148,6 +148,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertEqual(result['value']['messages'], [
             (5,),
             (1, message1.id, {
+                'sequence': 10,
                 'name': "[%s] %s" % ("Foo", USER.name),
                 'body': "ABC",
                 'author': USER.name_get()[0],
@@ -155,6 +156,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
                 'important': False,
             }),
             (1, message2.id, {
+                'sequence': 10,
                 'name': "[%s] %s" % ("Foo", USER.name),
                 'body': "XYZ",          # this must be sent back
                 'author': USER.name_get()[0],
@@ -162,6 +164,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
                 'important': False,
             }),
             (0, 0, {
+                'sequence': 10,
                 'name': "[%s] %s" % ("Foo", USER.name),
                 'body': "ABC",
                 'author': USER.name_get()[0],
@@ -193,7 +196,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertEqual(field_onchange.get('messages'), '1')
         self.assertItemsEqual(
             strip_prefix('messages.', field_onchange),
-            ['author', 'body', 'name', 'size', 'important'],
+            ['author', 'body', 'name', 'size', 'important', 'sequence'],
         )
 
         # modify discussion name, and check that the reference of the new line
@@ -219,6 +222,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertItemsEqual(result['value']['messages'], [
             (5,),
             (0, REFERENCE, {
+                'sequence': 10,
                 'name': "[%s] %s" % ("Foo", USER.name),
                 'body': BODY,
                 'author': USER.name_get()[0],
@@ -793,7 +797,7 @@ class TestComputeOnchange(common.TransactionCase):
         self.assertEqual(record.foo, "oof")
         self.assertEqual(record.count, 1, "value onchange must be called only one time")
 
-    def test_onchange_one2many(self):
+    def test_onchange_one2many_edit_line(self):
         record = self.env['test_new_api.model_parent_m2o'].create({
             'name': 'Family',
             'child_ids': [

--- a/odoo/addons/test_new_api/views/test_new_api_views.xml
+++ b/odoo/addons/test_new_api/views/test_new_api_views.xml
@@ -55,12 +55,14 @@
                             <page string="Messages">
                                 <field name="messages">
                                     <tree string="Messages">
+                                        <field name="sequence" widget="handle"/>
                                         <field name="name"/>
                                         <field name="body"/>
                                         <field name="important"/>
                                     </tree>
                                     <form string="Message">
                                         <group>
+                                            <field name="sequence" invisible="1"/>
                                             <field name="name"/>
                                             <field name="author"/>
                                             <field name="size"/>
@@ -124,6 +126,7 @@
                             <page string="Messages">
                                 <field name="messages">
                                     <tree name="Messages" editable="bottom">
+                                        <field name="sequence" widget="handle"/>
                                         <field name="name"/>
                                         <field name="author"/>
                                         <field name="body" required="1"/>
@@ -167,6 +170,7 @@
                             <field name="messages" />
                             <field name="important_messages">
                                 <tree string="Important messages">
+                                    <field name="sequence" widget="handle"/>
                                     <field name="name"/>
                                     <field name="author"/>
                                     <field name="size"/>
@@ -194,6 +198,7 @@
             <field name="model">test_new_api.message</field>
             <field name="arch" type="xml">
                 <tree string="Messages">
+                    <field name="sequence" invisible="1"/>
                     <field name="name"/>
                     <field name="author"/>
                     <field name="size"/>
@@ -210,6 +215,7 @@
                 <form string="Message">
                     <sheet>
                         <group>
+                            <field name="sequence" invisible="1"/>
                             <field name="discussion"/>
                             <field name="name"/>
                             <field name="author"/>

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -112,7 +112,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
 
         # create N lines on rec1: O(N) queries
         rec1.invalidate_cache()
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(3):
             rec1.write({'line_ids': [(0, 0, {'value': 0})]})
         self.assertEqual(len(rec1.line_ids), 1)
 
@@ -136,12 +136,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
 
         # delete N lines: O(1) queries
         rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=14, demo=14):
+        with self.assertQueryCount(__system__=15, demo=15):
             rec1.write({'line_ids': [(2, line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=12, demo=12):
+        with self.assertQueryCount(__system__=13, demo=13):
             rec1.write({'line_ids': [(2, line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
         self.assertFalse(lines.exists())
@@ -151,12 +151,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
 
         # unlink N lines: O(1) queries
         rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=11, demo=11):
+        with self.assertQueryCount(__system__=12, demo=13):
             rec1.write({'line_ids': [(3, line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=12, demo=12):
+        with self.assertQueryCount(__system__=13, demo=13):
             rec1.write({'line_ids': [(3, line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
         self.assertFalse(lines.exists())
@@ -167,7 +167,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
 
         # link N lines from rec1 to rec2: O(1) queries
         rec1.invalidate_cache()
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(3):
             rec2.write({'line_ids': [(4, line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
         self.assertEqual(rec2.line_ids, lines[0])
@@ -179,18 +179,18 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec2.line_ids, lines)
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(4):
+        with self.assertQueryCount(5):
             rec2.write({'line_ids': [(4, line.id) for line in lines[0]]})
         self.assertEqual(rec2.line_ids, lines)
 
         rec1.invalidate_cache()
-        with self.assertQueryCount(4):
+        with self.assertQueryCount(5):
             rec2.write({'line_ids': [(4, line.id) for line in lines[1:]]})
         self.assertEqual(rec2.line_ids, lines)
 
         # empty N lines in rec2: O(1) queries
         rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=13, demo=13):
+        with self.assertQueryCount(__system__=14, demo=14):
             rec2.write({'line_ids': [(5,)]})
         self.assertFalse(rec2.line_ids)
 
@@ -209,12 +209,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec1.line_ids, lines[1:])
         self.assertEqual(rec2.line_ids, lines[0])
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(6):
             rec2.write({'line_ids': [(6, 0, lines.ids)]})
         self.assertFalse(rec1.line_ids)
         self.assertEqual(rec2.line_ids, lines)
 
-        with self.assertQueryCount(3):
+        with self.assertQueryCount(4):
             rec2.write({'line_ids': [(6, 0, lines.ids)]})
         self.assertEqual(rec2.line_ids, lines)
 
@@ -354,7 +354,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
     @warmup
     def test_create_base_with_lines(self):
         """ Create records with one2many lines. """
-        with self.assertQueryCount(__system__=12, demo=12):
+        with self.assertQueryCount(__system__=13, demo=13):
             self.env['test_performance.base'].create({
                 'name': 'X',
                 'line_ids': [(0, 0, {'value': val}) for val in range(10)],

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3229,7 +3229,7 @@ class One2many(_RelationalMulti):
                     elif command[0] == 4:
                         to_link[recs[-1]].add(command[1])
                         allow_full_delete = False
-                    elif command[0] in (5, 6) :
+                    elif command[0] in (5, 6):
                         # do not try to delete anything in creation mode if nothing has been created before
                         line_ids = command[2] if command[0] == 6 else []
                         if not allow_full_delete and not line_ids:
@@ -3243,7 +3243,8 @@ class One2many(_RelationalMulti):
                         lines[inverse] = recs[-1]
 
             flush()
-
+            for rec in records:
+                rec.env.cache._data.pop(self, False)
         else:
             cache = records.env.cache
 


### PR DESCRIPTION
Consider a model A with one2many field F pointing to model B. The _order of B is defined as "S, id", where S is a field of B. Suppose the field F is filled with some record lines b1, b2, b3. If you reorder those lines by S in the form and save, it's expected that after the 'write' is done, the order of those lines in F are ordered by _order in B instead of by id. But in some cases it doesn't happen. The usual one is when the order of a new line is changed before save.

This patch ensures that after write, the lines are in the expected order defined by _order.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr