### PR TITLE
[FIX] account: fix bank statement import from BNP

### DIFF
--- a/addons/account_bank_statement_import/account_bank_statement_import.py
+++ b/addons/account_bank_statement_import/account_bank_statement_import.py
@@ -136,6 +136,8 @@ class AccountBankStatementImport(models.TransientModel):
         sanitized_acc_number = journal.bank_account_id.sanitized_acc_number
         if " " in sanitized_acc_number:
             sanitized_acc_number = sanitized_acc_number.split(" ")[0]
+        if len(sanitized_acc_number) == 27 and sanitized_acc_number[:2].upper() == "FR":
+            return sanitized_acc_number[14:-2] == account_number
         return sanitized_acc_number == account_number
 
     def _find_additional_data(self, currency_code, account_number):


### PR DESCRIPTION
This PR fixes bank statement import from BNP France

Before this commit, importing an .OFX file from BNP failed because the account number format is not the same.
This is a problem on BNP's side but it is blocking for our clients and needs to be fixed.

This commit fixes this by checking that the account number corresponds to a specific part of the IBAN (for France only).

Task id 2860720
