### PR TITLE
[FIX] sale: `test_fiscalposition_application` missing uom group

### DIFF
--- a/addons/sale/tests/test_sale_pricelist.py
+++ b/addons/sale/tests/test_sale_pricelist.py
@@ -164,7 +164,8 @@ class TestSaleOrder(TestSaleCommon):
         """Test application of a fiscal position mapping
         price included to price included tax
         """
-
+        # Required for `product_uom` to be visible in the view
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
         uom = self.env['uom.uom'].search([('name', '=', 'Units')])
         pricelist = self.env['product.pricelist'].search([('name', '=', 'Public Pricelist')])
 


### PR DESCRIPTION
When `sale` is installed alone,
the test fails because it changes the field `product_uom`
which is invisible in the view because the user executing the test
doesn't have the appropriate group.

```
FAIL: TestSaleOrder.test_fiscalposition_application
Traceback (most recent call last):
  File "/data/build/odoo/addons/sale/tests/test_sale_pricelist.py", line 292, in test_fiscalposition_application
    line.product_uom = uom
  File "/data/build/odoo/odoo/tests/common.py", line 2179, in __setattr__
    assert not self._get_modifier(field, 'invisible'), \
AssertionError: can't write on invisible field product_uom
```
