### PR TITLE
[MERGE][IMP] mail, rating: delay rating request sending

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -445,12 +445,12 @@ class Applicant(models.Model):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
         return super().get_view(view_id, view_type, **options)
 
-    def _notify_get_recipients(self, message, msg_vals):
+    def _notify_get_recipients(self, message, msg_vals, **kwargs):
         """
             Do not notify members of the Recruitment Interviewer group, as this
             might leak some data they shouldn't have access to.
         """
-        recipients = super()._notify_get_recipients(message, msg_vals)
+        recipients = super()._notify_get_recipients(message, msg_vals, **kwargs)
         interviewer_group = self.env.ref('hr_recruitment.group_hr_recruitment_interviewer').id
         return [recipient for recipient in recipients if interviewer_group not in recipient['groups']]
 

--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -148,7 +148,7 @@ class MailChannel(models.Model):
                 'id': message.id,
                 'body': message.body,
             })
-        super()._message_update_content_after_hook(message=message)
+        return super()._message_update_content_after_hook(message=message)
 
     def _get_visitor_leave_message(self, operator=False, cancel=False):
         return _('Visitor has left the conversation.')

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -73,6 +73,7 @@ For more specific needs, you may also assign custom-defined actions
         'views/mail_tracking_views.xml',
         'views/mail_notification_views.xml',
         'views/mail_message_views.xml',
+        'views/mail_message_schedule_views.xml',
         'views/mail_mail_views.xml',
         'views/mail_followers_views.xml',
         'views/mail_ice_server_views.xml',

--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -241,7 +241,13 @@ class DiscussController(http.Controller):
         message_sudo = guest.env['mail.message'].browse(message_id).sudo().exists()
         if not message_sudo.is_current_user_or_guest_author and not guest.env.user._is_admin():
             raise NotFound()
