### PR TITLE
[FIX] web, web_editor, website: batch of fixes for translation and caching snippet menus

### DIFF
--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -156,8 +156,9 @@ export function mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv) {
             // Add user context in kwargs if there are kwargs
             if (params && params.kwargs) {
                 params.kwargs.context = Object.assign(
-                    params.kwargs.context || {},
-                    legacyEnv.session.user_context
+                    {},
+                    legacyEnv.session.user_context,
+                    params.kwargs.context,
                 );
             }
             const jsonrpc = wowlEnv.services.rpc(route, params, {

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -71,6 +71,10 @@ class IrQWeb(models.AbstractModel):
     def _compile_directive_snippet(self, el, compile_context, indent):
         key = el.attrib.pop('t-snippet')
         el.set('t-call', key)
+        snippet_lang = self._context.get('snippet_lang')
+        if snippet_lang:
+            el.set('t-lang', f"'{snippet_lang}'")
+
         el.set('t-options', f"{{'snippet-key': {key!r}}}")
         view = self.env['ir.ui.view']._get(key).sudo()
         name = view.name

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2021,12 +2021,17 @@ var SnippetsMenu = Widget.extend({
             this._defLoadSnippets = cacheSnippetTemplate[this.options.snippets];
             return this._defLoadSnippets;
         }
+        let context = Object.assign({}, this.options.context);
+        if (context.user_lang) {
+            context.lang = this.options.context.user_lang;
+            context.snippet_lang = this.options.context.lang;
+        }
         this._defLoadSnippets = this._rpc({
             model: 'ir.ui.view',
             method: 'render_public_asset',
             args: [this.options.snippets, {}],
             kwargs: {
-                context: this.options.context,
+                context: context,
             },
         }, { shadow: true });
         cacheSnippetTemplate[this.options.snippets] = this._defLoadSnippets;

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -433,7 +433,9 @@ export class OptimizeSEODialog extends Component {
             }
         }
         data.website_meta_og_img = seoContext.metaImage;
-        await this.orm.write(this.object.model, [this.object.id], data);
+        await this.orm.write(this.object.model, [this.object.id], data, {
+            context: {lang: this.website.currentWebsite.metadata.lang},
+        });
         this.website.goToWebsite({path: this.url.replace(this.previousSeoName || this.seoNameDefault, seoContext.seoName)});
     }
 }

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -22,6 +22,14 @@ export class WebsiteEditorComponent extends Component {
         });
         this.wysiwygOptions = {};
 
