### PR TITLE
[IMP] base, mail: turns attachments into links when mail is too heavy

### DIFF
--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -29,5 +29,17 @@
 <div><t t-out="body"/></div>
 <blockquote><t t-out="message['body']"/></blockquote>
         </template>
+
+        <template id="mail_attachment_links" name="Attachment links">
+<div style="max-width: 900px; width: 100%;">
+    <hr style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 10px 0px;"/>
+    <div t-foreach="attachments" t-as="attachment">
+        <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
+           style="font-size: 12px; color: #875A7B; text-decoration:none !important; text-decoration:none; font-weight: 400;">
+            📥 <t t-out="attachment.name"/>
+        </a>
+    </div>
+</div>
+        </template>
     </data>
 </odoo>

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -62,11 +62,12 @@ class MailMail(models.Model):
             )
         return body
 
-    def _prepare_outgoing_list(self, recipients_follower_status=None):
+    def _prepare_outgoing_list(self, mail_server=False, recipients_follower_status=None):
         """ Update mailing specific links to replace generic unsubscribe and
         view links by email-specific links. Also add headers to allow
         unsubscribe from email managers. """
-        email_list = super()._prepare_outgoing_list(recipients_follower_status)
+        email_list = super()._prepare_outgoing_list(mail_server=mail_server,
+                                                    recipients_follower_status=recipients_follower_status)
         if not self.res_id or not self.mailing_id:
             return email_list
 

--- a/addons/mass_mailing/tests/test_mailing_retry.py
+++ b/addons/mass_mailing/tests/test_mailing_retry.py
@@ -27,7 +27,8 @@ class TestMailingRetry(MassMailCommon, CronMixinCase):
         mailing.action_launch()
 
         # force email sending to fail to test our retry mechanism
-        def patched_mail_mail_send(mail_records, auto_commit=False, raise_exception=False, smtp_session=None, alias_domain_id=False):
+        def patched_mail_mail_send(mail_records, auto_commit=False, raise_exception=False, smtp_session=None,
+                                   alias_domain_id=False, mail_server=False):
             mail_records.write({'state': 'exception', 'failure_reason': 'forced_failure'})
 
         with patch('odoo.addons.mail.models.mail_mail.MailMail._send', patched_mail_mail_send):

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -3,14 +3,16 @@
 
 import psycopg2
 import pytz
+import re
 import smtplib
+from email import message_from_string
 
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 from markupsafe import Markup
 from OpenSSL.SSL import Error as SSLError
 from socket import gaierror, timeout
-from unittest.mock import call, patch
+from unittest.mock import call, patch, PropertyMock
 
 from odoo import api, Command, fields
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
@@ -644,6 +646,10 @@ class TestMailMailServer(MailCommon):
             'name': 'Server 2',
             'smtp_host': 'test_2.com',
         })
+        cls.test_record = cls.env['mail.test.gateway'].with_context(cls._test_context).create({
+            'name': 'Test',
+            'email_from': 'ignasse@example.com',
+        }).with_context({})
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_mail_mail_send_server(self):
@@ -822,6 +828,102 @@ class TestMailMailServer(MailCommon):
         self.assertEqual(len(self._mails), 1)
         self.assertEqual(self._mails[0]['email_cc'], ['test.😊.cc@example.com'])
         self.assertEqual(self._mails[0]['email_to'], ['test.😊@example.com'])
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    @patch('odoo.addons.base.models.ir_attachment.IrAttachment.file_size', new_callable=PropertyMock)
+    def test_mail_mail_send_server_attachment_to_download_link(self, mock_attachment_file_size):
+        """ Test that when the mail size exceeds the max email size limit,
+        attachments are turned into download links added at the end of the
+        email content.
+
+        The feature is tested in the following conditions:
+        - using a specified server or the default one (to test command ICP parameter)
+        - in batch mode
+        - with mail that exceed (with one or more attachments) or not the limit
+        - with attachment owned by a business record or not: attachments not owned by a
+        business record are never turned into links because their lifespans are not
+        controlled by the user (might even be deleted right after the message is sent).
+        """
+        def count_attachments(message):
+            if isinstance(message, str):
+                return 0
+            elif message.is_multipart():
+                return sum(count_attachments(part) for part in message.get_payload())
+            elif 'attachment' in message.get('Content-Disposition', ''):
+                return 1
+            return 0
+
+        mock_attachment_file_size.return_value = 1024 * 128
+        # Define some constant to ease the understanding of the test
+        test_mail_server = self.mail_server_domain_2
+        max_size_always_exceed = 0.1
+        max_size_never_exceed = 10
+
+        for n_attachment, mail_server, business_attachment, expected_is_links in (
+                # 1 attachment which doesn't exceed max size
+                (1, self.env['ir.mail_server'], True, False),
+                # 3 attachment: exceed max size
+                (3, self.env['ir.mail_server'], True, True),
+                # 1 attachment: exceed max size
+                (1, self.env['ir.mail_server'], True, True),
+                # Same as above with a specific server. Note that the default and server max_email size are reversed.
+                (1, test_mail_server, True, False),
+                (3, test_mail_server, True, True),
+                (1, test_mail_server, True, True),
+                # Attachments not linked to a business record are never turned to link
+                (3, self.env['ir.mail_server'], False, False),
+                (1, test_mail_server, False, False),
+        ):
+            # Setup max email size to check that the right maximum is used (default or mail server one)
+            if expected_is_links:
+                max_size_test_succeed = max_size_always_exceed * n_attachment
+                max_size_test_fail = max_size_never_exceed
+            else:
+                max_size_test_succeed = max_size_never_exceed
+                max_size_test_fail = max_size_always_exceed * n_attachment
+            if mail_server:
+                self.env['ir.config_parameter'].sudo().set_param('base.default_max_email_size', max_size_test_fail)
+                mail_server.max_email_size = max_size_test_succeed
+            else:
+                self.env['ir.config_parameter'].sudo().set_param('base.default_max_email_size', max_size_test_succeed)
+
+            attachments = self.env['ir.attachment'].sudo().create([{
+                'name': f'attachment{idx_attachment}',
+                'res_name': 'test',
+                'res_model': self.test_record._name if business_attachment else 'mail.message',
+                'res_id': self.test_record.id if business_attachment else 0,
+                'datas': 'IA==',  # a non-empty base64 content. We mock attachment file_size to simulate bigger size.
+            } for idx_attachment in range(n_attachment)])
+            with self.mock_smtplib_connection():
+                mails = self.env['mail.mail'].create([{
+                    'attachment_ids': attachments.ids,
+                    'body_html': '<p>Test</p>',
+                    'email_from': 'test@test_2.com',
+                    'email_to': f'mail_{mail_idx}@test.com',
+                } for mail_idx in range(2)])
+                mails._send(mail_server=mail_server)
+
+            self.assertEqual(len(self.emails), 2)
+            for mail, outgoing_email in zip(mails, self.emails):
+                message_raw = outgoing_email['message']
+                message_parsed = message_from_string(message_raw)
+                message_cleaned = re.sub(r'[\s=]', '', message_raw)
+                with self.subTest(n_attachment=n_attachment, mail_server=mail_server,
+                                  business_attachment=business_attachment, expected_is_links=expected_is_links):
+                    if expected_is_links:
+                        self.assertEqual(count_attachments(message_parsed), 0,
+                                         'Attachments should have been removed (replaced by download links)')
+                        self.assertTrue(all(attachment.access_token for attachment in attachments),
+                                        'Original attachment should have been modified (access_token added)')
+                        self.assertTrue(all(attachment.access_token in message_cleaned for attachment in attachments),
+                                         'All attachments should have been turned into download links')
+                    else:
+                        self.assertEqual(count_attachments(message_parsed), n_attachment,
+                                         'All attachments should be present')
+                        self.assertEqual(message_cleaned.count('access_token'), 0,
+                                         'Attachments should not have been turned into download links')
+                        self.assertTrue(all(not attachment.access_token for attachment in attachments),
+                                        'Original attachment should not have been modified (access_token not added)')
 
 
 @tagged('mail_mail')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1387,7 +1387,7 @@ class TestPerformance(BaseMailPerformance):
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
         # enable_logging = self.cr._enable_logging() if self.warm else nullcontext()
         # with self.assertQueryCount(employee=63), enable_logging:
