### PR TITLE
14.0 fix for jammy

### DIFF
--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -194,7 +194,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             },
         )
         self.assertEqual(res.status_code, 403)
-        self.assertIn("You are not allowed to access 'Journal Entry' (account.move) records.", res.text)
+        self.assertIn("You are not allowed to access &#39;Journal Entry&#39; (account.move) records.", res.text)
 
         # Test attachment can't be associated if not "pending" state
         self.assertFalse(self.out_invoice.message_ids)

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -110,7 +110,7 @@ class ImDispatch(object):
             current = threading.current_thread()
             current._daemonic = True
             # rename the thread to avoid tests waiting for a longpolling
-            current.setName("openerp.longpolling.request.%s" % current.ident)
+            current.name = f"openerp.longpolling.request.{current.ident}"
 
         registry = odoo.registry(dbname)
 

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1810,7 +1810,7 @@ class Lead(models.Model):
         # - avoid blocking the table for too long with a too big transaction
         transactions_count, transactions_failed_count = 0, 0
         cron_update_lead_start_date = datetime.now()
-        auto_commit = not getattr(threading.currentThread(), 'testing', False)
+        auto_commit = not getattr(threading.current_thread(), 'testing', False)
         for probability, probability_lead_ids in probability_leads.items():
             for lead_ids_current in tools.split_every(PLS_UPDATE_BATCH_STEP, probability_lead_ids):
                 transactions_count += 1

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -179,7 +179,7 @@ You receive this email because you are:
                 self.invalidate_cache()
                 self._warn_template_error(scheduler, e)
             else:
-                if autocommit and not getattr(threading.currentThread(), 'testing', False):
+                if autocommit and not getattr(threading.current_thread(), 'testing', False):
                     self.env.cr.commit()
         return True
 

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -528,8 +528,13 @@ class IrHttp(models.AbstractModel):
             raise Exception("Rerouting limit exceeded")
         request.httprequest.environ['PATH_INFO'] = path
         # void werkzeug cached_property. TODO: find a proper way to do this
-        for key in ('path', 'full_path', 'url', 'base_url'):
+        for key in ('full_path', 'url', 'base_url'):
             request.httprequest.__dict__.pop(key, None)
+        # since werkzeug 2.0 `path`` became an attribute and is not a cached property anymore
+        if hasattr(type(request.httprequest), 'path'): # cached property
+            request.httprequest.__dict__.pop('path', None)
+        else: # direct attribute
+            request.httprequest.path = '/' + path.lstrip('/')
 
         return cls._dispatch()
 

--- a/addons/link_tracker/models/mail_render_mixin.py
+++ b/addons/link_tracker/models/mail_render_mixin.py
@@ -3,7 +3,8 @@
 
 import re
 
-from werkzeug import urls, utils
+from html import unescape
+from werkzeug import urls
 
 from odoo import api, models, tools
 
@@ -40,7 +41,7 @@ class MailRenderMixin(models.AbstractModel):
             label = (match[3] or '').strip()
 
             if not blacklist or not [s for s in blacklist if s in long_url] and not long_url.startswith(short_schema):
-                create_vals = dict(link_tracker_vals, url=utils.unescape(long_url), label=utils.unescape(label))
+                create_vals = dict(link_tracker_vals, url=unescape(long_url), label=unescape(label))
                 link = self.env['link.tracker'].create(create_vals)
                 if link.short_url:
                     new_href = href.replace(long_url, link.short_url)
@@ -69,7 +70,7 @@ class MailRenderMixin(models.AbstractModel):
             if blacklist and any(item in parsed.path for item in blacklist):
                 continue
 
-            create_vals = dict(link_tracker_vals, url= utils.unescape(original_url))
+            create_vals = dict(link_tracker_vals, url=unescape(original_url))
             link = self.env['link.tracker'].create(create_vals)
             if link.short_url:
                 content = content.replace(original_url, link.short_url, 1)

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -141,7 +141,7 @@ class MailMail(models.Model):
         res = None
         try:
             # auto-commit except in testing mode
-            auto_commit = not getattr(threading.currentThread(), 'testing', False)
+            auto_commit = not getattr(threading.current_thread(), 'testing', False)
             res = self.browse(ids).send(auto_commit=auto_commit)
         except Exception:
             _logger.exception("Failed processing mail queue")

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2341,7 +2341,7 @@ class MailThread(models.AbstractModel):
         #   2. do not send emails immediately if the registry is not loaded,
         #      to prevent sending email during a simple update of the database
         #      using the command-line.
-        test_mode = getattr(threading.currentThread(), 'testing', False)
+        test_mode = getattr(threading.current_thread(), 'testing', False)
         if force_send and len(emails) < recipients_max and (not self.pool._init or test_mode):
             # unless asked specifically, send emails after the transaction to
             # avoid side effects due to emails being sent while the transaction fails

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -615,7 +615,7 @@ class MassMailing(models.Model):
             extra_context = mailing._get_mass_mailing_context()
             composer = composer.with_context(active_ids=res_ids, **extra_context)
             # auto-commit except in testing mode
