### PR TITLE
[FIX] mail: misaligned channels kanban card layout

### DIFF
--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -20,7 +20,7 @@
                             </div>
                         </t>
                         <t t-name="kanban-box">
-                            <div class="oe_module_vignette oe_kanban_global_click">
+                            <div class="oe_module_vignette oe_kanban_global_click d-flex align-items-center">
                                 <img t-att-src="kanban_image('mail.channel', 'avatar_128', record.id.raw_value)" class="oe_module_icon" alt="Channel"/>
                                 <div class="oe_module_desc">
                                     <h4 class="o_kanban_record_title">#<field name="name"/></h4>


### PR DESCRIPTION
Since the new kanban view [1], the kanban card layout of the channels
had a weird alignment of its inner elements.

This is due to the fact that now the "kanban-box" defined in the arch
is wrapped inside the div.o_kanban_card instead of being merged with it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
