### PR TITLE
[FIX] test_website, web_editor, website: fix test_image_upload_progress and backend_dashboard tours

### DIFF
--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -136,7 +136,7 @@ wTourUtils.registerEditionTour('test_image_upload_progress', {
         },
     }, {
         content: "check upload progress bar is correctly shown",
-        trigger: ".o_we_progressbar:contains('image.png'):contains('File has been uploaded')",
+        trigger: ".o_we_progressbar:contains('image.png')",
         in_modal: false,
         run: function () {}, // it's a check
     }, {
@@ -150,8 +150,13 @@ wTourUtils.registerEditionTour('test_image_upload_progress', {
             }
         }
     }, {
-        content: "close media dialog",
-        trigger: 'button.btn.btn-secondary[type="button"]',
+        content: "media dialog has closed after the upload",
+        trigger: 'body:not(:has(.o_select_media_dialog))',
+        run: () => {}, // It's a check.
+    }, {
+        content: "the upload progress toast was updated",
+        trigger: ".o_we_progressbar:contains('image.png'):contains('File has been uploaded')",
+        run: () => {}, // It's a check.
     }, {
         content: "toaster should disappear after a few seconds if the uploaded image is successful",
         trigger: "body:not(:has(.o_we_progressbar))",

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.js
@@ -124,6 +124,7 @@ export class FileSelectorControlPanel extends Component {
             return;
         }
         await this.props.uploadFiles(inputFiles);
+        this.fileInput.el.value = '';
     }
 }
 FileSelectorControlPanel.template = 'web_editor.FileSelectorControlPanel';

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.js
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.js
@@ -1,6 +1,7 @@
 /** @odoo-module */
+import { useService } from '@web/core/utils/hooks';
 
-const { Component, useEffect, useState } = owl;
+const { Component, useState } = owl;
 
 export class ProgressBar extends Component {
     get progress() {
@@ -11,25 +12,11 @@ ProgressBar.template = 'web_editor.ProgressBar';
 
 export class UploadProgressToast extends Component {
     setup() {
-        this.state = useState({
-            isVisible: false,
-            numberOfFiles: 0,
-        });
+        this.uploadService = useService('upload');
 
-        useEffect((numberOfFiles) => {
-            if (numberOfFiles === 0) {
-                this.state.isVisible = false;
-            }
-            if (numberOfFiles > this.state.numberOfFiles) {
-                this.state.isVisible = true;
-            }
-            this.state.numberOfFiles = numberOfFiles;
-        }, () => [Object.keys(this.props.files).length]);
+        this.state = useState(this.uploadService.progressToast);
     }
 }
-UploadProgressToast.defaultProps = {
-    files: {},
-};
 UploadProgressToast.template = 'web_editor.UploadProgressToast';
 UploadProgressToast.components = {
     ProgressBar

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.xml
@@ -19,10 +19,10 @@
 <t t-name="web_editor.UploadProgressToast" owl="1">
     <div class="o_notification_manager o_upload_progress_toast">
         <div t-if="state.isVisible" class="o_notification position-relative show fade mb-2 border border-info bg-white" role="alert" aria-live="assertive" aria-atomic="true">
-            <button type="button" class="btn btn-close o_notification_close p-2" aria-label="Close" t-on-click="() => state.isVisible = false"/>
+            <button type="button" class="btn btn-close o_notification_close p-2" aria-label="Close" t-on-click="props.close"/>
             <div class="o_notification_body ps-2 pe-4 py-2">
                 <div class="me-auto o_notification_content">
-                    <div t-foreach="props.files" t-as="file" t-key="file" class="o_we_progressbar">
+                    <div t-foreach="state.files" t-as="file" t-key="file" class="o_we_progressbar">
                         <ProgressBar progress="file_value.progress"
                             errorMessage="file_value.errorMessage"
                             hasError="file_value.hasError"

--- a/addons/website/static/tests/tours/dashboard_tour.js
+++ b/addons/website/static/tests/tours/dashboard_tour.js
@@ -1,19 +1,15 @@
 odoo.define("website.tour.backend_dashboard", function (require) {
   "use strict";
 
-  var tour = require("web_tour.tour");
+  const wTourUtils = require("website.tour_utils");
 
-  tour.register(
+  wTourUtils.registerEditionTour(
     "backend_dashboard",
     {
       test: true,
-      url: "/web",
+      url: '/',
     },
     [
-      tour.stepUtils.showAppsMenuItem(),
-      {
-        trigger: '.o_app[data-menu-xmlid="website.menu_website_configuration"]',
-      },
       {
         trigger: 'button[data-menu-xmlid="website.menu_reporting"]',
       },
@@ -21,8 +17,8 @@ odoo.define("website.tour.backend_dashboard", function (require) {
         trigger: '.dropdown-item[data-menu-xmlid="website.menu_website_google_analytics"]',
       },
       {
-        // Visits section should always be present even when empty / not hooked to anything
-        trigger: 'h2:contains("Visits")',
+        // Analytics section should always be present even when empty / not hooked to anything
+        trigger: 'h2:contains("Analytics")',
         content: "Check if dashboard loads",
         run: function () {},
       },

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -143,7 +143,7 @@ class TestUi(odoo.tests.HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'restricted_editor', login='restricted')
 
     def test_03_backend_dashboard(self):
-        self.start_tour("/", 'backend_dashboard', login='admin')
+        self.start_tour('/@/', 'backend_dashboard', login='admin')
 
     def test_04_website_navbar_menu(self):
         website = self.env['website'].search([], limit=1)


### PR DESCRIPTION
[FIX] test_website, web_editor: fix test_image_upload_progress tour

Before this commit, the tour test_image_upload_progress was failing
inconsistently at the step "check that the file was correctly uploaded"
during the upload of a single image.

[1] adapted the upload progress toast to owl, but it used a state
variable isVisible, updated with a useEffect hook called on change of
the file props. This was not optimal: the visibility could be updated
directly through a reactive variable from the upload service. Instead of
automanaging its visibility, the component is completely driven by the
upload service.

This small optimization is useful in regards of the implementation of
the TourService.
As it is implemented now, the TourService works this way:
When it completed a step, it will check for the tooltip of the next
step, in the next javascript call stack.
If it does not find it in the DOM at that time, it will listen to the
mutations and wait for 750ms after the last one to check again.

Here, as the progress toast was rendered visible not directly when
uploading a file, but after another render, after the useEffect was
executed, the progress toast was sometimes not found directly after
playing the step sending the 'change' event. Then, the TourService was
waiting for all the mutations to execute (the progress toast appears,
the media dialog closes itself, the toast hides itself) and check again
after a delay. But by then the toast was already hidden.

With that, the tour steps are rewritten to follow the flow:
- Open the media dialog in single upload mode
- Upload an image
- The toast is shown
- The media dialog is closed
- The toast with "The file has been uploaded" is still there
- The toast autohides

Also, the file input value is reset after uploading files, otherwise it
was not possible to upload the same file twice (the 'change' event was
not triggered).

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

runbot-4117

-----

[FIX] website: fix backend_dashboard tour

The tour .test_03_backend_dashboard was failing inconsistently with a
"failed to fetch" error (which happens when fetching the frontend
assets, from the iframe).

The test is adapted to start directly in the backend, which seems to
prevent that error from happening.
It is also adapted to [1] which was merged during the investigation of
that error.

[1]: https://github.com/odoo/odoo/commit/985e49bdb5e22fa197ba267aa41d7a8ba7e50550

runbot-4418
runbot-4003
