### PR TITLE
Miscellaneous improvements of t-cache

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -15,7 +15,7 @@
         <link type="image/x-icon" rel="shortcut icon" t-att-href="x_icon or '/web/static/img/favicon.ico'"/>
         <script id="web.layout.odooscript" type="text/javascript">
             var odoo = {
-                csrf_token: "<t t-esc="request.csrf_token(None)"/>",
+                csrf_token: "<t t-nocache="The csrf token must always be up to date." t-esc="request.csrf_token(None)"/>",
                 debug: "<t t-esc="debug"/>",
             };
         </script>

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1933,8 +1933,6 @@ class IrQWeb(models.AbstractModel):
                     values['__qweb_attrs__'].update(field_attrs)
                 content = self._compile_to_str(content)
                 """, level))
-
-            code.append(indent_code("content = self._compile_to_str(content)", level))
             force_display_dependent = True
         else:
             if expr == T_CALL_SLOT:


### PR DESCRIPTION
[FIX] web: never cache the CSRF token

"website.layout" inherit of "portal.frontend_layout" which inherit of
"web.layout" which contains the creation of the CSRF token.
Add because "website.layout" add a t-cache key, the CSRF token is under
this cache key. But the CSRF token should be always generated,
then add t-nocache on CSRF token t-set.

[IMP] core: improve compilation result of qweb

`content = self._compile_to_str(content)` is done twice in the compiled
method of qweb. Remove it once.