### PR TITLE
[FIX] l10n_au: don't duplicate tax repartit° lines when upgrade

### DIFF
--- a/addons/l10n_au/data/account_tax_template_data.xml
+++ b/addons/l10n_au/data/account_tax_template_data.xml
@@ -22,7 +22,7 @@
         <field name="amount_type">percent</field>
         <field name="amount">-47.0</field>
         <field name="price_include" eval="0"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -34,7 +34,7 @@
                     'tag_ids': [(4, ref('tax_withheld_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -659,7 +659,7 @@
         <field name="amount">0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_0"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -670,7 +670,7 @@
                     'repartition_type': 'tax',
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -693,7 +693,7 @@
         <field name="amount">0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_0"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -704,7 +704,7 @@
                     'repartition_type': 'tax',
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -727,7 +727,7 @@
         <field name="amount">0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_0"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -739,7 +739,7 @@
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -784,7 +784,7 @@
         -->
         <field name="price_include" eval="1"/>
         <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -795,7 +795,7 @@
                     'repartition_type': 'tax',
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -818,7 +818,7 @@
         <field name="amount">100000000000</field>
         <field name="price_include" eval="1"/>
         <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -829,7 +829,7 @@
                     'repartition_type': 'tax',
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -852,7 +852,7 @@
         <field name="amount">100000000000</field>
         <field name="price_include" eval="1"/>
         <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -864,7 +864,7 @@
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -900,7 +900,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -912,7 +912,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g13')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -936,7 +936,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -948,7 +948,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g13')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -972,7 +972,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -985,7 +985,7 @@
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1022,7 +1022,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1034,7 +1034,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g15')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1058,7 +1058,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1070,7 +1070,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g15')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1094,7 +1094,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1107,7 +1107,7 @@
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1144,7 +1144,7 @@
         <field name="amount">100000000</field>
         <field name="price_include" eval="1"/>
         <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1156,7 +1156,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1180,7 +1180,7 @@
         <field name="amount">100000000</field>
         <field name="price_include" eval="1"/>
         <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1192,7 +1192,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1216,7 +1216,7 @@
         <field name="amount">100000000</field>
         <field name="price_include" eval="1"/>
         <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1229,7 +1229,7 @@
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1266,7 +1266,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1279,7 +1279,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_g18'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1304,7 +1304,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1317,7 +1317,7 @@
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_g18'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1342,7 +1342,7 @@
         <field name="amount">10.0</field>
         <field name="price_include" eval="0"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
-        <field name="invoice_repartition_line_ids" eval="[
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
@@ -1356,7 +1356,7 @@
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
             ]"/>
-        <field name="refund_repartition_line_ids" eval="[
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',


### PR DESCRIPTION
Complement of this commit 7d7c53edf714a07409316750b2b09deaa089a12d
because added records were missed during fw-port.

opw-2862296
opw-2877133

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
