### PR TITLE
[IMP] knowledge: introduce articles structure commands

### DIFF
--- a/addons/knowledge/__manifest__.py
+++ b/addons/knowledge/__manifest__.py
@@ -54,6 +54,7 @@
             'knowledge/static/src/models/*/*.js',
             'knowledge/static/src/js/form_controller.js',
             'knowledge/static/src/js/form_renderer.js',
+            'knowledge/static/src/js/knowledge_articles_structure.js',
             'knowledge/static/src/js/knowledge_macros.js',
             'knowledge/static/src/js/knowledge_behaviors.js',
             'knowledge/static/src/js/knowledge_behavior_table_of_content.js',
@@ -87,6 +88,7 @@
             'knowledge/static/tests/tours/*.js',
         ],
         'web.qunit_suite_tests': [
+            'knowledge/static/tests/knowledge_article_command_structure.js',
             'knowledge/static/tests/knowledge_article_command_toc.js',
             'knowledge/static/tests/test_services.js',
         ],

--- a/addons/knowledge/__manifest__.py
+++ b/addons/knowledge/__manifest__.py
@@ -56,6 +56,7 @@
             'knowledge/static/src/js/form_renderer.js',
             'knowledge/static/src/js/knowledge_macros.js',
             'knowledge/static/src/js/knowledge_behaviors.js',
+            'knowledge/static/src/js/knowledge_behavior_table_of_content.js',
             'knowledge/static/src/js/knowledge_toolbars.js',
             'knowledge/static/src/js/knowledge_field_html_injector.js',
             'knowledge/static/src/js/knowledge_plugin.js',