+        // TODO: This is done here because the snippet menu cannot access
+        // OWL services. Once it can, the logic for invalidating the
+        // cache should probably be moved there.
+        if (this.websiteService.invalidateSnippetCache) {
+            this.wysiwygOptions.invalidateSnippetCache = true;
+            this.websiteService.invalidateSnippetCache = false;
+        }
+
         useChildSubEnv(legacyEnv);
 
         onWillStart(async () => {

--- a/addons/website/static/src/components/views/theme_preview_form.js
+++ b/addons/website/static/src/components/views/theme_preview_form.js
@@ -23,6 +23,7 @@ export function useLoaderOnClick() {
         async onClickViewButton(params) {
             const name = params.clickParams.name;
             if (['button_refresh_theme', 'button_choose_theme'].includes(name)) {
+                website.invalidateSnippetCache = true;
                 website.showLoader({ showTips: name !== 'button_refresh_theme' });
                 try {
                     const resParams = params.getResParams();

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -208,6 +208,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             {
                 website_id: this.websiteService.currentWebsite.id,
                 lang: this.websiteService.currentWebsite.metadata.lang,
+                user_lang: this.userService.context.lang,
             },
         );
     }

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -42,6 +42,8 @@ export const websiteService = {
         let blockingProcesses = [];
         let modelNamesProm = null;
         const modelNames = {};
+        let invalidateSnippetCache = false;
+        let lastWebsiteId = null;
 
         const context = reactive({
             showNewContentModal: false,
@@ -71,6 +73,10 @@ export const websiteService = {
         });
         return {
             set currentWebsiteId(id) {
+                if (id && id !== lastWebsiteId) {
+                    invalidateSnippetCache = true;
+                    lastWebsiteId = id;
+                }
                 currentWebsiteId = id;
                 websiteSystrayRegistry.trigger('EDIT-WEBSITE');
             },
@@ -166,6 +172,13 @@ export const websiteService = {
             set actionJsId(jsId) {
                 actionJsId = jsId;
             },
+            get invalidateSnippetCache() {
+                return invalidateSnippetCache;
+            },
+            set invalidateSnippetCache(value) {
+                invalidateSnippetCache = value;
+            },
+
             goToWebsite({ websiteId, path, edition, translation } = {}) {
                 action.doAction('website.website_preview', {
                     clearBreadcrumbs: true,

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -1,0 +1,39 @@
+/** @odoo-module **/
+
+import wTourUtils from 'website.tour_utils';
+
+wTourUtils.registerWebsitePreviewTour('snippet_cache_across_websites', {
+    edition: true,
+    test: true,
+    url: '/@/'
+}, [
+    {
+        content: "Check that the custom snippet is displayed",
+        trigger: '#snippet_custom_body span:contains("custom_snippet_test")',
+        run: () => null,
+    },
+    // There's no need to save, but canceling might or might not show a popup...
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Click on the website switch to switch to website 2",
+        trigger: '.o_website_switcher_container button',
+    },
+    {
+        content: "Switch to website 2",
+        // Ensure data-website-id exists
+        extra_trigger: 'iframe html[data-website-id="1"]',
+        trigger: '.o_website_switcher_container .dropdown-item:nth-child(2)'
+    },
+    {
+        content: "Wait for the iframe to be loaded",
+        trigger: 'iframe html:not([data-website-id="1"])',
+        run: () => null,
+    },
+    wTourUtils.clickOnEdit(),
+    {
+        content: "Check that the custom snippet is not here",
+        extra_trigger: '#oe_snippets:not(:has(#snippet_custom_body span:contains("custom_snippet_test")))',
+        trigger: '#oe_snippets:has(#snippet_custom.d-none)',
+        run: () => null,
+    },
+]);

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import wTourUtils from 'website.tour_utils';
+
+wTourUtils.registerWebsitePreviewTour('snippet_translation', {
+    url: '/',
+    edition: true,
+    test: true,
+}, [
+    wTourUtils.dragNDrop({name: 'Cover'}),
+    {
+        content: "Check that contact us contain Parseltongue",
+        trigger: 'iframe .s_cover .btn-primary:contains("Contact us in Parseltongue")',
+        run: () => null, // it's a check
+    },
+    {
+        content: "Check that the save button contains 'in fu_GB'",
+        trigger: '.btn[data-action="save"]:contains("Save in fu_GB")',
+        run: () => null, // it's a check
+    },
+]);

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -1,0 +1,25 @@
+/** @odoo-module **/
+
+import wTourUtils from 'website.tour_utils';
+
+wTourUtils.registerWebsitePreviewTour('translate_menu_name', {
+    url: '/pa_GB',
+    test: true,
+    edition: false,
+}, [
+    {
+        content: "activate translate mode",
+        trigger: '.o_translate_website_container a',
+    },
+    {
+        content: "Close the dialog",
+        trigger: '.modal-footer .btn-primary',
+    },
+    wTourUtils.clickOnExtraMenuItem({}, true),
+    {
+        content: "translate the menu entry",
+        trigger: 'iframe a[href="/englishURL"] span',
+        run: 'text value pa-GB',
+    },
+    ...wTourUtils.clickOnSave(),
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -317,3 +317,17 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_23_website_multi_edition(self):
         self.start_tour('/@?enable_editor=1', 'website_multi_edition', login='admin')
+
+    def test_24_snippet_cache_across_websites(self):
+        default_website = self.env.ref('website.default_website')
+        self.env['ir.ui.view'].with_context(website_id=default_website.id).save_snippet(
+            name='custom_snippet_test',
+            arch="""
+                <section class="s_text_block">
+                    <div class="custom_snippet_website_1">Custom Snippet Website 1</div>
+                </section>
+            """,
+            thumbnail_url='/website/static/src/img/snippets_thumbs/s_text_block.svg',
+            snippet_key='s_text_block',
+            template_key='website.snippets')
+        self.start_tour('/@/', 'snippet_cache_across_websites', login='admin')


### PR DESCRIPTION

This branch contains 2 fixes related to the Snippet Menu as well as a forward-ported commit described below.

---
Commit [1] added back the user context to every RPC called from the
legacy env when it's mapped to the WowlEnv but in doing so, overrode
the params' context keys.

This caused issue in some situation, such as viewing and editing a
website in a different language than the current website's user, after
the merge backend-frontend of website edition at [2].

Steps to reproduce:

- Install website_hr_recruitment.
- Install another language on the website but _do not_ set it as the
  user's language.
- Go to /jobs
- Edit the translation of an offer
- The title of the offer is edited in both language

task-2687506

[1]: https://github.com/odoo/odoo/commit/2192480ed1262a13db8e6b0dd945ea91dee91aa9
[2]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

Forward-Port-Of: odoo/odoo#102100