### PR TITLE
[FIX] hr_attendance: change the user group check for Kiosk

### DIFF
--- a/addons/hr_attendance/i18n/hr_attendance.pot
+++ b/addons/hr_attendance/i18n/hr_attendance.pot
@@ -854,6 +854,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_attendance
+#: code:addons/hr_attendance/models/hr_employee.py:0
+#, python-format
+msgid ""
+"To activate Kiosk mode without pin code, you must have access right as an "
+"Officer or above in the Attendance app. Please contact your administrator."
+msgstr ""
+
+#. module: hr_attendance
 #. openerp-web
 #: code:addons/hr_attendance/static/src/xml/attendance.xml:0
 #: code:addons/hr_attendance/static/src/xml/attendance.xml:0

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -146,6 +146,8 @@ class HrEmployee(models.Model):
         can_check_without_pin = attendance_user_and_no_pin or (self.user_id == self.env.user and entered_pin is None)
         if can_check_without_pin or entered_pin is not None and entered_pin == self.sudo().pin:
             return self._attendance_action(next_action)
+        if not self.user_has_groups('hr_attendance.group_hr_attendance_user'):
+            return {'warning': _('To activate Kiosk mode without pin code, you must have access right as an Officer or above in the Attendance app. Please contact your administrator.')}
         return {'warning': _('Wrong PIN')}
 
     def _attendance_action(self, next_action):


### PR DESCRIPTION
Reproduction:
1. Install Attendance app
2. Create a new internal user “kiosk”, with only access right “Kiosk
Attendance” for app “Employee”, other places as blank
3. Make sure the Settings for Attendance app, Employee PIN is unchecked
4. In an incognito tab, log in as kiosk, go to Attendance, click “kiosk
mode”, then “identify manually”
5. Choose an employee, with a warning message “Wrong pin”

Reason: A recent update refined the user group check for the
attendance_manual function. Checking if the user is an officer in the
Attendance app can be over strict. However, after discussing with yti,
we decided to pop up a warning message for security reasons when the
user would like to use Kiosk mode without pin code.

Fix: Add a warning message for higher access right requirement

opw-2898452

Related fix in V15: https://github.com/odoo-dev/odoo/commit/2975c0539d8c2781ff56a9f8be8e302d45b7d80b

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
