### PR TITLE
[FIX] web: convert python/js bool values in read_progress_bar

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -349,8 +349,14 @@ var KanbanModel = BasicModel.extend({
             var data = results[1];
             _.each(list.data, function (groupID) {
                 var group = self.localData[groupID];
+                var value = group.value;
+                if (value === true) {
+                    value = "True";
+                } else if (value === false) {
+                    value = "False";
+                }
                 group.progressBarValues = _.extend({
-                    counts: data[group.value] || {},
+                    counts: data[value] || {},
                 }, list.progressBar);
             });
             return list;

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1056,6 +1056,15 @@ var MockServer = Class.extend({
         _.each(records, function (record) {
             var groupByValue = record[groupBy]; // always technical value here
 
+            // special case for bool values: rpc call response with capitalized strings
+            if (!(groupByValue in data)) {
+                if (groupByValue === true) {
+                    groupByValue = "True";
+                } else if (groupByValue === false) {
+                    groupByValue = "False";
+                }
+            }
+
             if (!(groupByValue in data)) {
                 data[groupByValue] = {};
                 _.each(progress_bar.colors, function (val, key) {


### PR DESCRIPTION
Because of an issue with converting bool values, read_progress_bar didn't work
on grouping by bool fields (e.g. Active).

Related tests worked fine because mocked server responses were different from
real server responsed. So, we need to adjust mocked server too.

opw-2870937