### PR TITLE
[ADD] l10n_gcc_invoice_stock_account: SN/LN is not on invoice

### DIFF
--- a/addons/l10n_gcc_invoice_stock_account/__init__.py
+++ b/addons/l10n_gcc_invoice_stock_account/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_gcc_invoice_stock_account/__manifest__.py
+++ b/addons/l10n_gcc_invoice_stock_account/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': "Gulf Cooperation Council WMS Accounting",
+    'version': '1.0',
+    'description': """
+        Arabic/English for GCC + lot/SN numbers
+    """,
+    'author': "Odoo S.A.",
+    'website': "https://www.odoo.com",
+    'category': 'Accounting/Localizations',
+
+    'depends': ['l10n_gcc_invoice', 'stock_account'],
+
+    'data': [
+        'views/report_invoice.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_gcc_invoice_stock_account/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice_stock_account/views/report_invoice.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="arabic_english_invoice_with_snln" inherit_id="l10n_gcc_invoice.arabic_english_invoice">
+        <xpath expr="//div[@id='total']" position="after">
+            <t t-set="lot_values" t-value="o._get_invoiced_lot_values()"/>
+            <t t-if="lot_values">
+                <br/>
+                <table groups="stock_account.group_lot_on_invoice" class="table table-sm" style="width: 50%;" name="invoice_snln_table">
+                    <thead>
+                        <tr>
+                            <th><span>
+                                Product
+                                </span>
+                                <br/>
+                                <span>
+                                 المنتج
+                                </span>
+                            </th>
+                            <th class="text-right">
+                                <span>
+                                    Quantity
+                                </span>
+                                <br/>
+                                <span>
+                                    الكمية
+                                </span>
+                            </th>
+                            <th class="text-right">
+                                <span>
+                                    SN/LN
+                                </span>
+                                <br/>
+                                <span>
+                                    رقم مسلسل\لوط
+                                </span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <t t-foreach="lot_values" t-as="snln_line">
+                            <tr>
+                                <td><t t-esc="snln_line['product_name']"/></td>
+                                <td class="text-right">
+                                    <t t-esc="snln_line['quantity']"/>
+                                    <t t-esc="snln_line['uom_name']" groups="uom.group_uom"/>
+                                </td>
+                                <td class="text-right"><t t-esc="snln_line['lot_name']"/></td>
+                            </tr>
+                        </t>
+                    </tbody>
+                </table>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Steps to reproduce:

1- create a company in saudi arabia
2- install l10n_sa and l10n_gcc_invoice
3- enable LN/SN on invoice from settings
4- configure a product with lot number
5- make a SO with that product
6- create an invoice and post it
7- print the invoice
8- Lot number information is missing on the invoice

Bug:

the implementation in
https://github.com/odoo/odoo/blob/15.0/addons/l10n_gcc_invoice/views/report_invoice.xml#L11-L16
is ignoring the inheritance in
https://github.com/odoo/odoo/blob/15.0/addons/stock_account/views/report_invoice.xml

so any view inheriting "account.report_invoice_document" will
not be called.

For stable, it can be solved with a bridge module.
For Master or for future versions, I think the implementation in
https://github.com/odoo/odoo/blob/15.0/addons/l10n_gcc_invoice/views/report_invoice.xml#L18

should be inheriting "account_report_invoice_document" instead
of overriding it. this will help eliminate the need for such
bridge modules in the future and reduce redundancy

Fix:
Create a bridge module between `l10n_gcc_invoice` and `stock_account`
OPW-2893130