### PR TITLE
[FIX] l10n_it_edi: fix missing DatiRiepilogo zero percent tax

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -161,7 +161,7 @@ class AccountMove(models.Model):
         # To solve this there is a <Arrotondamento> or 'rounding' field, such that:
         #   taxable base = sum(taxable base for each unit) + Arrotondamento
         tax_details = self._prepare_edi_tax_details(
-            filter_to_apply=lambda l: l['tax_repartition_line_id'].factor_percent > 0
+            filter_to_apply=lambda l: l['tax_repartition_line_id'].factor_percent >= 0
         )
         for _tax_name, tax_dict in tax_details['tax_details'].items():
             base_amount = tax_dict['base_amount_currency']

--- a/addons/l10n_it_edi_sdicoop/tests/expected_xmls/reverse_charge_invoice.xml
+++ b/addons/l10n_it_edi_sdicoop/tests/expected_xmls/reverse_charge_invoice.xml
@@ -5,7 +5,7 @@
                 <IdPaese>IT</IdPaese>
                 <IdCodice>01234560157</IdCodice>
             </IdTrasmittente>
-            <ProgressivoInvio>2022030008</ProgressivoInvio>
+            <ProgressivoInvio>___ignore___</ProgressivoInvio>
             <FormatoTrasmissione>FPR12</FormatoTrasmissione>
             <CodiceDestinatario>XXXXXXX</CodiceDestinatario>
             <ContattiTrasmittente>
@@ -54,7 +54,7 @@
                 <TipoDocumento>TD01</TipoDocumento>
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
-                <Numero>INV/2022/03/0008</Numero>
+                <Numero>___ignore___</Numero>
                 <ImportoTotaleDocumento>1600.80</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>
@@ -92,7 +92,7 @@
                     <ModalitaPagamento>MP05</ModalitaPagamento>
                     <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
                     <ImportoPagamento>1600.80</ImportoPagamento>
-                    <CodicePagamento>INV/2022/03/0008</CodicePagamento>
+                    <CodicePagamento>___ignore___</CodicePagamento>
                 </DettaglioPagamento>
         </DatiPagamento>
         <Allegati></Allegati>

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_reverse_charge_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_reverse_charge_xml.py
@@ -171,7 +171,7 @@ class TestItEdiReverseCharge(TestItEdi):
     def _test_invoice_with_sample_file(self, invoice, filename, xpaths_file=None, xpaths_result=None):
         result = self._cleanup_etree(invoice._export_as_xml(), xpaths_result)
         expected = self._cleanup_etree(self._get_test_file_content(filename), xpaths_file)
-        self.assertXmlTreeEqual(expected, result)
+        self.assertXmlTreeEqual(result, expected)
 
     def test_reverse_charge_invoice(self):
         self._test_invoice_with_sample_file(self.reverse_charge_invoice, "reverse_charge_invoice.xml")

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
@@ -47,6 +47,36 @@ class TestItEdi(AccountEdiTestCommon):
             'company_id': cls.company.id,
         })
 
+        cls.tax_zero_percent_hundred_percent_repartition = cls.env['account.tax'].create({
+            'name': 'all of nothing',
+            'amount': 0,
+            'amount_type': 'percent',
+            'company_id': cls.company.id,
+            'invoice_repartition_line_ids': [
+                (0, 0, {'factor_percent': 100, 'repartition_type': 'base'}),
+                (0, 0, {'factor_percent': 100, 'repartition_type': 'tax'}),
+            ],
+            'refund_repartition_line_ids': [
+                (0, 0, {'factor_percent': 100, 'repartition_type': 'base'}),
+                (0, 0, {'factor_percent': 100, 'repartition_type': 'tax'}),
+            ],
+        })
+
+        cls.tax_zero_percent_zero_percent_repartition = cls.env['account.tax'].create({
+            'name': 'none of nothing',
+            'amount': 0,
+            'amount_type': 'percent',
+            'company_id': cls.company.id,
+            'invoice_repartition_line_ids': [
+                (0, 0, {'factor_percent': 100, 'repartition_type': 'base'}),
+                (0, 0, {'factor_percent': 0, 'repartition_type': 'tax'}),
+            ],
+            'refund_repartition_line_ids': [
+                (0, 0, {'factor_percent': 100, 'repartition_type': 'base'}),
+                (0, 0, {'factor_percent': 0, 'repartition_type': 'tax'}),
+            ],
+        })
+
         cls.italian_partner_a = cls.env['res.partner'].create({
             'name': 'Alessi',
             'vat': 'IT00465840031',
@@ -261,6 +291,24 @@ class TestItEdi(AccountEdiTestCommon):
             'private_key': 'l10n_it_edi_sdicoop_test',
         })
 
