### PR TITLE
[FIX] pos_restaurant: refund order without table

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -26,7 +26,9 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 });
             }
             getTable(order) {
-                return `${order.table.floor.name} (${order.table.name})`;
+                if(order.table)
+                    return `${order.table.floor.name} (${order.table.name})`;
+                return null;
             }
             //@override
             _getSearchFields() {

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -124,6 +124,12 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 }
                 return result;
             }
+            async _onDoRefund() {
+                if(this.env.pos.config.iface_floorplan) {
+                    this.env.pos.set_table(this.getSelectedSyncedOrder().table ? this.getSelectedSyncedOrder().table : Object.values(this.env.pos.tables_by_id)[0]);
+                }
+                super._onDoRefund();
+            }
         };
 
     Registries.Component.extend(TicketScreen, PosResTicketScreen);


### PR DESCRIPTION
There were few error when doing refund if restaurant floor was used without table set on the order.
Now, when an order is refunded from the floor screen, we make sure a table will be link to the order that will be created to do the refund.

When we load the paid orders, if there wasn't any table on one of them, the list of orders was not displayed.
This PR now make sure that all the orders are displayed even if there isn't any table on a specific order.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
