### PR TITLE
[FIX] crm: missing company on default crm team ...

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1831,8 +1831,14 @@ class Lead(models.Model):
         defaults.update(custom_values)
 
         # assign right company
-        if 'company_id' not in defaults and 'team_id' in defaults:
-            defaults['company_id'] = self.env['crm.team'].browse(defaults['team_id']).company_id.id
+        company_id = defaults.get('company_id', False)
+        if not company_id:
+            if 'team_id' in defaults:
+                company_id = self.env['crm.team'].browse(defaults['team_id']).company_id
+            if not company_id and 'partner_id' in defaults:
+                company_id = self.env['res.partner'].browse(defaults['partner_id']).company_id
+            if company_id:
+                defaults['company_id'] = company_id.id
         return super(Lead, self).message_new(msg_dict, custom_values=defaults)
 
     def _message_post_after_hook(self, message, msg_vals):

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -754,3 +754,16 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.phone, self.test_phone_data[1])
         self.assertEqual(lead.mobile, self.test_phone_data[2])
         self.assertFalse(lead.phone_sanitized)
+
+    def test_incompatible_company_error_on_incoming_email(self):
+        partner_admin = self.env['res.partner'].search([('email', '=', 'admin@yourcompany.example.com')])
+        self.assertTrue(partner_admin)
+
+        new_lead = self.format_and_process(
+            INCOMING_EMAIL,
+            'admin@yourcompany.example.com',
+            '%s@%s' % (self.sales_team_1.alias_name, self.alias_domain),
+            subject='Helpdesk team having partner in company False',
+            target_model='crm.lead',
+        )
+        self.assertTrue(new_lead.company_id)


### PR DESCRIPTION
... on incoming emails

Commit 0edc854a8494eb475087d011efddc7e15b262127
introduce a company check on the salesperson,
partner & team on the lead model.

However 184334a97d1ccd19b9a7266a13ff51531d22cff4
was not able to find the expected company
on a lead created by email when the team did not
have a company set. Which is the case by default
for the following crm.team:
- Sales (3ad1867ea4d7fcda4ccfeb0a7f3d3860b16d389e)
- Pre-Sales
- Website (3ad1867ea4d7fcda4ccfeb0a7f3d3860b16d389e)
- PoS

Having added the company check introduce an
unexpected error:
"Incompatible companies on records:\n-
'[header subject of email]'
belongs to company False and 'Customer'
(partner_id: '[name in header from of email]')
belongs to another company."

Error was hard to spot as the db logs are reporting
that the routing of the email was correctly done.
But script to send eml using xmlrpc showed the error.

opw-2862509
opw-2783249

co-authored @alt-odoo 
