### PR TITLE
[FIX] crm: enable specifying lost reason on lead form view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -53,7 +53,8 @@
                             class="oe_highlight" attrs="{'invisible': ['|', ('type', '=', 'opportunity'), ('active', '=', False)]}"/>
                         <button name="toggle_active" string="Restore" type="object"
                             attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}"/>
-                        <button name="action_set_lost" string="Mark as Lost" type="object"
+                        <button name="%(crm.crm_lead_lost_action)d" string="Mark as Lost"
+                            type="action" class="oe_highlight" context="{'default_lead_id': active_id}"
                             attrs="{'invisible': ['|', ('type', '=', 'opportunity'), '&amp;', ('probability', '=', 0), ('active', '=', False)]}"/>
                         <field name="stage_id" widget="statusbar"
                             options="{'clickable': '1', 'fold_field': 'fold'}"


### PR DESCRIPTION
Steps ro reproduce:
- activate leads
- click on a lead
- click on "mark as lost"

Issue:
- The lead is marked as lost without being able to specify the reason (contrarily as in the tree view)

opw-2892752