### PR TITLE
[FW][FIX] web_editor, test_website: not crash when selecting icon after replacing image

### DIFF
--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -1,0 +1,45 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+/**
+ * The purpose of this tour is to check the media replacement flow.
+ */
+tour.register('test_replace_media', {
+    url: '/',
+    test: true
+}, [
+    {
+        content: "enter edit mode",
+        trigger: "a[data-action=edit]"
+    },
+    {
+        content: "drop picture snippet",
+        trigger: "#oe_snippets .oe_snippet[name='Picture'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+        extra_trigger: "body.editor_enable.editor_has_snippets",
+        moveTrigger: ".oe_drop_zone",
+        run: "drag_and_drop #wrap",
+    },
+    {
+        content: "select image",
+        trigger: "#wrapwrap .s_picture figure img",
+    },
+    {
+        content: "ensure image size is displayed",
+        trigger: "#oe_snippets we-title:contains('Image') .o_we_image_weight:contains('kb')",
+        run: function () {}, // check
+    },
+    {
+        content: "replace image",
+        trigger: "#oe_snippets we-button[data-replace-media]",
+    },
+    {
+        content: "select svg",
+        trigger: ".o_select_media_dialog img[title='sample.svg']",
+    },
+    {
+        content: "ensure image size is not displayed",
+        trigger: "#oe_snippets we-title:contains('Image'):not(:has(.o_we_image_weight:visible))",
+        run: function () {}, // check
+    },
+]);

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -42,4 +42,34 @@ tour.register('test_replace_media', {
         trigger: "#oe_snippets we-title:contains('Image'):not(:has(.o_we_image_weight:visible))",
         run: function () {}, // check
     },
+    {
+        content: "replace image",
+        trigger: "#oe_snippets we-button[data-replace-media]",
+    },
+    {
+        content: "go to pictogram tab",
+        trigger: ".o_select_media_dialog .nav-link#editor-media-icon-tab",
+    },
+    {
+        content: "select an icon",
+        trigger: ".o_select_media_dialog .tab-pane#editor-media-icon span.fa-lemon-o",
+    },
+    {
+        content: "ensure icon block is displayed",
+        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        run: function () {}, // check
+    },
+    {
+        content: "select footer",
+        trigger: "#wrapwrap footer",
+    },
+    {
+        content: "select icon",
+        trigger: "#wrapwrap .s_picture figure span.fa-lemon-o",
+    },
+    {
+        content: "ensure icon block is still displayed",
+        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        run: function () {}, // check
+    },
 ]);

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -2,6 +2,8 @@
 
 import tour from 'web_tour.tour';
 
+const VIDEO_URL = 'https://www.youtube.com/watch?v=Dpq87YCHmJc';
+
 /**
  * The purpose of this tour is to check the media replacement flow.
  */
