### PR TITLE
[FIX] l10n_fr_pos_cert: print report even with inconsistency

### DIFF
--- a/addons/l10n_fr_pos_cert/models/res_company.py
+++ b/addons/l10n_fr_pos_cert/models/res_company.py
@@ -56,7 +56,6 @@ class ResCompany(models.Model):
             order_reference_string = order.pos_reference and entry_reference % order.pos_reference or ''
             return [ctx_tz(order, 'date_order'), order.l10n_fr_hash, order.name, order_reference_string, ctx_tz(order, 'write_date')]
 
-        hash_verified = True
         msg_alert = ''
         report_dict = {}
         if self._is_accounting_unalterable():
@@ -65,32 +64,31 @@ class ResCompany(models.Model):
 
             if not orders:
                 msg_alert = (_('There isn\'t any order flagged for data inalterability yet for the company %s. This mechanism only runs for point of sale orders generated after the installation of the module France - Certification CGI 286 I-3 bis. - POS') % self.env.company.name)
-                hash_verified = False
 
             previous_hash = u''
-            start_order_info = []
+            corrupted_orders = []
             for order in orders:
                 if order.l10n_fr_hash != order._compute_hash(previous_hash=previous_hash):
+                    corrupted_orders.append(order.name)
                     msg_alert = (_('Corrupted data on point of sale order with id %s.') % order.id)
-                    hash_verified = False
-                    break
                 previous_hash = order.l10n_fr_hash
 
-            if hash_verified:
-                orders_sorted_date = orders.sorted(lambda o: o.date_order)
-                start_order_info = build_order_info(orders_sorted_date[0])
-                end_order_info = build_order_info(orders_sorted_date[-1])
+            orders_sorted_date = orders.sorted(lambda o: o.date_order)
+            start_order_info = build_order_info(orders_sorted_date[0])
+            end_order_info = build_order_info(orders_sorted_date[-1])
 
-                report_dict.update({
-                    'first_order_name': start_order_info[2],
-                    'first_order_hash': start_order_info[1],
-                    'first_order_date': start_order_info[0],
-                    'last_order_name': end_order_info[2],
-                    'last_order_hash': end_order_info[1],
-                    'last_order_date': end_order_info[0],
-                })
+            report_dict.update({
+                'first_order_name': start_order_info[2],
+                'first_order_hash': start_order_info[1],
+                'first_order_date': start_order_info[0],
+                'last_order_name': end_order_info[2],
+                'last_order_hash': end_order_info[1],
+                'last_order_date': end_order_info[0],
+            })
+            corrupted_orders = ', '.join([o for o in corrupted_orders])
             return {
-                'result': hash_verified and report_dict or 'None',
+                'result': report_dict or 'None',
                 'msg_alert': msg_alert or 'None',
                 'printing_date': format_date(self.env,  Date.to_string( Date.today())),
+                'corrupted_orders': corrupted_orders or 'None'
             }

--- a/addons/l10n_fr_pos_cert/report/pos_hash_integrity.xml
+++ b/addons/l10n_fr_pos_cert/report/pos_hash_integrity.xml
@@ -34,7 +34,7 @@
                                         <br/>
                                         <h3>Contrôle des données du point de vente</h3>
                                         <br/>
-                                        <t t-if="data['result'] != 'None' and data['msg_alert'] == 'None'">
+                                        <t t-if="data['result'] != 'None' and data['corrupted_orders'] == 'None'">
                                             <h5>
                                                 Toutes les ventes effectuées via le Point de Vente
                                                 sont bien dans la chaîne de hachage.
@@ -74,6 +74,14 @@
                                             </tbody>
                                         </table>
                                     </div>
+                                </div>
+                                <div>
+                                    <t t-if="data['corrupted_orders'] != 'None'">
+                                        <h5>
+                                            Données corrompues sur la commande du point de vente:
+                                        </h5>
+                                        <span t-esc="data['corrupted_orders']"/> <br/>
+                                    </t>
                                 </div>
                                 <div class="row" id="hash_last_div">
                                     <div class="col-12" id="hash_chain_compliant">


### PR DESCRIPTION
Before this commit: if one of the orders is corrupted, it will print an empty report.

The solution is to print corrupted orders in the report.

opw-2867770

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
