### PR TITLE
[FIX] board: deduplicate domain of domain and searchQuery

### DIFF
--- a/addons/board/static/src/js/add_to_board_menu.js
+++ b/addons/board/static/src/js/add_to_board_menu.js
@@ -103,8 +103,7 @@ var AddToBoardMenu = Widget.extend({
             }
         });
 
-        var domain = new Domain(this.action.domain || []);
-        domain = Domain.prototype.normalizeArray(domain.toArray().concat(searchQuery.domain));
+        var domain = Domain.prototype.normalizeArray(searchQuery.domain);
 
         var evalutatedContext = pyUtils.eval('context', context);
         for (var key in evalutatedContext) {

--- a/addons/board/static/tests/dashboard_tests.js
+++ b/addons/board/static/tests/dashboard_tests.js
@@ -846,7 +846,7 @@ QUnit.test('save a action domain to dashboard', async function (assert) {
     var filter_domain = ["display_name", "ilike", "b"];
 
     // The filter domain already contains the view domain, but is always added by dashboard..,
-    var expected_domain = ['&', '&', view_domain, view_domain, filter_domain]
+    var expected_domain = ['&', view_domain, filter_domain]
 
     var actionManager = await createActionManager({
         data: this.data,


### PR DESCRIPTION
Steps to reproduce:
- in contacts, edit action and define the domain as "[('name','=','Azure Interior')]"
- refresh and in favourite, click on "Add to Dashboard"
- in Home page, search "Customized Views"

Issue:
The domain will be doubled: "['&amp', ['name','=','Azure Interior'], ['name','=','Azure Interior']"

Solution:
Only use the `searchQuery.domain` since this one contains all informations needed:
https://github.com/odoo/odoo/blob/d3f4f99d795af4338e933fb7d31f142a1ec3cc2f/addons/web/static/src/js/views/control_panel/control_panel_model.js#L289-L293

opw-2888477