### PR TITLE
[FIX]  website_slides_survey: handle crash on deletion

### DIFF
--- a/addons/website_slides_survey/i18n/website_slides_survey.pot
+++ b/addons/website_slides_survey/i18n/website_slides_survey.pot
@@ -16,6 +16,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: website_slides_survey
+#: code:addons/website_slides_survey/models/survey_survey.py:0
+#, python-format
+msgid "- %s (Courses - %s)"
+msgstr ""
+
+#. module: website_slides_survey
 #: model_terms:ir.ui.view,arch_db:website_slides_survey.survey_survey_view_kanban
 msgid ""
 "<br/>\n"
@@ -383,8 +389,8 @@ msgstr ""
 #: code:addons/website_slides_survey/models/survey_survey.py:0
 #, python-format
 msgid ""
-"The Certification '%(certification_name)s' cannot be deleted because it is "
-"still being used by the Course(s) '%(courses_names)s'"
+"Any Survey listed below is currently used as a Course Certification and cannot be deleted:\n"
+"%s"
 msgstr ""
 
 #. module: website_slides_survey

--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -28,11 +28,12 @@ class Survey(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_to_course(self):
-        slides = self.slide_ids.filtered(lambda slide: slide.slide_type == "certification").exists()
-        if slides:
-            raise ValidationError(_("The Certification '%(certification_name)s' cannot be deleted because it is still being used by the Course(s) '%(courses_names)s'",
-                                    certification_name=self.title,
-                                    courses_names=', '.join(slides.mapped('channel_id.name'))))
+        certifications = self.sudo().slide_ids.filtered(lambda slide: slide.slide_type == "certification").mapped('survey_id').exists()
+        if certifications:
+            certifications_course_mapping = [_('- %s (Courses - %s)', certi.title, '; '.join(certi.slide_channel_ids.mapped('name'))) for certi in certifications]
+            raise ValidationError(_(
+                'Any Survey listed below is currently used as a Course Certification and cannot be deleted:\n%s',
+                '\n'.join(certifications_course_mapping)))
 
     # ---------------------------------------------------------
     # Actions


### PR DESCRIPTION
Currently, when we delete a single certification that is linked to a course,
it gives a validation error, which is good. But when we try to delete multiple
certifications that are linked with courses, it throws traceback.

This commit fixes the issue by properly handling multiple records in the
deletion check, and updates the ValidationError message accordingly.

taskID-2901629
