### PR TITLE
[FIX] web, mass_mailing, website: remove frontend debug icon 

### DIFF
--- a/addons/mass_mailing/views/mailing_templates_portal_layouts.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_layouts.xml
@@ -26,7 +26,6 @@
                         <a target="_blank" class="label label-danger" href="https://www.odoo.com/app/website">Odoo</a>
                     </div>
                     <div class="float-start text-muted" itemscope="itemscope" itemtype="https://schema.org/Organization">
-                        <t t-call="web.debug_icon"/>
                         Copyright &amp;copy; <span t-field="res_company.name" itemprop="name">Company name</span>
                     </div>
                 </div>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -66,7 +66,6 @@
                         <div class="container py-3">
                             <div class="row">
                                 <div class="col-sm text-center text-sm-start text-muted">
-                                    <t t-call="web.debug_icon"/>
                                     <span class="o_footer_copyright_name me-2">Copyright &amp;copy; <span t-field="res_company.name" itemprop="name">Company name</span></span>
                                 </div>
                                 <div class="col-sm text-center text-sm-end">
@@ -316,14 +315,6 @@
             </t>
             <t t-set="head" t-value="head_web + (head or '')"/>
             <t t-set="body_classname" t-value="'o_web_client'"/>
-        </t>
-    </template>
-
-    <template id="debug_icon" name="Debug Icon">
-        <t t-if="debug" t-nocache="The query strings and debug mode can change for the same page and the same rendering.">
-            <t t-set="debug_mode_help" t-value="' (%s)' % debug if debug != '1' else ''"/>
-            <a t-attf-href="?#{keep_query('*', debug='')}" t-attf-title="Debug mode is activated#{debug_mode_help}. Click here to exit debug mode."
-               class="o_debug_mode"><span class="fa fa-bug"/></a>
         </t>
     </template>
 

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -304,15 +304,6 @@ class WithContext(HttpCase):
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
         self.assertIn(canonical_url, [f"{website.domain}/", f"{website.domain}/page_1"])
 
-    def test_t_cache_footer_debug_link(self):
-        # Debug link (flag) should be use the current url.
-        self.url_open('/')
-        self.url_open('/contactus')
-        r = self.url_open('/?debug=1')
-        self.assertIn('<a class="o_debug_mode" href="?debug="', r.text)
-        r = self.url_open('/contactus?name=MyName')  # don't force debug here, already done on previous step
-        self.assertIn('<a class="o_debug_mode" href="?debug=&amp;name=MyName"', r.text)
-
     def test_07_alternatives(self):
         website = self.env.ref('website.default_website')
         lang_fr = self.env['res.lang']._activate_lang('fr_FR')


### PR DESCRIPTION
[FIX] web, mass_mailing, website: remove frontend debug icon

After [1] moved the website edition in the backend, there is no real use
for an additional debug icon in the footer of the frontend.

Before this commit, on a website page, it was not working: clicking on
it from the WebsitePreview client action would only remove the debug
mode of the frontend, and the backend would keep it.
The user can now leave the debug mode from the debug menu systray item.

task-2687506

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b


