### PR TITLE
[FIX] project_timesheet_holidays: add freeze_time in test using today

### DIFF
--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 from datetime import datetime, timedelta
+from freezegun import freeze_time
 
 from odoo import Command
 from odoo.tests import common
@@ -89,6 +90,7 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
 
         self.assertFalse(leave_task.timesheet_ids.ids)
 
+    @freeze_time('2022-01-01 08:00:00')
     def test_timesheet_creation_and_deletion_on_employee_archive(self):
         """ Test the timesheets linked to the global time off in the future when the employee is archived """
         today = datetime.today()


### PR DESCRIPTION
Before this commit, when the test is launched at the end of the working
date, the first global time off created will start at the end of the
next monday and so no timesheet will be generated for this day.

This commit adds a `freeze_time` for this test to have the expected
behavior. That is, a timesheet should be generated per global time off
created.

X-original-commit: cb51a3e311b98dc6a0b90a75024e772a27fd7958
