### PR TITLE
[FIX] base: convert barcode type if incorrect encoding

### DIFF
--- a/addons/barcodes/models/barcode_nomenclature.py
+++ b/addons/barcodes/models/barcode_nomenclature.py
@@ -23,50 +23,13 @@ class BarcodeNomenclature(models.Model):
 
     @api.model
     def get_barcode_check_digit(self, numeric_barcode):
-        """ Computes and returns the barcode check digit. The used algorithm
-        follows the GTIN specifications and can be used by all compatible
-        barcode nomenclature, like as EAN-8, EAN-12 (UPC-A) or EAN-13.
-
-        https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
-        https://www.gs1.org/services/how-calculate-check-digit-manually
-
-        :param numeric_barcode: the barcode to verify/recompute the check digit
-        :type numeric_barcode: str
-        :return: the number corresponding to the right check digit
-        :rtype: int
-        """
-        # Multiply value of each position by
-        # N1  N2  N3  N4  N5  N6  N7  N8  N9  N10 N11 N12 N13 N14 N15 N16 N17 N18
-        # x3  X1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  CHECKSUM
-        oddsum = evensum = total = 0
-        code = numeric_barcode[-2::-1]  # Remove the check digit and reverse the barcode.
-        # The CHECKSUM digit is removed because it will be recomputed and it must not interfer with
-        # the computation. Also, the barcode is inverted, so the barcode length doesn't matter.
-        # Otherwise, the digits' group (even or odd) could be different according to the barcode length.
-        for i, digit in enumerate(code):
-            if i % 2 == 0:
-                evensum += int(digit)
-            else:
-                oddsum += int(digit)
-        total = evensum * 3 + oddsum
-        return (10 - total % 10) % 10
+        # todo master: remove this method
+        return self.env['ir.actions.report'].get_barcode_check_digit(numeric_barcode)
 
     @api.model
     def check_encoding(self, barcode, encoding):
-        """ Checks if the given barcode is correctly encoded.
-
-        :return: True if the barcode string is encoded with the provided encoding.
-        :rtype: bool
-        """
-        if encoding == "any":
-            return True
-        barcode_sizes = {
-            'ean8': 8,
-            'ean13': 13,
-            'upca': 12,
-        }
-        barcode_size = barcode_sizes[encoding]
-        return len(barcode) == barcode_size and re.match(r"^\d+$", barcode) and self.get_barcode_check_digit(barcode) == int(barcode[-1])
+        # todo master: remove this method
+        return self.env['ir.actions.report'].check_barcode_encoding(barcode, encoding)
 
     @api.model
     def sanitize_ean(self, ean):

--- a/addons/barcodes/tests/test_barcode_nomenclature.py
+++ b/addons/barcodes/tests/test_barcode_nomenclature.py
@@ -12,13 +12,6 @@ class TestBarcodeNomenclature(common.TransactionCase):
             'name': 'Barcode Nomenclature Test',
         })
 
-    def test_barcode_check_digit(self):
-        barcode_nomenclature = self.env['barcode.nomenclature']
-        ean8 = "87111125"
-        self.assertEqual(barcode_nomenclature.get_barcode_check_digit("0" * 10 + ean8), int(ean8[-1]))
-        ean13 = "1234567891231"
-        self.assertEqual(barcode_nomenclature.get_barcode_check_digit("0" * 5 + ean13), int(ean13[-1]))
-
     def test_barcode_nomenclature_parse_barcode_ean8_01(self):
         """ Parses some barcodes with a simple EAN-8 barcode rule and checks the result.
         """

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -522,6 +522,56 @@ class IrActionsReport(models.Model):
         return report_obj.with_context(context).sudo().search(conditions, limit=1)
 
     @api.model
