### PR TITLE
[FIX] mail,web: DiscussPublicView layout broken

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -73,6 +73,8 @@
             'web/static/src/libs/bootstrap/pre_variables.scss',
             'web/static/lib/bootstrap/scss/_variables.scss',
             'web/static/src/legacy/scss/import_bootstrap.scss',
+            'web/static/src/libs/bootstrap/utilities_custom.scss',
+            'web/static/lib/bootstrap/scss/utilities/_api.scss',
             'web/static/src/legacy/scss/bootstrap_review.scss',
             'web/static/src/webclient/webclient.scss',
             'web/static/src/webclient/webclient_extra.scss',

--- a/addons/web/static/src/libs/bootstrap/utilities_custom.scss
+++ b/addons/web/static/src/libs/bootstrap/utilities_custom.scss
@@ -79,6 +79,8 @@ $utilities: map-merge(
                 "text-opacity": 1
             ),
             values: (
+                "black": $black,
+                "white": $white,
                 "muted": $text-muted,
                 "black-50": rgba($black, .5), // deprecated
                 "white-50": rgba($white, .5), // deprecated


### PR DESCRIPTION
Since BS5 migration [1], we added the possibility to customize the
BS utilities classes using Bootstrap API [2].

But in the mail module files was not added in the
`mail.assets_discuss_public` bundle so no utility class was generated.

Also, missing 'text-black' and 'text-white' are now added in the
compiled SCSS (for `mail.assets_discuss_public` bundle).

Refs:
[1] odoo/odoo#95450
[2] https://getbootstrap.com/docs/5.1/utilities/api/

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
