### PR TITLE
[FIX] website_event: fix rpc call done on the wrong object

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1549,7 +1549,8 @@ var SnippetsMenu = Widget.extend({
     init: function (parent, options) {
         this._super.apply(this, arguments);
         options = options || {};
-        this.$body = $((options.document || document).body);
+        this.editableOwnerDocument = (options.document || document);
+        this.$body = $(this.editableOwnerDocument.body);
 
         this.options = options;
         if (!this.options.snippets) {
@@ -1885,7 +1886,7 @@ var SnippetsMenu = Widget.extend({
             return;
         }
         for (const snippetEditor of this.snippetEditors) {
-            if (snippetEditor.$target.closest('body').length) {
+            if (snippetEditor.$target.closest('html').length) {
                 snippetEditor.cover();
                 continue;
             }
@@ -2437,7 +2438,7 @@ var SnippetsMenu = Widget.extend({
                 return $from.closest(selector, parentNode).filter(filterFunc);
             };
             functions.all = function ($from) {
-                return ($from ? dom.cssFind($from, selector) : self.$body.find(selector)).filter(filterFunc);
+                return ($from ? dom.cssFind($from, selector) : $(self.editableOwnerDocument).find(selector)).filter(filterFunc);
             };
         } else {
             functions.is = function ($from) {

--- a/addons/website_event/static/src/snippets/options.js
+++ b/addons/website_event/static/src/snippets/options.js
@@ -3,6 +3,7 @@
 import options from 'web_editor.snippets.options';
 
 options.registry.WebsiteEvent = options.Class.extend({
+    rpcFields: ['website_menu', 'website_url'],
 
     /**
      * @override
@@ -14,17 +15,17 @@ options.registry.WebsiteEvent = options.Class.extend({
         this.eventId = eventObject.id;
         // Only need for one RPC request as the option will be destroyed if a
         // change is made.
-        const rpcData = await this._rpc({
+        this.rpcData = await this._rpc({
             model: this.modelName,
             method: 'read',
             args: [
                 [this.eventId],
-                ['website_menu', 'website_url'],
+                this.rpcFields,
             ],
         });
-        this.eventUrl = rpcData[0]['website_url'];
+        this.eventUrl = this.rpcData[0]['website_url'];
         this.data.reload = this.eventUrl;
-        this.websiteMenu = rpcData[0]['website_menu'];
+        this.websiteMenu = this.rpcData[0]['website_menu'];
         return res;
     },
 

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -70,13 +70,13 @@
                          data-reload="/"/>
         </div>
         <!-- Event page  -->
-        <div data-selector="main:has(.o_wevent_event_title)" data-page-options="true" data-no-check="true" string="Event Page">
+        <div data-selector="main:has(.o_wevent_event_title)" data-page-options="true" data-no-check="true" string="Registration">
             <we-checkbox string="Fold Tickets Details"
                          data-customize-website-views="website_event.fold_register_details"
                          data-no-preview="true"
                          data-reload="/"/>
         </div>
-        <div data-js="WebsiteEvent" data-selector="main:has(.o_wevent_event)" data-page-options="true" data-no-check="true" string="Event Page">
+        <div data-js="WebsiteEvent" data-selector="[data-main-object^=&quot;event.event&quot;]" data-page-options="true" data-target="#wrapwrap" data-no-check="true" string="Event">
             <we-checkbox string="Sub-menu (Specific)"
                          data-display-submenu="true"
                          data-no-preview="true"

--- a/addons/website_event_meet/static/src/js/snippets/options.js
+++ b/addons/website_event_meet/static/src/js/snippets/options.js
@@ -3,6 +3,12 @@
 import options from 'web_editor.snippets.options';
 
 options.registry.WebsiteEvent.include({
+    rpcFields: options.registry.WebsiteEvent.prototype.rpcFields.concat(['meeting_room_allow_creation']),
+
+    async start() {
+        await this._super(...arguments);
+        this.meetingRoomAllowCreation = this.rpcData[0]['meeting_room_allow_creation'];
+    },
 
     //--------------------------------------------------------------------------
     // Options
@@ -12,13 +18,13 @@ options.registry.WebsiteEvent.include({
      * @see this.selectClass for parameters
      */
     allowRoomCreation(previewMode, widgetValue, params) {
-        this._rpc({
+        return this._rpc({
             model: this.modelName,
             method: 'write',
             args: [[this.eventId], {
                 meeting_room_allow_creation: widgetValue
             }],
-        }).then(() => this.trigger_up('request_save', {reload: true, optionSelector: this.data.selector}));
+        });
     },
 
     //--------------------------------------------------------------------------
@@ -31,7 +37,7 @@ options.registry.WebsiteEvent.include({
     async _computeWidgetState(methodName, params) {
         switch (methodName) {
             case 'allowRoomCreation': {
-                return this._getRpcData('meeting_room_allow_creation');
+                return this.meetingRoomAllowCreation;
             }
         }
         return this._super(...arguments);


### PR DESCRIPTION
Commit [1] adapted page options to work as Snippet Options.
The selectors made for the option targeted every event related pages
instead of every event.event pages.

This meant that the option would sometimes start on an event.track page
creating a traceback.

Steps to reproduce:
- Install website_event_track
- Go to a track page
- Click on Edit
- Click on a block
- A traceback appears

[1]: https://github.com/odoo/odoo/commit/208612b173b22d9a5a9dd356654db2b8c88db888

task-2687506