### PR TITLE
[FIX] web: support force_save attribute on fields

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -108,6 +108,7 @@ function mapActiveFieldsToFieldsInfo(activeFields, fields, viewType) {
             domain,
             context: fieldDescr.context,
             fieldDependencies: {}, // ??
+            force_save: fieldDescr.forceSave,
             mode: fieldDescr.viewMode,
             modifiers: fieldDescr.modifiers,
             name: fieldName,

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -202,6 +202,7 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         modifiers: JSON.parse(node.getAttribute("modifiers") || "{}"),
         onChange: archParseBoolean(node.getAttribute("on_change")),
         FieldComponent: getFieldClassFromRegistry(fields[name].type, widget, viewType, jsClass),
+        forceSave: archParseBoolean(node.getAttribute("force_save")),
         decorations: {}, // populated below
         noLabel: archParseBoolean(node.getAttribute("nolabel")),
         props: {},

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -641,7 +641,12 @@ export class Record extends DataPoint {
     getChanges(allFields = false, parentChanges = false) {
         const changes = { ...(allFields ? this.data : this._changes) };
         for (const fieldName in changes) {
-            if (!allFields && fieldName in this.activeFields && this.isReadonly(fieldName)) {
+            if (
+                !allFields &&
+                fieldName in this.activeFields &&
+                !this.activeFields[fieldName].forceSave &&
+                this.isReadonly(fieldName)
+            ) {
                 delete changes[fieldName];
                 continue;
             }


### PR DESCRIPTION
In an x2many sub view, the attribute "force_save" on a field
indicates that the field value must be saved, even if the field is
readonly. Before this commit, this attribute was ignored by the
new views. In the BasicRelationalModal, we only needed to propagate
this attribute to the fieldsInfo given to the BasicModel. In the
RelationalModel, we needed to take the attribute into account.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
