### PR TITLE
[FIX] account: change journal on draft invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2303,7 +2303,7 @@ class AccountMove(models.Model):
                 raise UserError(_('You cannot overwrite the values ensuring the inalterability of the accounting.'))
             if (move.posted_before and 'journal_id' in vals and move.journal_id.id != vals['journal_id']):
                 raise UserError(_('You cannot edit the journal of an account move if it has been posted once.'))
-            if (move.name and move.name != '/' and 'journal_id' in vals and move.journal_id.id != vals['journal_id']):
+            if (move.name and move.name != '/' and move.sequence_number not in (0, 1) and 'journal_id' in vals and move.journal_id.id != vals['journal_id']):
                 raise UserError(_('You cannot edit the journal of an account move if it already has a sequence number assigned.'))
 
             # You can't change the date of a move being inside a locked period.


### PR DESCRIPTION
Step to reproduce:

- Create a SO, save and confirm it
- Create an invoice, on edit mode, change the journal and click on save

Issue:

- If the invoice is the first one in the current month, a sequence
  number is automatically assigned and an error is displaid.

forwardport of https://github.com/odoo/odoo/commit/b8328e45d526d276b5781da3523a0d5874da64bd

opw-2660571
opw-2879716

closes odoo/odoo#79084

Signed-off-by: William André (wan) <wan@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
