### PR TITLE
[FIX] project_timesheet_holidays: search timesheet in sudo when employee archived

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -21,11 +21,11 @@ class Employee(models.Model):
         result = super(Employee, self).write(vals)
         if 'active' in vals:
             if vals.get('active'):
-                # Create furtur holiday timesheets
+                # Create future holiday timesheets
                 self._create_future_public_holidays_timesheets(self)
             else:
-                # Delete furtur holiday timesheets
-                future_timesheets = self.env['account.analytic.line'].search([('global_leave_id', '!=', False), ('date', '>=', fields.date.today()), ('employee_id', 'in', self.ids)])
+                # Delete future holiday timesheets
+                future_timesheets = self.env['account.analytic.line'].sudo().search([('global_leave_id', '!=', False), ('date', '>=', fields.date.today()), ('employee_id', 'in', self.ids)])
                 future_timesheets.write({'global_leave_id': False})
                 future_timesheets.unlink()
         return result


### PR DESCRIPTION
Before this commit, when the user archived an employee, the timesheets
generated based on the global time offs planned in the future should
be removed. However, the current user might not have access to the
timesheets app and so an Access Error will occur instead of searching
the timesheets to remove.

This commit adds a sudo to correctly search the timesheets to remove.

X-original-commit: cb51a3e311b98dc6a0b90a75024e772a27fd7958
