### PR TITLE
[IMP] Survey: Improve accessibility

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -309,7 +309,7 @@
              t-att-data-validation-error-msg="question.validation_error_msg">
             <div class="mb-4">
                 <h3 t-if="not hide_question_title">
-                    <span t-field='question.title' />
+                    <label t-attf-for="{{question.id}}-inputelement-id" t-field='question.title' />
                     <span t-if="question.constr_mandatory" class="text-danger">*</span>
                 </h3>
                 <div t-if="not is_html_empty(question.description)" t-field='question.description' class="text-muted oe_no_empty mt-1"/>
@@ -328,14 +328,14 @@
 
     <template id="question_text_box" name="Question: free text box">
         <div class="o_survey_comment_container p-0">
-            <textarea class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" rows="3" t-att-name="question.id"
+            <textarea t-attf-id="{{question.id}}-inputelement-id" class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" rows="3" t-att-name="question.id"
                       t-att-data-question-type="question.question_type"><t t-if="answer_lines" t-esc="answer_lines[0].value_text_box or None"/></textarea>
         </div>
     </template>
 
     <template id="question_char_box" name="Question: text box">
         <div class="o_survey_comment_container p-0">
-            <input t-att-type="'email' if question.validation_email else 'text'"
+            <input t-attf-id="{{question.id}}-inputelement-id" t-att-type="'email' if question.validation_email else 'text'"
                class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" t-att-name="question.id"
                t-att-value="answer_lines[0].value_char_box if answer_lines else None"
                t-att-data-question-type="question.question_type"
@@ -345,7 +345,7 @@
     </template>
 
     <template id="question_numerical_box" name="Question: numerical box">
-        <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent text-dark rounded-0 p-0"
+        <input t-attf-id="{{question.id}}-inputelement-id" type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent text-dark rounded-0 p-0"
                t-att-name="question.id" t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
                t-att-data-question-type="question.question_type"
                t-att-data-validation-float-min="question.validation_min_float_value if question.validation_required else False"
@@ -356,7 +356,7 @@
         <div class="input-group o_survey_form_date" t-attf-id="datetimepicker_#{question.id}" data-target-input="nearest"
                 t-att-data-mindate="question.validation_min_date"
                 t-att-data-maxdate="question.validation_max_date">
-            <input type="text" class="form-control datetimepicker-input o_survey_question_date bg-transparent text-dark rounded-0 p-0"
+            <input t-attf-id="{{question.id}}-inputelement-id" type="text" class="form-control datetimepicker-input o_survey_question_date bg-transparent text-dark rounded-0 p-0"
                    t-attf-data-target="#datetimepicker_#{question.id}" t-att-name="question.id"
                    t-att-value="format_date(answer_lines[0].value_date) if answer_lines else None"
                    t-att-data-question-type="question.question_type"/>
@@ -370,7 +370,7 @@
         <div class="input-group o_survey_form_date" t-attf-id="datetimepicker_#{question.id}" data-target-input="nearest"
                 t-att-data-mindate="question.validation_min_datetime"
                 t-att-data-maxdate="question.validation_max_datetime">
-            <input type="text" class="form-control datetimepicker-input o_survey_question_datetime bg-transparent text-dark rounded-0 p-0"
+            <input t-attf-id="{{question.id}}-inputelement-id" type="text" class="form-control datetimepicker-input o_survey_question_datetime bg-transparent text-dark rounded-0 p-0"
                    t-attf-data-target="#datetimepicker_#{question.id}" t-att-name="question.id"
                    t-att-value="format_datetime(answer_lines[0].value_datetime) if answer_lines else None"
                    t-att-data-question-type="question.question_type"/>

--- a/doc/cla/individual/JeroenRobben.md
+++ b/doc/cla/individual/JeroenRobben.md
@@ -1,0 +1,11 @@
+Belgium, 2022-07-08
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jeroen Robben jeroen@robben.io https://github.com/JeroenRobben


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR makes survey question labels use the html "label" element in stead of a "span". This is needed for correct behavior of assistive software, see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/forms/Basic_form_hints.

Current behavior before PR:
Question labels are not recognized by screen readers.

Desired behavior after PR is merged:
Question labels are recognized by screen readers.
