### PR TITLE
[FIX] pos_coupon: correclty award product reward

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -173,7 +173,7 @@ odoo.define('pos_coupon.pos', function (require) {
      * @returns {number} number of free items
      */
     function computeFreeQuantity(numberItems, n, m) {
-        let factor = Math.trunc(numberItems / (n + m));
+        let factor = Math.trunc(numberItems / n);
         let free = factor * m;
         let charged = numberItems - free;
         // adjust the calculated free quantities


### PR DESCRIPTION
Product rewards are not applied when their conditions are met (one more
product should be added).

Steps to reproduce:
1. Install Point of Sale
2. Go to Settings > Point of Sale > Pricing and enable Coupons &
   Promotions
3. Go to Point of Sale > Products > Promotion Programs and edit program
   'Code for 10% on orders' with values:
   - Promotion Code Usage: Automatically Applied
   - Reward: Free Product
   - Free Product: Acoustic Bloc Screens
4. Open a new session in Point of Sale 'Shop'
5. Add a product (e.g. Conference Chair), the reward is not granted

Solution:
To find the number of free products awarded, first we need to find if
the condition is met (the current number of items is greater or equal to
the number of items needed).

opw-2894007