### PR TITLE
[FIX] l10n_latam_invoice_document: Allow digitalization

### DIFF
--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -43,10 +43,10 @@
 
             <field name="journal_id" position="after">
                 <field name="l10n_latam_document_type_id"
-                    attrs="{'invisible': [('l10n_latam_use_documents', '=', False)], 'required': [('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"
+                    attrs="{'invisible': [('l10n_latam_use_documents', '=', False)], 'required': [('partner_id', '!=', False), ('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"
                     domain="[('id', 'in', l10n_latam_available_document_type_ids)]" options="{'no_open': True, 'no_create': True}"/>
                 <field name="l10n_latam_document_number"
-                    attrs="{'invisible': ['|', ('l10n_latam_sequence_id', '!=', False), ('l10n_latam_use_documents', '=', False)], 'required': [('l10n_latam_sequence_id', '=', False), ('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
+                    attrs="{'invisible': ['|', ('l10n_latam_sequence_id', '!=', False), ('l10n_latam_use_documents', '=', False)], 'required': [('partner_id', '!=', False), ('l10n_latam_sequence_id', '=', False), ('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce:

  - Install l10n_ar module (or any l10n_* module that depends on
    l10n_latam_invoice_document)
  - Go to Accounting -> Vendors -> Bills
  - Click on Upload and select a bill file
  - Open draft bill
  - Click on `Send For Digitalization`

Issue:

  Digitalization don't start and a warning message is displayed saying
  that some required fields are invalid.

Cause:

  When clicking on the button to digitalize the invoice, we try
  to save the form first before executing the action.
  By doing so, if some fields are required and empty, a warning message
  will be displayed.

  In this case, the issue is with the fields `Document Type` and
  `Document Number`.

Solution:

  Set `Document Type` and `Document Number` to not required if there is
  no partner_id set on the bill.

opw-2797444