### PR TITLE
[IMP] l10n_it: Import/Export non EU, fiscal position

### DIFF
--- a/addons/l10n_it/data/account.fiscal.position.template.csv
+++ b/addons/l10n_it/data/account.fiscal.position.template.csv
@@ -1,5 +1,5 @@
 "name","chart_template_id:id","id","sequence","auto_apply","vat_required","country_id:id","country_group_id:id","note"
 "Italia","l10n_it_chart_template_generic","it",1,1,1,base.it,,
-"Regime Extra comunitario","l10n_it_chart_template_generic","extra",4,1,,,,
 "Regime Intra comunitario privato","l10n_it_chart_template_generic","intra_private",2,1,,,base.europe,
 "Regime Intra comunitario","l10n_it_chart_template_generic","intra",3,1,1,,base.europe,"Fattura emessa ai sensi dell’art. 17, comma 2 del DPR 26/10/1972 n. 633, l’applicazione dell’IVA è a carico del destinatario."
+"Regime Extra comunitario","l10n_it_chart_template_generic","extra",4,1,,,,"Fattura emessa ai sensi dell’art. 17, comma 2 del DPR 26/10/1972 n. 633, l’applicazione dell’IVA è a carico del destinatario."

--- a/addons/l10n_it/data/account_fiscal_position_tax_template_data.xml
+++ b/addons/l10n_it/data/account_fiscal_position_tax_template_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- account.fiscal.position.tax.template -->
+    <!-- Intra EU -->
     <record id="afpttn_it_intra_1" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="intra"/>
         <field name="tax_src_id"  ref="22v"/>
@@ -75,6 +75,85 @@
     </record>
     <record id="afpttn_it_intra_15" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="intra"/>
+        <field name="tax_src_id"  ref="00as"/>
+        <field name="tax_dest_id" ref="00rcs"/>
+    </record>
+
+    <!-- Extra EU -->
+    <record id="afpttn_it_extra_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="22v"/>
+        <field name="tax_dest_id" ref="00ex"/>
+    </record>
+    <record id="afpttn_it_extra_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="10v"/>
+        <field name="tax_dest_id" ref="00ex"/>
+    </record>
+    <record id="afpttn_it_extra_3" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="5v"/>
+        <field name="tax_dest_id" ref="00ex"/>
+    </record>
+    <record id="afpttn_it_extra_4" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="4v"/>
+        <field name="tax_dest_id" ref="00ex"/>
+    </record>
+    <record id="afpttn_it_extra_5" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="00v"/>
+        <field name="tax_dest_id" ref="00ex"/>
+    </record>
+
+    <record id="afpttn_it_extra_6" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="22am"/>
+        <field name="tax_dest_id" ref="22rcm"/>
+    </record>
+    <record id="afpttn_it_extra_7" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="10am"/>
+        <field name="tax_dest_id" ref="10rcm"/>
+    </record>
+    <record id="afpttn_it_extra_8" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="5am"/>
+        <field name="tax_dest_id" ref="5rcm"/>
+    </record>
+    <record id="afpttn_it_extra_9" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="4am"/>
+        <field name="tax_dest_id" ref="4rcm"/>
+    </record>
+    <record id="afpttn_it_extra_10" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="00am"/>
+        <field name="tax_dest_id" ref="00rcm"/>
+    </record>
+
+    <record id="afpttn_it_extra_11" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="22as"/>
+        <field name="tax_dest_id" ref="22rcs"/>
+    </record>
+    <record id="afpttn_it_extra_12" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="10as"/>
+        <field name="tax_dest_id" ref="10rcs"/>
+    </record>
+    <record id="afpttn_it_extra_13" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="5as"/>
+        <field name="tax_dest_id" ref="5rcs"/>
+    </record>
+    <record id="afpttn_it_extra_14" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
+        <field name="tax_src_id"  ref="4as"/>
+        <field name="tax_dest_id" ref="4rcs"/>
+    </record>
+    <record id="afpttn_it_extra_15" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="extra"/>
         <field name="tax_src_id"  ref="00as"/>
         <field name="tax_dest_id" ref="00rcs"/>
     </record>

