### PR TITLE
    [FIX] crm: missing company on default crm_team

### DIFF
--- a/addons/sales_team/data/crm_team_data.xml
+++ b/addons/sales_team/data/crm_team_data.xml
@@ -4,7 +4,6 @@
         <record id="team_sales_department" model="crm.team">
             <field name="name">Sales</field>
             <field name="sequence">0</field>
-            <field name="company_id" eval="False"/>
         </record>
         <record id="crm_team_member_admin_sales" model="crm.team.member">
             <field name="crm_team_id" ref="team_sales_department"/>
@@ -13,13 +12,11 @@
 
         <record id="salesteam_website_sales" model="crm.team">
             <field name="name">Website</field>
-            <field name="company_id" eval="False"/>
             <field name="active" eval="False"/>
         </record>
 
         <record id="pos_sales_team" model="crm.team">
             <field name="name">Point of Sale</field>
-            <field name="company_id" eval="False"/>
             <field name="active" eval="False"/>
         </record>
 

--- a/addons/sales_team/data/crm_team_demo.xml
+++ b/addons/sales_team/data/crm_team_demo.xml
@@ -11,7 +11,6 @@
 
         <record model="crm.team" id="crm_team_1">
             <field name="name">Pre-Sales</field>
-            <field name="company_id" eval="False"/>
         </record>
 
         <record id="crm_team_member_demo_team_1" model="crm.team.member">


### PR DESCRIPTION
Commit 0edc854a8494eb475087d011efddc7e15b262127
introduce a company check on the team and lead.

However 184334a97d1ccd19b9a7266a13ff51531d22cff4
did not find the expected company:
defaults['company_id'] remains false

As the default company, as defined here
3ad1867ea4d7fcda4ccfeb0a7f3d3860b16d389e
is not set by default (5y old commit)
on the following crm_team:
- Sales
- Pre-Sales
- Website
- PoS

Having added the company check introduce an
unexpected error:
"Incompatible companies on records:\n-
'[header subject of email]'
belongs to company False and 'Customer'
(partner_id: '[name in header from of email]')
belongs to another company."

Error was hard to spot as the db logs are reporting
that the routing of the email was correctly done.
But script to send eml using xmlrpc showed the error.

This commit is fixing freshly created db.
To fix existing db:
Define a value on the field company_id on crm_team

opw-2862509
opw-2783249
