### PR TITLE
[IMP] mrp_subcontracting{_dropshipping}: dropship subcontractor route

### DIFF
--- a/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml
+++ b/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml
@@ -6,7 +6,7 @@
             <field name="company_id"></field>
             <field name="sequence">15</field>
         </record>
-        <function model="res.company" name="create_missing_subcontracting_location" />
+        <function model="res.company" name="_create_missing_subcontracting_location" />
         <function model="stock.warehouse" name="write">
             <value model="stock.warehouse" eval="obj().env['stock.warehouse'].search([]).ids"/>
             <value eval="{'subcontracting_to_resupply': True}"/>

--- a/addons/mrp_subcontracting/models/res_company.py
+++ b/addons/mrp_subcontracting/models/res_company.py
@@ -10,7 +10,7 @@ class ResCompany(models.Model):
     subcontracting_location_id = fields.Many2one('stock.location')
 
     @api.model
-    def create_missing_subcontracting_location(self):
+    def _create_missing_subcontracting_location(self):
         company_without_subcontracting_loc = self.env['res.company'].search(
             [('subcontracting_location_id', '=', False)])
         company_without_subcontracting_loc._create_subcontracting_location()

--- a/addons/mrp_subcontracting/models/stock_location.py
+++ b/addons/mrp_subcontracting/models/stock_location.py
@@ -13,6 +13,8 @@ class StockLocation(models.Model):
         help="Check this box to create a new dedicated subcontracting location for this company. Note that standard subcontracting routes will be adapted so as to take these into account automatically."
     )
 
+    subcontractor_ids = fields.One2many('res.partner', 'property_stock_subcontractor')
+
     @api.constrains('is_subcontracting_location', 'usage', 'location_id')
     def _check_subcontracting_location(self):
         for location in self:
@@ -24,7 +26,7 @@ class StockLocation(models.Model):
     @api.constrains('is_subcontracting_location')
     def _check_is_subcontracting_location(self):
         for location in self:
-            if not location.is_subcontracting_location and self.env['res.partner'].search([('property_stock_subcontractor', '=', location.id)]):
+            if not location.is_subcontracting_location and location.subcontractor_ids:
                 raise ValidationError(_("You cannot change the subcontracting location as it is still linked to a subcontractor partner"))
 
     @api.model_create_multi

