### PR TITLE
[IMP] mrp: default workorder `duration_expected` without form/onchanges

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -91,7 +91,7 @@ class MrpWorkorder(models.Model):
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]})
 
     duration_expected = fields.Float(
-        'Expected Duration', digits=(16, 2), default=60.0, compute='_compute_duration_expected',
+        'Expected Duration', digits=(16, 2), compute='_compute_duration_expected',
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
         readonly=False, store=True, help="Expected duration (in minutes)")
     duration = fields.Float(

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import Form
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
-from odoo.addons.mrp.tests.common import TestMrpCommon
+from odoo.tests import Form
 from odoo.tools.misc import format_date
+
+from odoo.addons.mrp.tests.common import TestMrpCommon
 
 class TestMrpOrder(TestMrpCommon):
 


### PR DESCRIPTION
With this revision, the expected duration is correctly set
when creating a production order with work orders without the need of
onchanges, through a form.

For instance, this allows an easier implementation to create a production
order with work orders through XMLRPC API calls,
as you will not need to manually set the expected duration value
or to call onchanges manually to set it.

For instance, without this change to remove the `default=60.0`,
the part added by this revision in the test `test_update_quantity_3`
would fail
```
2022-07-11 09:15:14,644 21 ERROR master odoo.addons.mrp.tests.test_order: FAIL: TestMrpOrder.test_update_quantity_3
Traceback (most recent call last):
  File "/home/odoo/src/odoo/master/addons/mrp/tests/test_order.py", line 347, in test_update_quantity_3
    self.assertEqual(production.workorder_ids.duration_expected, 90)
AssertionError: 60.0 != 90
```
while it just does the same thing than the existing `test_update_quantity_3` test
but without the use of a form / onchanges.