--- a/addons/l10n_it/data/account_tax_template.xml
+++ b/addons/l10n_it/data/account_tax_template.xml
@@ -563,6 +563,41 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
+                'minus_report_line_ids': [ref('tax_report_line_vp2')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+
+    <record id="00ex" model="account.tax.template">
+        <field name="description">00exp</field>
+        <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
+        <field name="name">0% EX</field>
+        <field name="sequence">17</field>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="price_include">False</field>
+        <field name="tax_group_id" ref="tax_group_fuori"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('tax_report_line_vp2')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'minus_report_line_ids': [ref('tax_report_line_vp2')],
             }),
             (0,0, {
                 'factor_percent': 100,
@@ -576,7 +611,7 @@
         <field name="description">00art15v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">0% Art.15</field>
-        <field name="sequence">17</field>
+        <field name="sequence">18</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -608,7 +643,7 @@
         <field name="description">00art15a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">0% Art.15</field>
-        <field name="sequence">18</field>
+        <field name="sequence">19</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -642,7 +677,7 @@
         <field name="description">22rcs</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">22% S RC</field>
-        <field name="sequence">19</field>
+        <field name="sequence">20</field>
         <field name="amount">22</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -690,7 +725,7 @@
         <field name="description">10rcs</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">10% S RC</field>
-        <field name="sequence">20</field>
+        <field name="sequence">21</field>
         <field name="amount">10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -738,7 +773,7 @@
         <field name="description">5rcs</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">5% S RC</field>
-        <field name="sequence">21</field>
+        <field name="sequence">22</field>
         <field name="active">False</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -787,7 +822,7 @@
         <field name="description">4rcs</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">4% S RC</field>
-        <field name="sequence">22</field>
+        <field name="sequence">23</field>
         <field name="active">False</field>
         <field name="amount">4</field>
         <field name="amount_type">percent</field>
@@ -836,7 +871,7 @@
         <field name="description">00rcs</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">0% S RC</field>
-        <field name="sequence">23</field>
+        <field name="sequence">24</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -886,7 +921,7 @@
         <field name="description">22rcm</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">22% G RC</field>
-        <field name="sequence">24</field>
+        <field name="sequence">25</field>
         <field name="amount">22</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -934,7 +969,7 @@
         <field name="description">10rcm</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">10% G RC</field>
-        <field name="sequence">25</field>
+        <field name="sequence">26</field>
         <field name="amount">10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -982,7 +1017,7 @@
         <field name="description">5rcm</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">5% G RC</field>
-        <field name="sequence">26</field>
+        <field name="sequence">27</field>
         <field name="active">False</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -1031,7 +1066,7 @@
         <field name="description">4rcm</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">4% G RC</field>
-        <field name="sequence">27</field>
+        <field name="sequence">28</field>
         <field name="active">False</field>
         <field name="amount">4</field>
         <field name="amount_type">percent</field>
@@ -1080,7 +1115,7 @@
         <field name="description">00rcm</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">0% G RC</field>
-        <field name="sequence">28</field>
+        <field name="sequence">29</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1130,7 +1165,7 @@
         <field name="description">22rcd</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">22% G Deposit</field>
-        <field name="sequence">29</field>
+        <field name="sequence">30</field>
         <field name="amount">22</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1178,7 +1213,7 @@
         <field name="description">10rcd</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">10% G Deposit</field>
-        <field name="sequence">30</field>
+        <field name="sequence">31</field>
         <field name="amount">10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1226,7 +1261,7 @@
         <field name="description">5rcd</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">5% G Deposit</field>
-        <field name="sequence">31</field>
+        <field name="sequence">32</field>
         <field name="active">False</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -1275,7 +1310,7 @@
         <field name="description">4rcd</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">4% G Deposit</field>
-        <field name="sequence">32</field>
+        <field name="sequence">33</field>
         <field name="active">False</field>
         <field name="amount">4</field>
         <field name="amount_type">percent</field>
@@ -1324,7 +1359,7 @@
         <field name="description">00rcd</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">0% G Deposit</field>
-        <field name="sequence">33</field>
+        <field name="sequence">34</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -134,9 +134,13 @@
                 </DatiBollo>
                 <ImportoTotaleDocumento t-esc="format_monetary(record.amount_total, currency)"/>
             </DatiGeneraliDocumento>
-            <DatiOrdineAcquisto t-if="record.ref">
+            <DatiOrdineAcquisto t-if="not is_self_invoice and record.ref">
                 <IdDocumento t-esc="format_alphanumeric(record.ref[:20])"/>
             </DatiOrdineAcquisto>
+            <DatiFattureCollegate t-if="is_self_invoice and record.ref">
+                <IdDocumento t-esc="format_alphanumeric(record.ref[:20])"/>
+                <Data t-esc="format_date(record.invoice_date)"/>
+            </DatiFattureCollegate>
             <DatiDDT t-if="record.l10n_it_ddt_id">
                 <NumeroDDT t-esc="format_alphanumeric(record.l10n_it_ddt_id.name[-20:])"/>
                 <DataDDT t-esc="format_date(record.l10n_it_ddt_id.date)"/>


### PR DESCRIPTION
The non-EU part of Reverse Charge was missing the specific export tax and the fiscal position table.