### PR TITLE
[FIX] website_sale: move product description into main page container

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -664,8 +664,8 @@
                             </div>
                         </div>
                     </div>
+                    <div itemprop="description" t-field="product.website_description" class="oe_structure oe_empty mt16" id="product_full_description"/>
                 </section>
-                <div itemprop="description" t-field="product.website_description" class="oe_structure oe_empty mt16" id="product_full_description"/>
                 <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
             </div>
         </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On the product page, adding a description through the website_description field will display it below the image. This can be changed and formatted through the website editor or by adding it to the product view.

Current behavior before PR:
The product's website description is currently spilling out and will appear at the left most side of the screen if there is no formatting done. In wider monitors, it appears very off center and throws off the alignment of the rest of the page elements.

Desired behavior after PR is merged:
This change will move the description element into the container <section> and display it with the expected alignment.


opw-2887530

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
