### PR TITLE
[FIX] repair: apply fiscal position account mapping

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -321,6 +321,7 @@ class Repair(models.Model):
 
             if not group or len(current_invoices_list) == 0:
                 fp_id = repair.partner_id.property_account_position_id.id or self.env['account.fiscal.position'].get_fiscal_position(repair.partner_id.id, delivery_id=repair.address_id.id)
+                fp = self.env['account.fiscal.position'].browse(fp_id)
                 invoice_vals = {
                     'type': 'out_invoice',
                     'partner_id': partner_invoice.id,
@@ -352,7 +353,7 @@ class Repair(models.Model):
                 else:
                     name = operation.name
 
-                account = operation.product_id.product_tmpl_id._get_product_accounts()['income']
+                account = operation.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fp)['income']
                 if not account:
                     raise UserError(_('No account defined for product "%s".') % operation.product_id.name)
 
@@ -394,7 +395,7 @@ class Repair(models.Model):
                 if not fee.product_id:
                     raise UserError(_('No product defined on fees.'))
 
-                account = fee.product_id.product_tmpl_id._get_product_accounts()['income']
+                account = fee.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fp)['income']
                 if not account:
                     raise UserError(_('No account defined for product "%s".') % fee.product_id.name)
 


### PR DESCRIPTION
When creating an invoice from a repair order, the account mapping of the
fiscal position doesn't apply even though the tax one does

Steps to reproduce:
1. Install Repair and Accounting
2. Go to Accounting > Configuration > Invoicing > Fiscal Positions and
   create a new fiscal position with:
   - Name: 'FP test'
   - Tax Mapping from 'Tax 15.00%' to a new tax 'Tax 10.00%'
   - Account Mapping from '400000 Product Sales' to '450000 Other
     Income'
3. Go to Sales > Products and create a new product 'Product A' with:
   - Product Type: 'Consumable'
   - Customer Taxes: 'Tax 15.00%'
   - Income Account: '400000 Product Sales'
4. Create another product 'Product B' with same values except type which
   is 'Service'
5. Go to Repairs and create a new repair order with:
   - Any Product to Repair
   - Any Customer (once set, edit the customer's fiscal position to 'FP
     test')
   - Invoice Method: 'Before Repair'
   - Parts: add a line of type 'Add' with product 'Product A'
   - Operations: add a line with product 'Product A'
6. Confirm the order, create an invoice and open it: the account mapping
   of the fiscal position didn't apply (it should be '450000 Other
   Income')

Solution:
Apply the fiscal position mapping on the income account of the product

opw-2902056