### PR TITLE
[14.0][FIX] discuss: fix error change url discuss

### DIFF
--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -160,7 +160,7 @@ const DiscussWidget = AbstractAction.extend({
     _pushStateActionManager() {
         this.actionManager.do_push_state({
             action: this.action.id,
-            active_id: this.discuss.activeId,
+            active_id: this.action.context.active_id ? this.action.context.active_id : this.discuss.activeId,
         });
     },
     /**


### PR DESCRIPTION
The user is opening a discussion window, then they paste a link to a specific chat channel. The system will not be able to navigate there. Because the system is getting the wrong active_id.

Video issuse: https://drive.google.com/file/d/14UdiuA5qskRHNzx5oev_DQRawEimSa0-/view?usp=sharing


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
