### PR TITLE
[FIX] web: take into account orientation classes on radio button field

### DIFF
--- a/addons/web/static/src/views/fields/radio/radio_field.scss
+++ b/addons/web/static/src/views/fields/radio/radio_field.scss
@@ -1,5 +1,4 @@
-.o_field_radio > div {
-    display: inline-flex;
+.o_field_radio {
     > span, > button {
         flex: 0 0 auto;
     }
@@ -15,6 +14,7 @@
     }
 
     .o_horizontal {
+        display: inline-flex;
         .o_radio_item {
             margin-right: $o-form-spacing-unit * 2;
         }

--- a/addons/web/static/tests/views/fields/radio_field_tests.js
+++ b/addons/web/static/tests/views/fields/radio_field_tests.js
@@ -226,10 +226,20 @@ QUnit.module("Fields", (hooks) => {
             ".o_field_radio > div.o_vertical",
             "should have o_vertical class"
         );
+        const verticalRadio = target.querySelector(".o_field_radio > div.o_vertical");
+        assert.strictEqual(
+            verticalRadio.querySelector(".o_radio_item:first-child").getBoundingClientRect().right,
+            verticalRadio.querySelector(".o_radio_item:last-child").getBoundingClientRect().right
+        );
         assert.containsOnce(
             target,
-            ".o_field_radio div.o_horizontal",
+            ".o_field_radio > div.o_horizontal",
             "should have o_horizontal class"
+        );
+        const horizontalRadio = target.querySelector(".o_field_radio > div.o_horizontal");
+        assert.strictEqual(
+            horizontalRadio.querySelector(".o_radio_item:first-child").getBoundingClientRect().top,
+            horizontalRadio.querySelector(".o_radio_item:last-child").getBoundingClientRect().top
         );
     });
 


### PR DESCRIPTION
Before this commit, all radio buttons were on horizontal style,
the o_vertical class was not taken into account.