### PR TITLE
[IMP] core: reintroduce test stats

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1271,6 +1271,7 @@ def preload_registries(dbnames):
                              time.time() - t0,
                              odoo.sql_db.sql_counter - t0_sql)
 
+                registry._assertion_report.log_stats()
             if not registry._assertion_report.wasSuccessful():
                 rc += 1
         except Exception:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -344,6 +344,7 @@ class Cursor(BaseCursor):
         return self._obj.mogrify(query, params).decode(encoding, 'replace')
 
     def execute(self, query, params=None, log_exceptions=None):
+        global sql_counter
         if params and not isinstance(params, (tuple, list, dict)):
             # psycopg2's TypeError is not clear if you mess up the params
             raise ValueError("SQL query parameters should be a tuple, list or dict; got %r" % (params,))
@@ -361,6 +362,8 @@ class Cursor(BaseCursor):
 
         # simple query count is always computed
         self.sql_log_count += 1
+        sql_counter += 1
+
         delay = (real_time() - start)
         current_thread = threading.current_thread()
         if hasattr(current_thread, 'query_count'):
@@ -437,15 +440,10 @@ class Cursor(BaseCursor):
             return self._close(False)
 
     def _close(self, leak=False):
-        global sql_counter
-
         if not self._obj:
             return
 
         del self.cache
-
-        # simple query count is always computed
-        sql_counter += self.sql_log_count
 
         # advanced stats only if sql_log is enabled
         self.print_log()

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -65,6 +65,7 @@ except ImportError:
     # chrome headless tests will be skipped
     websocket = None
 
+from .runner import stats_logger
 
 _logger = logging.getLogger(__name__)
 
@@ -187,9 +188,10 @@ class RecordCapturer:
 # ------------------------------------------------------------
 # Main classes
 # ------------------------------------------------------------
-class OdooSuite(unittest.suite.TestSuite):
-
-    if sys.version_info < (3, 8):
+if sys.version_info >= (3, 8):
+    BackportSuite = unittest.suite.TestSuite
+else:
+    class BackportSuite(unittest.suite.TestSuite):
         # Partial backport of bpo-24412, merged in CPython 3.8
 
         def _handleClassSetUp(self, test, result):
@@ -283,6 +285,37 @@ class OdooSuite(unittest.suite.TestSuite):
                                                                         'tearDownClass',
                                                                         className,
                                                                         info=exc)
+
+class OdooSuite(BackportSuite):
+    def _handleClassSetUp(self, test, result):
+        previous_test_class = getattr(result, '_previousTestClass', None)
+        if not (
+                previous_test_class != type(test)
+            and hasattr(result, 'stats')
+            and stats_logger.isEnabledFor(logging.INFO)
+        ):
+            super()._handleClassSetUp(test, result)
+            return
+
+        test_class = type(test)
+        test_id = f'{test_class.__module__}.{test_class.__qualname__}.setUpClass'
+        with result.collectStats(test_id):
+            super()._handleClassSetUp(test, result)
+
+    def _tearDownPreviousClass(self, test, result):
+        previous_test_class = getattr(result, '_previousTestClass', None)
+        if not (
+                previous_test_class
+            and previous_test_class != type(test)
+            and hasattr(result, 'stats')
+            and stats_logger.isEnabledFor(logging.INFO)
+        ):
+            super()._tearDownPreviousClass(test, result)
+            return
+
+        test_id = f'{previous_test_class.__module__}.{previous_test_class.__qualname__}.tearDownClass'
+        with result.collectStats(test_id):
+            super()._tearDownPreviousClass(test, result)
 
 
 class MetaCase(type):


### PR DESCRIPTION
Uses a dedicated logger (for easier filtering / silencing) for results output, and provides rough (module-level) stats in INFO but detailed (test-level) in DEBUG.

Also modifies the global query counter (`odoo.sql_db.query_counter`) to update after each query rather than on close: with test cursors the actual underlying counter is only rarely flushed. This allows using the global query count to track query counts using tests, under the assumption that the tests themselves don't run concurrently. This is both much simpler and more precise than trying to find the current test's cursor and messing about with it, especially during the class setup phase.