### PR TITLE
[FIX] sale_stock: sale order mobile cannot show product_forecast_report 

### DIFF
--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -96,6 +96,7 @@
                     <field name="scheduled_date" invisible="1"/>
                     <field name="forecast_expected_date" invisible="1"/>
                     <field name="warehouse_id" invisible="1"/>
+                    <field name="move_ids" invisible="1"/>
                     <field name="qty_to_deliver" invisible="1"/>
                     <field name="is_mto" invisible="1"/>
                     <field name="display_qty_widget" invisible="1"/>


### PR DESCRIPTION
Issue:

 sale order mobile view cannot show product_forecast_report.

Cause:

 move_ids field is missing in the view.

Solution:

 Add move_ids back to the view.

X-original-commit: b03e900