### PR TITLE
[IMP] sale_(project),hr_timesheet: generic UX improvement for project

### DIFF
--- a/addons/hr_timesheet/views/project_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_sharing_views.xml
@@ -21,15 +21,14 @@
                     <group>
                         <group>
                             <div class="o_td_label">
-                                <label for="planned_hours" string="Initially Planned Hours" attrs="{'invisible': [('encode_uom_in_days', '=', True)]}"/>
-                                <label for="planned_hours" string="Initially Planned Days" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
+                                <label for="planned_hours" string="Allocated Hours" class="me-2" attrs="{'invisible': [('encode_uom_in_days', '=', True)]}"/>
+                                <label for="planned_hours" string="Allocated Days" class="me-2" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
+                                <field name="planned_hours" class="oe_inline" widget="timesheet_uom_no_toggle"/>
+                                <span attrs="{'invisible': ['|', ('allow_subtasks', '=', False), ('subtask_count', '=', 0)]}">
+                                    (incl. <field name="subtask_planned_hours" nolabel="1" groups="project.group_subtask_project" widget="timesheet_uom_no_toggle"/> on
+                                    <span class="fw-bold text-dark"> Sub-tasks</span>)
+                                </span>
                             </div>
-                            <field name="planned_hours" widget="timesheet_uom_no_toggle" nolabel="1"/>
-                            <div class="o_td_label" attrs="{'invisible': ['|', ('allow_subtasks', '=', False), ('subtask_count', '=', 0)]}">
-                                <label for="subtask_planned_hours" string="Sub-tasks Planned Hours" attrs="{'invisible': [('encode_uom_in_days', '=', True)]}"/>
-                                <label for="subtask_planned_hours" string="Sub-tasks Planned Days" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
-                            </div>
-                            <field name="subtask_planned_hours" widget="timesheet_uom_no_toggle" nolabel="1" attrs="{'invisible': ['|', ('allow_subtasks', '=', False), ('subtask_count', '=', 0)]}"/>
                         </group>
                         <group>
                             <field name="progress" widget="progressbar"/>
@@ -82,9 +81,9 @@
                                 <label class="fw-bold" for="effective_hours" string="Days Spent" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
                             </span>
                             <field name="effective_hours" widget="timesheet_uom" nolabel="1"/>
-                            <button name="action_view_subtask_timesheet" type="object" class="o_td_label o_form_label o_form_subtask_button oe_inline oe_link me-0" attrs="{'invisible' : ['|', ('allow_subtasks', '=', False), ('subtask_effective_hours', '=', 0.0)]}">
-                                <span class="text-nowrap" attrs="{'invisible' : [('encode_uom_in_days', '=', True)]}">Sub-tasks Hours Spent</span>
-                                <span class="text-nowrap" attrs="{'invisible' : [('encode_uom_in_days', '=', False)]}">Sub-tasks Days Spent</span>
+                            <button name="action_view_subtask_timesheet" type="object" class="o_form_subtask_button oe_inline oe_link mb-2" attrs="{'invisible' : ['|', ('allow_subtasks', '=', False), ('subtask_effective_hours', '=', 0.0)]}">
+                                <span class="text-nowrap" attrs="{'invisible' : [('encode_uom_in_days', '=', True)]}">Hours Spent on Sub-tasks:</span>
+                                <span class="text-nowrap" attrs="{'invisible' : [('encode_uom_in_days', '=', False)]}">Days Spent on Sub-tasks:</span>
                             </button>
                             <field name="subtask_effective_hours" class="mt-2" widget="timesheet_uom"
                                   attrs="{'invisible' : ['|', ('allow_subtasks', '=', False), ('subtask_effective_hours', '=', 0.0)]}" nolabel="1"/>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2005,8 +2005,7 @@ class Task(models.Model):
         if 'parent_id' in vals and vals['parent_id'] in self.ids:
             raise UserError(_("Sorry. You can't set a task as its parent task."))
         if 'active' in vals and not vals.get('active') and any(self.mapped('recurrence_id')):
-            # TODO: show a dialog to stop the recurrence
-            raise UserError(_('You cannot archive recurring tasks. Please disable the recurrence first.'))
+            vals['recurring_task'] = False
         if 'recurrence_id' in vals and vals.get('recurrence_id') and any(not task.active for task in self):
             raise UserError(_('Archived tasks cannot be recurring. Please unarchive the task first.'))
         # stage change: update date_last_stage_update

--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -6,13 +6,13 @@
         <field name="model">project.task.burndown.chart.report</field>
         <field name="arch" type="xml">
             <search string="Burndown Chart">
+                <field name="stage_id" />
                 <field name="project_id" />
                 <field name="user_ids" />
                 <field name="milestone_id" groups="project.group_project_milestone"/>
                 <field name="date_assign"/>
                 <field name="date_deadline"/>
                 <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
-                <field name="stage_id" />
                 <separator/>
                 <filter name="filter_date" date="date" string="Date" default_period="this_year,last_year" />
                 <filter name="filter_date_deadline" date="date_deadline"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -45,6 +45,7 @@
                     <filter string="Not Blocking" name="not_blocking" domain="['|', ('is_closed', '=', True), ('dependent_ids', '=', False), ('is_private', '=', False)]" groups="project.group_project_task_dependencies"/>
                     <separator groups="project.group_project_task_dependencies"/>
                     <filter string="Late Tasks" name="late" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d')), ('is_closed', '=', False)]"/>
+                    <filter string="Stalling for 30 Days+" name="stall_last_30_days" domain="[('is_closed', '=', False), ('date_last_stage_update', '&lt;=', datetime.datetime.now() - relativedelta(days=30))]"/>
                     <separator/>
                     <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', False)]"/>
                     <filter string="Closed Tasks" name="closed_tasks" domain="[('is_closed', '=', True)]"/>
@@ -1679,7 +1680,7 @@
             <field name="name">My Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
-            <field name="context">{'search_default_my_tasks': 1, 'all_task': 0, 'default_user_ids': [(4, uid)]}</field>
+            <field name="context">{'search_default_my_tasks': 1, 'search_default_open_tasks': 1, 'all_task': 0, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form_extended"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -194,7 +194,7 @@
                             <label class="fw-bold text-danger" for="remaining_hours_so" string="Remaining Days on SO"
                                 attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&gt;=', 0)]}"/>
                         </span>
-                        <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}"></field>
+                        <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}" decoration-danger="remaining_hours_so &lt; 0"></field>
                     </t>
                 </xpath>
             </field>


### PR DESCRIPTION
Purpose of this commit to improve generic usage of project app.

So in this commit done following changes:
- apply the 'open tasks' filter by default for my task menu
- the search view set  the one from accounting and not timesheet for
  gross margin stat button
- add a 'stalling for 30 days+' filter that should return open tasks whose
  last stage update was more than 30 days ago  for project task form view
- move the 'stage' quicksearch above the 'project' one for burndown chart
- when archiving a project containing tasks that are recurrent, disable their recurrence instead of
  raising an error
- format some field in timesheets notebook in project sharing
- display the 'rating email template' field by default for task stages

task-2899490