### PR TITLE
[FIX] account: do not create exchange entry when using the credit note wizard

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4808,9 +4808,9 @@ class AccountMoveLine(models.Model):
         # Fix residual amounts.
         to_reconcile = _add_lines_to_exchange_difference_vals(self, exchange_diff_move_vals)
 
-        # Fix cash basis entries.
+        # Fix cash basis entries, only if not coming from the move reversal wizard.
         is_cash_basis_needed = self[0].account_internal_type in ('receivable', 'payable')
-        if is_cash_basis_needed:
+        if is_cash_basis_needed and not self._context.get('move_reverse_cancel'):
             _add_cash_basis_lines_to_exchange_difference_vals(self, exchange_diff_move_vals)
 
         # ==========================================================================


### PR DESCRIPTION
As of now, reversing an invoice using the credit note wizard is doing
the following:
   - Create the reversed invoice
   - Do not create the CABA entry
   - Yet still create the exchange difference entry for CABA rounding issue,
   this one with the full CABA amount.

This is an issue that this will fix by never creating the exchange difference
entry coming from the credit note wizard, the same way we do not create the
CABA entry.

Task id #2895267

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
