### PR TITLE
[FIX] tests: stop test runner from opening error dialogs in tours

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1095,6 +1095,8 @@ class ChromeBrowser():
     def _wait_ready(self, ready_code, timeout=60):
         self._logger.info('Evaluate ready code "%s"', ready_code)
         awaited_result = {'result': {'type': 'boolean', 'value': True}}
+        # catch errors in ready code to prevent opening error dialogs
+        ready_code = "try { %s } catch {}" % ready_code
         ready_id = self._websocket_send('Runtime.evaluate', params={'expression': ready_code})
         last_bad_res = ''
         start_time = time.time()


### PR DESCRIPTION
Previously, the test runner would evaluate an expression to check if the
tour that is about to be run is ready, but before the tour is ready,
this expression is invalid as the variables used in the expression are
undefined, causing a ReferenceError to be thrown by Chrome.

In Chrome >=102, errors that are thrown when writing code in the console
or by using Runtime.evaluate over CDP are thrown in the context of the
current tab, which means that they trip registered error handlers in
that tab. In Odoo, this means that we show error dialogs with the
traceback.

In the tour manager, when we are looking for an element  to trigger, we
only look for that element inside dialogs if there are any dialogs open
(unless the in_dialog option is false on that specific step). This means
that if an error dialog is open, most tours will fail (which is actually
what we want).

In order to avoid opening a bunch of error dialogs while waiting for the
tour to be ready, we simply use optional chaining in the start_tour
ready_code so that the experssion is always valid, and is simply falsy
until the tour is ready instead of throwing a ReferenceError.