### PR TITLE
[IMP] hr: make inheritable user fields to sync with employee

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -150,6 +150,11 @@ class User(models.Model):
             self = self.with_user(SUPERUSER_ID)
         return super(User, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
 
+    def _get_employee_fields_to_sync(self):
+        """Get values to sync to the related employee when the User is changed.
+        """
+        return ['name', 'email', 'image_1920', 'tz']
+
     def write(self, vals):
         """
         Synchronize user and its related employee
@@ -169,8 +174,9 @@ class User(models.Model):
         result = super(User, self).write(vals)
 
         employee_values = {}
-        for fname in [f for f in ['name', 'email', 'image_1920', 'tz'] if f in vals]:
+        for fname in [f for f in self._get_employee_fields_to_sync() if f in vals]:
             employee_values[fname] = vals[fname]
+
         if employee_values:
             if 'email' in employee_values:
                 employee_values['work_email'] = employee_values.pop('email')


### PR DESCRIPTION
By enabling the method 'employee_values_sync' the original behavior is kept. Furthermore, by overriding, the method now is possible to decide whether a field is synced or not into an employee.

Description of the issue/feature this PR addresses:
When you change a user's name (res.user), the employee's name related to the user is also changed. The option of deciding whether this behavior is wanted or not can be achieved by overriding the method. If no override exists, the method will behave exactly like the original 'write' method.

Current behavior before PR:
Changing the User name will cause the employee name related to being also changed.

Desired behavior after PR is merged:
ONLY if 'get_employee_values_sync' method is overridden, the name of the employee can remain the same even if the user name is changed. Otherwise, the 'write' method will remain the same.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
