### PR TITLE
[FIX] stock: filter/domain incomplete and not applied on scheduler task

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -516,6 +516,7 @@ class ProcurementGroup(models.Model):
         moves_domain = [
             ('state', 'in', ['confirmed', 'partially_available']),
             ('product_uom_qty', '!=', 0.0),
+            ('picking_type_id.reservation_method', '!=', 'manual'),
             ('reservation_date', '<=', fields.Date.today())
         ]
         if company_id:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As the domain and the filter do suggest that we always respect the reservation date
we need to make sure that changes in the operation type configuration is triggering
the change accordingly and that manual reservation should not automatically assign.

**Current behavior before PR:**
Multiple use cases are not working as expected

**Desired behavior after PR is merged:**
At least the issues I identified are fixed and working as expected

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
