### PR TITLE
[IMP] core: use slots for the environment

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -495,6 +495,13 @@ class Environment(Mapping):
         """ Reset the transaction, see :meth:`Transaction.reset`. """
         self.transaction.reset()
 
+    __slots__ = (
+        '__weakref__',
+        'cr', 'uid', 'context', 'su', 'args',
+        'transaction', 'all',
+        'registry', 'cache',
+        '_cache_key', '_protected',
+    )
     def __new__(cls, cr, uid, context, su=False):
         if uid == SUPERUSER_ID:
             su = True


### PR DESCRIPTION
On Python 3.8, this reduces the size of the object from 48 + 232 bytes to 128.