### PR TITLE
[FIX/IMP] crm: allow more specific lead default company

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -301,14 +301,15 @@ class Lead(models.Model):
                    (not lead.partner_id or lead.partner_id.company_id != proposal):
                     proposal = False
 
-            # propose a new company based on responsible, limited by team
+            # propose a new company based on team > user (respecting context) > partner
             if not proposal:
-                if lead.user_id and lead.team_id.company_id:
+                if lead.team_id.company_id:
                     proposal = lead.team_id.company_id
                 elif lead.user_id:
-                    proposal = lead.user_id.company_id & self.env.companies
-                elif lead.team_id:
-                    proposal = lead.team_id.company_id
+                    if self.env.company in lead.user_id.company_ids:
+                        proposal = self.env.company
+                    else:
+                        proposal = lead.user_id.company_id & self.env.companies
                 elif lead.partner_id:
                     proposal = lead.partner_id.company_id
                 else:


### PR DESCRIPTION
# Purpose

Take into account the current company when creating a new lead if not defined
earlier.

# Specifications

If there is no company provided by the sales team and the user belongs
to several companies and several companies are allowed by context,
we preferentially take the current company over the user's company if allowed.

# Additional considerations

This commit
* builds on the multi-company fix brought by e5f35a60 avoiding the restricted
access error when setting to the user's base company if not allowed by context,
but will also allow to first preferentially use the current company instead of None.
* completes tests

Task-2824913
See earlier discussion on #90053
