### PR TITLE
[IMP] requirements: adapt to latest Jammy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
-chardet==3.0.4
+chardet==4.0.0
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5
@@ -11,29 +11,29 @@ gevent==21.8.0 ; python_version > '3.9'  # (Jammy)
 greenlet==0.4.15 ; python_version == '3.7'
 greenlet==0.4.17 ; python_version > '3.7' and python_version <= '3.9'
 greenlet==1.1.2 ; python_version  > '3.9'  # (Jammy)
-idna==2.8
+idna==2.10
 Jinja2==2.11.3 # min version = 2.10.1 (Focal - with security backports)
-libsass==0.18.0
+libsass==0.20.1
 lxml==4.6.5 # min version = 4.5.0 (Focal - with security backports)
-MarkupSafe==1.1.0
-num2words==0.5.6
+MarkupSafe==1.1.1
+num2words==0.5.9
 ofxparse==0.19; python_version <= '3.9'
 ofxparse==0.21; python_version > '3.9'  # (Jammy)
-passlib==1.7.3 # min version = 1.7.2 (Focal with security backports)
+passlib==1.7.4
 Pillow==9.0.1  # min version = 7.0.0 (Focal with security backports)
 polib==1.1.0
-psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
+psutil==5.8.0
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
 psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
-pydot==1.4.1
-pyopenssl==19.0.0
+pydot==1.4.2
+pyopenssl==20.0.1
 PyPDF2==1.26.0
 pypiwin32 ; sys_platform == 'win32'
-pyserial==3.4
-python-dateutil==2.7.3
+pyserial==3.5
+python-dateutil==2.8.1
 python-ldap==3.4.0 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
-python-stdnum==1.13
-pytz==2019.3
+python-stdnum==1.16
+pytz==2021.1
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
@@ -46,4 +46,4 @@ xlrd==1.1.0; python_version < '3.8'
 xlrd==1.2.0; python_version >= '3.8'
 XlsxWriter==1.1.2
 xlwt==1.3.*
-zeep==3.4.0
+zeep==4.0.0


### PR DESCRIPTION
With the release of the Ubuntu 22.04 Jammy Jellyfish, the time has come
for our requirements to make the usual JCVD style big gap between the
latest Ubuntu stable and the latest Debian stable 11.4 Bullseye.

|                         |  Debian Bullseye    | Ubuntu Jammy |
| --------------------|---------------------------|----------------------|
| chardet | [4.0.0](https://packages.debian.org/bullseye/python3-chardet) | [4.0.0](https://packages.ubuntu.com/jammy/python3-chardet) |
| idna | [2.10](https://packages.debian.org/bullseye/python3-idna) | [3.3](https://packages.ubuntu.com/jammy/python3-idna)|
| libsass | [0.20.1](https://packages.debian.org/bullseye/python3-libsass) | [0.20.1](https://packages.ubuntu.com/jammy/python3-libsass)|
| Markupsafe | [1.1.1](https://packages.debian.org/bullseye/python3-markupsafe) | [2.0.1](https://packages.ubuntu.com/jammy/python3-markupsafe) |
| num2words | [0.5.9](https://packages.debian.org/bullseye/python3-num2words) | [0.5.10](https://packages.ubuntu.com/jammy/python3-num2words)|
|passlib| [1.7.4](https://packages.debian.org/bullseye/python3-passlib)|[1.7.4](https://packages.ubuntu.com/jammy/python3-passlib)|
|psutil |[5.8.0](https://packages.debian.org/bullseye/python3-psutil)|[5.9.0](https://packages.ubuntu.com/jammy/python3-psutil)|
|pydot|[1.4.2](https://packages.debian.org/bullseye/python3-pydot)|[1.4.2](https://packages.ubuntu.com/jammy/python3-pydot)|
|pyopenssl|[20.0.1](https://packages.debian.org/bullseye/python3-openssl)|[21.0.0](https://packages.ubuntu.com/jammy/python3-openssl)|
|pyserial|[3.5](https://packages.debian.org/bullseye/python3-serial)|[3.5](https://packages.ubuntu.com/jammy/python3-serial)|
|python-dateutil|[2.8.1](https://packages.debian.org/bullseye/python3-dateutil)|[2.8.1](https://packages.ubuntu.com/jammy/python3-dateutil)|
|stdnum|[1.16](https://packages.debian.org/bullseye/python3-stdnum)|[1.17](https://packages.ubuntu.com/jammy/python3-stdnum)|
|pytz|[2021.1](https://packages.debian.org/bullseye/python3-tz)|[2022.1](https://packages.ubuntu.com/jammy/python3-tz)|
|zeep|[4.0.0](https://packages.debian.org/bullseye/python3-zeep)|[4.1.0](https://packages.ubuntu.com/jammy/python3-zeep)|

