### PR TITLE
[FIX] pos_restaurant: PaymentScreen closes while paying

### DIFF
--- a/addons/pos_restaurant/static/src/js/Chrome.js
+++ b/addons/pos_restaurant/static/src/js/Chrome.js
@@ -76,7 +76,8 @@ odoo.define('pos_restaurant.chrome', function (require) {
                 this.showScreen('FloorScreen', { floor: table ? table.floor : null });
             }
             _shouldResetIdleTimer() {
-                return super._shouldResetIdleTimer() && this.env.pos.config.iface_floorplan && this.mainScreen.name !== 'FloorScreen';
+                const stayPaymentScreen = this.mainScreen.name === 'PaymentScreen' && this.env.pos.get_order().paymentlines.length > 0;
+                return super._shouldResetIdleTimer() && this.env.pos.config.iface_floorplan && !stayPaymentScreen && this.mainScreen.name !== 'FloorScreen';
             }
             __showScreen() {
                 super.__showScreen(...arguments);


### PR DESCRIPTION
Before this commit, if a user were inside
the PaymentScreen and stayed idle for more
than 1 min, the system would take
them back to the FloorScreen, even if they
were in the middle of a payment process.

This would interrupt their workflow and cause
a negative user experience. For this reason,
if a user has added payments (which means that
they are in the middle of a payment workflow)
the screen will not switch back to the FloorScreen.

Note: This task was implemented before at #92794 and reverted at #94878

### What's different from the last PR?
Note that `&& this.env.pos.config.iface_floorplan` condition is *not* redundant: That is because the `_setIdleTimer` function is called from 2 different places: from `_setActivityListeners` where the above mentioned condition is checked and from `__showScreen` where the condition was not checked, which caused the issue with pos crashing.

Because this is a stable version, in order to keep changes to a minimum, we reintroduced the check of the condition without further adjusting the code. 

opw-2849939
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
