### PR TITLE
[FIX] sale_product_configurator: use float quantities in configurator

### DIFF
--- a/addons/sale_product_configurator/controllers/main.py
+++ b/addons/sale_product_configurator/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.http import request
 class ProductConfiguratorController(http.Controller):
     @http.route(['/sale_product_configurator/configure'], type='json', auth="user", methods=['POST'])
     def configure(self, product_template_id, pricelist_id, **kw):
-        add_qty = int(kw.get('add_qty', 1))
+        add_qty = float(kw.get('add_qty', 1))
         product_template = request.env['product.template'].browse(int(product_template_id))
         pricelist = self._get_pricelist(pricelist_id)
 
@@ -39,7 +39,7 @@ class ProductConfiguratorController(http.Controller):
         return self._optional_product_items(product_id, pricelist, **kw)
 
     def _optional_product_items(self, product_id, pricelist, **kw):
-        add_qty = int(kw.get('add_qty', 1))
+        add_qty = float(kw.get('add_qty', 1))
         product = request.env['product.product'].browse(int(product_id))
 
         parent_combination = product.product_template_attribute_value_ids
@@ -64,7 +64,7 @@ class ProductConfiguratorController(http.Controller):
         if not has_optional_products:
             return False
 
-        add_qty = int(kw.get('add_qty', 1))
+        add_qty = float(kw.get('add_qty', 1))
 
         no_variant_attribute_values = combination.filtered(
             lambda product_template_attribute_value: product_template_attribute_value.attribute_id.create_variant == 'no_variant'

--- a/addons/sale_product_configurator/static/src/js/product_configurator_controller.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_controller.js
@@ -115,12 +115,13 @@ var ProductConfiguratorFormController = FormController.extend({
         var initialProduct = this.initialState.data.product_template_id;
         var changed = initialProduct && initialProduct.data.id !== productTemplateId;
         var data = this.renderer.state.data;
+        var quantity = initialProduct.context && initialProduct.context.default_quantity ? initialProduct.context.default_quantity : data.quantity;
         return this._rpc({
             route: '/sale_product_configurator/configure',
             params: {
                 product_template_id: productTemplateId,
                 pricelist_id: this.renderer.pricelistId,
-                add_qty: data.quantity,
+                add_qty: quantity,
                 product_template_attribute_value_ids: changed ? [] : this._getAttributeValueIds(
                     data.product_template_attribute_value_ids
                 ),

--- a/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
@@ -179,7 +179,7 @@ var OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, {
         var products = [this.rootProduct];
         this.$modal.find('.js_product.in_cart:not(.main_product)').each(function () {
             var $item = $(this);
-            var quantity = parseInt($item.find('input[name="add_qty"]').val(), 10);
+            var quantity = parseFloat($item.find('input[name="add_qty"]').val().replace(',', '.') || 1);
             var parentUniqueId = this.dataset.parentUniqueId;
             var uniqueId = this.dataset.uniqueId;
             var productCustomVariantValues = self.getCustomVariantValues($(this));
@@ -472,7 +472,7 @@ var OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, {
         if (this.$modal.find('.js_price_total').length) {
             var price = 0;
             this.$modal.find('.js_product.in_cart').each(function () {
-                var quantity = parseInt($(this).find('input[name="add_qty"]').first().val(), 10);
+                var quantity = parseFloat($(this).find('input[name="add_qty"]').first().val().replace(',', '.') || 1);
                 price += parseFloat($(this).find('.js_raw_price').html()) * quantity;
             });
 


### PR DESCRIPTION
The product configurator doesn't allow you to use non-integer quantities

Steps to reproduce:
1. Install Sales
2. Go to Settings > Sales > Product Catalog and enable Product
   Configurator
3. Go to Sales > Products and create a product 'Product A' with
   attribute Color and at least two values
4. Create a Quotation and add product 'Conference Chair (CONFIG)'
5. In the product configurator, specify 3.5 as quantity and click on
   'ADD'
6. The total price is wrong
7. Add the optional product 'Chair floor protection' and confirm
8. The quantity of 'Chair floor protection' rounds to 3

Solution:
Parse the quantity as a float instead of an integer (and replace
potential commas to dots in case of different decimal separator), get
the quantity from default_quantity for the rpc call (as it was converted
to an integer because of its type) and convert the quantity to float in
the controllers

Problem:
parseInt was used to retrieve the quantity and the controllers converted
the quantity to an integer. The field quantity of the
SaleProductConfigurator is of type Integer, which rounded the quantity
when opening the configurator.

opw-2896367