### PR TITLE
[FIX] point_of_sale: avoid rounding error when merging order lines

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1796,7 +1796,7 @@ exports.Orderline = Backbone.Model.extend({
     can_be_merged_with: function(orderline){
         var price = parseFloat(round_di(this.price || 0, this.pos.dp['Product Price']).toFixed(this.pos.dp['Product Price']));
         var order_line_price = orderline.get_product().get_price(orderline.order.pricelist, this.get_quantity());
-        order_line_price = orderline.compute_fixed_price(order_line_price);
+        order_line_price = round_di(orderline.compute_fixed_price(order_line_price), this.pos.currency.decimals);
         if( this.get_product().id !== orderline.get_product().id){    //only orderline of the same product can be merged
             return false;
         }else if(!this.get_unit() || !this.get_unit().is_pos_groupable){


### PR DESCRIPTION
Before this commit when multiple instances of the same product
were selected in a PoS session, `can_be_merged_with` checked if they
had the same price before merging them in a single order line. However
the order line prices were not rounded. In the case of a floating
point error in order line price calculation, this behavior resulted
in multiple order lines for the same product.

Steps to reproduce the issue:
1. Create a product
2. In the pricelist, create a formula of -10% discount based on cost, and 
set the cost as 136.35 $
4. Open a POS session, add the product multiple times
5. The products are not combined in one group, each creates their own order line

To fix this issue, we need to round the order line prices in this
function.

opw-2854304

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
