### PR TITLE
[FIX] mail: hide stat-buttons in activity popup form

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -99,7 +99,7 @@
         <field name="arch" type="xml">
             <form string="Log an Activity" create="false">
                 <sheet string="Activity">
-                    <div class="oe_button_box" name="button_box">
+                    <div class="oe_button_box" name="button_box" invisible="1">
                         <button name="action_open_document" string="Open Document"
                                 type="object" class="oe_link" icon="fa-file-text-o"
                                 attrs="{'invisible': ['|', ('res_model', '=', False), ('res_id', '=', 0)]}"/>
@@ -165,6 +165,9 @@
                 <field name="res_name" readonly="1" string="Document"/>
             </field>
             <footer position="replace"/>
+            <xpath expr="//div[hasclass('oe_button_box')]" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Small oversight of: 4c6a010730423a2aa7b19b61d2fcd8f07a630af6

This commit simply hides the stat-buttons when the mail.activity is opened in
the popup form.

When in that popup form, you don't want to switch your context, especially
considering the only button currently available allows you to open the related
document (from which you just opened the activity popup form, creating a loop).

Task-2920490

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
