### PR TITLE
[FIX] pos_mercury: charge the right amount

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -21,19 +21,22 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             useListener('send-payment-reverse', this._sendPaymentReverse);
             useListener('send-force-done', this._sendForceDone);
             this.lockedValidateOrder = useAsyncLockedMethod(this.validateOrder);
-            NumberBuffer.use({
+            NumberBuffer.use(this._getNumberBufferConfig);
+            onChangeOrder(this._onPrevOrder, this._onNewOrder);
+            useErrorHandlers();
+            this.payment_interface = null;
+            this.error = false;
+            this.payment_methods_from_config = this.env.pos.payment_methods.filter(method => this.env.pos.config.payment_method_ids.includes(method.id));
+        }
+        get _getNumberBufferConfig() {
+            return {
                 // The numberBuffer listens to this event to update its state.
                 // Basically means 'update the buffer when this event is triggered'
                 nonKeyboardInputEvent: 'input-from-numpad',
                 // When the buffer is updated, trigger this event.
                 // Note that the component listens to it.
                 triggerAtInput: 'update-selected-paymentline',
-            });
-            onChangeOrder(this._onPrevOrder, this._onNewOrder);
-            useErrorHandlers();
-            this.payment_interface = null;
-            this.error = false;
-            this.payment_methods_from_config = this.env.pos.payment_methods.filter(method => this.env.pos.config.payment_method_ids.includes(method.id));
+            }
         }
         get currentOrder() {
             return this.env.pos.get_order();

--- a/addons/pos_mercury/static/src/js/PaymentScreen.js
+++ b/addons/pos_mercury/static/src/js/PaymentScreen.js
@@ -110,6 +110,29 @@ odoo.define('pos_mercury.PaymentScreen', function (require) {
                 this.server_retries = 3;
             }
 
+            /**
+             * The card reader acts as a barcode scanner. This sets up
+             * the NumberBuffer to not immediately act on keyboard
+             * input.
+             *
+             * @override
+             */
+            get _getNumberBufferConfig() {
+                const res = super._getNumberBufferConfig;
+                res['useWithBarcode'] = true;
+                return res;
+            }
+
+            /**
+             * Finish any pending input before trying to validate.
+             *
+             * @override
+             */
+            async validateOrder(isForceValidate) {
+                NumberBuffer.capture();
+                return super.validateOrder(...arguments);
+            }
+
             _get_swipe_pending_line() {
                 var i = 0;
                 var lines = this.env.pos.get_order().get_paymentlines();


### PR DESCRIPTION
Without this the payment line amount is overridden before the request
is made to Mercury.

When a Mercury payment method is clicked a payment line with the right
amount is created. When a card is swiped it types a sequence like:

%B999000090000009^TEST...

The "typed" numbers are immediately interpreted by NumberBuffer and
will result in the payment line amount being updated to something like
9990000.... When the "barcode" is finished credit_code_transaction()
in pos_mercury will do the request using the amount from the
payment line (swipe_pending_line.get_amount()).

As a result a request is made to Mercury with a huge amount which
results in an error: "Error 1000211: Invalid Field - Purchase Amount".

Luckily NumberBuffer already supports barcodes, so the problem can be
solved by setting useWithBarcode. A small method was extracted to
override this cleanly.

opw-2892608

PS. The diff for the point_of_sale file is quite confusing, but all it does is extract a method.