### PR TITLE
[FIX] purchase: missing uom group for test_with_different_uom

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -240,6 +240,8 @@ class TestPurchase(AccountTestInvoicingCommon):
 
     def test_with_different_uom(self):
         """ This test ensures that the unit price is correctly computed"""
+        # Required for `product_uom` to be visibile in the view
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
         uom_units = self.env.ref('uom.product_uom_unit')
         uom_dozens = self.env.ref('uom.product_uom_dozen')
         uom_pairs = self.env['uom.uom'].create({


### PR DESCRIPTION
The user executing the test is changing the UOM
while the field was invisible because the user
did not have the multi uom group.

Therefore, add the group to the user for the test
so the field is visible in the form.

This is related to revision
odoo/odoo@5ccc32fcf72cbfb6bb077d99a7657416c502aac1

```
2022-07-12 11:59:39,526 22 ERROR master odoo.addons.purchase.tests.test_purchase: FAIL: TestPurchase.test_with_different_uom
Traceback (most recent call last):
  File "/home/odoo/src/odoo/master/addons/purchase/tests/test_purchase.py", line 268, in test_with_different_uom
    po_line.product_uom = uom_dozens
  File "/home/odoo/src/odoo/master/odoo/tests/common.py", line 2179, in __setattr__
    assert not self._get_modifier(field, 'invisible'), \
AssertionError: can't write on invisible field product_uom
```