### PR TITLE
[14.0][FIX] in multi warehouse case, purchase order must show the right del…

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -55,7 +55,7 @@ class PurchaseOrder(models.Model):
     @api.onchange('picking_type_id')
     def _onchange_picking_type_id(self):
         if self.picking_type_id.default_location_dest_id.usage != 'customer':
-            self.dest_address_id = False
+            self.dest_address_id = self.picking_type_id.warehouse_id.partner_id
 
     @api.onchange('company_id')
     def _onchange_company_id(self):
@@ -182,7 +182,7 @@ class PurchaseOrder(models.Model):
 
     def _get_destination_location(self):
         self.ensure_one()
-        if self.dest_address_id:
+        if self.dest_address_id and self.dest_address_id != self.picking_type_id.warehouse_id.partner_id:
             return self.dest_address_id.property_stock_customer.id
         return self.picking_type_id.default_location_dest_id.id
 

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -50,7 +50,7 @@
             </xpath>
             <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
                 <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                <field name="dest_address_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('default_location_dest_id_usage', '!=', 'customer')], 'required': [('default_location_dest_id_usage', '=', 'customer')]}"/>
+                <field name="dest_address_id" groups="stock.group_stock_multi_locations" attrs="{'required': [('default_location_dest_id_usage', '=', 'customer')]}"/>
                 <field name="default_location_dest_id_usage" invisible="1"/>
                 <field name="incoterm_id"/>
             </xpath>


### PR DESCRIPTION
…ivery address

Description of the issue/feature this PR addresses:
- setup a database with 2 warehouses
- make a purchase order A to warehouse 1
- make a purchase order B to warehouse 2

Current behavior before PR:
- the vendor has no information for the delivery address on the purchase order pdf report
- actually Odoo only supports dropshipping but not multiwarehouse delivery

Desired behavior after PR is merged:
- purchase order A shows warehouse 1 as delivery address
- purchase order B shows warehouse 2 as delivery address


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
