### PR TITLE
[FIX][14.0] account: invoices with blank names should be renamed

### DIFF
--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -367,6 +367,18 @@ class TestSequenceMixin(AccountTestInvoicingCommon):
             'first_name': '2',
         }).resequence()
 
+    def test_resequence_with_blank_name(self):
+        """When a blank name is used, Resequence does not clash."""
+        moves = self.env['account.move']
+        for _ in range(3):
+            moves += self.create_move(date='2016-01-01')
+        moves[:1].name = False
+
+        self.env['account.resequence.wizard'].create({
+            'move_ids': moves.ids,
+            'first_name': '2',
+        }).resequence()
+
     @freeze_time('2021-10-01 00:00:00')
     def test_change_journal_on_first_account_move(self):
         """Changing the journal on the first move is allowed"""

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -52,7 +52,7 @@ class ReSequenceWizard(models.TransientModel):
         self.first_name = ""
         for record in self:
             if record.move_ids:
-                record.first_name = min(record.move_ids._origin.mapped('name'))
+                record.first_name = min(record.move_ids._origin.mapped(lambda m: m.name or '/'))
 
     @api.depends('new_values', 'ordering')
     def _compute_preview_moves(self):
@@ -125,7 +125,7 @@ class ReSequenceWizard(models.TransientModel):
                 for move, new_name in zip(period_recs.sorted(lambda m: (m.sequence_prefix, m.sequence_number)), new_name_list):
                     new_values[move.id]['new_by_name'] = new_name
                 # For all the moves of this period, assign the name by increasing date
-                for move, new_name in zip(period_recs.sorted(lambda m: (m.date, m.name, m.id)), new_name_list):
+                for move, new_name in zip(period_recs.sorted(lambda m: (m.date, m.name or '/', m.id)), new_name_list):
                     new_values[move.id]['new_by_date'] = new_name
 
             record.new_values = json.dumps(new_values)


### PR DESCRIPTION
Currently, an invoice with a blank name cannot be modified and generates
an error, which the user does not understand,
which is rather silly.

Named invoices can be renamed via PR processing.

To demonstrate the issue, consider the following:
Go to Vendor Bills -> Delete bill name -> Select Bills-> Resequence action

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
Bill