### PR TITLE
[FIX] mail: process MediaDialog image attachments

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2157,6 +2157,8 @@ var FieldMany2ManyBinaryMultiFiles = AbstractField.extend({
     fieldsToFetch: {
         name: {type: 'char'},
         mimetype: {type: 'char'},
+        res_id: {type: 'number'},
+        access_token: {type: 'char'},
     },
     events: {
         'click .o_attach': '_onAttach',

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1548,7 +1548,7 @@
 <t t-name="FieldBinaryFileUploader.attachment_preview">
     <t t-set="url" t-value="widget.metadata[file.id] ? widget.metadata[file.id].url : false"/>
     <t t-if="file.data" t-set="file" t-value="file.data"/>
-    <t t-set="editable" t-value="widget.mode === 'edit'"/>
+    <t t-set="editable" t-value="widget.mode === 'edit' and !(file.res_id === 0 and file.access_token)"/>
     <t t-if="file.mimetype" t-set="mimetype" t-value="file.mimetype"/>
     <div t-attf-class="o_attachment o_attachment_many2many #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
         <div class="o_attachment_wrap">

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -2536,11 +2536,14 @@ QUnit.module('relational_fields', {
             fields: {
                 name: {string:"Name", type: "char"},
                 mimetype: {string: "Mimetype", type: "char"},
+                res_id: {type: "number"},
+                access_token: {type: "char"},
             },
             records: [{
                 id: 17,
                 name: 'Marley&Me.jpg',
                 mimetype: 'jpg',
+                res_id: 1,
             }],
         };
         this.data.turtle.fields.picture_ids = {
@@ -2564,7 +2567,7 @@ QUnit.module('relational_fields', {
             mockRPC: function (route, args) {
                 assert.step(route);
                 if (route === '/web/dataset/call_kw/ir.attachment/read') {
-                    assert.deepEqual(args.args[1], ['name', 'mimetype']);
+                    assert.deepEqual(args.args[1], ['name', 'mimetype', 'res_id', 'access_token']);
                 }
                 return this._super.apply(this, arguments);
             },

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -162,13 +162,13 @@ class Web_Editor(http.Controller):
         return True
 
     @http.route('/web_editor/attachment/add_data', type='json', auth='user', methods=['POST'], website=True)
-    def add_data(self, name, data, quality=0, width=0, height=0, res_id=False, res_model='ir.ui.view', **kwargs):
+    def add_data(self, name, data, quality=0, width=0, height=0, res_id=False, res_model='ir.ui.view', generate_access_token=False, **kwargs):
         try:
             data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
         except UserError:
             pass  # not an image
         self._clean_context()
-        attachment = self._attachment_create(name=name, data=data, res_id=res_id, res_model=res_model)
+        attachment = self._attachment_create(name=name, data=data, res_id=res_id, res_model=res_model, generate_access_token=generate_access_token)
         return attachment._get_media_info()
 
     @http.route('/web_editor/attachment/add_url', type='json', auth='user', methods=['POST'], website=True)
@@ -240,7 +240,7 @@ class Web_Editor(http.Controller):
             'original': (attachment.original_id or attachment).read(['id', 'image_src', 'mimetype'])[0],
         }
 
-    def _attachment_create(self, name='', data=False, url=False, res_id=False, res_model='ir.ui.view'):
+    def _attachment_create(self, name='', data=False, url=False, res_id=False, res_model='ir.ui.view', generate_access_token=False):
         """Create and return a new attachment."""
         if name.lower().endswith('.bmp'):
             # Avoid mismatch between content type and mimetype, see commit msg
@@ -272,6 +272,9 @@ class Web_Editor(http.Controller):
             raise UserError(_("You need to specify either data or url to create an attachment."))
 
         attachment = request.env['ir.attachment'].create(attachment_data)
+        if generate_access_token:
+            attachment.generate_access_token()
+
         return attachment
 
     def _clean_context(self):

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -243,9 +243,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * when closing the wizard.
      *
      * @private
-     * @param {Object} attachments
+     * @param {Object} event the event containing attachment data
      */
-    _onAttachmentChange: function (attachments) {
+    _onAttachmentChange: function (event) {
         if (!this.fieldNameAttachment) {
             return;
         }
@@ -253,7 +253,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             dataPointID: this.dataPointID,
             changes: _.object([this.fieldNameAttachment], [{
                 operation: 'ADD_M2M',
-                ids: attachments
+                ids: event.data
             }])
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -581,8 +581,10 @@ var FileWidget = SearchableMediaWidget.extend({
                             'res_model': self.options.res_model,
                             'width': 0,
                             'quality': 0,
+                            'generate_access_token': true,
                         },
                     }).then(function (attachment) {
+                        self.trigger_up('wysiwyg_attachment', attachment);
                         self._handleNewAttachment(attachment);
                     });
                 });


### PR DESCRIPTION
When adding an image inside a mail composer via the /image command or 'image' button of the editor, the related attachment was never processed.

This makes sense as we do not want to attach it to the resulting message(s). However as the attachment res_id and res_model were never updated from the compositor in which they originated, they would become dangling attachments and be garbage collected the next day (or the in the next pass of the GC) by _gc_lost_attachments.

This commit adds a step to retrieve the attachments embedded in the body by a MediaDialog and link them to the record where the message was posted.

Note:
These attachments will not be removed when the message is removed, it doesn't seem like they will be removed when the record is deleted either. However as they are embedded in emails as links, it's probably best to leave them for a decent period of time regardless. 

If not satisfactory, we could add something to autovacuum to remove really old mail attachments that are not referenced by any other record. Alternatively, the images could be added as attachments to the mail but this would probably mess with the presentation or add a bunch of useless attachments to the mail.


Task-2860761

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
