### PR TITLE
[FIX] web: CP lose init seach value

### DIFF
--- a/addons/mail/static/src/js/m2x_avatar_user.js
+++ b/addons/mail/static/src/js/m2x_avatar_user.js
@@ -96,7 +96,7 @@ export const Many2OneAvatarUser = Many2OneAvatar.extend(M2XAvatarMixin, {
                     hotkey: "alt+i",
                 },
                 async action() {
-                    return env.services.command.openPalette({
+                    return {
                         configByNamespace: {
                             default: {
                                 emptyMessage: env._t("No users found"),
@@ -104,7 +104,7 @@ export const Many2OneAvatarUser = Many2OneAvatar.extend(M2XAvatarMixin, {
                         },
                         placeholder: env._t("Select a user..."),
                         providers: [{ provide }],
-                    });
+                    };
                 },
             });
             core.bus.trigger("set_legacy_command", "web.Many2OneAvatar.assignTo", getCommandDefinition, self.el);
@@ -277,7 +277,7 @@ export const Many2ManyAvatarUser = FieldMany2ManyTagsAvatar.extend(M2MAvatarMixi
                     hotkey: "alt+i",
                 },
                 action() {
-                    return env.services.command.openPalette({
+                    return {
                         configByNamespace: {
                             default: {
                                 emptyMessage: env._t("No users found"),
@@ -285,9 +285,9 @@ export const Many2ManyAvatarUser = FieldMany2ManyTagsAvatar.extend(M2MAvatarMixi
                         },
                         placeholder: env._t("Select a user..."),
                         providers: [{ provide }],
-                    });
+                    };
                 },
-            })
+            });
             core.bus.trigger("set_legacy_command", "web.FieldMany2ManyTagsAvatar.assignTo", getCommandDefinition)
 
             getCommandDefinition = (env) => ({

--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -10,7 +10,15 @@ import { fuzzyLookup } from "@web/core/utils/search";
 import { debounce } from "@web/core/utils/timing";
 import { escapeRegExp } from "../utils/strings";
 
-const { Component, onWillStart, useRef, useState, markRaw, useExternalListener } = owl;
+const {
+    Component,
+    onWillStart,
+    onWillDestroy,
+    useRef,
+    useState,
+    markRaw,
+    useExternalListener,
+} = owl;
 
 const DEFAULT_PLACEHOLDER = _lt("Search...");
 const DEFAULT_EMPTY_MESSAGE = _lt("No result found");
@@ -81,6 +89,12 @@ DefaultCommandItem.template = "web.DefaultCommandItem";
 
 export class CommandPalette extends Component {
     setup() {
+        if (this.props.bus) {
+            const setConfig = ({ detail }) => this.setCommandPaletteConfig(detail);
+            this.props.bus.addEventListener(`SET-CONFIG`, setConfig);
+            onWillDestroy(() => this.props.bus.removeEventListener(`SET-CONFIG`, setConfig));
+        }
+
         this.keyId = 1;
         this.keepLast = new KeepLast();
         this._sessionId = CommandPalette.lastSessionId++;

--- a/addons/web/static/src/core/debug/debug_menu.js
+++ b/addons/web/static/src/core/debug/debug_menu.js
@@ -50,7 +50,7 @@ export class DebugMenu extends DebugMenuBasic {
                     configByNamespace,
                     providers: [provider],
                 };
-                return this.command.openPalette(commandPaletteConfig);
+                return commandPaletteConfig;
             },
             {
                 category: "debug",

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2577,10 +2577,10 @@ var PriorityWidget = AbstractField.extend({
                     hotkey: "alt+r",
                 },
                 action() {
-                    return env.services.command.openPalette({
+                    return {
                         placeholder: env._t("Set a priority..."),
                         providers: [{ provide }],
-                    })
+                    };
                 },
             });
             core.bus.trigger("set_legacy_command", "web.PriorityWidget.setPriority", getCommandDefinition);
@@ -2784,10 +2784,10 @@ var StateSelectionWidget = AbstractField.extend({
                     hotkey: "alt+shift+r",
                  },
                 action() {
-                    return env.services.command.openPalette({
+                    return {
                         placeholder: env._t("Set a kanban state..."),
                         providers: [{ provide }],
-                    })
+                    }
                 },
             });
             core.bus.trigger("set_legacy_command", "web.StateSelectionWidget.setKanbanState", getCommandDefinition);

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -3221,11 +3221,10 @@ var FieldStatus = AbstractField.extend({
                     hotkey: "alt+shift+x",
                 },
                 action() {
-                    return env.services.command.openPalette({
+                    return {
                         placeholder: statusLabel,
                         providers: [{ provide }],
-                    });
-                },
+                    }                },
             });
             core.bus.trigger("set_legacy_command", "web.FieldStatus.moveToStage", getCommandDefinition);
         }

--- a/addons/web/static/src/views/fields/priority/priority_field.js
+++ b/addons/web/static/src/views/fields/priority/priority_field.js
@@ -56,10 +56,10 @@ export class PriorityField extends Component {
             };
             const name = this.env._t("Set priority...");
             const action = () => {
-                return commandService.openPalette({
+                return {
                     placeholder: this.env._t("Set a priority..."),
                     providers: [{ provide }],
-                });
+                };
             };
             const options = {
                 category: "smart_action",

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.js
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.js
@@ -57,10 +57,10 @@ export class StateSelectionField extends Component {
             };
             const name = this.env._t("Set kanban state...");
             const action = () => {
-                return commandService.openPalette({
+                return {
                     placeholder: this.env._t("Set a kanban state..."),
                     providers: [{ provide }],
-                });
+                };
             };
             const options = {
                 category: "smart_action",

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -128,10 +128,10 @@ export class StatusBarField extends Component {
             };
             const name = sprintf(this.env._t(`Move to %s...`), escape(this.props.displayName));
             const action = () => {
-                return commandService.openPalette({
+                return {
                     placeholder: name,
                     providers: [{ provide }],
-                });
+                };
             };
             const options = {
                 category: "smart_action",

--- a/addons/web/static/tests/helpers/mock_env.js
+++ b/addons/web/static/tests/helpers/mock_env.js
@@ -50,6 +50,7 @@ function prepareRegistriesWithCleanup() {
     cloneRegistryWithCleanup(registry.category("views"));
     cloneRegistryWithCleanup(registry.category("error_handlers"));
     cloneRegistryWithCleanup(registry.category("command_provider"));
+    cloneRegistryWithCleanup(registry.category("command_setup"));
     cloneRegistryWithCleanup(registry.category("view_widgets"));
     cloneRegistryWithCleanup(registry.category("fields"));
 


### PR DESCRIPTION
Before this commit, in the HomeMenu, typing several characters very
quickly could result in some not being present in the command palette
when it was opened.

Exemple:
In the HomeMenu,if I type "a" "b" "c" quickly the command palette will
open with the search value "/a" or "/ac". So we have lost the second
and/or third character.

Why:
All characters typed between the first and the moment the command pallet
is not yet mounted are lost because the search bar of the command pallet
is not yet available.

Solution:
If you use openPalette and the command palette is already open.
The configuration of the command pallet will be overwritten by the one
given to openPalette.
In our case, we can pass new configurations with the correct searchValue
until the command palette is returned.

Task-ID: 2906623

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
