### PR TITLE
[IMP] project: adds access info under visibility settings

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -341,6 +341,7 @@ class Project(models.Model):
             "In any case, an internal user with no project access rights can still access a task, "
             "provided that they are given the corresponding URL (and that they are part of the followers if the project is private).")
     privacy_visibility_warning = fields.Char('Privacy Visibility Warning', compute='_compute_privacy_visibility_warning')
+    access_instruction_message = fields.Char('Access Instruction Message', compute='_compute_access_instruction_message')
     doc_count = fields.Integer(compute='_compute_attached_docs_count', string="Number of documents attached")
     date_start = fields.Date(string='Start Date')
     date = fields.Date(string='Expiration Date', index=True, tracking=True)
@@ -522,6 +523,16 @@ class Project(models.Model):
                 project.privacy_visibility_warning = _('Portal users will be removed from the followers of the project and its tasks.')
             else:
                 project.privacy_visibility_warning = ''
+
+    @api.depends('privacy_visibility')
+    def _compute_access_instruction_message(self):
+        for project in self:
+            if project.privacy_visibility == 'portal':
+                project.access_instruction_message = _('Grant portal users access to your project or tasks by adding them as followers.')
+            elif project.privacy_visibility == 'followers':
+                project.access_instruction_message = _('Grant employees access to your project or tasks by adding them as followers.')
+            else:
+                project.access_instruction_message = ''
 
     @api.model
     def _map_tasks_default_valeus(self, task, project):

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -544,6 +544,9 @@
                                     <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" context="{'default_partner_id': partner_id}" groups="analytic.group_analytic_accounting"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="privacy_visibility" widget="radio"/>
+                                    <span colspan="2" class="text-muted" attrs="{'invisible':[('access_instruction_message', '=', '')]}">
+                                        <i class="fa fa-lightbulb-o"/>&amp;nbsp;<field name="access_instruction_message" nolabel="1"/>  
+                                    </span>
                                     <span colspan="2" class="text-muted" attrs="{'invisible':[('privacy_visibility_warning', '=', '')]}">
                                         <i class="fa fa-warning">&amp;nbsp;</i>
                                         <field name="privacy_visibility_warning" nolabel="1"/>  


### PR DESCRIPTION
This commit introduces some information/instructions regarding the access
to the project/tasks depending on what the user has selected for the project visibility.
This should reduce confusion and thus increase productivity on the user side by
making the task of granting access rights more straightforward to the user.

Task: 2917471

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
