### PR TITLE
[FIX] website_event: hide online event if country selected

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -506,7 +506,7 @@ class Event(models.Model):
             if country == 'online':
                 domain.append([("country_id", "=", False)])
             elif country != 'all':
-                domain.append(['|', ("country_id", "=", int(country)), ("country_id", "=", False)])
+                domain.append([("country_id", "=", int(country))])
 
         no_date_domain = domain.copy()
         dates = self._search_build_dates()


### PR DESCRIPTION
Before this commit:
In the events view on the front end, if a country is selected in the
filters, the online events are also shown making it difficult to find
country-specific events if there are a lot of online events. This is the
case on www.odoo.com/event for example.

note: to easily test this exact change, add `?country=<country_id>`, for example, to the end of the `<yourdomain>/event`  URL

After this commit:
The events displayed actually match the filter selected

opw-2878254
