### PR TITLE
[FIX] website: remove useless list_website_pages rules

### DIFF
--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -95,29 +95,6 @@ body {
     }
 }
 
-// Pages Management
-#list_website_pages {
-    th {
-        background-color: $o-brand-odoo;
-        color: white;
-    }
-    td, th {
-        padding: 0.45rem;
-    }
-    td {
-        > a.fa {
-            margin-left: 5px;
-            color: $o-brand-odoo;
-        }
-        .text-muted {
-            opacity: 0.5;
-        }
-    }
-    .fa-check, .fa-eye-slash {
-        color: $info;
-    }
-}
-
 // Post Submit Links
 .post_link:not(.o_post_link_js_loaded) {
     pointer-events: none;

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2376,7 +2376,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 <template id="list_website_public_pages" name="Website Pages">
     <t t-call="website.layout">
         <div id="wrap">
-            <div class="container" id="list_website_pages">
+            <div class="container">
                 <t t-call="website.website_search_box_input">
                     <t t-set="_form_classes" t-valuef="mt8 float-right"/>
                     <t t-set="search_type" t-valuef="pages"/>
@@ -2397,11 +2397,6 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 </div>
                 <div t-if="pages" class="table-responsive">
                     <table class="table table-hover">
-                        <thead>
-                            <tr>
-                                <th>Name</th>
-                            </tr>
-                        </thead>
                         <tbody>
                             <tr t-foreach="pages" t-as="page">
                                 <td><a t-att-href="page.url"><t t-esc="page.name"/></a></td>
@@ -2420,7 +2415,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 <template id="list_hybrid" name="Any Search Results">
     <t t-call="website.layout">
         <div id="wrap">
-            <div class="container pt24 pb24" id="list_website_pages">
+            <div class="container pt24 pb24">
                 <t t-call="website.website_search_box_input">
                     <t t-set="_classes" t-valuef="mt8"/>
                     <t t-set="search_type" t-valuef="all"/>


### PR DESCRIPTION
Commit [1] made a mistake of copy/pasting the "list_website_pages" ID in
two views related to the "search in everything" and "search in pages"
views (used when checking all results after a search using the "search"
snippet that you can configure to search in everything or in pages).

At the time, that ID induced some CSS rules and JS related to the page
manager (not made for visitors).

- For the "search in everything" page, both the CSS rules and JS had no
  effect (except instantiating an useless widget in JS).

- For the "search in pages" page, the JS had no effect (except the same
  instantiation of an useless widget) but the CSS had an impact on the
  `<table>` used to display the results:

    - The header used an hardcoded odoo-purple background color.
    - The table paddings were not the ones defined by the theme.

Of course, in custos, more of the CSS could have had an impact (for
example some icons would use bootstrap blue info color by default for
no apparent reason).

Since [2], the page manager was removed (converted into a backend view)
so the CSS and JS rules actually became totally useless. The JS was
removed with [2] but the CSS was kept thinking it was necessary for the
"search in everything" and "search in pages" pages.
This commit removes the useless CSS and the useless ID in the two views.
It also modifies the "search in pages" layout a bit.

A fix could be made in stable later on to at least remove the hardcoded
odoo-purple background color in the "search in pages" page. The rest
should stay as per-stable policy.

[1]: https://github.com/odoo/odoo/commit/7559626c54e34b41e1549e28276a650accec6986
[2]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b