### PR TITLE
[FIX] website_livechat: installation performance

### DIFF
--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -24,8 +24,9 @@ class WebsiteVisitor(models.Model):
             ['livechat_visitor_id', 'livechat_operator_id']
         )
         visitor_operator_map = {int(result['livechat_visitor_id'][0]): int(result['livechat_operator_id'][0]) for result in results}
-        for visitor in self:
-            visitor.livechat_operator_id = visitor_operator_map.get(visitor.id, False)
+        if visitor_operator_map:
+            for visitor in self:
+                visitor.livechat_operator_id = visitor_operator_map.get(visitor.id, False)
 
     @api.depends('mail_channel_ids')
     def _compute_session_count(self):


### PR DESCRIPTION
When installing the module, all past visitors will be used to compute
their livechat operator. Since they never had a livechat session
before it will always be null but the loop takes a lot of resources,
especially with 9 million visitors, thus a MemoryError.

This fix skips the loop if there's no mapping found. The end result stays null.

opw-2890100

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
