### PR TITLE
[IMP] web: Tooltip UX on touch-enabled devices

### DIFF
--- a/addons/web/static/src/core/browser/browser.js
+++ b/addons/web/static/src/core/browser/browser.js
@@ -40,6 +40,7 @@ export const browser = {
     fetch: window.fetch.bind(window),
     innerHeight: window.innerHeight,
     innerWidth: window.innerWidth,
+    ontouchstart: window.ontouchstart,
 };
 
 Object.defineProperty(browser, "location", {
@@ -73,9 +74,7 @@ export function makeRAMLocalStorage() {
     return {
         setItem(key, value) {
             store[key] = value;
-            window.dispatchEvent(
-                new StorageEvent('storage', { key, newValue: value })
-            );
+            window.dispatchEvent(new StorageEvent("storage", { key, newValue: value }));
         },
         getItem(key) {
             return store[key];
@@ -85,9 +84,7 @@ export function makeRAMLocalStorage() {
         },
         removeItem(key) {
             delete store[key];
-            window.dispatchEvent(
-                new StorageEvent('storage', { key, newValue: null })
-            );
+            window.dispatchEvent(new StorageEvent("storage", { key, newValue: null }));
         },
         get length() {
             return Object.keys(store).length;

--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -20,8 +20,10 @@ export function isAndroid() {
 }
 
 export function isIOS() {
-    return /(iPad|iPhone|iPod)/i.test(browser.navigator.userAgent) ||
-        (browser.navigator.platform === 'MacIntel' && maxTouchPoints() > 1);
+    return (
+        /(iPad|iPhone|iPod)/i.test(browser.navigator.userAgent) ||
+        (browser.navigator.platform === "MacIntel" && maxTouchPoints() > 1)
+    );
 }
 
 export function isOtherMobileOS() {
@@ -41,7 +43,7 @@ export function isIosApp() {
 }
 
 export function hasTouch() {
-    return "ontouchstart" in window || "onmsgesturechange" in window;
+    return browser.ontouchstart !== undefined;
 }
 
 export function maxTouchPoints() {

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -40,6 +40,7 @@ class WebSuite(odoo.tests.HttpCase):
 @odoo.tests.tagged('post_install', '-at_install')
 class MobileWebSuite(odoo.tests.HttpCase):
     browser_size = '375x667'
+    touch_enabled = True
 
     def test_mobile_js(self):
         # webclient mobile test suite

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -78,6 +78,7 @@ class TestUi(BaseTestUi):
 class TestUiMobile(BaseTestUi):
 
     browser_size = '375x667'
+    touch_enabled = True
 
     def test_01_main_flow_tour_mobile(self):
 


### PR DESCRIPTION
Port of legacy's BasicRenderer for WOWL views.

In a nutshell: Tooltips are problematic in touch devices as they are
meant to appear on hover... which doesn't happen with touch events.

This commit implements a "tap-to-show" behavior which let the user see
the Tooltip by pressing the element, and letting it disappear when the
pressure ends.

Also, make the touch detection easier to test/mock.