### PR TITLE
[FIX] sale: only consider paid transactions when confirming orders

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -61,7 +61,9 @@ class PaymentTransaction(models.Model):
             # vice versa.
             if len(tx.sale_order_ids) == 1:
                 quotation = tx.sale_order_ids.filtered(lambda so: so.state in ('draft', 'sent'))
-                if quotation and len(quotation.transaction_ids) == 1:
+                if quotation and len(quotation.transaction_ids.filtered(
+                    lambda tx: tx.state in ('authorized', 'done')  # Only consider confirmed tx
+                )) == 1:
                     # Check if the SO is fully paid
                     if quotation.currency_id.compare_amounts(tx.amount, quotation.amount_total) == 0:
                         quotation.with_context(send_email=True).action_confirm()


### PR DESCRIPTION
Before this commit, orders were not confirmed when there was more than
one transaction linked to them, regardless of their state.

As of now, we check if there is only one confirmed transaction (meaning
that the state of the transaction is either 'authorized' or 'done').

Fix https://github.com/odoo/odoo/commit/4d2b04a843c27981e44d6f932d7cf7e6838b4b9d

task-2906040