### PR TITLE
[FIX] core, web: handle read_group ranges for multiple granularities

### DIFF
--- a/addons/crm/static/src/js/forecast/forecast_models.js
+++ b/addons/crm/static/src/js/forecast/forecast_models.js
@@ -41,7 +41,9 @@ const ForecastKanbanModel = KanbanModel.extend({
         let lastGroup = this.get(this.handle).data.filter(group => group.value).slice(-1)[0];
         if (lastGroup) {
             lastGroup = this.localData[lastGroup.id];
-            fillTemporalPeriod.setEnd(moment.utc(lastGroup.range[this.forecast_field].to));
+            const groupedBy = this.granularity === 'month' && this.forecast_field in lastGroup.range ?
+                this.forecast_field : `${this.forecast_field}:${this.granularity}`;
+            fillTemporalPeriod.setEnd(moment.utc(lastGroup.range[groupedBy].to));
         }
     },
 

--- a/addons/project/static/src/js/project_kanban.js
+++ b/addons/project/static/src/js/project_kanban.js
@@ -217,7 +217,7 @@ const ProjectTaskKanbanModel = KanbanModel.extend({
         const groupedField = parent.fields[groupedFieldName];
         // for a date/datetime field, we take the last moment of the group as the group value
         if (['date', 'datetime'].includes(groupedField.type)) {
-            changes[groupedFieldName] = viewUtils.getGroupValue(new_group, groupedFieldName);
+            changes[groupedFieldName] = viewUtils.getGroupValue(new_group, parent.groupedBy[0]);
         } else if (groupedField.type === 'many2one') {
             changes[groupedFieldName] = {
                 id: new_group.res_id,

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -3631,7 +3631,7 @@ var BasicModel = AbstractModel.extend({
         while (dataPoint.parentID) {
             var parent = this.localData[dataPoint.parentID];
             var groupByField = parent.groupedBy[0].split(':')[0];
-            var value = viewUtils.getGroupValue(dataPoint, groupByField);
+            var value = viewUtils.getGroupValue(dataPoint, parent.groupedBy[0]);
             if (value) {
                 defaultContext['default_' + groupByField] = value;
             }
@@ -4037,9 +4037,11 @@ var BasicModel = AbstractModel.extend({
      * @param {boolean} [params.static=false]
      * @param {string} [params.type='record'|'list']
      * @param {[type]} [params.value]
-     * @param {Object} [params.range] only for datapoints representing groups coming from a groupBy on a
-     *   date(time) field @see _readGroup format: {[fieldName]: {from: string, to: string}}, where
-     *   'from' (inclusive) and 'to' (exclusive) are the group bounds under the respective date format
+     * @param {Object} [params.range] only for datapoints representing groups
+     *   coming from a groupBy on a date(time) field @see _readGroup format:
+     *   {[fieldName:granularity]: {from: string, to: string}}, where
+     *   'from' (inclusive) and 'to' (exclusive) are the group bounds under the
+     *   respective date format
      * @param {string} [params.viewType] the type of the view, e.g. 'list' or 'form'
      * @returns {Object} the resource created
      */

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
@@ -214,7 +214,7 @@ var KanbanColumn = Widget.extend({
         this.trigger_up('close_quick_create'); // close other quick create widgets
         var context = this.data.getContext();
         var groupByField = viewUtils.getGroupByField(this.groupedBy);
-        context['default_' + groupByField] = viewUtils.getGroupValue(this.data, groupByField);
+        context['default_' + groupByField] = viewUtils.getGroupValue(this.data, this.groupedBy);
         this.quickCreateWidget = new RecordQuickCreate(this, {
             context: context,
             formViewRef: this.quickCreateView,

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_controller.js
@@ -455,7 +455,7 @@ var KanbanController = BasicController.extend({
                 var context = columnState.getContext();
                 var state = self.model.get(self.handle, {raw: true});
                 var groupByField = viewUtils.getGroupByField(state.groupedBy[0]);
-                context['default_' + groupByField] = viewUtils.getGroupValue(columnState, groupByField);
+                context['default_' + groupByField] = viewUtils.getGroupValue(columnState, state.groupedBy[0]);
                 new view_dialogs.FormViewDialog(self, {
                     res_model: state.model,
                     context: _.extend({default_name: values.name || values.display_name}, context),

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_model.js
@@ -114,7 +114,7 @@ var KanbanModel = BasicModel.extend({
         var context = this._getContext(group);
         var parent = this.localData[group.parentID];
         var groupByField = viewUtils.getGroupByField(parent.groupedBy[0]);
-        context['default_' + groupByField] = viewUtils.getGroupValue(group, groupByField);
+        context['default_' + groupByField] = viewUtils.getGroupValue(group, parent.groupedBy[0]);
         var def;
         if (Object.keys(values).length === 1 && 'display_name' in values) {
             // only 'display_name is given, perform a 'name_create'
@@ -240,7 +240,7 @@ var KanbanModel = BasicModel.extend({
         var groupedField = parent.fields[groupedFieldName];
         // for a date/datetime field, we take the last moment of the group as the group value
         if (['date', 'datetime'].includes(groupedField.type)) {
-            changes[groupedFieldName] = viewUtils.getGroupValue(new_group, groupedFieldName);
+            changes[groupedFieldName] = viewUtils.getGroupValue(new_group, parent.groupedBy[0]);
         } else if (groupedField.type === 'many2one') {
             changes[groupedFieldName] = {
                 id: new_group.res_id,

--- a/addons/web/static/src/legacy/js/views/sample_server.js
+++ b/addons/web/static/src/legacy/js/views/sample_server.js
@@ -559,7 +559,7 @@
                     if (['date', 'datetime'].includes(groupByField.type)) {
                         // we arbitrarily take the first date of the group as a default value to populate
                         // date/datetime groups
-                        return g.__range[groupByFieldName] ? g.__range[groupByFieldName].from : false;
+                        return g.__range[groupBy] ? g.__range[groupBy].from : false;
                     } else {
                         return g[groupBy];
                     }
@@ -643,7 +643,7 @@
                 } else if (['date', 'datetime'].includes(groupByField.type)) {
                     // we arbitrarily take the first date of the group as a default value to tweak
                     // date/datetime groups
-                    groupValue = g.__range[groupByFieldName] ? g.__range[groupByFieldName].from : false;
+                    groupValue = g.__range[groupBy] ? g.__range[groupBy].from : false;
                 }
                 const recordsInGroup = records.filter(r => r[groupByFieldName] === groupValue);
                 g[`${groupByFieldName}_count`] = recordsInGroup.length;

--- a/addons/web/static/src/legacy/js/views/view_utils.js
+++ b/addons/web/static/src/legacy/js/views/view_utils.js
@@ -21,11 +21,12 @@ var viewUtils = {
      * field for the records in that group.
      *
      * @param {Object} group dataPoint of type list, corresponding to a group
-     * @param {string} groupByField the name of the groupBy field
+     * @param {string} groupedBy the value of the groupby, i.e.
+     *                           field_name:granularity for date/datetime
      * @returns {string | integer | false}
      */
-    getGroupValue: function (group, groupByField) {
-        var groupedByField = group.fields[groupByField];
+    getGroupValue: function (group, groupedBy) {
+        var groupedByField = group.fields[this.getGroupByField(groupedBy)];
         switch (groupedByField.type) {
             case 'many2one':
                 return group.res_id || false;
@@ -42,8 +43,8 @@ var viewUtils = {
             case 'datetime':
                 const [format, granularity] = groupedByField.type === 'date' ?
                     ["YYYY-MM-DD", 'day'] : ["YYYY-MM-DD HH:mm:ss", 'second'];
-                return group.range[groupByField] ?
-                    moment.utc(group.range[groupByField].to).subtract(1, granularity).format(format) : false;
+                return group.range[groupedBy] ?
+                    moment.utc(group.range[groupedBy].to).subtract(1, granularity).format(format) : false;
             default:
                 return false; // other field types are not handled
         }

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1644,13 +1644,13 @@ var MockServer = Class.extend({
                         const to = type === "date"
                             ? endDate.format("YYYY-MM-DD")
                             : endDate.format("YYYY-MM-DD HH:mm:ss");
-                        group.__range[fieldName] = { from, to };
+                        group.__range[gbField] = { from, to };
                         group.__domain = [
                             [fieldName, ">=", from],
                             [fieldName, "<", to],
                         ].concat(group.__domain);
                     } else {
-                        group.__range[fieldName] = false;
+                        group.__range[gbField] = false;
                         group.__domain = [[fieldName, "=", value]].concat(group.__domain);
                     }
                 } else {

--- a/odoo/addons/test_read_group/tests/__init__.py
+++ b/odoo/addons/test_read_group/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_group_operator
 from . import test_fill_temporal
 from . import test_auto_join
 from . import test_m2m_grouping
+from . import test_date_range

--- a/odoo/addons/test_read_group/tests/test_date_range.py
+++ b/odoo/addons/test_read_group/tests/test_date_range.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Test for date ranges."""
+
+from odoo.tests import common
+
+
+class TestDateRange(common.TransactionCase):
+    """Test for date ranges.
+
+    When grouping on date/datetime fields, group.__range is populated with
+    formatted string dates which can be accurately converted to date objects
+    (backend and frontend), since the display value format can vary greatly and
+    it is not always possible to translate that display value to a real date.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Model = cls.env['test_read_group.on_date']
+
+    def test_undefined_range(self):
+        """Test an undefined range.
+
+        Records with an unset date value should be grouped in a group whose
+        range is False.
+        """
+        self.Model.create({'date': False, 'value': 1})
+
+        expected = [{
+            '__domain': [('date', '=', False)],
+            '__range': {'date': False},
+            'date': False,
+            'date_count': 1,
+            'value': 1
+        }]
+
+        groups = self.Model.read_group([], fields=['date', 'value'], groupby=['date'])
+        self.assertEqual(groups, expected)
+
+    def test_with_default_granularity(self):
+        """Test a range with the default granularity.
+
+        The default granularity is 'month' and is implied when not specified.
+        The key in group.__range should match the key in group.
+        """
+        self.Model.create({'date': '1916-02-11', 'value': 1})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 1,
+            'value': 1
+        }]
+
+        groups = self.Model.read_group([], fields=['date', 'value'], groupby=['date'])
+        self.assertEqual(groups, expected)
+
+    def test_lazy_with_multiple_granularities(self):
+        """Test a range with multiple granularities in lazy mode
+
+        The only value stored in __range should be the granularity of the first
+        groupby.
+        """
+        self.Model.create({'date': '1916-02-11', 'value': 1})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-01-01'), ('date', '<', '1916-04-01')],
+            '__context': {'group_by': ['date:day']},
+            '__range': {'date:quarter': {'from': '1916-01-01', 'to': '1916-04-01'}},
+            'date:quarter': 'Q1 1916',
+            'date_count': 1,
+            'value': 1
+        }]
+
+        groups = self.Model.read_group([], fields=['date', 'value'], groupby=['date:quarter', 'date:day'])
+        self.assertEqual(groups, expected)
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-11'), ('date', '<', '1916-02-12')],
+            '__context': {'group_by': ['date:quarter']},
+            '__range': {'date:day': {'from': '1916-02-11', 'to': '1916-02-12'}},
+            'date:day': '11 Feb 1916',
+            'date_count': 1,
+            'value': 1
+        }]
+
+        groups = self.Model.read_group([], fields=['date', 'value'], groupby=['date:day', 'date:quarter'])
+        self.assertEqual(groups, expected)
+
+    def test_not_lazy_with_multiple_granularities(self):
+        """Test a range with multiple granularities (not lazy)
+
+        There should be a range for each granularity.
+        """
+        self.Model.create({'date': '1916-02-11', 'value': 1})
+
+        expected = [{
+            '__domain': ['&',
+                '&', ('date', '>=', '1916-01-01'), ('date', '<', '1916-04-01'),
+                '&', ('date', '>=', '1916-02-11'), ('date', '<', '1916-02-12')
+            ],
+            '__range': {
+                'date:quarter': {'from': '1916-01-01', 'to': '1916-04-01'},
+                'date:day': {'from': '1916-02-11', 'to': '1916-02-12'}
+            },
+            'date:quarter': 'Q1 1916',
+            'date:day': '11 Feb 1916',
+            '__count': 1,
+            'value': 1
+        }]
+
+        groups = self.Model.read_group([], fields=['date', 'value'], groupby=['date:quarter', 'date:day'], lazy=False)
+        self.assertEqual(groups, expected)

--- a/odoo/addons/test_read_group/tests/test_empty.py
+++ b/odoo/addons/test_read_group/tests/test_empty.py
@@ -35,7 +35,7 @@ class TestEmptyDate(common.TransactionCase):
         self.assertEqual(gb, [{
             '__count': 3,
             '__domain': [('date', '=', False)],
-            '__range': {'date': False},
+            '__range': {'date:quarter': False},
             'date:quarter': False,
             'value': 6
         }])

--- a/odoo/addons/test_read_group/tests/test_fill_temporal.py
+++ b/odoo/addons/test_read_group/tests/test_fill_temporal.py
@@ -338,7 +338,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 01:00:00'),
                          ('datetime', '<', '1916-01-01 02:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 01:00:00', 'to': '1916-01-01 02:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 01:00:00', 'to': '1916-01-01 02:00:00'}},
             'datetime:hour': '01:00 01 Jan',
             'datetime_count': 2,
             'value': 10
@@ -346,7 +346,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 02:00:00'),
                          ('datetime', '<', '1916-01-01 03:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 02:00:00', 'to': '1916-01-01 03:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 02:00:00', 'to': '1916-01-01 03:00:00'}},
             'datetime:hour': '02:00 01 Jan',
             'datetime_count': 1,
             'value': 3
@@ -354,7 +354,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 03:00:00'),
                          ('datetime', '<', '1916-01-01 04:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 03:00:00', 'to': '1916-01-01 04:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 03:00:00', 'to': '1916-01-01 04:00:00'}},
             'datetime:hour': '03:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -362,7 +362,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 04:00:00'),
                          ('datetime', '<', '1916-01-01 05:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 04:00:00', 'to': '1916-01-01 05:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 04:00:00', 'to': '1916-01-01 05:00:00'}},
             'datetime:hour': '04:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -370,7 +370,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 05:00:00'),
                          ('datetime', '<', '1916-01-01 06:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 05:00:00', 'to': '1916-01-01 06:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 05:00:00', 'to': '1916-01-01 06:00:00'}},
             'datetime:hour': '05:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -378,7 +378,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 06:00:00'),
                          ('datetime', '<', '1916-01-01 07:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 06:00:00', 'to': '1916-01-01 07:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 06:00:00', 'to': '1916-01-01 07:00:00'}},
             'datetime:hour': '06:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -386,7 +386,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 07:00:00'),
                          ('datetime', '<', '1916-01-01 08:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 07:00:00', 'to': '1916-01-01 08:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 07:00:00', 'to': '1916-01-01 08:00:00'}},
             'datetime:hour': '07:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -394,7 +394,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 08:00:00'),
                          ('datetime', '<', '1916-01-01 09:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 08:00:00', 'to': '1916-01-01 09:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 08:00:00', 'to': '1916-01-01 09:00:00'}},
             'datetime:hour': '08:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -402,7 +402,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 09:00:00'),
                          ('datetime', '<', '1916-01-01 10:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 09:00:00', 'to': '1916-01-01 10:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 09:00:00', 'to': '1916-01-01 10:00:00'}},
             'datetime:hour': '09:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -410,7 +410,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 10:00:00'),
                          ('datetime', '<', '1916-01-01 11:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 10:00:00', 'to': '1916-01-01 11:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 10:00:00', 'to': '1916-01-01 11:00:00'}},
             'datetime:hour': '10:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -418,7 +418,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 11:00:00'),
                          ('datetime', '<', '1916-01-01 12:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 11:00:00', 'to': '1916-01-01 12:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 11:00:00', 'to': '1916-01-01 12:00:00'}},
             'datetime:hour': '11:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -426,7 +426,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 12:00:00'),
                          ('datetime', '<', '1916-01-01 13:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 12:00:00', 'to': '1916-01-01 13:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 12:00:00', 'to': '1916-01-01 13:00:00'}},
             'datetime:hour': '12:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -434,7 +434,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 13:00:00'),
                          ('datetime', '<', '1916-01-01 14:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 13:00:00', 'to': '1916-01-01 14:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 13:00:00', 'to': '1916-01-01 14:00:00'}},
             'datetime:hour': '01:00 01 Jan',
             'datetime_count': 1,
             'value': 5
