### PR TITLE
[FIX] web: add missing selector for badge field in legacy views

### DIFF
--- a/addons/web/static/src/views/fields/badge/badge_field.scss
+++ b/addons/web/static/src/views/fields/badge/badge_field.scss
@@ -1,4 +1,5 @@
-.o_field_badge span {
+// TODO: remove second selector when we remove legacy badge field
+.o_field_badge span, span.o_field_badge {
     border: 0;
     font-size: 12px;
     user-select: none;


### PR DESCRIPTION
The rule should apply to both the legacy badge field and the new badge
field, when adapting the css to the new badge field, the selector that
targets the legacy badge field was broken. This commit fixes that.
