### PR TITLE
[FIX] web_editor: properly remove img-thumbnail class on media change

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -939,7 +939,7 @@ var IconWidget = SearchableMediaWidget.extend({
      * @override
      */
     _clear: function () {
-        var allFaClasses = /(^|\s)(fa|(text-|bg-|fa-)\S*|rounded-circle|rounded|thumbnail|shadow)(?=\s|$)/g;
+        var allFaClasses = /(^|\s)(fa|(text-|bg-|fa-)\S*|rounded-circle|rounded|thumbnail|img-thumbnail|shadow)(?=\s|$)/g;
         this.media.className = this.media.className && this.media.className.replace(allFaClasses, ' ');
     },
     /**


### PR DESCRIPTION
Following [1], it was discovered that, before this commit, the
img-thumbnail class was properly removed when turning an image into an
icon, document or video but not when turning an icon into an image,
document or video. The working image case actually worked by chance as
we remove all classes starting by img-. The "thumbnail" class was
actually removed instead of the "img-thumbnail" one.

In stable, this fix only adds the "img-thumbnail" class to the list of
classes to remove. In master we will not consider "thumbnail" anymore
and the list of img-* classes will be explicitly used.

[1]: https://github.com/odoo/odoo/pull/95287#pullrequestreview-1031639109
