### PR TITLE
[FIX] mail: fix error on grouping in kanban view

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -764,6 +764,11 @@ class MailActivityMixin(models.AbstractModel):
         ]
         from_clause, where_clause, where_params = query.get_sql()
         tz = self._context.get('tz') or self.env.user.tz or 'UTC'
+        if "," in from_clause:
+            # Grouping by inherited fields is not supported in v13
+            # See https://github.com/odoo/odoo/issues/92731
+            return []
+
         select_query = """
             SELECT 1 AS id, count(*) AS "__count", {fields}
             FROM {from_clause}


### PR DESCRIPTION
On grouping in kanban view, Odoo fetches mail activity information for the
groups. The corresponding method `_read_progress_bar` constructs sql query based
on a query generated by ORM. It was found, that resulted query might be not
valid for models inherited from another.

As a quick fix, this commit just
disables fetching activity information in such cases.

The problem is not reproducible in v14+

STEPS:

* Go to Sales > Products > Product Variants > Kanban View
* clear filters from search bar
* try to group by a field that is stored in product.product, e.g. group by `active`

close #92731
opw-2870937

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
