### PR TITLE
[FIX] web: manifest typo in examples comment

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -34,7 +34,7 @@ This module provides the core of the Odoo Web Client.
         # 2) the prefix "assets_"
         # 3) an arbitrary name, relevant to the content of the bundle.
         #
-        # Exemples:
+        # Examples:
         #   > web.assets_common = assets common to both frontend and backend clients.
         #   > web_editor.assets_wysiwyg = assets needed by components defined in the "web_editor" module.
 


### PR DESCRIPTION
There was a typo in the comments of the web module's manifest.
After this commit it will be gone.

Description of the issue/feature this PR addresses:
There was a typo in the comments of the web module's manifest.

Current behavior before PR:
Typo in the web moduke manifest

Desired behavior after PR is merged:
After this commit the typo will be gone.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
