### PR TITLE
[FIX] account: bank account of current company selected

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1089,8 +1089,8 @@ class AccountMove(models.Model):
     @api.depends('bank_partner_id')
     def _compute_invoice_partner_bank_id(self):
         for move in self:
-            filtered_bank_partner_id = move.bank_partner_id.filtered(lambda bank: bank.company_id.id in (False, move.company_id.id))
-            move.invoice_partner_bank_id = filtered_bank_partner_id.bank_ids[:1]
+            filtered_bank_partner_id = move.bank_partner_id.bank_ids.filtered(lambda bank: bank.company_id is False or bank.company_id == move.company_id)
+            move.invoice_partner_bank_id = filtered_bank_partner_id and filtered_bank_partner_id[0]
 
     @api.depends('commercial_partner_id', 'type')
     def _compute_bank_partner_id(self):


### PR DESCRIPTION
How to reproduce the bug ?

- install accounting and contacts
- Create a second company
- In the contact app, create a new contact.
- As company 1, add a bank account for this contact
- Switch to company 2 and add a bank account for the same contact
- In the Accounting app, create a new bill
- Select the contact created earlier as partner.

What is the bug ?

In a multi company environment, if you have a contact accessible with
several companies who have defined a bank account for him, you get an
error when you select this contact as partner. The reason is the fact
that the account of the other company is selected.

opw-2893122

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
