### PR TITLE
[FIX] web: "last_[number]_days" domain needs 1 day more in right boundary

### DIFF
--- a/addons/web/static/src/js/core/domain.js
+++ b/addons/web/static/src/js/core/domain.js
@@ -351,22 +351,22 @@ var Domain = collections.Tree.extend({
                 return makeInterval();
             case 'last_7_days':
                 leftBoundaryParams = {days: -7};
-                rightBoundaryParams = {};
+                rightBoundaryParams = {days: 1};
                 offsetPeriodParams = {days: -7};
                 return makeInterval();
             case 'last_30_days':
                 leftBoundaryParams = {days: -30};
-                rightBoundaryParams = {};
+                rightBoundaryParams = {days: 1};
                 offsetPeriodParams = {days: -30};
                 return makeInterval();
             case 'last_365_days':
                 leftBoundaryParams = {days: -365};
-                rightBoundaryParams = {};
+                rightBoundaryParams = {days: 1};
                 offsetPeriodParams = {days: -365};
                 return makeInterval();
             case 'last_5_years':
                 leftBoundaryParams = {years: -5};
-                rightBoundaryParams = {};
+                rightBoundaryParams = {days: 1};
                 offsetPeriodParams = {years: -5};
                 return makeInterval();
         }

--- a/addons/web/static/tests/views/graph_tests.js
+++ b/addons/web/static/tests/views/graph_tests.js
@@ -1186,11 +1186,11 @@ QUnit.module('Views', {
 
             this.combinationsToCheck = {
                 'last_30_days,previous_period,day': {
-                    labels: [...Array(7).keys()].map(x => [x]),
+                    labels: [...Array(8).keys()].map(x => [x]),
                     legend: ["Last 30 Days", "Previous Period"],
                     datasets: [
                         {
-                            data: [26, 53, 2, 63, 110, 48, 48],
+                            data: [26, 53, 2, 4, 63, 110, 48, 48],
                             label: "Last 30 Days",
                         },
                         {
@@ -1206,11 +1206,12 @@ QUnit.module('Views', {
             await this.setMode('line');
             await this.testCombinations(combinations, assert);
             this.combinationsToCheck['last_30_days,previous_period,day'] = {
-                labels: [...Array(7).keys()].map(x => [x]),
+                labels: [...Array(8).keys()].map(x => [x]),
                 legend: [
                     "2016-12-15,2016-11-03",
                     "2016-12-17,2016-11-01",
                     "2016-11-22",
+                    "2016-12-20",
                     "2016-12-19",
                     "2016-12-01",
                     "2016-12-10",
@@ -1218,11 +1219,11 @@ QUnit.module('Views', {
                 ],
                 datasets: [
                     {
-                        data: [26, 53, 2, 63, 110, 48, 48],
+                        data: [26, 53, 2, 4, 63, 110, 48, 48],
                         label: "Last 30 Days",
                     },
                     {
-                        data: [24, 53, 0, 0, 0, 0, 0],
+                        data: [24, 53, 0, 0, 0, 0, 0, 0],
                         label: "Previous Period",
                     }
                 ],
@@ -1242,7 +1243,7 @@ QUnit.module('Views', {
                     legend: ["Last 30 Days", "Previous Period"],
                     datasets: [
                         {
-                            data: [350],
+                            data: [354],
                             label: "Last 30 Days",
                         },
                         {
@@ -1261,7 +1262,7 @@ QUnit.module('Views', {
                 legend: ["Last 30 Days", "Previous Period"],
                 datasets: [
                     {
-                        data: [undefined, 350],
+                        data: [undefined, 354],
                         label: "Last 30 Days",
                     },
                     {
@@ -1278,7 +1279,7 @@ QUnit.module('Views', {
                 legend: ["Total"],
                 datasets: [
                     {
-                        data: [350],
+                        data: [354],
                         label: "Last 30 Days",
                     },
                     {
@@ -1302,7 +1303,7 @@ QUnit.module('Views', {
                     legend: ["Last 30 Days", "Previous Period"],
                     datasets: [
                         {
-                            data: [151, 151, 48],
+                            data: [151, 155, 48],
                             label: "Last 30 Days",
                         },
                         {
@@ -1322,7 +1323,7 @@ QUnit.module('Views', {
                 legend: ["Last 30 Days", "Previous Period"],
                 datasets: [
                     {
-                        data: [151, 151],
+                        data: [151, 155],
                         label: "Last 30 Days",
                     },
                     {
@@ -1339,7 +1340,7 @@ QUnit.module('Views', {
                 legend: ["xphone", "xpad", "Undefined"],
                 datasets: [
                     {
-                        data: [151, 151, 48],
+                        data: [151, 155, 48],
                         label: "Last 30 Days",
                     },
                     {
@@ -1360,7 +1361,7 @@ QUnit.module('Views', {
             this.keepFirst = true;
             this.combinationsToCheck = {
                 'last_7_days,previous_period,day': {
-                    labels: [...Array(3).keys()].map(x => [x]),
+                    labels: [...Array(4).keys()].map(x => [x]),
                     legend: [
                         "Last 7 Days/xphone",
                         "Last 7 Days/xpad",
@@ -1368,11 +1369,11 @@ QUnit.module('Views', {
                     ],
                     datasets: [
                         {
-                            data: [3, 53, 0],
+                            data: [3, 53, 0, 0],
                             label: "Last 7 Days/xphone",
                         },
                         {
-                            data: [23, 0, 63],
+                            data: [23, 0, 4, 63],
                             label: "Last 7 Days/xpad",
                         },
                         {
@@ -1391,20 +1392,21 @@ QUnit.module('Views', {
 
 
             this.combinationsToCheck['last_7_days,previous_period,day'] = {
-                labels: [[0,"xphone"], [1,"xphone"], [2, "xpad"], [0, "xpad"]],
+                labels: [[0,"xphone"], [1,"xphone"], [2, "xpad"], [3, "xpad"], [0, "xpad"]],
                 legend: [
                     "2016-12-15,2016-12-10/xphone",
                     "2016-12-17/xphone",
+                    "2016-12-20/xpad",
                     "2016-12-19/xpad",
                     "2016-12-15,2016-12-10/xpad"
                 ],
                 datasets: [
                     {
-                        data: [3, 53, 63, 23],
+                        data: [3, 53, 4, 63, 23],
                         label: "Last 7 Days",
                     },
                     {
-                        data: [48, 0, 0, 0],
+                        data: [48, 0, 0, 0, 0],
                         label: "Previous Period",
                     }
                 ],

--- a/addons/web/static/tests/views/search_view_tests.js
+++ b/addons/web/static/tests/views/search_view_tests.js
@@ -224,13 +224,13 @@ QUnit.module('Search View', {
         // assuming that the current time is: 2017-03-22:01:00:00
         this.periodDomains = [
             // last 7 days (whole days)
-            ['&', ["date_field", ">=", "2017-03-15"],["date_field", "<", "2017-03-22"]],
+            ['&', ["date_field", ">=", "2017-03-15"],["date_field", "<", "2017-03-23"]],
             // last 30 days
-            ['&', ["date_field", ">=", "2017-02-20"],["date_field", "<", "2017-03-22"]],
+            ['&', ["date_field", ">=", "2017-02-20"],["date_field", "<", "2017-03-23"]],
             // last 365 days
-            ['&', ["date_field", ">=", "2016-03-22"],["date_field", "<", "2017-03-22"]],
+            ['&', ["date_field", ">=", "2016-03-22"],["date_field", "<", "2017-03-23"]],
             // last 5 years
-            ['&', ["date_field", ">=", "2012-03-22"],["date_field", "<", "2017-03-22"]],
+            ['&', ["date_field", ">=", "2012-03-22"],["date_field", "<", "2017-03-23"]],
             // today
             ['&', ["date_field", ">=", "2017-03-22"],["date_field", "<", "2017-03-23"]],
             // this week
@@ -289,13 +289,13 @@ QUnit.module('Search View', {
         // assuming that the current time is: 2017-03-22:01:00:00
         this.previousPeriodDomains = [
             // last 7 days (whole days) - 1 week
-            ['&', ["date_field", ">=", "2017-03-08"],["date_field", "<", "2017-03-15"]],
+            ['&', ["date_field", ">=", "2017-03-08"],["date_field", "<", "2017-03-16"]],
             // last 30 days - 30 days
-            ['&', ["date_field", ">=", "2017-01-21"],["date_field", "<", "2017-02-20"]],
+            ['&', ["date_field", ">=", "2017-01-21"],["date_field", "<", "2017-02-21"]],
             // last 365 days
-            ['&', ["date_field", ">=", "2015-03-23"],["date_field", "<", "2016-03-22"]],
+            ['&', ["date_field", ">=", "2015-03-23"],["date_field", "<", "2016-03-23"]],
             // last 5 years
-            ['&', ["date_field", ">=", "2007-03-22"],["date_field", "<", "2012-03-22"]],
+            ['&', ["date_field", ">=", "2007-03-22"],["date_field", "<", "2012-03-23"]],
             // today - 1 day
             ['&', ["date_field", ">=", "2017-03-21"],["date_field", "<", "2017-03-22"]],
             // this week - 1 week


### PR DESCRIPTION
(Only affects v13, as these things doesn't exist anymore in v14, no need to forward port.)

Steps to reproduce:

- Go to Sales. Create a new product. Then create a sale order with that product with 1 quantity and validate.
- Go to that product variant form. Button "X units sold" shows "1 units sold."
- Click on the button to go to the pivot view.
  => No records are shown in the pivot view (because today is wrongly excluded in the domain).


Video shows error:

![Peek 2022-07-14 17-27](https://user-images.githubusercontent.com/25005517/179019431-c4bbdf62-b639-4f86-af5e-af849160f551.gif)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
