### PR TITLE
[FIX] hr_gamification: grant badge to employee of another company

### DIFF
--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -14,7 +14,8 @@ class GamificationBadgeUser(models.Model):
     @api.constrains('employee_id')
     def _check_employee_related_user(self):
         for badge_user in self:
-            if badge_user.employee_id not in badge_user.user_id.employee_ids:
+            if badge_user.employee_id not in badge_user.user_id.\
+                with_context(allowed_company_ids=self.env.user.company_ids.ids).employee_ids:
                 raise ValidationError(_('The selected employee does not correspond to the selected user.'))
 
 


### PR DESCRIPTION
This is a side-effect of commit [1].

Consider we have access to companies A and B, and current active company
is A. Before the mentioned commit we were able to grand a badge to an
employee in company B. We should keep that behavior, as long as the
current user have also access to company B.

[1]:https://github.com/odoo/odoo/commit/b5b105eabd90419a5856e8279e277743c5915fc9

Description of the issue/feature this PR addresses:
opw-2827866

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
