### PR TITLE
[14.0][FIX] stock: package level still confirmed after being canceled

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -101,7 +101,7 @@ class StockPackageLevel(models.Model):
                 package_level.state = 'draft'
             elif not package_level.move_line_ids and package_level.move_ids.filtered(lambda m: m.state not in ('done', 'cancel')):
                 package_level.state = 'confirmed'
-            elif package_level.move_line_ids and not package_level.move_line_ids.filtered(lambda ml: ml.state == 'done'):
+            elif package_level.move_line_ids and not package_level.move_line_ids.filtered(lambda ml: ml.state in ('done', 'cancel')):
                 if package_level.is_fresh_package:
                     package_level.state = 'new'
                 elif package_level._check_move_lines_map_quant_package(package_level.package_id, 'product_uom_qty'):


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

When canceling a transfer, all its moves and move lines having qty done (if any) are canceled as well. But this doesn't happen on package levels having such move lines with qty done filled, the state was set to `confirmed` while all its move lines are `cancel`, which was not consistent.

### Current behavior before PR:

A package level having move lines with `qty_done` set was set to `confirmed` even if these move lines (and moves) are `cancel`.

### Desired behavior after PR is merged:

A package level having move lines with `qty_done` is now set to `cancel`, which is consistent with its move lines (and moves).

OPW #2917305

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
