### PR TITLE
[FIX] point_of_sale: minor UI improvements

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -503,6 +503,7 @@ td {
 }
 .pos .oe_status.oe_inactive{
     cursor: default;
+    background: #875A7B !important;
 }
 .pos .oe_status .oe_icon{
     color: white;

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -253,7 +253,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
 
         openCashControl() {
             if (this.shouldShowCashControl()) {
-                this.showPopup('CashOpeningPopup', { cancelKey: false });
+                this.showPopup('CashOpeningPopup', { cancelKey: false, confirmKey: false });
             }
         }
 

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/HeaderButton.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/HeaderButton.js
@@ -8,7 +8,7 @@ odoo.define('point_of_sale.HeaderButton', function(require) {
     // This is the close session button
     class HeaderButton extends PosComponent {
         onClick() {
-            this.showPopup('ClosePosPopup');
+            this.showPopup('ClosePosPopup', { confirmKey: false });
         }
     }
     HeaderButton.template = 'HeaderButton';

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/CashierName.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/CashierName.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="CashierName" owl="1">
-        <div class="oe_status">
+        <div class="oe_status" t-att-class="{ 'oe_inactive': !env.pos.config.module_pos_hr }">
             <span><img t-att-src="avatar" t-att-alt="username" class="avatar"/> <span t-if="!env.isMobile" t-esc="username" class="username"/></span>
         </div>
     </t>


### PR DESCRIPTION
This PR achieves multiple purposes: 

Commit 1.
Before this commit, while the user
was typing opening/closing notes,
if they pressed 'Enter' the cashOpening
and closePos popup would close. This is
because of the default action of the
'Enter' key. However, this is undesired 
behaviour and is removed.

Commit 2.
Before this commit, the employee head button
seemed to be clickable even when it shouldn't.
It should only appear to be clickable when
there are multiple employees using the same
PoS.

task-2895447
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
