### PR TITLE
[FIX] point_of_sale: Fix cleaning git between 2 version of iot

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
@@ -13,7 +13,7 @@ echo "addons/point_of_sale/tools/posbox/overwrite_after_init/home/pi/odoo" >> .g
 git fetch "${localremote}" "${localbranch}" --depth=1
 git reset "${localremote}"/"${localbranch}" --hard
 
-git clean -df
+git clean -dfx
 cp -a /home/pi/odoo/addons/point_of_sale/tools/posbox/overwrite_after_init/home/pi/odoo/* /home/pi/odoo/
 rm -r /home/pi/odoo/addons/point_of_sale/tools/posbox/overwrite_after_init
 


### PR DESCRIPTION
When iot switch between 2 version of odoo we must clean correctly the branch.

Now -dfx erases each and every file in git directory which is not part of repository.
(like drivers and interfaces)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
