### PR TITLE
[FIX] website_event: Display cover even if text too long

### DIFF
--- a/addons/website_event/static/src/scss/website_event.scss
+++ b/addons/website_event/static/src/scss/website_event.scss
@@ -92,6 +92,11 @@ $o-wevent-event-title-sizes-variants: (
                 }
             }
         }
+        @include media-breakpoint-up(sm) {
+            #o_wevent_index_main_col article div.col {
+                min-width: 0;
+            }
+        }
         &.opt_event_list_cards_bg {
             @if (color('body') == $o-portal-default-body-bg) {
                 @extend .bg-200;


### PR DESCRIPTION
Steps to reproduce:

  - Install `website_event` module
  - Go to Events and edit `Design Fair Los Angeles` event
  - Edit the title and make it very long then save
  - Go to the Website then click on Events in the menu
  - Click on Customize and disable `Layout - Columns` to have
    a list view.

Issue:

  The cover is hidden on edited event.

Cause:

  It's a known issue:
  https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size

Solution:

    Set min-width: 0 to the div around the title if screen size bigger than `sm`.


opw-2882533