### PR TITLE
[FIX] point_of_sale: automatically create new order

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -233,6 +233,16 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
         }
         //#endregion
         //#region PUBLIC METHODS
+        close() {
+            /**
+             * Automatically create new order when there is no currently active order.
+             * Important in fiscal modules to keep the sequence of the orders.
+             */
+            if (this.env.pos.orders.length == 0) {
+                this.env.pos.add_new_order();
+            }
+            super.close();
+        }
         getSelectedSyncedOrder() {
             if (this._state.ui.filter == 'SYNCED') {
                 return this._state.syncedOrders.cache[this._state.ui.selectedSyncedOrderId];


### PR DESCRIPTION
When in point_of_sale, the screen when getting out of the TicketScreen
is the current order's screen. However, when all the orders are deleted,
no new order is created, thus, pos crashes when clicking back button without
manually creating a new order. With this fix, when the TicketScreen is
closed (either by clicking an order, or clicking the TicketButton or
clicking Back button), a new order is automatically created when there
are no more orders. The sequence of the orders is also properly tracked
which is important in the fiscal data modules.

TASK-ID: 2886099

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
