### PR TITLE
[FIX] point_of_sale: undeletable order when it has fiscal position

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1098,7 +1098,7 @@ class PosGlobalState extends PosModel {
         return taxes;
     }
 
-    get_taxes_after_fp(taxes_ids){
+    get_taxes_after_fp(taxes_ids, order){
         var self = this;
         var taxes =  this.taxes;
         var product_taxes = [];
@@ -1106,7 +1106,7 @@ class PosGlobalState extends PosModel {
             var tax = _.detect(taxes, function(t){
                 return t.id === el;
             });
-            product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax));
+            product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax, order));
         });
         product_taxes = _.uniq(product_taxes, function(tax) { return tax.id; });
         return product_taxes;
@@ -1358,7 +1358,7 @@ class Product extends PosModel {
     }
     get_display_price(pricelist, quantity) {
         if (this.pos.config.iface_tax_included === 'total') {
-            const taxes = this.pos.get_taxes_after_fp(this.taxes_id);
+            const taxes = this.pos.get_taxes_after_fp(this.taxes_id, this.pos.get_order());
             const allPrices = this.pos.compute_all(taxes, this.get_price(pricelist, quantity), 1, this.pos.currency.rounding);
             return allPrices.total_included;
         } else {
@@ -1808,7 +1808,7 @@ class Orderline extends PosModel {
         return round_pr(this.get_unit_price() * this.get_quantity() * (1 - this.get_discount()/100), rounding);
     }
     get_taxes_after_fp(taxes_ids){
-        return this.pos.get_taxes_after_fp(taxes_ids);
+        return this.pos.get_taxes_after_fp(taxes_ids, this.order);
     }
     get_display_price_one(){
         var rounding = this.pos.currency.rounding;


### PR DESCRIPTION
When an order has a fiscal position, deleting it from the ui is impossible
unless it's deleted from the localStorage. To reproduce:
- Make an order with fiscal position
- Validate the order, and in receipt screen, click next order.
  - This will remove the paid order from `pos`.
- [BUG] Refresh the page the product screen will focus on that order.
  - This is because the order is kept in the localStorage.

Why? `save_to_db` is dependent on `pos.selectedOrder` when there is a fiscal
position in the order.

How come? This is because when computing tax mapping, it's using the
`selectedOrder`. And `save_to_db` is triggered because when deleting an order
`selectedOrder` is set to a order.

The proposed change removes this dependency of an order to the
`pos.selectedOrder` and it fixes the issue.

Screencast: https://drive.google.com/file/d/1HA3J_tq5Rd5g8L8Pkz-yFwsw7j2kKFuk/view?usp=sharing

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
