### PR TITLE
[FIX] hr_contract_salary: Fix email in simulation link.

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -432,6 +432,12 @@ class HrEmployeePrivate(models.Model):
         for employee in self:
             employee.barcode = '041'+"".join(choice(digits) for i in range(9))
 
+    @api.depends('address_home_id', 'user_partner_id')
+    def _compute_related_contacts(self):
+        super()._compute_related_contacts()
+        for employee in self:
+            employee.related_contact_ids |= employee.address_home_id | employee.user_partner_id
+
     @api.depends('address_home_id.parent_id')
     def _compute_is_address_home_a_company(self):
         """Checks that chosen address (res.partner) is not linked to a company.

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -28,8 +28,11 @@ class HrEmployeeBase(models.AbstractModel):
     address_id = fields.Many2one('res.partner', 'Work Address', compute="_compute_address_id", store=True, readonly=False,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     work_phone = fields.Char('Work Phone', compute="_compute_phones", store=True, readonly=False)
-    mobile_phone = fields.Char('Work Mobile')
-    work_email = fields.Char('Work Email')
+    mobile_phone = fields.Char('Work Mobile', compute="_compute_work_contact_details", store=True, inverse='_inverse_work_contact_details')
+    work_email = fields.Char('Work Email', compute="_compute_work_contact_details", store=True, inverse='_inverse_work_contact_details')
+    work_contact_id = fields.Many2one('res.partner', 'Work Contact')
+    related_contact_ids = fields.Many2many('res.partner', 'Related Contacts', compute='_compute_related_contacts')
+    related_contacts_count = fields.Integer('Number of related contacts', compute='_compute_related_contacts_count')
     work_location_id = fields.Many2one('hr.work.location', 'Work Location', compute="_compute_work_location_id", store=True, readonly=False,
     domain="[('address_id', '=', address_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     user_id = fields.Many2one('res.users')
@@ -155,6 +158,49 @@ class HrEmployeeBase(models.AbstractModel):
                 employee.work_phone = employee.address_id.phone
             else:
                 employee.work_phone = False
+
+    @api.depends('work_contact_id', 'work_contact_id.mobile', 'work_contact_id.email')
+    def _compute_work_contact_details(self):
+        for employee in self:
+            if employee.work_contact_id:
+                employee.mobile_phone = employee.work_contact_id.mobile
+                employee.work_email = employee.work_contact_id.email
+
+    def _inverse_work_contact_details(self):
+        for employee in self:
+            if not employee.work_contact_id:
+                employee.work_contact_id = self.env['res.partner'].sudo().create({
+                    'email': employee.work_email,
+                    'mobile': employee.mobile_phone,
+                    'name': employee.name,
+                    'image_1920': employee.image_1920,
+                    'company_id': employee.company_id.id
+                })
+            else:
+                employee.work_contact_id.sudo().write({
+                    'email': employee.work_email,
+                    'mobile': employee.mobile_phone,
+                })
+
+    @api.depends('work_contact_id')
+    def _compute_related_contacts(self):
+        for employee in self:
+            employee.related_contact_ids = employee.work_contact_id
+
+    @api.depends('related_contact_ids')
+    def _compute_related_contacts_count(self):
+        for employee in self:
+            employee.related_contacts_count = len(employee.related_contact_ids)
+
+    def action_related_contacts(self):
+        self.ensure_one()
+        return {
+            'name': _("Related Contacts"),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'kanban,tree,form',
+            'res_model': 'res.partner',
+            'domain': [('id', 'in', self.related_contact_ids.ids)]
+        }
 
     @api.depends('company_id')
     def _compute_address_id(self):

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -24,6 +24,8 @@ class HrEmployeePublic(models.Model):
     mobile_phone = fields.Char(readonly=True)
     work_phone = fields.Char(readonly=True)
     work_email = fields.Char(readonly=True)
+    work_contact_id = fields.Many2one(readonly=True)
+    related_contact_ids = fields.Many2many(readonly=True)
     work_location_id = fields.Many2one(readonly=True)
     user_id = fields.Many2one(readonly=True)
     resource_id = fields.Many2one(readonly=True)
@@ -55,6 +57,12 @@ class HrEmployeePublic(models.Model):
     def _compute_employee_id(self):
         for employee in self:
             employee.employee_id = self.env['hr.employee'].browse(employee.id)
+
+    @api.depends('user_partner_id')
+    def _compute_related_contacts(self):
+        super()._computer_related_contacts()
+        for employee in self:
+            employee.related_contact_ids |= employee.user_partner_id
 
     @api.model
     def _get_fields(self):

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -224,11 +224,36 @@
 
                     </sheet>
                     <div class="oe_chatter">
-                        <field name="message_follower_ids" groups="base.group_user"/>
+                        <field name="message_follower_ids" groups="base.group_user" options="{'post_refresh': 'recipients'}"/>
                         <field name="activity_ids"/>
                         <field name="message_ids"/>
                     </div>
                 </form>
+            </field>
+        </record>
+
+        <!-- This part of the view_employee_form is defined separately so that the
+             smartbutton can have lower priority and therefore be last in the list. -->
+        <record id="view_employee_form_smartbutton" model="ir.ui.view">
+            <field name="name">view.employee.form.smartbutton</field>
+            <field name="model">hr.employee</field>
+            <field name="inherit_id" ref="view_employee_form"/>
+            <field name="priority" eval="1000"/>
+            <field name="arch" type="xml">
+                <div name="button_box" position="inside">
+                    <field name="related_contacts_count" invisible="1"/>
+                    <button name="action_related_contacts"
+                        class="oe_stat_button"
+                        icon="fa-address-card-o"
+                        type="object"
+                        help="Related Contacts"
+                        attrs="{'invisible': [('related_contacts_count', '=', 0)]}">
+                        <div class="o_field_widget o_stat_info">
+                            <span class="o_stat_value"><field name="related_contacts_count"/></span>
+                            <span class="o_stat_text">Contacts</span>
+                        </div>
+                    </button>
+                </div>
             </field>
         </record>
 


### PR DESCRIPTION
Change the default recipient of the simulation link to be the employee's
work email address, instead of the private email address.

Currently the private email of employees is used for this but this doesn't
work because mail.compose.message does not allow allow private partners
to be configured as recipients. Secondly, it also just makes sense to send
work-related email to the work email address.

In addition, since a partner is automatically created when sending an
email to this work email address (which is currently a string field, a new
field is created to keep track of this partner, in addition to other
partners that might be linked to employee.

task-2790044

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
