### PR TITLE
[IMP] point_of_sale: better error message for identify customer failure

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1184,6 +1184,10 @@ class PosSession(models.Model):
 
     def _get_split_receivable_vals(self, payment, amount, amount_converted):
         accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
+        if not accounting_partner:
+            raise UserError(_("You have enabled the \"Identify Customer\" option for %s payment method,"
+                              "but the order %s does not contain a customer.") % (payment.payment_method_id.name,
+                               payment.pos_order_id.name))
         partial_vals = {
             'account_id': accounting_partner.property_account_receivable_id.id,
             'move_id': self.move_id.id,


### PR DESCRIPTION
Before this commit if "Identify Customer" option was enabled for a
payment method in point of sale but no customer was set for an order,
we get a SQL constraint error that has no hints on where the problem
comes from.

This process can be improved by a better error message that directly
points out the problem.

opw-2907152

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
