### PR TITLE
[FIX] mrp: do not confirm empty production with MTO rule

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -58,7 +58,8 @@ class StockRule(models.Model):
             self.env['stock.move'].sudo().create(productions._get_moves_raw_values())
             self.env['stock.move'].sudo().create(productions._get_moves_finished_values())
             productions._create_workorder()
-            productions.filtered(lambda p: not p.orderpoint_id or not p.move_raw_ids).action_confirm()
+            productions.filtered(lambda p: (not p.orderpoint_id and p.move_raw_ids) or\
+                (p.move_dest_ids.procure_method != 'make_to_order' and not p.move_raw_ids and not p.workorder_ids)).action_confirm()
 
             for production in productions:
                 origin_production = production.move_dest_ids and production.move_dest_ids[0].raw_material_production_id or False

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -300,7 +300,7 @@ class TestProcurement(TestMrpCommon):
 
     def test_procurement_with_empty_bom(self):
         """Ensure that a procurement request using a product with an empty BoM
-        will create an empty MO in confirmed state that can be completed afterwards.
+        will create an empty MO in draft state that can be completed afterwards.
         """
         self.warehouse = self.env.ref('stock.warehouse0')
         route_manufacture = self.warehouse.manufacture_pull_id.route_id.id
@@ -330,7 +330,7 @@ class TestProcurement(TestMrpCommon):
         production = self.env['mrp.production'].search([('product_id', '=', product.id)])
         self.assertTrue(production)
         self.assertFalse(production.move_raw_ids)
-        self.assertEqual(production.state, 'confirmed')
+        self.assertEqual(production.state, 'draft')
 
         comp1 = self.env['product.product'].create({
             'name': 'egg',


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - routes:
        - MTO
        - Manufacturing
- Create a SO:
    - Select the product “P1”
    - Confirm the SO

Problem:
The created MO is in confirmed state instead of draft.

This blocks the user, for example imagine that he has configured
the product with a first BOM without components and 2 others with
components. when the MO is created, the first bom will be selected,
and as the MO will be confirmed, the user will not be able to
select another BOM

Solution:
Since the MTO rule is not linked to an order point, we could be more
flexible, so the production created via `_run_manufacture()` without
bom or with a bom without component and operation via the MTO mechanism
will not be confirmed

opw-2897267




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
