### PR TITLE
[IMP] stock: added reverse inventory adjustment feature

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -426,6 +426,7 @@ class StockQuant(models.Model):
             'context': {
                 'search_default_inventory': 1,
                 'search_default_done': 1,
+                'stock_quant_id': self.id,
             },
             'domain': [
                 ('product_id', '=', self.product_id.id),

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -5,6 +5,9 @@
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
             <tree string="Move Lines" create="0" default_order="date">
+                <header>
+                    <button string="Revert Inventory" name="revert_inventory" type="object" />
+                </header>
                 <field name="date"/>
                 <field name="reference" string="Reference"
                        invisible="context.get('no_reference', False)"/>


### PR DESCRIPTION
Purpose
======
Purpose of the task is checking the inventory adjustment history and doing an
opposite adjustment by using `Revert Inventory` button.

So in this commit, I have added `Revert Inventory` button in Inventory Adjustments > History.
when you checking the history and click on the `Revert Inventory` button, this
method create opposite adjustment history with prefix `[reverted]`.

TaskID - 2859490