### PR TITLE
[FIX] project_timesheet_holidays: active change delete/create holiday timesheet

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -9,27 +9,44 @@ class Employee(models.Model):
 
     @api.model
     def create(self, vals):
-        result = super(Employee, self).create(vals)
+        employees = super(Employee, self).create(vals)
 
         # We need to create timesheet entries for the global time off that are already created
         # and are planned for after this employee creation date
 
-        # First we look for the global time off that are already planned after today
-        today = fields.Datetime.today()
-        global_leaves = result.resource_calendar_id.global_leave_ids.filtered(lambda l: l.date_from >= today)
-        work_hours_data = global_leaves._work_time_per_day()
+        self._create_future_public_holidays_timesheets(employees)
+        return employees
 
-        vals_list = []
-        for global_time_off in global_leaves:
-            for index, (day_date, work_hours_count) in enumerate(work_hours_data[global_time_off.id]):
-                vals_list.append(
-                    global_time_off._timesheet_prepare_line_values(
-                        index,
-                        result,
-                        work_hours_data[global_time_off.id],
-                        day_date,
-                        work_hours_count
-                    )
-                )
-        self.env['account.analytic.line'].sudo().create(vals_list)
+    def write(self, vals):
+        result = super(Employee, self).write(vals)
+        if 'active' in vals:
+            if vals.get('active'):
+                # Create furtur holiday timesheets
+                self._create_future_public_holidays_timesheets(self)
+            else:
+                # Delete furtur holiday timesheets
+                future_timesheets = self.env['account.analytic.line'].search([('global_leave_id', '!=', False), ('date', '>=', fields.date.today()), ('employee_id', 'in', self.ids)])
+                future_timesheets.write({'global_leave_id': False})
+                future_timesheets.unlink()
         return result
+
+    def _create_future_public_holidays_timesheets(self, employees):
+        lines_vals = []
+        for employee in employees:
+            if not employee.active:
+                continue
+            # First we look for the global time off that are already planned after today
+            global_leaves = employee.resource_calendar_id.global_leave_ids.filtered(lambda l: l.date_from >= fields.Datetime.today())
+            work_hours_data = global_leaves._work_time_per_day()
+            for global_time_off in global_leaves:
+                for index, (day_date, work_hours_count) in enumerate(work_hours_data[global_time_off.id]):
+                    lines_vals.append(
+                        global_time_off._timesheet_prepare_line_values(
+                            index,
+                            employee,
+                            work_hours_data[global_time_off.id],
+                            day_date,
+                            work_hours_count
+                        )
+                    )
+        return self.env['account.analytic.line'].sudo().create(lines_vals)


### PR DESCRIPTION
Previously we had an issue as we created an employee we
also created holiday timesheets for the employee even
if this employee was not active (for example a candidate
in the hiring process) so we had to restrict the creation
of holiday timesheets on employee creation to active
employees to avoid errors for the user.

Doing so we needed for a candidate that succeeded the hiring
process to have his holiday timesheets created. That why we
overwrite the write function and add the behavior that when
an employee is set to active (unactive) his future public
holiday timesheets are created (deleted).

opw-2887727
opw-2870739

backport of the second commit of https://github.com/odoo/odoo/pull/95016