-        message_sudo._update_content(body=body, attachment_ids=attachment_ids)
+        if not message_sudo.model or not message_sudo.res_id:
+            raise NotFound()
+        request.env[message_sudo.model].browse([message_sudo.res_id])._message_update_content(
+            message_sudo,
+            body,
+            attachment_ids=attachment_ids
+        )
         return {
             'id': message_sudo.id,
             'body': message_sudo.body,

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -54,5 +54,16 @@
             <!-- Active flag is set on fetchmail_server.create/write -->
             <field name="active" eval="False"/>
         </record>
+
+        <record id="ir_cron_send_scheduled_message" model="ir.cron">
+            <field name="name">Notification: Send scheduled message notifications</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+            <field name="model_id" ref="model_mail_message_schedule"/>
+            <field name="code">model._send_notifications_cron()</field>
+            <field name="state">code</field>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -24,6 +24,7 @@ from . import mail_blacklist
 from . import mail_followers
 from . import mail_gateway_allowed
 from . import mail_message_reaction
+from . import mail_message_schedule
 from . import mail_message_subtype
 from . import mail_message
 from . import mail_mail

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -498,13 +498,14 @@ class Channel(models.Model):
     # MAILING
     # ------------------------------------------------------------
 
-    def _notify_get_recipients(self, message, msg_vals):
+    def _notify_get_recipients(self, message, msg_vals, **kwargs):
         """ Override recipients computation as channel is not a standard
         mail.thread document. Indeed there are no followers on a channel.
         Instead of followers it has members that should be notified.
 
         :param message: see ``MailThread._notify_get_recipients()``;
         :param msg_vals: see ``MailThread._notify_get_recipients()``;
+        :param kwargs: see ``MailThread._notify_get_recipients()``;
 
         :return recipients: structured data holding recipients data. See
           ``MailThread._notify_thread()`` for more details about its content

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -808,25 +808,6 @@ class Message(models.Model):
         reaction.unlink()
         self.env[self.model].browse(self.res_id)._message_remove_reaction_after_hook(message=self, content=content)
 
-    def _update_content(self, body, attachment_ids):
-        self.ensure_one()
-        thread = self.env[self.model].browse(self.res_id)
-        thread._check_can_update_message_content(self)
-        self.body = body
-        if not attachment_ids:
-            self.attachment_ids._delete_and_notify()
-        else:
-            message_values = {
-                'model': self.model,
-                'body': body,
-                'res_id': self.res_id,
-            }
-            attachement_values = thread._message_post_process_attachments([], attachment_ids, message_values)
-            self.update(attachement_values)
-        # Cleanup related message data if the message is empty
-        self.sudo()._filter_empty()._cleanup_side_records()
-        thread._message_update_content_after_hook(self)
-
     # ------------------------------------------------------
     # MESSAGE READ / FETCH / FAILURE API
     # ------------------------------------------------------

--- a/addons/mail/models/mail_message_schedule.py
+++ b/addons/mail/models/mail_message_schedule.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import logging
+
+from datetime import datetime
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class MailMessageSchedule(models.Model):
+    """ Mail message notification schedule queue.
+
+    This model is used to store the mail messages scheduled. So we can
+    delay the sending of the notifications. A scheduled date field already
+    exists on the <mail.mail> but it does not allow us to delay the sending
+    of the <bus.bus> notifications.
+    """
+    _name = 'mail.message.schedule'
+    _description = 'Scheduled Messages'
+    _order = 'scheduled_datetime DESC, id DESC'
+    _rec_name = 'mail_message_id'
+
+    mail_message_id = fields.Many2one(
+        'mail.message', string='Message',
+        ondelete='cascade', required=True)
+    notification_parameters = fields.Text('Notification Parameter')
+    scheduled_datetime = fields.Datetime(
+        'Scheduled Send Date', required=True,
+        help='Datetime at which notification should be sent.')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        schedules = super().create(vals_list)
+        if schedules:
+            self.env.ref('mail.ir_cron_send_scheduled_message')._trigger_list(
+                set(schedules.mapped('scheduled_datetime'))
+            )
+        return schedules
+
+    @api.model
+    def _send_notifications_cron(self):
+        messages_scheduled = self.env['mail.message.schedule'].search(
+            [('scheduled_datetime', '<=', datetime.utcnow())]
+        )
+        if messages_scheduled:
+            _logger.info('Send %s scheduled messages', len(messages_scheduled))
+            messages_scheduled._send_notifications()
+
+    def force_send(self):
+        """ Launch notification process independently from the expected date. """
+        return self._send_notifications()
+
+    def _send_notifications(self, default_notify_kwargs=None):
+        """ Send notification for scheduled messages.
+
+        :param dict default_notify_kwargs: optional parameters to propagate to
+          ``notify_thread``. Those are default values overridden by content of
+          ``notification_parameters`` field.
+        """
+        for model, schedules in self._group_by_model().items():
+            if model:
+                records = self.env[model].browse(schedules.mapped('mail_message_id.res_id'))
+            else:
+                records = [self.env['mail.thread']] * len(schedules)
+
+            for record, schedule in zip(records, schedules):
+                notify_kwargs = dict(default_notify_kwargs or {}, skip_existing=True)
+                try:
+                    schedule_notify_kwargs = json.loads(schedule.notification_parameters)
+                except Exception:
+                    pass
+                else:
+                    schedule_notify_kwargs.pop('scheduled_date', None)
+                    notify_kwargs.update(schedule_notify_kwargs)
+
+                record._notify_thread(schedule.mail_message_id, msg_vals=False, **notify_kwargs)
+
+        self.unlink()
+        return True
+
+    @api.model
+    def _send_message_notifications(self, messages, default_notify_kwargs=None):
+        """ Send scheduled notification for given messages.
+
+        :param <mail.message> messages: scheduled sending related to those messages
+          will be sent now;
+        :param dict default_notify_kwargs: optional parameters to propagate to
+          ``notify_thread``. Those are default values overridden by content of
+          ``notification_parameters`` field.
+
+        :return bool: False if no schedule has been found, True otherwise
+        """
+        messages_scheduled = self.search(
+            [('mail_message_id', 'in', messages.ids)]
+        )
+        if not messages_scheduled:
+            return False
+
+        messages_scheduled._send_notifications(default_notify_kwargs=default_notify_kwargs)
+        return True
+
+    @api.model
+    def _update_message_scheduled_datetime(self, messages, new_datetime):
+        """ Update scheduled datetime for scheduled sending related to messages.
+
+        :param <mail.message> messages: scheduled sending related to those messages
+          will be updated. Missing one are skipped;
+        :param datetime new_datetime: new datetime for sending. New triggers
+          are created based on it;
+
+        :return bool: False if no schedule has been found, True otherwise
+        """
+        messages_scheduled = self.search(
+            [('mail_message_id', 'in', messages.ids)]
+        )
+        if not messages_scheduled:
+            return False
+
+        messages_scheduled.scheduled_datetime = new_datetime
+        self.env.ref('mail.ir_cron_send_scheduled_message')._trigger(new_datetime)
+        return True
+
+    def _group_by_model(self):
+        grouped = {}
+        for schedule in self:
+            model = schedule.mail_message_id.model if schedule.mail_message_id.model and schedule.mail_message_id.res_id else False
+            if model not in grouped:
+                grouped[model] = schedule
+            else:
+                grouped[model] += schedule
+        return grouped

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -204,6 +204,12 @@ class MailTemplate(models.Model):
                 values = results[res_id]
                 if values.get('body_html'):
                     values['body'] = tools.html_sanitize(values['body_html'])
+                # if asked in fields to return, parse generated date into tz agnostic UTC as expected by ORM
+                scheduled_date = values.pop('scheduled_date', None)
+                if 'scheduled_date' in fields and scheduled_date:
+                    parsed_datetime = self.env['mail.mail']._parse_scheduled_datetime(scheduled_date)
+                    values['scheduled_date'] = parsed_datetime.replace(tzinfo=None) if parsed_datetime else False
+
                 # technical settings
                 values.update(
                     mail_server_id=template.mail_server_id.id or False,

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -4,7 +4,6 @@
 import base64
 import logging
 
-
 from odoo import _, api, fields, models, tools, Command
 from odoo.exceptions import UserError
 from odoo.tools import is_html_empty

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2381,7 +2381,7 @@ class MailThread(models.AbstractModel):
         self.env['bus.bus'].sudo()._sendmany(bus_notifications)
 
     def _notify_thread_by_email(self, message, recipients_data, msg_vals=False,
-                                mail_auto_delete=True, # mail.mail
+                                mail_auto_delete=True,  # mail.mail
                                 model_description=False, force_email_company=False, force_email_lang=False,  # rendering
                                 resend_existing=False, force_send=True, send_after_commit=True,  # email send
                                 **kwargs):

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -3,6 +3,8 @@ access_fetchmail_server,fetchmail.server,model_fetchmail_server,base.group_syste
 access_mail_message_all,mail.message.all,model_mail_message,,1,0,0,0
 access_mail_message_portal,mail.message.portal,model_mail_message,base.group_portal,1,1,1,1
 access_mail_message_user,mail.message.user,model_mail_message,base.group_user,1,1,1,1
+access_mail_message_scheduled_all,mail.message.scheduled.all,model_mail_message_schedule,,0,0,0,0
+access_mail_message_scheduled_system,mail.message.scheduled.system,model_mail_message_schedule,base.group_system,1,1,1,1
 access_mail_mail_all,mail.mail.all,model_mail_mail,,0,0,0,0
 access_mail_mail_portal,mail.mail.portal,model_mail_mail,base.group_portal,0,0,0,0
 access_mail_mail_user,mail.mail.user,model_mail_mail,base.group_user,0,0,0,0

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -722,6 +722,17 @@ class MailCase(MockEmail):
             self.assertEqual(self._new_bus_notifs, found_bus_notifs)
 
     @contextmanager
+    def assertMsgWithoutNotifications(self, mail_unlink_sent=False):
+        try:
+            with self.mock_mail_gateway(mail_unlink_sent=mail_unlink_sent), self.mock_bus(), self.mock_mail_app():
+                yield
+        finally:
+            self.assertTrue(self._new_msgs)
+            self.assertFalse(bool(self._new_notifs))
+            self.assertFalse(bool(self._new_mails))
+            self.assertFalse(bool(self._mails))
+
+    @contextmanager
     def assertNoNotifications(self):
         try:
             with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_bus(), self.mock_mail_app():

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -62,6 +62,11 @@
         parent="mail.mail_menu_technical"
         action="action_view_mail_message"
         sequence="1"/>
+    <menuitem name="Scheduled Messages"
+        id="mail_message_schedule_menu"
+        parent="mail.mail_menu_technical"
+        action="mail_message_schedule_action"
+        sequence="2"/>
     <menuitem name="Subtypes"
         id="menu_message_subtype"
         parent="mail.mail_menu_technical"

--- a/addons/mail/views/mail_message_schedule_views.xml
+++ b/addons/mail/views/mail_message_schedule_views.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<odoo><data>
+    <record id="mail_message_schedule_view_form" model="ir.ui.view">
+        <field name="name">mail.message.schedule.view.form</field>
+        <field name="model">mail.message.schedule</field>
+        <field name="arch" type="xml">
+            <form string="Scheduled Message" duplicate="0">
+                <header>
+                    <button name="force_send" string="Force Send" type="object"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="mail_message_id"/>
+                        <field name="scheduled_datetime"/>
+                    </group>
+                    <group>
+                        <field name="notification_parameters"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="mail_message_schedule_view_tree" model="ir.ui.view">
+        <field name="name">mail.message.schedule.view.tree</field>
+        <field name="model">mail.message.schedule</field>
+        <field name="arch" type="xml">
+            <tree string="Emails">
+                <field name="mail_message_id"/>
+                <field name="scheduled_datetime"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="mail_message_schedule_view_search" model="ir.ui.view">
+        <field name="name">mail.message.schedule.view.search</field>
+        <field name="model">mail.message.schedule</field>
+        <field name="arch" type="xml">
+            <search string="Scheduled Messages">
+                <field name="mail_message_id"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="mail_message_schedule_action" model="ir.actions.act_window">
+        <field name="name">Scheduled Messages</field>
+        <field name="res_model">mail.message.schedule</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{}</field>
+    </record>
+
+</data></odoo>

--- a/addons/mail/wizard/mail_resend_message.py
+++ b/addons/mail/wizard/mail_resend_message.py
@@ -75,7 +75,7 @@ class MailResendMessage(models.TransientModel):
 
                 record._notify_thread_by_email(
                     message, email_partners_data,
-                    check_existing=True,
+                    resend_existing=True,
                     send_after_commit=False
                 )
 

--- a/addons/project/data/mail_template_data.xml
+++ b/addons/project/data/mail_template_data.xml
@@ -56,7 +56,7 @@
             <table border="0" cellpadding="0" cellspacing="0" width="590" summary="o_mail_notification" style="width:100%; margin: 32px 0px 32px 0px;">
                 <tr><td style="font-size: 13px;">
                     <strong>Tell us how you feel about our service</strong><br/>
-                    <span style="text-color: #888888">(click on one of these smileys)</span>
+                    <span style="font-size: 12px; opacity: 0.5; color: #454748;">(click on one of these smileys)</span>
                 </td></tr>
                 <tr><td style="font-size: 13px;">
                     <table style="width:100%;text-align:center;margin-top:2rem;">

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2554,8 +2554,11 @@ class Task(models.Model):
             return self.project_id.partner_id
         return res
 
-    def rating_apply(self, rate, token=None, rating=None, feedback=None, subtype_xmlid=None):
-        rating = super(Task, self).rating_apply(rate, token=token, rating=rating, feedback=feedback, subtype_xmlid=subtype_xmlid)
+    def rating_apply(self, rate, token=None, rating=None, feedback=None,
+                     subtype_xmlid=None, notify_delay_send=False):
+        rating = super(Task, self).rating_apply(
+            rate, token=token, rating=rating, feedback=feedback,
+            subtype_xmlid=subtype_xmlid, notify_delay_send=notify_delay_send)
         if self.stage_id and self.stage_id.auto_validation_kanban_state:
             kanban_state = 'done' if rating.rating >= rating_data.RATING_LIMIT_OK else 'blocked'
             self.write({'kanban_state': kanban_state})

--- a/addons/rating/static/src/scss/rating_templates.scss
+++ b/addons/rating/static/src/scss/rating_templates.scss
@@ -9,21 +9,22 @@
         &:hover {
             transform: scale(1.1);
         }
-        a {
+        img {
             &.bg-white:hover,
             &.bg-white:focus {
                 background-color: #ffffff !important;
             }
         }
-        &.active {
-            filter: drop-shadow(0 0 10px rgba(0,0,0,0.25));
-            -webkit-filter: drop-shadow(0 0 10px rgba(0,0,0,0.25));
-            transform: scale(1.1);
-            a {
-                &.bg-white:hover,
-                &.bg-white:focus {
-                    background-color: #ffffff !important;
-                }
+    }
+
+    .btn-check:checked + .o_rating_label {
+        filter: drop-shadow(0 0 10px rgba(0,0,0,0.25));
+        -webkit-filter: drop-shadow(0 0 10px rgba(0,0,0,0.25));
+        transform: scale(1.1);
+        img {
+            &.bg-white:hover,
+            &.bg-white:focus {
+                background-color: #ffffff !important;
             }
         }
     }

--- a/addons/rating/views/rating_templates.xml
+++ b/addons/rating/views/rating_templates.xml
@@ -23,22 +23,32 @@
                     <div class="row text-center justify-content-center">
                         <h1 class="col-12 mt-5">Thank you for rating our services!</h1>
                         <form class="col-md-6" t-attf-action="/rate/#{token}/submit_feedback" method="post">
-                            <div class="btn-group btn-group-toggle row flex-nowrap justify-content-center w-100 mt-5" data-bs-toggle="buttons">
+                            <div class="btn-group row flex-nowrap justify-content-center w-100 mt-5"
+                                 role="group"
+                                 data-bs-toggle="buttons">
                                 <t t-foreach="rate_names" t-as="rate_name">
-                                    <label t-attf-class="col p-4 btn o_rating_label shadow-none transition-base {{rate == rate_name and 'active' or ''}}">
-                                        <input type="radio" name="rate" t-attf-id="rate_{{rate_name}}" t-att-value="rate_name" t-att-checked="rate == rate_name"/>
-                                        <a class="o_rating d-block bg-white rounded-circle" href="#">
-                                            <img t-attf-src='/rating/static/src/img/rating_#{rate_name}.svg' t-att-alt="rate_name_value" t-att-title="rate_name_value"/>
-                                        </a>
+                                    <input type="radio" name="rate"
+                                           class="btn-check"
+                                           t-attf-id="rate_{{rate_name}}"
+                                           t-att-value="rate_name"
+                                           t-att-checked="rate == rate_name"/>
+                                    <label t-attf-class="col p-4 btn o_rating_label shadow-none transition-base {{rate == rate_name and 'active' or ''}}"
+                                           t-att-for="'rate_%s' % (rate_name)">
+                                        <img t-attf-src='/rating/static/src/img/rating_#{rate_name}.svg'
+                                             t-att-alt="rate_name_value"
+                                             t-att-title="rate_name_value"/>
                                     </label>
                                 </t>
                             </div>
                             <p class="mt-5">
                                 Feel free to write a feedback on your experience:
                             </p>
-                            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                            <textarea class="form-control" name="feedback" rows="8" t-att-value="rating.feedback"></textarea>
-                            <button type="submit" class="btn btn-primary mt-4" style="margin-top:8px;">Send Feedback</button>
+                            <input type="hidden" name="csrf_token"
+                                   t-att-value="request.csrf_token()"/>
+                            <textarea class="form-control" name="feedback" rows="8"
+                                      t-att-value="rating.feedback"></textarea>
+                            <button type="submit" class="btn btn-primary mt-4"
+                                    style="margin-top:8px;">Send Feedback</button>
                         </form>
                     </div>
                 </div>

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -243,7 +243,7 @@ class MailThread(models.AbstractModel):
 
     def _notify_thread_by_sms(self, message, recipients_data, msg_vals=False,
                               sms_numbers=None, sms_pid_to_number=None,
-                              check_existing=False, put_in_queue=False, **kwargs):
+                              resend_existing=False, put_in_queue=False, **kwargs):
         """ Notification method: by SMS.
 
         :param message: ``mail.message`` record to notify;
@@ -266,7 +266,7 @@ class MailThread(models.AbstractModel):
           and classic recipients;
         :param pid_to_number: force a number to notify for a given partner ID
               instead of taking its mobile / phone number;
-        :param check_existing: check for existing notifications to update based on
+        :param resend_existing: check for existing notifications to update based on
           mailed recipient, otherwise create new notifications;
         :param put_in_queue: use cron to send queued SMS instead of sending them
           directly;
@@ -318,7 +318,7 @@ class MailThread(models.AbstractModel):
         if sms_create_vals:
             sms_all |= self.env['sms.sms'].sudo().create(sms_create_vals)
 
-            if check_existing:
+            if resend_existing:
                 existing = self.env['mail.notification'].sudo().search([
                     '|', ('res_partner_id', 'in', partner_ids),
                     '&', ('res_partner_id', '=', False), ('sms_number', 'in', sms_numbers),

--- a/addons/sms/wizard/sms_resend.py
+++ b/addons/sms/wizard/sms_resend.py
@@ -99,7 +99,7 @@ class SMSResend(models.TransientModel):
                 record._notify_thread_by_sms(
                     self.mail_message_id, recipients_data,
                     sms_numbers=numbers, sms_pid_to_number=sms_pid_to_number,
-                    check_existing=True, put_in_queue=False
+                    resend_existing=True, put_in_queue=False
                 )
 
         self.mail_message_id._notify_message_notification_update()

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -231,7 +231,7 @@ class TestMailMail(TestMailCommon):
             (now + timedelta(hours=-3)).strftime("%H:%M:%S %d-%m-%Y") + " -0400",
         ]
         expected_datetimes = [
-            False, '', False,
+            False, False, False,
             now, now - pytz.timezone('Australia/Brisbane').utcoffset(now),
             now - timedelta(days=1), now + timedelta(days=1), now + timedelta(days=1),
             now + timedelta(hours=-1),
@@ -253,9 +253,8 @@ class TestMailMail(TestMailCommon):
         ])
 
         for mail, expected_datetime, scheduled_datetime in zip(mails, expected_datetimes, scheduled_datetimes):
-            expected = expected_datetime.strftime(tools.DEFAULT_SERVER_DATETIME_FORMAT) if expected_datetime else expected_datetime
-            self.assertEqual(mail.scheduled_date, expected,
-                             'Scheduled date: %s should be stored as %s, received %s' % (scheduled_datetime, expected, mail.scheduled_date))
+            self.assertEqual(mail.scheduled_date, expected_datetime,
+                             'Scheduled date: %s should be stored as %s, received %s' % (scheduled_datetime, expected_datetime, mail.scheduled_date))
             self.assertEqual(mail.state, 'outgoing')
 
         with freeze_time(now):

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -65,13 +65,13 @@ class TestMessageValues(TestMailCommon):
         self.assertFalse(message.sudo().tracking_value_ids)
 
         # Reset body case
-        message._update_content('<p><br /></p>', attachment_ids=message.attachment_ids.ids)
+        record._message_update_content(message, '<p><br /></p>', attachment_ids=message.attachment_ids.ids)
         self.assertTrue(is_html_empty(message.body))
         self.assertFalse(message.sudo()._filter_empty(), 'Still having attachments')
 
         # Subtype content
         note_subtype.write({'description': 'Very important discussions'})
-        message._update_content('', None)
+        record._message_update_content(message, '', [])
         self.assertFalse(message.attachment_ids)
         self.assertEqual(message.notified_partner_ids, self.partner_admin)
         self.assertEqual(message.starred_partner_ids, self.partner_admin)
@@ -80,7 +80,7 @@ class TestMessageValues(TestMailCommon):
         # Completely void now
         note_subtype.write({'description': ''})
         self.assertEqual(message.sudo()._filter_empty(), message)
-        message._update_content('', None)
+        record._message_update_content(message, '', [])
         self.assertFalse(message.notified_partner_ids)
         self.assertFalse(message.starred_partner_ids)
 
@@ -93,7 +93,7 @@ class TestMessageValues(TestMailCommon):
         self.assertFalse(tracking_message.subtype_id.description)
         self.assertFalse(tracking_message.sudo()._filter_empty(), 'Has tracking values')
         with self.assertRaises(UserError, msg='Tracking values prevent from updating content'):
-            tracking_message._update_content('', None)
+            record._message_update_content(tracking_message, '', [])
 
     @mute_logger('odoo.models.unlink')
     def test_mail_message_format(self):

--- a/addons/test_mail/tests/test_mail_template_preview.py
+++ b/addons/test_mail/tests/test_mail_template_preview.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.test_mail.tests.test_mail_template import TestMailTemplate
+from odoo.addons.test_mail.tests.test_mail_template import TestMailTemplateCommon
 from odoo.tests import tagged
 
 
-@tagged('mail_template')
-class TestMailTemplateTools(TestMailTemplate):
+@tagged('mail_template', 'multi_lang')
+class TestMailTemplateTools(TestMailTemplateCommon):
 
     def test_mail_template_preview_force_lang(self):
         test_record = self.env['mail.test.lang'].browse(self.test_record.ids)

--- a/addons/test_mail_sms/tests/test_sms_post.py
+++ b/addons/test_mail_sms/tests/test_sms_post.py
@@ -32,7 +32,7 @@ class TestSMSPost(TestSMSCommon, TestSMSRecipients):
         self.assertEqual(messages.subtype_id, self.env.ref('mail.mt_note'))
         self.assertSMSNotification([{'partner': self.partner_1}], 'Mega SMS\nTop moumoutte', messages)
 
-    def test_message_sms_internals_check_existing(self):
+    def test_message_sms_internals_resend_existingd(self):
         with self.with_user('employee'), self.mockSMSGateway(sim_error='wrong_number_format'):
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)
             messages = test_record._message_sms(self._test_body, partner_ids=self.partner_1.ids)
