### PR TITLE
[FIX] crm: a lead created through a contact should be an opportunity

### DIFF
--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -34,7 +34,7 @@
                             name="action_view_opportunity"
                             icon="fa-star"
                             groups="sales_team.group_sale_salesman"
-                            context="{'default_partner_id': active_id}">
+                            context="{'default_partner_id': active_id, 'default_type':'opportunity'}">
                             <field string="Opportunities" name="opportunity_count" widget="statinfo"/>
                         </button>
                     </div>


### PR DESCRIPTION
Currently, if you try to create an opportunity through the smart button on a contact form, a lead is created.
A lead created from a customer should be an opportunity.

opw-2886623