--- a/addons/mrp_subcontracting_dropshipping/__manifest__.py
+++ b/addons/mrp_subcontracting_dropshipping/__manifest__.py
@@ -13,6 +13,7 @@
     'data': [
         'data/mrp_subcontracting_dropshipping_data.xml',
         'views/stock_warehouse_views.xml',
+        'views/purchase_order_views.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/mrp_subcontracting_dropshipping/data/mrp_subcontracting_dropshipping_data.xml
+++ b/addons/mrp_subcontracting_dropshipping/data/mrp_subcontracting_dropshipping_data.xml
@@ -9,7 +9,9 @@
             <field name="product_selectable" eval="True"/>
         </record>
 
-        <function model="res.company" name="create_missing_subcontracting_dropshipping_rules"/>
+        <function model="res.company" name="_create_missing_subcontracting_dropshipping_sequence"/>
+        <function model="res.company" name="_create_missing_subcontracting_dropshipping_picking_type"/>
+        <function model="res.company" name="_create_missing_subcontracting_dropshipping_rules"/>
 
         <function model="stock.warehouse" name="write">
             <value model="stock.warehouse" eval="obj().env['stock.warehouse'].search([]).ids"/>

--- a/addons/mrp_subcontracting_dropshipping/models/__init__.py
+++ b/addons/mrp_subcontracting_dropshipping/models/__init__.py
@@ -6,3 +6,4 @@ from . import res_company
 from . import stock_warehouse
 from . import purchase
 from . import stock_rule
+from . import stock_orderpoint

--- a/addons/mrp_subcontracting_dropshipping/models/purchase.py
+++ b/addons/mrp_subcontracting_dropshipping/models/purchase.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
+
+    default_location_dest_id_is_subcontracting_loc = fields.Boolean(related='picking_type_id.default_location_dest_id.is_subcontracting_location')
+
+    @api.depends('default_location_dest_id_is_subcontracting_loc')
+    def _compute_dest_address_id(self):
+        dropship_subcontract_pos = self.filtered(lambda po: po.default_location_dest_id_is_subcontracting_loc)
+        for order in dropship_subcontract_pos:
+            subcontractor_ids = order.picking_type_id.default_location_dest_id.subcontractor_ids
+            order.dest_address_id = subcontractor_ids if len(subcontractor_ids) == 1 else False
+        super(PurchaseOrder, self - dropship_subcontract_pos)._compute_dest_address_id()
 
     def _get_destination_location(self):
         self.ensure_one()

--- a/addons/mrp_subcontracting_dropshipping/models/res_company.py
+++ b/addons/mrp_subcontracting_dropshipping/models/res_company.py
@@ -1,11 +1,48 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
+
+    dropship_subcontractor_pick_type_id = fields.Many2one('stock.picking.type')
+
+    def _create_subcontracting_dropshipping_sequence(self):
+        seq_vals = [{
+            'name': 'Dropship Subcontractor (%s)' % company.name,
+            'code': 'mrp.subcontracting.dropshipping',
+            'company_id': company.id,
+            'prefix': 'DSC/',
+            'padding': 5,
+        } for company in self]
+
+        if seq_vals:
+            self.env['ir.sequence'].create(seq_vals)
+
+    def _create_subcontracting_dropshipping_picking_type(self):
+        pick_type_vals = []
+        for company in self:
+            sequence = self.env['ir.sequence'].search([
+                ('code', '=', 'mrp.subcontracting.dropshipping'),
+                ('company_id', '=', company.id),
+            ])
+            pick_type_vals.append({
+                'name': 'Dropship Subcontractor',
+                'company_id': company.id,
+                'warehouse_id': False,
+                'sequence_id': sequence.id,
+                'code': 'incoming',
+                'default_location_src_id': self.env.ref('stock.stock_location_suppliers').id,
+                'default_location_dest_id': company.subcontracting_location_id.id,
+                'sequence_code': 'DSC',
+                'use_existing_lots': False,
+            })
+        if pick_type_vals:
+            pick_type_ids = self.env['stock.picking.type'].create(pick_type_vals)
+            for pick_type in pick_type_ids:
+                pick_type.company_id.dropship_subcontractor_pick_type_id = pick_type.id
 
     def _create_subcontracting_dropshipping_rules(self):
         route = self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping')
@@ -16,7 +53,7 @@ class ResCompany(models.Model):
             dropship_picking_type = self.env['stock.picking.type'].search([
                 ('company_id', '=', company.id),
                 ('default_location_src_id.usage', '=', 'supplier'),
-                ('default_location_dest_id.usage', '=', 'customer'),
+                ('default_location_dest_id', '=', subcontracting_location.id),
             ], limit=1, order='sequence')
             if dropship_picking_type:
                 vals.append({
@@ -33,14 +70,39 @@ class ResCompany(models.Model):
             self.env['stock.rule'].create(vals)
 
     @api.model
-    def create_missing_subcontracting_dropshipping_rules(self):
+    def _create_missing_subcontracting_dropshipping_rules(self):
         route = self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping')
         company_ids = self.env['res.company'].search([])
         company_has_rules = self.env['stock.rule'].search([('route_id', '=', route.id)]).mapped('company_id')
         company_todo_rules = company_ids - company_has_rules
         company_todo_rules._create_subcontracting_dropshipping_rules()
 
+    @api.model
+    def _create_missing_subcontracting_dropshipping_sequence(self):
+        company_ids = self.env['res.company'].search([])
+        company_has_seq = self.env['ir.sequence'].search([('code', '=', 'mrp.subcontracting.dropshipping')]).mapped('company_id')
+        company_todo_sequence = company_ids - company_has_seq
+        company_todo_sequence._create_subcontracting_dropshipping_sequence()
+
+    @api.model
+    def _create_missing_subcontracting_dropshipping_picking_type(self):
+        company_ids = self.env['res.company'].search([])
+        company_has_dropship_subcontractor_picking_type = self.env['stock.picking.type'].search([
+            ('default_location_src_id.usage', '=', 'supplier'),
+            ('default_location_dest_id', 'in', company_ids.subcontracting_location_id.ids),
+        ]).mapped('company_id')
+        company_todo_picking_type = company_ids - company_has_dropship_subcontractor_picking_type
+        company_todo_picking_type._create_subcontracting_dropshipping_picking_type()
+
+    def _create_per_company_sequences(self):
+        super()._create_per_company_sequences()
+        self._create_subcontracting_dropshipping_sequence()
+
     def _create_per_company_rules(self):
         res = super()._create_per_company_rules()
-        self.create_missing_subcontracting_dropshipping_rules()
+        self._create_subcontracting_dropshipping_rules()
         return res
+
+    def _create_per_company_picking_types(self):
+        super()._create_per_company_picking_types()
+        self._create_subcontracting_dropshipping_picking_type()

--- a/addons/mrp_subcontracting_dropshipping/models/stock_orderpoint.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_orderpoint.py
@@ -1,0 +1,15 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockWarehouseOrderpoint(models.Model):
+    _inherit = 'stock.warehouse.orderpoint'
+
+    def _prepare_procurement_values(self, date=False, group=False):
+        vals = super()._prepare_procurement_values(date, group)
+        if not vals.get('partner_id') and self.location_id.is_subcontracting_location:
+            subcontractors = self.location_id.subcontractor_ids
+            vals['partner_id'] = subcontractors.id if len(subcontractors) == 1 else False
+        return vals

--- a/addons/mrp_subcontracting_dropshipping/models/stock_picking.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_picking.py
@@ -7,6 +7,11 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
+    def _compute_is_dropship(self):
+        dropship_subcontract_pickings = self.filtered(lambda p: p.location_dest_id.is_subcontracting_location and p.location_id.usage == 'supplier')
+        dropship_subcontract_pickings.is_dropship = True
+        super(StockPicking, self - dropship_subcontract_pickings)._compute_is_dropship()
+
     def _get_warehouse(self, subcontract_move):
         if subcontract_move.sale_line_id:
             return subcontract_move.sale_line_id.order_id.warehouse_id

--- a/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
@@ -11,3 +11,9 @@ class StockRule(models.Model):
         if 'partner_id' not in values[0] and self.location_dest_id.is_subcontracting_location:
             values[0]['partner_id'] = values[0]['group_id'].partner_id.id
         return super()._prepare_purchase_order(company_id, origins, values)
+
+    def _make_po_get_domain(self, company_id, values, partner):
+        domain = super()._make_po_get_domain(company_id, values, partner)
+        if values.get('partner_id', False):
+            domain += (('dest_address_id', '=', values.get('partner_id')),)
+        return domain

--- a/addons/mrp_subcontracting_dropshipping/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_warehouse.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 
 
 class StockWarehouse(models.Model):
@@ -14,6 +14,58 @@ class StockWarehouse(models.Model):
     subcontracting_dropshipping_pull_id = fields.Many2one(
         'stock.rule', 'Subcontracting-Dropshipping MTS Rule'
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        # if new warehouse has resupply enabled, enable global route
+        if any([vals.get('subcontracting_dropshipping_to_resupply', False) for vals in vals_list]):
+            res.update_global_route_dropship_subcontractor()
+        return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        # if all warehouses have resupply disabled, disable global route, until its enabled on a warehouse
+        if 'subcontracting_dropshipping_to_resupply' in vals or 'active' in vals:
+            if 'subcontracting_dropshipping_to_resupply' in vals:
+                # ignore when warehouse archived since it will auto-archive all of its rules
+                self._update_dropship_subcontract_rules()
+            self.update_global_route_dropship_subcontractor()
+        return res
+
+    def _update_dropship_subcontract_rules(self):
+        '''update (archive/unarchive) any warehouse subcontracting location dropship rules'''
+        subcontracting_locations = self._get_subcontracting_locations()
+        route_id = self._find_global_route('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping',
+                                           _('Dropship Subcontractor on Order'))
+        warehouses_dropship = self.filtered(lambda w: w.subcontracting_dropshipping_to_resupply and w.active)
+        if warehouses_dropship:
+            self.env['stock.rule'].with_context(active_test=False).search([
+                ('route_id', '=', route_id.id),
+                ('action', '=', 'pull'),
+                ('warehouse_id', 'in', warehouses_dropship.ids),
+                ('location_src_id', 'in', subcontracting_locations.ids)]).action_unarchive()
+
+        warehouses_no_dropship = self - warehouses_dropship
+        if warehouses_no_dropship:
+            self.env['stock.rule'].search([
+                ('route_id', '=', route_id.id),
+                ('action', '=', 'pull'),
+                ('warehouse_id', 'in', warehouses_no_dropship.ids),
+                ('location_src_id', 'in', subcontracting_locations.ids)]).action_archive()
+
+    def update_global_route_dropship_subcontractor(self):
+        route_id = self._find_global_route('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping',
+                                           _('Dropship Subcontractor on Order'))
+        # if route has no pull rules, it means all warehouses have Dropship Subcontractor disabled
+        # Pick type is per company so we need to check rules per company to archive it, however
+        # the route is global so we need to check all rules regardless of company
+        all_rules = route_id.sudo().rule_ids.filtered(lambda r: r.active)
+        for company in self.company_id:
+            company_rules = all_rules.filtered(lambda r: r.company_id == company)
+            company.dropship_subcontractor_pick_type_id.active = bool(company_rules.filtered(lambda r: r.action == 'pull'))
+
+        route_id.active = bool(all_rules.filtered(lambda r: r.action == 'pull'))
 
     def _get_global_route_rules_values(self):
         rules = super()._get_global_route_rules_values()

--- a/addons/mrp_subcontracting_dropshipping/views/purchase_order_views.xml
+++ b/addons/mrp_subcontracting_dropshipping/views/purchase_order_views.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <record id="view_purchase_order_inherit" model="ir.ui.view">
+        <field name="name">Purchase Order Inherit Dropship Subcontractor</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <field name="dest_address_id" position="before">
+                <field name="default_location_dest_id_is_subcontracting_loc" invisible="1"/>
+            </field>
+            <field name="dest_address_id" position="attributes">
+                <attribute name="attrs">{'invisible': [('default_location_dest_id_usage', '!=', 'customer'), ('default_location_dest_id_is_subcontracting_loc', '=', False)],
+                    'required': ['|', ('default_location_dest_id_usage', '=', 'customer'), ('default_location_dest_id_is_subcontracting_loc', '=', True)]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -21,7 +21,7 @@ class PurchaseOrder(models.Model):
     incoterm_location = fields.Char(string='Incoterm Location', states={'done': [('readonly', True)]})
     incoming_picking_count = fields.Integer("Incoming Shipment count", compute='_compute_incoming_picking_count')
     picking_ids = fields.Many2many('stock.picking', compute='_compute_picking_ids', string='Receptions', copy=False, store=True)
-
+    dest_address_id = fields.Many2one('res.partner', compute='_compute_dest_address_id', store=True, readonly=False)
     picking_type_id = fields.Many2one('stock.picking.type', 'Deliver To', states=Purchase.READONLY_STATES, required=True, default=_default_picking_type, domain="['|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]",
         help="This will determine operation type of incoming shipment")
     default_location_dest_id_usage = fields.Selection(related='picking_type_id.default_location_dest_id.usage', string='Destination Location Type',
@@ -73,10 +73,9 @@ class PurchaseOrder(models.Model):
             else:
                 order.receipt_status = 'pending'
 
-    @api.onchange('picking_type_id')
-    def _onchange_picking_type_id(self):
-        if self.picking_type_id.default_location_dest_id.usage != 'customer':
-            self.dest_address_id = False
+    @api.depends('picking_type_id')
+    def _compute_dest_address_id(self):
+        self.filtered(lambda po: po.picking_type_id.default_location_dest_id.usage != 'customer').dest_address_id = False
 
     @api.onchange('company_id')
     def _onchange_company_id(self):


### PR DESCRIPTION
When subcontracting with reordering rule on subcontract location, using dropshipping in the PO,
the user was unable to set Dropship address since subcontracting location was not a
customer location. The Dropship address is now shown and a new operation type is used
to classify dropshipping subcontractor transfers.

Task Id: 2848013
Upgrade: odoo/upgrade#3852

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
