### PR TITLE
[FIX] hr_holidays: wrong nbr of days in accrual plans

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -226,7 +226,7 @@ class AccrualPlanLevel(models.Model):
             else:
                 return last_call + relativedelta(months=1, day=self.first_day)
         elif self.frequency == 'monthly':
-            date = last_call + relativedelta(self.first_day)
+            date = last_call + relativedelta(day=self.first_day)
             if last_call < date:
                 return date
             else:


### PR DESCRIPTION
Steps to reproduce:
- Create an accrual plan with one level and a first_day A
- Create an holiday allocation with this accrual plan and
a start date B so that the day in B < A
- Validate the allocation and run the accrual scheduler

Expected behavior:
There is the right number of allocated days

Current behavior:
There is the wrong number of allocated days

Explanation:
Because in the relativedelta the day parameter is missing,
then date is equal to last_call and the else case of the following
condition is always applied.

opw-2868297
