### PR TITLE
[FIX] account: fix the account selection widget

### DIFF
--- a/addons/account/static/src/js/account_selection.js
+++ b/addons/account/static/src/js/account_selection.js
@@ -1,100 +1,31 @@
-odoo.define('account.hierarchy.selection', function (require) {
-"use strict";
+/** @odoo-module **/
 
-    var core = require('web.core');
-    var relational_fields = require('web.relational_fields');
-    var _t = core._t;
-    var registry = require('web.field_registry');
+import { qweb, _t } from 'web.core';
+import fieldRegistry from 'web.field_registry';
+import { FieldSelection } from 'web.relational_fields';
 
 
-    var FieldSelection = relational_fields.FieldSelection;
+export const HierarchySelection = FieldSelection.extend({
 
-    var HierarchySelection = FieldSelection.extend({
-        _renderEdit: function () {
-            var self = this;
-            var selectSuper = this._super;
-            var prom = Promise.resolve();
-            if (!self.hierarchy_groups) {
-                prom = this._rpc({
-                    model: 'account.account.type',
-                    method: 'search_read',
-                    kwargs: {
-                        domain: self.record.context && self.record.context.account_type_domain || [],
-                        fields: ['id', 'internal_group', 'display_name'],
-                    },
-                }).then(function(arg) {
-                    self.values = _.map(arg, v => [v['id'], v['display_name']]);
-                    var unique_groups = _.uniq(_.map(arg, v => v['internal_group']));
-                    if (unique_groups.length > 1) {
-                        var parent_lookup = {
-                            'bs': {'name': _t('Balance Sheet'), 'index': 0},
-                            'pl': {'name': _t('Profit & Loss'), 'index': 1},
-                        }
-                        var lookup = {
-                            'asset': {'parent': 'bs', 'name': _t('Assets')},
-                            'liability': {'parent': 'bs', 'name': _t('Liabilities')},
-                            'equity': {'parent': 'bs', 'name': _t('Equity')},
-                            'income': {'parent': 'pl', 'name': _t('Income')},
-                            'expense': {'parent': 'pl', 'name': _t('Expense')},
-                        }
-                        var unique_parents = _.uniq(_.map(_.filter(unique_groups, u => u in lookup), g => lookup[g].parent));
-                        self.hierarchy_groups = [];
-                        _.each(unique_parents, parent_id => {
-                            var parent = parent_lookup[parent_id];
-                            self.hierarchy_groups.splice(parent.index, 0, {'name': parent.name, 'children': []});
-                        });
-                        var other_accounts_added = false;
-                        _.each(unique_groups, g => {
-                            if (g in lookup){
-                                var rec = lookup[g];
-                                self.hierarchy_groups[parent_lookup[rec.parent].index].children.push({
-                                    'name': rec['name'],
-                                    'ids': _.map(_.filter(arg, v => v['internal_group'] == g), v => v['id'])
-                                });
-                            } else if (!other_accounts_added){
-                                self.hierarchy_groups.push({
-                                    'name': _t('Other'),
-                                    'ids': _.map(_.filter(arg, v => !_.keys(lookup).includes(v['internal_group'])), v => v['id'])
-                                });
-                                other_accounts_added = true;
-                            }
-                        })
-                    }
-                });
-            }
+    init: function () {
+        this._super.apply(this, arguments);
+        this.hierarchyGroups = [
+            {name: _t('Balance Sheet')},
+            {name: _t('Assets'), children: this.values.filter(x => x[0] && x[0].startsWith('asset'))},
+            {name: _t('Liabilities'), children: this.values.filter(x => x[0] && x[0].startsWith('liability'))},
+            {name: _t('Equity'), children: this.values.filter(x => x[0] && x[0].startsWith('equity'))},
+            {name: _t('Profit & Loss')},
+            {name: _t('Income'), children: this.values.filter(x => x[0] && x[0].startsWith('income'))},
+            {name: _t('Expense'), children: this.values.filter(x => x[0] && x[0].startsWith('expense'))},
+            {name: _t('Other'), children: this.values.filter(x => x[0] && x[0] == 'off_balance')},
+        ];
+    },
 
-            Promise.resolve(prom).then(function() {
-                if (!self.hierarchy_groups) {
-                    return selectSuper.apply(self, arguments);
-                }
-                self.$el.empty();
-                self._addHierarchy(self.$el, self.hierarchy_groups, 0);
-                var value = self.value;
-                if (self.field.type === 'many2one' && value) {
-                    value = value.data.id;
-                }
-                self.$el.val(JSON.stringify(value));
-            });
-        },
-        _addHierarchy: function(el, group, level) {
-            var self = this;
-            _.each(group, function(item) {
-                var optgroup = $('<optgroup/>').attr(({
-                    'label': $('<div/>').html('&nbsp;'.repeat(6 * level) + item['name']).text(),
-                }))
-                _.each(item['ids'], function(id) {
-                    var value = _.find(self.values, v => v[0] == id)
-                    optgroup.append($('<option/>', {
-                        value: JSON.stringify(value[0]),
-                        text: value[1],
-                    }));
-                })
-                el.append(optgroup)
-                if (item['children']) {
-                    self._addHierarchy(el, item['children'], level + 1);
-                }
-            })
-        }
-    });
-    registry.add("account_hierarchy_selection", HierarchySelection);
+    _renderEdit: function () {
+        this.$el.empty();
+        this.$el.append(qweb.render('accountTypeSelection', {widget: this}));
+        this.$el.val(JSON.stringify(this._getRawValue()));
+    }
 });
+
+fieldRegistry.add("account_type_selection", HierarchySelection);

--- a/addons/account/static/src/xml/account_type_selection.xml
+++ b/addons/account/static/src/xml/account_type_selection.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+
+    <t t-name="accountTypeSelection">
+        <t t-foreach="widget.hierarchyGroups" t-as="group">
+            <optgroup t-att-label="group.name">
+                <t t-if="group.children">
+                    <t t-foreach="group.children" t-as="child">
+                        <option t-att-value="JSON.stringify(child[0])" t-out="child[1]"/>
+                    </t>
+                </t>
+            </optgroup>
+        </t>
+    </t>
+
+</templates>

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -59,13 +59,12 @@
                             <page name="accounting" string="Accounting">
                                 <group>
                                     <group>
-                                        <field name="account_type"/>
+                                        <field name="account_type" widget="account_type_selection"/>
                                         <field name="tax_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]" attrs="{'invisible': [('internal_group', '=', 'off_balance')]}"/>
                                         <field name="tag_ids" widget="many2many_tags" domain="[('applicability', '=', 'accounts')]" context="{'default_applicability': 'accounts'}" options="{'no_create_edit': True}"/>
                                         <field name="allowed_journal_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]" options="{'no_create_edit': True}"/>
                                     </group>
                                     <group>
-                                        <field name="account_type" invisible="1" readonly="1"/>
                                         <field name="internal_group" invisible="1" readonly="1"/>
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                         <field name="deprecated"/>
@@ -92,9 +91,8 @@
                 <tree editable="top" create="1" delete="1" multi_edit="1" string="Chart of accounts">
                     <field name="code"/>
                     <field name="name"/>
-                    <field name="account_type"/>
+                    <field name="account_type" widget="account_type_selection"/>
                     <field name="group_id" optional="hide"/>
-                    <field name="account_type" invisible="1"/>
                     <field name="internal_group" invisible="1"/>
                     <field name="reconcile" widget="boolean_toggle" attrs="{'invisible': ['|', ('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('internal_group', '=', 'off_balance')]}"/>
                     <field name="non_trade" widget="boolean_toggle" attrs="{'invisible': [('account_type', 'not in', ('liability_payable', 'asset_receivable'))]}" optional="hide"/>

--- a/addons/account/views/account_chart_template_views.xml
+++ b/addons/account/views/account_chart_template_views.xml
@@ -83,7 +83,7 @@
                         <field name="name"/>
                         <field name="code"/>
                         <newline/>
-                        <field name="account_type"/>
+                        <field name="account_type" widget="account_type_selection"/>
                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                         <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" widget="many2many_tags" context="{'default_applicability': 'accounts'}"/>
                         <field name="reconcile"/>

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -73,7 +73,7 @@
                     <field name="code"/>
                     <field name="name"/>
                     <field name="company_id" invisible="1"/>
-                    <field name="account_type"/>
+                    <field name="account_type" widget="account_type_selection"/>
                     <field name="reconcile" widget="boolean_toggle"/>
                     <field name="opening_debit"/>
                     <field name="opening_credit"/>


### PR DESCRIPTION
Task 2917456

After the change in the account_type field in the account.account, the old selection widget didn't work.
Fixing the selection widget and adding it back to the account_type field.

As account types cannot be custom anymore, the account types within the hierarchy can be hardcoded.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
