### PR TITLE
[FIX] snailmail_account: remaining legacy dependencies to wowl bus

### DIFF
--- a/addons/snailmail_account/static/src/js/snailmail_account_notification_manager.js
+++ b/addons/snailmail_account/static/src/js/snailmail_account_notification_manager.js
@@ -5,14 +5,14 @@ var AbstractService = require('web.AbstractService');
 var core = require("web.core");
 
 var SnailmailAccountNotificationManager =  AbstractService.extend({
-    dependencies: ['bus_service'],
-
     /**
      * @override
      */
     start: function () {
         this._super.apply(this, arguments);
-        this.call('bus_service', 'onNotification', this, this._onNotification);
+        core.bus.on('web_client_ready', null, () => {
+            this.call('bus_service', 'onNotification', this, this._onNotification);
+        });
     },
 
     _onNotification: function(notifications) {


### PR DESCRIPTION
Some legacy services are still relying on the bus_service as a dependency.
However, this service is now a wowl service which means those services
won't start.
