### PR TITLE
[FIX] base: test_create_res_partner with only account_accountant

### DIFF
--- a/odoo/addons/base/tests/test_form_create.py
+++ b/odoo/addons/base/tests/test_form_create.py
@@ -12,10 +12,14 @@ class TestFormCreate(TransactionCase):
     """
 
     def test_create_res_partner(self):
-        # Required for `property_account_payable_id`, `property_account_receivable_id` to be visible in the view
-        group_account_readonly = self.env.ref('account.group_account_readonly', raise_if_not_found=False)
-        if group_account_readonly:
+        # YTI: Clean that brol
+        if hasattr(self.env['res.partner'], 'property_account_payable_id'):
+            # Required for `property_account_payable_id`, `property_account_receivable_id` to be visible in the view
+            # By default, it's the `group` `group_account_readonly` which is required to see it, in the `account` module
+            # But once `account_accountant` gets installed, it becomes `account.group_account_manager`
+            # https://github.com/odoo/enterprise/blob/bfa643278028da0bfabded2f87ccb7e323d697c1/account_accountant/views/product_views.xml#L9
             self.env.user.groups_id += self.env.ref('account.group_account_readonly')
+            self.env.user.groups_id += self.env.ref('account.group_account_manager')
         partner_form = Form(self.env['res.partner'])
         partner_form.name = 'a partner'
         # YTI: Clean that brol


### PR DESCRIPTION
This is about the same than
d6ad39abba12d8da302e0ecc9c24e064b1768300

but with account_accountant installed

```
FAIL: TestFormCreate.test_create_res_partner
Traceback (most recent call last):
  File "/data/build/odoo/odoo/addons/base/tests/test_form_create.py", line 35, in test_create_res_partner
    partner_form.property_account_payable_id = property_account_payable_id
  File "/data/build/odoo/odoo/tests/common.py", line 2179, in __setattr__
    assert not self._get_modifier(field, 'invisible'), \
AssertionError: can't write on invisible field property_account_payable_id
```
