### PR TITLE
[IMP] point_of_sale: invoice order from closed session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1432,6 +1432,7 @@ class PosSession(models.Model):
     def _get_related_account_moves(self):
         pickings = self.picking_ids | self.order_ids.mapped('picking_ids')
         invoices = self.mapped('order_ids.account_move')
+        invoices |= invoices.mapped('reversal_move_id')
         invoice_payments = self.mapped('order_ids.payment_ids.account_move_id')
         stock_account_moves = pickings.mapped('move_ids.account_move_ids')
         cash_moves = self.cash_register_id.line_ids.mapped('move_id')

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
@@ -21,8 +21,6 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
             } else {
                 return this.isAlreadyInvoiced
                     ? this.env._t('Reprint Invoice')
-                    : this.props.order.isFromClosedSession
-                    ? this.env._t('Cannot Invoice')
                     : this.env._t('Invoice');
             }
         }
@@ -59,19 +57,9 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
 
             const orderId = order.backendId;
 
-            // Part 0.1. If already invoiced, print the invoice.
+            // Part 0: If already invoiced, print the invoice.
             if (this.isAlreadyInvoiced) {
                 await this._downloadInvoice(orderId);
-                return;
-            }
-
-            // Part 0.2. Check if order belongs to an active session.
-            // If not, do not allow invoicing.
-            if (order.isFromClosedSession) {
-                this.showPopup('ErrorPopup', {
-                    title: this.env._t('Session is closed'),
-                    body: this.env._t('Cannot invoice order from closed session.'),
-                });
                 return;
             }
 

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2312,7 +2312,6 @@ class Order extends PosModel {
         this.amount_return = json.amount_return;
         this.account_move = json.account_move;
         this.backendId = json.id;
-        this.isFromClosedSession = json.is_session_closed;
         this.is_tipped = json.is_tipped || false;
         this.tip_amount = json.tip_amount || 0;
     }

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -3,8 +3,10 @@
 
 import odoo
 
-from odoo import tools
+from odoo import fields
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+from freezegun import freeze_time
+from dateutil.relativedelta import relativedelta
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -829,3 +831,48 @@ class TestPoSBasicConfig(TestPoSCommon):
 
         # calling load_pos_data should not raise an error
         self.pos_session.load_pos_data()
+
+    def test_invoice_past_order(self):
+        # create 1 uninvoiced order then close the session
+        self._run_test({
+            'payment_methods': self.cash_pm1 | self.bank_pm1,
+            'orders': [
+                {'pos_order_lines_ui_args': [(self.product99, 1)], 'payments': [(self.bank_pm1, 99)], 'customer': False, 'is_invoiced': False, 'uid': '00100-010-0001'},
+            ],
+            'journal_entries_before_closing': {},
+            'journal_entries_after_closing': {
+                'session_journal_entry': {
+                    'line_ids': [
+                        {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 99, 'reconciled': False},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 99, 'credit': 0, 'reconciled': True},
+                    ],
+                },
+                'cash_statement': [],
+                'bank_payments': [
+                    ((99, ), {
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 99, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 99, 'reconciled': True},
+                        ]
+                    })
+                ],
+            },
+        })
+
+        # keep reference of the closed session
+        closed_session = self.pos_session
+        self.assertTrue(closed_session.state == 'closed', 'Session should be closed.')
+
+        order_to_invoice = closed_session.order_ids[0]
+        test_customer = self.env['res.partner'].create({'name': 'Test Customer'})
+
+        with freeze_time(fields.Datetime.now() + relativedelta(days=2)):
+            # create new session after 2 days
+            self.open_new_session(0)
+            # invoice the uninvoiced order
+            order_to_invoice.write({'partner_id': test_customer.id})
+            order_to_invoice.action_pos_order_invoice()
+            # check invoice
+            self.assertTrue(order_to_invoice.account_move, 'Invoice should be created.')
+            self.assertTrue(order_to_invoice.account_move.invoice_date != order_to_invoice.date_order.date(), 'Invoice date should not be the same as order date since the session was closed.')
+            self.assertTrue(order_to_invoice.account_move.reversal_move_id, 'Reversed entry should be created. It served as the payment to the invoice.')


### PR DESCRIPTION
This change allows the invoicing of orders from closed session.
This is accomplished by creating an invoice and immediately reversing
it because the order was already counted in the move_id of the
closed session.

A message containing links of related records is posted in the reverse
move for tracking.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
