### PR TITLE
[FIX] mrp: allow creation of QC for MO backorders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1714,9 +1714,11 @@ class MrpProduction(models.Model):
                     workorder.qty_produced = max(workorder.qty_production, remaining_qty)
                     initial_workorder_remaining_qty[index % workorders_len] = max(remaining_qty - workorder.qty_produced, 0)
 
-        backorders.workorder_ids._action_confirm()
-
+        backorders._action_confirm_mo_backorders()
         return self.env['mrp.production'].browse(production_ids)
+
+    def _action_confirm_mo_backorders(self):
+        self.workorder_ids._action_confirm()
 
     def button_mark_done(self):
         self._button_mark_done_sanity_checks()


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/77254, Quality Checks are not
created on the backorders of a MO because the moves of the backorders
are not confirmed anymore. We therefore create the QC of the backorders
at the confirmation of the workorders.

Task-ID: 2901900
Enterprise-PR: https://github.com/odoo/enterprise/pull/29476


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
