### PR TITLE
[FIX] web: ExportDataDialog behavior and style

### DIFF
--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.scss
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.scss
@@ -1,41 +1,33 @@
-.o_export_data_dialog{
-    .modal-body {
-        display: flex;
-        margin: auto -16px;
+.o_export_data_dialog .modal-body {
+    display: flex;
 
-        .o_left_panel, .o_right_panel {
-            height: inherit;
+    .row {
+        flex: 1;
+    }
 
-            .o_left_field_panel, .o_right_field_panel {
-                user-select: none;
-                .o_export_tree_item {
-                    &:hover:not(.o_expanded) {
-                        background: rgba($o-brand-odoo, .3);
-                        color: white;
-                    }
+    .o_left_panel, .o_right_panel {
 
-                    &.o_expanded {
-                        border-bottom: 1px solid grey;
-                        margin-bottom: 0.2em;
-                        background: rgba($o-brand-odoo, .2);
-                    }
+        .o_left_field_panel, .o_right_field_panel {
+            user-select: none;
 
-                    .o_tree_column {
-                        justify-content: space-between;
-                    }
-
-                    .o_inactive {
-                        opacity: 0.2;
-                    }
-
-                    .o_expand_parent {
-                        inset: 4px auto auto 0.5em;
-                    }
+            .o_export_tree_item {
+                &:hover:not(.o_expanded) {
+                    background: rgba($o-brand-odoo, .7);
+                    color: white;
                 }
 
-                .o_export_field > *:not(.o_remove_field) {
-                    @include o-grab-cursor;
+                &.o_expanded {
+                    border-bottom: 1px solid grey;
+                    background: rgba($o-brand-odoo, .2);
                 }
+
+                .o_expand_parent {
+                    inset: 4px auto auto 0.5em;
+                }
+            }
+
+            .o_export_field_sortable > *:not(.o_remove_field) {
+                @include o-grab-cursor;
             }
         }
     }

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -12,12 +12,12 @@
     </t>
 
     <t t-name="web.ExportDataItem" owl="1">
-        <div t-att-data-field_id="props.field.name" t-attf-class="o_export_tree_item o_cursor_pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded' : '' }}" role="treeitem" t-on-click.stop="onClick" t-on-dblclick="(ev) => !props.isFieldExpandable(props.field) and !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)">
+        <div t-att-data-field_id="props.field.name" t-attf-class="o_export_tree_item o_cursor_pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded mb-2' : '' }}" role="treeitem" t-on-click.stop="onClick" t-on-dblclick="(ev) => !props.isFieldExpandable(props.field) and !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)">
             <span t-if="props.isFieldExpandable(props.field)" t-attf-class="o_expand_parent d-inline-block position-absolute small fa {{ state.isExpanded ? 'fa-chevron-down' : 'fa-chevron-right' }}" role="img" aria-label="Show sub-fields" title="expandText" />
-            <div class="o_tree_column d-flex align-items-center">
-                <span t-if="props.isDebug and props.field.id" t-esc="`${props.field.string} (${props.field.id})`" />
-                <span t-else="" t-esc="props.field.string" />
-                <span title="Select field" t-attf-class="fa fa-plus float-end m-1 o_add_field {{ isFieldSelected(props.field.name) ? 'o_inactive' : '' }}" t-on-click.stop="(ev) => !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)" />
+            <div t-attf-class="o_tree_column d-flex justify-content-between align-items-center {{ props.field.required ? 'font-weight-bolder' : ''}}">
+                <span t-if="props.isDebug and props.field.id" class="overflow-hidden" t-esc="`${props.field.string} (${props.field.id})`" />
+                <span t-else="" class="overflow-hidden" t-esc="props.field.string" />
+                <span title="Select field" t-attf-class="fa fa-plus float-end m-1 o_add_field {{ isFieldSelected(props.field.name) ? 'o_inactive opacity-25' : '' }}" t-on-click.stop="(ev) => !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)" />
             </div>
             <t t-if="state.isExpanded">
                 <t t-foreach="subFields" t-as="field" t-key="field.name">
@@ -31,90 +31,91 @@
     </t>
 
     <t t-name="web.ExportDataDialog" owl="1">
-        <Dialog contentClass="'o_export_data_dialog h100'" title="title" size="'lg'">
-            <div class="o_left_panel col-12 col-md-6 d-flex flex-column flex-nowrap">
-                <div class="o_import_compat">
-                    <CheckBox className="'o_import_compat'" id="'o-update-data'" value="state.isCompatible" onChange.bind="onToggleCompatibleExport">
-                        I want to update data (import-compatible export)
-                    </CheckBox>
-                </div>
-                <h4 class="mt-3">Available fields</h4>
-                <input t-ref="search" type="search" class="form-control mb-3 o_export_search_input" id="o-export-search-filter" placeholder="Search" t-on-input="onSearch" />
-                <div class="o_left_field_panel h-100 overflow-auto border">
-                    <div class="o_field_tree_structure">
-                        <t t-if="fieldsAvailable">
-                            <t t-foreach="rootFields" t-as="field" t-key="field.name">
-                                <ExportDataItem
-                                    field="field"
-                                    expandedContent.bind="expandedContent"
-                                    isFieldExpanded.bind="isFieldExpanded"
-                                    exportList="state.exportList"
-                                    isFieldExpandable="isFieldExpandable"
-                                    isDebug="isDebug"
-                                    onClick.bind="onToggleExpandField"
-                                    onAdd.bind="onAddItemExportList"
-                                />
-                            </t>
-                        </t>
-                        <h3 t-else="" class="text-center text-muted mt-5 o_no_match">No match found.</h3>
+        <Dialog contentClass="'o_export_data_dialog'" title="title" size="'lg'">
+            <div class="row w-100">
+                <div class="o_left_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap">
+                    <div class="o_import_compat">
+                        <CheckBox className="'o_import_compat'" id="'o-update-data'" value="state.isCompatible" onChange.bind="onToggleCompatibleExport">
+                            I want to update data (import-compatible export)
+                        </CheckBox>
                     </div>
-                </div>
-            </div>
-            <div class="o_right_panel col-12 col-md-6 d-flex flex-column flex-nowrap mt-3 mt-md-0">
-                <div class="o_export_format">
-                    <strong>Export Format:</strong>
-                    <t t-foreach="availableFormats" t-as="format" t-key="format.tag">
-                        <div class="radio form-check form-check-inline ps-4">
-                            <input t-att-id="'o_radio' + format.tag" type="radio" t-att-checked="format.tag === availableFormats[state.selectedFormat].tag" name="o_export_format_name" t-att-value="format.tag" class="form-check-input" t-on-change="setFormat" />
-                            <label class="form-check-label" t-att-for="'o_radio' + format.tag" t-esc="format.label" />
-                        </div>
-                    </t>
-                </div>
-                <div class="mt-3">
-                    <h4>Fields to export</h4>
-                </div>
-                <div class="o_exported_lists">
-                    <div class="input-group mb-3">
-                        <t t-if="state.templateId === 'new_template'">
-                            <label class="pt-2 mb-0 fw-bold">Save as: </label>
-                            <input t-ref="exportList" class="form-control ms-4 o_save_list_name" t-att-placeholder="newTemplateText" />
-                        </t>
-                        <t t-else="">
-                            <label class="pt-2 mb-0 fw-bold">Template: </label>
-                            <select class="form-select ms-4 o_exported_lists_select" t-on-change="onChangeExportList">
-                                <option />
-                                <t t-foreach="templates" t-as="template" t-key="template.id">
-                                    <option t-att-value="template.id" t-esc="template.name or 'undefined'" t-att-selected="state.templateId === template.id" />
+                    <h4 class="mt-3">Available fields</h4>
+                    <input t-ref="search" type="search" class="form-control mb-3 o_export_search_input" id="o-export-search-filter" placeholder="Search" t-on-input="onSearch" />
+                    <div class="o_left_field_panel h-100 overflow-auto border">
+                        <div class="o_field_tree_structure">
+                            <t t-if="fieldsAvailable">
+                                <t t-foreach="rootFields" t-as="field" t-key="field.name">
+                                    <ExportDataItem
+                                        field="field"
+                                        expandedContent.bind="expandedContent"
+                                        isFieldExpanded.bind="isFieldExpanded"
+                                        exportList="state.exportList"
+                                        isFieldExpandable="isFieldExpandable"
+                                        isDebug="isDebug"
+                                        onClick.bind="onToggleExpandField"
+                                        onAdd.bind="onAddItemExportList"
+                                    />
                                 </t>
-                                <option class="fst-italic" value="new_template">New template </option>
-                            </select>
-                        </t>
-                        <t t-if="state.isEditingTemplate">
-                            <button t-if="state.templateId === 'new_template'" type="button" class="btn btn-secondary ms-1 o_save_list_btn" t-on-click.stop="onSaveExportTemplate">
-                                <i class="fa fa-floppy-o" />
-                            </button>
-                            <button type="button" class="btn btn-secondary ms-1 o_cancel_list_btn" t-on-click.stop="onCancelExportTemplate">
-                                <i t-attf-class="fa {{ state.templateId === 'new_template' ? 'fa-times' : 'fa-undo' }}" />
-                            </button>
-                        </t>
-                        <t t-else="">
-                            <button t-if="state.templateId" type="button" class="btn btn-secondary ms-1 o_delete_exported_list" t-on-click.stop="onDeleteExportTemplate">
-                                <i class="fa fa-trash" />
-                            </button>
-                        </t>
+                            </t>
+                            <h3 t-else="" class="text-center text-muted mt-5 o_no_match">No match found.</h3>
+                        </div>
                     </div>
                 </div>
-                <div class="o_right_field_panel h-100 px-2 overflow-auto border">
-                    <ul class="o_fields_list list-unstyled" t-ref="draggable">
-                        <t t-foreach="state.exportList" t-as="field" t-key="field.name">
-                            <li class="o_export_field" t-att-data-field_id="field.name">
-                                <span class="fa fa-sort o_sort_field mx-1" t-attf-style="opacity:{{ state.exportList.length === 1 ? 0 : 1 }}" />
-                                <span t-if="isDebug and field.id" t-esc="`${field.string or field.label} (${field.id})`" />
-                                <span t-else="" t-esc="field.string or field.label" />
-                                <span class="fa fa-trash m-1 float-end o_remove_field o_cursor_pointer" t-att-title="removeFieldText" t-on-click.stop="onRemoveItemExportList" />
-                            </li>
+                <div t-attf-class="o_right_panel col-12 col-md-6 {{ state.isSmall ? 'h-50' : 'h-100' }} d-flex flex-column flex-nowrap mt-3 mt-md-0">
+                    <div class="o_export_format">
+                        <strong>Export Format:</strong>
+                        <t t-foreach="availableFormats" t-as="format" t-key="format.tag">
+                            <div class="radio form-check form-check-inline ps-5">
+                                <input t-att-id="'o_radio' + format.tag" type="radio" t-att-checked="format.tag === availableFormats[state.selectedFormat].tag" name="o_export_format_name" t-att-value="format.tag" class="form-check-input" t-on-change="setFormat" />
+                                <label class="form-check-label" t-att-for="'o_radio' + format.tag" t-esc="format.label" />
+                            </div>
                         </t>
-                    </ul>
+                    </div>
+                    <div class="mt-3">
+                        <h4>Fields to export</h4>
+                    </div>
+                    <div class="o_exported_lists">
+                        <div class="input-group mb-3">
+                            <t t-if="state.templateId === 'new_template'">
+                                <label class="pt-2 mb-0 font-weight-bold">Save as: </label>
+                                <input t-ref="exportList" class="form-control ms-4 o_save_list_name" t-att-placeholder="newTemplateText" />
+                            </t>
+                            <t t-else="">
+                                <label class="pt-2 mb-0 font-weight-bold">Template: </label>
+                                <select class="form-control ms-4 o_exported_lists_select" t-on-change="onChangeExportList">
+                                    <option />
+                                    <t t-foreach="templates" t-as="template" t-key="template.id">
+                                        <option t-att-value="template.id" t-esc="template.name or 'undefined'" t-att-selected="state.templateId === template.id" />
+                                    </t>
+                                    <option class="font-italic" value="new_template">New template </option>
+                                </select>
+                            </t>
+                            <t t-if="state.isEditingTemplate">
+                                <button t-if="state.templateId === 'new_template'" type="button" class="btn btn-secondary ms-1 o_save_list_btn" t-on-click.stop="onSaveExportTemplate">
+                                    <i class="fa fa-floppy-o" />
+                                </button>
+                                <button type="button" class="btn btn-secondary ms-1 o_cancel_list_btn" t-on-click.stop="onCancelExportTemplate">
+                                    <i t-attf-class="fa {{ state.templateId === 'new_template' ? 'fa-times' : 'fa-undo' }}" />
+                                </button>
+                            </t>
+                            <t t-else="">
+                                <button t-if="state.templateId" type="button" class="btn btn-secondary ms-1 o_delete_exported_list" t-on-click.stop="onDeleteExportTemplate">
+                                    <i class="fa fa-trash" />
+                                </button>
+                            </t>
+                        </div>
+                    </div>
+                    <div class="o_right_field_panel h-100 px-2 overflow-auto border">
+                        <ul class="o_fields_list list-unstyled" t-ref="draggable">
+                            <t t-foreach="state.exportList" t-as="field" t-key="field.name">
+                                <li t-attf-class="o_export_field {{ state.isSmall ? '' : 'o_export_field_sortable' }}" t-att-data-field_id="field.name">
+                                    <span t-if="!state.isSmall" class="fa fa-sort o_sort_field mx-1" t-attf-style="opacity:{{ state.exportList.length === 1 ? 0 : 1 }}" />
+                                    <span t-esc="isDebug and field.id ? `${field.string or field.label} (${field.id})` : field.string or field.label" />
+                                    <span class="fa fa-trash m-1 float-end o_remove_field o_cursor_pointer" t-att-title="removeFieldText" t-on-click.stop="onRemoveItemExportList" />
+                                </li>
+                            </t>
+                        </ul>
+                    </div>
                 </div>
             </div>
             <t t-set-slot="footer">


### PR DESCRIPTION
When unselecting an export template, the list was empty
instead of just keeping the current list. I also added
some tests for this component introduced in Owl recently.
Some scss changes have been done to remove unnecessary
lines from the file and fix the style in a small window.

With a small window, items from the export list are not
draggable and the list must be placed at the bottom
part of the dialog