### PR TITLE
[FIX] point_of_sale,pos_sale: load the missing partners

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -568,8 +568,9 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                     args: [idsNotInCache],
                     context: this.env.session.user_context,
                 });
-                // Check for missing products and load them in the PoS
+                // Check for missing products and partners and load them in the PoS
                 await this.env.pos._loadMissingProducts(fetchedOrders);
+                await this.env.pos._loadMissingPartners(fetchedOrders);
                 // Cache these fetched orders so that next time, no need to fetch
                 // them again, unless invalidated. See `_onInvoiceOrder`.
                 fetchedOrders.forEach((order) => {

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -857,6 +857,7 @@ exports.PosModel = Backbone.Model.extend({
     load_orders: async function(){
         var jsons = this.db.get_unpaid_orders();
         await this._loadMissingProducts(jsons);
+        await this._loadMissingPartners(jsons);
         var orders = [];
 
         for (var i = 0; i < jsons.length; i++) {
@@ -909,6 +910,23 @@ exports.PosModel = Backbone.Model.extend({
         });
         productModel.loaded(this, products);
     },
+
+    // load the partners based on the ids
+    async _loadPartners(partnerIds) {
+        if (partnerIds.length > 0) {
+            var fields = _.find(this.models, function(model){ return model.label === 'load_partners'; }).fields;
+            var domain = [['id','in', partnerIds]];
+            const fetchedPartners = await this.env.services.rpc({
+                model: 'res.partner',
+                method: 'search_read',
+                args: [domain, fields],
+            }, {
+                timeout: 3000,
+                shadow: true,
+            });
+            this.env.pos.db.add_partners(fetchedPartners);
+        }
+    },
     async _loadMissingPartners(orders) {
         const missingPartnerIds = new Set([]);
         for (const order of orders) {
@@ -918,17 +936,7 @@ exports.PosModel = Backbone.Model.extend({
                 missingPartnerIds.add(partnerId);
             }
         }
-        const partnerModel = _.find(this.models, function(model){return model.model === 'res.partner';});
-        const fields = partnerModel.fields;
-        if(missingPartnerIds) {
-            const partners = await this.rpc({
-                model: 'res.partner',
-                method: 'read',
-                args: [[...missingPartnerIds], fields],
-                context: Object.assign(this.session.user_context, { display_default_code: false }),
-            });
-            partnerModel.loaded(this, partners);
-        }
+        await this._loadPartners([...missingPartnerIds]);
     },
     // Load the products following specific rules into the `db`
     loadLimitedProducts: async function() {

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -88,7 +88,21 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
               }
               catch (error){
               }
-              currentPOSOrder.set_client(this.env.pos.db.get_partner_by_id(sale_order.partner_id[0]));
+              let order_partner = this.env.pos.db.get_partner_by_id(sale_order.partner_id[0])
+              if(order_partner){
+                currentPOSOrder.set_client(order_partner);
+              } else {
+                try {
+                    await this.env.pos._loadPartners([sale_order.partner_id[0]]);
+                }
+                catch (error){
+                    const title = this.env._t('Customer loading error');
+                    const body = _.str.sprintf(this.env._t('There was a problem in loading the %s customer.'), sale_order.partner_id[1]);
+                    await this.showPopup('ErrorPopup', { title, body });
+                }
+                currentPOSOrder.set_client(this.env.pos.db.get_partner_by_id(sale_order.partner_id[0]));
+              }
+
               let orderFiscalPos = sale_order.fiscal_position_id ? this.env.pos.fiscal_positions.find(
                   (position) => position.id === sale_order.fiscal_position_id[0]
               )


### PR DESCRIPTION
Before this commit: if the "Limited Partners Loading" were enabled, the
partner wouldn't set when using the "Quotation/Order" functionality
for unsynced partners.

Steps to reproduce the issue on the runbot:

	Enable developer mode.
	Go to the Point of Sale.
	Open the config of any pos.
	Enable "Limited Partners Loading" and set "Number of Partners
    Loaded" to a low number (like 5 or 10)
	Disable "Load all remaining partners in the background."
	Open a new PoS session for the configured PoS
	Use the "Quotation/Order" functionality.
	Select any order, for example, S00043.

	The customer is not set for the current pos order.

Solution

	The solution is to load the partner.

Also, there was an issue when using the limited number of partner loading
when it tried to load the cached and paid orders' partners. I added a function
to load missing partners.

opw-2883686

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
