### PR TITLE
[IMP] account_edi: remove EDI Documents tab, hide factur-x checkbox on journal

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -286,6 +286,14 @@ class AccountEdiFormat(models.Model):
         # TO OVERRIDE
         self.ensure_one()
 
+    def _is_attachment_included_in_mail(self):
+        """
+        Indicate whether the attachment linked to the EDI format should appear or not in the email generated
+        (when clicking on the 'Send & Print' button).
+        """
+        # TO OVERRIDE
+        return True
+
     ####################################################
     # Import Internal methods (not meant to be overridden)
     ####################################################

--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -13,7 +13,7 @@ class MailTemplate(models.Model):
         :param document: an edi document
         :return: list with a tuple with the name and base64 content of the attachment
         """
-        if not document.attachment_id:
+        if not document.attachment_id or not document.edi_format_id._is_attachment_included_in_mail():
             return []
         return [(document.attachment_id.name, document.attachment_id.datas)]
 

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -97,28 +97,6 @@
                 <xpath expr="//div[@name='journal_div']" position="after">
                     <field name="edi_state" attrs="{'invisible': ['|', ('edi_state', '=', False), ('state', '=', 'draft')]}"/>
                 </xpath>
-                <xpath expr="//page[@id='other_tab']" position="after">
-                    <page id="edi_documents"
-                          string="EDI Documents"
-                          groups="base.group_no_one"
-                          attrs="{'invisible': [('edi_document_ids', '=', [])]}">
-                        <field name="edi_document_ids" options="{'no_open': '1'}">
-                            <tree create="false" delete="false" edit="false" decoration-danger="error">
-                                <field name="name"/>
-                                <field name="edi_format_name"/>
-                                <field name="state"/>
-                                <field name="error" invisible="1"/>
-                                <field name="blocking_level" invisible="1"/>
-                                <button name="action_export_xml"
-                                        type="object"
-                                        class="oe_link oe_inline"
-                                        string="Download"
-                                        groups="base.group_no_one"
-                                        attrs="{'invisible': ['|', ('error', '=', False), ('blocking_level', '=', 'info')]}"/>
-                            </tree>
-                        </field>
-                    </page>
-                </xpath>
             </field>
         </record>
     </data>

--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -140,6 +140,12 @@ class AccountEdiFormat(models.Model):
             return True
         return super()._is_embedding_to_invoice_pdf_needed()
 
+    def _is_attachment_included_in_mail(self):
+        # EXTENDS account_edi
+        if self.code == 'facturx_1_0_05':
+            return False
+        return super()._is_attachment_included_in_mail()
+
     def _prepare_invoice_report(self, pdf_writer, edi_document):
         # EXTENDS account_edi
         self.ensure_one()


### PR DESCRIPTION
Since Factur-X is always generated, it's useless to show the option
on the journal. Also remove the EDI Documents tab on the account.move.
Finally, do not show the Factur-X xml when clicking on
'send & print', indeed, the Factur-X xml is already present inside
the generated pdf.

TODO: do we really want to drop the edi.document tab ?

task-2894072