### PR TITLE
[FIX] sale_product_configurator: clarifies tour

### DIFF
--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -31,15 +31,19 @@ tour.register('sale_product_configurator_tour', {
 }, {
     trigger: 'input[data-value_name="Black"]'
 }, {
-    trigger: '.btn-primary.disabled',
-    extra_trigger: '.show .modal-footer'
+    trigger: '.btn-primary.disabled span:contains("Confirm")',
+    extra_trigger: '.show .modal-footer' // check confirm is disable and try to do it anyway
 }, {
     trigger: 'input[data-value_name="White"]'
 }, {
-    trigger: '.btn-primary:not(.disabled)',
-    extra_trigger: '.show .modal-footer'
+    trigger: '.btn-primary:not(.disabled)  span:contains("Confirm")',
+    extra_trigger: '.show .modal-footer',
+    run: function (){} // check confirm is available
 }, {
     trigger: 'span:contains("Aluminium"):eq(1)',
+    extra_trigger: '.oe_advanced_configurator_modal',
+}, {
+    trigger: '.js_product:has(strong:contains(Conference Chair)) .js_add',
     extra_trigger: '.oe_advanced_configurator_modal',
 }, {
     trigger: '.js_product:has(strong:contains(Chair floor protection)) .js_add',


### PR DESCRIPTION
Due to a race condition, the chair product was sometimes added before
the js of the product configurator applied the changed attribute.
Changing the rhythm of the tour and making it clearer solves the problem
for the runbot. As the race condition itself will be solved soon with
the owl migration and isn't a problem customers can trigger themselves, 
it was decided that it stays as is for now.

task-2909387