### PR TITLE
[FIX] sale_timesheet: fix traceback on project sharing

### DIFF
--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -115,8 +115,10 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
         except (AccessError, MissingError):
             pass
 
-        if task.sale_order_id.invoice_ids:
-            moves = request.env['account.move'].search([('id', 'in', task.sale_order_id.invoice_ids.ids)])
+        moves = request.env['account.move']
+        invoice_ids = task.sale_order_id.invoice_ids
+        if invoice_ids and request.env['account.move'].check_access_rights('read', raise_exception=False):
+            moves = request.env['account.move'].search([('id', 'in', invoice_ids.ids)])
             values['invoices_accessible'] = moves.ids
             if moves:
                 if len(moves) == 1:

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -111,7 +111,7 @@
                     <span t-if="so_accessible"><a t-attf-href="/my/orders/{{ task.sale_order_id.id }}" t-field="task.sale_order_id"></a></span>
                     <span t-else="" t-field="task.sale_order_id"></span>
                 </div>
-                <div t-if="task.sale_order_id.invoice_ids"><strong>Invoices:</strong>
+                <div t-if="invoices_accessible"><strong>Invoices:</strong>
                     <span t-foreach="task.sale_order_id.invoice_ids" t-as="invoice_line">
                         <t t-if="invoice_line.id in invoices_accessible">
                             <a t-attf-href="/my/invoices/{{ invoice_line.id }}">


### PR DESCRIPTION
Before this commit, When we share the project in reading only access that time access error is raised when we try to open the task by shared link due to invalid access on account. move.

So in this commit, check the read access for the account.move and if the public user has right to read the invoice then allow to search on move.

task-2889455