### PR TITLE
[IMP] base: Adding a limit=None argument to search_count(), like sear…

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1867,13 +1867,13 @@ class BaseModel(metaclass=MetaModel):
         return self.get_formview_action(access_uid=access_uid)
 
     @api.model
-    def search_count(self, domain):
+    def search_count(self, domain, limit=None):
         """ search_count(domain) -> int
 
         Returns the number of records in the current model matching :ref:`the
         provided domain <reference/orm/domains>`.
         """
-        res = self.search(domain, count=True)
+        res = self.search(domain, limit=limit, count=True)
         return res if isinstance(res, int) else len(res)
 
     @api.model
@@ -4872,17 +4872,19 @@ class BaseModel(metaclass=MetaModel):
 
         query = self._where_calc(domain)
         self._apply_ir_rules(query, 'read')
+        query.limit = limit
 
         if count:
             # Ignore order, limit and offset when just counting, they don't make sense and could
             # hurt performance
-            query_str, params = query.select("count(*)")
+            query_str, params = query.select(limit and "1" or "count(*)")
+            if limit:
+                query_str = "select count(*) from (" + query_str + ") t"
             self._cr.execute(query_str, params)
             res = self._cr.fetchone()
             return res[0]
 
         query.order = self._generate_order_by(order, query).replace('ORDER BY ', '')
-        query.limit = limit
         query.offset = offset
 
         return query


### PR DESCRIPTION
[IMP] base: Adding a limit=None argument to search_count(), like search()
    
Search count on large tables can be very slow (it takes 4s to search_count the list counter of res.partner on our production DB)
This will allow to display a 10000+ counter for large DBs, if we put a limit. The default is limit=None, like preceding behaviour of search_count: count all records.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
