### PR TITLE
[FIX] web: ImageField supports preview_image option

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -29,23 +29,6 @@ export class ImageField extends Component {
         });
     }
 
-    get url() {
-        if (this.state.isValid && this.props.value) {
-            if (isBinarySize(this.props.value)) {
-                const previewFieldName = this.props.previewImage || this.props.name;
-                return url("/web/image", {
-                    model: this.props.resModel,
-                    id: this.props.resId,
-                    field: previewFieldName,
-                });
-            } else {
-                // Use magic-word technique for detecting image type
-                const magic = fileTypeMagicWordMap[this.props.value[0]] || "png";
-                return `data:image/${magic};base64,${this.props.value}`;
-            }
-        }
-        return placeholder;
-    }
     get sizeStyle() {
         let style = "";
         if (this.props.width) {
@@ -62,10 +45,26 @@ export class ImageField extends Component {
     get tooltipAttributes() {
         return {
             template: "web.ImageZoomTooltip",
-            info: JSON.stringify({ url: this.url }),
+            info: JSON.stringify({ url: this.getUrl(this.props.name) }),
         };
     }
 
+    getUrl(previewFieldName) {
+        if (this.state.isValid && this.props.value) {
+            if (previewFieldName !== this.props.name || isBinarySize(this.props.value)) {
+                return url("/web/image", {
+                    model: this.props.resModel,
+                    id: this.props.resId,
+                    field: previewFieldName,
+                });
+            } else {
+                // Use magic-word technique for detecting image type
+                const magic = fileTypeMagicWordMap[this.props.value[0]] || "png";
+                return `data:image/${magic};base64,${this.props.value}`;
+            }
+        }
+        return placeholder;
+    }
     onFileRemove() {
         this.state.isValid = true;
         this.props.update(false);
@@ -108,7 +107,7 @@ ImageField.extractProps = (fieldName, record, attrs) => {
     return {
         enableZoom: attrs.options.zoom,
         zoomDelay: attrs.options.zoom_delay,
-        previewImage: attrs.preview_image,
+        previewImage: attrs.options.preview_image,
         acceptedFileExtensions: attrs.options.accepted_file_extensions,
         width: attrs.options.size ? attrs.options.size[0] : attrs.width,
         height: attrs.options.size ? attrs.options.size[1] : attrs.height,

--- a/addons/web/static/src/views/fields/image/image_field.xml
+++ b/addons/web/static/src/views/fields/image/image_field.xml
@@ -31,7 +31,7 @@
         <img
             class="img img-fluid"
             alt="Binary file"
-            t-att-src="url"
+            t-att-src="getUrl(props.previewImage or props.name)"
             t-att-border="props.readonly ? 0 : 1"
             t-att-name="props.name"
             t-att-height="props.height"

--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -266,6 +266,43 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
+    QUnit.test(
+        "ImageField displays the right images with zoom and preview_image options",
+        async function (assert) {
+            serverData.models.partner.records[0].document = MY_IMAGE;
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                <form>
+                    <field name="document" widget="image" options="{'zoom': true, 'preview_image': 'document_preview', 'zoom_delay': 600}" />
+                </form>`,
+            });
+
+            assert.strictEqual(
+                JSON.parse(target.querySelector(".o_field_image img").dataset["tooltipInfo"]).url,
+                `data:image/png;base64,${MY_IMAGE}`,
+                "tooltip show the full image from the field value"
+            );
+            assert.strictEqual(
+                target.querySelector(".o_field_image img").dataset["tooltipDelay"],
+                "600",
+                "tooltip has the right delay"
+            );
+            assert.ok(
+                target
+                    .querySelector(".o_field_image img")
+                    .dataset["src"].includes(
+                        "/web/image?model=partner&id=1&field=document_preview"
+                    ),
+                "image src is the preview image given in option"
+            );
+        }
+    );
+
     QUnit.test("ImageField in subviews is loaded correctly", async function (assert) {
         serverData.models.partner.records[0].__last_update = "2017-02-08 10:00:00";
         serverData.models.partner.records[0].document = MY_IMAGE;


### PR DESCRIPTION
This commit fixes the behavior of the tooltip
enabled by the zoom option which displays
the full image when the field is hovered.
Before the commit, the preview_image option was
not used by the field and the full value was used
for both the field and the tooltip.
A test has been introduced to check that the
field uses the right images sources.