### PR TITLE
[FIX] sale_timesheet: prevent sale_timesheet_tour to indeterministically fail

### DIFF
--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -47,7 +47,12 @@ tour.register('sale_timesheet_tour', {
     run: 'click',
 }, {
     trigger: 'button.o_form_button_save',
+    extra_trigger: '.o_form_view:not(:has(button[name="action_confirm"]:not(.o_invisible_modifier)))',
     content: 'Click on Save button to save the Sales Order.',
+    run: 'click',
+}, {
+    trigger: '.o_form_readonly',
+    content: 'Save is done and form is reloaded.',
     run: 'click',
 }, tour.stepUtils.toggleHomeMenu(),
 ...tour.stepUtils.goToAppSteps("project.menu_main_pm", 'Go to the Project app.'),


### PR DESCRIPTION
Prior to this commit, the `sale_timesheet_tour` was indeterministically failing
due to the fact that the tour step responsible of saving the data was not waiting
for the previous step (responsible to confirm the SO) to be finished.

This commit fixes this issue by ensuring that the buttons that allow confirming
the SO are not visible any more.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
