### PR TITLE
Fix active pricelist item filtering when retrieving prices

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -93,7 +93,9 @@ class Pricelist(models.Model):
     def _compute_price_rule_get_items(self, products_qty_partner, date, uom_id, prod_tmpl_ids, prod_ids, categ_ids):
         self.ensure_one()
         # Load all rules
-        self.env['product.pricelist.item'].flush(['price', 'currency_id', 'company_id'])
+        self.env['product.pricelist.item'].flush(
+            ['price', 'currency_id', 'company_id', 'active']
+        )
         self.env.cr.execute(
             """
             SELECT
@@ -108,6 +110,7 @@ class Pricelist(models.Model):
                 AND (item.pricelist_id = %s)
                 AND (item.date_start IS NULL OR item.date_start<=%s)
                 AND (item.date_end IS NULL OR item.date_end>=%s)
+                AND item.active = TRUE
             ORDER BY
                 item.applied_on, item.min_quantity desc, categ.complete_name desc, item.id desc
             """,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Prices are wrongly computed when there is archived pricelist items on pricelists.

Current behavior before PR:
When retrieving pricelist items, archived ones were also retrieved.

Desired behavior after PR is merged:
When retrieving pricelist items, we only want to get unarchived ones.

OPW #2917322

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
