### PR TITLE
[FIX] project,website{_form_project}: reduce loading of project sharing

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -205,7 +205,7 @@ class ProjectCustomerPortal(CustomerPortal):
         project = request.env['project.project'].sudo().browse(project_id)
         if not project.exists() or not project.with_user(request.env.user)._check_project_sharing_access():
             return request.not_found()
-
+        request.session['project_sharing'] = True
         return request.render(
             'project.project_sharing_embed',
             {'session_info': self._prepare_project_sharing_session_info(project)},

--- a/addons/website/models/ir_asset.py
+++ b/addons/website/models/ir_asset.py
@@ -17,11 +17,17 @@ class IrAsset(models.Model):
         assets = super()._get_related_assets(domain)
         return assets.filter_duplicate()
 
+    def _get_active_addons_list_skip_theme(self):
+        return False
+
     def _get_active_addons_list(self):
         """Overridden to discard inactive themes."""
         addons_list = super()._get_active_addons_list()
-        website = self.env['website'].get_current_website(fallback=False)
 
+        if self._get_active_addons_list_skip_theme():
+            return addons_list
+
+        website = self.env['website'].get_current_website(fallback=False)
         if not website:
             return addons_list
 

--- a/addons/website_form_project/models/__init__.py
+++ b/addons/website_form_project/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
+from . import ir_assets

--- a/addons/website_form_project/models/ir_assets.py
+++ b/addons/website_form_project/models/ir_assets.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.http import request
+
+
+class IrAsset(models.Model):
+    _inherit = 'ir.asset'
+
+    def _get_active_addons_list_skip_theme(self):
+        if request and request.session.get('project_sharing'):
+            return True
+        return super()._get_active_addons_list_skip_theme()


### PR DESCRIPTION
Before this commit, when the user enters in the project sharing feature
by clicking on a project in its portal view and he has the edit access,
the project sharing feature takes several seconds to appear because the
project sharing webclient has to be loaded. During the creation of the
session info for the project sharing feature, the website themes are
also loaded, those themes are useless in the iframe displayed the
backend for project sharing feature.

This commit avoids fetching the website theme for the project sharing
feature to reduce the number of queries by 1600 and reduce by 1 second
in the controller in which the project sharing feature is rendered.

task-2909059

Co-Authored-By: Xavier Bol (xbo) <xbo@odoo.com>

