### PR TITLE
[FIX] sign: tour without demo data

### DIFF
--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -17,7 +17,6 @@ const { WidgetAdapterMixin } = require('web.OwlCompatibility');
 var widgetRegistry = require('web.widget_registry');
 const widgetRegistryOwl = require('web.widgetRegistry');
 const WidgetWrapper = require("web.WidgetWrapper");
-var session = require("web.session")
 
 var _t = core._t;
 var QWeb = core.qweb;
@@ -578,7 +577,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
             selection_mode: this.selectionMode,
             read_only_mode: this.read_only_mode,
             record: this.record,
-            user_context: session.user_context,
+            user_context: this.getSession().user_context,
             widget: this,
         };
     },

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -17,6 +17,7 @@ const { WidgetAdapterMixin } = require('web.OwlCompatibility');
 var widgetRegistry = require('web.widget_registry');
 const widgetRegistryOwl = require('web.widgetRegistry');
 const WidgetWrapper = require("web.WidgetWrapper");
+var session = require("web.session")
 
 var _t = core._t;
 var QWeb = core.qweb;
@@ -577,7 +578,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
             selection_mode: this.selectionMode,
             read_only_mode: this.read_only_mode,
             record: this.record,
-            user_context: this.getSession().user_context,
+            user_context: session.user_context,
             widget: this,
         };
     },


### PR DESCRIPTION
Added sign test tour to prevent further owl2 regression.
It works with demo data, using an existing template, added a signature item and
signed the document with the current user.

task-2869973

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
