### PR TITLE
[FIX] board: get view from key or viewType

### DIFF
--- a/addons/board/static/src/legacy/js/board_view.js
+++ b/addons/board/static/src/legacy/js/board_view.js
@@ -271,7 +271,7 @@ var BoardRenderer = FormRenderer.extend({
                     var viewInfo = viewsInfo[viewType];
                     var xml = new DOMParser().parseFromString(viewInfo.arch, "text/xml")
                     var key = xml.documentElement.getAttribute("js_class");
-                    var View = viewRegistry.get(key || viewType);
+                    var View = viewRegistry.get(key) || viewRegistry.get(viewType);
 
                     const searchQuery = {
                         context: context,


### PR DESCRIPTION
Adding the eCommerce dashboard to your dashboard causes the Dashboards
app to raise an error, preventing its use.

Steps to reproduce:
1. Install Dashboards and eCommerce
2. Open Website app and add the eCommerce Dashboard to your dashboard by
   clicking on Favorites > Add to my dashboard > ADD
3. Refresh the page
4. Open Dashboards app: an error is raised

Solution:
If the viewRegistry doesn't contain the key (or if the key is null), use
the viewType to get the view

Problem:
viewRegistry might not contain the key so View will be undefined
since https://github.com/odoo/odoo/pull/84864

opw-2888351