### PR TITLE
[POC] base: store gzipped assets for streaming

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -23,7 +23,7 @@ except ImportError:
 from odoo import release, SUPERUSER_ID
 from odoo.http import request
 from odoo.modules.module import get_resource_path
-from odoo.tools import func, misc, transpile_javascript, is_odoo_module, SourceMapGenerator, profiler
+from odoo.tools import config, func, misc, transpile_javascript, is_odoo_module, SourceMapGenerator, profiler
 from odoo.tools.misc import file_open, html_escape as escape
 from odoo.tools.pycompat import to_text
 
@@ -314,6 +314,9 @@ class AssetsBundle(object):
         """
         assert extension in ('js', 'min.js', 'js.map', 'css', 'min.css', 'css.map')
         ira = self.env['ir.attachment']
+        if config['x_sendfile']:
+            ira = ira.with_context(create_extra_gzip_file=True)
+
 
         # Set user direction in name to store two bundles
         # 1 for ltr and 1 for rtl, this will help during cleaning of assets bundle


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/da8def8e410 https://github.com/odoo/documentation/commit/0f2b82cb Odoo delegates
serving attachments to NGINX. In case of an uncompressed text-file such
as css and js files and when the browser advertise it understands gzip
via the `Accept-Content: gzip` request header, NGINX will gzip the file
on-the-fly and add a `Content-Encoding: gzip` response header in order
to save some bandwidth. It is important that NGINX gzips the file on the
fly as transmitting an uncompressed file takes more time than
compressing it server side, transmitting it and uncompressing it client
side.

In this commit, using the `--x-sendfile` CLI option, new bundled assets
are stored twice in the filestore: uncompressed and gzipped (same path
with an extra `.gz` suffix to the filename). Using the `gzip_static: on`
directive in the `/web/filestore` internal NGINX location, NGINX locates
and streams the gzipped file right-away instead of compressing the
uncompressed file on-the-fly.

See the [Serving static files and attachments] section in the
documentation.

[Serving static files and attachments]: https://www.odoo.com/documentation/master/administration/install/deploy.html#serving-static-files-and-attachments

Troubleshooting
---------------

In order for the `gzip_static` directive to work, NGINX must have been
compiled with the `--with-http_gzip_static_module` flag. On debian-based
system that module is enabled by default. You can verify you support it
via `nginx -V`.

In order for nginx to stream the `.gz` assets, the `.gz` assets must
exist on disk. The `.gz` assets are only created upon compiling the
bundles with the `--x-sendfile` CLI option set.

To verify it works, you can `strace` the nginx workers as you access the
home page via your browser (make sure to disable the cache and the debug
mode). The workers should open some files in the filestore, they are
js/css assets and images. For the js/css files, make sure the workers
**ONLY** open the `.gz` version of the file.

Task: 2901173