### PR TITLE
[FIX] web: edit radio and boolean widget fields

### DIFF
--- a/addons/web/static/src/legacy/js/_deprecated/basic_fields.js
+++ b/addons/web/static/src/legacy/js/_deprecated/basic_fields.js
@@ -126,7 +126,7 @@ var FieldBoolean = AbstractField.extend({
     _render: function () {
         var $checkbox = this._formatValue(this.value);
         this.$input = $checkbox.find('input');
-        this.$input.prop('disabled', this.hasReadonlyModifier);
+        this.$input.prop('disabled', this.hasReadonlyModifier && this.mode != 'edit');
         this.$el.addClass($checkbox.attr('class'));
         this.$el.empty().append($checkbox.contents());
     },

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -3484,7 +3484,7 @@ var FieldRadio = FieldSelection.extend({
                 index: index,
                 name: self.unique_id,
                 value: value,
-                disabled: self.hasReadonlyModifier,
+                disabled: self.hasReadonlyModifier && self.mode != 'edit',
             }));
         });
     },

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -395,6 +395,68 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('boolean field is editable in an editable form', async function (assert) {
+        assert.expect(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form edit="1">' +
+                    '<field name="bar" widget="boolean"/>' +
+                '</form>',
+        });
+
+        assert.containsOnce(form, '.o_field_boolean input:enabled',
+            "the field should be editable");
+
+        await testUtils.form.clickSave(form);
+
+        assert.containsOnce(form, '.o_field_boolean input:enabled',
+            "the field should be editable");
+
+        form.destroy();
+    });
+
+    QUnit.test('boolean field is not editable in a readonly form', async function (assert) {
+        assert.expect(1);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form edit="0">' +
+                    '<field name="bar" widget="boolean"/>' +
+                '</form>',
+            viewOptions: {
+               mode: 'readonly',
+            },
+        });
+
+        assert.containsOnce(form, '.o_field_boolean input:disabled',
+            "the field should not be editable");
+
+        form.destroy();
+    });
+
+    QUnit.test('boolean field is not editable with a readonly modifier', async function (assert) {
+        assert.expect(1);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form>' +
+                    '<field name="bar" widget="boolean" readonly="1"/>' +
+                '</form>',
+        });
+
+        assert.containsOnce(form, '.o_field_boolean input:disabled',
+            "the field should not be editable");
+
+        form.destroy();
+    });
+
     QUnit.module('FieldBooleanToggle');
 
     QUnit.test('use boolean toggle widget in form view', async function (assert) {

--- a/addons/web/static/tests/legacy/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields_tests.js
@@ -2281,6 +2281,68 @@ QUnit.module('relational_fields', {
         form.destroy();
     });
 
+    QUnit.test('radio field is editable in an editable form', async function (assert) {
+        assert.expect(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form edit="1">' +
+                    '<field name="product_id" widget="radio"/>' +
+                '</form>',
+        });
+
+        assert.containsN(form, '.o_field_radio input:enabled', 2,
+            "the field should be editable");
+
+        await testUtils.form.clickSave(form);
+
+        assert.containsN(form, '.o_field_radio input:enabled', 2,
+            "the field should be editable");
+
+        form.destroy();
+    });
+
+    QUnit.test('radio field is not editable in a readonly form', async function (assert) {
+        assert.expect(1);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form edit="0">' +
+                    '<field name="product_id" widget="radio"/>' +
+                '</form>',
+            viewOptions: {
+               mode: 'readonly',
+            },
+        });
+
+        assert.containsN(form, '.o_field_radio input:disabled', 2,
+            "the field should not be editable");
+
+        form.destroy();
+    });
+
+    QUnit.test('radio field is not editable with a readonly modifier', async function (assert) {
+        assert.expect(1);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form>' +
+                    '<field name="product_id" widget="radio" readonly="1"/>' +
+                '</form>',
+        });
+
+        assert.containsN(form, '.o_field_radio input:disabled', 2,
+            "the field should not be editable");
+
+        form.destroy();
+    });
+
     QUnit.test('fieldradio change value by onchange', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
Fields with widget `radio` and `boolean` can't be edited

Steps to reproduce:
1. Install Discuss
2. Connect as demo and go to your preferences (top right)
3. You can't edit your notification type

Solution:
Use widgetOptions' mode along with hasReadonlyModifier to disable the
fields

Problem:
This PR https://github.com/odoo/odoo/pull/88223 modified the value of
hasReadonlyModifier which is used to disable radio and boolean fields

opw-2898464