+        cls.zero_tax_invoice = cls.env['account.move'].with_company(cls.company).create({
+            'move_type': 'out_invoice',
+            'invoice_date': datetime.date(2022, 3, 24),
+            'partner_id': cls.italian_partner_a.id,
+            'invoice_line_ids': [
+                (0, 0, {
+                    **cls.standard_line,
+                    'name': 'line with tax of 0% with repartition line of 100% ',
+                    'tax_ids': [(6, 0, [cls.tax_zero_percent_hundred_percent_repartition.id])],
+                }),
+                (0, 0, {
+                    **cls.standard_line,
+                    'name': 'line with tax of 0% with repartition line of 0% ',
+                    'tax_ids': [(6, 0, [cls.tax_zero_percent_zero_percent_repartition.id])],
+                }),
+            ],
+        })
+
         # post the invoices
         cls.price_included_invoice._post()
         cls.partial_discount_invoice._post()
@@ -269,6 +317,7 @@ class TestItEdi(AccountEdiTestCommon):
         cls.below_400_codice_simplified_invoice._post()
         cls.total_400_VAT_simplified_invoice._post()
         cls.pa_partner_invoice._post()
+        cls.zero_tax_invoice._post()
 
         cls.edi_basis_xml = cls._get_test_file_content('IT00470550013_basis.xml')
         cls.edi_simplified_basis_xml = cls._get_test_file_content('IT00470550013_simpl.xml')
@@ -571,3 +620,51 @@ class TestItEdi(AccountEdiTestCommon):
     def test_send_pa_partner(self):
         res = self.edi_format._l10n_it_post_invoices_step_1(self.pa_partner_invoice)
         self.assertEqual(res[self.pa_partner_invoice], {'attachment': self.pa_partner_invoice.l10n_it_edi_attachment_id, 'success': True})
+
+    def test_zero_percent_taxes(self):
+        invoice_etree = etree.fromstring(self.zero_tax_invoice._export_as_xml())
+        expected_etree = self.with_applied_xpath(
+            etree.fromstring(self.edi_basis_xml),
+            '''
+            <xpath expr="//FatturaElettronicaBody//DatiBeniServizi" position="replace">
+                <DatiBeniServizi>
+                  <DettaglioLinee>
+                    <NumeroLinea>1</NumeroLinea>
+                    <Descrizione>line with tax of 0% with repartition line of 100%</Descrizione>
+                    <Quantita>1.00</Quantita>
+                    <PrezzoUnitario>800.400000</PrezzoUnitario>
+                    <PrezzoTotale>800.40</PrezzoTotale>
+                    <AliquotaIVA>0.00</AliquotaIVA>
+                  </DettaglioLinee>
+                  <DettaglioLinee>
+                    <NumeroLinea>2</NumeroLinea>
+                    <Descrizione>line with tax of 0% with repartition line of 0%</Descrizione>
+                    <Quantita>1.00</Quantita>
+                    <PrezzoUnitario>800.400000</PrezzoUnitario>
+                    <PrezzoTotale>800.40</PrezzoTotale>
+                    <AliquotaIVA>0.00</AliquotaIVA>
+                  </DettaglioLinee>
+                  <DatiRiepilogo>
+                    <AliquotaIVA>0.00</AliquotaIVA>
+                    <ImponibileImporto>800.40</ImponibileImporto>
+                    <Imposta>0.00</Imposta>
+                    <EsigibilitaIVA>I</EsigibilitaIVA>
+                  </DatiRiepilogo>
+                  <DatiRiepilogo>
+                    <AliquotaIVA>0.00</AliquotaIVA>
+                    <ImponibileImporto>800.40</ImponibileImporto>
+                    <Imposta>0.00</Imposta>
+                    <EsigibilitaIVA>I</EsigibilitaIVA>
+                  </DatiRiepilogo>
+                </DatiBeniServizi>
+            </xpath>
+            <xpath expr="//DettaglioPagamento//ImportoPagamento" position="inside">
+                1600.80
+            </xpath>
+            <xpath expr="//DatiGeneraliDocumento//ImportoTotaleDocumento" position="inside">
+                1600.80
+            </xpath>
+            '''
+        )
+        invoice_etree = self.with_applied_xpath(invoice_etree, "<xpath expr='.//Allegati' position='replace'/>")
+        self.assertXmlTreeEqual(invoice_etree, expected_etree)


### PR DESCRIPTION
For zero percent taxes, when the repartition lines are defined as 0% of
the 0% tax, the DatiReipilogo elements are not generated.

This is because of the recent addition of a filter to the calling of the
_prepare_edi_tax_details inside of the function that generates the
values for the template. The filter specifies that the tax data
retrieved relates to repartition lines with a percentage > 0. This
excludes taxes that are 0% of a 0% tax (which would be the same as a
repartition line of 100% of a 0% tax).

The solution is to change the > to >= so that these 0% tax repartition
lines are included.

A test is created with an invoice with two 0% taxes. One tax has a 100%
tax repartition line, and one has a 0% tax repartition line. With the
fix, there should be DatiReipilogo for both taxes in the xml.