### PR TITLE
[FIX] web,*: kanban: support t-set defined outside cards 

### DIFF
--- a/addons/event/static/src/scss/event.scss
+++ b/addons/event/static/src/scss/event.scss
@@ -1,5 +1,5 @@
 .o_kanban_view .o_event_kanban_view {
-    .o_kanban_record {
+    .o_kanban_record > div {
         min-height: 140px;
     }
     .o_kanban_content {

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -11,7 +11,7 @@
         padding: 0px!important;
     }
 
-    .o_kanban_record, .o_kanban_quick_create {
+    .o_kanban_record > div, .o_kanban_quick_create {
         padding: $o-kanban-inside-vgutter $o-kanban-inside-hgutter;
         border: 1px solid $border-color;
         background-color: $o-view-background-color;
@@ -52,9 +52,13 @@
         min-width: 150px;
         margin: 0 0 -1px;
 
+        > div {
+            height: 100%;
+        }
+
         // ------- Kanban Record, v11 Layout -------
         // Records colours
-        &::after {
+        > div::after {
             content: "";
             @include o-position-absolute(0, auto, 0, 0);
             width: $o-kanban-color-border-width;
@@ -155,7 +159,7 @@
         // ---------- Kanban Record, fill image design ----------
         // Records with images that compensate record's padding
         // filling all the available space (eg. hr, partners.. )
-        &.o_kanban_record_has_image_fill {
+        .o_kanban_record_has_image_fill {
             display: flex;
 
             .o_kanban_image_fill_left {
@@ -228,6 +232,8 @@
 
     .o_dragged {
         @extend .shadow;
+        transform: rotate(-3deg);
+        transition: transform 0.6s, box-shadow 0.3s;
     }
 
     // -------  Compatibility of old (<= v10) Generic layouts -------
@@ -331,17 +337,13 @@
         }
 
         // Kanban Record - Utility classes
-        &.oe_kanban_global_click, &.oe_kanban_global_click_edit {
+        &.oe_kanban_global_click, &.oe_kanban_global_click_edit,
+        .oe_kanban_global_click, .oe_kanban_global_click_edit {
             cursor: pointer;
             &:focus, &:focus-within {
                 outline: thin solid mix(theme-color('primary'), gray('400'));
                 outline-offset: -1px;
             }
-        }
-
-        &.o_dragged {
-            transform: rotate(-3deg);
-            transition: transform 0.6s, box-shadow 0.3s;
         }
 
         .o_attachment_image > img {

--- a/addons/web/static/src/views/kanban/kanban_dashboard.scss
+++ b/addons/web/static/src/views/kanban/kanban_dashboard.scss
@@ -1,10 +1,10 @@
-.o_kanban_dashboard {
+.o_kanban_dashboard:not(.o_legacy_kanban_view) {
     &:not(.o_kanban_grouped) {
         // correctly display the no_content_helper in dashboards
         flex-flow: row wrap;
     }
 
-    .o_kanban_record {
+    .o_kanban_record > div {
         position: relative;
         display: flex;
         flex-flow: column nowrap;

--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -339,7 +339,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         assert.containsOnce(target, `img[data-src="data:image/png;base64,${MY_IMAGE}"]`);
-        assert.containsOnce(target, ".o_kanban_record.oe_kanban_global_click");
+        assert.containsOnce(target, ".o_kanban_record .oe_kanban_global_click");
 
         // Actual flow: click on an element of the m2m to get its form view
         await click(target, ".oe_kanban_global_click");

--- a/addons/web/static/tests/views/fields/image_url_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_url_field_tests.js
@@ -145,7 +145,7 @@ QUnit.module("Fields", (hooks) => {
         );
         assert.containsOnce(
             target,
-            ".o_kanban_record.oe_kanban_global_click",
+            ".o_kanban_record .oe_kanban_global_click",
             "There should be one record in the many2many"
         );
 

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -602,7 +602,7 @@ QUnit.module("Views", (hooks) => {
                 [...target.querySelectorAll(".o_kanban_group")].map((el) =>
                     el.innerText.replace(/\s/g, " ")
                 ),
-                ["None (1)", "gold yopblip", "silver yopgnap"]
+                ["None (1)", "gold yop blip", "silver yop gnap"]
             );
 
             await click(getColumn(0));
@@ -704,6 +704,31 @@ QUnit.module("Views", (hooks) => {
         assert.deepEqual(
             getNodesTextContent(target.querySelectorAll(".o_kanban_record:not(.o_kanban_ghost)")),
             ["yop", "blip", "gnap", "blip"]
+        );
+    });
+
+    QUnit.test("kanban with t-set outside card", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban>
+                    <field name="int_field"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <t t-set="x" t-value="record.int_field.value"/>
+                            <div>
+                                <t t-esc="x"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        assert.deepEqual(
+            getNodesTextContent(target.querySelectorAll(".o_kanban_record:not(.o_kanban_ghost)")),
+            ["10", "9", "17", "-4"]
         );
     });
 
@@ -3537,7 +3562,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 4);
 
-        await click(target, ".oe_kanban_global_click:first-child .o_field_monetary[name=salary]");
+        await click(target.querySelector(".oe_kanban_global_click .o_field_monetary[name=salary]"));
     });
 
     QUnit.test("o2m loaded in only one batch", async (assert) => {

--- a/odoo/addons/base/static/src/css/modules.css
+++ b/odoo/addons/base/static/src/css/modules.css
@@ -12,7 +12,7 @@
     width: 77%;
 }
 
-.o_kanban_view .oe_module_vignette.o_kanban_record {
+.o_kanban_view .o_modules_kanban .oe_module_vignette {
     align-items: center;
     display: flex;
 }


### PR DESCRIPTION
*base, event, hr_holidays

Before this commit, `<t t-set/>` nodes declared outside the main
div of a kanban card where ignored by the kanban compiler. This
commit fixes that issue. To do so, we refactor a bit the way the
compiler and KanbanRecord handle multiple root cards (typically,
several roots with a t-if/t-elif/t-else, s.t. there's a unique
rendered root), by removing the faulty logic from the compiler
that identified card root nodes (and filtered out t-set nodes),
and introducing a div for the KanbanRecord component on which we
can set classNames, attributes and handlers.

The issue could be observed on the Apps kanban view, as it
displayed the "Install" button, whether the app was already
installed or not.