### PR TITLE
[FIX] mail: remove readonly from isSquashed

### DIFF
--- a/addons/mail/static/src/models/message_list_view_message_view_item.js
+++ b/addons/mail/static/src/models/message_list_view_message_view_item.js
@@ -13,7 +13,6 @@ registerModel({
     identifyingFields: ['messageListViewOwner', 'message'],
     fields: {
         isSquashed: attr({
-            readonly: true,
             required: true,
         }),
         message: one('Message', {


### PR DESCRIPTION
There are situations where a message view is re-used in a different context
where the isSquashed value has to change.

For example a message being starred could be squashed in its original thread but
not squashed in the starred box, leading to a crash before this fix.