### PR TITLE
[IMP] core: add unaccent to index when needed

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -77,7 +77,7 @@ class AccountMove(models.Model):
         compute='_compute_name', readonly=False, store=True,
         copy=False,
         tracking=True,
-        index='btree',
+        index='btree',  # We need the btree index for unicity constraint (`_check_unique_sequence_number`)
     )
     ref = fields.Char(string='Reference', copy=False, tracking=True)
     date = fields.Date(
@@ -543,8 +543,8 @@ class AccountMove(models.Model):
 
     def _auto_init(self):
         super()._auto_init()
-        if sql.install_pg_trgm(self._cr):
-            # We need the btree index for unicity constraint (on field) AND this one for human searches
+        if self.pool.has_trigram:
+            # This index is for human searches
             sql.create_index(self._cr, 'account_move_name_trigram_index', self._table, ['"name" gin_trgm_ops'], 'gin')
 
         self.env.cr.execute("""

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -116,14 +116,22 @@ def _create_empty_database(name):
                 sql.Identifier(name), collate, sql.Identifier(chosen_template)
             ))
 
-    if odoo.tools.config['unaccent']:
-        try:
-            db = odoo.sql_db.db_connect(name)
-            with closing(db.cursor()) as cr:
+    # TODO: add --extension=trigram,unaccent
+    try:
+        db = odoo.sql_db.db_connect(name)
+        with db.cursor() as cr:
+            cr.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+            if odoo.tools.config['unaccent']:
                 cr.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
-                cr.commit()
-        except psycopg2.Error:
-            pass
+                # From PostgreSQL's point of view, making 'unaccent' immutable is incorrect
+                # because it depends on external data - see
+                # https://www.postgresql.org/message-id/flat/201012021544.oB2FiTn1041521@wwwmaster.postgresql.org#201012021544.oB2FiTn1041521@wwwmaster.postgresql.org
+                # But in the case of Odoo, we consider that those data don't
+                # change in the lifetime of a database. If they do change, all
+                # indexes created with this function become corrupted!
+                cr.execute("ALTER FUNCTION unaccent(text) IMMUTABLE")
+    except psycopg2.Error as e:
+        _logger.warning("Unable to create PostgreSQL extensions : %s", e)
 
 @check_db_management_enabled
 def exp_create_database(db_name, demo, lang, user_password='admin', login='admin', country_code=None, phone=None):

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -234,26 +234,6 @@ def fix_foreign_key(cr, tablename1, columnname1, tablename2, columnname2, ondele
     if not found:
         return add_foreign_key(cr, tablename1, columnname1, tablename2, columnname2, ondelete)
 
-def install_pg_trgm(cr):
-    cr.execute("SELECT installed_version FROM pg_available_extensions WHERE name='pg_trgm'")
-    version = cr.fetchone()
-    if version is None:
-        return False
-    if version[0]:
-        return True
-    cr.execute('SELECT usesuper FROM pg_user WHERE usename = CURRENT_USER')
-    if not cr.fetchone()[0]:
-        return False
-    try:
-        db = odoo.sql_db.db_connect(cr.dbname)
-        with closing(db.cursor()) as cr:
-            cr.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-            cr.commit()
-        return True
-    except psycopg2.Error:
-        return False
-
-
 def index_exists(cr, indexname):
     """ Return whether the given index exists. """
     cr.execute("SELECT 1 FROM pg_indexes WHERE indexname=%s", (indexname,))


### PR DESCRIPTION
We added trigram index for char fields since https://github.com/odoo/odoo/pull/83015.
But if unaccent is installed in the database (and isn't force to False
on field), these new trigram indexes is pointless and cost a lot for
nothing (almost nothing, it still can be used for equality operator).

The easy way to fix it add `unaccent(<column>)` in the index trigram
definition but unfortunately unaccent postgresql function is not
immutable, then we must ensure that the immutable version
of unaccent exist in the Database to be usable in indexes (See
https://stackoverflow.com/questions/11005036/does-postgresql-support-accent-insensitive-collations/11007216#11007216
for more information and how to do that).

Now, trigram index are created with `unaccent(<column>)` if the unaccent
is installed in the DB and the field is not force as `unaccent=False`.
Also, if the unaccent version isn't immutable then put a warning (because
all trigram will be useless if it is not the case).

https://github.com/odoo/upgrade/pull/3736
task-2551518