### PR TITLE
[FIX] core/tests: test form without fields specified

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2676,6 +2676,8 @@ def record_to_values(fields, record):
     # emergency_contact or whatever. Since we always get the id anyway, just
     # remove it from the fields to read
     to_read = list(fields.keys() - {'id'})
+    if not to_read:
+        return r
     for f, v in record.read(to_read)[0].items():
         descr = fields[f]
         if descr['type'] == 'many2one':


### PR DESCRIPTION
Since #91909, the settings form view is tested with different levels
of access rights, post install.

But when the test is run with only the base module, it crashes because
the settings view specified in base is empty, without any field.

On save, the test form reads the view fields, but read fallbacks on
all fields if no field is specified, and it breaks when we try to
compare the read results to the fields requested (empty).

This commit skips the read when no fields is present in the view.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
