### PR TITLE
[FIX] project: fix project sharing

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -103,7 +103,7 @@ class ProjectCustomerPortal(CustomerPortal):
                  '/my/project/<int:project_id>/project_sharing'], type='http', auth="public")
     def portal_project_routes_outdated(self, **kwargs):
         """ Redirect the outdated routes to the new routes. """
-        return request.redirect(request.httprequest.path.replace('/my/project/', '/my/projects/'))
+        return request.redirect(request.httprequest.full_path.replace('/my/project/', '/my/projects/'))
 
     @http.route(['/my/task', '/my/task/page/<int:page>'], type='http', auth='public')
     def portal_my_task_routes_outdated(self, **kwargs):

--- a/addons/project/views/project_sharing_templates.xml
+++ b/addons/project/views/project_sharing_templates.xml
@@ -10,7 +10,7 @@
 
     <template id="project_sharing" name="Project Sharing View">
         <!--    We need to forward the request lang to ensure that the lang set on the portal match the lang delivered -->
-        <iframe width="100%" height="100%" frameborder="0" t-attf-src="/{{ request.context['lang'] }}/my/project/{{ str(project_id) }}/project_sharing{{ '?task_id=' + task_id if task_id else '' }}"/>
+        <iframe width="100%" height="100%" frameborder="0" t-attf-src="/{{ request.context['lang'] }}/my/projects/{{ str(project_id) }}/project_sharing{{ '?task_id=' + task_id if task_id else '' }}"/>
     </template>
 
     <template id="project_sharing_embed" name="Project Sharing View Embed">


### PR DESCRIPTION
## [FIX] project: redirect old routes with parameters

Before this commit, the redirection does not take into account the
parameters passed into the url.

This commit uses the full path instead of the path to get the url with
the GET parameters.

## [FIX] project: use the new route instead of the old one

Before this commit, the route used for the project sharing always used
the old one.

This commit changes the url to use the new one to avoid redirecting the
old route to the new one each time the user goes to the Project Sharing
feature.