### PR TITLE
[FIX] mrp: Access Error on MRP Stock Picking Type

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -48,7 +48,7 @@ class StockPickingType(models.Model):
             remaining.count_mo_late = False
 
     def get_mrp_stock_picking_action_picking_type(self):
-        action = self.env.ref('mrp.mrp_production_action_picking_deshboard').read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id('mrp.mrp_production_action_picking_deshboard')
         if self:
             action['display_name'] = self.display_name
         return action


### PR DESCRIPTION
### OPW 2901176
### Solves Issue https://github.com/odoo/odoo/issues/95155

Now the way of access to an action is using the method `_for_xml_id` of the model `ir.actions.actions` and not reading the action itself because they need the access of the group "Administration/Settings" which not all the users have it, so we were having an error with users that have the permissions to see MRP Picking Types but they didn't have the group mentioned above.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
