### PR TITLE
[FIX] mail: correctly return a field command when guest

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1183,7 +1183,7 @@ class Channel(models.Model):
                     'id': member.partner_id.id,
                     'name': member.partner_id.name,
                     'im_status': member.partner_id.im_status,
-                })]
+                })] if member.partner_id else [('clear',)],
             } for member in channel_partners])],
             'memberCount': count,
         }

--- a/addons/mail/static/src/models/channel_member.js
+++ b/addons/mail/static/src/models/channel_member.js
@@ -27,6 +27,9 @@ registerModel({
          * @returns {string}
          */
         _computeName() {
+            if (!this.partner) {
+                return;
+            }
             return this.partner.nameOrDisplayName;
         },
     },


### PR DESCRIPTION
Before this commit, field command was returning incorrect value if the channel_partner was a guest. At the very least we have to return a `clear` command.
