### PR TITLE
[FIX] payment(_transfer): only leave the status page when state is final

### DIFF
--- a/addons/payment/static/src/js/post_processing.js
+++ b/addons/payment/static/src/js/post_processing.js
@@ -76,14 +76,6 @@ odoo.define('payment.post_processing', function (require) {
                 'tx_error': [],
             };
 
-            if (display_values_list.length > 0) {
-                // In almost every cases there will be a single transaction to display. If there are
-                // more than one transaction, the last one will most likely be the one that was
-                // confirmed. We use this one to redirect the user to the final page.
-                window.location = display_values_list[0].landing_route;
-                return;
-            }
-
             // group the transaction according to their state
             display_values_list.forEach(function (display_values) {
                 var key = 'tx_' + display_values.state;
@@ -129,4 +121,6 @@ odoo.define('payment.post_processing', function (require) {
             });
         },
     });
+
+    return publicWidget.registry.PaymentPostProcessing;
 });

--- a/addons/payment/static/src/xml/payment_post_processing.xml
+++ b/addons/payment/static/src/xml/payment_post_processing.xml
@@ -9,7 +9,7 @@
                 <h1>Payments failed</h1>
                 <ul class="list-group">
                     <t t-foreach="tx_error" t-as="tx">
-                        <li class="list-group-item">
+                        <a t-att-href="tx['landing_route']" class="list-group-item">
                             <h4 class="list-group-item-heading mb5">
                                 <t t-esc="tx['reference']"/>
                                 <span class="badge float-end"><t t-esc="tx['amount']"/> <t t-esc="tx['currency_code']"/></span>
@@ -18,7 +18,7 @@
                                 An error occurred during the processing of this payment.<br/>
                                 <strong>Reason:</strong> <t t-esc="tx['state_message']"/>
                             </small>
-                        </li>
+                        </a>
                     </t>
                 </ul>
             </div>
@@ -66,7 +66,7 @@
                     </t>
                     <!-- Authorized transactions -->
                     <t t-foreach="tx_authorized" t-as="tx">
-                        <li class="list-group-item">
+                        <a t-att-href="tx['landing_route']" class="list-group-item">
                             <h4 class="list-group-item-heading mb5">
                                 <t t-esc="tx['reference']"/>
                                 <span class="badge float-end"><t t-esc="tx['amount']"/> <t t-esc="tx['currency_code']"/></span>
@@ -82,7 +82,7 @@
                                     You will be notified when the payment is confirmed.
                                 </t>
                             </small>
-                        </li>
+                        </a>
                     </t>
                 </div>
             </div>
@@ -91,7 +91,7 @@
                 <h1>Waiting for payment</h1>
                 <ul class="list-group">
                     <t t-foreach="tx_draft" t-as="tx">
-                        <li class="list-group-item">
+                        <a t-att-href="tx['landing_route']" class="list-group-item">
                             <h4 class="list-group-item-heading mb5">
                                 <t t-esc="tx['reference']"/>
                                 <span class="badge float-end"><t t-esc="tx['amount']"/> <t t-esc="tx['currency_code']"/></span>
@@ -106,7 +106,7 @@
                                     We are waiting for the payment acquirer to confirm the payment.
                                 </t>
                             </small>
-                        </li>
+                        </a>
                     </t>
                 </ul>
             </div>
@@ -115,7 +115,7 @@
                 <h1>Cancelled payments</h1>
                 <ul class="list-group">
                     <t t-foreach="tx_cancel" t-as="tx">
-                        <li class="list-group-item">
+                        <a t-att-href="tx['landing_route']" class="list-group-item">
                             <h4 class="list-group-item-heading mb5">
                                 <t t-esc="tx['reference']"/>
                                 <span class="badge float-end"><t t-esc="tx['amount']"/> <t t-esc="tx['currency_code']"/></span>
@@ -124,7 +124,7 @@
                                 This transaction has been cancelled.<br/>
                                 No payment has been processed.
                             </small>
-                        </li>
+                        </a>
                     </t>
                 </ul>
             </div>

--- a/addons/payment_transfer/__manifest__.py
+++ b/addons/payment_transfer/__manifest__.py
@@ -13,6 +13,11 @@
         'data/payment_acquirer_data.xml',
     ],
     'auto_install': True,
+    'assets': {
+        'web.assets_frontend': [
+            'payment_transfer/static/src/js/post_processing.js',
+        ],
+    },
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/payment_transfer/static/src/js/post_processing.js
+++ b/addons/payment_transfer/static/src/js/post_processing.js
@@ -1,0 +1,25 @@
+odoo.define('payment_transfer.post_processing', require => {
+    'use strict';
+
+    const paymentPostProcessing = require('payment.post_processing');
+
+    paymentPostProcessing.include({
+        /**
+         * Don't wait for the transaction to be confirmed before redirecting customers to the
+         * landing route because Wire Transfer transactions remain in the state 'pending' forever.
+         *
+         * @override method from `payment.post_processing`
+         * @param {Object} display_values_list - The post-processing values of the transactions
+         */
+        processPolledData: function (display_values_list) {
+            // In almost every case, there will be a single transaction to display. If there are
+            // more than one transaction, the last one will most likely be the one that counts. We
+            // use that one to redirect the user to the landing page.
+            if (display_values_list.length > 0 && display_values_list[0].provider === 'transfer') {
+                window.location = display_values_list[0].landing_route;
+            } else {
+                return this._super(...arguments);
+            }
+        }
+    });
+});


### PR DESCRIPTION
Before this commit, customers never waited on the status page for their
payment to be confirmed. Instead, they were redirected to the landing
route before that the transaction reaches a final state.

Although this bug is present since version 15.0, it not considered as a
problem worth fixing in stable since redirecting customers in advance is
already supported. It is fixed in master to lay ground for further work
that will require customers to wait for the payment confirmation.

After this commit, customers will remain on the status page until their
transaction state is updated to a final state ('authorized', 'done',
'error'). An exception is made for Wire Transfer's payments that are
never confirmed and should not block the customer on the status page.

task-2908493

See also:
- ~~https://github.com/odoo/enterprise/pull/29439~~