### PR TITLE
[FIX] web : fix bg for bold document layout

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -400,7 +400,7 @@
             </div>
         </div>
 
-        <div t-attf-class="article o_report_layout_bold o_company_#{company.id}_layout {{  'o_layout_background' if company.layout_background in ['Geometric', 'Custom']  else  '' }}" t-attf-style="background-image: url({{ 'data:image/png;base64,%s' % company.layout_background_image.decode('utf-8') if company.layout_background_image and company.layout_background == 'Custom' else '/base/static/img/bg_background_template.jpg' }});" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
+        <div t-attf-class="article o_report_layout_bold o_company_#{company.id}_layout {{  'o_layout_background' if company.layout_background in ['Geometric', 'Custom']  else  '' }}" t-attf-style="background-image: url({{ 'data:image/png;base64,%s' % company.layout_background_image.decode('utf-8') if company.layout_background_image and company.layout_background == 'Custom' else ('/base/static/img/bg_background_template.jpg' if company.layout_background == 'Geometric' else '') }});" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <t t-call="web.address_layout"/>
             <t t-out="0"/>
         </div>


### PR DESCRIPTION
To reproduce
============

on settings -> document layout -> choose Bold with blank background.
print a document (quotation for example) that has at least 2 pages.
the second page of the document has a background.

Purpose
=======

the issue is caused by the condition :
https://github.com/odoo/odoo/blob/0436709f33e57479bd6d62c2e0a2de74743cbaa4/addons/web/views/report_templates.xml#L403
where we don't take into account the case where no background is set.

Specification
=============

to solve the issue the condition was corrected

opw-2888650