### PR TITLE
[FIX] web_editor, website_forum: fix missing editor commands

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -70,6 +70,8 @@ const Wysiwyg = Widget.extend({
         recordInfo: {context: {}},
         document: document,
         allowCommandVideo: true,
+        allowCommandImage: true,
+        allowCommandLink: true,
     },
     init: function (parent, options) {
         this._super.apply(this, arguments);

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -137,9 +137,9 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 resizable: true,
                 userGeneratedContent: true,
             };
-            if (hasFullEdit) {
-                options.allowCommandLink = true;
-                options.allowCommandImage = true;
+            if (!hasFullEdit) {
+                options.allowCommandLink = false;
+                options.allowCommandImage = false;
             }
             wysiwygLoader.loadFromTextarea(self, $textarea[0], options).then(wysiwyg => {
                 if (!hasFullEdit) {


### PR DESCRIPTION
"/image", "/link", "/button" are missing from the command box.

Before commit [1], "/image" was added if the user was an internal user,
and "/link" and "/button" were added by default.
Commit [1] introduced new options "allowCommandImage" and
"allowCommandLink" for the command box, which have to be set to true
if one wants to add "/image" or "/link" and "/button" to the commands.
This allows portal users to uplaod images in website_forum, by setting
the "allowCommandImage" to true.
However, these options are not set for other modules.

Instead of setting "allowCommandImage" to true in website_forum, we now
set it to false when needed, and added "allowCommandImage" and
"allowCommandLink" as true in the default options for the command box.

[1]: https://github.com/odoo/odoo/commit/e104937

Task-2917285