@@ -442,7 +442,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 14:00:00'),
                          ('datetime', '<', '1916-01-01 15:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 14:00:00', 'to': '1916-01-01 15:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 14:00:00', 'to': '1916-01-01 15:00:00'}},
             'datetime:hour': '02:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -450,7 +450,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 15:00:00'),
                          ('datetime', '<', '1916-01-01 16:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 15:00:00', 'to': '1916-01-01 16:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 15:00:00', 'to': '1916-01-01 16:00:00'}},
             'datetime:hour': '03:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -458,7 +458,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 16:00:00'),
                          ('datetime', '<', '1916-01-01 17:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 16:00:00', 'to': '1916-01-01 17:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 16:00:00', 'to': '1916-01-01 17:00:00'}},
             'datetime:hour': '04:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -466,7 +466,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 17:00:00'),
                          ('datetime', '<', '1916-01-01 18:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 17:00:00', 'to': '1916-01-01 18:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 17:00:00', 'to': '1916-01-01 18:00:00'}},
             'datetime:hour': '05:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -474,7 +474,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 18:00:00'),
                          ('datetime', '<', '1916-01-01 19:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 18:00:00', 'to': '1916-01-01 19:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 18:00:00', 'to': '1916-01-01 19:00:00'}},
             'datetime:hour': '06:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -482,7 +482,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 19:00:00'),
                          ('datetime', '<', '1916-01-01 20:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 19:00:00', 'to': '1916-01-01 20:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 19:00:00', 'to': '1916-01-01 20:00:00'}},
             'datetime:hour': '07:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -490,7 +490,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 20:00:00'),
                          ('datetime', '<', '1916-01-01 21:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 20:00:00', 'to': '1916-01-01 21:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 20:00:00', 'to': '1916-01-01 21:00:00'}},
             'datetime:hour': '08:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -498,7 +498,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 21:00:00'),
                          ('datetime', '<', '1916-01-01 22:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 21:00:00', 'to': '1916-01-01 22:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 21:00:00', 'to': '1916-01-01 22:00:00'}},
             'datetime:hour': '09:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -506,7 +506,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 22:00:00'),
                          ('datetime', '<', '1916-01-01 23:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 22:00:00', 'to': '1916-01-01 23:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 22:00:00', 'to': '1916-01-01 23:00:00'}},
             'datetime:hour': '10:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -514,7 +514,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 23:00:00'),
                          ('datetime', '<', '1916-01-02 00:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 23:00:00', 'to': '1916-01-02 00:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 23:00:00', 'to': '1916-01-02 00:00:00'}},
             'datetime:hour': '11:00 01 Jan',
             'datetime_count': 1,
             'value': 7
