### PR TITLE
[FIX] web_editor: properly paste newlines on Windows

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -3176,7 +3176,7 @@ export class OdooEditor extends EventTarget {
                         }
                     }
                 } else if (splitAroundUrl[i] !== '') {
-                    const textFragments = splitAroundUrl[i].split('\n');
+                    const textFragments = splitAroundUrl[i].split(/\r?\n/);
                     let textIndex = 1;
                     for (const textFragment of textFragments) {
                         this.execCommand('insertText', textFragment);

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -157,6 +157,26 @@ describe('Copy and paste', () => {
                     contentAfter: '<p>a<span>bx[]c</span>d</p>',
                 });
             });
+            // TODO: We might want to have it consider \n as paragraph breaks
+            // instead of linebreaks but that would be an opinionated choice.
+            it('should paste text and understand \n newlines', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br/></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'a\nb\nc\nd');
+                    },
+                    contentAfter: '<p>a<br>b<br>c<br>d[]<br></p>',
+                });
+            });
+            it('should paste text and understand \r\n newlines', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br/></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'a\r\nb\r\nc\r\nd');
+                    },
+                    contentAfter: '<p>a<br>b<br>c<br>d[]<br></p>',
+                });
+            });
         });
         describe('range not collapsed', async () => {
             it('should paste a text in a p', async () => {


### PR DESCRIPTION
Windows uses /r/n as newlines and the split parameter was not taking
that into account, thus inserting the /r character.

task-2742071
