### PR TITLE
14.0 IMP pad_project: Allow pad editing in sharing mode.

### DIFF
--- a/addons/pad_project/models/project.py
+++ b/addons/pad_project/models/project.py
@@ -3,6 +3,19 @@
 
 from odoo import api, fields, models
 
+PROJECT_TASK_READABLE_FIELDS = {
+    "description",
+    "description_pad",
+    "use_pad"
+}
+
+
+PROJECT_TASK_WRITABLE_FIELDS = {
+    "description",
+    "description_pad",
+    "use_pad"
+}
+
 
 class ProjectTask(models.Model):
     _name = "project.task"
@@ -51,6 +64,14 @@ class ProjectTask(models.Model):
         """
         self.ensure_one()
         return self.pad_get_content(self.description_pad)
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return PROJECT_TASK_READABLE_FIELDS | super().SELF_READABLE_FIELDS
+
+    @property
+    def SELF_WRITABLE_FIELDS(self):
+        return PROJECT_TASK_WRITABLE_FIELDS | super().SELF_WRITABLE_FIELDS
 
 
 class ProjectProject(models.Model):

--- a/addons/pad_project/views/project_sharing_views.xml
+++ b/addons/pad_project/views/project_sharing_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="project_task_portal_description_form" model="ir.ui.view">
+        <field
+            name="inherit_id"
+            ref="project.project_sharing_project_task_view_form"
+        />
+        <field name="name">project.task.description.portal.form</field>
+        <field name="model">project.task</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='description']" position="attributes">
+                <attribute name="attrs">{'invisible': [('use_pad', '=', True)], 'readonly': [('use_pad', '=', True)]}</attribute>
+            </xpath>
+            <field name="description" position="after">
+                <field name="use_pad" invisible="1"/>
+                <field name="description_pad" widget="pad" options="{'collaborative': true}" attrs="{'invisible': [('use_pad', '=', False)], 'readonly': [('use_pad', '=', False)]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If you activate pad project, the pad is not editable in the sharing workflow.

Current behavior before PR:
Pad cannot be edited.

Desired behavior after PR is merged:
Pad can be edited in the sharing mode.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
