### PR TITLE
[FIX] web: initialize iOS native app with all allowed companies

### DIFF
--- a/addons/web/static/src/js/chrome/abstract_web_client.js
+++ b/addons/web/static/src/js/chrome/abstract_web_client.js
@@ -118,6 +118,16 @@ var AbstractWebClient = Widget.extend(ServiceProviderMixin, KeyboardNavigationMi
         // If not set on the url, retrieve cids from the local storage
         // of from the default company on the user
         var current_company_id = session.user_companies.current_company[0]
+        if (config.device.isIosApp) {
+            // Native apps can be opened via native notification. In order to
+            // avoid multi-company access error, the app must be initialized
+            // with all allowed companies active. It works well on Android
+            // because it has cookie cids equal to all allowed companies.
+            // However, iOS app has session id cookie only and there is no way
+            // to update iOS app. So, as a workaround we force cids here.
+            var allowed_company_ids = session.user_companies.allowed_companies.map(value => value[0]);
+            state.cids = allowed_company_ids.join(",");
+        }
         if (!state.cids) {
             state.cids = utils.get_cookie('cids') !== null ? utils.get_cookie('cids') : String(current_company_id);
         }

--- a/addons/web/static/src/js/services/config.js
+++ b/addons/web/static/src/js/services/config.js
@@ -13,6 +13,7 @@ odoo.define('web.config', function () {
 const maxTouchPoints = navigator.maxTouchPoints || 1;
 const isAndroid = /Android/i.test(navigator.userAgent);
 const isIOS = /(iPad|iPhone|iPod)/i.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && maxTouchPoints > 1);
+const isIosApp = /OdooMobile \(iOS\)/i.test(navigator.userAgent);
 const isOtherMobileDevice = /(webOS|BlackBerry|Windows Phone)/i.test(navigator.userAgent);
 
 var config = {
@@ -65,6 +66,12 @@ var config = {
          * Mapping between the numbers 0,1,2,3,4,5,6 and some descriptions
          */
         SIZES: { XS: 0, VSM: 1, SM: 2, MD: 3, LG: 4, XL: 5, XXL: 6 },
+        /**
+         * OdooMobile (iOS) App detection using userAgent.
+         *
+         * @return Boolean
+         */
+        isIosApp: isIosApp,
     },
     /**
      * States whether the current environment is in debug or not.


### PR DESCRIPTION
This commit detects iOS app by User Agent value and sets cids to all allowed companies.
Check comment in the code for more details.

opw-2696836

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
