### PR TITLE
[FIX] project:  hide milestone option from burger menu

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -826,7 +826,7 @@
                                                 <div role="menuitem">
                                                     <a name="action_view_tasks" type="object">Tasks</a>
                                                 </div>
-                                                <div role="menuitem">
+                                                <div role="menuitem" groups="project.group_project_milestone">
                                                     <a name="action_get_list_view" type="object">Milestones</a>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Before this commit,  milestone is still showing in project burger menu even
when we disable the milestone feature.

In this commit, add groups on milestone option on project burger menu.

task-2918411