### PR TITLE
[FIX] website: make enable_editor=1 links work from backend

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -184,7 +184,7 @@ export class WebsitePreview extends Component {
      */
     _isTopWindowURL({ host, pathname }) {
         const backendRoutes = ['/web', '/web/session/logout'];
-        return host !== window.location.host || (pathname && backendRoutes.includes(pathname));
+        return host !== window.location.host || (pathname && (backendRoutes.includes(pathname) || pathname.startsWith('/@/')));
     }
 
     _onPageLoaded() {

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -1,0 +1,81 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+
+const testUrl = '/test_client_action_redirect';
+
+const goToFrontendSteps = [{
+    content: "Go to the frontend",
+    trigger: 'body',
+    run: () => {
+        window.location.href = testUrl;
+    },
+}, {
+    content: "Check we are in the frontend",
+    trigger: 'body:not(:has(.o_website_preview)) #test_contact_FE',
+    run: () => null, // it's a check
+}];
+const goToBackendSteps = [{
+    content: "Go to the backend",
+    trigger: 'body',
+    run: () => {
+        window.location.href = `/@${testUrl}`;
+    },
+}, {
+    content: "Check we are in the backend",
+    trigger: '.o_website_preview',
+    run: () => null, // it's a check
+}];
+const checkEditorSteps = [{
+    content: "Check that the editor is loaded",
+    trigger: 'iframe body.editor_enable',
+    timeout: 30000,
+    run: () => null, // it's a check
+}, {
+    content: "exit edit mode",
+    trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',
+}, {
+    content: "wait for editor to close",
+    trigger: 'iframe body:not(.editor_enable)',
+    run: () => null, // It's a check
+}];
+
+tour.register('client_action_redirect', {
+    test: true,
+    url: testUrl,
+},
+[
+    // Case 1: From frontend, click on `enable_editor=1` link without `/@/` in it
+    ...goToFrontendSteps,
+    {
+        content: "Click on the link to frontend",
+        trigger: '#test_contact_FE',
+    },
+    ...checkEditorSteps,
+
+    // Case 2: From frontend, click on `enable_editor=1` link with `/@/` in it
+    ...goToFrontendSteps,
+    {
+        content: "Click on the link to backend",
+        trigger: '#test_contact_BE',
+    },
+    ...checkEditorSteps,
+
+    // Case 3: From backend, click on `enable_editor=1` link without `/@/` in it
+    // TODO: This will be fixed in another fix related to the listening of the
+    //       URL changes from the client action.
+    // ...goToBackendSteps,
+    // {
+    //     content: "Click on the link to frontend (2)",
+    //     trigger: 'iframe #test_contact_FR',
+    // },
+    // ...checkEditorSteps,
+
+    // Case 4: From backend, click on `enable_editor=1` link with `/@/` in it
+    ...goToBackendSteps,
+    {
+        content: "Click on the link to backend (2)",
+        trigger: 'iframe #test_contact_BE',
+    },
+    ...checkEditorSteps,
+]);

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_attachment
 from . import test_auth_signup_uninvited
 from . import test_automatic_editor
 from . import test_base_url
+from . import test_client_action
 from . import test_configurator
 from . import test_controllers
 from . import test_converter

--- a/addons/website/tests/test_client_action.py
+++ b/addons/website/tests/test_client_action.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestClientAction(odoo.tests.HttpCase):
+
+    def test_01_client_action_redirect(self):
+        page = self.env['website.page'].create({
+            'name': 'Base',
+            'type': 'qweb',
+            'arch': """
+                <t t-call="website.layout">
+                    <a id="test_contact_BE" href="/@/contactus?enable_editor=1">Contact</a>
+                    <a id="test_contact_FE" href="/contactus?enable_editor=1">Contact</a>
+                </t>
+            """,
+            'key': 'website.test_client_action_redirect',
+            'url': '/test_client_action_redirect',
+            'is_published': True,
+        })
+        self.start_tour(page.url, 'client_action_redirect', login='admin')


### PR DESCRIPTION
Since frontend to backend commit [1], links having `enable_editor=1` to
enable edit mode were not working anymore in certain cases.

Case 1 [OK]*:
From frontend, click on `enable_editor=1` link without `/@/` in it.

Case 2 [OK]:
From frontend, click on `enable_editor=1` link with `/@/` in it.

Case 3 [KO]*:
From backend, click on `enable_editor=1` link without `/@/` in it.

Case 4 [KO]:
From backend, click on `enable_editor=1` link with `/@/` in it.

This commit fixes case 4 and adds a test for all cases, while leaving
case 3 commented as it will be fixed later with a larger fix related to
URL change listener.

\* Note that we will probably change the behavior for case 1 and 3: if
  the version with /@/ + enable_editor=1 enters edit mode properly in
  both frontend and backend contexts (case 2 and 4), it's probably not
  worth having code to support case 1 and 3.

The issue for case 4 was that it was trying to load the whole Odoo app
inside of website preview iframe instead of making the parent window
load that URL.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b
