### PR TITLE
[FIX] mrp: display qty consumed instead of to consume when MO is done

### DIFF
--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -85,12 +85,17 @@
                         </thead>
                         <tbody>
                             <t t-if="o.move_raw_ids">
-                                <tr t-foreach="o.move_raw_ids" t-as="raw_line">
+                                <tr t-foreach="o.move_raw_ids.filtered(lambda m: m.state != 'cancel')" t-as="raw_line">
                                     <td>
                                         <span t-field="raw_line.product_id"/>
                                     </td>
                                     <td t-attf-class="{{ 'text-right' if not has_product_barcode else '' }}">
-                                        <span t-field="raw_line.product_uom_qty"/>
+                                        <t t-if="o.state == 'done'">
+                                            <span t-field="raw_line.quantity_done"/>
+                                        </t>
+                                        <t t-else="">
+                                            <span t-field="raw_line.product_uom_qty"/>
+                                        </t>
                                         <span t-field="raw_line.product_uom" groups="uom.group_uom"/>
                                     </td>
                                     <td t-if="has_product_barcode" width="15%" class="text-center">


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BOM:
    - component: C1, Qty: 2
- Create a MO:
    - Select the product “P1”
    - Qty to produce: 3
    - Confirm it
    - Edit producing qty to 2
    - Mark the MO as done without creating a backorder
- Print > Production order

Problem:
When the MO is done, we display the qty consumed in the report,
but we only make the difference for the displayed name and not the
field: https://github.com/odoo/odoo/blob/80592bcd72811da4e45928e1281a69c9136b81d1/addons/mrp/report/mrp_production_templates.xml#L68-L75

opw-2917558
opw-2918077




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
