### PR TITLE
[FIX][14.0] hr_expense: Can't create payment

### DIFF
--- a/addons/hr_expense/wizard/account_payment_register.py
+++ b/addons/hr_expense/wizard/account_payment_register.py
@@ -16,7 +16,7 @@ class AccountPaymentRegister(models.TransientModel):
         res = super()._get_line_batch_key(line)
         expense_sheet = self.env['hr.expense.sheet'].search([('payment_mode', '=', 'own_account'), ('account_move_id', 'in', line.move_id.ids)])
         if expense_sheet and not line.move_id.partner_bank_id:
-            res['partner_bank_id'] = expense_sheet.employee_id.bank_account_id.id or line.partner_id.bank_ids and line.partner_id.bank_ids.ids[0]
+            res['partner_bank_id'] = expense_sheet.employee_id.sudo().bank_account_id.id or line.partner_id.bank_ids and line.partner_id.bank_ids.ids[0]
         return res
 
     def _init_payments(self, to_process, edit_mode=False):


### PR DESCRIPTION
- A user has accounting permission but no employee permission, when that user creates a payment in spending it gives an error that does not have access to the bank_account_id field
- This commit allows the user to read the bank_account_id field when creating a payment





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
