### PR TITLE
[IMP] website_sale_autocomplete: add log on error

### DIFF
--- a/addons/website_sale_autocomplete/models/website.py
+++ b/addons/website_sale_autocomplete/models/website.py
@@ -9,3 +9,6 @@ class Website(models.Model):
     google_places_api_key = fields.Char(
         string='Google Places API Key',
         groups="base.group_system")
+
+    def has_google_places_api_key(self):
+        return bool(self.sudo().google_places_api_key)

--- a/addons/website_sale_autocomplete/static/src/xml/autocomplete.xml
+++ b/addons/website_sale_autocomplete/static/src/xml/autocomplete.xml
@@ -2,14 +2,13 @@
 
 <templates>
     <t t-name="website_sale_autocomplete.AutocompleteDropDown">
-        <div t-attf-class="dropdown-menu w-100 #{results ? 'show' : ''}">
+        <div t-attf-class="dropdown-menu w-100 #{results.length ? 'show' : ''}">
             <a class="dropdown-item js_autocomplete_result"
                t-foreach="results" t-as="result"
                t-att-data-google-place-id="result['google_place_id']">
                 <t t-out="result['formatted_address']"/>
             </a>
-            <img class="p-2" src="/website_sale_autocomplete/static/src/img/powered_by_google_on_white.png" alt="Powered by Google"/>
+            <img class="pull-right pr-1" src="/website_sale_autocomplete/static/src/img/powered_by_google_on_white.png" alt="Powered by Google"/>
         </div>
     </t>
-
 </templates>

--- a/addons/website_sale_autocomplete/views/templates.xml
+++ b/addons/website_sale_autocomplete/views/templates.xml
@@ -4,7 +4,7 @@
     <template id="website_sale_address_with_autocomplete" inherit_id="website_sale.address">
         <xpath expr="//input[@name='street']" position="attributes">
             <attribute name="t-att-data-autocomplete-enabled">
-                1 if website.sudo().google_places_api_key else 0
+                1 if website.has_google_places_api_key() else 0
             </attribute>
         </xpath>
     </template>


### PR DESCRIPTION

    In case of wrong whitelisted method e.g., the error was not visible.
    Now we log it in odoo-log.

    Add arbitrary limit of 5 char before to make api call
    (limit: 'Rue X', 'Street', ...)

    task-2806842 (partially)
