### PR TITLE
[FIX] website_sale: time to unlink order.line

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -365,7 +365,7 @@ class SaleOrderLine(models.Model):
 
     name_short = fields.Char(compute="_compute_name_short")
 
-    linked_line_id = fields.Many2one('sale.order.line', string='Linked Order Line', domain="[('order_id', '=', order_id)]", ondelete='cascade', copy=False)
+    linked_line_id = fields.Many2one('sale.order.line', string='Linked Order Line', domain="[('order_id', '=', order_id)]", ondelete='cascade', copy=False, index=True)
     option_line_ids = fields.One2many('sale.order.line', 'linked_line_id', string='Options Linked')
 
     def get_sale_order_line_multiline_description_sale(self, product):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this commit, in large database the time to unlink is very long.
Before 500 ms after a few ms



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
