### PR TITLE
[FIX] pos_sale: misspelled setup method

### DIFF
--- a/addons/point_of_sale/static/src/js/Gui.js
+++ b/addons/point_of_sale/static/src/js/Gui.js
@@ -36,6 +36,7 @@ odoo.define('point_of_sale.Gui', function (require) {
     const configureGui = ({ component }) => {
         config.component = component;
         config.availableMethods = new Set([
+            'showScreen',
             'showPopup',
             'showTempScreen',
             'playSound',

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/MobileSaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/MobileSaleOrderManagementScreen.js
@@ -7,7 +7,7 @@ odoo.define('point_of_sale.MobileSaleOrderManagementScreen', function (require) 
 
     const MobileSaleOrderManagementScreen = (SaleOrderManagementScreen) => {
         class MobileSaleOrderManagementScreen extends SaleOrderManagementScreen {
-            settup() {
+            setup() {
                 super.setup();
                 useListener('click-order', this._onShowDetails)
                 this.mobileState = useState({ showDetails: false });

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementControlPanel.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementControlPanel.js
@@ -37,9 +37,8 @@ odoo.define('pos_sale.SaleOrderManagementControlPanel', function (require) {
             let currentPartner = this.env.pos.get_order().get_partner();
             if (currentPartner) {
                 this.orderManagementContext.searchString = currentPartner.name;
-                let domain = this._computeDomain();
-                SaleOrderFetcher.setSearchDomain(domain);
             }
+            SaleOrderFetcher.setSearchDomain(this._computeDomain());
         }
         onInputKeydown(event) {
             if (event.key === 'Enter') {

--- a/addons/pos_sale/static/src/js/SetSaleOrderButton.js
+++ b/addons/pos_sale/static/src/js/SetSaleOrderButton.js
@@ -6,6 +6,7 @@ odoo.define('pos_sale.SetSaleOrderButton', function(require) {
     const { useListener } = require("@web/core/utils/hooks");
     const Registries = require('point_of_sale.Registries');
     const { isConnectionError } = require('point_of_sale.utils');
+    const { Gui } = require('point_of_sale.Gui');
 
     class SetSaleOrderButton extends PosComponent {
         setup() {
@@ -18,13 +19,18 @@ odoo.define('pos_sale.SetSaleOrderButton', function(require) {
         async onClick() {
           try {
               // ping the server, if no error, show the screen
-              await this.rpc({
+              // Use rpc from services which resolves even when this
+              // component is destroyed (removed together with the popup).
+              await this.env.services.rpc({
                   model: 'sale.order',
                   method: 'browse',
                   args: [[]],
                   kwargs: { context: this.env.session.user_context },
               });
-              this.showScreen('SaleOrderManagementScreen');
+              // LegacyComponent doesn't work the same way as before.
+              // We need to use Gui here to show the screen. This will work
+              // because ui methods in Gui is bound to the root component.
+              Gui.showScreen('SaleOrderManagementScreen');
           } catch (error) {
               if (isConnectionError(error)) {
                   this.showPopup('ErrorPopup', {

--- a/addons/pos_sale/static/src/js/SetSaleOrderButton.js
+++ b/addons/pos_sale/static/src/js/SetSaleOrderButton.js
@@ -30,7 +30,8 @@ odoo.define('pos_sale.SetSaleOrderButton', function(require) {
               // LegacyComponent doesn't work the same way as before.
               // We need to use Gui here to show the screen. This will work
               // because ui methods in Gui is bound to the root component.
-              Gui.showScreen('SaleOrderManagementScreen');
+              const screen = this.env.isMobile ? 'MobileSaleOrderManagementScreen' : 'SaleOrderManagementScreen';
+              Gui.showScreen(screen);
           } catch (error) {
               if (isConnectionError(error)) {
                   this.showPopup('ErrorPopup', {

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/MobileSaleOrderManagementScreen.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/MobileSaleOrderManagementScreen.xml
@@ -2,6 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <div t-name="MobileSaleOrderManagementScreen" class="screen-full-width" owl="1">
+    <div class="order-management-screen screen" t-att-class="{ oe_hidden: !props.isShown }">
         <div t-if="mobileState.showDetails" class="leftpane">
             <OrderDetails order="orderManagementContext.selectedOrder" />
             <div class="pads">
@@ -25,6 +26,7 @@
                 <SaleOrderList orders="orders" initHighlightedOrder="orderManagementContext.selectedOrder" />
             </div>
         </div>
+    </div>
     </div>
 
 </templates>

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementScreen.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementScreen.xml
@@ -3,15 +3,12 @@
 
     <t t-name="SaleOrderManagementScreen" owl="1">
         <div class="order-management-screen screen" t-att-class="{ oe_hidden: !props.isShown }">
-            <div t-if="!env.isMobile" class="screen-full-width">
                 <div class="rightpane">
                     <div class="flex-container">
                         <SaleOrderManagementControlPanel />
                         <SaleOrderList orders="orders" initHighlightedOrder="orderManagementContext.selectedOrder" />
                     </div>
                 </div>
-            </div>
-            <MobileSaleOrderManagementScreen t-else="" />
         </div>
     </t>
 


### PR DESCRIPTION
Because the setup method is not properly executed, sale order management
screen crashes when viewed in mobile screen.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
