### PR TITLE
[REM] web_editor: remove dead code about overlay handles

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -584,7 +584,6 @@ var SnippetEditor = Widget.extend({
             // In preview mode, the sticky classes are left untouched, we only
             // add/remove the preview class when toggling/untoggling
             this.$el.toggleClass('o_we_overlay_preview', show);
-            this.$el.find('.o_handle').removeClass('d-none');
         } else {
             // In non preview mode, the preview class is always removed, and the
             // sticky class is added/removed when toggling/untoggling


### PR DESCRIPTION
Commit [1] introduced some lines of code which added/removed the d-none
class on the overlay handles in some context. Commit [2] later reviewed
that code and removed the addition of the d-none class... but kept the
removal part by mistake.

It of course did not hurt at the time but now impacts new task being
developed in master.

[1]: https://github.com/odoo/odoo/commit/9bbe5be3fb0d995374a369851df3641979d8e553
[2]: https://github.com/odoo/odoo/commit/50cb0f3276819e22a6014bdb7895c7cbc0315ca8

Related to task-2825241
