### PR TITLE
[FIX] base : fix importing file with special character

### DIFF
--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -408,7 +408,7 @@ class IrFieldsConverter(models.AbstractModel):
                 if len(ids) > 1:
                     warnings.append(ImportWarning(
                         _(u"Found multiple matches for value '%s' in field '%%(field)s' (%d matches)")
-                        % (value, len(ids))))
+                        %(str(value).replace('%', '%%'), len(ids))))
                 id, _name = ids[0]
             else:
                 name_create_enabled_fields = self.env.context.get('name_create_enabled_fields') or {}


### PR DESCRIPTION
To reproduce
============

for example on accounting, attempt to import a record from excel containing a special character like `%`.
Gets error stating the system doesn't support these

Purpose
=======

the issue is caused by misfromatted error string :
https://github.com/odoo/odoo/blob/b859d78c3d56526f44fbdd9ce5e84d34cf8a0a35/odoo/addons/base/models/ir_fields.py#L410-L411

Specification
=============

to solve the issue use :
`str(value).replace('%', '%%')`

opw-2838573
