### PR TITLE
[13.0][FIX] l10n_es: Remove non existing field country_id

### DIFF
--- a/addons/l10n_es/data/account_data.xml
+++ b/addons/l10n_es/data/account_data.xml
@@ -68,7 +68,6 @@
         </record>
         <record id="tax_group_iva_5" model="account.tax.group">
             <field name="name">IVA 5%</field>
-            <field name="country_id" ref="base.es"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
The tax group in version 13 doesn't have country_id field yet.

Oversight of 4aa3c140be387ea9e33f617b599f94543cf55918.

@Tecnativa