### PR TITLE
[FIX] account: bank statement with erroneous partner_bank_id

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1370,10 +1370,10 @@ class AccountMove(models.Model):
     @api.depends('commercial_partner_id', 'move_type')
     def _compute_bank_partner_id(self):
         for move in self:
-            if move.is_outbound():
-                move.bank_partner_id = move.commercial_partner_id
-            else:
+            if move.is_inbound():
                 move.bank_partner_id = move.company_id.partner_id
+            else:
+                move.bank_partner_id = move.commercial_partner_id
 
     @api.model
     def _get_invoice_in_payment_state(self):


### PR DESCRIPTION
Bug introduced in commit : https://github.com/odoo/odoo/pull/92660/commits/f4bf83382d479cd7060d09ccfe7bd528ec9e29dd would trigger partner_bank_id computation on bst entries and erroneously set the company bank as partner bank.

opw-2900828