### PR TITLE
[IMP] account: improve fiduciary mode

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -47,6 +47,9 @@ class SequenceMixin(models.AbstractModel):
                     field=sql.Identifier(self._sequence_field),
                 ))
 
+    def _must_check_constrains_date_sequence(self):
+        return True
+
     @api.constrains(lambda self: (self._sequence_field, self._sequence_date_field))
     def _constrains_date_sequence(self):
         # Make it possible to bypass the constraint to allow edition of already messed up documents.
@@ -56,6 +59,8 @@ class SequenceMixin(models.AbstractModel):
             '1970-01-01'
         ))
         for record in self:
+            if not record._must_check_constrains_date_sequence():
+                continue
             date = fields.Date.to_date(record[record._sequence_date_field])
             sequence = record[record._sequence_field]
             if sequence and date and date > constraint_date:

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -681,8 +681,9 @@
                             <div class="col-12 col-lg-12 o_setting_box">
                                 <div class="text-muted">
                                     <p style="margin-bottom: 0">Accounting firm mode will change invoice/bill encoding:</p>
-                                    <p style="margin-bottom: 0"> - The sequence’s document becomes manageable for each document.</p>
+                                    <p style="margin-bottom: 0"> - The document's sequence becomes editable on all documents.</p>
                                     <p style="margin-bottom: 0"> - A new field « Total (tax inc.) » to speed up and control the encoding by automating line creation with the right account &amp; tax.</p>
+                                    <p style="margin-bottom: 0"> - A default Customer Invoice / Vendor Bill date will be suggested.</p>
                                 </div>
                                 <div class="o_setting_right_pane mt16">
                                     <label for="quick_edit_mode"/>

--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -52,7 +52,8 @@
 
             <!-- on latam_documents we use document_number to set name -->
             <field name="name" position="attributes">
-                <attribute name="attrs">{'readonly': ['|', ('state', '!=', 'draft'), ('l10n_latam_use_documents', '=', True)]}</attribute>
+                <attribute name="attrs">{'invisible':[('name', '=', '/'), ('posted_before', '=', False), ('quick_edit_mode', '=', False)],
+                                         'readonly': ['|', ('state', '!=', 'draft'), ('l10n_latam_use_documents', '=', True)]}</attribute>
             </field>
 
         </field>


### PR DESCRIPTION
This PR improves the fiduciary mode by:
- removing message error about the change of sequence format
- suggesting the Customer Invoice / Vendor Bill date according to the following heuristic:
	- Last day of the month of the most recent Customer Invoice / Vendor Bill (ignoring drafts) OR today (whichever is the smallest)
	- If this date falls before a Lock Date, pick the last day of the first month that is not locked

	Example 1 :
		We are June 17th 2022. No Lock date. Bill Date of the most recent Vendor Bill : March 15th 2022
		==> Default New Vendor Bill date = March 31st 2022 (last day of March 2022)
	Example 2 :
		We are June 17th 2022. No Lock date. Bill Date of the most recent Vendor Bill : March 31st 2022
		==> Default New Vendor Bill date = March 31st 2022 (last day of March 2022)
	Example 3 :
		We are June 17th 2022. No Lock date. Bill Date of the most recent Vendor Bill : June 2nd 2022
		==> Default New Vendor Bill date = June 17th 2022 (today is the smallest)
	Example 4 :
		We are June 17th 2022. Lock date : April 30th 2022. Bill Date of the most recent Vendor Bill : April 30th 2022
		==> Default New Vendor Bill date = May 31st 2022 (last day of the first month not locked)

- renaming the invoice according to suggested date

Task id: 2887007

