### PR TITLE
[REF] core: replace towrite by dirty flag in cache

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -150,7 +150,7 @@ class Lead(models.Model):
                                                 compute="_compute_recurring_revenue_monthly")
     recurring_revenue_monthly_prorated = fields.Monetary('Prorated MRR', currency_field='company_currency', store=True,
                                                          compute="_compute_recurring_revenue_monthly_prorated")
-    company_currency = fields.Many2one("res.currency", string='Currency', compute="_compute_company_currency", readonly=True)
+    company_currency = fields.Many2one("res.currency", string='Currency', compute="_compute_company_currency", compute_sudo=True)
     # Dates
     date_closed = fields.Datetime('Closed Date', readonly=True, copy=False)
     date_action_last = fields.Datetime('Last Action', readonly=True)

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -98,7 +98,8 @@ class WebsiteVisitor(models.Model):
             # If the access_token is not a 32 length hexa string, it means that
             # the visitor is linked to a logged in user, in which case its
             # partner_id is used instead as the token.
-            visitor.partner_id = len(visitor.access_token) != 32 and self.env['res.partner'].browse([visitor.access_token])
+            partner_id = len(visitor.access_token) != 32 and int(visitor.access_token)
+            visitor.partner_id = self.env['res.partner'].browse(partner_id)
 
     @api.depends('partner_id.email_normalized', 'partner_id.mobile', 'partner_id.phone')
     def _compute_email_phone(self):

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -779,11 +779,11 @@ class IrModelFields(models.Model):
             return
 
         # remove pending write of this field
-        # DLE P16: if there are pending towrite of the field we currently try to unlink, pop them out from the towrite queue
+        # DLE P16: if there are pending updates of the field we currently try to unlink, pop them out from the cache
         # test `test_unlink_with_dependant`
         for record in self:
-            for record_values in self.env.all.towrite[record.model].values():
-                record_values.pop(record.name, None)
+            field = self.pool[record.model]._fields[record.name]
+            self.env.cache.clear_dirty_field(field)
         # remove fields from registry, and check that views are not broken
         fields = [self.env[record.model]._pop_field(record.name) for record in self]
         domain = expression.OR([('arch_db', 'like', record.name)] for record in self)

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -593,7 +593,7 @@ class IrTranslation(models.Model):
         # When assigning a translation to a field
         # e.g. email.with_context(lang='fr_FR').label = "bonjour"
         # and then search on translations for this translation, must flush as the translation has not yet been written in database
-        if any(self.env[model]._fields[field].translate for model, ids in self.env.all.towrite.items() for record_id, fields in ids.items() for field in fields):
+        if any(field.translate for field in self.env.cache.get_dirty_fields()):
             self.env.flush_all()
         return super(IrTranslation, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
 


### PR DESCRIPTION
Merging both the memory of field values and suspended updates has several advantages:
 - avoid inconsistencies between `cache` and `towrite`
 - cache updates can be made safer w.r.t. dirty flag

However, the dirty flag in cache does not go well with context-dependent fields.  When a context-dependent field is dirty in cache, the value to store in the database is accessible through some context values.  But when the model is flushed, the context values on the current environment may be different.  When this happens, the method `flush_X()` fails to retrieve the data to flush.

The proposed solution is to store the "dirty" value in cache under conventional context values, and to retrieve them under the same conventional context values to flush them.  For instance, when storing the value of a binary field, it will be stored once under the context value `context.get('bin_size')`, and a second time under the context value `None`.  The flush implementation will then retrieve the value using the context value `None`.

Translated fields are also problematic when a value is put in cache with an environment where `lang=False`, and the value is retrieved with another environment where `lang=None`.  This issue is addressed by normalizing the context key `lang` to `None` when the context value is `False`.