### PR TITLE
[FIX] product_matrix : fix _grid_header_cell

### DIFF
--- a/addons/product_matrix/models/product_template.py
+++ b/addons/product_matrix/models/product_template.py
@@ -81,5 +81,5 @@ class ProductTemplateAttributeValue(models.Model):
         if extra_price:
             header_cell['currency_id'] = to_currency.id
             header_cell['price'] = fro_currency._convert(
-                extra_price, to_currency, company.id, fields.Date.today())
+                extra_price, to_currency, company, fields.Date.today())
         return header_cell


### PR DESCRIPTION
To reproduce
============

- Make sure you have a product with variants with grid entry enabled.
- Make sure there is "value price extra" on some of the attribute values of the product.
- Make sure multicurrency is enabled and there is a pricelist using other than the main currency of the system, to compute the final price from product sales price.
- Then try to create a new sales order, using that pricelist, adding the product to it.

A traceback is raised.

Purpose
=======

the method `_convert` expects the `company` argument to be a `res.company` and not an `int`

Specification
=============

to solve the issue we use `company` instead of `company.id`

opw-2897688