### PR TITLE
[FIX] hr: Prevent user to access to activities without rights

### DIFF
--- a/addons/hr/i18n/hr.pot
+++ b/addons/hr/i18n/hr.pot
@@ -2985,6 +2985,12 @@ msgid "You cannot create recursive departments."
 msgstr ""
 
 #. module: hr
+#: code:addons/hr/models/hr_employee.py:0
+#, python-format
+msgid "You do not have access to this document."
+msgstr ""
+
+#. module: hr
 #: code:addons/hr/models/res_config_settings.py:0
 #, python-format
 msgid "You should select at least one Advanced Presence Control option."

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -219,7 +219,10 @@ class HrEmployeePrivate(models.Model):
         """
         if self.check_access_rights('read', raise_exception=False):
             return super(HrEmployeePrivate, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
-        ids = self.env['hr.employee.public']._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
+        try:
+            ids = self.env['hr.employee.public']._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
+        except ValueError:
+            raise AccessError(_('You do not have access to this document.'))
         if not count and isinstance(ids, Query):
             # the result is expected from this table, so we should link tables
             ids = super(HrEmployeePrivate, self.sudo())._search([('id', 'in', ids)])


### PR DESCRIPTION
Steps:
- Schedule some activities to `admin` (users with hr officer)
- Remove hr rights to `admin`
- Log-in with `admin` and click on notification
- Click on `Summary`
- Traceback

If we click on `Summary` a `_search` is executed in `hr.employee`
When a user does not have the required rights we will apply `_search` on
the fields on `hr.employee.public` instead of `hr.employee.private`.
Except that in the case of `activity_ids` this field does not exist in
`hr.employee.public`

opw-2765032