### PR TITLE
[FIX] hr_recruitment: make interviewer field tracked

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -178,7 +178,7 @@ class Applicant(models.Model):
     medium_id = fields.Many2one(ondelete='set null')
     source_id = fields.Many2one(ondelete='set null')
     interviewer_id = fields.Many2one(
-        'res.users', string='Interviewer', index=True,
+        'res.users', string='Interviewer', index=True, tracking=True,
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]")
 
     @api.depends('date_open', 'date_closed')


### PR DESCRIPTION
The interviewer field was added by #78622, and adds access control for `hr.applicant` based on whoever was assigned as the interviewer.

Due to the access control implications, it's useful to track the value of this field in the applicant history.