### PR TITLE
[FIX] account_edi_ubl_cii,l10n_it_edi: fix import and embed pdf to efff

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -503,7 +503,7 @@ class AccountEdiCommon(models.AbstractModel):
 
         # quantity
         invoice_line_form.quantity = billed_qty * qty_factor
-        if product_uom_id is not None:
+        if product_uom_id is not None and not invoice_line_form._get_modifier('product_uom_id', 'invisible'):
             invoice_line_form.product_uom_id = product_uom_id
 
         # price_unit

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -225,7 +225,7 @@ class AccountEdiXmlCII(models.AbstractModel):
         # ==== currency_id ====
 
         currency_code_node = tree.find('.//{*}InvoiceCurrencyCode')
-        if currency_code_node is not None:
+        if currency_code_node is not None and self.env.user.has_group('base.group_multi_currency'):
             currency = self.env['res.currency'].with_context(active_test=False).search([
                 ('name', '=', currency_code_node.text),
             ], limit=1)

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -476,7 +476,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # ==== currency_id ====
 
         currency_code_node = tree.find('.//{*}DocumentCurrencyCode')
-        if currency_code_node is not None:
+        if currency_code_node is not None and self.env.user.has_group('base.group_multi_currency'):
             currency = self.env['res.currency'].with_context(active_test=False).search([
                 ('name', '=', currency_code_node.text),
             ], limit=1)

--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -13,8 +13,7 @@ class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
     def _add_pdf_into_invoice_xml(self, invoice, stream_data):
-        # exclude efff because it's handled by l10n_be_edi
-        format_codes = ['ubl_bis3', 'ubl_de', 'nlcius_1']
+        format_codes = ['ubl_bis3', 'ubl_de', 'nlcius_1', 'efff_1']
         edi_attachments = invoice.edi_document_ids.filtered(lambda d: d.edi_format_id.code in format_codes).attachment_id
         for edi_attachment in edi_attachments:
             old_xml = base64.b64decode(edi_attachment.with_context(bin_size=False).datas, validate=True)

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -471,7 +471,7 @@ class AccountEdiFormat(models.Model):
 
                 # Currency. <2.1.1.2>
                 elements = body_tree.xpath('.//DatiGeneraliDocumento/Divisa')
-                if elements:
+                if elements and self.env.user.has_group('base.group_multi_currency'):
                     currency_str = elements[0].text
                     currency = self.env.ref('base.%s' % currency_str.upper(), raise_if_not_found=False)
                     if currency != self.env.company.currency_id and currency.active:


### PR DESCRIPTION
Fix E-FFF: it is no longer handled by l10n_be_edi, the addition of
the pdf inside the xml should occur in the account_edi_ubl_cii module.
See https://github.com/odoo/odoo/commit/4cdd9a0d86d466f200dddd52bca8f48449834f82

In addition, fix the import of EDI documents is broken since it's no
longer possible to write on invisible fields.
Add checks before assigning product_uom_id or currency_id.
See https://github.com/odoo/odoo/commit/5ccc32fcf72cbfb6bb077d99a7657416c502aac1