### PR TITLE
[FIX] mail: fix css for o_kanban_attachment

### DIFF
--- a/addons/mail/static/src/scss/kanban_view.scss
+++ b/addons/mail/static/src/scss/kanban_view.scss
@@ -2,7 +2,8 @@ $o-kanban-attachement-image-size: 80px;
 
 .o_legacy_kanban_view, .o_kanban_renderer {
 
-    .o_kanban_record.o_kanban_attachment {
+    .o_kanban_record.o_kanban_attachment,
+    .o_kanban_record .o_kanban_attachment {
         padding: map-get($spacers, 0);
 
         .o_kanban_image {


### PR DESCRIPTION
This commit fixes the css rule for the class `o_kanban_attachment` that
was broken for owl kanban views since f795af0160ed7977d07041d1bb1923598df48320.
