### PR TITLE
[FIX] point_of_sale:PoS Iot without order

### DIFF
--- a/pos_iot/static/src/js/iot_longpolling.js
+++ b/pos_iot/static/src/js/iot_longpolling.js
@@ -1,0 +1,43 @@
+/* global posmodel */
+odoo.define('pos_iot.IoTLongpolling', function (require) {
+'use strict';
+
+var core = require('web.core');
+var IoTLongpolling = require('iot.IoTLongpolling');
+const { Gui } = require('point_of_sale.Gui');
+
+var _t = core._t;
+
+IoTLongpolling.include({
+    _doWarnFail: function (url) {
+        Gui.showPopup('IoTErrorPopup', {
+            title: _t('Connection to IoT Box failed'),
+            url: url,
+        });
+        posmodel.proxy.proxy_connection_status(url, false);
+        const order = posmodel.get_order();
+        if (order && order.selected_paymentline &&
+            order.selected_paymentline.payment_method.use_payment_terminal === 'worldline' &&
+            ['waiting', 'waitingCard', 'waitingCancel'].includes(order.selected_paymentline.payment_status)) {
+            order.selected_paymentline.set_payment_status('force_done');
+        }
+    },
+
+    _onSuccess: function (iot_ip, result) {
+        posmodel.proxy.proxy_connection_status(iot_ip, true);
+        return this._super.apply(this, arguments);
+    },
+    action: function (iot_ip, device_identifier, data) {
+        var res = this._super.apply(this, arguments);
+        res.then(function () {
+            posmodel.proxy.proxy_connection_status(iot_ip, true);
+        }).guardedCatch(function () {
+            posmodel.proxy.proxy_connection_status(iot_ip, false);
+        });
+        return res;
+    },
+});
+
+return IoTLongpolling;
+
+});


### PR DESCRIPTION
Description:

Having IoT devices configured, and floors maganment in a PoS:

![conf](https://user-images.githubusercontent.com/104511957/177385018-69f777e7-03b6-4b9c-96fd-18206a7078a8.png)


This code is executed:

https://github.com/odoo/enterprise/blob/15.0/pos_iot/static/src/js/iot_longpolling.js#L19

Which is not prepared to be executed when the PoS has no active order, throwing this traceback:

![error_screenshot](https://user-images.githubusercontent.com/104511957/177385063-562a9cbe-644d-4d07-9bfa-7626e3eb1320.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
