### PR TITLE
[IMP] stock: compute package level destination location by default

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -21,6 +21,7 @@ class StockPackageLevel(models.Model):
     location_id = fields.Many2one('stock.location', 'From', compute='_compute_location_id', check_company=True)
     location_dest_id = fields.Many2one(
         'stock.location', 'To', check_company=True,
+        compute="_compute_location_dest_id", store=True, readonly=False, precompute=True,
         domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     is_done = fields.Boolean('Done', compute='_compute_is_done', inverse='_set_is_done')
     state = fields.Selection([
@@ -183,6 +184,11 @@ class StockPackageLevel(models.Model):
                 pl.location_id = pl.move_line_ids[0].location_id
             else:
                 pl.location_id = pl.picking_id.location_id
+
+    @api.depends('picking_id', 'picking_id.location_dest_id')
+    def _compute_location_dest_id(self):
+        for pl in self:
+            pl.location_dest_id = pl.picking_id.location_dest_id
 
     def action_show_package_details(self):
         self.ensure_one()

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -109,7 +109,6 @@ class TestPacking(TestPackingCommon):
         package_level = self.env['stock.package_level'].create({
             'package_id': pack.id,
             'picking_id': picking.id,
-            'location_dest_id': self.stock_location.id,
             'company_id': picking.company_id.id,
         })
         self.assertEqual(package_level.state, 'draft',
@@ -172,13 +171,11 @@ class TestPacking(TestPackingCommon):
         package_level = self.env['stock.package_level'].create({
             'package_id': pack.id,
             'picking_id': picking.id,
-            'location_dest_id': self.stock_location.id,
             'company_id': picking.company_id.id,
         })
         package_level = self.env['stock.package_level'].create({
             'package_id': pack.id,
             'picking_id': picking.id,
-            'location_dest_id': self.stock_location.id,
             'company_id': picking.company_id.id,
         })
         picking.action_confirm()
@@ -918,7 +915,6 @@ class TestPacking(TestPackingCommon):
         package_level = self.env['stock.package_level'].create({
             'package_id': pack.id,
             'picking_id': picking.id,
-            'location_dest_id': picking.location_dest_id.id,
             'company_id': picking.company_id.id,
         })
 


### PR DESCRIPTION
This allows to create a stock.package_level record without
the need to set the `location_dest_id` during the `create` call.

For instance, this makes easier to create a package level
using XMLRPC when you do not use multiple locations.