### PR TITLE
[FIX] web: missing class on monetary field

### DIFF
--- a/addons/web/static/src/views/fields/monetary/monetary_field.xml
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.MonetaryField" owl="1">
         <span t-if="props.readonly" t-esc="formattedValue" />
-        <div t-else="">
+        <div class="text-nowrap" t-else="">
             <span t-if="!props.hideSymbol and currencyPosition === 'before'" t-out="currencySymbol" />
             <input t-ref="numpadDecimal" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" class="o_input"/>
             <span t-if="!props.hideSymbol and currencyPosition === 'after'" t-out="currencySymbol" />

--- a/addons/web/static/tests/views/fields/monetary_field_tests.js
+++ b/addons/web/static/tests/views/fields/monetary_field_tests.js
@@ -115,6 +115,12 @@ QUnit.module("Fields", (hooks) => {
         );
 
         await clickEdit(target);
+
+        assert.containsOnce(
+            target,
+            ".o_field_monetary > div.text-nowrap",
+            "should have o_horizontal class"
+        );
         assert.strictEqual(
             target.querySelector(".o_field_widget input").value,
             "9.10",


### PR DESCRIPTION
Before this commit, a class was missing when the monetary field was on
edit mode. This results in a non-alignment between the monetary symbol
and the value.