### PR TITLE
[FIX] web_editor: stop crash after switch cropped image to another media

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -794,7 +794,7 @@ var ImageWidget = FileWidget.extend({
      */
     _clear: function (type) {
         // Not calling _super: we don't want to call the document widget's _clear method on images
-        var allImgClasses = /(^|\s+)(img|img-\S*|o_we_custom_image|rounded-circle|rounded|thumbnail|shadow)(?=\s|$)/g;
+        var allImgClasses = /(^|\s+)(img|img-\S*|o_we_custom_image|o_cropped_img_to_save|rounded-circle|rounded|thumbnail|shadow)(?=\s|$)/g;
         this.media.className = this.media.className && this.media.className.replace(allImgClasses, ' ');
     },
 });


### PR DESCRIPTION
This is a backport of [1].

Since [2], crop dialog is adding an extra class to mark the image for
later creation. But when we change marked image with any other media
like icon, document, or video from media dialog. The extra class is
still there so in this case editor will try to create an attachment for
changed media on save.

After this commit media dialog will always remove that extra class.

[1]: https://github.com/odoo/odoo/commit/378196559ccb8264bd63e87739f000848546c0db
[2]: https://github.com/odoo/odoo/commit/a473453b3166a381130d9bd6ec4851b9e1ecab26

Follow-up of https://github.com/odoo/odoo/pull/92668