@@ -538,7 +538,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1915-12-31 22:00:00'),
                          ('datetime', '<', '1915-12-31 23:00:00')],
-            '__range': {'datetime': {'from': '1915-12-31 22:00:00', 'to': '1915-12-31 23:00:00'}},
+            '__range': {'datetime:hour': {'from': '1915-12-31 22:00:00', 'to': '1915-12-31 23:00:00'}},
             'datetime:hour': '04:00 01 Jan',
             'datetime_count': 1,
             'value': 2
@@ -546,7 +546,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1915-12-31 23:00:00'),
                          ('datetime', '<', '1916-01-01 00:00:00')],
-            '__range': {'datetime': {'from': '1915-12-31 23:00:00', 'to': '1916-01-01 00:00:00'}},
+            '__range': {'datetime:hour': {'from': '1915-12-31 23:00:00', 'to': '1916-01-01 00:00:00'}},
             'datetime:hour': '05:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -554,7 +554,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 00:00:00'),
                          ('datetime', '<', '1916-01-01 01:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 00:00:00', 'to': '1916-01-01 01:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 00:00:00', 'to': '1916-01-01 01:00:00'}},
             'datetime:hour': '06:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -562,7 +562,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 01:00:00'),
                          ('datetime', '<', '1916-01-01 02:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 01:00:00', 'to': '1916-01-01 02:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 01:00:00', 'to': '1916-01-01 02:00:00'}},
             'datetime:hour': '07:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -570,7 +570,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 02:00:00'),
                          ('datetime', '<', '1916-01-01 03:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 02:00:00', 'to': '1916-01-01 03:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 02:00:00', 'to': '1916-01-01 03:00:00'}},
             'datetime:hour': '08:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -578,7 +578,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 03:00:00'),
                          ('datetime', '<', '1916-01-01 04:00:00')],
