### PR TITLE
[FIX] sale_project: fix the tooltip for service_tracking type

### DIFF
--- a/addons/sale_project/models/product.py
+++ b/addons/sale_project/models/product.py
@@ -65,13 +65,13 @@ class ProductTemplate(models.Model):
                 elif record.service_tracking == 'task_in_project':
                     record.product_tooltip = _(
                         "Invoice ordered quantities as soon as this service is sold. "
-                        "Create an empty project for the order to track the time spent."
+                        "Create a project for the order with a task for each sales order line "
+                        "to track the time spent."
                     )
                 elif record.service_tracking == 'project_only':
                     record.product_tooltip = _(
                         "Invoice ordered quantities as soon as this service is sold. "
-                        "Create a project for the order with a task for each sales order line "
-                        "to track the time spent."
+                        "Create an empty project for the order to track the time spent."
                     )
             elif record.service_policy == 'delivered_milestones':
                 if record.service_tracking == 'no':
@@ -86,13 +86,13 @@ class ProductTemplate(models.Model):
                 elif record.service_tracking == 'task_in_project':
                     record.product_tooltip = _(
                         "Invoice your milestones when they are reached. "
-                        "Create an empty project for the order to track the time spent."
+                        "Create a project for the order with a task for each sales order line "
+                        "to track the time spent."
                     )
                 elif record.service_tracking == 'project_only':
                     record.product_tooltip = _(
                         "Invoice your milestones when they are reached. "
-                        "Create a project for the order with a task for each sales order line "
-                        "to track the time spent."
+                        "Create an empty project for the order to track the time spent."
                     )
             elif record.service_policy == 'delivered_manual':
                 if record.service_tracking == 'no':
@@ -107,12 +107,13 @@ class ProductTemplate(models.Model):
                 elif record.service_tracking == 'task_in_project':
                     record.product_tooltip = _(
                         "Invoice this service when it is delivered (set the quantity by hand on your sales order lines). "
-                        "Create an empty project for the order to track the time spent."
+                        "Create a project for the order with a task for each sales order line "
+                        "to track the time spent."
                     )
                 elif record.service_tracking == 'project_only':
                     record.product_tooltip = _(
                         "Invoice this service when it is delivered (set the quantity by hand on your sales order lines). "
-                        "Create a project for the order with a task for each sales order line to track the time spent."
+                        "Create an empty project for the order to track the time spent."
                     )
 
     def _get_service_to_general_map(self):


### PR DESCRIPTION
Before this commit, the tooltip for service_tracking type is mismatched with task_in_project and project_only.

So in this commit, fixes the tooltip of the product in the 'task_in_project' and 'project_only' fields.

task-2891983