### PR TITLE
[IMP] *: have replace as default command on update

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
@@ -6,7 +6,7 @@ import time from 'web.time';
 import utils from 'web.utils';
 
 import LivechatButton from '@im_livechat/legacy/widgets/livechat_button';
-import { increment, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { increment, insertAndReplace } from '@mail/model/model_field_command';
 
 const _t = core._t;
 
@@ -108,11 +108,9 @@ const _t = core._t;
 
         const welcomeMessagesIds = welcomeMessages.map(welcomeMessage => welcomeMessage.id);
         this.messaging.publicLivechatGlobal.update({
-            messages: replace(
-                this.messaging.publicLivechatGlobal.messages.filter((message) => {
-                    !welcomeMessagesIds.includes(message.id);
-                }),
-            ),
+            messages: this.messaging.publicLivechatGlobal.messages.filter((message) => {
+                !welcomeMessagesIds.includes(message.id);
+            }),
         });
 
         postedWelcomeMessages.reverse();

--- a/addons/im_livechat/static/src/models/livechat_button_view.js
+++ b/addons/im_livechat/static/src/models/livechat_button_view.js
@@ -4,7 +4,7 @@ import PublicLivechatMessage from '@im_livechat/legacy/models/public_livechat_me
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 import { qweb } from 'web.core';
 import { get_cookie, set_cookie, unaccent } from 'web.utils';
@@ -45,11 +45,11 @@ registerModel({
 
             if (options && options.prepend) {
                 this.messaging.publicLivechatGlobal.update({
-                    messages: replace([message, ...this.messaging.publicLivechatGlobal.messages]),
+                    messages: [message, ...this.messaging.publicLivechatGlobal.messages],
                 });
             } else {
                 this.messaging.publicLivechatGlobal.update({
-                    messages: replace([...this.messaging.publicLivechatGlobal.messages, message]),
+                    messages: [...this.messaging.publicLivechatGlobal.messages, message],
                 });
             }
         },

--- a/addons/im_livechat/static/src/models/notification_list_view.js
+++ b/addons/im_livechat/static/src/models/notification_list_view.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { patchRecordMethods } from '@mail/model/model_core';
-import { replace } from '@mail/model/model_field_command';
 import '@mail/models/notification_list_view'; // ensure the model definition is loaded before the patch
 
 patchRecordMethods('NotificationListView', {
@@ -10,11 +9,11 @@ patchRecordMethods('NotificationListView', {
      */
     _computeFilteredThreads() {
         if (this.filter === 'livechat') {
-            return replace(this.messaging.models['Thread'].all(thread =>
+            return this.messaging.models['Thread'].all(thread =>
                 thread.channel &&
                 thread.channel.channel_type === 'livechat' &&
                 thread.isPinned
-            ));
+            );
         }
         return this._super();
     },

--- a/addons/im_livechat/static/src/models/public_livechat_global.js
+++ b/addons/im_livechat/static/src/models/public_livechat_global.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 import { qweb } from 'web.core';
 
@@ -98,7 +98,7 @@ registerModel({
             if (this.messages.length === 0) {
                 return clear();
             }
-            return replace(this.messages[this.messages.length - 1]);
+            return this.messages[this.messages.length - 1];
         },
         /**
          * @private

--- a/addons/im_livechat/static/src/models/thread.js
+++ b/addons/im_livechat/static/src/models/thread.js
@@ -2,7 +2,7 @@
 
 import { addFields, addRecordMethods, patchModelMethods, patchRecordMethods } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, insert, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insert, link, unlink } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/thread';
 
@@ -25,7 +25,7 @@ addRecordMethods('Thread', {
         if (!this.messaging || !this.channel || this.channel.channel_type !== 'livechat' || !this.isPinned) {
             return clear();
         }
-        return replace(this.messaging);
+        return this.messaging;
     },
 });
 
@@ -65,7 +65,7 @@ patchModelMethods('Thread', {
                     )
                 );
                 data2.members.push(link(partner));
-                data2.correspondent = replace(partner);
+                data2.correspondent = partner;
             } else {
                 const partnerData = this.messaging.models['Partner'].convertData(data.livechat_visitor);
                 data2.members.push(insert(partnerData));

--- a/addons/mail/static/src/components/web_client_view_attachment_view_container/web_client_view_attachment_view_container.js
+++ b/addons/mail/static/src/components/web_client_view_attachment_view_container/web_client_view_attachment_view_container.js
@@ -3,7 +3,6 @@
 import { useModels } from '@mail/component_hooks/use_models';
 // ensure components are registered beforehand.
 import '@mail/components/web_client_view_attachment_view/web_client_view_attachment_view';
-import { replace } from '@mail/model/model_field_command';
 import { getMessagingComponent } from '@mail/utils/messaging_component';
 
 const { Component, onWillDestroy, onWillUpdateProps } = owl;
@@ -71,7 +70,7 @@ export class WebClientViewAttachmentViewContainer extends Component {
         });
         this.webClientViewAttachmentView = messaging.models['WebClientViewAttachmentView'].insert({
             id: this.webClientViewAttachmentViewId,
-            thread: replace(thread),
+            thread,
         });
         this.render();
     }

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { clear, FieldCommand, link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
+import { clear, FieldCommand, link, unlink, unlinkAll } from '@mail/model/model_field_command';
 
 /**
  * Class whose instances represent field on a model.
@@ -223,7 +223,7 @@ export class ModelField {
                 }
             }
             if (this.fieldType === 'relation') {
-                return replace(newVal);
+                return newVal;
             }
             return newVal;
         }
@@ -234,7 +234,7 @@ export class ModelField {
                 return clear();
             }
             if (this.fieldType === 'relation') {
-                return replace(newVal);
+                return newVal;
             }
             return newVal;
         }
@@ -253,8 +253,11 @@ export class ModelField {
         } else if (newVal instanceof Array && newVal[0] instanceof FieldCommand) {
             return newVal;
         } else if (this.fieldType === 'relation') {
-            // Deprecated. Used only to support old syntax: `[...[name, value]]` command
-            return newVal.map(([name, value]) => new FieldCommand(name, value));
+            if (newVal instanceof Array && newVal[0] && ['clear', 'insert', 'insert-and-replace', 'insert-and-unlink', 'link', 'replace', 'unlink', 'unlink-all'].includes(newVal[0][0])) {
+                return newVal.map(([name, value]) => new FieldCommand(name, value));
+            } else {
+                return [new FieldCommand('replace', newVal)];
+            }
         } else {
             return [new FieldCommand('set', newVal)];
         }
@@ -475,7 +478,7 @@ export class ModelField {
         for (const recordData of (isMulti ? data : [data])) {
             const recordData2 = { ...recordData };
             if (otherField.relationType === 'one') {
-                recordData2[this.inverse] = replace(record);
+                recordData2[this.inverse] = record;
             } else {
                 recordData2[this.inverse] = link(record);
             }

--- a/addons/mail/static/src/model/model_field_command.js
+++ b/addons/mail/static/src/model/model_field_command.js
@@ -136,22 +136,6 @@ function link(newValue) {
 }
 
 /**
- * Returns a replace command to give to the model manager at create/update.
- * `replace` command can be used for relation fields.
- * - Unlink the current record and then link `newValue`
- * if the current value differs from `newValue` for a x2one field;
- * - Unlink records in the field value if they are not in `newValue`,
- * link the missing values, and then sort field value by the order they are given in `newValue`
- * for a x2many field.
- *
- * @param {Record|Record[]} newValue - record or records array to be replaced.
- * @returns {FieldCommand}
- */
-function replace(newValue) {
-    return new FieldCommand('replace', newValue);
-}
-
-/**
  * Returns a set command to give to the model manager at create/update.
  * `set` command can be used for attribute fields.
  * - Write the `newValue` on the field value.
@@ -197,7 +181,6 @@ export {
     insert,
     insertAndReplace,
     link,
-    replace,
     set,
     unlink,
     unlinkAll,

--- a/addons/mail/static/src/models/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ActivityBoxView',
@@ -20,7 +20,7 @@ registerModel({
          */
         _computeActivityViews() {
             return insertAndReplace(this.chatter.thread.activities.map(activity => {
-                return { activity: replace(activity) };
+                return { activity };
             }));
         },
     },

--- a/addons/mail/static/src/models/activity_mark_done_popover_content_view.js
+++ b/addons/mail/static/src/models/activity_mark_done_popover_content_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ActivityMarkDonePopoverContentView',
@@ -77,7 +77,7 @@ registerModel({
          */
         _computeActivityViewOwner() {
             if (this.popoverViewOwner.activityViewOwnerAsMarkDone) {
-                return replace(this.popoverViewOwner.activityViewOwnerAsMarkDone);
+                return this.popoverViewOwner.activityViewOwnerAsMarkDone;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/activity_menu_view.js
+++ b/addons/mail/static/src/models/activity_menu_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 import session from 'web.session';
 
@@ -70,7 +70,7 @@ registerModel({
         _computeActivityGroupViews() {
             return insertAndReplace(this.activityGroups.map(activityGroup => {
                 return {
-                    activityGroup: replace(activityGroup),
+                    activityGroup,
                 };
             }));
         },

--- a/addons/mail/static/src/models/activity_view.js
+++ b/addons/mail/static/src/models/activity_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 import { auto_str_to_date, getLangDateFormat, getLangDatetimeFormat } from 'web.time';
 import { sprintf } from '@web/core/utils/strings';
@@ -144,7 +144,7 @@ registerModel({
             }
             return insertAndReplace(
                 this.activity.mailTemplates.map(
-                    mailTemplate => ({ mailTemplate: replace(mailTemplate) })
+                    mailTemplate => ({ mailTemplate })
                 ),
             );
         },

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, replace } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Attachment',
@@ -263,7 +263,7 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeThreadsAsAttachmentsInWebClientView() {
-            return (this.isPdf || this.isImage) && !this.isUploading ? replace(this.allThreads) : clear();
+            return (this.isPdf || this.isImage) && !this.isUploading ? this.allThreads : clear();
         },
         /**
          * @private

--- a/addons/mail/static/src/models/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentCard',
@@ -16,7 +16,7 @@ registerModel({
             }
             this.attachmentList.update({
                 attachmentListViewDialog: insertAndReplace(),
-                selectedAttachment: replace(this.attachment),
+                selectedAttachment: this.attachment,
             });
         },
         /**

--- a/addons/mail/static/src/models/attachment_delete_confirm_view.js
+++ b/addons/mail/static/src/models/attachment_delete_confirm_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
@@ -33,10 +33,10 @@ registerModel({
          */
         _computeAttachment() {
             if (this.dialogOwner && this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm) {
-                return replace(this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm.attachment);
+                return this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm.attachment;
             }
             if (this.dialogOwner && this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm) {
-                return replace(this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm.attachment);
+                return this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm.attachment;
             }
             return clear();
         },
@@ -57,14 +57,14 @@ registerModel({
                 this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner &&
                 this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner.chatter
             ) {
-                return replace(this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner.chatter);
+                return this.dialogOwner.attachmentCardOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner.chatter;
             }
             if (
                 this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm &&
                 this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner &&
                 this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner.chatter
             ) {
-                return replace(this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner.chatter);
+                return this.dialogOwner.attachmentImageOwnerAsAttachmentDeleteConfirm.attachmentList.attachmentBoxViewOwner.chatter;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
@@ -37,7 +37,7 @@ registerModel({
             }
             this.attachmentList.update({
                 attachmentListViewDialog: insertAndReplace(),
-                selectedAttachment: replace(this.attachment),
+                selectedAttachment: this.attachment,
             });
         },
         /**

--- a/addons/mail/static/src/models/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentList',
@@ -14,7 +14,7 @@ registerModel({
         selectNextAttachment() {
             const index = this.attachments.findIndex(attachment => attachment === this.selectedAttachment);
             const nextIndex = index === this.attachments.length - 1 ? 0 : index + 1;
-            this.update({ selectedAttachment: replace(this.attachments[nextIndex]) });
+            this.update({ selectedAttachment: this.attachments[nextIndex] });
         },
         /**
          * Select the previous attachment.
@@ -22,19 +22,19 @@ registerModel({
         selectPreviousAttachment() {
             const index = this.attachments.findIndex(attachment => attachment === this.selectedAttachment);
             const prevIndex = index === 0 ? this.attachments.length - 1 : index - 1;
-            this.update({ selectedAttachment: replace(this.attachments[prevIndex]) });
+            this.update({ selectedAttachment: this.attachments[prevIndex] });
         },
         _computeAttachmentImages() {
             return insertAndReplace(this.imageAttachments.map(attachment => {
                 return {
-                    attachment: replace(attachment),
+                    attachment,
                 };
             }));
         },
         _computeAttachmentCards() {
             return insertAndReplace(this.nonImageAttachments.map(attachment => {
                 return {
-                    attachment: replace(attachment),
+                    attachment,
                 };
             }));
         },
@@ -43,13 +43,13 @@ registerModel({
          */
         _computeAttachments() {
             if (this.messageViewOwner) {
-                return replace(this.messageViewOwner.message.attachments);
+                return this.messageViewOwner.message.attachments;
             }
             if (this.attachmentBoxViewOwner) {
-                return replace(this.attachmentBoxViewOwner.chatter.thread.allAttachments);
+                return this.attachmentBoxViewOwner.chatter.thread.allAttachments;
             }
             if (this.composerViewOwner && this.composerViewOwner.composer) {
-                return replace(this.composerViewOwner.composer.attachments);
+                return this.composerViewOwner.composer.attachments;
             }
             return clear();
         },
@@ -57,19 +57,19 @@ registerModel({
          * @returns {Attachment[]}
          */
         _computeImageAttachments() {
-            return replace(this.attachments.filter(attachment => attachment.isImage));
+            return this.attachments.filter(attachment => attachment.isImage);
         },
         /**
          * @returns {Attachment[]}
          */
         _computeNonImageAttachments() {
-            return replace(this.attachments.filter(attachment => !attachment.isImage));
+            return this.attachments.filter(attachment => !attachment.isImage);
         },
         /**
          * @returns {Attachment[]}
          */
         _computeViewableAttachments() {
-            return replace(this.attachments.filter(attachment => attachment.isViewable));
+            return this.attachments.filter(attachment => attachment.isViewable);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentViewer',
@@ -185,7 +185,7 @@ registerModel({
         _computeAttachmentViewerViewable() {
             if (this.attachmentList) {
                 return insertAndReplace({
-                    attachmentOwner: replace(this.attachmentList.selectedAttachment),
+                    attachmentOwner: this.attachmentList.selectedAttachment,
                 });
             }
             return clear();
@@ -197,7 +197,7 @@ registerModel({
             if (this.attachmentList) {
                 return insertAndReplace(
                     this.attachmentList.viewableAttachments.map((attachment) => {
-                        return { attachmentOwner: replace(attachment) };
+                        return { attachmentOwner: attachment };
                     })
                 );
             }

--- a/addons/mail/static/src/models/call_main_view.js
+++ b/addons/mail/static/src/models/call_main_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
@@ -135,9 +135,9 @@ registerModel({
          */
         _computeMainTiles() {
             if (this.callView.activeRtcSession) {
-                return insertAndReplace([{ channelMember: replace(this.callView.activeRtcSession.channelMember) }]);
+                return insertAndReplace([{ channelMember: this.callView.activeRtcSession.channelMember }]);
             }
-            return insertAndReplace(this.callView.filteredChannelMembers.map(channelMember => ({ channelMember: replace(channelMember) })));
+            return insertAndReplace(this.callView.filteredChannelMembers.map(channelMember => ({ channelMember })));
         },
         /**
          * Shows the overlay (buttons) for a set a mount of time.

--- a/addons/mail/static/src/models/call_participant_card.js
+++ b/addons/mail/static/src/models/call_participant_card.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 import { sprintf } from '@web/core/utils/strings';
@@ -28,7 +28,7 @@ registerModel({
                 if (this.callView.activeRtcSession === this.rtcSession && this.mainViewTileOwner) {
                     this.callView.update({ activeRtcSession: clear() });
                 } else {
-                    this.callView.update({ activeRtcSession: replace(this.rtcSession) });
+                    this.callView.update({ activeRtcSession: this.rtcSession });
                 }
                 return;
             }
@@ -72,9 +72,9 @@ registerModel({
          */
         _computeCallView() {
             if (this.sidebarViewTileOwner) {
-                return replace(this.sidebarViewTileOwner.callSidebarViewOwner.callView);
+                return this.sidebarViewTileOwner.callSidebarViewOwner.callView;
             }
-            return replace(this.mainViewTileOwner.callMainViewOwner.callView);
+            return this.mainViewTileOwner.callMainViewOwner.callView;
         },
         /**
          * @private
@@ -82,9 +82,9 @@ registerModel({
          */
          _computeChannelMember() {
             if (this.sidebarViewTileOwner) {
-                return replace(this.sidebarViewTileOwner.channelMember);
+                return this.sidebarViewTileOwner.channelMember;
             }
-            return replace(this.mainViewTileOwner.channelMember);
+            return this.mainViewTileOwner.channelMember;
          },
         /**
          * @private

--- a/addons/mail/static/src/models/call_participant_video_view.js
+++ b/addons/mail/static/src/models/call_participant_video_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'CallParticipantVideoView',
@@ -30,7 +30,7 @@ registerModel({
          */
         _computeRtcSession() {
             if (this.callParticipantCardOwner.rtcSession) {
-                return replace(this.callParticipantCardOwner.rtcSession);
+                return this.callParticipantCardOwner.rtcSession;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/call_sidebar_view.js
+++ b/addons/mail/static/src/models/call_sidebar_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { many, one } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'CallSidebarView',
@@ -12,7 +12,7 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeSidebarTiles() {
-            return insertAndReplace(this.callView.filteredChannelMembers.map(channelMember => ({ channelMember: replace(channelMember) })));
+            return insertAndReplace(this.callView.filteredChannelMembers.map(channelMember => ({ channelMember })));
         },
     },
     fields: {

--- a/addons/mail/static/src/models/call_view.js
+++ b/addons/mail/static/src/models/call_view.js
@@ -5,7 +5,7 @@ import { browser } from "@web/core/browser/browser";
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'CallView',
@@ -92,7 +92,7 @@ registerModel({
                 }
                 channelMembers.push(channelMember);
             }
-            return replace(channelMembers);
+            return channelMembers;
         },
         /**
          * @private

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one, many } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Channel',
@@ -37,7 +37,7 @@ registerModel({
             for (const rtcSession of this.thread.rtcSessions) {
                 callParticipants.push(rtcSession.channelMember);
             }
-            return replace(callParticipants);
+            return callParticipants;
         },
         /**
          * @private

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
 import { sprintf } from '@web/core/utils/strings';
@@ -201,7 +201,7 @@ registerModel({
             if (this.selectablePartners.length === 0) {
                 return clear();
             }
-            return insertAndReplace(this.selectablePartners.map(partner => ({ partner: replace(partner) })));
+            return insertAndReplace(this.selectablePartners.map(partner => ({ partner })));
         },
         /**
          * @private
@@ -211,7 +211,7 @@ registerModel({
             if (this.selectedPartners.length === 0) {
                 return clear();
             }
-            return insertAndReplace(this.selectedPartners.map(partner => ({ partner: replace(partner) })));
+            return insertAndReplace(this.selectedPartners.map(partner => ({ partner })));
         },
         /**
          * @private
@@ -223,10 +223,10 @@ registerModel({
                 this.popoverViewOwner.threadViewTopbarOwnerAsInvite &&
                 this.popoverViewOwner.threadViewTopbarOwnerAsInvite.thread
             ) {
-                return replace(this.popoverViewOwner.threadViewTopbarOwnerAsInvite.thread);
+                return this.popoverViewOwner.threadViewTopbarOwnerAsInvite.thread;
             }
             if (this.chatWindow && this.chatWindow.thread) {
-                return replace(this.chatWindow.thread);
+                return this.chatWindow.thread;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/channel_member.js
+++ b/addons/mail/static/src/models/channel_member.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one, many } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ChannelMember',
@@ -26,10 +26,10 @@ registerModel({
          */
         _computeChannelAsOfflineMember() {
             if (this.persona.partner) {
-                return !this.persona.partner.isOnline ? replace(this.channel) : clear();
+                return !this.persona.partner.isOnline ? this.channel : clear();
             }
             if (this.persona.guest) {
-                return !this.persona.guest.isOnline ? replace(this.channel) : clear();
+                return !this.persona.guest.isOnline ? this.channel : clear();
             }
             return clear();
         },
@@ -39,10 +39,10 @@ registerModel({
          */
         _computeChannelAsOnlineMember() {
             if (this.persona.partner) {
-                return this.persona.partner.isOnline ? replace(this.channel) : clear();
+                return this.persona.partner.isOnline ? this.channel : clear();
             }
             if (this.persona.guest) {
-                return this.persona.guest.isOnline ? replace(this.channel) : clear();
+                return this.persona.guest.isOnline ? this.channel : clear();
             }
             return clear();
         },

--- a/addons/mail/static/src/models/channel_member_list_category_view.js
+++ b/addons/mail/static/src/models/channel_member_list_category_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 import { sprintf } from '@web/core/utils/strings';
 
@@ -16,10 +16,10 @@ registerModel({
          */
         _computeChannel() {
             if (this.channelMemberListViewOwnerAsOffline) {
-                return replace(this.channelMemberListViewOwnerAsOffline.channel);
+                return this.channelMemberListViewOwnerAsOffline.channel;
             }
             if (this.channelMemberListViewOwnerAsOnline) {
-                return replace(this.channelMemberListViewOwnerAsOnline.channel);
+                return this.channelMemberListViewOwnerAsOnline.channel;
             }
         },
         /**
@@ -31,7 +31,7 @@ registerModel({
                 return clear();
             }
             return insertAndReplace(
-                this.members.map(member => ({ channelMember: replace(member) })),
+                this.members.map(channelMember => ({ channelMember })),
             );
         },
         /**
@@ -43,10 +43,10 @@ registerModel({
                 return clear();
             }
             if (this.channelMemberListViewOwnerAsOnline) {
-                return replace(this.channel.orderedOnlineMembers);
+                return this.channel.orderedOnlineMembers;
             }
             if (this.channelMemberListViewOwnerAsOffline) {
-                return replace(this.channel.orderedOfflineMembers);
+                return this.channel.orderedOfflineMembers;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/channel_member_list_view.js
+++ b/addons/mail/static/src/models/channel_member_list_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ChannelMemberListView',
@@ -25,10 +25,10 @@ registerModel({
          */
         _computeChannel() {
             if (this.chatWindowOwner) {
-                return replace(this.chatWindowOwner.thread.channel);
+                return this.chatWindowOwner.thread.channel;
             }
             if (this.threadViewOwner) {
-                return replace(this.threadViewOwner.thread.channel);
+                return this.threadViewOwner.thread.channel;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
@@ -482,7 +482,7 @@ registerModel({
             return insertAndReplace({
                 compact: true,
                 hasThreadView: this.hasThreadView,
-                thread: this.thread ? replace(this.thread) : clear(),
+                thread: this.thread ? this.thread : clear(),
             });
         },
         /**

--- a/addons/mail/static/src/models/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, link } from '@mail/model/model_field_command';
 
 const BASE_VISUAL = {
     /**
@@ -86,7 +86,7 @@ registerModel({
         },
         openNewMessage() {
             if (!this.newMessageChatWindow) {
-                this.update({ newMessageChatWindow: insertAndReplace({ manager: replace(this) }) });
+                this.update({ newMessageChatWindow: insertAndReplace({ manager: this }) });
             }
             this.newMessageChatWindow.makeActive();
         },
@@ -114,8 +114,8 @@ registerModel({
             if (!chatWindow) {
                 chatWindow = this.messaging.models['ChatWindow'].insert({
                     isFolded,
-                    manager: replace(this),
-                    thread: replace(thread),
+                    manager: this,
+                    thread,
                 });
             } else {
                 chatWindow.update({ isFolded });
@@ -149,7 +149,7 @@ registerModel({
             const _newOrdered = [...this.allOrdered];
             _newOrdered[index1] = chatWindow2;
             _newOrdered[index2] = chatWindow1;
-            this.update({ allOrdered: replace(_newOrdered) });
+            this.update({ allOrdered: _newOrdered });
             for (const chatWindow of [chatWindow1, chatWindow2]) {
                 if (chatWindow.threadView) {
                     chatWindow.threadView.addComponentHint('adjust-scroll');
@@ -168,14 +168,14 @@ registerModel({
          * @returns {ChatWindow[]}
          */
         _computeAllOrderedHidden() {
-            return replace(this.visual.hiddenChatWindows);
+            return this.visual.hiddenChatWindows;
         },
         /**
          * @private
          * @returns {ChatWindow[]}
          */
         _computeAllOrderedVisible() {
-            return replace(this.visual.visible.map(({ chatWindow }) => chatWindow));
+            return this.visual.visible.map(({ chatWindow }) => chatWindow);
         },
         /**
          * @private
@@ -207,7 +207,7 @@ registerModel({
          */
         _computeHiddenChatWindowHeaderViews() {
             if (this.allOrderedHidden.length > 0) {
-                return insertAndReplace(this.allOrderedHidden.map(chatWindow => ({ chatWindowOwner: replace(chatWindow) })));
+                return insertAndReplace(this.allOrderedHidden.map(chatWindow => ({ chatWindowOwner: chatWindow })));
             }
             return clear();
         },
@@ -220,7 +220,7 @@ registerModel({
             if (!lastVisible) {
                 return clear();
             }
-            return replace(lastVisible);
+            return lastVisible;
         },
         /**
          * @private

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, link, replace } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, link } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 const getThreadNextTemporaryId = (function () {
@@ -264,7 +264,7 @@ registerModel({
             return insertAndReplace({
                 hasThreadView: this.hasThreadView,
                 order: 'desc',
-                thread: this.thread ? replace(this.thread) : clear(),
+                thread: this.thread ? this.thread : clear(),
             });
         },
         /**
@@ -288,7 +288,7 @@ registerModel({
             } else if (!this.thread || !this.thread.isTemporary) {
                 const currentPartner = this.messaging.currentPartner;
                 const message = this.messaging.models['Message'].insert({
-                    author: replace(currentPartner),
+                    author: currentPartner,
                     body: this.env._t("Creating a new record..."),
                     id: getMessageNextTemporaryId(),
                     isTemporary: true,

--- a/addons/mail/static/src/models/composer.js
+++ b/addons/mail/static/src/models/composer.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, replace, unlink } from '@mail/model/model_field_command';
+import { clear, unlink } from '@mail/model/model_field_command';
 import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
@@ -15,10 +15,10 @@ registerModel({
          */
         _computeActiveThread() {
             if (this.messageViewInEditing && this.messageViewInEditing.message && this.messageViewInEditing.message.originThread) {
-                return replace(this.messageViewInEditing.message.originThread);
+                return this.messageViewInEditing.message.originThread;
             }
             if (this.thread) {
-                return replace(this.thread);
+                return this.thread;
             }
             return clear();
         },
@@ -121,7 +121,7 @@ registerModel({
                     }
                 }
             }
-            return replace(recipients);
+            return recipients;
         },
         /**
          * @private

--- a/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ComposerSuggestedRecipientListView',
@@ -36,13 +36,13 @@ registerModel({
             if (this.hasShowMoreButton) {
                 return insertAndReplace(
                     this.thread.suggestedRecipientInfoList.map(
-                        suggestedRecipientInfo => ({ suggestedRecipientInfo: replace(suggestedRecipientInfo) })
+                        suggestedRecipientInfo => ({ suggestedRecipientInfo })
                     ),
                 );
             } else {
                 return insertAndReplace(
                     this.thread.suggestedRecipientInfoList.slice(0, 3).map(
-                        suggestedRecipientInfo => ({ suggestedRecipientInfo: replace(suggestedRecipientInfo) })
+                        suggestedRecipientInfo => ({ suggestedRecipientInfo })
                     ),
                 );
             }
@@ -52,7 +52,7 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeThread() {
-            return replace(this.composerViewOwner.composer.activeThread);
+            return this.composerViewOwner.composer.activeThread;
         },
     },
     fields: {

--- a/addons/mail/static/src/models/composer_suggestion_list_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ComposerSuggestionListView',
@@ -13,7 +13,7 @@ registerModel({
          */
         setFirstSuggestionViewActive() {
             const firstSuggestionView = this.suggestionViews[0];
-            this.update({ activeSuggestionView: replace(firstSuggestionView) });
+            this.update({ activeSuggestionView: firstSuggestionView });
         },
         /**
          * Sets the last suggestion as active. Main and extra records are
@@ -21,7 +21,7 @@ registerModel({
          */
         setLastSuggestionViewActive() {
             const { length, [length - 1]: lastSuggestionView } = this.suggestionViews;
-            this.update({ activeSuggestionView: replace(lastSuggestionView) });
+            this.update({ activeSuggestionView: lastSuggestionView });
         },
         /**
          * Sets the next suggestion as active. Main and extra records are
@@ -37,7 +37,7 @@ registerModel({
                 return;
             }
             const nextSuggestionView = this.suggestionViews[activeElementIndex + 1];
-            this.update({ activeSuggestionView: replace(nextSuggestionView) });
+            this.update({ activeSuggestionView: nextSuggestionView });
         },
         /**
          * Sets the previous suggestion as active. Main and extra records are
@@ -53,7 +53,7 @@ registerModel({
                 return;
             }
             const previousSuggestionView = this.suggestionViews[activeElementIndex - 1];
-            this.update({ activeSuggestionView: replace(previousSuggestionView) });
+            this.update({ activeSuggestionView: previousSuggestionView });
         },
         /**
          * Adapts the active suggestion it if the active suggestion is no longer
@@ -67,7 +67,7 @@ registerModel({
                 return;
             }
             const firstSuggestionView = this.suggestionViews[0];
-            return replace(firstSuggestionView);
+            return firstSuggestionView;
         },
         /**
          * @returns {FieldCommand}
@@ -75,7 +75,7 @@ registerModel({
         _computeComposerSuggestionListViewExtraComposerSuggestionViewItems() {
             return insertAndReplace(this.composerViewOwner.extraSuggestions.map(suggestable => {
                 return {
-                    suggestable: replace(suggestable),
+                    suggestable,
                 };
             }));
         },
@@ -85,7 +85,7 @@ registerModel({
         _computeComposerSuggestionListViewMainComposerSuggestionViewItems() {
             return insertAndReplace(this.composerViewOwner.mainSuggestions.map(suggestable => {
                 return {
-                    suggestable: replace(suggestable),
+                    suggestable,
                 };
             }));
         },
@@ -95,7 +95,7 @@ registerModel({
         _computeSuggestionViews() {
             const mainSuggestionViews = this.composerSuggestionListViewMainComposerSuggestionViewItems.map(item => item.composerSuggestionView);
             const extraSuggestionViews = this.composerSuggestionListViewExtraComposerSuggestionViewItems.map(item => item.composerSuggestionView);
-            return replace(mainSuggestionViews.concat(extraSuggestionViews));
+            return mainSuggestionViews.concat(extraSuggestionViews);
         },
     },
     fields: {

--- a/addons/mail/static/src/models/composer_suggestion_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { sprintf } from '@web/core/utils/strings';
 
 /**
@@ -20,7 +20,7 @@ registerModel({
          */
         onClick(ev) {
             ev.preventDefault();
-            this.composerSuggestionListViewOwner.update({ activeSuggestionView: replace(this) });
+            this.composerSuggestionListViewOwner.update({ activeSuggestionView: this });
             const composerViewOwner = this.composerSuggestionListViewOwner.composerViewOwner;
             composerViewOwner.insertSuggestion();
             composerViewOwner.closeSuggestions();
@@ -32,10 +32,10 @@ registerModel({
          */
         _computeComposerSuggestionListViewOwner() {
             if (this.composerSuggestionListViewExtraComposerSuggestionViewItemOwner) {
-                return replace(this.composerSuggestionListViewExtraComposerSuggestionViewItemOwner.composerSuggestionListViewOwner);
+                return this.composerSuggestionListViewExtraComposerSuggestionViewItemOwner.composerSuggestionListViewOwner;
             }
             if (this.composerSuggestionListViewMainComposerSuggestionViewItemOwner) {
-                return replace(this.composerSuggestionListViewMainComposerSuggestionViewItemOwner.composerSuggestionListViewOwner);
+                return this.composerSuggestionListViewMainComposerSuggestionViewItemOwner.composerSuggestionListViewOwner;
             }
             return clear();
         },
@@ -73,10 +73,10 @@ registerModel({
          */
         _computeSuggestable() {
             if (this.composerSuggestionListViewExtraComposerSuggestionViewItemOwner) {
-                return replace(this.composerSuggestionListViewExtraComposerSuggestionViewItemOwner.suggestable);
+                return this.composerSuggestionListViewExtraComposerSuggestionViewItemOwner.suggestable;
             }
             if (this.composerSuggestionListViewMainComposerSuggestionViewItemOwner) {
-                return replace(this.composerSuggestionListViewMainComposerSuggestionViewItemOwner.suggestable);
+                return this.composerSuggestionListViewMainComposerSuggestionViewItemOwner.suggestable;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 import { addLink, escapeAndCompactTextContent, parseAndTransform } from '@mail/js/utils';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
@@ -741,17 +741,17 @@ registerModel({
             if (this.threadView) {
                 // When replying to a message, always use the composer from that message's thread
                 if (this.threadView && this.threadView.replyingToMessageView) {
-                    return replace(this.threadView.replyingToMessageView.message.originThread.composer);
+                    return this.threadView.replyingToMessageView.message.originThread.composer;
                 }
                 if (this.threadView.thread && this.threadView.thread.composer) {
-                    return replace(this.threadView.thread.composer);
+                    return this.threadView.thread.composer;
                 }
             }
             if (this.messageViewInEditing && this.messageViewInEditing.composerForEditing) {
-                return replace(this.messageViewInEditing.composerForEditing);
+                return this.messageViewInEditing.composerForEditing;
             }
             if (this.chatter && this.chatter.thread && this.chatter.thread.composer) {
-                return replace(this.chatter.thread.composer);
+                return this.chatter.thread.composer;
             }
             return clear();
         },
@@ -1341,8 +1341,8 @@ registerModel({
             mainSuggestedRecords.length = Math.min(mainSuggestedRecords.length, limit);
             extraSuggestedRecords.length = Math.min(extraSuggestedRecords.length, limit - mainSuggestedRecords.length);
             this.update({
-                extraSuggestions: replace(extraSuggestedRecords.map(record => record.suggestable)),
-                mainSuggestions: replace(mainSuggestedRecords.map(record => record.suggestable)),
+                extraSuggestions: extraSuggestedRecords.map(record => record.suggestable),
+                mainSuggestions: mainSuggestedRecords.map(record => record.suggestable),
             });
             if (this.composerSuggestionListView) {
                 this.composerSuggestionListView.update({ hasToScrollToActiveSuggestionView: true });

--- a/addons/mail/static/src/models/delete_message_confirm_view.js
+++ b/addons/mail/static/src/models/delete_message_confirm_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'DeleteMessageConfirmView',
@@ -30,14 +30,14 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeMessage() {
-            return replace(this.dialogOwner.messageActionListOwnerAsDeleteConfirm.message);
+            return this.dialogOwner.messageActionListOwnerAsDeleteConfirm.message;
         },
         /**
          * @private
          * @returns {MessageView}
          */
         _computeMessageView() {
-            return this.message ? insertAndReplace({ message: replace(this.message) }) : clear();
+            return this.message ? insertAndReplace({ message: this.message }) : clear();
         },
     },
     fields: {

--- a/addons/mail/static/src/models/dialog.js
+++ b/addons/mail/static/src/models/dialog.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Dialog',
@@ -125,7 +125,7 @@ registerModel({
          */
         _computeManager() {
             if (this.messaging.dialogManager) {
-                return replace(this.messaging.dialogManager);
+                return this.messaging.dialogManager;
             }
             return clear();
         },
@@ -135,16 +135,16 @@ registerModel({
          */
         _computeRecord() {
             if (this.attachmentViewer) {
-                return replace(this.attachmentViewer);
+                return this.attachmentViewer;
             }
             if (this.attachmentDeleteConfirmView) {
-                return replace(this.attachmentDeleteConfirmView);
+                return this.attachmentDeleteConfirmView;
             }
             if (this.deleteMessageConfirmView) {
-                return replace(this.deleteMessageConfirmView);
+                return this.deleteMessageConfirmView;
             }
             if (this.followerSubtypeList) {
-                return replace(this.followerSubtypeList);
+                return this.followerSubtypeList;
             }
         },
         /**

--- a/addons/mail/static/src/models/discuss.js
+++ b/addons/mail/static/src/models/discuss.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { escape, sprintf } from '@web/core/utils/strings';
 
 registerModel({
@@ -154,9 +154,7 @@ registerModel({
          * @param {Boolean} [param1.focus]
          */
         async openThread(thread, { focus } = {}) {
-            this.update({
-                thread: replace(thread),
-            });
+            this.update({ thread });
             if (focus !== undefined ? focus : !this.messaging.device.isMobileDevice) {
                 this.focus();
             }
@@ -310,7 +308,7 @@ registerModel({
                 hasMemberList: true,
                 hasThreadView: this.hasThreadView,
                 hasTopbar: true,
-                thread: this.thread ? replace(this.thread) : clear(),
+                thread: this.thread ? this.thread : clear(),
             });
         },
     },

--- a/addons/mail/static/src/models/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view.js
@@ -2,7 +2,7 @@
 
 import { attr, one } from '@mail/model/model_field';
 import { registerModel } from '@mail/model/model_core';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'DiscussPublicView',
@@ -17,7 +17,7 @@ registerModel({
                     hasMemberList: true,
                     hasThreadView: true,
                     hasTopbar: true,
-                    thread: replace(this.channel),
+                    thread: this.channel,
                 }),
                 welcomeView: clear(),
             });
@@ -37,7 +37,7 @@ registerModel({
             this.update({
                 threadViewer: clear(),
                 welcomeView: insertAndReplace({
-                    channel: replace(this.channel),
+                    channel: this.channel,
                     isDoFocusGuestNameInput: true,
                     originalGuestName: this.messaging.currentGuest && this.messaging.currentGuest.name,
                     pendingGuestName: this.messaging.currentGuest && this.messaging.currentGuest.name,

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -57,8 +57,8 @@ registerModel({
             const channel = this.messaging.discuss.thread && this.messaging.discuss.thread.channel;
             if (channel && this.supportedChannelTypes.includes(channel.channel_type)) {
                 return insertAndReplace({
-                    thread: replace(channel.thread),
-                    category: replace(this),
+                    thread: channel.thread,
+                    category: this,
                 });
             }
             return clear();
@@ -113,7 +113,7 @@ registerModel({
                     return nameVal.includes(qsVal);
                 });
             }
-            return replace(categoryItems);
+            return categoryItems;
         },
         /**
          * @private

--- a/addons/mail/static/src/models/discuss_sidebar_mailbox_view.js
+++ b/addons/mail/static/src/models/discuss_sidebar_mailbox_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'DiscussSidebarMailboxView',
@@ -14,13 +14,13 @@ registerModel({
          */
         _computeMailbox() {
             if (this.discussViewOwnerAsHistory) {
-                return replace(this.messaging.history);
+                return this.messaging.history;
             }
             if (this.discussViewOwnerAsInbox) {
-                return replace(this.messaging.inbox);
+                return this.messaging.inbox;
             }
             if (this.discussViewOwnerAsStarred) {
-                return replace(this.messaging.starred);
+                return this.messaging.starred;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/emoji.js
+++ b/addons/mail/static/src/models/emoji.js
@@ -2,7 +2,6 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Emoji',
@@ -12,7 +11,7 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeEmojiRegistry() {
-            return replace(this.messaging.emojiRegistry);
+            return this.messaging.emojiRegistry;
         },
     },
     fields: {

--- a/addons/mail/static/src/models/emoji_category_bar_view.js
+++ b/addons/mail/static/src/models/emoji_category_bar_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { many, one } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'EmojiCategoryBarView',
@@ -13,9 +13,9 @@ registerModel({
          */
         _computeActiveCategoryView() {
             if (!this.activeByUserCategoryView) {
-                return replace(this.defaultActiveCategoryView);
+                return this.defaultActiveCategoryView;
             }
-            return replace(this.activeByUserCategoryView);
+            return this.activeByUserCategoryView;
         },
         /**
          * @private
@@ -24,7 +24,7 @@ registerModel({
         _computeDefaultActiveCategoryView() {
             return insertAndReplace({
                 emojiCategory: insertAndReplace({ categoryName: "all" }),
-                emojiCategoryBarViewOwner: replace(this),
+                emojiCategoryBarViewOwner: this,
             });
         },
         /**
@@ -34,7 +34,7 @@ registerModel({
         _computeEmojiCategoryViews() {
             return insertAndReplace(
                 this.messaging.emojiRegistry.allCategories.map(emojiCategory => {
-                    return { emojiCategory: replace(emojiCategory) };
+                    return { emojiCategory };
                 })
             );
         },

--- a/addons/mail/static/src/models/emoji_category_view.js
+++ b/addons/mail/static/src/models/emoji_category_view.js
@@ -2,7 +2,6 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'EmojiCategoryView',
@@ -11,7 +10,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         onClick() {
-            this.update({ emojiCategoryBarViewOwnerAsActiveByUser: replace(this.emojiCategoryBarViewOwner) });
+            this.update({ emojiCategoryBarViewOwnerAsActiveByUser: this.emojiCategoryBarViewOwner });
         },
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/emoji_grid_view.js
+++ b/addons/mail/static/src/models/emoji_grid_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'EmojiGridView',
@@ -17,7 +17,7 @@ registerModel({
             }
             return insertAndReplace(
                 this.emojiPickerViewOwner.emojiCategoryBarView.activeCategoryView.emojiCategory.allEmojis.map(emoji => {
-                    return { emoji: replace(emoji) };
+                    return { emoji };
                 })
             );
         },

--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 import core from 'web.core';
 
@@ -68,16 +68,16 @@ registerModel({
          */
         _computeThread() {
             if (this.activityView) {
-                return replace(this.activityView.activity.thread);
+                return this.activityView.activity.thread;
             }
             if (this.attachmentBoxView) {
-                return replace(this.attachmentBoxView.chatter.thread);
+                return this.attachmentBoxView.chatter.thread;
             }
             if (this.chatterOwner) {
-                return replace(this.chatterOwner.thread);
+                return this.chatterOwner.thread;
             }
             if (this.composerView) {
-                return replace(this.composerView.composer.activeThread);
+                return this.composerView.composer.activeThread;
             }
             return clear();
         },
@@ -115,8 +115,8 @@ registerModel({
                 return;
             }
             return (composer || thread).messaging.models['Attachment'].insert({
-                composer: composer && replace(composer),
-                originThread: (!composer && thread) ? replace(thread) : undefined,
+                composer: composer,
+                originThread: (!composer && thread) ? thread : undefined,
                 ...attachmentData,
             });
         },
@@ -138,13 +138,13 @@ registerModel({
             const uploadingAttachments = new Map();
             for (const file of files) {
                 uploadingAttachments.set(file, this.messaging.models['Attachment'].insert({
-                    composer: composer && replace(composer),
+                    composer,
                     filename: file.name,
                     id: getAttachmentNextTemporaryId(),
                     isUploading: true,
                     mimetype: file.type,
                     name: file.name,
-                    originThread: (!composer && thread) ? replace(thread) : undefined,
+                    originThread: (!composer && thread) ? thread : undefined,
                 }));
             }
             const attachments = [];

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Follower',
@@ -153,7 +153,7 @@ registerModel({
                 return clear();
             }
             if (this.partner === this.messaging.currentPartner) {
-                return replace(this.followedThread);
+                return this.followedThread;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/follower_list_menu_view.js
+++ b/addons/mail/static/src/models/follower_list_menu_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'FollowerListMenuView',
@@ -34,7 +34,7 @@ registerModel({
          */
         _computeFollowerViews() {
             return insertAndReplace(this.chatterOwner.thread.followers.map(follower => {
-                return { follower: replace(follower) };
+                return { follower };
             }));
         },
         /**

--- a/addons/mail/static/src/models/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'FollowerSubtypeList',
@@ -40,7 +40,7 @@ registerModel({
             if (this.follower.subtypes.length === 0) {
                 return clear();
             }
-            return insertAndReplace(this.follower.subtypes.map(subtype => ({ subtype: replace(subtype) })));
+            return insertAndReplace(this.follower.subtypes.map(subtype => ({ subtype })));
         },
         /**
          * @private

--- a/addons/mail/static/src/models/mailbox.js
+++ b/addons/mail/static/src/models/mailbox.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -31,7 +31,7 @@ registerModel({
             if (!this.messaging) {
                 return clear();
             }
-            return replace(this.messaging);
+            return this.messaging;
         },
         /**
          * @returns {string|FieldCommand}

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace } from '@mail/model/model_field_command';
 import { addLink, htmlToTextContentInline, parseAndTransform } from '@mail/js/utils';
 
 import { session } from '@web/session';
@@ -173,8 +173,8 @@ registerModel({
                         continue;
                     }
                     this.messaging.models['MessageSeenIndicator'].insert({
-                        thread: replace(thread),
-                        message: replace(message),
+                        thread,
+                        message,
                     });
                 }
             }
@@ -373,7 +373,7 @@ registerModel({
          * @returns {boolean}
          */
         _computeFailureNotifications() {
-            return replace(this.notifications.filter(notifications => notifications.isFailure));
+            return this.notifications.filter(notifications => notifications.isFailure);
         },
         /**
          * @private
@@ -523,7 +523,7 @@ registerModel({
                 [l - 1]: lastTrackingValue,
             } = this.trackingValues;
             if (lastTrackingValue) {
-                return replace(lastTrackingValue);
+                return lastTrackingValue;
             }
             return clear();
         },
@@ -612,7 +612,7 @@ registerModel({
             if (this.originThread) {
                 threads.push(this.originThread);
             }
-            return replace(threads);
+            return threads;
         },
         _sortTrackingValues() {
             return [

--- a/addons/mail/static/src/models/message_author_prefix_view.js
+++ b/addons/mail/static/src/models/message_author_prefix_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessageAuthorPrefixView',
@@ -14,10 +14,10 @@ registerModel({
          */
         _computeMessage() {
             if (this.threadNeedactionPreviewViewOwner) {
-                return replace(this.threadNeedactionPreviewViewOwner.thread.lastNeedactionMessageAsOriginThread);
+                return this.threadNeedactionPreviewViewOwner.thread.lastNeedactionMessageAsOriginThread;
             }
             if (this.threadPreviewViewOwner) {
-                return replace(this.threadPreviewViewOwner.thread.lastMessage);
+                return this.threadPreviewViewOwner.thread.lastMessage;
             }
             return clear();
         },
@@ -27,10 +27,10 @@ registerModel({
          */
         _computeThread() {
             if (this.threadNeedactionPreviewViewOwner) {
-                return replace(this.threadNeedactionPreviewViewOwner.thread);
+                return this.threadNeedactionPreviewViewOwner.thread;
             }
             if (this.threadPreviewViewOwner) {
-                return replace(this.threadPreviewViewOwner.thread);
+                return this.threadPreviewViewOwner.thread;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view.js
@@ -2,7 +2,6 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { replace } from '@mail/model/model_field_command';
 import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
@@ -20,8 +19,8 @@ registerModel({
                 return;
             }
             const parentMessageListViewMessageViewItem = this.messaging.models['MessageListViewMessageViewItem'].findFromIdentifyingData({
-                message: replace(parentMessage),
-                messageListViewOwner: replace(messageListViewMessageViewItem.messageListViewOwner),
+                message: parentMessage,
+                messageListViewOwner: messageListViewMessageViewItem.messageListViewOwner,
             });
             if (!parentMessageListViewMessageViewItem) {
                 return;

--- a/addons/mail/static/src/models/message_list_view.js
+++ b/addons/mail/static/src/models/message_list_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessageListView',
@@ -75,7 +75,7 @@ registerModel({
             for (const message of orderedMessages) {
                 messageViewsData.push({
                     isSquashed: this.threadViewOwner._shouldMessageBeSquashed(prevMessage, message),
-                    message: replace(message),
+                    message,
                 });
                 prevMessage = message;
             }

--- a/addons/mail/static/src/models/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
@@ -135,7 +135,7 @@ registerModel({
             if (otherPartnersThatHaveFetched.length === 0) {
                 return clear();
             }
-            return replace(otherPartnersThatHaveFetched);
+            return otherPartnersThatHaveFetched;
         },
         /**
          * Manually called as not always called when necessary
@@ -163,7 +163,7 @@ registerModel({
             if (otherPartnersThatHaveSeen.length === 0) {
                 return clear();
             }
-            return replace(otherPartnersThatHaveSeen);
+            return otherPartnersThatHaveSeen;
         },
         /**
          * @private

--- a/addons/mail/static/src/models/message_seen_indicator_view.js
+++ b/addons/mail/static/src/models/message_seen_indicator_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessageSeenIndicatorView',
@@ -14,8 +14,8 @@ registerModel({
         _computeMessageSeenIndicator() {
             if (this.messageViewOwner.messageListViewMessageViewItemOwner && this.messageViewOwner.messageListViewMessageViewItemOwner.messageListViewOwner.threadViewOwner.thread) {
                 return insertAndReplace({
-                    message: replace(this.messageViewOwner.message),
-                    thread: replace(this.messageViewOwner.messageListViewMessageViewItemOwner.messageListViewOwner.threadViewOwner.thread),
+                    message: this.messageViewOwner.message,
+                    thread: this.messageViewOwner.messageListViewMessageViewItemOwner.messageListViewOwner.threadViewOwner.thread,
                 });
             }
             return clear();

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
@@ -65,7 +65,7 @@ registerModel({
                 if (this.messagingAsClickedMessageView) {
                     this.messaging.update({ clickedMessageView: clear() });
                 } else {
-                    this.messaging.update({ clickedMessageView: replace(this) });
+                    this.messaging.update({ clickedMessageView: this });
                 }
             }
         },
@@ -143,7 +143,7 @@ registerModel({
                 }),
             });
             this.messageListViewMessageViewItemOwner.messageListViewOwner.threadViewOwner.update({
-                replyingToMessageView: replace(this),
+                replyingToMessageView: this,
                 composerView: insertAndReplace({
                     doFocus: true,
                 }),
@@ -158,7 +158,7 @@ registerModel({
             const textInputContent = htmlDoc.body.textContent;
             this.update({
                 composerForEditing: insertAndReplace({
-                    mentionedPartners: replace(this.message.recipients),
+                    mentionedPartners: this.message.recipients,
                     textInputContent,
                     textInputCursorEnd: textInputContent.length,
                     textInputCursorStart: textInputContent.length,
@@ -370,10 +370,10 @@ registerModel({
          */
         _computeMessage() {
             if (this.messageListViewMessageViewItemOwner) {
-                return replace(this.messageListViewMessageViewItemOwner.message);
+                return this.messageListViewMessageViewItemOwner.message;
             }
             if (this.deleteMessageConfirmViewOwner) {
-                return replace(this.deleteMessageConfirmViewOwner.message);
+                return this.deleteMessageConfirmViewOwner.message;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -3,7 +3,7 @@
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred';
 
 import { browser } from '@web/core/browser/browser';
@@ -291,7 +291,7 @@ registerModel({
             if (this.ringingThreads.length === 0) {
                 return clear();
             }
-            return replace(this.ringingThreads.map(thread => thread.callInviteRequestPopup));
+            return this.ringingThreads.map(thread => thread.callInviteRequestPopup);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { executeGracefully } from '@mail/utils/utils';
-import { link, insert, replace } from '@mail/model/model_field_command';
+import { link, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessagingInitializer',
@@ -193,7 +193,7 @@ registerModel({
                 // implicit: failures are sent by the server at initialization
                 // only if the current partner is author of the message
                 if (!message.author && this.messaging.currentPartner) {
-                    message.update({ author: replace(this.messaging.currentPartner) });
+                    message.update({ author: this.messaging.currentPartner });
                 }
             }));
         },

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { decrement, increment, insert, insertAndReplace, replace, unlink } from '@mail/model/model_field_command';
+import { decrement, increment, insert, insertAndReplace, unlink } from '@mail/model/model_field_command';
 import { htmlToTextContentInline } from '@mail/js/utils';
 
 import { escape, sprintf } from '@web/core/utils/strings';
@@ -176,11 +176,11 @@ registerModel({
             this.messaging.models['ThreadPartnerSeenInfo'].insert({
                 lastFetchedMessage: insert({ id: last_message_id }),
                 partner: insertAndReplace({ id: partner_id }),
-                thread: replace(channel.thread),
+                thread: channel.thread,
             });
             this.messaging.models['MessageSeenIndicator'].insert({
                 message: insertAndReplace({ id: last_message_id }),
-                thread: replace(channel.thread),
+                thread: channel.thread,
             });
         },
         /**
@@ -317,13 +317,13 @@ registerModel({
             const shouldComputeSeenIndicators = channel.channel_type !== 'channel';
             if (shouldComputeSeenIndicators) {
                 this.messaging.models['ThreadPartnerSeenInfo'].insert({
-                    lastSeenMessage: replace(lastMessage),
+                    lastSeenMessage: lastMessage,
                     partner: insertAndReplace({ id: partner_id }),
-                    thread: replace(channel.thread),
+                    thread: channel.thread,
                 });
                 this.messaging.models['MessageSeenIndicator'].insert({
-                    message: replace(lastMessage),
-                    thread: replace(channel.thread),
+                    message: lastMessage,
+                    thread: channel.thread,
                 });
             }
             if (this.messaging.currentPartner && this.messaging.currentPartner.id === partner_id) {
@@ -474,7 +474,7 @@ registerModel({
                 // implicit: failures are sent by the server as notification
                 // only if the current partner is author of the message
                 if (!message.author && this.messaging.currentPartner) {
-                    message.update({ author: replace(this.messaging.currentPartner) });
+                    message.update({ author: this.messaging.currentPartner });
                 }
             }
         },
@@ -557,7 +557,7 @@ registerModel({
             );
             const partnerRoot = this.messaging.partnerRoot;
             const message = this.messaging.models['Message'].insert(Object.assign(convertedData, {
-                author: replace(partnerRoot),
+                author: partnerRoot,
                 id: lastMessageId + 0.01,
                 isTransient: true,
             }));

--- a/addons/mail/static/src/models/mobile_messaging_navbar_view.js
+++ b/addons/mail/static/src/models/mobile_messaging_navbar_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MobileMessagingNavbarView',
@@ -21,7 +21,7 @@ registerModel({
                     this.discuss.activeMobileNavbarTabId === 'mailbox' &&
                     (!this.discuss.thread || !this.discuss.thread.mailbox)
                 ) {
-                    this.discuss.update({ thread: replace(this.messaging.inbox.thread) });
+                    this.discuss.update({ thread: this.messaging.inbox.thread });
                 }
                 if (this.discuss.activeMobileNavbarTabId !== 'mailbox') {
                     this.discuss.update({ thread: clear() });

--- a/addons/mail/static/src/models/notification_list_view.js
+++ b/addons/mail/static/src/models/notification_list_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'NotificationListView',
@@ -33,31 +33,28 @@ registerModel({
         _computeFilteredThreads() {
             switch (this.filter) {
                 case 'channel': {
-                    return replace(this.messaging.models['Thread']
+                    return this.messaging.models['Thread']
                         .all(thread =>
                             thread.channel &&
                             thread.channel.channel_type === 'channel' &&
                             thread.isPinned
                         )
-                        .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1)
-                    );
+                        .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
                 }
                 case 'chat': {
-                    return replace(this.messaging.models['Thread']
+                    return this.messaging.models['Thread']
                         .all(thread =>
                             thread.isChatChannel &&
                             thread.isPinned &&
                             thread.model === 'mail.channel'
                         )
-                        .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1)
-                    );
+                        .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
                 }
                 case 'all': {
                     // "All" filter is for channels and chats
-                    return replace(this.messaging.models['Thread']
+                    return this.messaging.models['Thread']
                         .all(thread => thread.isPinned && thread.model === 'mail.channel')
-                        .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1)
-                    );
+                        .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
                 }
             }
             return clear();
@@ -75,7 +72,7 @@ registerModel({
                     .all()
                     .sort((group1, group2) => group1.sequence - group2.sequence)
                     .map(notificationGroup => {
-                        return { notificationGroup: replace(notificationGroup) };
+                        return { notificationGroup };
                     })
             );
         },
@@ -98,7 +95,7 @@ registerModel({
             notifications.push(...this.notificationGroupViews);
             notifications.push(...this.threadNeedactionPreviewViews);
             notifications.push(...this.threadPreviewViews);
-            return replace(notifications);
+            return notifications;
         },
         /**
          * @private
@@ -130,7 +127,7 @@ registerModel({
                         return t1.id < t2.id ? -1 : 1;
                     })
                     .map(thread => {
-                        return { thread: replace(thread) };
+                        return { thread };
                     })
             );
         },
@@ -161,7 +158,7 @@ registerModel({
                     })
                     .map(thread => {
                         return {
-                            thread: replace(thread),
+                            thread,
                         };
                     })
             );

--- a/addons/mail/static/src/models/persona_im_status_icon_view.js
+++ b/addons/mail/static/src/models/persona_im_status_icon_view.js
@@ -2,7 +2,7 @@
 
 import { one } from '@mail/model/model_field';
 import { registerModel } from '@mail/model/model_core';
-import { clear, replace } from '@mail/model/model_field_command';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'PersonaImStatusIconView',
@@ -14,30 +14,30 @@ registerModel({
          */
         _computePersona() {
             if (this.channelInvitationFormSelectablePartnerViewOwner) {
-                return replace(this.channelInvitationFormSelectablePartnerViewOwner.partner.persona);
+                return this.channelInvitationFormSelectablePartnerViewOwner.partner.persona;
             }
             if (this.channelMemberViewOwner) {
-                return replace(this.channelMemberViewOwner.channelMember.persona);
+                return this.channelMemberViewOwner.channelMember.persona;
             }
             if (this.composerSuggestionViewOwner) {
-                return replace(this.composerSuggestionViewOwner.suggestable.partner.persona);
+                return this.composerSuggestionViewOwner.suggestable.partner.persona;
             }
             if (this.messageViewOwner) {
                 if (this.messageViewOwner.message.author) {
-                    return replace(this.messageViewOwner.message.author.persona);
+                    return this.messageViewOwner.message.author.persona;
                 }
                 if (this.messageViewOwner.message.guestAuthor) {
-                    return replace(this.messageViewOwner.message.guestAuthor.persona);
+                    return this.messageViewOwner.message.guestAuthor.persona;
                 }
             }
             if (this.notificationRequestViewOwner) {
-                return replace(this.messaging.partnerRoot.persona);
+                return this.messaging.partnerRoot.persona;
             }
             if (this.threadNeedactionPreviewViewOwner) {
-                return replace(this.threadNeedactionPreviewViewOwner.thread.correspondent.persona);
+                return this.threadNeedactionPreviewViewOwner.thread.correspondent.persona;
             }
             if (this.threadPreviewViewOwner) {
-                return replace(this.threadPreviewViewOwner.thread.correspondent.persona);
+                return this.threadPreviewViewOwner.thread.correspondent.persona;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/popover_view.js
+++ b/addons/mail/static/src/models/popover_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'PopoverView',
@@ -71,13 +71,13 @@ registerModel({
          */
         _computeContent() {
             if (this.activityMarkDonePopoverContentView) {
-                return replace(this.activityMarkDonePopoverContentView);
+                return this.activityMarkDonePopoverContentView;
             }
             if (this.channelInvitationForm) {
-                return replace(this.channelInvitationForm);
+                return this.channelInvitationForm;
             }
             if (this.emojiPickerView) {
-                return replace(this.emojiPickerView);
+                return this.emojiPickerView;
             }
             return clear();
         },
@@ -129,7 +129,7 @@ registerModel({
          */
         _computeManager() {
             if (this.messaging.popoverManager) {
-                return replace(this.messaging.popoverManager);
+                return this.messaging.popoverManager;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -4,7 +4,7 @@ import { browser } from "@web/core/browser/browser";
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, unlink } from '@mail/model/model_field_command';
 import { monitorAudio } from '@mail/utils/media_monitoring';
 import { sprintf } from '@web/core/utils/strings';
 
@@ -493,7 +493,7 @@ registerModel({
             rtcSession.update({ rtcPeerConnection: insertAndReplace({ peerConnection }) });
             this.messaging.models['RtcDataChannel'].insert({
                 dataChannel,
-                rtcSession: replace(rtcSession),
+                rtcSession,
             });
             return rtcSession;
         },

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'RtcSession',
@@ -240,7 +240,7 @@ registerModel({
                 return clear();
             }
             if (this.rtcPeerConnection) {
-                return replace(this.messaging.rtc);
+                return this.messaging.rtc;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, insertAndUnlink, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, insertAndUnlink, link, unlink } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 import { cleanSearchTerm } from '@mail/utils/utils';
 import * as mailUtils from '@mail/js/utils';
@@ -656,7 +656,7 @@ registerModel({
                 return;
             }
             this.update({
-                rtc: replace(this.messaging.rtc),
+                rtc: this.messaging.rtc,
                 rtcInvitingSession: clear(),
                 rtcSessions,
                 invitedMembers,
@@ -875,8 +875,8 @@ registerModel({
         refreshOtherMemberTypingMember(partner) {
             this.update({
                 otherMembersLongTypingTimers: [
-                    insertAndUnlink({ partner: replace(partner) }),
-                    insert({ partner: replace(partner) }),
+                    insertAndUnlink({ partner }),
+                    insert({ partner }),
                 ],
             });
         },
@@ -899,7 +899,7 @@ registerModel({
             ];
             this.update({
                 isCurrentPartnerTyping: true,
-                orderedTypingMembers: replace(newOrderedTypingMembers),
+                orderedTypingMembers: newOrderedTypingMembers,
                 typingMembers: link(currentPartner),
             });
             // Notify typing status to other members.
@@ -912,13 +912,13 @@ registerModel({
          * @param {Partner} partner
          */
         registerOtherMemberTypingMember(partner) {
-            this.update({ otherMembersLongTypingTimers: insert({ partner: replace(partner) }) });
+            this.update({ otherMembersLongTypingTimers: insert({ partner }) });
             const newOrderedTypingMembers = [
                 ...this.orderedTypingMembers.filter(member => member !== partner),
                 partner,
             ];
             this.update({
-                orderedTypingMembers: replace(newOrderedTypingMembers),
+                orderedTypingMembers: newOrderedTypingMembers,
                 typingMembers: link(partner),
             });
         },
@@ -956,7 +956,7 @@ registerModel({
          * @param {Attachment} attachment
          */
         async setMainAttachment(attachment) {
-            this.update({ mainAttachment: replace(attachment) });
+            this.update({ mainAttachment: attachment });
             if (this.model === 'account.move.line') {
                 // account.move.line is not actually a thread in python
                 return;
@@ -1005,7 +1005,7 @@ registerModel({
             const newOrderedTypingMembers = this.orderedTypingMembers.filter(member => member !== currentPartner);
             this.update({
                 isCurrentPartnerTyping: false,
-                orderedTypingMembers: replace(newOrderedTypingMembers),
+                orderedTypingMembers: newOrderedTypingMembers,
                 typingMembers: unlink(currentPartner),
             });
             // Notify typing status to other members.
@@ -1021,10 +1021,10 @@ registerModel({
          * @param {Partner} partner
          */
         unregisterOtherMemberTypingMember(partner) {
-            this.update({ otherMembersLongTypingTimers: insertAndUnlink({ partner: replace(partner) }) });
+            this.update({ otherMembersLongTypingTimers: insertAndUnlink({ partner }) });
             const newOrderedTypingMembers = this.orderedTypingMembers.filter(member => member !== partner);
             this.update({
-                orderedTypingMembers: replace(newOrderedTypingMembers),
+                orderedTypingMembers: newOrderedTypingMembers,
                 typingMembers: unlink(partner),
             });
         },
@@ -1053,7 +1053,7 @@ registerModel({
                     // "most-recent" before "oldest" attachments.
                     return Math.abs(a2.id) - Math.abs(a1.id);
                 });
-            return replace(allAttachments);
+            return allAttachments;
         },
         /**
          * @private
@@ -1081,11 +1081,11 @@ registerModel({
             );
             if (correspondents.length === 1) {
                 // 2 members chat
-                return replace(correspondents[0]);
+                return correspondents[0];
             }
             if (this.members.length === 1) {
                 // chat with oneself
-                return replace(this.members[0]);
+                return this.members[0];
             }
             return clear();
         },
@@ -1100,7 +1100,7 @@ registerModel({
                 this.correspondent &&
                 this.public === 'private'
             ) {
-                return replace(this.correspondent);
+                return this.correspondent;
             }
             return clear();
         },
@@ -1122,7 +1122,7 @@ registerModel({
             if (!discussSidebarCategory) {
                 return clear();
             }
-            return insertAndReplace({ category: replace(discussSidebarCategory) });
+            return insertAndReplace({ category: discussSidebarCategory });
         },
         /**
          * @private
@@ -1176,7 +1176,7 @@ registerModel({
          * @returns {Activity[]}
          */
         _computeFutureActivities() {
-            return replace(this.activities.filter(activity => activity.state === 'planned'));
+            return this.activities.filter(activity => activity.state === 'planned');
         },
         /**
          * @private
@@ -1317,7 +1317,7 @@ registerModel({
             ) {
                 return clear();
             }
-            return replace(currentPartnerOrderedSeenMessages.slice().pop());
+            return currentPartnerOrderedSeenMessages.slice().pop();
         },
         /**
          * @private
@@ -1329,7 +1329,7 @@ registerModel({
                 [l - 1]: lastMessage,
             } = this.orderedMessages;
             if (lastMessage) {
-                return replace(lastMessage);
+                return lastMessage;
             }
             return clear();
         },
@@ -1343,7 +1343,7 @@ registerModel({
                 [l - 1]: lastMessage,
             } = this.orderedNonTransientMessages;
             if (lastMessage) {
-                return replace(lastMessage);
+                return lastMessage;
             }
             return clear();
         },
@@ -1395,7 +1395,7 @@ registerModel({
                 [l - 1]: lastNeedactionMessageAsOriginThread,
             } = orderedNeedactionMessagesAsOriginThread;
             if (lastNeedactionMessageAsOriginThread) {
-                return replace(lastNeedactionMessageAsOriginThread);
+                return lastNeedactionMessageAsOriginThread;
             }
             return clear();
         },
@@ -1440,7 +1440,7 @@ registerModel({
          */
         _computeMessagingAsRingingThread() {
             if (this.rtcInvitingSession) {
-                return replace(this.messaging);
+                return this.messaging;
             }
             return clear();
         },
@@ -1453,7 +1453,7 @@ registerModel({
                 return clear();
             }
             return (this.model === 'mail.channel' && this.isPinned && this.localMessageUnreadCounter > 0)
-                ? replace(this.messaging.messagingMenu)
+                ? this.messaging.messagingMenu
                 : clear();
         },
         /**
@@ -1461,7 +1461,7 @@ registerModel({
          * @returns {Message[]}
          */
         _computeNeedactionMessagesAsOriginThread() {
-            return replace(this.messagesAsOriginThread.filter(message => message.isNeedaction));
+            return this.messagesAsOriginThread.filter(message => message.isNeedaction);
         },
         /**
          * @private
@@ -1484,37 +1484,37 @@ registerModel({
             if (!message) {
                 return clear();
             }
-            return replace(message);
+            return message;
         },
         /**
          * @private
          * @returns {Message[]}
          */
         _computeOrderedMessages() {
-            return replace(this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
+            return this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1);
         },
         /**
          * @private
          * @returns {Message[]}
          */
         _computeOrderedNonTransientMessages() {
-            return replace(this.orderedMessages.filter(m => !m.isTransient));
+            return this.orderedMessages.filter(m => !m.isTransient);
         },
         /**
          * @private
          * @returns {Partner[]}
          */
         _computeOrderedOtherTypingMembers() {
-            return replace(this.orderedTypingMembers.filter(
+            return this.orderedTypingMembers.filter(
                 member => member !== this.messaging.currentPartner
-            ));
+            );
         },
         /**
          * @private
          * @returns {Activity[]}
          */
         _computeOverdueActivities() {
-            return replace(this.activities.filter(activity => activity.state === 'overdue'));
+            return this.activities.filter(activity => activity.state === 'overdue');
         },
         /**
          * @private
@@ -1540,7 +1540,7 @@ registerModel({
          * @returns {Activity[]}
          */
         _computeTodayActivities() {
-            return replace(this.activities.filter(activity => activity.state === 'today'));
+            return this.activities.filter(activity => activity.state === 'today');
         },
         /**
          * @private

--- a/addons/mail/static/src/models/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, link, unlink } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -89,7 +89,7 @@ registerModel({
             if (!lastFetchedMessage) {
                 return clear();
             }
-            return replace(lastFetchedMessage);
+            return lastFetchedMessage;
         },
         /**
          * @private
@@ -103,7 +103,7 @@ registerModel({
             if (!lastMessage) {
                 return clear();
             }
-            return replace(lastMessage);
+            return lastMessage;
         },
         /**
          * @private
@@ -121,21 +121,21 @@ registerModel({
                     message.id > this.lastFetchedMessage.id
                 );
             }
-            return replace(this.fetchedMessages.concat(newerMessages));
+            return this.fetchedMessages.concat(newerMessages);
         },
         /**
          * @private
          * @returns {Message[]}
          */
         _computeOrderedFetchedMessages() {
-            return replace(this.fetchedMessages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
+            return this.fetchedMessages.sort((m1, m2) => m1.id < m2.id ? -1 : 1);
         },
         /**
          * @private
          * @returns {Message[]}
          */
         _computeOrderedMessages() {
-            return replace(this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
+            return this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1);
         },
         /**
          *
@@ -143,7 +143,7 @@ registerModel({
          * @returns {Message[]}
          */
         _computeOrderedNonEmptyMessages() {
-            return replace(this.orderedMessages.filter(message => !message.isEmpty));
+            return this.orderedMessages.filter(message => !message.isEmpty);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { htmlToTextContentInline } from '@mail/js/utils';
 
 registerModel({
@@ -58,7 +58,7 @@ registerModel({
          */
         _computeLastTrackingValue() {
             if (this.thread.lastMessage && this.thread.lastMessage.lastTrackingValue) {
-                return replace(this.thread.lastMessage.lastTrackingValue);
+                return this.thread.lastMessage.lastTrackingValue;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/thread_preview_view.js
+++ b/addons/mail/static/src/models/thread_preview_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { htmlToTextContentInline } from '@mail/js/utils';
 
 registerModel({
@@ -56,7 +56,7 @@ registerModel({
          */
         _computeLastTrackingValue() {
             if (this.thread.lastMessage && this.thread.lastMessage.lastTrackingValue) {
-                return replace(this.thread.lastMessage.lastTrackingValue);
+                return this.thread.lastMessage.lastTrackingValue;
             }
             return clear();
         },

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -36,7 +36,7 @@ registerModel({
          */
         handleVisibleMessage(message) {
             if (!this.lastVisibleMessage || this.lastVisibleMessage.id < message.id) {
-                this.update({ lastVisibleMessage: replace(message) });
+                this.update({ lastVisibleMessage: message });
             }
         },
         /**
@@ -150,7 +150,7 @@ registerModel({
                 return clear();
             }
             const { length, [length - 1]: messageListViewMessageViewItem } = this.messageListView.messageListViewMessageViewItems;
-            return messageListViewMessageViewItem ? replace(messageListViewMessageViewItem.messageView) : clear();
+            return messageListViewMessageViewItem ? messageListViewMessageViewItem.messageView : clear();
         },
         /**
          * @private

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/link_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/link_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insertAndReplace, link, replace } from '@mail/model/model_field_command';
+import { insertAndReplace, link } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
@@ -13,7 +13,7 @@ QUnit.test('link: should link a record to an empty x2one field', async function 
 
     const contact = messaging.models['TestContact'].insert({ id: 10 });
     const address = messaging.models['TestAddress'].insert({ id: 10 });
-    contact.update({ address: replace(address) });
+    contact.update({ address });
     assert.strictEqual(
         contact.address,
         address,
@@ -36,7 +36,7 @@ QUnit.test('link: should replace a record to a non-empty x2one field', async fun
     });
     const address10 = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     const address20 = messaging.models['TestAddress'].insert({ id: 20 });
-    contact.update({ address: replace(address20) });
+    contact.update({ address: address20 });
     assert.strictEqual(
         contact.address,
         address20,

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/replace_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/replace_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insertAndReplace } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
@@ -13,7 +13,7 @@ QUnit.test('replace: should link a record for an empty x2one field', async funct
 
     const contact = messaging.models['TestContact'].insert({ id: 10 });
     const address = messaging.models['TestAddress'].insert({ id: 10 });
-    contact.update({ address: replace(address) });
+    contact.update({ address });
     assert.strictEqual(
         contact.address,
         address,
@@ -36,7 +36,7 @@ QUnit.test('replace: should replace a record for a non-empty x2one field', async
     });
     const address10 = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     const address20 = messaging.models['TestAddress'].insert({ id: 20 });
-    contact.update({ address: replace(address20) });
+    contact.update({ address: address20 });
     assert.strictEqual(
         contact.address,
         address20,
@@ -60,7 +60,7 @@ QUnit.test('replace: should link a record for an empty x2many field', async func
 
     const contact = messaging.models['TestContact'].insert({ id: 10 });
     const task = messaging.models['TestTask'].insert({ id: 10 });
-    contact.update({ tasks: replace(task) });
+    contact.update({ tasks: task });
     assert.strictEqual(
         contact.tasks.length,
         1,
@@ -97,7 +97,7 @@ QUnit.test('replace: should replace all records for a non-empty field', async fu
     const task10 = messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     const task20 = messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     const task30 = messaging.models['TestTask'].insert({ id: 30 });
-    contact.update({ tasks: replace(task30) });
+    contact.update({ tasks: task30 });
     assert.strictEqual(
         contact.tasks.length,
         1,
@@ -139,7 +139,7 @@ QUnit.test('replace: should order the existing records for x2many field', async 
     const task10 = messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     const task20 = messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
     contact.update({
-        tasks: replace([task20, task10]),
+        tasks: [task20, task10],
     });
     assert.strictEqual(
         contact.tasks.length,

--- a/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insert, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { insert, insertAndReplace } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 import { str_to_datetime } from 'web.time';
@@ -39,7 +39,7 @@ QUnit.test('create', async function (assert) {
         id: 4000,
         isNeedaction: true,
         isStarred: true,
-        originThread: replace(thread),
+        originThread: thread,
     });
 
     assert.ok(messaging.models['Partner'].findFromIdentifyingData({ id: 5 }));

--- a/addons/snailmail/static/src/models/dialog.js
+++ b/addons/snailmail/static/src/models/dialog.js
@@ -2,7 +2,7 @@
 
 import { addFields, addRecordMethods, patchRecordMethods } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+import { clear, insertAndReplace } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/dialog';
 
@@ -57,7 +57,7 @@ patchRecordMethods('Dialog', {
      */
     _computeRecord() {
         if (this.snailmailErrorView) {
-            return replace(this.snailmailErrorView);
+            return this.snailmailErrorView;
         }
         return this._super();
     },

--- a/addons/snailmail/static/src/models/snailmail_error_view.js
+++ b/addons/snailmail/static/src/models/snailmail_error_view.js
@@ -2,7 +2,6 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'SnailmailErrorView',
@@ -45,14 +44,14 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeMessage() {
-            return replace(this.dialogOwner.messageViewOwnerAsSnailmailError.message);
+            return this.dialogOwner.messageViewOwnerAsSnailmailError.message;
         },
         /**
          * @private
          * @returns {FieldCommand}
          */
         _computeNotification() {
-            return replace(this.message.notifications[0]);
+            return this.message.notifications[0];
         },
     },
     fields: {

--- a/addons/website_livechat/static/src/models/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, replace } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Visitor',
@@ -64,10 +64,10 @@ registerModel({
          */
         _computeCountry() {
             if (this.partner && this.partner.country) {
-                return replace(this.partner.country);
+                return this.partner.country;
             }
             if (this.country) {
-                return replace(this.country);
+                return this.country;
             }
             return clear();
         },


### PR DESCRIPTION
\* im_livechat, mail, snailmail, website_livechat

**Current behavior before PR:**

A `replace` command should be default while updating a field.

**Desired behavior after PR is merged:**

- If no command is passed while updating a field, add a `replace` command as
default.
- Remove all the existing occurrences of `replace` command.

Task-2851488

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
