### PR TITLE
[FIX] mail: remove deprecated exists check

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -1237,10 +1237,6 @@ export class ModelManager {
             for (const fieldName of Object.keys(model.__fieldMap)) {
                 Object.defineProperty(model.prototype, fieldName, {
                     get: function getFieldValue() { // this is bound to record
-                        if (!this.exists()) {
-                            // Deprecated, allows reading fields on deleted records. Use exists() instead.
-                            return undefined;
-                        }
                         const field = model.__fieldMap[fieldName];
                         if (this.modelManager._listeners.size) {
                             if (!this.modelManager._listenersObservingLocalId.has(this.localId)) {

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -197,7 +197,9 @@ registerModel({
             if (isEventHandled(ev, 'MessageActionList.replyTo')) {
                 return;
             }
-            this.discard();
+            if (this.exists()) {
+                this.discard();
+            }
         },
         /**
          * Called when clicking on "discard" button.

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -1550,7 +1550,7 @@ QUnit.test('[technical] does not crash when an attachment is removed before its 
         }
     );
     // Simulates the completion of the upload of the first attachment
-    uploadPromise.resolve();
+    await afterNextRender(() => uploadPromise.resolve());
     assert.containsOnce(
         document.body,
         '.o_AttachmentCard:contains("text1.txt")',


### PR DESCRIPTION
The deprecated exists check(located in getFieldValue (ModelManager)) is removed,
but a lot of tests will fail after removing this check because it will try to
read fields after records are deleted. So added some missing exists checks.

**Task**-2871062