### PR TITLE
[FIX] calendar: open calendar view from 'Reschedule' activity button

### DIFF
--- a/addons/calendar/static/src/components/activity/activity.xml
+++ b/addons/calendar/static/src/components/activity/activity.xml
@@ -7,7 +7,7 @@
         </xpath>
         <xpath expr="//button[hasclass('o_Activity_editButton')]" position="after">
             <t t-if="activityView.activity.calendar_event_id">
-                <button class="o_Activity_toolButton o_Activity_editButton btn btn-link" t-on-click="activityView.onClickEdit">
+                <button class="o_Activity_toolButton o_Activity_editButton btn btn-link pt-0" t-on-click="activityView.onClickEdit">
                     <i class="fa fa-calendar"/> Reschedule
                 </button>
             </t>

--- a/addons/calendar/static/src/models/activity.js
+++ b/addons/calendar/static/src/models/activity.js
@@ -55,9 +55,7 @@ patchRecordMethods('Activity', {
                 method: 'action_create_calendar_event',
                 args: [[this.id]],
             });
-            this.env.bus.trigger('do-action', {
-                action
-            });
+            this.env.services.action.doAction(action);
         }
     },
 });

--- a/addons/calendar/static/tests/activity_tests.js
+++ b/addons/calendar/static/tests/activity_tests.js
@@ -1,0 +1,50 @@
+/** @odoo-module **/
+
+import { start, startServer } from '@mail/../tests/helpers/test_utils';
+
+QUnit.module('calendar', () => {
+QUnit.module('components', () => {
+QUnit.module('activity_tests.js');
+
+QUnit.test('activity click on Reschedule', async function (assert) {
+    assert.expect(1);
+
+    const pyEnv = await startServer();
+    const resPartnerId = pyEnv['res.partner'].create({});
+    const meetingActivityTypeId = pyEnv['mail.activity.type'].create({ icon: 'fa-calendar', name: "Meeting" });
+    const calendarAttendeeId = pyEnv['calendar.attendee'].create({ partner_id: resPartnerId });
+    const calendaMeetingId = pyEnv['calendar.event'].create({
+        res_model: "calendar.event",
+        name: "meeting1",
+        start: "2022-07-06 06:30:00",
+        attendee_ids: [calendarAttendeeId],
+    });
+    pyEnv['mail.activity'].create({
+        name: "Small Meeting",
+        activity_type_id: meetingActivityTypeId,
+        can_write: true,
+        res_id: resPartnerId,
+        res_model: 'res.partner',
+        calendar_event_id: calendaMeetingId,
+    });
+    const views = {
+        'calendar.event,false,calendar': `<calendar date_start="start"/>`,
+    };
+
+    const { click, createChatterContainerComponent } = await start({serverData: {views}});
+
+    await createChatterContainerComponent({
+        threadId: resPartnerId,
+        threadModel: 'res.partner',
+    });
+
+    await click('.o_Activity_editButton');
+    assert.containsOnce(
+        document.body,
+        '.o_calendar_view',
+        "should have opened calendar view"
+    );
+});
+
+});
+});

--- a/addons/calendar/static/tests/helpers/mock_server.js
+++ b/addons/calendar/static/tests/helpers/mock_server.js
@@ -10,6 +10,32 @@ import { datetime_to_str } from 'web.time';
 
 patch(MockServer.prototype, 'calendar', {
     //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async _performRPC(route, args) {
+        // mail.activity methods
+        if (args.model === 'mail.activity' && args.method === 'action_create_calendar_event') {
+            return {
+                type: 'ir.actions.act_window',
+                name: "Meetings",
+                res_model: 'calendar.event',
+                view_mode: 'calendar',
+                views: [[false, 'calendar']],
+                target: 'current',
+            };
+        }
+        // calendar.event methods
+        if (args.model === 'calendar.event' && args.method === "check_access_rights") {
+            return true;
+        }
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
     // Private Mocked Methods
     //--------------------------------------------------------------------------
 


### PR DESCRIPTION
With recent commit[1], we now use the wowlEnv instead of the legacy one,
and use the service provided by env for the rpc.

This was adapted in the activity model, but not on the patched method
under calendar.

This commit fixes the issues by adpating the change, and so the 'Reschedule'
button for the meeting activity now opens the calendar view as expected.

Apart from that, this commit also tries to align this button with other
activity buttons, for better UI.

commit[1] - https://github.com/odoo/odoo/commit/3573a7fef497d

taskID-2899402

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
