### PR TITLE
[FIX] website_sale, website_sale_wishlist: fix and unify warnings box

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -317,21 +317,10 @@ publicWidget.registry.WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             if (!data.cart_quantity) {
                 return window.location = '/shop/cart';
             }
-            wSaleUtils.updateCartNavBar(data);
             $input.val(data.quantity);
-            $('.js_quantity[data-line-id='+line_id+']').val(data.quantity).html(data.quantity);
 
-            if (data.warning) {
-                var cart_alert = $('.oe_cart').parent().find('#data_warning');
-                if (cart_alert.length === 0) {
-                    $('.oe_cart').prepend('<div class="alert alert-danger alert-dismissable" role="alert" id="data_warning">'+
-                            '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button> ' + data.warning + '</div>');
-                }
-                else {
-                    cart_alert.html('<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button> ' + data.warning);
-                }
-                $input.val(data.quantity);
-            }
+            wSaleUtils.updateCartNavBar(data);
+            wSaleUtils.showWarning(data.warning);
         });
     },
     /**

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -60,19 +60,44 @@ function animateClone($cart, $elem, offsetTop, offsetLeft) {
  * @param {Object} data
  */
 function updateCartNavBar(data) {
-    var $qtyNavBar = $(".my_cart_quantity");
-    _.each($qtyNavBar, function (qty) {
-        var $qty = $(qty);
-        $qty.parents('li:first').removeClass('d-none');
-        $qty.html(data.cart_quantity).hide().fadeIn(600);
-    });
+    $(".my_cart_quantity")
+        .parents('li.o_wsale_my_cart').removeClass('d-none').end()
+        .toggleClass('fa fa-warning', !data.cart_quantity)
+        .attr('title', data.warning)
+        .text(data.cart_quantity || '')
+        .hide()
+        .fadeIn(600);
+
     $(".js_cart_lines").first().before(data['website_sale.cart_lines']).end().remove();
     $(".js_cart_summary").first().before(data['website_sale.short_cart_summary']).end().remove();
+}
+
+/**
+ * Displays `message` in an alert box at the top of the page if it's a
+ * non-empty string.
+ *
+ * @param {string | null} message
+ */
+function showWarning(message) {
+    if (!message) {
+        return;
+    }
+    var $page = $('.oe_website_sale');
+    var cart_alert = $page.children('#data_warning');
+    if (!cart_alert.length) {
+        cart_alert = $(
+            '<div class="alert alert-danger alert-dismissible" role="alert" id="data_warning">' +
+                '<button type="button" class="close" data-dismiss="alert">&times;</button> ' +
+                '<span></span>' +
+            '</div>').prependTo($page);
+    }
+    cart_alert.children('span:last-child').text(message);
 }
 
 return {
     animateClone: animateClone,
     getNavBarButton: getNavBarButton,
     updateCartNavBar: updateCartNavBar,
+    showWarning: showWarning,
 };
 });

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -178,15 +178,9 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
                 add_qty: parseInt(qty_id, 10),
                 display: false,
             },
-        }).then(function (resp) {
-            if (resp.warning) {
-                if (! $('#data_warning').length) {
-                    $('.wishlist-section').prepend('<div class="mt16 alert alert-danger alert-dismissable" role="alert" id="data_warning"></div>');
-                }
-                var cart_alert = $('.wishlist-section').parent().find('#data_warning');
-                cart_alert.html('<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button> ' + resp.warning);
-            }
-            $('.my_cart_quantity').html(resp.cart_quantity || '<i class="fa fa-warning" /> ');
+        }).then(function (data) {
+            wSaleUtils.updateCartNavBar(data);
+            wSaleUtils.showWarning(data.warning);
         });
     },
     /**


### PR DESCRIPTION
The two modules both implemented the cart update warnings box
incorrectly, and differently (though in part because of later
changes):

- `aria-hidden` has meant `display: none` for a while, so the dismiss
  button would never show up
- the class is alert-dismiss*i*ble, not alert-dismiss*a*ble
- unnecessarily complicated dom manipulation on updating the warning
- wishlist would go and update the cart badge by hand, unnecessarily

Extracted the warnings stuff to its own helper, with a fixed DOM, and
a slightly modified structure so it's possible to update the message
without having to rewrite the entire box content.

Also modified wishlist to update the cart badge via the existing
helper, this way both modules just call

    updateCartNavBar(data);
    showWarning(data.warning);

the same way in the same order, and everything is clear.

Also simplified `updateCartNavBar` a bit:

- removed the iteration as it seems unnecessary
- removed the visibility change on the list item as it also seems
  unnecessary
