### PR TITLE
[FIX] fleet: properly archive Contract/Services

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -277,6 +277,10 @@ class FleetVehicle(models.Model):
                 if self.vehicle_type == 'car':
                     future_driver.sudo().write({'plan_to_change_car': True})
 
+        if 'active' in vals and not vals['active']:
+            self.env['fleet.vehicle.log.contract'].search([('vehicle_id', 'in', self.ids)]).active = False
+            self.env['fleet.vehicle.log.services'].search([('vehicle_id', 'in', self.ids)]).active = False
+
         res = super(FleetVehicle, self).write(vals)
         return res
 
@@ -307,11 +311,6 @@ class FleetVehicle(models.Model):
                 vehicle.future_driver_id.sudo().write({'plan_to_change_car': False})
             vehicle.driver_id = vehicle.future_driver_id
             vehicle.future_driver_id = False
-
-    def toggle_active(self):
-        self.env['fleet.vehicle.log.contract'].with_context(active_test=False).search([('vehicle_id', 'in', self.ids)]).toggle_active()
-        self.env['fleet.vehicle.log.services'].with_context(active_test=False).search([('vehicle_id', 'in', self.ids)]).toggle_active()
-        super(FleetVehicle, self).toggle_active()
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):


### PR DESCRIPTION
When archiving a vehicle, the active state of its Contracts/Services
were toggled, which was confusing (an archived Contract would suddently
become unarchived on an archived vehicle).

Now we only archive the Contracts/Services when the Vehicle is archived,
and no unarchiving is done.

task-2898104

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
