### PR TITLE
[FIX] point_of_sale: cash amount disappears at open/close pos popup

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
@@ -19,7 +19,6 @@ odoo.define('point_of_sale.CashOpeningPopup', function(require) {
         openDetailsPopup() {
             if (this.moneyDetailsRef.comp.isClosed()){
                 this.moneyDetailsRef.comp.openPopup();
-                this.state.openingCash = 0;
                 this.state.notes = "";
                 if (this.manualInputCashCount) {
                     this.moneyDetailsRef.comp.reset();

--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -72,8 +72,6 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
         openDetailsPopup() {
             if (this.moneyDetailsRef.comp.isClosed()){
                 this.moneyDetailsRef.comp.openPopup();
-                this.state.payments[this.defaultCashDetails.id].counted = 0;
-                this.state.payments[this.defaultCashDetails.id].difference = -this.defaultCashDetails.amount;
                 this.state.notes = '';
                 if (this.manualInputCashCount) {
                     this.moneyDetailsRef.comp.reset();


### PR DESCRIPTION
Before this commit, when the user
opened the money details popup in
order to manually count the amount
of bills/coins  in the cash box,
the previous amount of cash would
be deleted, even if the user clicked
"Discard" at the money details popup.
This is undesired behavior and is fixed
at the current commit.

task-2895447
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
