### PR TITLE
[FIX] stock: check if a move is linked before checking

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -465,7 +465,7 @@ class StockMoveLine(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for ml in self:
             # Unlinking a move line should unreserve.
-            if ml.product_id.type == 'product' and not ml.move_id._should_bypass_reservation(ml.location_id) and not float_is_zero(ml.product_qty, precision_digits=precision):
+            if ml.move_id and ml.product_id.type == 'product' and not ml.move_id._should_bypass_reservation(ml.location_id) and not float_is_zero(ml.product_qty, precision_digits=precision):
                 self.env['stock.quant']._update_reserved_quantity(ml.product_id, ml.location_id, -ml.product_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
         moves = self.mapped('move_id')
         res = super(StockMoveLine, self).unlink()


### PR DESCRIPTION
_should_bypass_reservation has an ensured one testing,
so in this case we do not have any reservation on a
move linked to a ml to be unlinked

**Description of the issue/feature this PR addresses:**
Coming from https://github.com/odoo/odoo/blob/6aa0000a89c29136dbc4757ff618ba02590fd0f3/addons/mrp/models/mrp_production.py#L1736-L1738
where the move is unlinked before unlinking, this will lead to a traceback for no useful reason

**Current behavior before PR:**
Traceback

**Desired behavior after PR is merged:**
No Traceback


Info: @wt-io-it


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
