### PR TITLE
[FIX] crm:  duplicate 'lost' button on a lead's form view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -48,7 +48,7 @@
                             type="object" class="oe_highlight"
                             attrs="{'invisible': ['|','|', ('active','=',False), ('probability', '=', 100), ('type', '=', 'lead')]}"/>
                         <button name="%(crm.crm_lead_lost_action)d" string="Mark Lost"
-                            type="action" class="oe_highlight" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'),('active', '=', False),('probability', '&lt;', 100)]}"/>
+                            type="action" class="oe_highlight" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'), '&amp;',('active', '=', False),('probability', '&lt;', 100)]}"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action" help="Convert to Opportunity"
                             class="oe_highlight" attrs="{'invisible': ['|', ('type', '=', 'opportunity'), ('active', '=', False)]}"/>
                         <button name="toggle_active" string="Restore" type="object"


### PR DESCRIPTION
Currently,  two lost buttons will appear, if you go to the form view of a lead that has 100% probability. The difference between the two duplicated "Lost" buttons is that one ask for a "lost reason" before marking a lead/opportunity as lost, the other does not.

After discussing with the PO for CRM, it appears that the button that asks for a "lost reason" should not be displayed for leads. This commit makes the necessary changes to reflect that behavior.

opw-2886623