### PR TITLE
[FIX] mrp: prevent the creation of component SN if option is disabled

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -21,6 +21,9 @@
                 <xpath expr="//label[@for='quantity_done']" position="attributes">
 		    <attribute name="string">Consumed</attribute>
                 </xpath>
+                <xpath expr="//field[@name='quantity_done']" position='after'>
+                    <field name="raw_material_production_id" invisible="1"/>
+                </xpath>
             </field>
         </record>
 
@@ -36,6 +39,23 @@
                 </xpath>
                 <xpath expr="//label[@for='quantity_done']" position="attributes">
 		    <attribute name="string">Produced</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_stock_move_line_operation_tree_finished" model="ir.ui.view">
+            <field name="name">stock.move.line.operation.tree.finished</field>
+            <field name="model">stock.move.line</field>
+            <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='lot_id']" position="attributes">
+		            <attribute name="context">{
+                        'active_mo_id': parent.raw_material_production_id,
+                        'active_picking_id': picking_id,
+                        'default_company_id': parent.company_id,
+                        'default_product_id': parent.product_id,
+                        }
+                    </attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Inventory→ Configuration→ Warehouse Management →Operations Types
- Go inside “Manufacturing”, and disable the checkbox
“Create New Lots/Serial Numbers for Components” under the traceability
section
- create a MO with a traceable component
- Confirm the MO

Problem:
You can create a new SN for the component without any warning, while the user is supposed to be blocked by a user error:
https://github.com/odoo/odoo/blob/master/addons/mrp/models/stock_lot.py#L11-L16

The solution:
We need to add the `active_mo_id` key in the context so that the user error will be triggered

opw-2900256




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