-        with self.assertQueryCount(employee=68):
+        with self.assertQueryCount(employee=69):
             record_container.with_context({}).message_post(
                 body=Markup('<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>'),
                 subject='Test Subject',

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -91,7 +91,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         record_ticket = self.env['mail.test.ticket.mc'].browse(self.record_ticket.ids)
         attachments = self.env['ir.attachment'].create(self.test_attachments_vals)
 
-        with self.assertQueryCount(employee=97):  # test_mail_full: 96
+        with self.assertQueryCount(employee=99):  # test_mail_full: 98
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -41,6 +41,7 @@ The kernel of Odoo, needed for all installation.
         'views/ir_ui_menu_views.xml',
         'views/ir_ui_view_views.xml',
         'views/ir_default_views.xml',
+        'data/ir_config_parameter_data.xml',
         'data/ir_cron_data.xml',
         'report/ir_model_report.xml',
         'report/ir_model_templates.xml',

--- a/odoo/addons/base/data/ir_config_parameter_data.xml
+++ b/odoo/addons/base/data/ir_config_parameter_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="default_max_email_size" model="ir.config_parameter">
+            <field name="key">base.default_max_email_size</field>
+            <field name="value">10</field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -19,6 +19,17 @@
                             </group>
                             <group>
                                 <field name="sequence"/>
+                                <div colspan="2" class="d-flex justify-content-between">
+                                    <div>
+                                        <label for="max_email_size"
+                                               string="Convert attachments to links for emails over"/>
+                                        <field name="max_email_size" class="oe_inline mx-1"/>
+                                        <span class="o_form_label">MB</span>
+                                    </div>
+                                    <button class="btn btn-link pt-0" type="object" name="action_retrieve_max_email_size">
+                                        <i class="fa fa-gear"/> Detect Max Limit
+                                    </button>
+                                </div>
                             </group>
                         </group>
                         <group>


### PR DESCRIPTION
The email was not sent when it was too heavy for the outgoing server. This
implementation solves the problem by allowing to specify (and even autodetect
when supported) a maximum size for email for each outgoing server. If that
limit is reached for an email, its attachment are automatically turned into
downloadable links inserted at the end of the email so that it can be sent and
the recipient can download the attachment through the provided links.

Note that there could still be an error if the recipient server cannot handle
the email size. But it can be mitigated by setting a low value for the max
email size of the outgoing servers.

Limitation: the attachments are only turned into links if they are owned by a
business model. The goal is to delegate the attachment life cycle to the user;
when the attachment is owned by a record, the user can delete it through the
chatter of that record. And of course if the user delete the attachment, the
related link in the email will lead to a 404.

Technical note: You can specify the maximum email size on each outgoing server
(ir.mail_server) and for the smtp server specified on the command line with
the added parameter max-outgoing-email-size (default 5MB).

Task-2474726