### PR TITLE
[IMP] tests: allow to disable auto retry

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -10,6 +10,7 @@ RE_ONLY = re.compile(r'QUnit\.(only|debug)\(')
 @odoo.tests.tagged('post_install', '-at_install')
 class WebSuite(odoo.tests.HttpCase):
 
+    @odoo.tests.no_retry
     def test_js(self):
         # webclient desktop test suite
         self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -388,7 +388,14 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
         self.addTypeEqualityFunc(html.HtmlElement, self.assertTreesEqual)
 
     def run(self, result):
-        tests_run_count = int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', 0)) + 1
+        testMethod = getattr(self, self._testMethodName)
+
+        if getattr(testMethod, '_retry', True) and getattr(self, '_retry', True):
+            tests_run_count = int(os.environ.get('ODOO_TEST_FAILURE_RETRIES', 0)) + 1
+        else:
+            tests_run_count = 1
+            _logger.info('Auto retry disabled for %s', self)
+
         failure = False
         for retry in range(tests_run_count):
             if retry:
@@ -1766,6 +1773,12 @@ class HttpSavepointCase(HttpCase):
             "Deprecated class HttpSavepointCase has been merged into HttpCase",
             DeprecationWarning, stacklevel=2,
         )
+
+
+def no_retry(arg):
+    """Disable auto retry on decorated test method or test class"""
+    arg._retry = False
+    return arg
 
 
 def users(*logins):


### PR DESCRIPTION
Auto retry can be usefull to avoid breaking a build because of a
small tour or query count, but for long tests like qunit, this can be
painfull when a real error is triggered.

This commit proposes to disable autoretry on demand for some tests
to solve this issue.

This may be applied on all tests longer than a few seconds.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
