### PR TITLE
[IMP] bump num2words version to support Thai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Jinja2==2.11.3 # min version = 2.10.1 (Focal - with security backports)
 libsass==0.18.0
 lxml==4.6.5 # min version = 4.5.0 (Focal - with security backports)
 MarkupSafe==1.1.0
-num2words==0.5.6
+num2words==0.5.7
 ofxparse==0.19; python_version <= '3.9'
 ofxparse==0.21; python_version > '3.9'  # (Jammy)
 passlib==1.7.3 # min version = 1.7.2 (Focal with security backports)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: num2words version 0.5.6 do not support Thai

Current behavior before PR:
num2words Thai language not implement

Desired behavior after PR is merged:
num2words Thai language implemented




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
