### PR TITLE
[FIX] web: form: correctly handle empty buttonbox

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -123,12 +123,13 @@ export class FormCompiler extends ViewCompiler {
         el.classList.remove("oe_button_box");
         const buttonBox = createElement("ButtonBox");
         let slotId = 0;
-
+        let hasContent = false;
         for (const child of el.children) {
             const invisible = getModifier(child, "invisible");
             if (isAlwaysInvisible(invisible, params)) {
                 continue;
             }
+            hasContent = true;
             const mainSlot = createElement("t", {
                 "t-set-slot": `slot_${slotId++}`,
                 isVisible:
@@ -140,7 +141,7 @@ export class FormCompiler extends ViewCompiler {
             append(buttonBox, mainSlot);
         }
 
-        return buttonBox;
+        return hasContent ? buttonBox : null;
     }
 
     /**

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -5721,6 +5721,22 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("empty button box", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <div class="oe_button_box" name="button_box">
+                    </div>
+                </form>`,
+            resId: 2,
+        });
+
+        assert.containsNone(target, ".o-form-buttonbox");
+    });
+
     QUnit.test("one2many default value creation", async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
Before this commit, a form view with an empty button box would
produce a crash, in the ButtonBox component, because it assumed to
have slots. This commit prevents this from happening as we no
longer put a ButtonBox component in the template if there's nothing
in it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
