### PR TITLE
[IMP] web: dynamic placeholder for column creation

### DIFF
--- a/addons/project/static/tests/tours/personal_stage_tour.js
+++ b/addons/project/static/tests/tours/personal_stage_tour.js
@@ -32,7 +32,7 @@ tour.register('personal_stage_tour', {
     trigger: '.o_column_quick_create .o_quick_create_folded'
 }, {
     content: "Create a new personal stage",
-    trigger: 'input[placeholder="Column title"]',
+    trigger: 'input.form-control.o_input',
     run: 'text Never',
 }, {
     content: "Confirm create",

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column_quick_create.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column_quick_create.js
@@ -38,6 +38,7 @@ var ColumnQuickCreate = Widget.extend({
         this.folded = true;
         this.isMobile = config.device.isMobile;
         this.isFirstColumn = options.isFirstColumn;
+        this.groupByFieldString = options.groupByFieldString;
     },
     /**
      * @override

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
@@ -377,6 +377,7 @@ var KanbanRenderer = BasicRenderer.extend({
                     applyExamplesText: this.examples && this.examples.applyExamplesText,
                     examples: this.examples && this.examples.examples,
                     isFirstColumn: !self.state.data.length,
+                    groupByFieldString: this.state.fields[this.state.groupedBy].string,
                 });
                 this.defs.push(this.quickCreate.appendTo(fragment).then(function () {
                     // Open it directly if there is no column yet

--- a/addons/web/static/src/legacy/xml/kanban.xml
+++ b/addons/web/static/src/legacy/xml/kanban.xml
@@ -46,14 +46,13 @@
     <div class="o_column_quick_create">
         <div class="o_quick_create_folded">
             <button class="o_kanban_add_column btn btn-outline-secondary w-100">
-                <i class="fa fa-plus" role="img" aria-label="Add column" title="Add column"/>
-                Add a Column
+                <i class="fa fa-plus me-2" role="img" aria-label="Add column" title="Add column"/><t t-out="widget.groupByFieldString"/>
             </button>
         </div>
         <div class="o_quick_create_unfolded">
             <div class="o_kanban_header">
                 <div class="input-group">
-                    <input type="text" class="form-control o_input" placeholder="Column title"/>
+                    <input type="text" class="form-control o_input" t-attf-placeholder="{{ widget.groupByFieldString }}..."/>
                     <button class="btn btn-primary o_kanban_add" type="button">Add</button>
                 </div>
                 <span t-if="!widget.isMobile" class="o_discard_msg text-muted float-end">Esc to discard</span>

--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
@@ -5,8 +5,7 @@
         <div class="o_column_quick_create" t-ref="root">
             <div t-if="props.folded" class="o_quick_create_folded" t-on-click="unfold">
                 <button class="o_kanban_add_column btn btn-outline-secondary w-100">
-                    <i class="fa fa-plus" role="img" aria-label="Add column" title="Add column"/>
-                    Add a Column
+                    <i class="fa fa-plus me-2" role="img" aria-label="Add column" title="Add column"/><t t-out="props.groupByFieldString"/>
                 </button>
             </div>
             <div t-else="" class="o_quick_create_unfolded">
@@ -14,7 +13,7 @@
                     <div class="input-group">
                         <input type="text"
                             class="form-control o_input"
-                            placeholder="Column title"
+                            t-attf-placeholder="{{ props.groupByFieldString }}..."
                             t-ref="autofocus"
                             t-model.trim="state.columnTitle"
                             t-on-focus="() => state.hasInputFocused = true"

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -140,6 +140,7 @@
                         onFoldChange="folded => state.columnQuickCreateIsFolded = props.list.groups.length > 0 and folded"
                         onValidate="name => props.list.createGroup(name)"
                         exampleData="exampleData"
+                        groupByFieldString="props.list.groupByField.string"
                     />
                 </t>
                 <!-- Kanban Example Background -->

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -8523,5 +8523,28 @@ QUnit.module('LegacyViews', {
         kanban.destroy();
         delete widgetRegistry.map.optionwidget;
     });
+
+    QUnit.test('column quick create - title and placeholder', async function (assert) {
+        assert.expect(2);
+
+        var kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch:
+                '<kanban>' +
+                    '<templates><t t-name="kanban-box">' +
+                        '<div>' +
+                            '<field name="int_field"/>' +
+                        '</div>' +
+                    '</t></templates>' +
+                '</kanban>',
+            groupBy: ['product_id'],
+        });
+
+        const productFieldName = this.data.partner.fields.product_id.string;
+        assert.strictEqual(kanban.el.querySelector('.o_column_quick_create .o_quick_create_folded').innerText, productFieldName);
+        assert.strictEqual(kanban.el.querySelector('.o_column_quick_create .o_quick_create_unfolded .input-group .o_input').getAttribute('placeholder'), productFieldName + '...');
+    });
 });
 });

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -10853,4 +10853,29 @@ QUnit.module("Views", (hooks) => {
             assert.verifySteps(["get_views", "web_search_read"]);
         }
     );
+
+    QUnit.test('column quick create - title and placeholder', async function (assert) {
+        assert.expect(2);
+
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch:
+                '<kanban>' +
+                    '<templates><t t-name="kanban-box">' +
+                        '<div>' +
+                            '<field name="int_field"/>' +
+                        '</div>' +
+                    '</t></templates>' +
+                '</kanban>',
+            groupBy: ['product_id'],
+        });
+
+        const productFieldName = serverData.models.partner.fields.product_id.string;
+        assert.strictEqual(target.querySelector('.o_column_quick_create .o_quick_create_folded').innerText, productFieldName);
+
+        await click(target, "button.o_kanban_add_column");
+        assert.strictEqual(target.querySelector('.o_column_quick_create .o_quick_create_unfolded .input-group .o_input').getAttribute('placeholder'), productFieldName + '...');
+    });
 });


### PR DESCRIPTION
- Purpose

Improve the UX of the "column creation" mechanism in the kanban view
so that users better understand what it is they are creating.

- Specifications

In the kanban creation mechanism, use the name of field on the model
(e.g. when grouped by stage_id in project.tasks kanban, "Add a Column"
would become "Add a Stage" because the stage_id field's name is "Stage").

task-2755570

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
