### PR TITLE
[FIX] web: fallback for domain selector operator

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_leaf_node.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_leaf_node.js
@@ -24,7 +24,20 @@ export class DomainSelectorLeafNode extends Component {
     }
 
     get displayedOperator() {
-        const op = this.getOperatorInfo(this.props.node.operator);
+        let op = this.getOperatorInfo(this.props.node.operator);
+        if (op) {
+            return op.label;
+        }
+        op = registry
+            .category("domain_selector/operator")
+            .getAll()
+            .find((op) =>
+                op.matches({
+                    field: this.fieldInfo,
+                    operator: this.props.node.operator,
+                    value: this.props.node.operands[1],
+                })
+            );
         return op ? op.label : "?";
     }
     get isValueHidden() {

--- a/addons/web/static/src/core/domain_selector/domain_selector_operators.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operators.js
@@ -84,6 +84,7 @@ dso.add("like", {
     label: _lt("like"),
     value: "like",
     onDidChange: onDidChange(() => ({ value: "" })),
+    matches: matchValue(),
 });
 dso.add("not like", {
     category: "like",

--- a/addons/web/static/tests/core/domain_selector_tests.js
+++ b/addons/web/static/tests/core/domain_selector_tests.js
@@ -339,4 +339,16 @@ QUnit.module("Components", (hooks) => {
             "should still have a single domain node"
         );
     });
+
+    QUnit.test("operator fallback", async (assert) => {
+        await mount(DomainSelector, target, {
+            env,
+            props: {
+                resModel: "partner",
+                value: "[['foo', 'like', 'kikou']]",
+            },
+        });
+
+        assert.strictEqual(target.querySelector(".o_domain_leaf").textContent, `Foo like "kikou"`);
+    });
 });


### PR DESCRIPTION
Before this commit, it happened that the domain selector
couldn't find the operator linked to the field.
This commit adds a fallback on the existing operators
to find an operator that matches.

for example the domain `[["name", "like", "M"]]` gave
`Name ? "M"`, now it correctly gives `Name like "M"`.
