### PR TITLE
[IMP] mrp: convert production order product, uom, bom onchanges

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -57,7 +57,7 @@ class MrpProduction(models.Model):
                 ('company_id', '=', company_id)
         ]
         """,
-        compute='_compute_product_id', store=True, copy=True,
+        compute='_compute_product_id', store=True, copy=True, precompute=True,
         readonly=True, required=True, check_company=True,
         states={'draft': [('readonly', False)]})
     product_variant_attributes = fields.Many2many('product.template.attribute.value', related='product_id.product_template_attribute_value_ids')
@@ -69,7 +69,7 @@ class MrpProduction(models.Model):
         compute='_compute_product_qty', store=True, copy=True)
     product_uom_id = fields.Many2one(
         'uom.uom', 'Product Unit of Measure',
-        readonly=False, required=True, compute='_compute_uom_id', store=True, copy=True,
+        readonly=False, required=True, compute='_compute_uom_id', store=True, copy=True, precompute=True,
         domain="[('category_id', '=', product_uom_category_id)]")
     lot_producing_id = fields.Many2one(
         'stock.lot', string='Lot/Serial Number', copy=False,
@@ -129,7 +129,7 @@ class MrpProduction(models.Model):
                         ('product_tmpl_id.product_variant_ids','=',product_id),
                         ('product_id','=',False),
         ('type', '=', 'normal')]""",
-        check_company=True, compute='_compute_bom_id', store=True,
+        check_company=True, compute='_compute_bom_id', store=True, precompute=True,
         help="Bill of Materials allow you to define the list of required components to make a finished product.")
 
     state = fields.Selection([

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2922,3 +2922,33 @@ class TestMrpOrder(TestMrpCommon):
         self.assertFalse(wo_01.show_json_popover)
         self.assertFalse(wo_02.show_json_popover)
         self.assertEqual(wo_01.date_planned_finished, wo_02.date_planned_start)
+
+    def test_compute_product_id(self):
+        """
+            Tests the creation of a production order automatically sets the product when the bom is provided,
+            without the need to put it in the vals of the create nor to call onchanges.
+        """
+        order = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+        })
+        self.assertEqual(order.product_id, self.bom_1.product_id)
+
+    def test_compute_product_uom_id(self):
+        """
+            Tests the creation of a production order automatically sets the uom when the bom is provided,
+            without the need to put it in the vals of the create nor to call onchanges.
+        """
+        order = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+        })
+        self.assertEqual(order.product_uom_id, self.bom_1.product_uom_id)
+
+    def test_compute_bom_id(self):
+        """
+            Tests the creation of a production order automatically sets the bom when the product is provided,
+            without the need to put it in the vals of the create nor to call onchanges.
+        """
+        order = self.env['mrp.production'].create({
+            'product_id': self.bom_1.product_id.id,
+        })
+        self.assertEqual(order.bom_id, self.bom_1)


### PR DESCRIPTION
This allows to create a production order record without
the need to call the onchanges to set the product, uom or bom
or to set them manually during the `create` call.

For instance, this makes easier to create production orders
using XMLRPC when you do not use multiple UOMs.