### PR TITLE
[IMP] hr_timesheet,mail,portal**: view improvements for project

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -50,6 +50,7 @@
                                     <div t-attf-class="oe_kanban_card oe_kanban_global_click">
                                         <div class="row">
                                             <div class="col-6">
+                                                <field name="employee_id"/>
                                                 <strong><span><t t-esc="record.employee_id.value"/></span></strong>
                                             </div>
                                             <div class="col-6 float-end text-end">

--- a/addons/portal/data/mail_templates.xml
+++ b/addons/portal/data/mail_templates.xml
@@ -3,8 +3,9 @@
 
     <template id="portal_share_template">
         <div>
+            <br/>
             <p>Dear <span t-esc="partner.name"/>,</p>
-            <p>You have been invited to access the following document:</p>
+            <p><span t-out="user.name"/> has invited you to access the following <span t-out="model_description"/>:</p>
             <br/>
             <a t-attf-href="#{share_link}" style="background-color: #875A7B; padding: 10px; text-decoration: none; color: #fff; border-radius: 5px; font-size: 12px;"><strong>Open </strong><strong t-esc="record.display_name"/></a><br/>
             <br/>

--- a/addons/portal/wizard/portal_share.py
+++ b/addons/portal/wizard/portal_share.py
@@ -67,8 +67,9 @@ class PortalShare(models.TransientModel):
             self.resource_ref.message_post_with_source(
                 'portal.portal_share_template',
                 render_values={'partner': partner, 'note': self.note, 'record': self.resource_ref,
-                        'share_link': share_link},
-                subject=_("You are invited to access %s", self.resource_ref.display_name),
+                        'share_link': share_link,
+                        'model_description': self.env['ir.model']._get(self.resource_ref._name).display_name.lower()},
+                subject=_("Invitation to access %s", self.resource_ref.display_name),
                 subtype_xmlid='mail.mt_note',
                 email_layout_xmlid='mail.mail_notification_light',
                 partner_ids=partner.ids)
@@ -86,8 +87,9 @@ class PortalShare(models.TransientModel):
             self.resource_ref.message_post_with_source(
                 'portal.portal_share_template',
                 render_values={'partner': partner, 'note': self.note, 'record': self.resource_ref,
-                        'share_link': share_link},
-                subject=_("You are invited to access %s", self.resource_ref.display_name),
+                        'share_link': share_link,
+                        'model_description': self.env['ir.model']._get(self.resource_ref._name).display_name.lower()},
+                subject=_("Invitation to access %s", self.resource_ref.display_name),
                 subtype_xmlid='mail.mt_note',
                 email_layout_xmlid='mail.mail_notification_light',
                 partner_ids=partner.ids)

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -28,7 +28,7 @@ class ReportProjectTaskUser(models.Model):
     nbr = fields.Integer('# of Tasks', readonly=True)  # TDE FIXME master: rename into nbr_tasks
     working_hours_open = fields.Float(string='Working Hours to Assign', digits=(16, 2), readonly=True, group_operator="avg")
     working_hours_close = fields.Float(string='Working Hours to Close', digits=(16, 2), readonly=True, group_operator="avg")
