### PR TITLE
[13.0][IMP] website: performance enumerate pages

### DIFF
--- a/addons/website_event_track/controllers/main.py
+++ b/addons/website_event_track/controllers/main.py
@@ -16,7 +16,7 @@ from odoo.tools.misc import babel_locale_parse
 
 class WebsiteEventTrackController(http.Controller):
 
-    @http.route(['''/event/<model("event.event", "[('website_id', 'in', (False, current_website_id))]"):event>/track/<model("event.track", "[('event_id','=',event[0])]"):track>'''], type='http', auth="public", website=True)
+    #@http.route(['''/event/<model("event.event", "[('website_id', 'in', (False, current_website_id))]"):event>/track/<model("event.track", "[('event_id','=',event[0])]"):track>'''], type='http', auth="public", website=True)
     def event_track_view(self, event, track, **post):
         if not event.can_access_from_current_website():
             raise NotFound()
@@ -27,7 +27,6 @@ class WebsiteEventTrackController(http.Controller):
 
     def _get_locale_time(self, dt_time, lang_code):
         """ Get locale time from datetime object
-
             :param dt_time: datetime object
             :param lang_code: language code (eg. en_US)
         """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Adding links on text in the website module takes minutes.
Scenario: large number of web pages + multi language + several users. 
Comparing with laters versions some improvements in the loops and in the tables are done. 


The desired behavior after PR is merged is speed up the task of adding hiperlinks in website with the editor mode. 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
