### PR TITLE
[FIX] sale(*_): wrong translation for SOL variant description

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1721,8 +1721,9 @@ class SaleOrderLine(models.Model):
             vals['product_uom'] = self.product_id.uom_id
             vals['product_uom_qty'] = self.product_uom_qty or 1.0
 
+        lang = get_lang(self.env, self.order_id.partner_id.lang).code
         product = self.product_id.with_context(
-            lang=get_lang(self.env, self.order_id.partner_id.lang).code,
+            lang=lang,
             partner=self.order_id.partner_id,
             quantity=vals.get('product_uom_qty') or self.product_uom_qty,
             date=self.order_id.date_order,
@@ -1730,7 +1731,7 @@ class SaleOrderLine(models.Model):
             uom=self.product_uom.id
         )
 
-        vals.update(name=self.get_sale_order_line_multiline_description_sale(product))
+        vals.update(name=self.with_context(lang=lang).get_sale_order_line_multiline_description_sale(product))
 
         self._compute_tax_id()
 
@@ -1945,12 +1946,12 @@ class SaleOrderLine(models.Model):
         # display the no_variant attributes, except those that are also
         # displayed by a custom (avoid duplicate description)
         for ptav in (no_variant_ptavs - custom_ptavs):
-            name += "\n" + ptav.with_context(lang=self.order_id.partner_id.lang).display_name
+            name += "\n" + ptav.display_name
 
         # Sort the values according to _order settings, because it doesn't work for virtual records in onchange
         custom_values = sorted(self.product_custom_attribute_value_ids, key=lambda r: (r.custom_product_template_attribute_value_id.id, r.id))
         # display the is_custom values
         for pacv in custom_values:
-            name += "\n" + pacv.with_context(lang=self.order_id.partner_id.lang).display_name
+            name += "\n" + pacv.display_name
 
         return name

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -185,7 +185,8 @@ class SaleOrderLine(models.Model):
         if self.product_id and self.order_id.sale_order_template_id:
             for line in self.order_id.sale_order_template_id.sale_order_template_line_ids:
                 if line.product_id == self.product_id:
-                    self.name = line.with_context(lang=self.order_id.partner_id.lang).name + self._get_sale_order_line_multiline_description_variants()
+                    lang = self.order_id.partner_id.lang
+                    self.name = line.with_context(lang=lang).name + self.with_context(lang=lang)._get_sale_order_line_multiline_description_variants()
                     break
         return domain
 

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -521,7 +521,7 @@ class SaleOrderLine(models.Model):
             'route_ids': self.route_id,
             'warehouse_id': self.order_id.warehouse_id or False,
             'partner_id': self.order_id.partner_shipping_id.id,
-            'product_description_variants': self._get_sale_order_line_multiline_description_variants(),
+            'product_description_variants': self.with_context(lang=self.order_id.partner_id.lang)._get_sale_order_line_multiline_description_variants(),
             'company_id': self.order_id.company_id,
         })
         return values


### PR DESCRIPTION
Steps to reproduce:
- Install eCommerce
- Enable at least one more language
- Get an attribute with translations done (creation mode : never)
- Get a product with this attribute
- Go to the shop and add the product to the cart
- Go to the summary page and change the language
- Attributes fields aren't translated

Explanation:
This commit reverts the fix commit 47777ce1a7ee189c9328f53143abe492e861779e
that set the language of this description variants in function
of the order partner lang. We move where the language is added
in the context so that other cases like the source of the ecommerce issue here https://github.com/odoo/odoo/blob/054db0a1b9b9d88d41b981fbed7553d0dc2ed637/addons/website_sale/models/sale_order.py#L283 still have the right translations. Because we don't add the partner language in the
get_sale_order_line_multiline_description_sale function anymore we need to add it at the
various places it is called and when it is necessary. We do the same for the 
 get_sale_order_line_multiline_description_sale function.

opw-2790240

replace https://github.com/odoo/odoo/pull/88094 that was started by THCL (who left odoo), the changes are sufficiently different to deserve another PR 