### PR TITLE
[FIX] http_routing: infinite redirect due to unmatched path with the generated one

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -538,7 +538,10 @@ class IrHttp(models.AbstractModel):
         super(IrHttp, cls)._postprocess_args(arguments, rule)
 
         try:
-            _, path = rule.build(arguments)
+            escaped_args = {}
+            for key, value in arguments:
+                escaped_args = {key : werkzeug.url_unquote_plus(value)}
+            _, path = rule.build(escaped_args)
             assert path is not None
         except odoo.exceptions.MissingError:
             return cls._handle_exception(werkzeug.exceptions.NotFound())


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

ERR_TOO_MANY_REDIRECTS being generated when visiting https://odoo.com/blog/tag/test+test

This happens due to an unmatched value between `current_path` and `generated_path` the latter one is coming from the build function which URL encodes it so when running url_encode_plus on it the "+" remains there whilst the current path has no plus sign.

These unmatched values result in trying to redirect to the generated path which throws us in a loop of redirects.

    opw-2865670

Current behavior before PR: ERR_TOO_MANY_REDIRECTS


Desired behavior after PR is merged: 404 Page




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
