### PR TITLE
[FIX] project: fix widget project.task view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1034,7 +1034,7 @@
                     <group>
                         <field name="name" string = "Task Title" placeholder="e.g. New Design"/>
                         <field name="user_ids" options="{'no_open': True,'no_create': True}" domain="[('share', '=', False), ('active', '=', True)]"
-                            widget="many2many_tags"/>
+                            widget="many2many_avatar_user"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>
                     </group>


### PR DESCRIPTION
before this commit,  project task kanban view for some reason are not  display
 the  user_ids avatars.

after this commit, project task kanban view are display the user_ids avatars.

TaskId: 2871552

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
