### PR TITLE
[FIX] website, website_crm: remove useless confusing contact form option

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -615,6 +615,19 @@ class Website(Home):
     @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True)
     def get_switchable_related_views(self, key):
         views = request.env["ir.ui.view"].get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
+
+        # TODO remove in master: customize_show was kept by mistake on a view
+        # in website_crm. It was removed in stable at the same time this hack is
+        # introduced but would still be shown for existing customers if nothing
+        # else was done here. For users that disabled the view but were not
+        # supposed to be able to, we hide it too. The feature does not do much
+        # and is not a discoverable feature anyway, best removing the confusion
+        # entirely. If someone somehow wants that very technical feature, they
+        # can still enable the view again via the backend. We will also
+        # re-enable the view automatically in master.
+        crm_contactus_view = request.website.viewref('website_crm.contactus_form', raise_if_not_found=False)
+        views -= crm_contactus_view
+
         views = views.sorted(key=lambda v: (v.inherit_id.id, v.name))
         return views.with_context(display_website=False).read(['name', 'id', 'key', 'xml_id', 'active', 'inherit_id'])
 

--- a/addons/website_crm/views/website_templates_contactus.xml
+++ b/addons/website_crm/views/website_templates_contactus.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <template id="contactus_form" name="Contact Form (Opportunity)" inherit_id="website.contactus" customize_show="True">
+        <!-- TODO review in master, many of the values added in the dict are -->
+        <!-- already in there initially -->
+        <template id="contactus_form" name="Contact Form (Opportunity)" inherit_id="website.contactus">
             <xpath expr="//span[@data-for='contactus_form']" position="before">
                 <t t-set="contactus_form_values" t-value="dict(contactus_form_values, **{
                     'contact_name': request.params.get('contact_name', ''),


### PR DESCRIPTION
Follow-up of [1].

With [2], the contact us page was made entirely static to ease and allow
more things in its customization. The customize_show option of the
website_crm app which added the possibility to switch between sending
emails or creating opportunities was to be removed to rather be done via
the standard edit-mode option, by clicking on the form itself. Part of
this option view was however kept (the auto-fill of some more values)...
but it was not supposed to be kept as a customize_show view. With this,
a customize_show option with the same name "Contact Form (Opportunity)"
still appeared and gave the illusion that this is the way to make the
form create opportunities instead of sending emails.

After this commit, we remove the customize_show of the view at the same
time as introducing a hack to not show the option for existing users.
For users that disabled the view (but were thus not supposed to be able
to), we hide it too. The feature does not do much and is not a very
discoverable feature anyway, best removing the confusion entirely. If
someone somehow wants that very technical "more auto-fill via the URL"
feature, they can still enable the view again via the backend. We will
also re-enable the view automatically in 16.0.

[1]: https://github.com/odoo/odoo/pull/69888#discussion_r921081562
[2]: https://github.com/odoo/odoo/commit/417138b44311a05aa206b6e2e38bb67863843c74

Related to task-2462993
