### PR TITLE
[FIX] core: use record name while exporting

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -881,8 +881,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                             continue
 
                         # recursively export the fields that follow name; use
-                        # 'display_name' where no subfield is exported
-                        fields2 = [(p[1:] or ['display_name'] if p and p[0] == name else [])
+                        # 'display_name' where no subfield is exported if the
+                        # import-compatible option is disabled, otherwise use
+                        # '_rec_name'
+                        name_field = (import_compatible and value._rec_name) or 'display_name'
+                        fields2 = [(p[1:] or [name_field] if p and p[0] == name else [])
                                    for p in fields]
                         lines2 = value._export_rows(fields2, _is_toplevel_call=False)
                         if lines2:


### PR DESCRIPTION
In some cases, when a user exports a record with the option
'import-compatible', he won't be able to import the record later (he
will have to fix the exported file first).

To reproduce the issue:
(Need stock. Use demo data)
1. Inventory > Operations > Transfers
2. Select a transfer (without opening it)
3. Action > Export:
    - Enable the option "import-compatible"
    - Add the field "Operation Type"
    - Export the transfer
4. Back to the transfers list view, click on Import
5. Load the exported file and click on Test

Error: An error message is displayed ("No matching record [...] in field
'Operation Type'"). However, the option "import-compatible" was enabled
and the operation does exist, so the record should be found.

When exporting a record, if one of the selected fields is a relational
one, we use its `display_name` as value:
https://github.com/odoo/odoo/blob/5797fd80a63309269f15bcbe4948d4429a53eec2/odoo/models.py#L883-L886
However, when importing, we use `name_search` to retreive the record:
https://github.com/odoo/odoo/blob/662ecf4e20ceab92b62804cb2a06e51f6b897623/odoo/addons/base/models/ir_fields.py#L406
Therefore, since the used value is the `display_name` and not the
`name`, the search may not return any results.

This is what happened in the above use case. If an operation type has a
warehouse, its display name will be the combination of the warehouse
name and its name:
https://github.com/odoo/odoo/blob/b6833702044b0d3057d543dae71fbea7ef091d98/addons/stock/models/stock_picking.py#L146-L151
However, the `_name_search` does not handle this type of search key:
https://github.com/odoo/odoo/blob/b6833702044b0d3057d543dae71fbea7ef091d98/addons/stock/models/stock_picking.py#L157-L164
Therefore, using that value ("Warehouse: Operation name") in this
`name_search` will not work. If the search key was the operation name,
this `name_search` would find and return the record.

From a more generic point of view, the standard version of
`_name_search` is based on the field `_rec_name` of a record:
https://github.com/odoo/odoo/blob/5797fd80a63309269f15bcbe4948d4429a53eec2/odoo/models.py#L1755-L1758
So, when exporting, if the option import-compatible is enabled, we
should use this value too.

OPW-2739786