### PR TITLE
[FIX] website: remove visitor-related dead JS files

### DIFF
--- a/addons/website/static/lib/jstz.min.js
+++ b/addons/website/static/lib/jstz.min.js
@@ -1,1 +1,0 @@
-// To remove after v14.0

--- a/addons/website/static/src/js/visitor_timezone.js
+++ b/addons/website/static/src/js/visitor_timezone.js
@@ -1,1 +1,0 @@
-// To remove after v14.0


### PR DESCRIPTION
Some files were emptied in stable at [1] but were not properly removed
via the forward-port PR. This commit does that, in master.

[1]: https://github.com/odoo/odoo/commit/3d9a2de3575777c87327691319d89f9de6b8eada
