### PR TITLE
[FIX] web: display checkbox correctly

### DIFF
--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -402,6 +402,8 @@
         }
         .o_radio_input {
             outline: none;
+            padding-right: 3px;
+            aspect-ratio: 1 / 1;
         }
 
         .o_radio_item {


### PR DESCRIPTION
In some circumstances, like in settings forms,
when followed by a long label, the checkboxes are ugly.
https://viji.nimbusweb.me/share/7255794/gxdomzrk540o2uar9mg3

With this fix, they will always be round,
and not in contact with their label.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