@@ -86,6 +87,7 @@
             'knowledge/static/tests/tours/*.js',
         ],
         'web.qunit_suite_tests': [
+            'knowledge/static/tests/knowledge_article_command_toc.js',
             'knowledge/static/tests/test_services.js',
         ],
         'web.qunit_mobile_suite_tests': [

--- a/addons/knowledge/data/knowledge_data.xml
+++ b/addons/knowledge/data/knowledge_data.xml
@@ -162,6 +162,16 @@
             <field name="name">Sales Playbook</field>
             <field name="icon">📘</field>
             <field name="body" type="html">
+                <div class="o_knowledge_toc o_knowledge_behavior_anchor o_knowledge_behavior_type_toc" contenteditable="false">
+                    <div class="o_knowledge_toc_content">
+                        <a data-oe-nodeid="0" contenteditable="false" href="#" class="oe_unremovable o_no_link_popover d-block o_toc_link o_toc_link_depth_0">Sales Playbook</a>
+                        <a data-oe-nodeid="1" contenteditable="false" href="#" class="oe_unremovable o_no_link_popover d-block o_toc_link o_toc_link_depth_1">Prospection Templates 👌</a>
+                        <a data-oe-nodeid="2" contenteditable="false" href="#" class="oe_unremovable o_no_link_popover d-block o_toc_link o_toc_link_depth_1">Prospect Qualification</a>
+                        <a data-oe-nodeid="3" contenteditable="false" href="#" class="oe_unremovable o_no_link_popover d-block o_toc_link o_toc_link_depth_2">The 5 Commandments 🙏</a>
+                        <a data-oe-nodeid="4" contenteditable="false" href="#" class="oe_unremovable o_no_link_popover d-block o_toc_link o_toc_link_depth_2">Tips to close more deals 🤝</a>
+                        <a data-oe-nodeid="5" contenteditable="false" href="#" class="oe_unremovable o_no_link_popover d-block o_toc_link o_toc_link_depth_2">Company Abbreviations 📚</a>
+                    </div>
+                </div>
                 <h1>Sales Playbook</h1>
                 <hr />
                 <p>

--- a/addons/knowledge/static/src/js/knowledge_articles_structure.js
+++ b/addons/knowledge/static/src/js/knowledge_articles_structure.js
@@ -1,0 +1,253 @@
+
+/** @odoo-module */
+
+import { qweb, _t } from 'web.core';
+import Dialog from "web.Dialog";
+
+import { ContentsContainerBehavior } from './knowledge_behaviors.js';
+import { KnowledgeToolbar } from './knowledge_toolbars.js';
+
+const ArticlesStructureBehaviorMixin = {
+    //--------------------------------------------------------------------------
+    // Articles Structure - BUSINESS LOGIC
+    //--------------------------------------------------------------------------
+
+    /**
+     * Updates the article structure.
+     * This will display the children of this article.
+     * We only take the direct children if 'this.onlyDirectChildren' is True.
+     *
+     * This block is used by the /articles_structure and /articles_index commands and their
+     * respective toolbars through a system of Mixin to avoid code duplication.
+     *
+     * This mixin only needs those parameters set to be able to function:
+     * - this.articleId - the id of the concerned article
+     * - this.onlyDirectChildren - controls if we only display one level of depth or ALL children
+     * - this.articlesStructureAnchor - the 'o_knowledge_articles_structure_wrapper' linked to the
+     *   behavior or toolbar
+     * - (direct access to the '_rpc' and 'do_action' methods).
+     *
+     * Small design effect note:
+     * We use a fake promise that is resolved after 500ms when updating the Articles Structure.
+     * The allows avoiding the search_read completing very fast and creating a "flicker effect".
+     */
+    _updateArticlesStructure: async function () {
+        this.minimumWait = this.minimumWait !== undefined ? this.minimumWait : 500;
+
+        const articlesStructureElement = this.articlesStructureAnchor.getElementsByClassName('o_knowledge_articles_structure_content');
+
+        articlesStructureElement[0].innerHTML = '<i class="fa fa-refresh fa-spin ml-3 mb-3"/>';
+
+        const domain = [[
+            'parent_id',
+            this.onlyDirectChildren ? '=' : 'child_of',
+            this.articleId
+        ]]
+
+        const minimumWaitPromise = new Promise(resolve => setTimeout(resolve, this.minimumWait));
+        const articlesChildrenPromise = this._rpc({
+            model: 'knowledge.article',
+            method: 'search_read',
+            fields: ['id', 'display_name', 'parent_id'],
+            orderBy: [{name: 'sequence', asc: true}],
+            domain: domain,
+        });
+
+        const [ _, articlesChildren ] = await Promise.all([
+            minimumWaitPromise,
+            articlesChildrenPromise]
+        );
+
+        const articlesStructure = this.buildArticlesStructure(
+            this.articleId, articlesChildren);
+
+        const updatedStructure = qweb.render('knowledge.articles_structure', {
+            'articles': articlesStructure
+        });
+
+        articlesStructureElement[0].innerHTML = updatedStructure;
+
+        $(this.articlesStructureAnchor).on(
+            'click',
+            '.o_knowledge_article_structure_link',
+            this._onArticleLinkClick.bind(this)
+        );
+    },
+
+    /**
+     * Transforms the flat search_read result into a parent/children articles hierarchy.
+     *
+     * @param {Integer} parent
+     * @param {Array} allArticles
+     * @returns {Array} articles structure
+     */
+    buildArticlesStructure: function (parent, allArticles) {
+        return allArticles
+            .filter((article) => article.parent_id && article.parent_id[0] == parent)
+            .map((article) => {
+                return {
+                    id: article.id,
+                    name: article.display_name,
+                    children: this.buildArticlesStructure(article.id, allArticles),
+                }
+            });
+    },
+
+    //--------------------------------------------------------------------------
+    // Articles Structure - HANDLERS
+    //--------------------------------------------------------------------------
+
+    /**
+     * Opens the article in the side tree menu.
+     *
+     * @param {Event} event
+     */
+     _onArticleLinkClick: async function (event) {
+        event.preventDefault();
+
+        const actionPromise = this.do_action('knowledge.ir_actions_server_knowledge_home_page', {
+            stackPosition: 'replaceCurrentAction',
+            additional_context: {
+                res_id: parseInt(event.target.getAttribute('data-oe-nodeid'))
+            }
+        });
+
+        await actionPromise.catch(() => {
+            Dialog.alert(this,
+                _t("This article was deleted or you don't have the rights to access it."), {
+                title: _t('Error'),
+            });
+        });
+    },
+};
+
+/**
+ * A behavior for the /articles_structure command @see Wysiwyg.
+ * It creates a listing of children of this article.
+ *
+ * It is used by 2 different commands:
+ * - /articles_structure that only list direct children
+ * - /articles_index that lists all children
+ *
+ * It is an extension of @see ContentsContainerBehavior
+ */
+const ArticlesStructureBehavior = ContentsContainerBehavior.extend(ArticlesStructureBehaviorMixin, {
+    //--------------------------------------------------------------------------
+    // 'ContentsContainerBehavior' overrides
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    init: function () {
+        this._super.apply(this, arguments);
+    },
+
+    /**
+     * Re-apply contenteditable="false" that is turned on automatically by the base editor code.
+     * This avoids having our custom links opening the editor toolbar on click.
+     *
+     * @override
+     */
+    applyAttributes: function () {
+        this._super.apply(this, arguments);
+        if (this.mode === 'edit') {
+            this.anchor.querySelectorAll('a').forEach(element => {
+                element.setAttribute('contenteditable', 'false');
+            });
+        }
+    },
+
+    /**
+     * Adds the Article Click listener to open the associated article.
+     *
+     * @override
+     */
+     applyListeners: async function () {
+        this._super.apply(this, arguments);
+
+        if (this.mode === 'edit') {
+            $(this.anchor).data('articleId', this.articleId);
+        }
+
+        if (this.mode === 'edit' && !$(this.anchor).hasClass('o_knowledge_articles_structure_loaded')) {
+            this.articlesStructureAnchor = this.anchor;
+            this.onlyDirectChildren = $(this.anchor).hasClass('o_knowledge_articles_structure_only_direct_children');
+            await this._updateArticlesStructure();
+            $(this.anchor).addClass('o_knowledge_articles_structure_loaded');
+        } else {
+            $(this.anchor).on(
+                'click',
+                '.o_knowledge_article_structure_link',
+                this._onArticleLinkClick.bind(this)
+            );
+        }
+    },
+
+    /**
+     * @override
+     */
+    disableListeners: function () {
+        this._super.apply(this, arguments);
+        $(this.anchor).off('click', '.o_knowledge_article_structure_link');
+    },
+
+    //--------------------------------------------------------------------------
+    // Proxies
+    //--------------------------------------------------------------------------
+
+    /**
+     * Since 'ContentsContainerBehavior' extends 'Class' and not Widget, we need to go through
+     * our handler to proxy the do_action calls. As the handler properly extends Widget.
+     */
+    do_action: async function () {
+        return this.handler.do_action.apply(this.handler, arguments);
+    },
+
+    /**
+     * Since 'ContentsContainerBehavior' extends 'Class' and not Widget, we need to go through
+     * our handler to proxy the _rpc calls. As the handler properly extends Widget.
+     */
+    _rpc: async function () {
+        return this.handler._rpc.apply(this.handler, arguments);
+    },
+});
+
+/**
+ * Toolbar for the /articles_structure command
+ */
+ const ArticlesStructureToolbar = KnowledgeToolbar.extend(ArticlesStructureBehaviorMixin, {
+    /**
+     * Recover the eventual related record from @see KnowledgeService
+     *
+     * @override
+     */
+    init: function () {
+        this._super.apply(this, arguments);
+        this.articlesStructureAnchor = this.container;
+    },
+
+    /**
+     * @override
+     */
+    _setupButton: function (button) {
+        this._super.apply(this, arguments);
+
+        if (button.dataset.call === 'update_articles_structure') {
+            button.addEventListener("click", this._onUpdateArticlesStructureClick.bind(this));
+        }
+    },
+
+    _onUpdateArticlesStructureClick: function (ev) {
+        ev.stopPropagation();
+        ev.preventDefault();
+
+        this.articleId = parseInt($(this.container).data('articleId'));
+        this.onlyDirectChildren = $(this.container).hasClass(
+            'o_knowledge_articles_structure_only_direct_children');
+
+        this._updateArticlesStructure();
+    }
+});
+
+export { ArticlesStructureBehavior, ArticlesStructureToolbar };

--- a/addons/knowledge/static/src/js/knowledge_behavior_table_of_content.js
+++ b/addons/knowledge/static/src/js/knowledge_behavior_table_of_content.js
@@ -1,0 +1,207 @@
+
+/** @odoo-module */
+
+import core from 'web.core';
+import { ContentsContainerBehavior } from './knowledge_behaviors.js';
+
+const qweb = core.qweb;
+
+const HEADINGS = [
+    'H1',
+    'H2',
+    'H3',
+    'H4',
+    'H5',
+    'H6',
+];
+/**
+ * A behavior for the /toc command @see Wysiwyg . This behavior use a
+ * mutationObserver to listen to changes on <h1> -> <h6> nodes, and create
+ * a table of contents. It is an extension of @see ContentsContainerBehavior
+ */
+const TableOfContentsBehavior = ContentsContainerBehavior.extend({
+    //--------------------------------------------------------------------------
+    // 'ContentsContainerBehavior' overrides
+    //--------------------------------------------------------------------------
+
+    /**
+     * Initialize the editor content observer.
+     * It listens to changes on H1 through H6 tags and updates a Table of Content accordingly.
+     *
+     * @override
+     */
+    init: function () {
+        this.observer = new MutationObserver((mutationList) => {
+            const update = mutationList.find(mutation => {
+                if (Array.from(mutation.addedNodes).find((node) => HEADINGS.includes(node.tagName)) ||
+                    Array.from(mutation.removedNodes).find((node) => HEADINGS.includes(node.tagName))) {
+                    // We just added/removed a header node -> update the ToC
+                    return true;
+                }
+
+                // Command bar is active -> do not attempt to update the ToC
+                if (this.handler.editor.commandBar._active) {
+                    if (this.updateTimeout) {
+                        clearTimeout(this.updateTimeout);
+                    }
+                    return false;
+                }
+
+                let target = mutation.target;
+                if (target) {
+                    // the text node is the actual text of the header element, we need the tag element
+                    if (target.nodeType === Node.TEXT_NODE && target.parentElement) {
+                        target = target.parentElement;
+                    }
+                    return target.parentElement === this.handler.field && target.nodeType === Node.ELEMENT_NODE && HEADINGS.includes(target.tagName);
+                }
+                return false;
+            });
+
+            if (update) {
+                this.delayedUpdateTableOfContents();
+            }
+        });
+
+        this._super.apply(this, arguments);
+    },
+
+    /**
+     * Adds the ToC click listener to scroll towards to associated heading tag.
+     * Also adds the listener that will update the ToC as the user is typing.
+     *
+     * @override
+     */
+    applyListeners: function () {
+        this._super.apply(this, arguments);
+        $(this.anchor).on('click', '.o_toc_link', this._onTocLinkClick.bind(this));
+        if (this.mode === 'edit') {
+            this.observer.observe(this.handler.field, {
+                childList: true,
+                attributes: false,
+                subtree: true,
+                characterData: true,
+            });
+
+            this._updateTableOfContents();
+        }
+    },
+    /**
+     * @override
+     */
+    disableListeners: function () {
+        $(this.anchor).off('click', '.o_toc_link');
+        if (this.mode === 'edit') {
+            this.observer.disconnect();
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Table of content - BUSINESS LOGIC
+    //--------------------------------------------------------------------------
+
+    /**
+     * Allows to debounce the update of the Table of Content to avoid updating whenever every single
+     * character is typed. The debounce is set to 500ms.
+     */
+    delayedUpdateTableOfContents() {
+        if (this.updateTimeout) {
+            clearTimeout(this.updateTimeout);
+        }
+        this.updateTimeout = setTimeout(this._updateTableOfContents.bind(this), 500);
+    },
+
+    /**
+     * Updates the Table of Content to match the document headings.
+     * We pause our observer during the process.
+     */
+    _updateTableOfContents: function () {
+        this.handler.editor.observerUnactive('knowledge_toc_update');
+
+        const allHeadings = Array.from(this.handler.field.querySelectorAll('h1,h2,h3,h4,h5,h6'))
+            .filter((heading) => heading.innerText.trim().length > 0);
+
+        let currentDepthByTag = {};
+        let previousTag = undefined;
+        let previousDepth = -1;
+        let index = 0;
+        const headingStructure = allHeadings.map((heading) => {
+            let depth = HEADINGS.indexOf(heading.tagName)
+            // Compute the 'depth' we want to display when increasing
+            if (depth !== previousDepth && heading.tagName === previousTag) {
+                // Same tag name as previous one -> use same depth
+                depth = previousDepth;
+            } else if (depth > previousDepth) {
+                // This is done only when changing tags, as 2 h4 in our previous example
+                // need to be at the same depth
+                if (heading.tagName !== previousTag) {
+                    // We only go max +1 depth at the time, meaning if a h4 follows a h1,
+                    // we want only one extra depth
+                    depth = previousDepth + 1;
+                }
+            } else if (depth < previousDepth) {
+                // When going down, it's different, we need to see if our current tree already
+                // has this tag at a certain depth, and use that
+                if (currentDepthByTag.hasOwnProperty(heading.tagName)) {
+                    depth = currentDepthByTag[heading.tagName];
+                }
+            }
+
+            previousTag = heading.tagName;
+            previousDepth = depth;
+
+            // going back to 0 depth, wipe-out the 'currentDepthByTag'
+            if (depth === 0) {
+                currentDepthByTag = {};
+            }
+            currentDepthByTag[heading.tagName] = depth;
+
+            return {
+                depth: depth,
+                index: index++,
+                name: heading.innerText,
+                tagName: heading.tagName,
+            }
+        });
+
+        const updatedToc = qweb.render('knowledge.knowledge_table_of_content', {
+            'headings': headingStructure
+        });
+        const knowledgeToCElement = this.handler.field.getElementsByClassName('o_knowledge_toc_content');
+        if (knowledgeToCElement.length !== 0) {
+            knowledgeToCElement[0].innerHTML = updatedToc;
+        }
+
+        this.handler.editor.observerActive('knowledge_toc_update');
+    },
+
+    //--------------------------------------------------------------------------
+    // Table of content - HANDLERS
+    //--------------------------------------------------------------------------
+
+    /**
+     * Scroll through the view to display the matching heading.
+     * Adds a small highlight in/out animation using a class.
+     *
+     * @param {Event} event
+     */
+    _onTocLinkClick: function (event) {
+        event.preventDefault();
+        const headingIndex = parseInt(event.target.getAttribute('data-oe-nodeid'));
+        const targetHeading = Array.from(this.handler.field.querySelectorAll('h1, h2, h3, h4, h5, h6'))
+            .filter((heading) => heading.innerText.trim().length > 0)[headingIndex];
+        if (targetHeading){
+            targetHeading.scrollIntoView({
+                behavior: 'smooth',
+            });
+            targetHeading.setAttribute('highlight', true);
+            setTimeout(() => {
+                targetHeading.removeAttribute('highlight');
+            }, 2000);
+        } else {
+            this._updateTableOfContents();
+        }
+    },
+});
+
+export { TableOfContentsBehavior };

--- a/addons/knowledge/static/src/js/knowledge_behaviors.js
+++ b/addons/knowledge/static/src/js/knowledge_behaviors.js
@@ -27,11 +27,13 @@ const KnowledgeBehavior = Class.extend({
      *                         widget specific functions
      * @param {Element} anchor dom node to apply the behavior to
      * @param {string} mode edit/readonly
+     * @param {Integer} articleId this id of the currently edited knowledge.article
      */
-    init: function (handler, anchor, mode) {
+    init: function (handler, anchor, mode, articleId) {
         this.handler = handler;
         this.anchor = anchor;
         this.mode = mode;
+        this.articleId = articleId;
         if (this.handler.editor) {
             this.handler.editor.observerUnactive('knowledge_attributes');
         }

--- a/addons/knowledge/static/src/js/knowledge_field_html_injector.js
+++ b/addons/knowledge/static/src/js/knowledge_field_html_injector.js
@@ -4,6 +4,7 @@ import { ComponentWrapper, WidgetAdapterMixin } from 'web.OwlCompatibility';
 import { useService } from "@web/core/utils/hooks";
 import { TemplateToolbar, FileToolbar } from './knowledge_toolbars';
 import { ArticleBehavior, ContentsContainerBehavior } from './knowledge_behaviors';
+import { TableOfContentsBehavior } from './knowledge_behavior_table_of_content';
 const { Component } = owl;
 
 /**
@@ -52,6 +53,9 @@ const FieldHtmlInjector = Widget.extend(WidgetAdapterMixin, {
         },
         o_knowledge_behavior_type_article: {
             Behavior: ArticleBehavior,
+        },
+        o_knowledge_behavior_type_toc: {
+            Behavior: TableOfContentsBehavior,
         },
     },
     /**

--- a/addons/knowledge/static/src/js/knowledge_field_html_injector.js
+++ b/addons/knowledge/static/src/js/knowledge_field_html_injector.js
@@ -5,6 +5,7 @@ import { useService } from "@web/core/utils/hooks";
 import { TemplateToolbar, FileToolbar } from './knowledge_toolbars';
 import { ArticleBehavior, ContentsContainerBehavior } from './knowledge_behaviors';
 import { TableOfContentsBehavior } from './knowledge_behavior_table_of_content';
+import { ArticlesStructureBehavior, ArticlesStructureToolbar } from './knowledge_articles_structure';
 const { Component } = owl;
 
 /**
@@ -42,6 +43,10 @@ const FieldHtmlInjector = Widget.extend(WidgetAdapterMixin, {
             template: 'knowledge.file_toolbar',
             Toolbar: FileToolbar,
         },
+        o_knowledge_toolbar_type_articles_structure: {
+            template: 'knowledge.articles_structure_toolbar',
+            Toolbar: ArticlesStructureToolbar,
+        },
     },
     /**
      * Map classes used in @see OdooEditor blocks to their corresponding
@@ -56,6 +61,9 @@ const FieldHtmlInjector = Widget.extend(WidgetAdapterMixin, {
         },
         o_knowledge_behavior_type_toc: {
             Behavior: TableOfContentsBehavior,
+        },
+        o_knowledge_behavior_type_articles_structure: {
+            Behavior: ArticlesStructureBehavior,
         },
     },
     /**
@@ -74,6 +82,7 @@ const FieldHtmlInjector = Widget.extend(WidgetAdapterMixin, {
         this.mode = mode;
         this.field = field;
         this.editor = editor;
+        this.articleId = parent.record.data.id;
     },
     /**
      * Start the injection process and setup injection event listeners.
@@ -237,7 +246,7 @@ const FieldHtmlInjector = Widget.extend(WidgetAdapterMixin, {
                 return;
             }
             if (!anchor.oKnowledgeBehavior) {
-                anchor.oKnowledgeBehavior = new Behavior(this, anchor, this.mode);
+                anchor.oKnowledgeBehavior = new Behavior(this, anchor, this.mode, this.articleId);
             }
             this.behavior_anchors.add(anchor);
         });

--- a/addons/knowledge/static/src/js/knowledge_frontend.js
+++ b/addons/knowledge/static/src/js/knowledge_frontend.js
@@ -11,6 +11,7 @@ publicWidget.registry.KnowledgeWidget = publicWidget.Widget.extend(KnowledgeTree
         'keyup .knowledge_search_bar': '_searchArticles',
         'click .o_article_caret': '_onFold',
         'click .o_favorites_toggle_button': '_toggleFavorite',
+        'click .o_toc_link': '_onTocLinkClick',
     },
 
     /**
@@ -85,5 +86,27 @@ publicWidget.registry.KnowledgeWidget = publicWidget.Widget.extend(KnowledgeTree
                 this._setTreeFavoriteListener();
             });
         });
+    },
+
+    /**
+     * Scroll through the view to display the matching heading.
+     * Adds a small highlight in/out animation using a class.
+     *
+     * @param {Event} event
+     */
+    _onTocLinkClick: function (event) {
+        event.preventDefault();
+        const headingIndex = parseInt(event.target.getAttribute('data-oe-nodeid'));
+        const targetHeading = Array.from(this.$el[0].querySelectorAll('h1, h2, h3, h4, h5, h6'))
+            .filter((heading) => heading.innerText.trim().length > 0)[headingIndex];
+        if (targetHeading){
+            targetHeading.scrollIntoView({
+                behavior: 'smooth',
+            });
+            targetHeading.setAttribute('highlight', true);
+            setTimeout(() => {
+                targetHeading.removeAttribute('highlight');
+            }, 2000);
+        }
     },
 });

--- a/addons/knowledge/static/src/js/wysiwyg.js
+++ b/addons/knowledge/static/src/js/wysiwyg.js
@@ -88,6 +88,22 @@ Wysiwyg.include({
                 callback: () => {
                     this._insertTableOfContent();
                 }
+            }, {
+                groupName: 'Knowledge',
+                title: _t('Articles Structure'),
+                description: _t('Add your sub-articles structure.'),
+                fontawesome: 'fa-share-alt',
+                callback: () => {
+                    this._insertArticlesStructure(true);
+                }
+            }, {
+                groupName: 'Knowledge',
+                title: _t('Articles Index'),
+                description: _t('Add all your sub-articles index.'),
+                fontawesome: 'fa-share-alt',
+                callback: () => {
+                    this._insertArticlesStructure(false);
+                }
             });
         }
         return commands;
@@ -137,6 +153,20 @@ Wysiwyg.include({
         const tocBlock = $(QWeb.render('knowledge.toc_block', {}))[0];
         tocFragment.append(tocBlock);
         const [container] = this.odooEditor.execCommand('insertFragment', tocFragment);
+        this._notifyNewToolbars(container);
+        this._notifyNewBehaviors(container);
+    },
+    /**
+     * Insert a /structure block.
+     * It will list all the articles that are direct children of this one.
+     */
+     _insertArticlesStructure: function (onlyDirectChildren) {
+        const articlesStructureFragment = new DocumentFragment();
+        const articlesStructureBlock = $(QWeb.render('knowledge.articles_structure_wrapper', {
+            onlyDirectChildren: onlyDirectChildren
+        }))[0];
+        articlesStructureFragment.append(articlesStructureBlock);
+        const [container] = this.odooEditor.execCommand('insertFragment', articlesStructureFragment);
         this._notifyNewToolbars(container);
         this._notifyNewBehaviors(container);
     },

--- a/addons/knowledge/static/src/js/wysiwyg.js
+++ b/addons/knowledge/static/src/js/wysiwyg.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { qweb as QWeb } from 'web.core';
+import { qweb as QWeb, _t } from 'web.core';
 import Wysiwyg from 'web_editor.wysiwyg';
 import { KnowledgeArticleLinkModal } from './wysiwyg/knowledge_article_link.js';
 import { preserveCursor, setCursorStart } from '@web_editor/../lib/odoo-editor/src/OdooEditor';
@@ -80,6 +80,14 @@ Wysiwyg.include({
                 callback: () => {
                     this._insertTemplate();
                 },
+            }, {
+                groupName: 'Knowledge',
+                title: _t('Table Of Content'),
+                description: _t('Add a table of content.'),
+                fontawesome: 'fa-bookmark',
+                callback: () => {
+                    this._insertTableOfContent();
+                }
             });
         }
         return commands;
@@ -120,6 +128,17 @@ Wysiwyg.include({
             });
         }
         this.$editable.trigger('refresh_behaviors', { behaviorsData: behaviorsData});
+    },
+    /**
+     * Insert a /toc block (table of content)
+     */
+    _insertTableOfContent: function () {
+        const tocFragment = new DocumentFragment();
+        const tocBlock = $(QWeb.render('knowledge.toc_block', {}))[0];
+        tocFragment.append(tocBlock);
+        const [container] = this.odooEditor.execCommand('insertFragment', tocFragment);
+        this._notifyNewToolbars(container);
+        this._notifyNewBehaviors(container);
     },
     /**
      * Insert a /template block

--- a/addons/knowledge/static/src/scss/knowledge_blocks.scss
+++ b/addons/knowledge/static/src/scss/knowledge_blocks.scss
@@ -37,6 +37,34 @@
     }
 }
 
+.o_knowledge_toc {
+    box-shadow: 0 2px 4px 4px $o-gray-200;
+    padding: 10px;
+    margin: 15px 0 15px 0;
+    & > .o_knowledge_toc_content {
+        @for $depth from 0 through 5 {
+            a.o_toc_link_depth_#{$depth} {
+                padding-left: calc(5px + Min(30px, 10%) * #{$depth});
+                font-family: $font-family-base !important;
+                font-weight: $font-weight-bolder !important;
+                border-radius: 5px;
+                min-height: $line-height-base * $font-size-base;
+                border: transparent;
+
+                &:hover {
+                    background-color: $o-gray-300;
+                    text-decoration: none;
+                }
+            }
+
+            a.o_toc_link_depth_0 {
+                // initial 5px padding to give some space to first level
+                padding-left: 5px;
+            }
+        }
+    }
+}
+
 .o_knowledge_behavior_type_article {
     border-color: $o-gray-200;
 }

--- a/addons/knowledge/static/src/scss/knowledge_blocks.scss
+++ b/addons/knowledge/static/src/scss/knowledge_blocks.scss
@@ -65,6 +65,37 @@
     }
 }
 
+.o_knowledge_articles_structure_wrapper {
+    box-shadow: 0 2px 4px 4px $o-gray-200;
+    padding: 10px;
+    margin: 15px 0 15px 0;
+    .o_knowledge_articles_structure_content {
+        ol {
+            list-style-type: none;
+            margin: 0;
+            width: 100%;
+            padding-left: Min(30px, 10%);
+            li {
+                a {
+                    padding-left: 5px;
+                    width: 100%;
+                    font-family: $font-family-base !important;
+                    font-weight: $font-weight-bolder !important;
+                    border-radius: 5px;
+                    min-height: $line-height-base * $font-size-base;
+                }
+                a:hover {
+                    background-color: $o-gray-300;
+                }
+            }
+        }
+
+        > ol {
+            padding-left: 5px;
+        }
+    }
+}
+
 .o_knowledge_behavior_type_article {
     border-color: $o-gray-200;
 }

--- a/addons/knowledge/static/src/scss/knowledge_frontend.scss
+++ b/addons/knowledge/static/src/scss/knowledge_frontend.scss
@@ -5,6 +5,14 @@
         cursor: default;
     }
 
+    @include o-position-absolute(0, 0, 0, 0);
+    h1, h2, h3, h4, h5, h6 {
+        &[highlight="true"] {
+            background-color: $o-gray-300;
+            transition: background-color 0.5s ease;
+        }
+    }
+
     .o_favorites_toggle_button {
         i.fa-star, i:hover {
             color: #f3cc00;

--- a/addons/knowledge/static/src/scss/knowledge_views.scss
+++ b/addons/knowledge/static/src/scss/knowledge_views.scss
@@ -198,6 +198,12 @@
     .o_knowledge_form_view {
         .o_scroll_view {
             @include o-position-absolute(0, 0, 0, 0);
+            h1, h2, h3, h4, h5, h6 {
+                &[highlight="true"] {
+                    background-color: $o-gray-300;
+                    transition: background-color 0.5s ease;
+                }
+            }
             overflow-y: auto;
             overflow-x: hidden;
         }

--- a/addons/knowledge/static/src/xml/knowledge_editor.xml
+++ b/addons/knowledge/static/src/xml/knowledge_editor.xml
@@ -39,4 +39,30 @@
             </div>
         </div><br/>
     </t>
+    <t t-name="knowledge.articles_structure_wrapper">
+        <div
+            t-attf-class="o_knowledge_articles_structure_wrapper o_knowledge_toolbars_container
+                o_knowledge_behavior_anchor o_knowledge_behavior_type_articles_structure
+                #{onlyDirectChildren ? 'o_knowledge_articles_structure_only_direct_children' : ''}">
+            <div class="o_knowledge_toolbar_anchor o_knowledge_toolbar_type_articles_structure"/>
+            <div class="o_knowledge_articles_structure_content"/>
+        </div>
+    </t>
+    <t t-name="knowledge.articles_structure">
+        <i t-if="!articles or articles.length === 0">No sub-articles found under this document.</i>
+        <ol t-foreach="articles" t-as="article">
+            <li>
+                <!-- Use 'data-oe-nodeid' as we need something that is not removed during sanitizing -->
+                <a t-attf-href="/knowledge/article/#{article.id}" t-att-data-oe-nodeid="article.id"
+                    class="btn btn-sm text-left o_knowledge_article_structure_link"
+                    contenteditable="false" t-out="article.name">
+                </a>
+            </li>
+            <li t-if="article.children and article.children.length !== 0">
+                <t t-call="knowledge.articles_structure">
+                    <t t-set="articles" t-value="article.children"/>
+                </t>
+            </li>
+        </ol>
+    </t>
 </templates>

--- a/addons/knowledge/static/src/xml/knowledge_editor.xml
+++ b/addons/knowledge/static/src/xml/knowledge_editor.xml
@@ -32,4 +32,11 @@
             </div>
         </form>
     </t>
+    <t t-name="knowledge.toc_block">
+        <div class="o_knowledge_toc o_knowledge_behavior_anchor o_knowledge_behavior_type_toc">
+            <div class="o_knowledge_toc_content">
+                <i>No heading found in this document.</i>
+            </div>
+        </div><br/>
+    </t>
 </templates>

--- a/addons/knowledge/static/src/xml/knowledge_templates.xml
+++ b/addons/knowledge/static/src/xml/knowledge_templates.xml
@@ -20,4 +20,12 @@
             </div>
         </form>
     </t>
+    <t t-name="knowledge.knowledge_table_of_content">
+        <i t-if="!headings or headings.length === 0">Add headings in this Article to create a Table of Content</i>
+        <t t-foreach="headings" t-as="heading">
+            <!-- Use 'data-oe-nodeid' as we need something that is not removed during sanitizing -->
+            <a t-out="heading.name" t-att-data-oe-nodeid="heading.index" href="#"
+                t-attf-class="oe_unremovable o_no_link_popover d-block o_toc_link #{'o_toc_link_depth_' + depth}"/>
+        </t>
+    </t>
 </templates>

--- a/addons/knowledge/static/src/xml/knowledge_toolbars.xml
+++ b/addons/knowledge/static/src/xml/knowledge_toolbars.xml
@@ -30,4 +30,14 @@
             </div>
         </div>
     </t>
+    <t t-name="knowledge.articles_structure_toolbar">
+        <div class="o_knowledge_toolbar" contenteditable="false">
+            <div class="btn-group">
+                <button t-if="widget.mode === 'edit'" data-call="update_articles_structure" title="Update"
+                    class="btn btn-link btn-sm border-0">
+                    <i class="fa fa-refresh"/> <span class="o_knowledge_toolbar_button_text">Refresh</span>
+                </button>
+            </div>
+        </div>
+    </t>
 </templates>

--- a/addons/knowledge/static/tests/knowledge_article_command_structure.js
+++ b/addons/knowledge/static/tests/knowledge_article_command_structure.js
@@ -1,0 +1,175 @@
+/** @odoo-module */
+
+import FormView from 'web.FormView';
+import testUtils from 'web.test_utils';
+const { createView } = testUtils;
+
+import { ArticlesStructureBehavior, ArticlesStructureToolbar } from '@knowledge/js/knowledge_articles_structure';
+import { FieldHtmlInjector } from '@knowledge/js/knowledge_field_html_injector';
+import { nextTick } from "@web/../tests/helpers/utils";
+
+const getArch = function (){
+    return '<form js_class="knowledge_article_view_form">' +
+        '<sheet>' +
+            '<div class="o_knowledge_editor d-flex flex-grow-1">' +
+                '<field name="body" widget="html"/>' +
+            '</div>' +
+        '</sheet>' +
+    '</form>';
+};
+
+/**
+ * Will make sure that the "Behaviors" are correctly initialized before calling the structure command.
+ * See 'FieldHtmlInjector#start' for details.
+ */
+const insertArticlesStructure = async (form, onlyDirectChildren) => {
+    const behaviorInitialized = testUtils.makeTestPromise();
+
+    testUtils.mock.patch(ArticlesStructureBehavior, {
+        applyListeners: function () {
+            this.minimumWait = 0;
+            this._super(...arguments);
+        }
+    });
+
+    testUtils.mock.patch(ArticlesStructureToolbar, {
+        init: function () {
+            this._super(...arguments);
+            this.minimumWait = 0;
+        }
+    });
+
+    testUtils.mock.patch(FieldHtmlInjector, {
+        start: async function () {
+            await this._super(...arguments);
+            behaviorInitialized.resolve();
+        }
+    });
+
+    await testUtils.form.clickEdit(form);
+    await testUtils.dom.click(form.$("p:first"));
+    const wysiwyg = form.$('.note-editable').data('wysiwyg');
+    await nextTick();
+    await behaviorInitialized;
+
+    testUtils.mock.unpatch(FieldHtmlInjector);
+
+    wysiwyg._insertArticlesStructure(onlyDirectChildren);
+    await nextTick();
+
+    testUtils.mock.unpatch(ArticlesStructureBehavior);
+    testUtils.mock.unpatch(ArticlesStructureToolbar);
+};
+
+const articlesStructureSearch = [
+    { id: 1, display_name: 'My Article', parent_id: false },
+    { id: 2, display_name: 'Child 1', parent_id: [1, 'My Article'] },
+    { id: 3, display_name: 'Child 2', parent_id: [1, 'My Article'] },
+];
+
+const articlesIndexSearch = articlesStructureSearch.concat([
+    { id: 4, display_name: 'Grand-child 1', parent_id: [2, 'Child 1'] },
+    { id: 5, display_name: 'Grand-child 2', parent_id: [2, 'Child 1'] },
+    { id: 6, display_name: 'Grand-child 3', parent_id: [3, 'Child 2'] },
+]);
+
+QUnit.module('Knowledge - Articles Structure Command', {
+    beforeEach: function () {
+        this.data = {
+            'knowledge_article': {
+                fields: {
+                    body: {type: 'html'},
+                },
+                records: [{
+                    id: 1,
+                    display_name: "My Article",
+                    body: '<p>Initial Content</p>',
+                }]
+            },
+        };
+    }
+}, function (){
+    QUnit.test('Check Articles Structure is correctly built', async function (assert) {
+        assert.expect(3);
+
+        const form = await createView({
+            View: FormView,
+            model: 'knowledge_article',
+            data: this.data,
+            arch: getArch(),
+            res_id: 1,
+            mockRPC: function(route, args) {
+                if (args.method === 'search_read' && args.model === 'knowledge.article') {
+                    return Promise.resolve(articlesStructureSearch);
+                }
+                return this._super(route, args);
+            }
+        });
+
+        await insertArticlesStructure(form, true);
+        const $editorEl = form.$(".odoo-editor-editable");
+
+        // /articles_structure only considers the direct children - "Child 1" and "Child 2"
+        assert.containsN($editorEl, '.o_knowledge_articles_structure_content ol a', 2);
+        assert.containsOnce($editorEl, '.o_knowledge_articles_structure_content ol a:contains("Child 1")');
+        assert.containsOnce($editorEl, '.o_knowledge_articles_structure_content ol a:contains("Child 2")');
+
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+
+    QUnit.test('Check Articles Index is correctly built - and updated', async function (assert) {
+        assert.expect(8);
+
+        let searchReadCallCount = 0;
+        const form = await createView({
+            View: FormView,
+            model: 'knowledge_article',
+            data: this.data,
+            arch: getArch(),
+            res_id: 1,
+            mockRPC: function(route, args) {
+                if (args.method === 'search_read' && args.model === 'knowledge.article') {
+                    if (searchReadCallCount === 0) {
+                        searchReadCallCount++;
+                        return Promise.resolve(articlesIndexSearch);
+                    } else {
+                        // return updated result (called when clicking on the refresh button)
+                        return Promise.resolve(articlesIndexSearch.concat([
+                            { id: 7, display_name: 'Grand-child 4', parent_id: [3, 'Child 2'] },
+                        ]));
+                    }
+                }
+                return this._super(route, args);
+            }
+        });
+
+        await insertArticlesStructure(form, false);
+        const $editorEl = form.$(".odoo-editor-editable");
+
+        // /articles_index considers whole children - "Child 1" and "Child 2" and then their respective children
+        assert.containsN($editorEl, '.o_knowledge_articles_structure_content ol a', 5);
+        assert.containsOnce($editorEl, '.o_knowledge_articles_structure_content ol a:contains("Child 1")');
+        assert.containsOnce($editorEl, '.o_knowledge_articles_structure_content ol a:contains("Child 2")');
+        assert.containsOnce($editorEl,
+            '.o_knowledge_articles_structure_content ol:contains("Child 1") ol a:contains("Grand-child 1")');
+        assert.containsOnce($editorEl,
+            '.o_knowledge_articles_structure_content ol:contains("Child 1") ol a:contains("Grand-child 2")');
+        assert.containsOnce($editorEl,
+            '.o_knowledge_articles_structure_content ol:contains("Child 2") ol a:contains("Grand-child 3")');
+
+        // clicking on update yields an additional Grand-child (see 'mockRPC' here above)
+        // make sure our structure is correctly updated
+        await testUtils.dom.click(form.$('button[data-call="update_articles_structure"]'));
+        await nextTick();
+
+        assert.containsN($editorEl, '.o_knowledge_articles_structure_content ol a', 6);
+        assert.containsOnce($editorEl,
+            '.o_knowledge_articles_structure_content ol:contains("Child 2") ol a:contains("Grand-child 4")');
+
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+});

--- a/addons/knowledge/static/tests/knowledge_article_command_toc.js
+++ b/addons/knowledge/static/tests/knowledge_article_command_toc.js
@@ -1,0 +1,163 @@
+/** @odoo-module */
+
+import FormView from 'web.FormView';
+import testUtils from 'web.test_utils';
+const { createView } = testUtils;
+
+import { FieldHtmlInjector } from '@knowledge/js/knowledge_field_html_injector';
+import { nextTick } from "@web/../tests/helpers/utils";
+
+const getArch = function (){
+    return '<form js_class="knowledge_article_view_form">' +
+        '<sheet>' +
+            '<div class="o_knowledge_editor d-flex flex-grow-1">' +
+                '<field name="body" widget="html"/>' +
+            '</div>' +
+        '</sheet>' +
+    '</form>';
+};
+
+/**
+ * Will make sure that the "Behaviors" are correctly initialized before calling the ToC command.
+ * See 'FieldHtmlInjector#start' for details.
+ */
+const insertTableOfContent = async (form) => {
+    const behaviorInitialized = testUtils.makeTestPromise();
+    testUtils.mock.patch(FieldHtmlInjector, {
+        start: async function () {
+            await this._super(...arguments);
+            behaviorInitialized.resolve();
+        }
+    });
+
+    await testUtils.form.clickEdit(form);
+    await testUtils.dom.click(form.$("h1:first"));
+    const wysiwyg = form.$('.note-editable').data('wysiwyg');
+    await nextTick();
+    await behaviorInitialized;
+    testUtils.mock.unpatch(FieldHtmlInjector);
+    wysiwyg._insertTableOfContent();
+    await nextTick();
+};
+
+const assertHeadings = (assert, $editorEl, expectedHeadings) => {
+    const allHeadings = Array.from($editorEl[0].querySelectorAll('a.o_toc_link'));
+    for (let index = 0; index < expectedHeadings.length; index++) {
+        const { title, depth } = expectedHeadings[index];
+        const headingSelector = `a:contains("${title}").o_toc_link_depth_${depth}`;
+        // we have the heading in the DOM
+        assert.containsOnce($editorEl, headingSelector);
+
+        const $headingEl = $editorEl.find(headingSelector);
+        // is has the correct index (as item order is important)
+        assert.equal(index, allHeadings.indexOf($headingEl[0]));
+    }
+};
+
+QUnit.module('Knowledge Table of Content', {
+    beforeEach: function () {
+        this.data = {
+            'knowledge_article': {
+                fields: {
+                    body: {type: 'html'},
+                },
+                records: [{
+                    id: 1,
+                    display_name: "My Article",
+                    body: '' +
+                    '<h1>Main 1</h1>' +
+                        '<h2>Sub 1-1</h2>' +
+                            '<h3>Sub 1-1-1</h3>' +
+                            '<h3>Sub 1-1-2</h3>' +
+                        '<h2>Sub 1-2</h2>' +
+                            '<h3>Sub 1-2-1</h3>' +
+                    '<h1>Main 2</h1>' +
+                        '<h3>Sub 2-1</h3>' +
+                        '<h3>Sub 2-2</h3>' +
+                            '<h4>Sub 2-2-1</h4>' +
+                                '<h5>Sub 2-2-1-1</h5>' +
+                        '<h3>Sub 2-3</h3>',
+                }, {
+                    id: 2,
+                    display_name: "My Article",
+                    body: '' +
+                    '<h2>Main 1</h2>' +
+                        '<h3>Sub 1-1</h3>' +
+                            '<h4>Sub 1-1-1</h4>' +
+                            '<h4>Sub 1-1-2</h4>' +
+                    '<h1>Main 2</h1>' +
+                        '<h2>Sub 2-1</h2>',
+                }]
+            },
+        };
+    }
+}, function (){
+    QUnit.test('Check Table of Content is correctly built', async function (assert) {
+        assert.expect(24);
+
+        const form = await createView({
+            View: FormView,
+            model: 'knowledge_article',
+            data: this.data,
+            arch: getArch(),
+            res_id: 1,
+        });
+
+        await insertTableOfContent(form);
+
+        const $editorEl = form.$(".odoo-editor-editable");
+        const expectedHeadings = [
+            {title: 'Main 1',      depth: 0},
+            {title: 'Sub 1-1',     depth: 1},
+            {title: 'Sub 1-1-1',   depth: 2},
+            {title: 'Sub 1-1-2',   depth: 2},
+            {title: 'Sub 1-2',     depth: 1},
+            {title: 'Sub 1-2-1',   depth: 2},
+            {title: 'Main 2',      depth: 0},
+            // the next <h3>'s should be at depth 1, because we don't have any <h2> in this subtree
+            {title: 'Sub 2-1',     depth: 1},
+            {title: 'Sub 2-2',     depth: 1},
+            {title: 'Sub 2-2-1',   depth: 2},
+            {title: 'Sub 2-2-1-1', depth: 3},
+            // the next <h3> should be at depth 1, because we don't have any <h2> in this subtree
+            {title: 'Sub 2-3',     depth: 1},
+        ]
+
+        assertHeadings(assert, $editorEl, expectedHeadings);
+
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+
+    QUnit.test('Check Table of Content is correctly built - starting with H2', async function (assert) {
+        assert.expect(12);
+
+        const form = await createView({
+            View: FormView,
+            model: 'knowledge_article',
+            data: this.data,
+            arch: getArch(),
+            res_id: 2,
+        });
+
+        await insertTableOfContent(form);
+
+        const $editorEl = form.$(".odoo-editor-editable");
+        const expectedHeadings = [
+            // The "Main 1" section is a <h2>, but it should still be at depth 0
+            // as there is no <h1> above it
+            {title: 'Main 1',      depth: 0},
+            {title: 'Sub 1-1',     depth: 1},
+            {title: 'Sub 1-1-1',   depth: 2},
+            {title: 'Sub 1-1-2',   depth: 2},
+            {title: 'Main 2',      depth: 0},
+            {title: 'Sub 2-1',     depth: 1},
+        ]
+        assertHeadings(assert, $editorEl, expectedHeadings);
+
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+});


### PR DESCRIPTION
This commit introduces commands to add your children articles' structure into
your article body field through the editor.

It is composed of 2 different editor commands:
- /articles_structure that will only list direct children of this article
- /articles_index that will list ALL children of this article

The rendered layout is a simple ol/li list that gives a hierarchical view of
the children articles, with clickable names that send the user to the
corresponding article.

It can be refreshed using a 'Update' button in our special "Knowledge Toolbar"
implementation.

The blocks created by those commands are currently NOT editable since that
would cause issues with the way we build links.
Indeed, they are themselves non-editable because they cannot be manually
"reproduced" using native editor commands (such as /link or /article).

Further improvements may come later to allow end-users to edit these blocks.

Task-2818474