### PR TITLE
[FIX] calendar_sms: send sms to partner with phone numbers

### DIFF
--- a/addons/calendar_sms/models/calendar.py
+++ b/addons/calendar_sms/models/calendar.py
@@ -15,7 +15,7 @@ class CalendarEvent(models.Model):
         """ Method overridden from mail.thread (defined in the sms module).
             SMS text messages will be sent to attendees that haven't declined the event(s).
         """
-        return self.mapped('attendee_ids').filtered(lambda att: att.state != 'declined').mapped('partner_id')
+        return self.mapped('attendee_ids').filtered(lambda att: att.state != 'declined' and att.partner_id.phone_sanitized).mapped('partner_id')
 
     def _do_sms_reminder(self):
         """ Send an SMS text reminder to attendees that haven't declined the event """

--- a/addons/calendar_sms/tests/__init__.py
+++ b/addons/calendar_sms/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_calendar_sms

--- a/addons/calendar_sms/tests/test_calendar_sms.py
+++ b/addons/calendar_sms/tests/test_calendar_sms.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+
+from odoo.tests.common import SingleTransactionCase
+
+
+class TestCalendarSms(SingleTransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCalendarSms, cls).setUpClass()
+
+        cls.partner_phone = cls.env['res.partner'].create({
+            'name': 'Partner With Phone Number',
+            'phone': '0477777777',
+            'country_id': cls.env.ref('base.be').id,
+        })
+        cls.partner_no_phone = cls.env['res.partner'].create({
+            'name': 'Partner With No Phone Number',
+            'country_id': cls.env.ref('base.be').id,
+        })
+
+    def test_attendees_with_number(self):
+        """Test if only partners with sanitized number are returned."""
+        attendees = self.env['calendar.event'].create({
+            'name': "Boostrap vs Foundation",
+            'start': datetime(2022, 1, 1, 11, 11),
+            'stop': datetime(2022, 2, 2, 22, 22),
+            'partner_ids': [(6, 0, [self.partner_phone.id, self.partner_no_phone.id])],
+        })._sms_get_default_partners()
+        self.assertEqual(len(attendees), 1, "There should be only one partner retrieved")


### PR DESCRIPTION
Steps to reproduce:
- create a contact with a phone number
- enable IAP-sms
- take off the phone number of the admin-contact
- create an event in the calendar with a "text-sms reminder" with the new created user

Issue:
No sms will be sent

Cause:
The IAP server-side does not accept request with `number` set to False such as in:
```
{'messages': [
{'res_id': 23, 'number': False, 'content': 'Event reminder: test-local, 07/11/2022 at (15:46:00 To 16:46:00) (Europe/Brussels)'}, 
{'res_id': 24, 'number': '+32487253270', 'content': 'Event reminder: test-local, 07/11/2022 at (15:46:00 To 16:46:00) (Europe/Brussels)'}
]}
```

Solution:
Filter partners with a valid phone number in `_sms_get_default_partner`

opw-2867763