### PR TITLE
[IMP] requirements.txt: Add cryptography library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
+cryptography==3.4.8
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5


### PR DESCRIPTION
Installed by dependency with another lib, but the version 3.4.8 is
required to sign the DmfA declaration.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
