### PR TITLE
[FIX] product : variant of other company

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -40,6 +40,9 @@ class ProductAttribute(models.Model):
     def _compute_products(self):
         for pa in self:
             pa.with_context(active_test=False).product_tmpl_ids = pa.attribute_line_ids.product_tmpl_id
+        # avoid multi-company records in cache (that were an issue for subsequent read)
+        self.flush(fnames=['product_tmpl_ids'], records=self)
+        self.invalidate_cache(fnames=['product_tmpl_ids'], ids=self.ids)
 
     def _without_no_variant_attributes(self):
         return self.filtered(lambda pa: pa.create_variant != 'no_variant')


### PR DESCRIPTION
Steps to reproduce:
        - install sale_management
        - enable variant in the setting of sales
        - create a second company
        - create a product with at least a variant and set the company
        to the active one
        - switch to the second company
        - create another product and select the same variant
        - error on creation

Cause:

        The stored compute is executed as sudo, therefor a value that the user has no access to stays in the cache.
	This causes an issue when trying to write()

Solution:

	Flush the cache early after the compute

opw-2898457

