### PR TITLE
[IMP] mail: add support for RTL in discuss public

### DIFF
--- a/addons/mail/views/discuss_public_templates.xml
+++ b/addons/mail/views/discuss_public_templates.xml
@@ -37,6 +37,11 @@
     <template id="mail.discuss_public_channel_template" name="Discuss Public Channel Template">
         <t t-call="mail.discuss_public_layout">
             <t t-set="head">
+                <style>
+                    body {
+                        direction: <t t-out="env['res.lang']._lang_get(lang or env.user.lang).direction or 'ltr'" />;
+                    }
+                </style>
                 <script>
                     odoo.define('mail.discuss_public_channel_template', function() {
                         return {


### PR DESCRIPTION
As `discuss_public_channel_template` is sandboxed for the `webclient`
the following CSS rule is not applied anymore.
```css
.o_web_client {
  direction: ltr;
}
```

This commit adds it specifically for this template to reflect the
language direction in this sandboxed environment.
