### PR TITLE
[FIX] website_sale_stock_wishlist: show notify button to connected users

### DIFF
--- a/addons/website_sale_stock_wishlist/views/templates.xml
+++ b/addons/website_sale_stock_wishlist/views/templates.xml
@@ -6,7 +6,7 @@
         </xpath>
         <xpath expr="//button[hasclass('o_wish_rm')]" position="after">
             <t t-set="notify" t-value="wish.stock_notification"/>
-            <button groups="base.group_no_one" t-att-data-notify="notify" t-if="notify or wish.product_id.product_tmpl_id._is_sold_out()" type="button" class="btn btn-link o_notify_stock no-decoration">
+            <button groups="base.group_user,base.group_portal" t-att-data-notify="notify" t-if="notify or wish.product_id.product_tmpl_id._is_sold_out()" type="button" class="btn btn-link o_notify_stock no-decoration">
                 <small><i t-attf-class="fa #{'fa-check-square-o' if notify else 'fa-square-o'}"></i> Be notified when back in stock</small>
             </button>
         </xpath>


### PR DESCRIPTION
The option to be notified when an item in your wishlist is back in stock
only shows when the debug mode is enabled

Steps to reproduce:
1. Install Inventory and eCommerce
2. Go to Settings > Website > Products and enable Wishlists
3. Open Website and go to the website
4. Open the shop and add 'Three-Seat Sofa' to your wishlist (with the
   heart button)
5. Open your wishlist, the product is out of stock but you can't see the
   'Be notified when back in stock' button (it's only visible in debug
   mode)

Solution:
Change the groups for which the button is displayed

Problem:
The button was restricted to `base.group_no_one` which refers to debug
mode

opw-2904847