### PR TITLE
[FIX] pos_stripe: Display correctly error to the GUI

### DIFF
--- a/addons/pos_stripe/models/pos_payment_method.py
+++ b/addons/pos_stripe/models/pos_payment_method.py
@@ -3,6 +3,7 @@
 import logging
 import requests
 import werkzeug
+import json
 
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError, UserError, AccessError
@@ -83,6 +84,8 @@ class PosPaymentMethod(models.Model):
 
         if resp.ok:
             return resp.json()
+        else:
+            return json.loads(resp.text)
 
         _logger.error("Unexpected stripe_payment_intent response: %s", resp.status_code)
         raise UserError(_("Unexpected error between us and Stripe."))


### PR DESCRIPTION
When we make a payment intent and return a error this one is not
correctly displayed with the user.

With this commit the variable returned to user contain a message
with the error



![Screenshot from 2022-07-08 15-30-22](https://user-images.githubusercontent.com/38907656/178001809-6b37db35-fcc3-485b-96f4-78e74f8e9108.png)



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
