### PR TITLE
Fix Wave Transfer create

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -17,7 +17,7 @@
         <field name="res_model">stock.picking.batch</field>
         <field name="type">ir.actions.act_window</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True}</field>
+        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True, 'default_is_wave': True}</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'tree', 'view_id': ref('stock_picking_batch.stock_picking_wave_tree')})]"/>
         <field name="domain">[('is_wave', '=', True)]</field>

--- a/doc/cla/individual/aqeebimtiaz.md
+++ b/doc/cla/individual/aqeebimtiaz.md
@@ -1,0 +1,11 @@
+Bangladesh, 2022-07-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Aqeeb Imtiaz Harun aqeebimtiaz@gmail.com https://github.com/aqeebimtiaz


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR will fix creating new Wave Transfers from the Kanban view.

Current behavior before PR:
Currently, when creating new Wave Transfers, `is_wave` field is not passed in the context & as a result it automatically converts to Batch Transfer. Recently I discovered it when testing & also saw an [issue](https://github.com/odoo/odoo/issues/92221) reported on May 25 2022.

Desired behavior after PR is merged:
Once this PR is merged, we will be able to create Wave Transfers normally, without converting it to Batch Transfer.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
