### PR TITLE
[FIX] web_editor: keep classes that exist in both source & target media

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/document_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/document_selector.js
@@ -69,6 +69,7 @@ export class DocumentSelector extends FileSelector {
     }
 }
 DocumentSelector.mediaSpecificClasses = ['o_image'];
+DocumentSelector.mediaSpecificStyles = [];
 DocumentSelector.mediaExtraClasses = [];
 DocumentSelector.tagNames = ['A'];
 DocumentSelector.attachmentsListTemplate = 'web_editor.DocumentsListTemplate';

--- a/addons/web_editor/static/src/components/media_dialog/icon_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/icon_selector.js
@@ -63,6 +63,7 @@ export class IconSelector extends Component {
     }
 }
 IconSelector.mediaSpecificClasses = ['fa'];
+IconSelector.mediaSpecificStyles = ['color', 'background-color'];
 IconSelector.mediaExtraClasses = [
     'rounded-circle', 'rounded', 'img-thumbnail', 'shadow',
     /^text-\S+$/, /^bg-\S+$/, /^fa-\S+$/,

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -257,6 +257,7 @@ export class ImageSelector extends FileSelector {
 }
 
 ImageSelector.mediaSpecificClasses = ['img', 'img-fluid', 'o_we_custom_image'];
+ImageSelector.mediaSpecificStyles = [];
 ImageSelector.mediaExtraClasses = [
     'rounded-circle', 'rounded', 'img-thumbnail', 'shadow',
     'w-25', 'w-50', 'w-75', 'w-100',

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -159,6 +159,9 @@ export class MediaDialog extends Component {
                     }
                 }
                 for (const otherTab of Object.keys(TABS).filter(key => key !== this.state.activeTab)) {
+                    for (const property of TABS[otherTab].Component.mediaSpecificStyles) {
+                        element.style.removeProperty(property);
+                    }
                     element.classList.remove(...TABS[otherTab].Component.mediaSpecificClasses);
                     const extraClassesToRemove = [];
                     for (const name of TABS[otherTab].Component.mediaExtraClasses) {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -172,7 +172,23 @@ export class MediaDialog extends Component {
                             }
                         }
                     }
-                    element.classList.remove(...extraClassesToRemove);
+                    // Remove classes that do not also exist in the target type.
+                    element.classList.remove(...extraClassesToRemove.filter(candidateName => {
+                        for (const name of TABS[this.state.activeTab].Component.mediaExtraClasses) {
+                            if (typeof(name) === 'string') {
+                                if (candidateName === name) {
+                                    return false;
+                                }
+                            } else { // Regex
+                                for (const className of element.classList) {
+                                    if (className.match(candidateName)) {
+                                        return false;
+                                    }
+                                }
+                            }
+                        }
+                        return true;
+                    }));
                 }
                 element.classList.remove(...this.initialIconClasses);
                 element.classList.remove('o_modified_image_to_save');

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -193,6 +193,7 @@ export class VideoSelector extends Component {
     }
 }
 VideoSelector.mediaSpecificClasses = ['media_iframe_video'];
+VideoSelector.mediaSpecificStyles = [];
 VideoSelector.mediaExtraClasses = [];
 VideoSelector.tagNames = ['IFRAME', 'DIV'];
 VideoSelector.template = 'web_editor.VideoSelector';


### PR DESCRIPTION
Since [1] when replacing a media by a media of the same type or that has
some extra classes in common, those classes were removed instead of
being kept.

This commit makes sure only the classes that do not exist in the newly
selected media type are removed.

This PR also filters the inline styles depending on the reached media type.

Steps to reproduce:
- Drop a "Text - Image".
- Replace the image by an icon.
- Apply a circle effect and colors on the icon.
- Replace the icon by another icon.
=> The applied effect and colors were lost.

[1]: https://github.com/odoo/odoo/commit/9ca349bbdb75505e8dbd31898f05ba8d694e7953

task-2687506

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