-            '__range': {'datetime': {'from': '1916-01-01 03:00:00', 'to': '1916-01-01 04:00:00'}},
+            '__range': {'datetime:hour': {'from': '1916-01-01 03:00:00', 'to': '1916-01-01 04:00:00'}},
             'datetime:hour': '09:00 01 Jan',
             'datetime_count': 1,
             'value': 3
@@ -602,7 +602,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                 ('datetime', '>=', '2015-12-31 17:00:00'),
                 ('datetime', '<', '2016-03-31 16:00:00')],
-            '__range': {'datetime': {'from': '2015-12-31 17:00:00', 'to': '2016-03-31 16:00:00'}},
+            '__range': {'datetime:quarter': {'from': '2015-12-31 17:00:00', 'to': '2016-03-31 16:00:00'}},
             'datetime:quarter': 'Q1 2016',
             'datetime_count': 1,
             'value': 2
@@ -610,7 +610,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                        ('datetime', '>=', '2016-03-31 16:00:00'),
                        ('datetime', '<', '2016-06-30 16:00:00')],
-            '__range': {'datetime': {'from': '2016-03-31 16:00:00', 'to': '2016-06-30 16:00:00'}},
+            '__range': {'datetime:quarter': {'from': '2016-03-31 16:00:00', 'to': '2016-06-30 16:00:00'}},
             'datetime:quarter': 'Q2 2016',
             'datetime_count': 0,
             'value': False
