### PR TITLE
[IMP] hr_holidays: make duration field read only

### DIFF
--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -571,7 +571,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         req1_form.request_date_from = fields.Date.to_date('2021-12-06')
         req1_form.request_date_to = fields.Date.to_date('2021-12-08')
 
-        self.assertEqual(req1_form.number_of_days, 3)
+        self.assertEqual(req1_form.number_of_days_display, 3)
         req1_form.save().action_approve()
 
         req2_form = Form(self.env['hr.leave'].sudo())
@@ -580,7 +580,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         req2_form.request_date_from = fields.Date.to_date('2021-12-06')
         req2_form.request_date_to = fields.Date.to_date('2021-12-08')
 
-        self.assertEqual(req2_form.number_of_days, 3)
+        self.assertEqual(req2_form.number_of_days_display, 3)
 
     def test_leave_with_public_holiday_other_company(self):
         other_company = self.env['res.company'].create({

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -335,17 +335,11 @@
                                 </div>
                             </div>
 
-                            <!-- When the user is leave manager, he should always see `number_of_days` to allow
-                            him to edit the value. `number_of_hours_display` is only an informative field -->
-                            <label for="number_of_days" string="Duration" attrs="{'invisible': [('request_unit_half', '=', True), ('leave_type_request_unit', '!=', 'hour')]}"/>
+                            <label for="number_of_days_display" string="Duration" attrs="{'invisible': [('request_unit_half', '=', True), ('leave_type_request_unit', '!=', 'hour')]}"/>
                             <div name="duration_display">
                                 <div class="o_row">
-                                    <div groups="!hr_holidays.group_hr_holidays_manager" attrs="{'invisible': ['|', ('request_unit_half', '=', True), ('request_unit_hours', '=', True)]}" class="o_row">
-                                        <field name="number_of_days_display" nolabel="1" readonly="1" class="oe_inline"/>
-                                        <span>Days</span>
-                                    </div>
-                                    <div groups="hr_holidays.group_hr_holidays_manager" class="o_row" attrs="{'invisible': ['|', ('request_unit_half', '=', True), ('request_unit_hours', '=', True)]}">
-                                        <field name="number_of_days" nolabel="1" class="oe_inline"/>
+                                    <div attrs="{'invisible': ['|', ('request_unit_half', '=', True), ('request_unit_hours', '=', True)]}" class="o_row">
+                                        <field name="number_of_days_display" nolabel="1" class="oe_inline"/>
                                         <span>Days</span>
                                     </div>
                                     <div attrs="{'invisible': [('leave_type_request_unit', '!=', 'hour')]}" class="o_row">


### PR DESCRIPTION
In hr_holidays, the duration field is editable but doesn't bring any added value.
The field is errorprone and not editable if you are not HR Officer. It should be the same in every case.

The duration field should be read only on the dashboard and time off creation screens.

task-2901951

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
