### PR TITLE
[IMP] bus, *: remove obsolete web_client_ready when using bus

### DIFF
--- a/addons/bus/static/src/services/assets_watchdog_service.js
+++ b/addons/bus/static/src/services/assets_watchdog_service.js
@@ -11,10 +11,8 @@ export const assetsWatchdogService = {
         let isNotificationDisplayed = false;
         let bundleNotifTimerID = null;
 
-        env.bus.on("WEB_CLIENT_READY", null, async () => {
-            bus_service.onNotification(this, onNotification);
-            bus_service.startPolling();
-        });
+        bus_service.onNotification(this, onNotification);
+        bus_service.startPolling();
 
         /**
          * Displays one notification on user's screen when assets have changed

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -113,7 +113,7 @@ export class BusService extends CrossTab {
 }
 
 export const busService = {
-    dependencies: ['notification'],
+    dependencies: ['notification', 'rpc'],
     start(env, services) {
         return new BusService(env, services);
     },

--- a/addons/calendar/static/src/js/services/calendar_notification_service.js
+++ b/addons/calendar/static/src/js/services/calendar_notification_service.js
@@ -12,16 +12,14 @@ export const calendarNotificationService = {
         let nextCalendarNotifTimeout = null;
         const displayedNotifications = new Set();
 
-        env.bus.on("WEB_CLIENT_READY", null, async () => {
-            bus_service.onNotification(this, (notifications) => {
-                for (const { payload, type } of notifications) {
-                    if (type === "calendar.alarm") {
-                        displayCalendarNotification(payload);
-                    }
+        bus_service.onNotification(this, (notifications) => {
+            for (const { payload, type } of notifications) {
+                if (type === "calendar.alarm") {
+                    displayCalendarNotification(payload);
                 }
-            });
-            bus_service.startPolling();
+            }
         });
+        bus_service.startPolling();
 
         /**
          * Displays the Calendar notification on user's screen

--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -7,20 +7,18 @@ export const iapNotificationService = {
     dependencies: ["bus_service", "notification"],
 
     start(env, { bus_service, notification }) {
-        env.bus.on("WEB_CLIENT_READY", null, async () => {
-            bus_service.onNotification(this, (notifications) => {
-                for (const { payload, type } of notifications) {
-                    if (type === 'iap_notification') {
-                        if (payload.error_type == 'success') {
-                            displaySuccessIapNotification(payload);
-                        } else if (payload.error_type == 'danger') {
-                            displayFailureIapNotification(payload);
-                        }
+        bus_service.onNotification(this, (notifications) => {
+            for (const { payload, type } of notifications) {
+                if (type === 'iap_notification') {
+                    if (payload.error_type == 'success') {
+                        displaySuccessIapNotification(payload);
+                    } else if (payload.error_type == 'danger') {
+                        displayFailureIapNotification(payload);
                     }
                 }
-            });
-            bus_service.startPolling();
+            }
         });
+        bus_service.startPolling();
 
         /**
          * Displays the IAP success notification on user's screen

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -18,9 +18,7 @@ registerModel({
             odoo.__DEBUG__.messaging = this;
         },
         _willDelete() {
-            if (this.env.services['bus_service']) {
-                this.env.services['bus_service'].off('window_focus', null, this._handleGlobalWindowFocus);
-            }
+            this.env.services['bus_service'].off('window_focus', null, this._handleGlobalWindowFocus);
             delete odoo.__DEBUG__.messaging;
         },
     },

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -16,10 +16,8 @@ registerModel({
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _willDelete() {
-            if (this.env.services['bus_service']) {
-                this.env.services['bus_service'].off('notification');
-                this.env.services['bus_service'].stopPolling();
-            }
+            this.env.services['bus_service'].off('notification');
+            this.env.services['bus_service'].stopPolling();
         },
     },
     recordMethods: {


### PR DESCRIPTION
*: calendar, iap_mail.

Now that the bus service is a wowl service, we don't need to wait for
the webclient to be ready before using it. Indeed, the services now
have the bus service as a dependency which means it will always be ready
in time.