### PR TITLE
[FIX] l10n_es_edi_sii: fix URL of a tax agency's test server

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -404,9 +404,15 @@ class AccountEdiFormat(models.Model):
 
     def _l10n_es_edi_web_service_aeat_vals(self, invoices):
         if invoices[0].is_sale_document():
-            return {'url': 'https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactEmitidas.wsdl'}
+            return {
+                'url': 'https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactEmitidas.wsdl',
+                'test_url': 'https://prewww1.aeat.es/wlpl/SSII-FACT/ws/fe/SiiFactFEV1SOAP',
+            }
         else:
-            return {'url': 'https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactRecibidas.wsdl'}
+            return {
+                'url': 'https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactRecibidas.wsdl',
+                'test_url': 'https://prewww1.aeat.es/wlpl/SSII-FACT/ws/fr/SiiFactFRV1SOAP',
+            }
 
     def _l10n_es_edi_web_service_bizkaia_vals(self, invoices):
         if invoices[0].is_sale_document():


### PR DESCRIPTION
The URL to the Spanish tax agency Agencia Tributaria's test server was changed.
This causes an error when trying to access the file.

## Steps to reproduce

1. You need a company located in Spain. One will be automatically created for you at step 2.
2. Install the module called “Spain-SII EDI Suministro de Libros” (l10n_es_edi_sii). As mentioned previously, a Spanish company called 'Es company' is automatically created. 
3. Select the Spanish company. 
4. In your accounting settings you will now have a new menu called “Registro de libros connection SII” in which you can select the Spanish tax agency. Select "Agencia Tributaria española". Make sure to check “check this box if test env:”
5.  In the menu, go to “Accounting > Configuration > Certificates (ES) > Click on create”. You will need to upload a certificate for EDI invoices and the associated password.
6. Now create a customer invoice.
7. Validate it.
8. Click on the "Send Now" button that has appeared. 

## Result
```
HTTPSConnectionPool(host='www7.aeat.es', port=443): Max retries exceeded with url: /wlpl/SSII-FACT/ws/fe/SiiFactFEV1SOAP (Caused by NewConnectionError(': Failed to establish a new connection: [Errno -2] Name or service not known'))
```

## Expected Result
No error should appear. 

## Why this is happening
The address to the test server, found  in a WSDL file, does not exist anymore. Let's take a look at one of the problematic WSDL files:
https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactEmitidas.wsdl
If you open that file and go at the very bottom, you will see 3 URLs. The last one (https://www7.aeat.es/wlpl/SSII-FACT/ws/fe/SiiFactFEV1SOAP) is the URL to the test server. If you try to access that URL, you will be met with an error that says the address was not found. That's what is causing the issue.

## The initial fix (and why it does not work)
The obvious fix is to replace the faulty WSDL URLs by new ones (provided on Agencia Tributaria's website).  However, when you try this, you're met with another error. After some investigation, it has been revealed that the new WSDL files are referencing other files that are not where they're supposed to be. For example, take a look at the first `<xs:import>` tag in https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/WSDL/SuministroFactEmitidas.wsdl, one of the updated WSDL files.

You can see that it has an attribute called `schemaLocation`; this attribute indicates the location of the file to import. Notice how it's value, `SuministroInformacion.xsd`, is a relative path; that means that that file should be in the same location as the current WSDL file, i.e.
https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/WSDL/SuministroInformacion.xsd.

However, if you visit this link, you can see it does not exist. This is a problem that Agencia Tributaria has to fix.

## The workaround
Fortunately, the new WSDL contains a new working URL for the test server. So we've implemented a workaround, by using the old WSDL and defining the test URL "by hand" in our source code. 

opw-2888531