### PR TITLE
[FIX] mail: force partner's lang for button in emails

### DIFF
--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -64,6 +64,7 @@ class MailTestLang(models.Model):
     name = fields.Char()
     email_from = fields.Char()
     customer_id = fields.Many2one('res.partner')
+    partner_id = fields.Many2one('res.partner')
     lang = fields.Char('Lang')
 
     def _notify_get_recipients_groups(self, msg_vals=None):


### PR DESCRIPTION
Email Access buttons (e.g. "View Task") must be in partner's language and not current user's language
