### PR TITLE
[FIX] mrp: Wrong replenishment order notification

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -16,7 +16,7 @@ class StockWarehouseOrderpoint(models.Model):
     def _get_replenishment_order_notification(self):
         self.ensure_one()
         domain = [('orderpoint_id', 'in', self.ids)]
-        if self.env.context.get('written_date'):
+        if self.env.context.get('written_after'):
             domain = AND([domain, [('write_date', '>', self.env.context.get('written_after'))]])
         production = self.env['mrp.production'].search(domain, limit=1)
         if production:

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -240,7 +240,7 @@ class Orderpoint(models.Model):
     def _get_replenishment_order_notification(self):
         self.ensure_one()
         domain = [('orderpoint_id', 'in', self.ids)]
-        if self.env.context.get('written_date'):
+        if self.env.context.get('written_after'):
             domain = AND([domain, [('write_date', '>', self.env.context.get('written_after'))]])
         order = self.env['purchase.order.line'].search(domain, limit=1).order_id
         if order:

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -429,7 +429,7 @@ class StockWarehouseOrderpoint(models.Model):
     def _get_replenishment_order_notification(self):
         self.ensure_one()
         domain = [('orderpoint_id', 'in', self.ids)]
-        if self.env.context.get('written_date'):
+        if self.env.context.get('written_after'):
             domain = expression.AND([domain, [('write_date', '>', self.env.context.get('written_after'))]])
         move = self.env['stock.move'].search(domain, limit=1)
         if move.picking_id:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On the commit 69dcdd4, the order='create_date desc' was removed and the way of getting the MO for the notification changed. The context should now be used.
Unfortunately, the wrong MO is being shown on the notification.

Current behavior before PR:
Instead of showing the MO that was just created, the pop-up shows an older MO that can even be in state canceled.
(The MO created is correct, only the notification is wrong)

Desired behavior after PR is merged:
The last MO created should be shown on the pop-up.
To achieve that, the context should be used (written_after instead of written_date).

(The MO created is correct, only the notification is wrong)

OPW-2877457

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
