### PR TITLE
[IMP] core: improve search count with a limit

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1144,11 +1144,24 @@ class TestQueries(TransactionCase):
         Model.search([('name', 'like', 'foo')])
 
         with self.assertQueries(['''
-            SELECT count(*)
+            SELECT COUNT(*)
             FROM "res_partner"
             WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
         ''']):
             Model.search_count([('name', 'like', 'foo')])
+
+    def test_count_limit(self):
+        Model = self.env['res.partner']
+        Model.search([('name', 'like', 'foo')])
+
+        with self.assertQueries(['''
+            SELECT COUNT(*) FROM (
+                SELECT FROM "res_partner"
+                WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
+                LIMIT 1
+            ) t
+        ''']):
+            Model.search_count([('name', 'like', 'foo')], limit=1)
 
     def test_translated_field(self):
         self.env['res.lang']._activate_lang('fr_FR')

--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -192,3 +192,18 @@ class test_search(TransactionCase):
         })
         cc_search = model_bank.search([('name', '=', 'Crédit Communal')])
         self.assertNotIn(bank_credit_communal, cc_search, "Search for inactive record with x_active set to True has failed")
+
+    def test_21_search_count(self):
+        Partner = self.env['res.partner']
+        count_partner_before = Partner.search_count([])
+        partners = Partner.create([
+            {'name': 'abc'},
+            {'name': 'zer'},
+            {'name': 'christope'},
+            {'name': 'runbot'},
+        ])
+        self.assertEqual(len(partners) + count_partner_before, Partner.search_count([]))
+        self.assertEqual(len(partners) + count_partner_before, Partner.search([], count=True))
+
+        self.assertEqual(3, Partner.search_count([], limit=3))
+        self.assertEqual(3, Partner.search([], count=True, limit=3))


### PR DESCRIPTION
The new feature (search count with limit) introduced by https://github.com/odoo/odoo/pull/95589 lacks of test and code readability:
- Add tests to check the result and query generate
- Increase the readability of SQL/python code.
- Change a little bit the SQL request generate: in the subquery, change `SELECT 1 FROM...` into `SELECT  FROM` which avoid extra work in the postgreSQL side (-+ 3% faster on my machine).

task-2761165