@@ -41,7 +41,7 @@ class TestSMSPost(TestSMSCommon, TestSMSRecipients):
 
         with self.with_user('employee'), self.mockSMSGateway():
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)
-            test_record._notify_thread_by_sms(messages, [{'id': self.partner_1.id, 'notif': 'sms'}], check_existing=True)
+            test_record._notify_thread_by_sms(messages, [{'id': self.partner_1.id, 'notif': 'sms'}], resend_existing=True)
         self.assertSMSNotification([{'partner': self.partner_1}], self._test_body, messages)
 
     def test_message_sms_internals_sms_numbers(self):


### PR DESCRIPTION
FUNCTIONAL ISSUE

When they receive a rating request email, customers can click on this email to
pick a satisfaction level. However, this feedback is currently effectively
posted only when customers submit the feedback form.

Many customers do not go that far in the process and just close that form. This
means that while the feedback is caught and stored in DB nothing is posted and
users are not notified of this rating.


PURPOSE

When the customer clicks on an emoji, post a message in the chatter without
launching notifications. After 2 hours notify followers. If before this delay
the customer fills in the form, update the post content (new face, feedback)
and launch notification process with the feedback (inbox, emails, ...).

By default, the user has 2 hours to fill the feedback, after those 2 hours
we notify the message containing only the first rating without feedback.

TECHNICAL

Currently, rating from email (route with token) is the following

  * Customer receives an email;
  * Customer clicks one of the smiley face that redirects to a ``/rate`` route
    with the token and rate value;
  * the linked ``rating.rating`` record is updated and set consumed;
  * Customer may change its face and add a feedback. In that case a message
    is posted with the rating face in it;

Issues raised by this

  * first rating update does not notify anyone, no message is posted;
  * if Customer does not give a feedback, process is stuck at that point;
  * the rating is not really linked to the posted message (see ``message_id``
    field of ``rating`` record);

Fix that issue to have message directly at beginning of the flow and improve
log and notifications. Update ``rating_apply`` to post the message and update
it when feedback is given.

Allow to delay sending of notifications using a ``mail.message.schedule``
queue model that stores when to launch the notification process for a given
message.

See sub commits for more details.

LINKS

Task-2826699 (Mail: use datetime for scheduled_date mail field instead of char)
Task-2207626 (Rating: Log ratings, post feedbacks)