### PR TITLE
[FIX] website: apply correctly the css to the website theme selector

### DIFF
--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -221,7 +221,7 @@
     pointer-events: none;
 }
 
-.o_theme_kanban {
+.o_legacy_kanban_view.o_theme_kanban {
     $o-theme-kanban-gray: #fcfcfc;
     background-color: $o-theme-kanban-gray;
 


### PR DESCRIPTION
Since 4f984568e139d8da448018af12ef79005e317cf6, the css theme is not
correctly applied to the website theme selector.

The order in which the css rules were applied without the
'.o_legacy_kanban_view' selector removed a margin from the
kanban_record element.