-            auto_commit = not getattr(threading.currentThread(), 'testing', False)
+            auto_commit = not getattr(threading.current_thread(), 'testing', False)
             composer.send_mail(auto_commit=auto_commit)
             mailing.write({
                 'state': 'done',

--- a/addons/pos_mercury/models/pos_mercury_transaction.py
+++ b/addons/pos_mercury/models/pos_mercury_transaction.py
@@ -4,7 +4,8 @@
 from datetime import date, timedelta
 
 import requests
-import werkzeug
+
+from html import unescape
 
 from odoo import models, api, service
 from odoo.tools.translate import _
@@ -69,7 +70,7 @@ class MercuryTransaction(models.Model):
         try:
             r = requests.post(url, data=xml_transaction, headers=headers, timeout=65)
             r.raise_for_status()
-            response = werkzeug.utils.unescape(r.content.decode())
+            response = unescape(r.content.decode())
         except Exception:
             response = "timeout"
 

--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -98,7 +98,7 @@ class ProductTemplate(models.Model):
 
     def write(self, vals):
         # timesheet product can't be archived
-        test_mode = getattr(threading.currentThread(), 'testing', False) or self.env.registry.in_test_mode()
+        test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
         if not test_mode and 'active' in vals and not vals['active']:
             time_product = self.env.ref('sale_timesheet.time_product')
             if time_product.product_tmpl_id in self:
@@ -143,7 +143,7 @@ class ProductProduct(models.Model):
 
     def write(self, vals):
         # timesheet product can't be archived
-        test_mode = getattr(threading.currentThread(), 'testing', False) or self.env.registry.in_test_mode()
+        test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
         if not test_mode and 'active' in vals and not vals['active']:
             time_product = self.env.ref('sale_timesheet.time_product')
             if time_product in self:

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -55,7 +55,7 @@ class SmsSms(models.Model):
         for batch_ids in self._split_batch():
             self.browse(batch_ids)._send(delete_all=delete_all, raise_exception=raise_exception)
             # auto-commit if asked except in testing mode
-            if auto_commit is True and not getattr(threading.currentThread(), 'testing', False):
+            if auto_commit is True and not getattr(threading.current_thread(), 'testing', False):
                 self._cr.commit()
 
     def cancel(self):
@@ -81,7 +81,7 @@ class SmsSms(models.Model):
         res = None
         try:
             # auto-commit except in testing mode
-            auto_commit = not getattr(threading.currentThread(), 'testing', False)
+            auto_commit = not getattr(threading.current_thread(), 'testing', False)
             res = self.browse(ids).send(delete_all=False, auto_commit=auto_commit, raise_exception=False)
         except Exception:
             _logger.exception("Failed processing SMS queue")

--- a/addons/stock_sms/models/stock_picking.py
+++ b/addons/stock_sms/models/stock_picking.py
@@ -23,7 +23,7 @@ class Picking(models.Model):
             is_delivery = picking.company_id.stock_move_sms_validation \
                     and picking.picking_type_id.code == 'outgoing' \
                     and (picking.partner_id.mobile or picking.partner_id.phone)
-            if is_delivery and not getattr(threading.currentThread(), 'testing', False) \
+            if is_delivery and not getattr(threading.current_thread(), 'testing', False) \
                     and not self.env.registry.in_test_mode() \
                     and not picking.company_id.has_received_warning_stock_sms \
                     and picking.company_id.stock_move_sms_validation:
@@ -52,7 +52,7 @@ class Picking(models.Model):
 
     def _send_confirmation_email(self):
         super(Picking, self)._send_confirmation_email()
-        if not self.env.context.get('skip_sms') and not getattr(threading.currentThread(), 'testing', False) and not self.env.registry.in_test_mode():
+        if not self.env.context.get('skip_sms') and not getattr(threading.current_thread(), 'testing', False) and not self.env.registry.in_test_mode():
             pickings = self.filtered(lambda p: p.company_id.stock_move_sms_validation and p.picking_type_id.code == 'outgoing' and (p.partner_id.mobile or p.partner_id.phone))
             for picking in pickings:
                 # Sudo as the user has not always the right to read this sms template.

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1104,10 +1104,9 @@ class Proxy(http.Controller):
             if not data:
                 raise werkzeug.exceptions.BadRequest()
             from werkzeug.test import Client
-            from werkzeug.wrappers import BaseResponse
             base_url = request.httprequest.base_url
             query_string = request.httprequest.query_string
-            client = Client(http.root, BaseResponse)
+            client = Client(http.root, werkzeug.wrappers.Response)
             headers = {'X-Openerp-Session-Id': request.session.sid}
             return client.post('/' + path, base_url=base_url, query_string=query_string,
                                headers=headers, data=data)

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -279,7 +279,7 @@ class IrUiView(models.Model):
         # During a theme module update, theme views' copies receiving an arch
         # update should not be considered as `arch_updated`, as this is not a
         # user made change.
-        test_mode = getattr(threading.currentThread(), 'testing', False)
+        test_mode = getattr(threading.current_thread(), 'testing', False)
         if not (test_mode or self.pool._init):
             return super().write(vals)
         no_arch_updated_views = other_views = self.env['ir.ui.view']

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -70,7 +70,7 @@ class TestQweb(TransactionCaseWithUserDemo):
         <img src="http://test.cdn/website/static/img.png" loading="lazy"/>
         <a href="http://test.external.link/link">x</a>
         <a href="http://test.cdn/web/content/local_link">x</a>
-        <span style="background-image: url('http://test.cdn/web/image/2')">xxx</span>
+        <span style="background-image: url(&#39;http://test.cdn/web/image/2&#39;)">xxx</span>
         <div widget="html"><span class="toto">
                 span<span class="fa"></span><img src="http://test.cdn/web/image/1" loading="lazy">
             </span></div>

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -100,7 +100,7 @@ def registry(database_name=None):
     """
     if database_name is None:
         import threading
-        database_name = threading.currentThread().dbname
+        database_name = threading.current_thread().dbname
     return modules.registry.Registry(database_name)
 
 #----------------------------------------------------------

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -4,6 +4,7 @@ from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.exceptions import UserError, AccessError
 from odoo.tools.safe_eval import safe_eval, time
 from odoo.tools.misc import find_in_path
+from odoo.tools import config, is_html_empty, parse_version
 from odoo.tools import config
 from odoo.sql_db import TestCursor
 from odoo.http import request
@@ -21,7 +22,6 @@ import json
 
 from lxml import etree
 from contextlib import closing
-from distutils.version import LooseVersion
 from reportlab.graphics.barcode import createBarcodeDrawing
 from PyPDF2 import PdfFileWriter, PdfFileReader, utils
 from collections import OrderedDict
@@ -63,12 +63,12 @@ else:
     match = re.search(b'([0-9.]+)', out)
     if match:
         version = match.group(0).decode('ascii')
-        if LooseVersion(version) < LooseVersion('0.12.0'):
+        if parse_version(version) < parse_version('0.12.0'):
             _logger.info('Upgrade Wkhtmltopdf to (at least) 0.12.0')
             wkhtmltopdf_state = 'upgrade'
         else:
             wkhtmltopdf_state = 'ok'
-        if LooseVersion(version) >= LooseVersion('0.12.2'):
+        if parse_version(version) >= parse_version('0.12.2'):
             wkhtmltopdf_dpi_zoom_ratio = True
 
         if config['workers'] == 1:

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -186,7 +186,7 @@ class IrMailServer(models.Model):
            :param mail_server_id: ID of specific mail server to use (overrides other parameters)
         """
         # Do not actually connect while running in test mode
-        if getattr(threading.currentThread(), 'testing', False):
+        if getattr(threading.current_thread(), 'testing', False):
             return None
 
         mail_server = smtp_encryption = None
@@ -488,7 +488,7 @@ class IrMailServer(models.Model):
             message['To'] = x_forge_to
 
         # Do not actually send emails in testing mode!
-        if getattr(threading.currentThread(), 'testing', False) or self.env.registry.in_test_mode():
+        if getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode():
             _test_logger.info("skip sending email in test mode")
             return message['Message-Id']
 

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -570,7 +570,7 @@ class Module(models.Model):
         }
 
     def _button_immediate_function(self, function):
-        if getattr(threading.currentThread(), 'testing', False):
+        if getattr(threading.current_thread(), 'testing', False):
             raise RuntimeError(
                 "Module operations inside tests are not transactional and thus forbidden.\n"
                 "If you really need to perform module operations to test a specific behavior, it "

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -9,13 +9,13 @@ from collections import OrderedDict
 from collections.abc import Sized, Mapping
 from functools import reduce
 from itertools import tee, count
+from markupsafe import escape
 from textwrap import dedent
 
 import itertools
 from lxml import etree, html
 from psycopg2.extensions import TransactionRollbackError
 import werkzeug
-from werkzeug.utils import escape as _escape
 
 from odoo.tools import pycompat, freehash
 from odoo.tools.safe_eval import check_values
@@ -160,8 +160,6 @@ class QWebException(Exception):
     def __repr__(self):
         return str(self)
 
-# Avoid DeprecationWarning while still remaining compatible with werkzeug pre-0.9
-escape = (lambda text: _escape(text, quote=True)) if parse_version(getattr(werkzeug, '__version__', '0.0')) < parse_version('0.9.0') else _escape
 
 def foreach_iterator(base_ctx, enum, name):
     ctx = base_ctx.copy()

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -559,6 +559,6 @@ class TestEmailMessage(TransactionCase):
         msg['References'] = '<345227342212345.1596730777.324691772483620-example-30453-other.reference@test-123.example.com>'
 
         smtp = FakeSMTP()
-        self.patch(threading.currentThread(), 'testing', False)
+        self.patch(threading.current_thread(), 'testing', False)
         self.env['ir.mail_server'].send_email(msg, smtp_session=smtp)
         self.assertTrue(smtp.email_sent)

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -647,7 +647,7 @@ class TestQWeb(TransactionCase):
             result = doc.find('result[@id="{}"]'.format(template)).text
             self.assertEqual(
                 qweb._render(template, values=params, load=loader).strip(),
-                (result or u'').strip().encode('utf-8'),
+                (result or u'').strip().replace('&quot;', '&#34;').encode('utf-8'),
                 template
             )
 

--- a/odoo/addons/test_converter/tests/test_html.py
+++ b/odoo/addons/test_converter/tests/test_html.py
@@ -198,7 +198,7 @@ class TestTextExport(TestBasicExport):
         """)
         self.assertEqual(value, """<br>
         fgdkls;hjas;lj &lt;b&gt;fdslkj&lt;/b&gt; d;lasjfa lkdja &lt;a href=http://spam.com&gt;lfks&lt;/a&gt;<br>
-        fldkjsfhs &lt;i style=&quot;color: red&quot;&gt;&lt;a href=&quot;http://spamspam.com&quot;&gt;fldskjh&lt;/a&gt;&lt;/i&gt;<br>
+        fldkjsfhs &lt;i style=&#34;color: red&#34;&gt;&lt;a href=&#34;http://spamspam.com&#34;&gt;fldskjh&lt;/a&gt;&lt;/i&gt;<br>
         """)
 
 
@@ -244,7 +244,7 @@ class TestSelectionExport(TestBasicExport):
     def test_selection(self):
         converter = self.get_converter('selection_str')
         value = converter('C')
-        self.assertEqual(value, u"Qu'est-ce qu'il fout ce maudit pancake, tabernacle ?")
+        self.assertEqual(value, u"Qu&#39;est-ce qu&#39;il fout ce maudit pancake, tabernacle ?")
 
 
 class TestHTMLExport(TestBasicExport):

--- a/odoo/addons/test_lint/tests/test_pylint.py
+++ b/odoo/addons/test_lint/tests/test_pylint.py
@@ -7,7 +7,6 @@ try:
 except ImportError:
     pylint = None
 import subprocess
-from distutils.version import LooseVersion
 import os
 from os.path import join
 import sys
@@ -51,10 +50,10 @@ class TestPyLint(TransactionCase):
     def test_pylint(self):
         if pylint is None:
             self._skip_test('please install pylint')
-        required_pylint_version = LooseVersion('1.6.4')
+        required_pylint_version = tools.parse_version('1.6.4')
         if sys.version_info >= (3, 6):
-            required_pylint_version = LooseVersion('1.7.0')
-        if LooseVersion(getattr(pylint, '__version__', '0.0.1')) < required_pylint_version:
+            required_pylint_version = tools.parse_version('1.7.0')
+        if tools.parse_version(getattr(pylint, '__version__', '0.0.1')) < required_pylint_version:
             self._skip_test('please upgrade pylint to >= %s' % required_pylint_version)
 
         paths = [tools.config['root_path']]

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -173,7 +173,10 @@ def redirect_with_hash(url, code=303):
     # so we don't need any special handling anymore. This function could be dropped in the future.
     # seealso : http://www.rfc-editor.org/info/rfc7231
     #           https://tools.ietf.org/html/rfc7231#section-7.1.2
-    return werkzeug.utils.redirect(url, code)
+    if isinstance(url, str):
+        return werkzeug.utils.redirect(url, code)
+    else:
+        return werkzeug.utils.redirect(url.decode(), code)
 
 class WebRequest(object):
     """ Parent class for all Odoo Web request types, mostly deals with

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -55,6 +55,7 @@ from .tools import ustr, consteq, frozendict, pycompat, unique, date_utils
 from .tools.mimetypes import guess_mimetype
 from .tools.misc import str2bool
 from .tools._vendor import sessions
+from .tools._vendor.useragents import UserAgent
 from .modules.module import module_manifest
 
 _logger = logging.getLogger(__name__)
@@ -1467,6 +1468,7 @@ class Root(object):
         """
         try:
             httprequest = werkzeug.wrappers.Request(environ)
+            httprequest.user_agent_class = UserAgent  # use vendored userAgent since it will be removed in 2.1
             httprequest.parameter_storage_class = werkzeug.datastructures.ImmutableOrderedMultiDict
 
             current_thread = threading.current_thread()

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -538,7 +538,7 @@ def route(route=None, **kw):
 
             if isinstance(response, werkzeug.exceptions.HTTPException):
                 response = response.get_response(request.httprequest.environ)
-            if isinstance(response, werkzeug.wrappers.BaseResponse):
+            if isinstance(response, werkzeug.wrappers.Response):
                 response = Response.force_type(response)
                 response.set_default()
                 return response
@@ -1448,7 +1448,7 @@ class Root(object):
 
     def set_csp(self, response):
         # ignore HTTP errors
-        if not isinstance(response, werkzeug.wrappers.BaseResponse):
+        if not isinstance(response, werkzeug.wrappers.Response):
             return
 
         headers = response.headers

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -60,7 +60,7 @@ def load_data(cr, idref, mode, kind, package):
     filename = None
     try:
         if kind in ('demo', 'test'):
-            threading.currentThread().testing = True
+            threading.current_thread().testing = True
         for filename in _get_files_of_kind(kind):
             _logger.info("loading %s/%s", package.name, filename)
             noupdate = False
@@ -69,7 +69,7 @@ def load_data(cr, idref, mode, kind, package):
             tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
     finally:
         if kind in ('demo', 'test'):
-            threading.currentThread().testing = False
+            threading.current_thread().testing = False
 
     return bool(filename)
 

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -127,7 +127,7 @@ def init_logger():
     warnings.filterwarnings('default', category=DeprecationWarning)
     # ignore deprecation warnings from invalid escape (there's a ton and it's
     # pretty likely a super low-value signal)
-    warnings.filterwarnings('ignore', r'^invalid escape sequence \\.', category=DeprecationWarning)
+    warnings.filterwarnings('ignore', r'^invalid escape sequence \'?\\.', category=DeprecationWarning)
     # recordsets are both sequence and set so trigger warning despite no issue
     warnings.filterwarnings('ignore', r'^Sampling from a set', category=DeprecationWarning, module='odoo')
     # ignore a bunch of warnings we can't really fix ourselves

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -169,7 +169,7 @@ def execute_kw(db, uid, obj, method, args, kw=None):
 
 @check
 def execute(db, uid, obj, method, *args, **kw):
-    threading.currentThread().dbname = db
+    threading.current_thread().dbname = db
     with odoo.registry(db).cursor() as cr:
         check_method_name(method)
         res = execute_cr(cr, uid, obj, method, *args, **kw)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -290,7 +290,7 @@ class FSWatcherInotify(FSWatcherBase):
     def start(self):
         self.started = True
         self.thread = threading.Thread(target=self.run, name="odoo.service.autoreload.watcher")
-        self.thread.setDaemon(True)
+        self.thread.daemon = True
         self.thread.start()
 
     def stop(self):
@@ -431,7 +431,7 @@ class ThreadedServer(CommonServer):
             def target():
                 self.cron_thread(i)
             t = threading.Thread(target=target, name="odoo.service.cron.cron%d" % i)
-            t.setDaemon(True)
+            t.daemon = True
             t.type = 'cron'
             t.start()
             _logger.debug("cron%d started!" % i)
@@ -444,7 +444,7 @@ class ThreadedServer(CommonServer):
 
     def http_spawn(self):
         t = threading.Thread(target=self.http_thread, name="odoo.service.httpd")
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
     def start(self, stop=False):
@@ -487,8 +487,8 @@ class ThreadedServer(CommonServer):
         me = threading.current_thread()
         _logger.debug('current thread: %r', me)
         for thread in threading.enumerate():
-            _logger.debug('process %r (%r)', thread, thread.isDaemon())
-            if (thread != me and not thread.isDaemon() and thread.ident != self.main_thread_id and
+            _logger.debug('process %r (%r)', thread, thread.daemon)
+            if (thread != me and not thread.daemon and thread.ident != self.main_thread_id and
                     thread not in self.limits_reached_threads):
                 while thread.is_alive() and (time.time() - stop_time) < 1:
                     # We wait for requests to finish, up to 1 second.

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -123,7 +123,7 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             self.timeout = 5
         # flag the current thread as handling a http request
         super(RequestHandler, self).setup()
-        me = threading.currentThread()
+        me = threading.current_thread()
         me.name = 'odoo.service.http.request.%s' % (me.ident,)
 
 
@@ -336,7 +336,7 @@ class CommonServer(object):
 class ThreadedServer(CommonServer):
     def __init__(self, app):
         super(ThreadedServer, self).__init__(app)
-        self.main_thread_id = threading.currentThread().ident
+        self.main_thread_id = threading.current_thread().ident
         # Variable keeping track of the number of calls to the signal handler defined
         # below. This variable is monitored by ``quit_on_signals()``.
         self.quit_signals_received = 0
@@ -371,7 +371,7 @@ class ThreadedServer(CommonServer):
         memory = memory_info(psutil.Process(os.getpid()))
         if config['limit_memory_soft'] and memory > config['limit_memory_soft']:
             _logger.warning('Server memory limit (%s) reached.', memory)
-            self.limits_reached_threads.add(threading.currentThread())
+            self.limits_reached_threads.add(threading.current_thread())
 
         for thread in threading.enumerate():
             if not thread.daemon or getattr(thread, 'type', None) == 'cron':
@@ -407,7 +407,7 @@ class ThreadedServer(CommonServer):
             _logger.debug('cron%d polling for jobs', number)
             for db_name, registry in registries.d.items():
                 if registry.ready:
-                    thread = threading.currentThread()
+                    thread = threading.current_thread()
                     thread.start_time = time.time()
                     try:
                         ir_cron._acquire_job(db_name)
@@ -484,7 +484,7 @@ class ThreadedServer(CommonServer):
         # Manually join() all threads before calling sys.exit() to allow a second signal
         # to trigger _force_quit() in case some non-daemon threads won't exit cleanly.
         # threading.Thread.join() should not mask signals (at least in python 2.5).
-        me = threading.currentThread()
+        me = threading.current_thread()
         _logger.debug('current thread: %r', me)
         for thread in threading.enumerate():
             _logger.debug('process %r (%r)', thread, thread.isDaemon())
@@ -1172,7 +1172,7 @@ def _reexec(updated_modules=None):
 
 def load_test_file_py(registry, test_file):
     from odoo.tests.common import OdooSuite
-    threading.currentThread().testing = True
+    threading.current_thread().testing = True
     try:
         test_path, _ = os.path.splitext(os.path.abspath(test_file))
         for mod in [m for m in get_modules() if '/%s/' % m in test_file]:
@@ -1188,7 +1188,7 @@ def load_test_file_py(registry, test_file):
                         _logger.error('%s: at least one error occurred in a test', test_file)
                     return
     finally:
-        threading.currentThread().testing = False
+        threading.current_thread().testing = False
 
 def preload_registries(dbnames):
     """ Preload a registries, possibly run a test file."""

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -71,12 +71,12 @@ def run_suite(suite, module_name):
     # avoid dependency hell
     from ..modules import module
     module.current_test = module_name
-    threading.currentThread().testing = True
+    threading.current_thread().testing = True
 
     results = OdooTestResult()
     suite(results)
 
-    threading.currentThread().testing = False
+    threading.current_thread().testing = False
     module.current_test = None
     return results
 

--- a/odoo/tools/_vendor/sessions.py
+++ b/odoo/tools/_vendor/sessions.py
@@ -19,14 +19,13 @@ import os
 import re
 import tempfile
 from hashlib import sha1
-from os import path
+from os import path, replace as rename
 from pickle import dump
 from pickle import HIGHEST_PROTOCOL
 from pickle import load
 from time import time
 
 from werkzeug.datastructures import CallbackDict
-from werkzeug.posixemulation import rename
 
 _sha1_re = re.compile(r"^[a-f0-9]{40}$")
 

--- a/odoo/tools/_vendor/useragents.py
+++ b/odoo/tools/_vendor/useragents.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""
+    werkzeug.useragents
+    ~~~~~~~~~~~~~~~~~~~
+    This module provides a helper to inspect user agent strings.  This module
+    is far from complete but should work for most of the currently available
+    browsers.
+    :copyright: 2007 Pallets
+    :license: BSD-3-Clause
+    This package was vendored in odoo in order to prevent errors with werkzeug 2.1
+"""
+import re
+
+
+class UserAgentParser(object):
+    """A simple user agent parser.  Used by the `UserAgent`."""
+
+    platforms = (
+        ("cros", "chromeos"),
+        ("iphone|ios", "iphone"),
+        ("ipad", "ipad"),
+        (r"darwin|mac|os\s*x", "macos"),
+        ("win", "windows"),
+        (r"android", "android"),
+        ("netbsd", "netbsd"),
+        ("openbsd", "openbsd"),
+        ("freebsd", "freebsd"),
+        ("dragonfly", "dragonflybsd"),
+        ("(sun|i86)os", "solaris"),
+        (r"x11|lin(\b|ux)?", "linux"),
+        (r"nintendo\s+wii", "wii"),
+        ("irix", "irix"),
+        ("hp-?ux", "hpux"),
+        ("aix", "aix"),
+        ("sco|unix_sv", "sco"),
+        ("bsd", "bsd"),
+        ("amiga", "amiga"),
+        ("blackberry|playbook", "blackberry"),
+        ("symbian", "symbian"),
+    )
+    browsers = (
+        ("googlebot", "google"),
+        ("msnbot", "msn"),
+        ("yahoo", "yahoo"),
+        ("ask jeeves", "ask"),
+        (r"aol|america\s+online\s+browser", "aol"),
+        ("opera", "opera"),
+        ("edge", "edge"),
+        ("chrome|crios", "chrome"),
+        ("seamonkey", "seamonkey"),
+        ("firefox|firebird|phoenix|iceweasel", "firefox"),
+        ("galeon", "galeon"),
+        ("safari|version", "safari"),
+        ("webkit", "webkit"),
+        ("camino", "camino"),
+        ("konqueror", "konqueror"),
+        ("k-meleon", "kmeleon"),
+        ("netscape", "netscape"),
+        (r"msie|microsoft\s+internet\s+explorer|trident/.+? rv:", "msie"),
+        ("lynx", "lynx"),
+        ("links", "links"),
+        ("Baiduspider", "baidu"),
+        ("bingbot", "bing"),
+        ("mozilla", "mozilla"),
+    )
+
+    _browser_version_re = r"(?:%s)[/\sa-z(]*(\d+[.\da-z]+)?"
+    _language_re = re.compile(
+        r"(?:;\s*|\s+)(\b\w{2}\b(?:-\b\w{2}\b)?)\s*;|"
+        r"(?:\(|\[|;)\s*(\b\w{2}\b(?:-\b\w{2}\b)?)\s*(?:\]|\)|;)"
+    )
+
+    def __init__(self):
+        self.platforms = [(b, re.compile(a, re.I)) for a, b in self.platforms]
+        self.browsers = [
+            (b, re.compile(self._browser_version_re % a, re.I))
+            for a, b in self.browsers
+        ]
+
+    def __call__(self, user_agent):
+        for platform, regex in self.platforms:  # noqa: B007
+            match = regex.search(user_agent)
+            if match is not None:
+                break
+        else:
+            platform = None
+        for browser, regex in self.browsers:  # noqa: B007
+            match = regex.search(user_agent)
+            if match is not None:
+                version = match.group(1)
+                break
+        else:
+            browser = version = None
+        match = self._language_re.search(user_agent)
+        if match is not None:
+            language = match.group(1) or match.group(2)
+        else:
+            language = None
+        return platform, browser, version, language
+
+
+class UserAgent(object):
+    """Represents a user agent.  Pass it a WSGI environment or a user agent
+    string and you can inspect some of the details from the user agent
+    string via the attributes.  The following attributes exist:
+    .. attribute:: string
+       the raw user agent string
+    .. attribute:: platform
+       the browser platform.  The following platforms are currently
+       recognized:
+       -   `aix`
+       -   `amiga`
+       -   `android`
+       -   `blackberry`
+       -   `bsd`
+       -   `chromeos`
+       -   `dragonflybsd`
+       -   `freebsd`
+       -   `hpux`
+       -   `ipad`
+       -   `iphone`
+       -   `irix`
+       -   `linux`
+       -   `macos`
+       -   `netbsd`
+       -   `openbsd`
+       -   `sco`
+       -   `solaris`
+       -   `symbian`
+       -   `wii`
+       -   `windows`
+    .. attribute:: browser
+        the name of the browser.  The following browsers are currently
+        recognized:
+        -   `aol` *
+        -   `ask` *
+        -   `baidu` *
+        -   `bing` *
+        -   `camino`
+        -   `chrome`
+        -   `edge`
+        -   `firefox`
+        -   `galeon`
+        -   `google` *
+        -   `kmeleon`
+        -   `konqueror`
+        -   `links`
+        -   `lynx`
+        -   `mozilla`
+        -   `msie`
+        -   `msn`
+        -   `netscape`
+        -   `opera`
+        -   `safari`
+        -   `seamonkey`
+        -   `webkit`
+        -   `yahoo` *
+        (Browsers marked with a star (``*``) are crawlers.)
+    .. attribute:: version
+        the version of the browser
+    .. attribute:: language
+        the language of the browser
+    """
+
+    _parser = UserAgentParser()
+
+    def __init__(self, environ_or_string):
+        if isinstance(environ_or_string, dict):
+            environ_or_string = environ_or_string.get("HTTP_USER_AGENT", "")
+        self.string = environ_or_string
+        self.platform, self.browser, self.version, self.language = self._parser(
+            environ_or_string
+        )
+
+    def to_header(self):
+        return self.string
+
+    def __str__(self):
+        return self.string
+
+    def __nonzero__(self):
+        return bool(self.browser)
+
+    __bool__ = __nonzero__
+
+    def __repr__(self):
+        return "<%s %r/%s>" % (self.__class__.__name__, self.browser, self.version)

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -201,7 +201,7 @@ def log_ormcache_stats(sig=None, frame=None):
     from odoo.modules.registry import Registry
     import threading
 
-    me = threading.currentThread()
+    me = threading.current_thread()
     me_dbname = getattr(me, 'dbname', 'n/a')
 
     for dbname, reg in sorted(Registry.registries.d.items()):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -486,7 +486,7 @@ def email_send(email_from, email_to, subject, body, email_cc=None, email_bcc=Non
     # If not cr, get cr from current thread database
     local_cr = None
     if not cr:
-        db_name = getattr(threading.currentThread(), 'dbname', None)
+        db_name = getattr(threading.current_thread(), 'dbname', None)
         if db_name:
             local_cr = cr = odoo.registry(db_name).cursor()
         else:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -29,13 +29,13 @@ from contextlib import contextmanager
 from difflib import HtmlDiff
 from functools import wraps
 from itertools import islice, groupby as itergroupby
+from markupsafe import escape
 from operator import itemgetter
 
 import babel
 import babel.dates
 import passlib.utils
 import pytz
-import werkzeug.utils
 from lxml import etree
 
 import odoo
@@ -1227,13 +1227,8 @@ def ignore(*exc):
     except exc:
         pass
 
-# Avoid DeprecationWarning while still remaining compatible with werkzeug pre-0.9
-if parse_version(getattr(werkzeug, '__version__', '0.0')) < parse_version('0.9.0'):
-    def html_escape(text):
-        return werkzeug.utils.escape(text, quote=True)
-else:
-    def html_escape(text):
-        return werkzeug.utils.escape(text)
+def html_escape(text):
+    return str(escape(text))
 
 def get_lang(env, lang_code=False):
     """

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -86,6 +86,8 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     # specialised comparisons
     'IS_OP', 'CONTAINS_OP',
     'DICT_MERGE', 'DICT_UPDATE',
+    # Basically used in any "generator literal"
+    'GEN_START',  # added in 3.10 but already removed from 3.11.
 ])) - _BLACKLIST
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -371,7 +371,7 @@ class GettextAlias(object):
 
     def _get_db(self):
         # find current DB based on thread/worker db name (see netsvc)
-        db_name = getattr(threading.currentThread(), 'dbname', None)
+        db_name = getattr(threading.current_thread(), 'dbname', None)
         if db_name:
             return odoo.sql_db.db_connect(db_name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,13 @@ freezegun==0.3.11; python_version < '3.8'
 freezegun==0.3.15; python_version >= '3.8'
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version == '3.7'
-gevent==20.9.0 ; python_version >= '3.8'
+gevent==20.9.0 ; python_version > '3.7' and python_version <= '3.9'
+gevent==21.8.0 ; python_version > '3.9'  # (Jammy)
 gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
 greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version == '3.7'
-greenlet==0.4.17 ; python_version > '3.7'
+greenlet==0.4.17 ; python_version > '3.7' and python_version <= '3.9'
+greenlet==1.1.2 ; python_version  > '3.9'  # (Jammy)
 idna==2.6
 Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
@@ -24,7 +26,8 @@ lxml ; sys_platform == 'win32'
 Mako==1.0.7
 MarkupSafe==1.1.0
 num2words==0.5.6
-ofxparse==0.19
+ofxparse==0.19; python_version <= '3.9'
+ofxparse==0.21; python_version > '3.9'  # (Jammy)
 passlib==1.7.1
 Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
@@ -47,7 +50,8 @@ requests==2.21.0
 zeep==3.2.0
 python-stdnum==1.8
 vobject==0.9.6.1
-Werkzeug==0.16.1
+Werkzeug==0.16.1 ; python_version <= '3.9'
+Werkzeug==2.0.2 ; python_version > '3.9'  # (Jammy)
 XlsxWriter==1.1.2
 xlwt==1.3.*
 xlrd==1.1.0; python_version < '3.8'


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR is mostly the commits included in https://github.com/odoo/odoo/pull/88803 to adapt Odoo 15.0 to work on Ubuntu 22.04 LTS (Jammy Jellyfish), but for Odoo 14.0

The main changes listed on https://github.com/odoo/odoo/pull/88803 are:

- python 3.10
- werkzeug 2.0+, including vendoring werkzeug's user agent parser in odoo/tools/_vendor/useragents.py (= the one from version 0.16) as it is discontinued after v2.1
- currentThread is now deprecated (use current_thread instead)
- default requirement version (based on deb package version)
- new opcode in python 3.10
- distutils.version.LooseVersion is deprecated
- wkhtmltopd version packaged with ubuntu jammy don't have patched qt but will work without headers and footers. Suggested wkhtmltopdf version 0.12.5 doesn't have a build working with jammy yet because of incompatible libssl dependencies. A parallel wip may provide a 0.12.5 version compatible with jamm

Additional to these:
- werkzeug.utils.redirect uses html.escape which expects 'str'. Pass url decoded in local_redirect and redirect_with_hash (http) 
- werkzeug.utils.escape is deprecated
- current_thread().setName() is deprecated

**Current behavior before PR:**
Odoo 14.0 can't be deployed on Ubuntu 22.04

**Desired behavior after PR is merged:**
Odoo 14.0 can be deployed on Ubuntu 22.04 while keeping compatibility with previous version Ubuntu 20.04.4 LTS (Focal Fossa)
On my tests I have been able to do that with the proposed changes.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
