### PR TITLE
[FIX] web_editor: pasting image have 100% default width

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -3007,6 +3007,7 @@ export class OdooEditor extends EventTarget {
     addImagesFiles(imageFiles) {
         for (const imageFile of imageFiles) {
             const imageNode = document.createElement('img');
+            imageNode.style.width = '100%';
             imageNode.dataset.fileName = imageFile.name;
             getImageUrl(imageFile).then((url)=> {
                 imageNode.src = url;


### PR DESCRIPTION
**Current behavior before PR:**

On pasting image to editor, the default width was set to auto.

**Desired behavior after PR is merged:**

On pasting image to editor, the default width is to be 100%.

Task-2862892

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
