### PR TITLE
[FIX] web_editor: replace button should replace the image then add another

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1292,7 +1292,7 @@ const Wysiwyg = Widget.extend({
                     break;
                 case 'media-insert':
                 case 'media-replace':
-                    this.openMediaDialog();
+                    this.openMediaDialog({ node: this.lastMediaClicked });
                     break;
                 case 'media-description':
                     new weWidgets.AltDialog(this, {}, this.lastMediaClicked).open();


### PR DESCRIPTION
**Current behavior before PR:**

Replace button was adding another image without replacing the existing one.

**Desired behavior after PR is merged:**

Now replace button replaces the existing image with another one.

Task-2895601

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