+    def get_barcode_check_digit(self, numeric_barcode):
+        """ Computes and returns the barcode check digit. The used algorithm
+        follows the GTIN specifications and can be used by all compatible
+        barcode nomenclature, like as EAN-8, EAN-12 (UPC-A) or EAN-13.
+
+        https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
+        https://www.gs1.org/services/how-calculate-check-digit-manually
+
+        :param numeric_barcode: the barcode to verify/recompute the check digit
+        :type numeric_barcode: str
+        :return: the number corresponding to the right check digit
+        :rtype: int
+        """
+        # Multiply value of each position by
+        # N1  N2  N3  N4  N5  N6  N7  N8  N9  N10 N11 N12 N13 N14 N15 N16 N17 N18
+        # x3  X1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  x1  x3  CHECKSUM
+        oddsum = evensum = 0
+        code = numeric_barcode[-2::-1]  # Remove the check digit and reverse the barcode.
+        # The CHECKSUM digit is removed because it will be recomputed and it must not interfer with
+        # the computation. Also, the barcode is inverted, so the barcode length doesn't matter.
+        # Otherwise, the digits' group (even or odd) could be different according to the barcode length.
+        for i, digit in enumerate(code):
+            if i % 2 == 0:
+                evensum += int(digit)
+            else:
+                oddsum += int(digit)
+        total = evensum * 3 + oddsum
+        return (10 - total % 10) % 10
+
+    @api.model
+    def check_barcode_encoding(self, barcode, encoding):
+        """ Checks if the given barcode is correctly encoded.
+
+        :return: True if the barcode string is encoded with the provided encoding.
+        :rtype: bool
+        """
+        if encoding == "any":
+            return True
+        barcode_sizes = {
+            'ean8': 8,
+            'ean13': 13,
+            'upca': 12,
+        }
+        barcode_size = barcode_sizes[encoding]
+        return (encoding != 'ean13' or barcode[0] != '0') \
+               and len(barcode) == barcode_size \
+               and re.match(r"^\d+$", barcode) \
+               and self.get_barcode_check_digit(barcode) == int(barcode[-1])
+
+    @api.model
     def barcode(self, barcode_type, value, **kwargs):
         defaults = {
             'width': (600, int),
@@ -553,6 +603,14 @@ class IrActionsReport(models.Model):
             # But we can use `barBorder` to get a similar behaviour.
             if kwargs['quiet']:
                 kwargs['barBorder'] = 0
+
+        if barcode_type in ('EAN8', 'EAN13') and not self.check_barcode_encoding(value, barcode_type.lower()):
+            # If the barcode does not respect the encoding specifications, convert its type into Code128.
+            # Otherwise, the report-lab method may return a barcode different from its value. For instance,
+            # if the barcode type is EAN-8 and the value 11111111, the report-lab method will take the first
+            # seven digits and will compute the check digit, which gives: 11111115 -> the barcode does not
+            # match the expected value.
+            barcode_type = 'Code128'
 
         try:
             barcode = createBarcodeDrawing(barcode_type, value=value, format='png', **kwargs)

--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -31,3 +31,23 @@ class TestReports(odoo.tests.TransactionCase):
                 report._render_qweb_html(report_records.ids)
             else:
                 continue
+
+    def test_barcode_check_digit(self):
+        ean8 = "87111125"
+        self.assertEqual(self.env['ir.actions.report'].get_barcode_check_digit("0" * 10 + ean8), int(ean8[-1]))
+        ean13 = "1234567891231"
+        self.assertEqual(self.env['ir.actions.report'].get_barcode_check_digit("0" * 5 + ean13), int(ean13[-1]))
+
+    def test_barcode_encoding(self):
+        self.assertTrue(self.env['ir.actions.report'].check_barcode_encoding('20220006', 'ean8'))
+        self.assertTrue(self.env['ir.actions.report'].check_barcode_encoding('93855341', 'ean8'))
+        self.assertTrue(self.env['ir.actions.report'].check_barcode_encoding('2022071416014', 'ean13'))
+        self.assertTrue(self.env['ir.actions.report'].check_barcode_encoding('9745213796142', 'ean13'))
+
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('2022a006', 'ean8'), 'should contains digits only')
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('20220000', 'ean8'), 'incorrect check digit')
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('93855341', 'ean13'), 'ean13 is a 13-digits barcode')
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('9745213796142', 'ean8'), 'ean8 is a 8-digits barcode')
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('9745213796148', 'ean13'), 'incorrect check digit')
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('2022!71416014', 'ean13'), 'should contains digits only')
+        self.assertFalse(self.env['ir.actions.report'].check_barcode_encoding('0022071416014', 'ean13'), 'when starting with one zero, it indicates that a 12-digit UPC-A code follows')


### PR DESCRIPTION
To reproduce the issue:
(Need stock_barcode)
1. Create a product:
    - Barcode: 1234567890123
2. Print the label
3. Try to scan the barcode and check the value read.

Error: The value is 1234567890128, the last digit is incorrect (8
instead of 3)

When printing a barcode, we use the library 'report-lab' to generate a
barcode image from a value and a barcode type. In case of EAN-13, if the
value contains a non-digit character, it will raise an error. We then
catch the error and retry to generate the barcode according to the
barcode type Code128:
https://github.com/odoo/odoo/blob/87698d90f02bfe93c6e643f4876a5ccd74788eff/odoo/addons/base/models/ir_actions_report.py#L569-L575
However, if the value contains only digits, the method will use the 12
first digits:
https://github.com/mattjmorrison/ReportLab/blob/dade0f303cb6fcdbe535c4cc92e6102c2417b699/src/reportlab/graphics/barcode/eanbc.py#L187-L188
and will then add the last one, the check digit, which is computed by
the library. This explains why, in the above use case, the barcode value
returned by the scanner is not the same than the expected one.

Note: Similar behavior with type EAN-8

OPW-2902150