### PR TITLE
[FIX] hr_holidays: fix a bad call to relativedelta

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -226,7 +226,7 @@ class AccrualPlanLevel(models.Model):
             else:
                 return last_call + relativedelta(months=1, day=self.first_day)
         elif self.frequency == 'monthly':
-            date = last_call + relativedelta(self.first_day)
+            date = last_call + relativedelta(day=self.first_day)
             if last_call < date:
                 return date
             else:


### PR DESCRIPTION
This commit fixes a bad call to relativedelta missing a `day` key for an
argument.
