### PR TITLE
[FIX] point_of_sale: use js cache to search clients

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -101,7 +101,6 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
         // We declare this event handler as a debounce function in
         // order to lower its trigger rate.
         async updateClientList(event) {
-            var newClientList = await this.getNewClient();
             this.state.query = event.target.value;
             const clients = this.clients;
             if (event.code === 'Enter' && clients.length === 1) {


### PR DESCRIPTION
Method `updateClientList` is called when user types a search query in customer
list screen. Previous implementation always did RPC call even though customers
list (or part of it) is already cached. It makes searching slow (debounce delay
\+ rpc call time). The customer search doesn't work at all in offline mode.

In new implementation cache is always used. If customer list is not fully loaded
or changed in backend, user can click button "Load Customers".

opw-2883049

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
