### PR TITLE
[FIX] account: customer address show in invoice report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -37,7 +37,7 @@
                 </t>
                 <t t-else="">
                     <t t-set="address">
-                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' groups="!account.group_delivery_invoice_address"/>
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                         <div t-if="o.partner_id.vat">
                             <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                             <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>


### PR DESCRIPTION
When printing an invoice, the customer address
was not displayed if there was no delivery
address specified.

As the address should be displayed at the same place
than when the delivery address and customer address
are the same, we just paste the code from the related
condition.

opw-2899259

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
