### PR TITLE
[IMP] mrp: convert byproduct product_id onchange to compute

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -506,6 +506,7 @@ class MrpByProduct(models.Model):
         default=1.0, digits='Product Unit of Measure', required=True)
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
     product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', required=True,
+                                     compute="_compute_product_uom_id", store=True, readonly=False, precompute=True,
                                      domain="[('category_id', '=', product_uom_category_id)]")
     bom_id = fields.Many2one('mrp.bom', 'BoM', ondelete='cascade', index=True)
     allowed_operation_ids = fields.One2many('mrp.routing.workcenter', related='bom_id.operation_ids')
@@ -523,11 +524,11 @@ class MrpByProduct(models.Model):
         help="The percentage of the final production cost for this by-product line (divided between the quantity produced)."
              "The total of all by-products' cost share must be less than or equal to 100.")
 
-    @api.onchange('product_id')
-    def _onchange_product_id(self):
+    @api.depends('product_id')
+    def _compute_product_uom_id(self):
         """ Changes UoM if product_id changes. """
-        if self.product_id:
-            self.product_uom_id = self.product_id.uom_id.id
+        for record in self:
+            record.product_uom_id = record.product_id.uom_id.id
 
     def _skip_byproduct_line(self, product):
         """ Control if a byproduct line should be produced, can be inherited to add

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -117,3 +117,18 @@ class TestMrpByProduct(common.TransactionCase):
         mnf_product_a = mnf_product_a_form.save()
         self.assertEqual(mnf_product_a.move_raw_ids.product_id.id, self.product_c_id)
         self.assertFalse(mnf_product_a.move_byproduct_ids)
+
+    def test_default_uom(self):
+        """ Tests the `uom_id` on the byproduct gets set automatically while creating a byproduct with a product,
+            without the need to call an onchange or to set the uom manually in the create.
+        """
+        # Set a specific UOM on the byproduct on purpose to make sure it's not just a default on the unit UOM
+        # that makes the test pass.
+        self.product_b.product_tmpl_id.uom_id = self.env.ref('uom.product_uom_dozen')
+        bom = self.MrpBom.create({
+            'product_tmpl_id': self.product_a.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'byproduct_ids': [(0, 0, {'product_id': self.product_b.id, 'product_qty': 1})]
+        })
+        self.assertEqual(bom.byproduct_ids.product_uom_id, self.env.ref('uom.product_uom_dozen'))


### PR DESCRIPTION
Convert the onchange on `product_id` to a compute field

This allows to create a `mrp.bom.byproduct` record without
the need to specify the uom during the creation nor calling the onchange
method. The uom defaults from the product uom.

This way, if the database is not configured to use multi UOMs,
the users do not have the specify the UOM to use.
For instance during an XMLRPC call to create a byproduct.