@@ -618,7 +618,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                        ('datetime', '>=', '2016-06-30 16:00:00'),
                        ('datetime', '<', '2016-09-30 17:00:00')],
-            '__range': {'datetime': {'from': '2016-06-30 16:00:00', 'to': '2016-09-30 17:00:00'}},
+            '__range': {'datetime:quarter': {'from': '2016-06-30 16:00:00', 'to': '2016-09-30 17:00:00'}},
             'datetime:quarter': 'Q3 2016',
             'datetime_count': 0,
             'value': False
@@ -626,7 +626,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                        ('datetime', '>=', '2016-09-30 17:00:00'),
                        ('datetime', '<', '2016-12-31 17:00:00')],
-            '__range': {'datetime': {'from': '2016-09-30 17:00:00', 'to': '2016-12-31 17:00:00'}},
+            '__range': {'datetime:quarter': {'from': '2016-09-30 17:00:00', 'to': '2016-12-31 17:00:00'}},
             'datetime:quarter': 'Q4 2016',
             'datetime_count': 1,
             'value': 3


### PR DESCRIPTION
There was an issue with the computed `read_group` `__range` when grouping on
the same date/datetime field on multiple granularities (i.e. month, week).
Since the range was stored with the field_name as a key, the last evaluated
range would override the previous ones.

Impacted Versions:

  - master
  (- exists since 15.0 but it does not impact the user directly so it has been
  decided to fix this only in master, since the API is modified)

Steps to reproduce:

  1. Open a list view and group by a date field with at least 2 granularities
  2. Open the chrome debugger (network) and check a web_read_group rpc preview
  3. Find the web_read_group for groups related to one of the largest
     granularities and check the `__range`

Current behavior:

  - `__range = {field_name: false}`

Expected behavior:

  - `__range = {field_name: {from: range_start, to: range_end}`

Explanation

Since the smaller granularities are evaluated last, and the condition to update
`__range` is related to the field_name and not the granularity, the range is
always overriden by the smaller granularities (even if their value is False)
when grouping on the same field with multiple granularities.

Furthermore, there is a conceptual problem with the current solution: it does
not allow to store multiple ranges when the read_group is not lazy and when
grouping on the same field with multiple granularities.

Therefore, the proposed solution is to use the full groupby keys in the
`__range` to allow storing multiple ranges depending on granularity. The keys
in `__range` would thus match the group value keys and allow more flexibility
if a domain must be forged from the group(s) range(s).

Task-2894519
