### PR TITLE
[FIX] sale: avoid creating analytic lines for section & notes.

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1520,7 +1520,7 @@ class SaleOrderLine(models.Model):
             'discount': self.discount,
             'price_unit': self.price_unit,
             'tax_ids': [(6, 0, self.tax_id.ids)],
-            'analytic_account_id': self.order_id.analytic_account_id.id,
+            'analytic_account_id': self.order_id.analytic_account_id.id if not self.display_type else False,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'sale_line_ids': [(4, self.id)],
         }

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -97,7 +97,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 'tax_ids': [(6, 0, so_line.tax_id.ids)],
                 'sale_line_ids': [(6, 0, [so_line.id])],
                 'analytic_tag_ids': [(6, 0, so_line.analytic_tag_ids.ids)],
-                'analytic_account_id': order.analytic_account_id.id or False,
+                'analytic_account_id': order.analytic_account_id.id if not so_line.display_type and order.analytic_account_id.id else False,
             })],
         }
 


### PR DESCRIPTION
Currently, When we create an invoice from a sale order containing some notes or sections. The analytic account from the sale order is set on the invoice/move line. During the creation of analytic lines, a line is created from the section/note line.

This commit makes no analytic line is created for section/notes.

Video : 

https://youtu.be/AqyrXEIcKvg


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
