### PR TITLE
[FIX] l10n_it, l10n_it_edi_sdicoop: Backport of staging fixes

### DIFF
--- a/addons/l10n_it/data/report_invoice.xml
+++ b/addons/l10n_it/data/report_invoice.xml
@@ -2,8 +2,13 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//p[@name='note']" position="replace">
-            <p t-if="o.move_type == 'out_invoice' and o.fiscal_position_id.note" name="note">
-                <span t-field="o.fiscal_position_id.note"/>
+            <p name="note">
+                <t t-if="o.move_type == 'out_invoice' and o.fiscal_position_id.note">
+                    <span t-field="o.fiscal_position_id.note"/>
+                </t>
+                <t t-else="">
+                    <span/>
+                </t>
             </p>
         </xpath>
     </template>

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_reverse_charge_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_reverse_charge_xml.py
@@ -19,7 +19,10 @@ class TestItEdiReverseCharge(TestItEdi):
         # Helper functions -----------
         def get_tag_ids(tag_codes):
             """ Helper function to define tag ids for taxes """
-            return cls.env['account.account.tag'].search([('applicability', '=', 'taxes'), ('name', 'in', tag_codes)]).ids
+            return cls.env['account.account.tag'].search([
+                ('applicability', '=', 'taxes'),
+                ('country_id.code', '=', 'IT'),
+                ('name', 'in', tag_codes)]).ids
 
         RepartitionLine = namedtuple('Line', 'factor_percent repartition_type tag_ids')
         def repartition_lines(*lines):


### PR DESCRIPTION
Fixes to:  https://github.com/odoo/odoo/pull/94406
backported from its fw-port:  https://github.com/odoo/odoo/pull/95176

1) The test for reverse charge should only consider tags for its country (Italy)
2) The report template shouldn't change its structure, even if one field is not shown.
3) (enterprise) Mexican invoice template should target the note by name and not by t-if condition

Enterprise PR: https://github.com/odoo/enterprise/pull/29088