@@ -14,9 +16,27 @@ tour.register('test_replace_media', {
         trigger: "a[data-action=edit]"
     },
     {
+        trigger: 'body.editor_enable.editor_has_snippets',
+        run: function () {
+            // Patch the VideoDialog so that it does not do external calls
+            // during the test (note that we don't unpatch but as the patch
+            // is only done after the execution of a test_website test and
+            // specific to an URL only, it is acceptable).
+            // TODO if we ever give the possibility to upload its own videos,
+            // this won't be necessary anymore.
+            odoo.__DEBUG__.services['wysiwyg.widgets.media'].VideoWidget.include({
+                _getVideoURLData: function (src) {
+                    if (src === VIDEO_URL || src === 'about:blank') {
+                        return {platform: 'youtube', embed_url: 'about:blank'};
+                    }
+                    return this._super(...arguments);
+                },
+            });
+        },
+    },
+    {
         content: "drop picture snippet",
         trigger: "#oe_snippets .oe_snippet[name='Picture'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
-        extra_trigger: "body.editor_enable.editor_has_snippets",
         moveTrigger: ".oe_drop_zone",
         run: "drag_and_drop #wrap",
     },
@@ -40,6 +60,65 @@ tour.register('test_replace_media', {
     {
         content: "ensure image size is not displayed",
         trigger: "#oe_snippets we-title:contains('Image'):not(:has(.o_we_image_weight:visible))",
+        run: function () {}, // check
+    },
+    {
+        content: "replace image",
+        trigger: "#oe_snippets we-button[data-replace-media]",
+    },
+    {
+        content: "go to pictogram tab",
+        trigger: ".o_select_media_dialog .nav-link#editor-media-icon-tab",
+    },
+    {
+        content: "select an icon",
+        trigger: ".o_select_media_dialog .tab-pane#editor-media-icon span.fa-lemon-o",
+    },
+    {
+        content: "ensure icon block is displayed",
+        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        run: function () {}, // check
+    },
+    {
+        content: "select footer",
+        trigger: "#wrapwrap footer",
+    },
+    {
+        content: "select icon",
+        trigger: "#wrapwrap .s_picture figure span.fa-lemon-o",
+    },
+    {
+        content: "ensure icon block is still displayed",
+        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        run: function () {}, // check
+    },
+    {
+        content: "replace icon",
+        trigger: "#oe_snippets we-button[data-replace-media]",
+    },
+    {
+        content: "go to video tab",
+        trigger: ".o_select_media_dialog .nav-link#editor-media-video-tab",
+    },
+    {
+        content: "enter a video URL",
+        trigger: ".o_select_media_dialog #o_video_text",
+        // Design your first web page.
+        run: `text ${VIDEO_URL}`,
+    },
+    {
+        content: "wait for preview to appear",
+        // "about:blank" because the VideoWidget was patched at the start of this tour
+        trigger: ".o_select_media_dialog div.media_iframe_video iframe[src='about:blank']",
+        run: function () {}, // check
+    },
+    {
+        content: "confirm selection",
+        trigger: ".o_select_media_dialog .modal-footer .btn-primary",
+    },
+    {
+        content: "ensure video option block is displayed",
+        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Video')",
         run: function () {}, // check
     },
     {

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_custom_snippet
 from . import test_error
 from . import test_image_upload_progress
 from . import test_is_multilang
+from . import test_media
 from . import test_multi_company
 from . import test_performance
 from . import test_redirect

--- a/addons/test_website/tests/test_media.py
+++ b/addons/test_website/tests/test_media.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+
+import odoo.tests
+from odoo.tools import mute_logger
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestMedia(odoo.tests.HttpCase):
+
+    @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
+    def test_01_replace_media(self):
+        SVG = base64.b64encode(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+        self.env['ir.attachment'].create({
+            'name': 'sample.svg',
+            'public': True,
+            'mimetype': 'image/svg+xml',
+            'datas': SVG,
+        })
+        self.start_tour("/", 'test_replace_media', login="admin")

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4948,6 +4948,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         await this._super(...arguments);
 
         if (this._filesize === undefined) {
+            this.$weight.addClass('d-none');
             await this._applyOptions(false);
         }
         if (this._filesize !== undefined) {
@@ -5115,6 +5116,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         }
         if (!this._isImageSupportedForProcessing(img)) {
             this.originalId = null;
+            this._filesize = undefined;
             return;
         }
         const dataURL = await applyModifications(img, {mimetype: this._getImageMimetype(img)});

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -1118,12 +1118,27 @@ var IconWidget = SearchableMediaWidget.extend({
     /**
      * @override
      */
-    save: function () {
+    save: async function () {
         var style = this.$media.attr('style') || '';
         var iconFont = this._getFont(this.selectedIcon) || {base: 'fa', font: ''};
         if (!this.$media.is('span, i')) {
             var $span = $('<span/>');
-            $span.data(this.$media.data());
+            if (this.$media.length) {
+                // Make sure jquery data() is clean by signaling the removal
+                // (e.g. website wants to remove SnippetEditor references from
+                // the data).
+                // TODO make sure copying the data is in fact useful at all, but
+                // in stable it did not feel safe to remove anyway.
+                //
+                // Note: done with an array of promises filled by the event
+                // handler instead of a Promise created here to be resolved by
+                // the event handler as the event handler does not necessarily
+                // exists (in simple HTML fields for example).
+                const data = { proms: [] };
+                this.$media.trigger('before_replace_target', data);
+                await Promise.all(data.proms);
+                $span.data(this.$media.data());
+            }
             this.$media = $span;
             this.media = this.$media[0];
             style = style.replace(/\s*width:[^;]+/, '');

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media_dialog.js
@@ -168,6 +168,7 @@ var MediaDialog = Dialog.extend({
             self.final_data = data;
             _super.apply(self, args);
             $(data).trigger('content_changed');
+            $(data).trigger('replace_target', data);
         });
     },
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1217,8 +1217,9 @@ const Wysiwyg = Widget.extend({
         const restoreSelection = preserveCursor(this.odooEditor.document);
 
         const $node = $(params.node);
-        // We need to keep track of FA icon because media.js will _clear those classes
+        // We need to keep track of FA icon or video because media.js will _clear those classes
         const wasFontAwesome = $node.hasClass('fa');
+        const wasImageOrVideo = wysiwygUtils.isImg($node[0]);
         const $editable = $(OdooEditorLib.closestElement(range.startContainer, '.o_editable'));
         const model = $editable.data('oe-model');
         const field = $editable.data('oe-field');
@@ -1242,7 +1243,7 @@ const Wysiwyg = Widget.extend({
                 element.className += " " + params.htmlClass;
             }
             restoreSelection();
-            if (wysiwygUtils.isImg($node[0]) || wasFontAwesome) {
+            if (wasImageOrVideo || wasFontAwesome) {
                 $node.replaceWith(element);
                 this.odooEditor.unbreakableStepUnactive();
                 this.odooEditor.historyStep();


### PR DESCRIPTION
Since [1](https://github.com/odoo/odoo/commit/d934b81aaae8d68b5579d1489b1fbe8ea347b4ed) replacing an image by an icon then selecting the icon opens an
error popup.

After this commit there is no error when selecting the icon that
replaces an image.
Also, the image size is not displayed anymore if an image having its size displayed is replaced by an image that does not have its size displayed (e.g. an animated gif).
This PR also fixes the fact that videos were not replaced correctly either.

task-2729177




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
