### PR TITLE
[IMP] hr_expense: disable Expense dashboard on Analysis

### DIFF
--- a/addons/hr_expense/static/src/views/kanban.js
+++ b/addons/hr_expense/static/src/views/kanban.js
@@ -16,10 +16,10 @@ patch(ExpenseKanbanController.prototype, 'expense_kanban_controller_upload', Exp
 
 export class ExpenseKanbanRenderer extends KanbanRenderer {}
 patch(ExpenseKanbanRenderer.prototype, 'expense_kanban_renderer_qrcode', ExpenseMobileQRCode);
-ExpenseKanbanRenderer.template = 'hr_expense.KanbanRenderer';
 
 export class ExpenseDashboardKanbanRenderer extends ExpenseKanbanRenderer {}
 patch(ExpenseDashboardKanbanRenderer.prototype, 'expense_kanban_renderer_dashboard', ExpenseDashboardMixin);
+ExpenseDashboardKanbanRenderer.template = 'hr_expense.KanbanRenderer';
 
 registry.category('views').add('hr_expense_kanban', {
     ...kanbanView,


### PR DESCRIPTION
The expense dashboard was displayed on the Expenses Analysis whilst it
shouldn't have.