### PR TITLE
[IMP] bus: replace on/off by (add/remove)EventListener

### DIFF
--- a/addons/bus/static/src/services/assets_watchdog_service.js
+++ b/addons/bus/static/src/services/assets_watchdog_service.js
@@ -11,7 +11,7 @@ export const assetsWatchdogService = {
         let isNotificationDisplayed = false;
         let bundleNotifTimerID = null;
 
-        bus_service.onNotification(this, onNotification);
+        bus_service.onNotification(onNotification.bind(this));
         bus_service.startPolling();
 
         /**

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -54,11 +54,19 @@ export class BusService extends CrossTab {
     /**
      * Register listeners on notifications received on this bus service
      *
-     * @param {Object} receiver
-     * @param {function} func
+     * @param {function} callback
      */
-    onNotification() {
-        this.on.apply(this, ["notification"].concat(Array.prototype.slice.call(arguments)));
+    onNotification(callback) {
+        this.addEventListener('notification', ({ detail }) => callback(detail));
+    }
+
+    /**
+     * Unregister listeners on notifications received on this bus service.
+     *
+     * @param {function} callback
+     */
+    offNotification(callback) {
+        this.removeEventListener('notification', callback);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/bus/static/src/services/presence_service.js
+++ b/addons/bus/static/src/services/presence_service.js
@@ -9,7 +9,7 @@ export const presenceService = {
         const LOCAL_STORAGE_PREFIX = 'presence';
 
         // map window_focus event from the wowlBus to the legacy one.
-        env.bus.on('window_focus', null, isOdooFocused => {
+        env.bus.addEventListener('window_focus', isOdooFocused => {
             core.bus.trigger('window_focus', isOdooFocused);
         });
 

--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -44,7 +44,7 @@ QUnit.module('Bus', {
                 }
             },
         });
-        env.services['bus_service'].onNotification(null, notifications => {
+        env.services['bus_service'].onNotification(notifications => {
             assert.step('notification - ' + notifications.toString());
         });
         env.services['bus_service'].addChannel('lambda');
@@ -161,7 +161,7 @@ QUnit.module('Bus', {
                 }
             }
         });
-        masterEnv.services['bus_service'].onNotification(null, notifications => {
+        masterEnv.services['bus_service'].onNotification(notifications => {
             assert.step('master - notification - ' + notifications.toString());
         });
         masterEnv.services['bus_service'].addChannel('lambda');
@@ -174,7 +174,7 @@ QUnit.module('Bus', {
                 }
             }
         });
-        slaveEnv.services['bus_service'].onNotification(null, notifications => {
+        slaveEnv.services['bus_service'].onNotification(notifications => {
             assert.step('slave - notification - ' + notifications.toString());
         });
         slaveEnv.services['bus_service'].addChannel('lambda');
@@ -211,7 +211,7 @@ QUnit.module('Bus', {
             }
         });
 
-        masterEnv.services['bus_service'].onNotification(null, notifications => {
+        masterEnv.services['bus_service'].onNotification(notifications => {
             assert.step('master - notification - ' + notifications.toString());
         });
         masterEnv.services['bus_service'].addChannel('lambda');
@@ -228,7 +228,7 @@ QUnit.module('Bus', {
                 }
             }
         });
-        slaveEnv.services['bus_service'].onNotification(null, notifications => {
+        slaveEnv.services['bus_service'].onNotification(notifications => {
             assert.step('slave - notification - ' + notifications.toString());
         });
         slaveEnv.services['bus_service'].addChannel('lambda');

--- a/addons/calendar/static/src/js/services/calendar_notification_service.js
+++ b/addons/calendar/static/src/js/services/calendar_notification_service.js
@@ -12,7 +12,7 @@ export const calendarNotificationService = {
         let nextCalendarNotifTimeout = null;
         const displayedNotifications = new Set();
 
-        bus_service.onNotification(this, (notifications) => {
+        bus_service.onNotification(notifications => {
             for (const { payload, type } of notifications) {
                 if (type === "calendar.alarm") {
                     displayCalendarNotification(payload);

--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -7,7 +7,7 @@ export const iapNotificationService = {
     dependencies: ["bus_service", "notification"],
 
     start(env, { bus_service, notification }) {
-        bus_service.onNotification(this, (notifications) => {
+        bus_service.onNotification(notifications => {
             for (const { payload, type } of notifications) {
                 if (type === 'iap_notification') {
                     if (payload.error_type == 'success') {

--- a/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
+++ b/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
@@ -68,7 +68,7 @@ const LivechatButton = Widget.extend({
                 });
             }
         }
-        this.call('bus_service', 'onNotification', this, this._onNotification);
+        this.call('bus_service', 'onNotification', this._onNotification.bind(this));
         if (this.messaging.livechatButtonView.buttonBackgroundColor) {
             this.$el.css('background-color', this.messaging.livechatButtonView.buttonBackgroundColor);
         }

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -18,7 +18,7 @@ registerModel({
             odoo.__DEBUG__.messaging = this;
         },
         _willDelete() {
-            this.env.services['bus_service'].off('window_focus', null, this._handleGlobalWindowFocus);
+            this.env.bus.removeEventListener('window_focus', this._handleGlobalWindowFocus);
             delete odoo.__DEBUG__.messaging;
         },
     },
@@ -27,7 +27,7 @@ registerModel({
          * Starts messaging and related records.
          */
         async start() {
-            this.env.bus.on('window_focus', null, this._handleGlobalWindowFocus);
+            this.env.bus.addEventListener('window_focus', this._handleGlobalWindowFocus);
             await this.initializer.start();
             if (!this.exists()) {
                 return;

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -16,7 +16,7 @@ registerModel({
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         _willDelete() {
-            this.env.services['bus_service'].off('notification');
+            this.env.services['bus_service'].offNotification(this._handleNotifications);
             this.env.services['bus_service'].stopPolling();
         },
     },
@@ -26,7 +26,7 @@ registerModel({
          * the current users. This includes pinned channels for instance.
          */
         start() {
-            this.env.services['bus_service'].onNotification(null, notifs => this._handleNotifications(notifs));
+            this.env.services['bus_service'].onNotification(this._handleNotifications);
             this.env.services['bus_service'].startPolling();
         },
         /**

--- a/addons/snailmail_account/static/src/js/snailmail_account_notification_manager.js
+++ b/addons/snailmail_account/static/src/js/snailmail_account_notification_manager.js
@@ -11,7 +11,7 @@ var SnailmailAccountNotificationManager =  AbstractService.extend({
     start: function () {
         this._super.apply(this, arguments);
         core.bus.on('web_client_ready', null, () => {
-            this.call('bus_service', 'onNotification', this, this._onNotification);
+            this.call('bus_service', 'onNotification', this._onNotification.bind(this));
         });
     },
 

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -943,7 +943,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
                 }, 2000);
             }
 
-            this.call('bus_service', 'onNotification', this, this._onNotification);
+            this.call('bus_service', 'onNotification', this._onNotification.bind(this));
         }
     },
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -381,7 +381,7 @@ const Wysiwyg = Widget.extend({
         this._collaborationChannelName = channelName;
         Wysiwyg.activeCollaborationChannelNames.add(channelName);
 
-        this.call('bus_service', 'onNotification', this, (notifications) => {
+        this.call('bus_service', 'onNotification', notifications => {
             for (const { payload, type } of notifications) {
                 if (
                     type === 'editor_collaboration' &&


### PR DESCRIPTION
on/off are deprecated in favor of  addEventListener/removeEventListener.
Calls to the bus service have been updated to reflect those changes.

task-2053917

enterprise: https://github.com/odoo/enterprise/pull/29501