### PR TITLE
[FIX] web: fix the error that the name of the line is too long

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -474,7 +474,8 @@ return AbstractRenderer.extend({
                         // don't use bind:  callback is called with 'index' as second parameter
                         // with value labels.indexOf(label)!
                         callback: function (label) {
-                            return self._relabelling(label);
+                            var fullText = self._relabelling(label);
+                            return self._shortenLabel(fullText);
                         },
                     },
                 }],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix the error that the name of the line is too long

Current behavior before PR:
The label of the lines is not limited to the number of characters. When the user gives a name that is too long, the graph will not be displayed.

Desired behavior after PR is merged:
This commit limits the number of labels, if exceeded it will display as ...
![Screen Shot 2022-07-05 at 10 11 22](https://user-images.githubusercontent.com/55737816/177242058-169b6c0d-577f-41b4-ac55-e0c8e6d5f4da.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
