### PR TITLE
[FIX] sale: prevent -0.00 amount

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -996,6 +996,12 @@ Reason(s) of this behavior could be:
                             res[group]['amount'] += t['amount']
                             res[group]['base'] += t['base']
             res = sorted(res.items(), key=lambda l: l[0].sequence)
+
+            # round amount and prevent -0.00
+            for group_data in res:
+                group_data[1]['amount'] = currency.round(group_data[1]['amount']) + 0.0
+                group_data[1]['base'] = currency.round(group_data[1]['base']) + 0.0
+
             order.amount_by_group = [(
                 l[0].name, l[1]['amount'], l[1]['base'],
                 fmt(l[1]['amount']), fmt(l[1]['base']),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In some circonstance user can show -0.00 on taxe. It is more logical to show 0.00



![image](https://user-images.githubusercontent.com/16716992/177550179-022f7ea0-3ddb-4f04-802b-d5f4ab464bbf.png)


https://user-images.githubusercontent.com/16716992/177550202-a5ecb31c-c437-4c91-9ed6-5aa2b4a61428.mov




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
