### PR TITLE
[FIX] web_editor, mass_mailing: properly size the codeview

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -300,8 +300,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
      */
     _toggleCodeView: function ($codeview) {
         this._super(...arguments);
-        const isFullWidth = !!$(window.top.document).find('.o_mass_mailing_form_full_width')[0];
-        $codeview.css('height', isFullWidth ? $(window).height() : '');
         if ($codeview.hasClass('d-none')) {
             this.trigger_up('iframe_updated', { $iframe: this.wysiwyg.$iframe });
         }

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -230,25 +230,12 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      */
     _toggleCodeView: function ($codeview) {
         this.wysiwyg.odooEditor.observerUnactive();
-        $codeview.height(this.$content.height());
         $codeview.toggleClass('d-none');
         this.$content.toggleClass('d-none');
         if ($codeview.hasClass('d-none')) {
-            if (this.resizerHandleObserver) {
-                this.resizerHandleObserver.disconnect();
-                delete this.resizerHandleObserver;
-            }
             this.wysiwyg.odooEditor.observerActive();
             this.wysiwyg.setValue($codeview.val());
         } else {
-            this.resizerHandleObserver = new MutationObserver((mutations, observer) => {
-                for (let mutation of mutations) {
-                    if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
-                        $codeview[0].style.height = this.$content[0].style.height;
-                    }
-                }
-            });
-            this.resizerHandleObserver.observe(this.$content[0], {attributes: true});
             $codeview.val(this.$content.html());
             this.wysiwyg.odooEditor.observerActive();
         }

--- a/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
@@ -64,12 +64,15 @@ body.o_in_iframe {
         }
     }
     textarea.o_codeview {
-        width: 100%;
-        height: 100%;
+        position: absolute;
         font-family: 'Courier New', Courier, monospace;
-        padding: 5px;
         outline: none;
         resize: none;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 291px;
+        border: none;
     }
 
     .o_height_400 {


### PR DESCRIPTION
The codeview of mass_mailing had the wrong height in non full-width contexts.

task-2894177

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
