### PR TITLE
[FIX] uom: add sudo when accessing ir.model.data

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -243,7 +243,7 @@ class UoM(models.Model):
 
     def _filter_protected_uoms(self):
         """Verifies self does not contain protected uoms."""
-        linked_model_data = self.env['ir.model.data'].search([
+        linked_model_data = self.env['ir.model.data'].sudo().search([
             ('model', '=', self._name),
             ('res_id', 'in', self.ids),
             ('module', '=', 'uom'),


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a user with only  "Inventory/Administrator" access right
- Connect with this user
- Go to Inventory/Configuration/UoM Categories
- Try to add/delete/change any unit of measure in any category

Problem:
an access error is triggered `You are not allowed to access 'Model Data'
(ir.model.data) records.`

opw-2905840



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
