### PR TITLE
[FIX] web: search model: groupBy not in searchMenuTypes

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -485,6 +485,9 @@ export class SearchModel extends EventBus {
      * @returns {string[]}
      */
     get groupBy() {
+        if (!this.searchMenuTypes.has("groupBy")) {
+            return [];
+        }
         if (!this._groupBy) {
             this._groupBy = this._getGroupBy();
         }

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -18,6 +18,7 @@ import {
     getPagerLimit,
     getPagerValue,
     pagerNext,
+    toggleFilterMenu,
     validateSearch,
 } from "@web/../tests/search/helpers";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
@@ -4306,12 +4307,6 @@ QUnit.module("Views", (hooks) => {
     QUnit.test("kanban view not groupable", async (assert) => {
         patchWithCleanup(kanbanView, { searchMenuTypes: ["filter", "favorite"] });
 
-        serverData.views["partner,false,search"] = `
-            <search>
-                <filter string="candle" name="itsName" context="{'group_by': 'foo'}"/>
-            </search>
-        `;
-
         await makeView({
             type: "kanban",
             resModel: "partner",
@@ -4326,6 +4321,12 @@ QUnit.module("Views", (hooks) => {
                     </templates>
                 </kanban>
             `,
+            searchViewArch: `
+                <search>
+                    <filter string="Filter" name="filter" domain="[]"/>
+                    <filter string="candle" name="itsName" context="{'group_by': 'foo'}"/>
+                </search>
+            `,
             async mockRPC(route, { method }) {
                 if (method === "web_read_group") {
                     throw new Error("Should not do a read_group RPC");
@@ -4337,6 +4338,10 @@ QUnit.module("Views", (hooks) => {
         assert.doesNotHaveClass(target.querySelector(".o_kanban_renderer"), "o_kanban_grouped");
         assert.containsNone(target, ".o_control_panel div.o_search_options div.o_group_by_menu");
         assert.deepEqual(getFacetTexts(target), []);
+
+        // validate presence of the search arch info
+        await toggleFilterMenu(target);
+        assert.containsOnce(target, ".o_filter_menu .o_menu_item");
     });
 
     QUnit.test("kanban view with create=False", async (assert) => {


### PR DESCRIPTION
The search model should always return [] as groupBy if searchMenuTypes
does not contain "groupBy". This allows a kanban view (for instance) to
define easily that it should not never be grouped.
