### PR TITLE
[IMP] mail, web: allow deployment of wowlServices into legacyEnv

### DIFF
--- a/addons/im_livechat/static/src/public/main.js
+++ b/addons/im_livechat/static/src/public/main.js
@@ -22,5 +22,9 @@ const messagingValuesService = {
 const serviceRegistry = registry.category('services');
 serviceRegistry.add('messaging', messagingService);
 serviceRegistry.add('messagingValues', messagingValuesService);
-serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));
 serviceRegistry.add('public_livechat_service', publicLivechatService);
+
+registry.category('wowlToLegacyServiceMappers').add(
+    'messaging_service_to_legacy_env',
+    makeMessagingToLegacyEnv
+);

--- a/addons/mail/static/src/main.js
+++ b/addons/mail/static/src/main.js
@@ -20,7 +20,11 @@ const serviceRegistry = registry.category('services');
 serviceRegistry.add('messaging', messagingService);
 serviceRegistry.add('messagingValues', messagingValuesService);
 serviceRegistry.add('systray_service', systrayService);
-serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));
+
+registry.category('wowlToLegacyServiceMappers').add(
+    'messaging_service_to_legacy_env',
+    makeMessagingToLegacyEnv
+);
 
 registry.category('actions').add('mail.action_discuss', DiscussContainer);
 

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -46,10 +46,14 @@ Component.env = legacyEnv;
     serviceRegistry.add('legacy_notification', makeLegacyNotificationService(Component.env));
     serviceRegistry.add('legacy_crash_manager', makeLegacyCrashManagerService(Component.env));
     serviceRegistry.add('legacy_dialog_mapping', makeLegacyDialogMappingService(Component.env));
-    serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(Component.env));
 
     serviceRegistry.add('messaging', messagingService);
     serviceRegistry.add('messagingValues', messagingValuesService);
+
+    registry.category('wowlToLegacyServiceMappers').add(
+        'messaging_service_to_legacy_env',
+        makeMessagingToLegacyEnv
+    );
 
     const mainComponentsRegistry = registry.category('main_components');
     mainComponentsRegistry.add('DiscussPublicViewContainer', { Component: DiscussPublicViewContainer });

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -377,6 +377,14 @@ export async function createPublicRoot(RootWidget) {
     serviceRegistry.add("legacy_notification", makeLegacyNotificationService(legacyEnv));
     serviceRegistry.add("legacy_dialog_mapping", makeLegacyDialogMappingService(legacyEnv));
     serviceRegistry.add("legacy_rainbowman_service", makeLegacyRainbowManService(legacyEnv));
+    // Wait for all synchronous code to ensure all mappers have been
+    // added to the registry.
+    await Promise.resolve();
+    // deploy wowl services into the legacy env.
+    const wowlToLegacyServiceMappers = registry.category('wowlToLegacyServiceMappers').getEntries();
+    for (const [legacyServiceName, wowlToLegacyServiceMapper] of wowlToLegacyServiceMappers) {
+        serviceRegistry.add(legacyServiceName, wowlToLegacyServiceMapper(legacyEnv));
+    }
     await Promise.all([whenReady(), session.is_bound]);
 
     // Patch browser.fetch and the rpc service to use the correct base url when

--- a/addons/web/static/src/legacy/legacy_setup.js
+++ b/addons/web/static/src/legacy/legacy_setup.js
@@ -46,6 +46,14 @@ export const legacySetupProm = new Promise((resolve) => {
     const legacyCommandService = makeLegacyCommandService(legacyEnv);
     serviceRegistry.add("legacy_command", legacyCommandService);
     serviceRegistry.add("legacy_dropdown", makeLegacyDropdownService(legacyEnv));
+    // Wait for all synchronous code to ensure all mappers have been
+    // added to the registry.
+    await Promise.resolve();
+    // deploy wowl services into the legacy env.
+    const wowlToLegacyServiceMappers = registry.category('wowlToLegacyServiceMappers').getEntries();
+    for (const [legacyServiceName, wowlToLegacyServiceMapper] of wowlToLegacyServiceMappers) {
+        serviceRegistry.add(legacyServiceName, wowlToLegacyServiceMapper(legacyEnv));
+    }
     await Promise.all([whenReady(), session.is_bound]);
     legacyEnv.templates = session.owlTemplates;
     legacySetupResolver(legacyEnv);

--- a/addons/web/static/tests/helpers/mock_env.js
+++ b/addons/web/static/tests/helpers/mock_env.js
@@ -55,6 +55,7 @@ function prepareRegistriesWithCleanup() {
 
     cloneRegistryWithCleanup(registry.category("main_components"));
     cloneRegistryWithCleanup(registry.category("fields"));
+    cloneRegistryWithCleanup(registry.category("wowlToLegacyServiceMappers"));
 
     // Clear registries
     clearRegistryWithCleanup(registry.category("command_categories"));
@@ -71,6 +72,7 @@ function prepareRegistriesWithCleanup() {
     clearRegistryWithCleanup(registry.category("kanban_examples"));
     clearRegistryWithCleanup(registry.category("__processed_archs__"));
     clearRegistryWithCleanup(registry.category("action_menus"));
+    clearRegistryWithCleanup(registry.category("wowlToLegacyServiceMappers"));
     // fun fact: at least one registry is missing... this shows that we need a
     // better design for the way we clear these registries...
 }

--- a/addons/web/static/tests/webclient/helpers.js
+++ b/addons/web/static/tests/webclient/helpers.js
@@ -194,10 +194,10 @@ export async function addLegacyMockEnvironment(env, legacyParams = {}) {
     const legacyActionManagerService = makeLegacyActionManagerService(legacyEnv);
     serviceRegistry.add("legacy_action_manager", legacyActionManagerService);
     serviceRegistry.add("legacy_notification", makeLegacyNotificationService(legacyEnv));
-    // deploy the legacyServices given in parameter in WowlEnv
-    const { legacyServicesToDeployInWowlEnv } = legacyParams;
-    for (const legacyServiceName in legacyServicesToDeployInWowlEnv) {
-        serviceRegistry.add(legacyServiceName, legacyServicesToDeployInWowlEnv[legacyServiceName]);
+    // deploy wowl services into legacy env.
+    const wowlToLegacyServiceMappers = registry.category('wowlToLegacyServiceMappers').getEntries();
+    for (const [legacyServiceName, wowlToLegacyServiceMapper] of wowlToLegacyServiceMappers) {
+        serviceRegistry.add(legacyServiceName, wowlToLegacyServiceMapper(legacyEnv));
     }
     // patch DebouncedField delay
     const debouncedField = basicFields.DebouncedField;


### PR DESCRIPTION
In order to ease the PR adapting the bus service to be a wowl
service, a way to add wowl services to the legacy env have been
added. In order to do so, use the wowlToLegacyServiceMappers
registry.
