### PR TITLE
[FIX] account: compute partner_bank_id only if it is an invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1363,7 +1363,7 @@ class AccountMove(models.Model):
 
     @api.depends('bank_partner_id')
     def _compute_partner_bank_id(self):
-        for move in self:
+        for move in self.filtered(lambda x: x.is_invoice(include_receipts=True)):
             bank_ids = move.bank_partner_id.bank_ids.filtered(lambda bank: bank.company_id is False or bank.company_id == move.company_id)
             move.partner_bank_id = bank_ids and bank_ids[0]
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

From this commit https://github.com/odoo/odoo/commit/f4bf83382d479cd7060d09ccfe7bd528ec9e29dd, when a bank statement is created by account_online_synchronization, the field partner_bank_id of account.move is computed (because it is not set during create).

The issue of that is when you open reconciliation, the partner is pre-set every where.

@oco-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
