### PR TITLE
[FIX] web_editor: setTag after triple click should not update the next line

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -558,7 +558,8 @@ export const editorCommands = {
     // Change tags
     setTag(editor, tagName) {
         const restoreCursor = preserveCursor(editor.document);
-        const selectedBlocks = [...new Set(getTraversedNodes(editor.editable).map(closestBlock))];
+        const range = getDeepRange(editor.editable, { correctTripleClick: true });
+        const selectedBlocks = [...new Set(getTraversedNodes(editor.editable, range).map(closestBlock))];
         for (const block of selectedBlocks) {
             if (
                 ['P', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE'].includes(

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -557,9 +557,8 @@ export function getCursorDirection(anchorNode, anchorOffset, focusNode, focusOff
  * @param {Node} editable
  * @returns {Node[]}
  */
-export function getTraversedNodes(editable) {
+export function getTraversedNodes(editable, range = getDeepRange(editable)) {
     const document = editable.ownerDocument;
-    const range = getDeepRange(editable);
     if (!range) return [];
     const iterator = document.createNodeIterator(range.commonAncestorContainer);
     let node;


### PR DESCRIPTION
Before this commit:

Changing header style with triple clickk selection bring changes to the next
line also which it should not.

After this commit:

Now even after triple click selection the change stays with the selected part.

Task-2810134

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
