### PR TITLE
[FIX] web_editor: undo should work after table insertion

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/tablepicker/TablePicker.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/tablepicker/TablePicker.js
@@ -64,7 +64,10 @@ export class TablePicker extends EventTarget {
                     this.options.document.removeEventListener('mousemove', bindMouseMove);
                 };
                 this.options.document.addEventListener('mousemove', bindMouseMove);
-                cell.addEventListener('mousedown', this.selectCell.bind(this));
+                cell.addEventListener('mousedown', (e) => {
+                    this.selectCell();
+                    e.preventDefault();
+                });
             }
         }
 


### PR DESCRIPTION
**Current behavior before PR:**

After inserting table undo (ctrl + z) was not working

**Desired behavior after PR is merged:**

Now undo is working

Task-2858145




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
