### PR TITLE
[IMP] web_unsplash: allow to specify image orientation

### DIFF
--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
@@ -120,7 +120,7 @@ patch(ImageSelector.prototype, 'image_selector_unsplash', {
             return { records: [], isMaxed: false };
         }
         try {
-            const { isMaxed, images } = await this.unsplash.getImages(this.state.needle, offset, this.NUMBER_OF_ATTACHMENTS_TO_DISPLAY);
+            const { isMaxed, images } = await this.unsplash.getImages(this.state.needle, offset, this.NUMBER_OF_ATTACHMENTS_TO_DISPLAY, this.props.orientation);
             this.state.isFetchingUnsplash = false;
             this.state.unsplashError = false;
             const records = images.map(record => {


### PR DESCRIPTION
Web_unsplash:
=
Purpose:
-
The MediaSelector is now used for selecting covers in Knowledge, because
it is prettier than the standard avatar picker, and it allows to search
landscape oriented images on unsplash.

Specs:
-
Modified unsplash_service and image_selector so that one can specify
the orientation of the images to fetch from unsplash. One would like
to show only images with a landscape orientation when selecting a
cover in knowledge, since images with other orientations do not fit
properly.

Base / ir_attachment:
=

Purpose:
-
Move in a separate method the logic collecting the records one needs to
ensure the user can access when checking attachments in `ir_attachment`,
so that one can override this logic when needed.

Motivation:
-
The access of an attachment with `res_model` set and `res_id=0` is normally
restricted except for the user that uploaded that attachment. However, in
the knowledge app, one would like any user to access any attachments with
`res_model='knowledge.article'` and `res_id=0` (these attachments are the
covers of the articles).

Task-2852916
