### PR TITLE
[FIX][14.0] discuss: fix error open document inside channel on mobile device

### DIFF
--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -101,6 +101,8 @@ function factory(dependencies) {
                 },
             });
             if (this.env.messaging.device.isMobile) {
+                // When opening documents chat windows need to be closed
+                this.env.messaging.chatWindowManager.closeAll();
                 // messaging menu has a higher z-index than views so it must
                 // be closed to ensure the visibility of the view
                 this.env.messaging.messagingMenu.close();


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the user opens a document from the chat channel, the system opened the document, but the chat window is still there and covers the document.

Current behavior before PR:
Will hide all chat window when open document
Desired behavior after PR is merged:


https://user-images.githubusercontent.com/55737816/177705066-1a5e82f9-98bd-4866-b4dd-aeaa67ed1b6d.mov




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
