### PR TITLE
[FIX] web: BS5: restore table-striped behaviour

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -127,6 +127,7 @@ $headings-color: $o-main-headings-color !default;
 //
 // Customizes the `.table` component with basic values, each used across all table variations.
 
+$table-striped-color: inherit !default;
 $table-striped-bg-factor: .01 !default;
 $table-hover-bg: rgba($black, .04) !default;
 $table-border-color: $gray-200 !default;


### PR DESCRIPTION
In BS4 text color wasn't defined for `table-striped`.
In BS5 color text decorations in list views was broken because of BS5
sets the color of all `td` in a stripped table.
Now we simply override the value of the variable to inherit.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
