### PR TITLE
[FIX] mail: dropdown menu not at the right position

### DIFF
--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -11,7 +11,7 @@
                     </button>
 
                     <t t-if="followerListMenuView.isDropdownOpen">
-                        <div class="o_FollowerListMenu_dropdown dropdown-menu dropdown-menu-end flex-column d-flex" role="menu">
+                        <div class="o_FollowerListMenu_dropdown o-dropdown-menu dropdown-menu-end flex-column d-flex" role="menu">
                             <t t-if="followerListMenuView.chatterOwner.thread.model !== 'channel' and followerListMenuView.chatterOwner.thread.hasWriteAccess">
                                 <a class="o_FollowerListMenu_addFollowersButton dropdown-item" href="#" role="menuitem" t-on-click="_onClickAddFollowers">
                                     Add Followers

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
@@ -21,11 +21,6 @@
         top: $o-mail-chat-window-header-height-mobile;
         max-height: none;
     }
-
-    &.dropdown-menu-end {
-        right: 0;
-        left: auto;
-    }
 }
 
 .o_MessagingMenu_dropdownMenuHeader.o-isDeviceSmall {

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
@@ -16,7 +16,7 @@
                     </t>
                 </a>
                 <t t-if="messagingMenu.isOpen">
-                    <div class="o_MessagingMenu_dropdownMenu dropdown-menu dropdown-menu-end d-flex flex-column mt-0 py-0 overflow-auto" t-att-class="{ 'o-isDeviceSmall position-fixed bottom-0 start-0 end-0 flex-grow-1 w-100 m-0 border-0': messaging.device.isSmall, 'border': !messaging.device.isSmall, 'o-messaging-not-initialized align-items-center justify-content-center': !messaging.isInitialized }" role="menu">
+                    <div class="o_MessagingMenu_dropdownMenu o-dropdown-menu dropdown-menu-end d-flex flex-column mt-0 py-0 overflow-auto" t-att-class="{ 'o-isDeviceSmall position-fixed bottom-0 start-0 end-0 flex-grow-1 w-100 m-0 border-0': messaging.device.isSmall, 'border': !messaging.device.isSmall, 'o-messaging-not-initialized align-items-center justify-content-center': !messaging.isInitialized }" role="menu">
                         <t t-if="!messaging.isInitialized">
                             <span><i class="o_MessagingMenu_dropdownLoadingIcon fa fa-circle-o-notch fa-spin me-1"/>Please wait...</span>
                         </t>


### PR DESCRIPTION
[FIX] mail: dropdown menu not at the right position
Since Bootstrap 5 migration, when we use the OWL `dropdown` component
it must have the class `o-dropdown-menu` and not `dropdown-menu`.

This commit replaces this class and also clean some CSS.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
