### PR TITLE
[FIX] account: allow missing account_id in account.move.line vals

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4939,7 +4939,7 @@ class AccountMoveLine(models.Model):
             and self._context.get('default_move_type') in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'):
             # Fill missing 'account_id'.
             journal = self.env['account.journal'].browse(self._context.get('default_journal_id') or self._context['journal_id'])
-            if values['partner_id']:
+            if values.get('partner_id'):
                 # Get most used account of the partner as the default.
                 account_id = self.env['account.account']._order_by_frequency_per_partner(
                     journal.company_id.id, values['partner_id'], self._context.get("default_move_type"), limit=1)[0]


### PR DESCRIPTION
When an invoice line has a display_type, account addon is expecting
account_id=False in vals. Replacing the normal dict access with a
`get` will fix the error when invoicing with note/section lines
without explicitly specifying the `account_id` to be false.

**Old description which is still relevant:**

When an orderline has a note, invoicing fails because of missing
account_id key in the invoice line vals. For notes and section lines
to work, we need to explicitly specify that the account_id is false.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
