### PR TITLE
[FIX] payment: hide the tokenization input when required by the provider

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -337,14 +337,12 @@ class PaymentAcquirer(models.Model):
         compatible_acquirers = self.env['payment.acquirer'].search(domain)
         return compatible_acquirers
 
-    @api.model
-    def _is_tokenization_required(self, provider=None, **kwargs):
+    def _is_tokenization_required(self, **kwargs):
         """ Return whether tokenizing the transaction is required given its context.
 
         For a module to make the tokenization required based on the transaction context, it must
         override this method and return whether it is required.
 
-        :param str provider: The provider of the acquirer handling the transaction
         :param dict kwargs: The transaction context. This parameter is not used here
         :return: Whether tokenizing the transaction is required
         :rtype: bool


### PR DESCRIPTION
Due to an oversight, the "Save my payment details" checkbox was shown on
the inline payment form of SEPA Direct Debit acquirers, which should
never happen because the transaction is *always* tokenized with those.

With this commit, the `_is_tokenization_required` method is slightly
refactored to read the provider from the current `payment.acquirer`
record rather than from the kwargs. This conveniently fixes the issue
and prevents it from happening again elsewhere.

See also:
- https://github.com/odoo/enterprise/pull/29201