### PR TITLE
[CLA] Update Vauxoo's Contributor CLA

### DIFF
--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -56,3 +56,4 @@ Luigys Toro luigys@vauxoo.com https://github.com/desdelinux
 Francisco J. Luna fluna@vauxoo.com https://github.com/frahikLV
 Andrea Arce andrea@vauxoo.com https://github.com/andreaarce
 Francisco Alejandro González Luna aluna@vauxoo.com https://github.com/TheAlekLuna
+Juan Benavente jbenavente@vauxoo.com https://github.com/jjbenavaz


### PR DESCRIPTION
Incorporate Juan Benavente (jjbenavaz) as Vauxoo's contributor


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
