### PR TITLE
[FIX] base: Multi company issue with CRM

### DIFF
--- a/odoo/addons/base/data/res_partner_data.xml
+++ b/odoo/addons/base/data/res_partner_data.xml
@@ -21,7 +21,6 @@
 
         <record model="res.partner" id="base.partner_admin">
             <field name="name">Administrator</field>
-            <field name="company_id" ref="main_company"/>
             <field name="email">admin@example.com</field>
         </record>
 


### PR DESCRIPTION
To reproduce:

- Create a new database with the CRM app
- Send an email to info@ alias from the email address of the admin user

--> The email is rejected

The sender receives a bounce notification with the error :

550 5.7.1 Mailbox unavailable - Incompatible companies on records:

In logs :

'XXX' belongs to company False and 'Customer' (partner_id: 'YYY')) belongs to another company

The field company_id of the Administrator is set to base.main_company
https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/res_partner_data.xml#L24
But the multi company setting was not set

If the field company_id is empty, sending an email to info@ alias from the email address of the admin user will
create a lead in the pipeline.

opw:2893505