### PR TITLE
[FIX] product : variant of other company

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -77,6 +77,10 @@ class ProductAttribute(models.Model):
                 )
         return super(ProductAttribute, self).unlink()
 
+    @api.model
+    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+        restrict_domain = args + ['|', ('product_tmpl_ids.company_id', '=', False), ('product_tmpl_ids.company_id', '=', self.env.company.id)]
+        return super(ProductAttribute, self)._name_search(name=name, args=restrict_domain, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
 class ProductAttributeValue(models.Model):
     _name = "product.attribute.value"


### PR DESCRIPTION
Steps to reproduce:
        - install sale_management
        - enable variant in the setting of sales
        - create a second company
        - create a product with at least a variant and set the company
        to the active one
        - switch to the second company
        - create another product and select the same variant
        - error on creation

Cause:

        During the validation process, the model of the product is read in
        order to get the variant info. But since this product belongs to another company, it doesn't have the right.

Solution:

	Make variants from other companies not selectable.

Setting a domain directly on the field didn't work because the information is
not passed to _name_search

opw-2898457


