### PR TITLE
[FIX] pos_coupon: correct unit_price for rewardProduct

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -22,7 +22,7 @@ odoo.define('pos_coupon.pos', function (require) {
     const session = require('web.session');
     const concurrency = require('web.concurrency');
     const { Gui } = require('point_of_sale.Gui');
-    const { float_is_zero } = require('web.utils');
+    const { float_is_zero,round_decimals } = require('web.utils');
 
     const dp = new concurrency.DropPrevious();
 
@@ -882,7 +882,7 @@ odoo.define('pos_coupon.pos', function (require) {
                     [
                         new Reward({
                             product: discountLineProduct,
-                            unit_price: -rewardProduct.lst_price,
+                            unit_price: -round_decimals(rewardProduct.get_price(this.pricelist, freeQuantity), this.pos.currency.decimals),
                             quantity: freeQuantity,
                             program: program,
                             tax_ids: rewardProduct.taxes_id,


### PR DESCRIPTION
Steps to reproduce:
- set a pricelist: discount, global, 10%
- set promotion program: free product
- In pos, select the product

Issue:
The product is deducted at its lst_price and not at the discounted price such as in `Sales`.

opw-2892748