### PR TITLE
[FIX] website_sale_delivery: display delivery price with tax incl.

### DIFF
--- a/addons/website_sale_delivery/views/website_sale_delivery_templates.xml
+++ b/addons/website_sale_delivery/views/website_sale_delivery_templates.xml
@@ -32,18 +32,7 @@
         <input t-att-value="delivery.id" t-att-id="'delivery_%i' % delivery.id" type="radio" name="delivery_type" t-att-checked="order.carrier_id and order.carrier_id.id == delivery.id and 'checked' or False" t-att-class="'d-none' if delivery_nb == 1 else ''"/>
         <label class="label-optional" t-field="delivery.name"/>
         <t t-set='badge_class' t-value="(delivery_nb != 1 and 'float-right ' or '') + 'badge badge-secondary'" />
-        <t t-if="delivery.delivery_type == 'fixed'">
-          <span t-if="delivery.fixed_price > 0.0" t-att-class="badge_class">
-            <t t-esc="delivery.rate_shipment(website_sale_order)['price'] if delivery.free_over else delivery.fixed_price"
-               t-options='{"widget": "monetary",
-                           "from_currency": website_sale_order.currency_id if delivery.free_over else delivery.product_id.company_id.currency_id or website_sale_order.company_id.currency_id,
-                           "display_currency": website_sale_order.currency_id}'/>
-          </span>
-          <span t-else="" t-att-class="badge_class">Free</span>
-        </t>
-        <t t-else="">
-            <span t-attf-class="#{badge_class} o_wsale_delivery_badge_price">Select to compute delivery rate</span>
-        </t>
+        <span t-attf-class="#{badge_class} o_wsale_delivery_badge_price">Select to compute delivery rate</span>
         <t t-if="delivery.website_description">
             <div t-field="delivery.website_description" class="text-muted mt8"/>
         </t>


### PR DESCRIPTION
When displaying the price of a shipping method, if its type is "Fixed
Price", the option "Tax-Included" is not considered.

To reproduce the issue:
(Use demo data)
1. In Settings:
    - Product Prices: Tax-Included
2. Create two shipping methods:
    - SM01:
        - Provider: Fixed Price
        - Set a customer tax of 15% on the associated delivery product
        - Fixed Price: 100
        - Published: True
    - SM02:
        - Provider: Based on Rules
        - Set a customer tax of 15% on the associated delivery product
        - Pricing:
            - If weight >= 0: Cost = 100 + 0 * weight
        - Published: True
3. Open the eShop
4. Add the Customizable Desk to the cart
5. Process checkout

Error: When displaying the delivery methods, the price of SM01 is
incorrect: $100 instead of $115. In other words: the tax is not in the
price, as it should according to the settings. (The price of SM02 is
correct: $115).

The displaying of the shipping method price depends on the shipping
method type:
https://github.com/odoo/odoo/blob/68b08164e5de353ea0c48de92d0c0e028b49bc52/addons/website_sale_delivery/views/website_sale_delivery_templates.xml#L35-L46
If the type is `fixed`, we display the `fixed_price` field of the record
(that is the value encoded on the shipping method form, so it does not
include any tax)
If the type is different, we just display a text: "Select to compute
delivery rate". And, when loading the page, a JS widget gets and
displays the rate for each shipping method (including SM01!)
https://github.com/odoo/odoo/blob/204a2bb5553a275e785fbb9ccefbe26b06ef4ba1/addons/website_sale_delivery/static/src/js/website_sale_delivery.js#L38-L47
And in that case, the rate returned by the RPC includes the tax (if
needed):
https://github.com/odoo/odoo/blob/bc2615d8ab5135f21c488c5a260c59605b0da498/addons/website_sale_delivery/controllers/main.py#L57-L60
That is the reason why the displayed price of SM02 is correct.

When the widget gets the prices, it uses the classes to find and replace
the rate with the one returned by the server:
https://github.com/odoo/odoo/blob/204a2bb5553a275e785fbb9ccefbe26b06ef4ba1/addons/website_sale_delivery/static/src/js/website_sale_delivery.js#L95-L105
However, if the shipping method type is `fixed`, it does not have the
class `o_wsale_delivery_badge_price`, so the SM is not found and its
type is not updated (that explains why the displayed price of SM01 is
not correct).

Because the widget gets the rate of all shipping methods, we should take
advantage of that and let the widget apply the result on each method,
even if the type is `fixed`

OPW-2854341