### PR TITLE
[FIX] event: update event tags when modifying event template

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -418,8 +418,14 @@ class EventEvent(models.Model):
         onchange: if event type is changed, update event configuration. Changing
         event type content itself should not trigger this method. """
         for event in self:
-            if not event.tag_ids and event.event_type_id.tag_ids:
-                event.tag_ids = event.event_type_id.tag_ids
+            if event.event_type_id:
+                if not event.tag_ids and event.event_type_id.tag_ids:
+                    event.tag_ids = event.event_type_id.tag_ids
+                    return
+                saved_event = self.env['event.event'].browse(event.ids)
+                if saved_event:
+                    if event.tag_ids.ids == saved_event.event_type_id.tag_ids.ids:
+                        event.tag_ids = event.event_type_id.tag_ids
 
     @api.depends('event_type_id')
     def _compute_event_ticket_ids(self):


### PR DESCRIPTION
Modifying the template used by an event doesn't update the event tags
with the tags of the template

Steps to reproduce:
1. Install Events
2. Go to Events > Configuration > Event Templates and add different tags
on templates 'Ticketing' and 'Conference'
3. Create an event with template 'Ticketing' and save
4. Edit the event and modify the template to 'Conference'
5. The tags are not modified

Solution:
When we modify the event template, change the event tags if they were
the same as the previous template used on the event

opw-2907647