### PR TITLE
[FIX] web: use OnboardingBanner as default banner

### DIFF
--- a/addons/web/static/src/core/utils/objects.js
+++ b/addons/web/static/src/core/utils/objects.js
@@ -28,6 +28,6 @@ export function deepCopy(obj) {
  * @param {...(keyof T)} properties
  * @returns {Partial<T>}
  */
-export function pluck(object, ...properties) {
+export function pick(object, ...properties) {
     return Object.fromEntries(Object.entries(object).filter(([k]) => properties.includes(k)));
 }

--- a/addons/web/static/src/search/layout.js
+++ b/addons/web/static/src/search/layout.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
-import { ControlPanel } from "@web/search/control_panel/control_panel";
-import { SearchPanel } from "@web/search/search_panel/search_panel";
+import { pick } from "@web/core/utils/objects";
 
 const { Component } = owl;
 
@@ -10,11 +9,7 @@ const { Component } = owl;
  * @returns {Object}
  */
 export function extractLayoutComponents(params) {
-    return {
-        ControlPanel: params.ControlPanel || ControlPanel,
-        SearchPanel: params.SearchPanel || SearchPanel,
-        Banner: params.Banner || false,
-    };
+    return pick(params, "ControlPanel", "SearchPanel", "Banner");
 }
 
 export class Layout extends Component {

--- a/addons/web/static/src/search/layout.xml
+++ b/addons/web/static/src/search/layout.xml
@@ -7,7 +7,7 @@
         </t>
         <t t-component="components.ControlPanel" slots="controlPanelSlots" t-if="display.controlPanel"/>
         <div class="o_content" t-attf-class="{{props.className}}" t-att-class="{ o_component_with_search_panel: display.searchPanel }">
-            <t t-component="components.Banner" t-if="components.Banner and display.banner"/>
+            <t t-component="components.Banner" t-if="display.banner"/>
             <t t-component="components.SearchPanel" t-if="display.searchPanel"/>
             <t t-slot="default"/>
         </div>

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1377,7 +1377,7 @@ export class SearchModel extends EventBus {
      * is instanciated in a view (this doesn't apply for any other action type).
      * @private
      * @param {Object} [display={}]
-     * @returns {{ controlPanel: Object | false, searchPanel: boolean }}
+     * @returns {{ controlPanel: Object | false, searchPanel: boolean, banner: boolean }}
      */
     _getDisplay(display = {}) {
         const { viewTypes } = this.searchPanelInfo;

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -4,7 +4,7 @@ import { evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { useService } from "@web/core/utils/hooks";
-import { deepCopy, pluck } from "@web/core/utils/objects";
+import { deepCopy, pick } from "@web/core/utils/objects";
 import { extractLayoutComponents } from "@web/search/layout";
 import { WithSearch } from "@web/search/with_search/with_search";
 import { useActionLinks } from "@web/views/view_hook";
@@ -360,8 +360,8 @@ export class View extends Component {
     }
 
     onWillUpdateProps(nextProps) {
-        const oldProps = pluck(this.props, "arch", "type", "resModel");
-        const newProps = pluck(nextProps, "arch", "type", "resModel");
+        const oldProps = pick(this.props, "arch", "type", "resModel");
+        const newProps = pick(nextProps, "arch", "type", "resModel");
         if (JSON.stringify(oldProps) !== JSON.stringify(newProps)) {
             return this.loadView(nextProps);
         }

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -5,8 +5,11 @@ import { registry } from "@web/core/registry";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { useService } from "@web/core/utils/hooks";
 import { deepCopy, pick } from "@web/core/utils/objects";
+import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { extractLayoutComponents } from "@web/search/layout";
+import { SearchPanel } from "@web/search/search_panel/search_panel";
 import { WithSearch } from "@web/search/with_search/with_search";
+import { OnboardingBanner } from "@web/views/onboarding_banner";
 import { useActionLinks } from "@web/views/view_hook";
 
 const { Component, markRaw, onWillUpdateProps, onWillStart, toRaw, useSubEnv } = owl;
@@ -22,6 +25,9 @@ const viewRegistry = registry.category("views");
  *  @property {() => Object} getPagerProps
  *  @property {Object[]} viewSwitcherEntry
  *  @property {Object[]} viewSwitcherEntry
+ *  @property {Component} ControlPanel
+ *  @property {Component} SearchPanel
+ *  @property {Component} Banner
  */
 
 /**
@@ -50,6 +56,9 @@ export function getDefaultConfig() {
         },
         viewSwitcherEntries: [],
         views: [],
+        ControlPanel: ControlPanel,
+        SearchPanel: SearchPanel,
+        Banner: OnboardingBanner,
     };
     return config;
 }

--- a/addons/web/static/tests/core/utils/objects_tests.js
+++ b/addons/web/static/tests/core/utils/objects_tests.js
@@ -1,16 +1,16 @@
 /** @odoo-module **/
 
-import { pluck, shallowEqual } from "@web/core/utils/objects";
+import { pick, shallowEqual } from "@web/core/utils/objects";
 
 QUnit.module("utils", () => {
     QUnit.module("Objects");
 
-    QUnit.test("pluck", function (assert) {
-        assert.deepEqual(pluck({}), {});
-        assert.deepEqual(pluck({}, "a"), {});
-        assert.deepEqual(pluck({ a: 3, b: "a", c: [] }, "a"), { a: 3 });
-        assert.deepEqual(pluck({ a: 3, b: "a", c: [] }, "a", "c"), { a: 3, c: [] });
-        assert.deepEqual(pluck({ a: 3, b: "a", c: [] }, "a", "b", "c"), { a: 3, b: "a", c: [] });
+    QUnit.test("pick", function (assert) {
+        assert.deepEqual(pick({}), {});
+        assert.deepEqual(pick({}, "a"), {});
+        assert.deepEqual(pick({ a: 3, b: "a", c: [] }, "a"), { a: 3 });
+        assert.deepEqual(pick({ a: 3, b: "a", c: [] }, "a", "c"), { a: 3, c: [] });
+        assert.deepEqual(pick({ a: 3, b: "a", c: [] }, "a", "b", "c"), { a: 3, b: "a", c: [] });
     });
 
     QUnit.test("shallowEqual: simple valid cases", function (assert) {

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -10633,4 +10633,31 @@ QUnit.module("Views", (hooks) => {
         );
         assert.verifySteps(["notification"]);
     });
+
+    QUnit.test("renders banner_route", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban banner_route="/mybody/isacage">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div/>
+                        </t>
+                    </templates>
+                </kanban>
+            `,
+            groupBy: ["bar"],
+            async mockRPC(route) {
+                if (route === "/mybody/isacage") {
+                    assert.step(route);
+                    return { html: `<div class="setmybodyfree">myBanner</div>` };
+                }
+            },
+        });
+
+        assert.verifySteps(["/mybody/isacage"]);
+        assert.containsOnce(target, ".setmybodyfree");
+    });
 });

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -14130,4 +14130,25 @@ QUnit.module("Views", (hooks) => {
 
         assert.containsNone(target, ".o_selected_row");
     });
+
+    QUnit.test("renders banner_route", async (assert) => {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree banner_route="/mybody/isacage">
+                    <field name="foo"/>
+                </tree>`,
+            async mockRPC(route) {
+                if (route === "/mybody/isacage") {
+                    assert.step(route);
+                    return { html: `<div class="setmybodyfree">myBanner</div>` };
+                }
+            },
+        });
+
+        assert.verifySteps(["/mybody/isacage"]);
+        assert.containsOnce(target, ".setmybodyfree");
+    });
 });


### PR DESCRIPTION
[FIX] web: use OnboardingBanner as default banner
Before this commit, the List and Kanban views did not allow the use of
a Banner without adding it in the View definition.

Like this:
```
export const listView = {
    ...
    Banner: OnboardingBanner,
    ...
}
```

Now, we use by default OnboardingBanner as Banner if no other has been
defined in the View definition.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
