### PR TITLE
[PERF] web: speed up pager total counter for large DB

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -66,7 +66,7 @@ class Base(models.AbstractModel):
                 'records': []
             }
         if limit and (len(records) == limit or self.env.context.get('force_search_count')):
-            length = self.search_count(domain)
+            length = self.search_count(domain, limit=10000)
         else:
             length = len(records) + offset
         return {

--- a/addons/web/static/src/core/pager/pager.js
+++ b/addons/web/static/src/core/pager/pager.js
@@ -60,7 +60,7 @@ export class Pager extends Component {
      * Recompute total number of records, if we were at the limit of 10000
      */
     async updateCounter() {
-        if (this.state.total == 10000) {
+        if (this.state.total === 10000) {
             this.state.total = await this.env.searchModel.getSearchCount();
         }
     }

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -12,7 +12,7 @@
                 </t>
                 <span> / </span>
                 <t t-if="state.total == 10000">
-                    <span class="o_pager_limit" t-on-click.stop="() => this.updateCounter()">10000+</span>
+                    <span class="o_pager_limit o_pager_limit_fetch" t-on-click.stop="() => this.updateCounter()">10000+</span>
                 </t>
                 <t t-else="">
                     <span class="o_pager_limit" t-esc="state.total"/>

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -11,7 +11,12 @@
                     <span class="o_pager_value d-inline-block border-bottom border-white" t-esc="value" t-on-click="onValueClick" />
                 </t>
                 <span> / </span>
-                <span class="o_pager_limit" t-esc="props.total" />
+                <t t-if="state.total == 10000">
+                    <span class="o_pager_limit" t-on-click.stop="() => this.updateCounter()">10000+</span>
+                </t>
+                <t t-else="">
+                    <span class="o_pager_limit" t-esc="state.total"/>
+                </t>
             </span>
             <span class="btn-group" aria-atomic="true">
                 <!-- accesskeys not wanted in X2Many widgets -->

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -78,6 +78,10 @@
             padding-left: 5px;
             text-align: center;
             user-select: none;
+
+            .o_pager_limit_fetch, .o_pager_value {
+                cursor: pointer;
+            }
         }
 
         > .o_cp_switch_buttons {

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -779,7 +779,12 @@ export class SearchModel extends EventBus {
         }
         return searchItems;
     }
-
+    /**
+     * Returns the total (unbounded) number of records in the domain
+     */
+    async getSearchCount() {
+        return await this.orm.call(this.resModel, "search_count", [this._getDomain()]);
+    }
     /**
      * Returns a sorted list of a copy of all sections. This list can be
      * filtered by a given predicate.

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1867,13 +1867,13 @@ class BaseModel(metaclass=MetaModel):
         return self.get_formview_action(access_uid=access_uid)
 
     @api.model
-    def search_count(self, domain):
+    def search_count(self, domain, limit=None):
         """ search_count(domain) -> int
 
         Returns the number of records in the current model matching :ref:`the
         provided domain <reference/orm/domains>`.
         """
-        res = self.search(domain, count=True)
+        res = self.search(domain, limit=limit, count=True)
         return res if isinstance(res, int) else len(res)
 
     @api.model
@@ -4872,17 +4872,19 @@ class BaseModel(metaclass=MetaModel):
 
         query = self._where_calc(domain)
         self._apply_ir_rules(query, 'read')
+        query.limit = limit
 
         if count:
             # Ignore order, limit and offset when just counting, they don't make sense and could
             # hurt performance
-            query_str, params = query.select("count(*)")
+            query_str, params = query.select(limit and "1" or "count(*)")
+            if limit:
+                query_str = "select count(*) from (" + query_str + ") t"
             self._cr.execute(query_str, params)
             res = self._cr.fetchone()
             return res[0]
 
         query.order = self._generate_order_by(order, query).replace('ORDER BY ', '')
-        query.limit = limit
         query.offset = offset
 
         return query


### PR DESCRIPTION
  
Doing a `search_count` on millions of records could be very slow. On
large databases, the pager counter "1-80 / 8000000" could take several
seconds just to get the total number of records.
    
This commit limits the counter to 10k records, and show this if it
happens: "1-80 / 10000+". If you click on 10000+, it updates with the
real count (or if you go up to 10000 with pager or input value).
 
The search_count on res.partner of odoo.com takes 4s. With this patch,
it will take ~20ms.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
