### PR TITLE
[FIX] sale: avoid package removing on qty change

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -411,7 +411,9 @@ class SaleOrderLine(models.Model):
             self.product_packaging_id = False
         # suggest biggest suitable packaging
         if self.product_id and self.product_uom_qty and self.product_uom:
-            self.product_packaging_id = self.product_id.packaging_ids.filtered('sales')._find_suitable_product_packaging(self.product_uom_qty, self.product_uom)
+            product_packaging_id = self.product_id.packaging_ids.filtered('sales')._find_suitable_product_packaging(self.product_uom_qty, self.product_uom)
+            if product_packaging_id:
+                self.product_packaging_id = product_packaging_id
 
     @api.onchange('product_packaging_id')
     def _onchange_product_packaging_id(self):


### PR DESCRIPTION
Odoo automatically changes product package on changing quantity in SO. The idea
is find biggest package, e.g. sale 2 packages of 100 units, instead of 20
packages of 10 unites. However, this mechanism doesn't work well on manual
package selection: if quantity is changed because of roundings, onchange method
removes package completly.

This commits keeps the selected value, so user can adjust qty afterwards.

STEPS:
* add package of 12 units to the product
* select product in SO, qty is set to 1
* select package of 12

BEFORE this commit the package is removed, because Packaging Quantity is set to
0.08 (rounded value of 1 / 12), which triggers to change product Quantity to
0.96 (=12*0,8), which trigger method `_onchange_suggest_packaging`, which removes
packaging value, because there is no package for 0,96 units. However, if user
selects the package again, it's not removed, because qty is already 0,96 and
hence the onchange method is not triggered.

This commits also changes behavior in another scenario: if we have SO with 200
units packed into 2 packages of 100 units, then on changing qty to 199, the
package value is not removed automatically and Packaging Quantity is changed to
1,99 instead.

opw-2890380

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
