### PR TITLE
[IMP] stock: add revert inventory adjustment feature 

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -192,6 +192,16 @@
         </field>
     </record>
 
+    <record id="action_revert_inventory_adjustment" model="ir.actions.server">
+        <field name="name">Revert Inventory Adjustment</field>
+        <field name="model_id" ref="stock.model_stock_move_line"/>
+        <field name="binding_model_id" ref="stock.model_stock_move_line"/>
+        <field name="state">code</field>
+        <field name="code">
+            action = records.action_revert_inventory()
+        </field>
+    </record>
+
     <record id="stock_move_line_action" model="ir.actions.act_window">
             <field name="name">Moves History</field>
             <field name="res_model">stock.move.line</field>


### PR DESCRIPTION
Purpose of the task is to be able to click on inventory adjustment
history and do a reverse adjustment by using `Revert Inventory` action.

`Revert Inventory` action is available in Inventory Adjustments > History
and Product Moves > select some lines > actions dropdown. This
method creates a new move that reverts the quantity (including negative
values) with prefix `[reverted]`.

TaskID - 2859490