### PR TITLE
[FIX] web: Allow users to import csv file with safari

### DIFF
--- a/addons/web/static/src/legacy/js/chrome/action_mixin.js
+++ b/addons/web/static/src/legacy/js/chrome/action_mixin.js
@@ -178,7 +178,7 @@ odoo.define('web.ActionMixin', function (require) {
          * @returns {Promise}
          */
         updateControlPanel: async function (newProps = {}) {
-            if (!this.withControlPanel && !this.hasControlPanel) {
+            if ((!this.withControlPanel && !this.hasControlPanel) || !this._controlPanelWrapper) {
                 return;
             }
             const props = Object.assign({}, newProps); // Work with a clean new object


### PR DESCRIPTION
Steps:
- Go to Accounting / Accounting Dashboard
- click on `import` button in the `Bank` category
- Select a random csv file and click on upload

A traceback occurs: `this._controlPanelWrapper` is undefined

opw-2709316