### PR TITLE
[IMP] - repair -  set context default type for created product

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -171,7 +171,7 @@
                             </form>
                             <tree string="Fees" editable="bottom">
                                 <field name="company_id" invisible="1" force_save="1"/>
-                                <field name="product_id" required="True"/>
+                                <field name="product_id" required="True" context="{'default_type': 'service'}"/>
                                 <field name='name' optional="show"/>
                                 <field name="product_uom_qty" string="Quantity"/>
                                 <field name="product_uom_category_id" invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When creating an operation product from repair view, created product is defaulted to be consumable, 
As domain for operations is set to services only, such created product is not visible on next repair order, 

Current behavior before PR:

Product created from operations tab i created as consumable and as such not usable for future operations.

Desired behavior after PR is merged:

Product created from operations is defined as service and usable in next repair orders



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
