### PR TITLE
[FIX] website: missing alternate URLs for pages

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1312,11 +1312,11 @@ class Website(models.Model):
 
             router = http.root.get_db_router(request.db).bind('')
             path = router.build(rule.endpoint, args)
-            if lang != self.default_lang_id:
-                path = f'/{lang.url_code}{path if path != "/" else ""}'
         except (NotFound, AccessError, MissingError):
             # The build method returns a quoted URL so convert in this case for consistency.
-            path = urls.url_quote_plus(request.httprequest.environ['REQUEST_URI'], safe='/')
+            path = urls.url_quote_plus(request.httprequest.path, safe='/')
+        if lang != self.default_lang_id:
+            path = f'/{lang.url_code}{path if path != "/" else ""}'
         canonical_query_string = f'?{urls.url_encode(canonical_params)}' if canonical_params else ''
         return self.get_base_url() + path + canonical_query_string
 

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -302,4 +302,37 @@ class WithContext(HttpCase):
                          "There should be no crash when a public user is accessing `/` which is rerouting to another page with a different URL.")
         root_html = html.fromstring(r.content)
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
-        self.assertEqual(canonical_url, website.domain + "/")
+        self.assertIn(canonical_url, [f"{website.domain}/", f"{website.domain}/page_1"])
+
+    def test_06_alternatives(self):
+        website = self.env.ref('website.default_website')
+        lang_fr = self.env['res.lang']._activate_lang('fr_FR')
+        lang_fr.write({'url_code': 'fr'})
+        website.language_ids = self.env.ref('base.lang_en') + lang_fr
+        website.default_lang_id = self.env.ref('base.lang_en')
+
+        with self.subTest(url='/page_1'):
+            res = self.url_open('/page_1')
+            res.raise_for_status()
+
+            root_html = html.fromstring(res.content)
+            canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
+            alternate_en_url = root_html.xpath('//link[@rel="alternate"][@hreflang="en"]')[0].attrib['href']
+            alternate_fr_url = root_html.xpath('//link[@rel="alternate"][@hreflang="fr"]')[0].attrib['href']
+
+            self.assertEqual(canonical_url, f'{self.base_url()}/page_1')
+            self.assertEqual(alternate_en_url, f'{self.base_url()}/page_1')
+            self.assertEqual(alternate_fr_url, f'{self.base_url()}/fr/page_1')
+
+        with self.subTest(url='/fr/page_1'):
+            res = self.url_open('/fr/page_1')
+            res.raise_for_status()
+
+            root_html = html.fromstring(res.content)
+            canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
+            alternate_en_url = root_html.xpath('//link[@rel="alternate"][@hreflang="en"]')[0].attrib['href']
+            alternate_fr_url = root_html.xpath('//link[@rel="alternate"][@hreflang="fr"]')[0].attrib['href']
+
+            self.assertEqual(canonical_url, f'{self.base_url()}/fr/page_1')
+            self.assertEqual(alternate_en_url, f'{self.base_url()}/page_1')
+            self.assertEqual(alternate_fr_url, f'{self.base_url()}/fr/page_1')


### PR DESCRIPTION
Install multiple langages, each time translating the website. In a
private browsing session access /contactus, show the page source, the
multiple alternate URL (`<link rel="alternative">` in the `<head>`) are
all pointing the canonical URL instead of the alternative.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