-    rating_last_value = fields.Float('Rating Value (/5)', group_operator="avg", readonly=True, groups="project.group_project_rating")
+    rating_last_value = fields.Float('Rating (/5)', group_operator="avg", readonly=True, groups="project.group_project_rating")
     rating_avg = fields.Float('Average Rating', readonly=True, group_operator='avg', groups="project.group_project_rating")
     priority = fields.Selection([
         ('0', 'Low'),

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -10,6 +10,7 @@
                     <field name="working_hours_open" widget="timesheet_uom"/>
                     <field name="working_hours_close" widget="timesheet_uom"/>
                     <field name="nbr" invisible="1"/>
+                    <field name="rating_avg" invisible="1"/>
                 </pivot>
             </field>
         </record>
@@ -22,6 +23,7 @@
                      <field name="project_id"/>
                      <field name="stage_id"/>
                      <field name="nbr" invisible="1"/>
+                     <field name="rating_avg" invisible="1"/>
                  </graph>
              </field>
         </record>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -26,7 +26,7 @@
                             <group>
                                 <field name="name"/>
                                 <field name="mail_template_id" context="{'default_model': 'project.task'}"/>
-                                <field name="rating_template_id" groups="project.group_project_rating" context="{'default_model': 'project.task'}"/>
+                                <field name="rating_template_id" placeholder="Task: Rating Request" groups="project.group_project_rating" context="{'default_model': 'project.task'}"/>
                                 <div class="alert alert-warning" role="alert" colspan='2' attrs="{'invisible': ['|', ('rating_template_id','=', False), ('disabled_rating_warning', '=', False)]}" groups="project.group_project_rating">
                                     <i class="fa fa-warning" title="Customer disabled on projects"/><b> Customer Ratings</b> are disabled on the following project(s) : <br/>
                                     <field name="disabled_rating_warning" class="mb-0" />

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -6,6 +6,14 @@
         <field name="model">project.share.wizard</field>
         <field name="arch" type="xml">
             <form string="Share Project">
+                <p class="text-muted" attrs="{'invisible': [('access_mode', '!=', 'edit')]}">
+                    When sharing a project in edit mode, you are giving people access to the kanban and list views of your tasks.
+                    Collaborators will be able to view and modify part of the tasks' information.
+                </p>
+                <p class="text-muted" attrs="{'invisible': [('access_mode', '=', 'edit')]}">
+                    When sharing a project in read-only mode, you are giving people access to the tasks in their portal.
+                    These people will be able to view the tasks, but not edit them.
+                </p>
                 <field name="res_model" invisible="1"/>
                 <field name="res_id" invisible="1"/>
                 <field name="display_access_mode" invisible="1" />

--- a/addons/project_sms/views/project_task_type_views.xml
+++ b/addons/project_sms/views/project_task_type_views.xml
@@ -16,7 +16,7 @@
         <field name="model">project.task.type</field>
         <field name="inherit_id" ref="project.task_type_tree_inherited"/>
         <field name="arch" type="xml">
-            <field name="mail_template_id" position="after">
+            <field name="mail_template_id" position="before">
                 <field name="sms_template_id" optional="hide"/>
             </field>
         </field>

--- a/addons/rating/views/rating_templates.xml
+++ b/addons/rating/views/rating_templates.xml
@@ -20,6 +20,7 @@
         <template id="rating_external_page_submit" name="Rate our Services">
             <t t-call="web.frontend_layout">
                 <div class="container mb-5 mt-4 o_rating_page_submit">
+                    <div class="oe_structure" id="oe_structure_rate_submit_header"/>
                     <div class="row text-center justify-content-center">
                         <h1 class="col-12 mt-5">Thank you for rating our services!</h1>
                         <form class="col-md-6" t-attf-action="/rate/#{token}/submit_feedback" method="post">
@@ -51,6 +52,7 @@
                             <button type="submit" class="btn btn-primary mt-4"
                                     style="margin-top:8px;">Send Feedback</button>
                         </form>
+                        <div class="oe_structure" id="oe_structure_rate_submit_footer"/>
                     </div>
                 </div>
             </t>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -40,6 +40,11 @@
                             <field name="cost_currency_id" invisible="1"/>
                         </tree>
                     </field>
+                    <p class="text-muted">
+                        <i class="fa fa-lightbulb-o"/>
+                        Define the rate at which an employee's time is billed based on their expertise, skills, or experience.
+                        To bill the same service at a different rate, create separate sales order items.
+                    </p>
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
*= project, project_sms, rating, sale_project, sale_timesheet

The purpose of this PR is to improve the generic usage of the project app.

So, in this PR done following changes:
- In reporting > tasks analysis measures:
   - removed the # of tasks and average rating measures
   - Changed rating value (/5) to rating (/5)
- In task analysis reporting formatted overtime as hh: mm
- In the project  burndown chart added tip to action helper
- In project.task search view > quick searches:
   - changed sale order to sales order
   - under the SO one, a 'sales order item' has been added to the quick search
- Added many2one_avatar_employee widget in project sharing-> timesheets notebook
- In project.project form view > share editable added text in muted
- Added tip in the project.project form view > invoicing notebook under
   employee/SOL o2m
- A placeholder has been added to the rating email template field in the project
  task stages: 'Task: Rating Request'
- now rating submission page is editable
- In project > share > invitation email template made some changes as follows:
   - You have been invited -> Mitchell Admin has invited
   - following document -> following project
- In task stages list view :
   - moved the project field on the right of the name
    - switched the 'SMS template' and 'email template' fields from the place
- In project.task > recurrence notebook:
   - moved the 'next tasks' list to the right of the recurrence
      configuration fields
- In project.task > sub-tasks notebook > optional fields >
   renamed 'initially planned hours' into 'allocated hours'
- In project.task portal form view: renamed
   'history' into 'Message and communication history'
- Added 'open' filter in my tasks menu search view
- Added 'schedule an activity' status in the kanban activity widget

task-2903637