### PR TITLE
[FIX] purchase_stock: add field to check Downstream moves

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -60,7 +60,7 @@ class ProductProduct(models.Model):
                 '|',
                     ('order_id.picking_type_id.default_location_dest_id', 'in', location_ids),
                     '&',
-                        ('move_dest_ids', '=', False),
+                        ('move_dest_bool', '=', False),
                         ('orderpoint_id.location_id', 'in', location_ids)
             ]])
         if warehouse_ids:
@@ -68,7 +68,7 @@ class ProductProduct(models.Model):
                 '|',
                     ('order_id.picking_type_id.warehouse_id', 'in', warehouse_ids),
                     '&',
-                        ('move_dest_ids', '=', False),
+                        ('move_dest_bool', '=', False),
                         ('orderpoint_id.warehouse_id', 'in', warehouse_ids)
             ]])
             domain = expression.OR([domain, wh_domain])

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -298,9 +298,15 @@ class PurchaseOrderLine(models.Model):
     move_ids = fields.One2many('stock.move', 'purchase_line_id', string='Reservation', readonly=True, copy=False)
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Orderpoint', copy=False, index='btree_not_null')
     move_dest_ids = fields.Many2many('stock.move', 'stock_move_created_purchase_line_rel', 'created_purchase_line_id', 'move_id', 'Downstream moves alt')
+    move_dest_bool = fields.Boolean('Has Downstream Moves', compute='_compute_move_dest_bool', store=True, readonly=True, index=True)
     product_description_variants = fields.Char('Custom Description')
     propagate_cancel = fields.Boolean('Propagate cancellation', default=True)
     forecasted_issue = fields.Boolean(compute='_compute_forecasted_issue')
+
+    @api.depends('move_dest_ids')
+    def _compute_move_dest_bool(self):
+        for record in self:
+            record.move_dest_bool = bool(record.move_dest_ids)
 
     def _compute_qty_received_method(self):
         super(PurchaseOrderLine, self)._compute_qty_received_method()


### PR DESCRIPTION
Method `_get_quantity_in_progress` constructs a domain for `purchase.order.line`
[1], which particularly has a leaf `('move_dest_ids', '=', False)`. The field
`move_dest_ids` is one2many with `stock.move` [2]. So, the leaf adds inefficient
where-clause.

```
        (
          "purchase_order_line"."id" not in (
            SELECT
              "created_purchase_line_id"
            FROM
              "stock_move"
            WHERE
              "created_purchase_line_id" IS NOT NULL
          )
        )
```

To avoid reading `stock_move` table, this commit adds new computed field.

[1]: https://github.com/odoo/odoo/blob/ba37803064837521bb356285143b42e365ef9bf3/addons/purchase_stock/models/product.py#L41-L60
[2]: https://github.com/odoo/odoo/blob/ba37803064837521bb356285143b42e365ef9bf3/addons/purchase_stock/models/purchase.py#L292

opw-2852585

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
