### PR TITLE
Batch of "Website in backend" fixes (media upload / URL hash / custom resources pages)

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.xml
@@ -49,7 +49,8 @@
                         altDescription="media.tooltip"
                         minRowHeight="MIN_ROW_HEIGHT"
                         selected="this.selectedMediaIds.includes(media.id)"
-                        onImageClick="() => this.onClickMedia(media)"/>
+                        onImageClick="() => this.onClickMedia(media)"
+                        onLoaded="(imgEl) => this.onLibraryImageLoaded(imgEl, media)"/>
                 </t>
             </t>
             <!-- 20 placeholders is just enough for a 5K screen, change this if ImageWidget.MIN_ROW_HEIGHT changes -->

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.scss
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.scss
@@ -38,8 +38,12 @@ $min-row-height: 128;
                     opacity: 1;
                 }
 
-                img {
-                    width: 100%;
+                .o_we_media_dialog_img_wrapper {
+                    @extend %o-preview-alpha-background;
+
+                    img {
+                        width: 100%;
+                    }
                 }
             }
 

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.js
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.js
@@ -11,20 +11,20 @@ ProgressBar.template = 'web_editor.ProgressBar';
 
 export class UploadProgressToast extends Component {
     setup() {
-        this.state = useState({ hide: false });
+        this.state = useState({
+            isVisible: false,
+            numberOfFiles: 0,
+        });
 
         useEffect((numberOfFiles) => {
-            if (numberOfFiles) {
-                this.state.hide = false;
+            if (numberOfFiles === 0) {
+                this.state.isVisible = false;
             }
+            if (numberOfFiles > this.state.numberOfFiles) {
+                this.state.isVisible = true;
+            }
+            this.state.numberOfFiles = numberOfFiles;
         }, () => [Object.keys(this.props.files).length]);
-    }
-
-    get show() {
-        if (!this.props.files || !Object.keys(this.props.files).length) {
-            return false;
-        }
-        return !this.state.hide;
     }
 }
 UploadProgressToast.defaultProps = {

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_progress_toast.xml
@@ -18,10 +18,8 @@
 
 <t t-name="web_editor.UploadProgressToast" owl="1">
     <div class="o_notification_manager o_upload_progress_toast">
-        <div t-if="show" class="o_notification position-relative show fade mb-2 border border-info bg-white" role="alert" aria-live="assertive" aria-atomic="true">
-            <button type="button" class="close o_notification_close" aria-label="Close" t-on-click="() => this.state.hide = true">
-                <i class="oi oi-close"/>
-            </button>
+        <div t-if="state.isVisible" class="o_notification position-relative show fade mb-2 border border-info bg-white" role="alert" aria-live="assertive" aria-atomic="true">
+            <button type="button" class="btn btn-close o_notification_close p-2" aria-label="Close" t-on-click="() => state.isVisible = false"/>
             <div class="o_notification_body ps-2 pe-4 py-2">
                 <div class="me-auto o_notification_content">
                     <div t-foreach="props.files" t-as="file" t-key="file" class="o_we_progressbar">

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -187,16 +187,22 @@ export class WebsitePreview extends Component {
         return host !== window.location.host || (pathname && (backendRoutes.includes(pathname) || pathname.startsWith('/@/')));
     }
 
-    _onPageLoaded() {
-        this.iframe.el.contentWindow.addEventListener('beforeunload', this._onPageUnload.bind(this));
-
-        // This replaces the browser url (/web#action=website...) with
-        // the iframe's url (it is clearer for the user).
+    /**
+     * This replaces the browser url (/web#action=website...) with
+     * the iframe's url (it is clearer for the user).
+     */
+    _replaceBrowserUrl() {
         const currentUrl = new URL(this.iframe.el.contentDocument.location.href);
         currentUrl.pathname = `/@${currentUrl.pathname}`;
         this.currentTitle = this.iframe.el.contentDocument.title;
         history.replaceState({}, this.currentTitle, currentUrl.href);
         this.title.setParts({ action: this.currentTitle });
+    }
+
+    _onPageLoaded() {
+        this.iframe.el.contentWindow.addEventListener('beforeunload', this._onPageUnload.bind(this));
+        this._replaceBrowserUrl();
+        this.iframe.el.contentWindow.addEventListener('hashchange', this._replaceBrowserUrl.bind(this));
 
         this.websiteService.pageDocument = this.iframe.el.contentDocument;
 

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -192,11 +192,11 @@ export const websiteService = {
                 }
                 return Wysiwyg;
             },
-            blockIframe(showLoader = true, loaderDelay = 0) {
-                bus.trigger('BLOCK', {showLoader, loaderDelay});
+            blockIframe(showLoader = true, loaderDelay = 0, processId) {
+                bus.trigger('BLOCK', {showLoader, loaderDelay, processId});
             },
-            unblockIframe() {
-                bus.trigger('UNBLOCK');
+            unblockIframe(processId) {
+                bus.trigger('UNBLOCK', { processId });
             },
             leaveEditMode() {
                 // FIXME this does not care about if the page is dirty or not.

--- a/addons/website/static/src/systray_items/new_content.js
+++ b/addons/website/static/src/systray_items/new_content.js
@@ -152,10 +152,7 @@ export class NewContentModal extends Component {
         });
     }
 
-    async installModule(id, redirectUrl, moduleName) {
-        this.website.showLoader({
-            title: sprintf(this.env._t("Building your %s"), moduleName),
-        });
+    async installModule(id, redirectUrl) {
         await this.orm.silent.call(
             'ir.module.module',
             'button_immediate_install',
@@ -190,9 +187,13 @@ export class NewContentModal extends Component {
                     }
                     return el;
                 });
+                this.website.showLoader({
+                    title: sprintf(this.env._t("Building your %s"), name),
+                });
                 try {
-                    await this.installModule(id, element.redirectUrl, name);
+                    await this.installModule(id, element.redirectUrl);
                 } catch (error) {
+                    this.website.hideLoader();
                     // Update the NewContentElement with failure icon and text.
                     this.state.newContentElements = this.state.newContentElements.map(el => {
                         if (el.moduleXmlId === element.moduleXmlId) {

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -326,7 +326,7 @@ publicWidget.registry.WebsiteSale = publicWidget.Widget.extend(VariantMixin, car
         var attributeIds = _.map($attributes, function (elem) {
             return $(elem).data('value_id');
         });
-        history.replaceState(undefined, undefined, '#attr=' + attributeIds.join(','));
+        window.location.hash = 'attr=' + attributeIds.join(',');
     },
     /**
      * Set the checked values active.
@@ -784,7 +784,7 @@ publicWidget.registry.WebsiteSale = publicWidget.Widget.extend(VariantMixin, car
                 }
             }
             if (dataValueIds.length) {
-                history.replaceState(undefined, undefined, `#attr=${dataValueIds.join(',')}`);
+                window.location.hash = `attr=${dataValueIds.join(',')}`;
             }
         }
         this._applyHash();
@@ -957,7 +957,7 @@ publicWidget.registry.websiteSaleCarouselProduct = publicWidget.Widget.extend({
     /**
      * Center the selected indicator to scroll the indicators list when it
      * overflows.
-     * 
+     *
      * @private
      * @param {Event} ev
      */


### PR DESCRIPTION
[FIX] website: remove loader when installing "new content" module fails

Before this commit, if installing a new module from the "new content"
modal would fail, the "Building your website" gif was not removed.
This commit removes it when the installation fails.

task-2687506

-----

[FIX] web_editor: fix multi upload from the media dialog

Before this commit, uploading multiple files could lead to inconsistent
results: the files array was sorted from the lower to the higher size,
but this sorted array was not used after (the unsorted one was).

This commit fixes this issue by clearly defining a sorted array, and
uploading the files sequentially, as it was done before [1].

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] web_editor: fix media dialog's svg upload

Before this commit, the media dialog was not handling properly the
upload of svg files from the media library: a whole part of the original
ImageWidget was missing in the converted media dialog from [1], which
was converting the svg with the appropriate color codes from the color
palette, to allow for color customization.
See original file from 15.4: web_editor/static/src/js/widgets/media.js.

Also, it was not displaying those svg correctly with the appropriate
background.

This commit fixes those issues by adding back the code handling the
dynamic colors detection and the background css rule.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: unblock iframe on not editable content

Before this commit, following those steps:
- Go to /hello.css
- Create the page/file
- View in page manager
- Click on its row
-> You're redirected to the file, with infinite loading

This commit fixes this behaviour by unblocking the iframe:
- on the OdooFrameContentLoaded event for frontend pages
- on the load event for other pages

To do that, the BlockIframe component is changed to handle process ids.
Before this commit, the BlockIframe component would count the calls to
block or unblock the iframe (and store it in an iframeLocks variable),
so that multiple processes can block the iframe independently from each
other.
As an exemple, for two processes A and B, the iframe should remain
blocked during those two processes, and released at the end:
(A) blockIframe => (B) blockIframe => (B) unblockIframe => (A)
unblockIframe.

But that iframeLocks variable was fragile: a process that blocks the
iframe should unblock it once, otherwise it would mess up the locks
count. It was not appropriate for a process that could be ended with two
events, for example loading the iframe. The first of the 'load' or
'OdooFrameContentLoaded' events should unblock it.

To change that, a process can block the iframe with a processId. The
first unblock call with the same processId will unblock the iframe, the
other ones will be ignored.

task-2687506

-----

[FIX] web_editor: fix upload progress toast visibility

Before this commit, when uploading multiple files and clicking on the
cross button, the toast was reappearing every time a new file was
succesfully uploaded.

This commit changes its state so that it is only visible when one or
multiple files are added to the uploading queue. The user can still hide
it with the cross.

task-2687506

-----

[FIX] website, website_sale: update client action url on variant change

Before this commit, clicking on a different variant of a product from
the WebsitePreview client action introduced in [1] would not update the
browser's url.

This commit adds an event listener to update the browser url on hash
changes, as load events are currently handled.

The product variant buttons are directly changing the hash instead of
replacing the state of the history.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
