### PR TITLE
[FIX] stock: display Reserve button only if relevant

### DIFF
--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -121,7 +121,7 @@
                                 </t>
                                 <t t-elif="line['replenishment_filled']">
                                     <t t-if="line['document_out']">Inventory On Hand
-                                        <button t-if="line['move_out'] and line['move_out'].picking_id"
+                                        <button t-if="line['move_out'] and line['move_out'].state in ('confirmed', 'partially_available') and line['move_out'].picking_id"
                                             class="btn btn-sm btn-primary o_report_replenish_reserve"
                                             t-attf-model="stock.picking"
                                             t-att-model-id="line['move_out'].picking_id.id"


### PR DESCRIPTION
3-steps delivery. A user confirms a SO with a storable product, it
generates 3 pickings (pick, pack, ship). On the Forecasted Report of P,
there is a line for that SO. A button is available (Reserve) but if the
user clicks on that button, it won't do anything (even if there are some
P in stock).

The Reserve button is linked to the ship SM, so trying to assign it is
useless, we first need to process the pick/pack steps.

In such situation, displaying the button is confusing.

OPW-2784998