### PR TITLE
[FIX] portal: fix project sharing  chatter upload file on delete icon

### DIFF
--- a/addons/project/static/src/scss/project_sharing/chatter.scss
+++ b/addons/project/static/src/scss/project_sharing/chatter.scss
@@ -18,6 +18,15 @@
 
                 .o_portal_chatter_attachments {
                     margin-bottom: 1rem;
+                    .o_portal_chatter_attachment {
+                        .o_portal_chatter_attachment_delete {
+                            @include o-position-absolute($top: 0, $right: 0);
+                            opacity: 0;
+                        }
+                        &:hover .o_portal_chatter_attachment_delete {
+                            opacity: 1;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Before this commit : on project sharing chatter upload file delete icon should
be displayed in left bottom corner
After this commit: now on uploaded file the delete icon display in
top right corner of the file and only displayed on hover.

task - 2904015

