### PR TITLE
[FIX] mail: Give reply-to non-template value

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -281,7 +281,8 @@ class MailComposer(models.TransientModel):
         reply_to_value = dict.fromkeys(res_ids, None)
         if mass_mail_mode and not self.no_auto_thread:
             records = self.env[self.model].browse(res_ids)
-            reply_to_value = records._notify_get_reply_to(default=self.email_from)
+            reply_to_value = records._notify_get_reply_to(default="")
+            reply_to_value = reply_to_value or self.render_field('email_from')
 
         blacklisted_rec_ids = set()
         if mass_mail_mode and issubclass(type(self.env[self.model]), self.pool['mail.thread.blacklist']):


### PR DESCRIPTION
V14 test update for [#95227](https://github.com/odoo/odoo/pull/95227)
------

When sending a mass mail through the composer, if the field ``reply_to``
had to fall back to being ``email_from``, reply_to
would take the value of the template syntax.

This is notably the case when mass-mailing invoices through the accounting app.
Resulting in reply_to fields such as: '{{user.email}}'

On some mail clients (including mailhog), this could also result in template
syntax being shown as part of the subject or sender field.

Task-2816845
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
