### PR TITLE
[FIX] mrp: do not set the remaining_qty as qty_producing in backorder

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1562,10 +1562,6 @@ class MrpProduction(models.Model):
             if not wo_to_update or wo_to_update[-1].production_id != wo.production_id:
                 wo_to_update += wo
             wo.qty_produced = max(old_wo.qty_produced - old_wo.qty_producing, 0)
-            if wo.product_tracking == 'serial':
-                wo.qty_producing = 1
-            else:
-                wo.qty_producing = wo.qty_remaining
         wo_to_cancel.action_cancel()
         for wo in wo_to_update:
             wo.state = 'ready' if wo.next_work_order_id.production_availability == 'assigned' else 'waiting'

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2214,7 +2214,7 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.state, 'done')
 
         mo_2 = self.env['mrp.production'].browse(mo.id + 1)
-        self.assertEqual(mo_2.state, 'progress')
+        self.assertEqual(mo_2.state, 'confirmed')
         wo_4, wo_5, wo_6 = mo_2.workorder_ids
 
         self.assertEqual(wo_4.state, 'cancel')


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BOM:
    - Component: 1 unit of C1
    - operation: OP1
- Create a MO to produce “P1”:
    - Qty to produce: 3.0
- Confirm the MO
- Set the qty producing to: 1.0
- Validate the MO and confirm the backorder

Problem:
The back order will be in `"in progress"` stage instead of `confirmed`,
with qty_producing equal to the remaining amount instead of zero

When the backorder is created, the qty_remaining should not be
automatically set as qty_producing

opw-2867167




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
