### PR TITLE
[FIX] purchase_product_matrix: add the package on product variants automatically

### DIFF
--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -117,6 +117,7 @@ class PurchaseOrder(models.Model):
                 for line in self.order_line.filtered(lambda line: line.product_id.id in product_ids):
                     line._product_id_change()
                     line._onchange_quantity()
+                    line._onchange_suggest_packaging()
                     res = line.onchange_product_id_warning() or res
                 return res
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Install `”purchase_product_matrix”`
- Go to the purchase settings and enable “Product Packagings” option
- Create a storable product “P1” with attributes:
    - Configure a package in each of the variants
- Create a PO:
    - Select the product “P1”:
        - on the grid product configurator: Add quantity set on Package
        - Confirm

Problem:
The chosen quantity must be automatically put in a package,
but as we are in the case of a grid, the `_onchange_suggest_packaging`
is not triggered automatically, and therefore the package is not set.

Solution:
We have to trigger the onchange manually in the grid case

opw-2896050


https://user-images.githubusercontent.com/78867936/177765933-9d989f8b-be14-4880-87cc-702f3df6ed20.mp4



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
