### PR TITLE
[IMP] mail, *: always add activity menu item during tests

### DIFF
--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -1,11 +1,8 @@
 /** @odoo-module **/
 
 import { start, startServer } from '@mail/../tests/helpers/test_utils';
-import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 
-import { Items as legacySystrayItems } from 'web.SystrayMenu';
 import testUtils from 'web.test_utils';
-import { registerCleanup } from '@web/../tests/helpers/cleanup';
 import { patchDate, patchWithCleanup } from "@web/../tests/helpers/utils";
 
 QUnit.module('calendar', {}, function () {
@@ -31,8 +28,6 @@ QUnit.test('activity menu widget:today meetings', async function (assert) {
             attendee_ids: [calendarAttendeeId1],
         },
     ]);
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => legacySystrayItems.pop());
     const { env } = await start();
     assert.containsOnce(document.body, '.o_mail_systray_item', 'should contain an instance of widget');
 

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -8,17 +8,21 @@ import { ChatWindowManagerContainer } from '@mail/components/chat_window_manager
 import { DialogManagerContainer } from '@mail/components/dialog_manager_container/dialog_manager_container';
 import { DiscussContainer } from '@mail/components/discuss_container/discuss_container';
 import { PopoverManagerContainer } from '@mail/components/popover_manager_container/popover_manager_container';
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 import { messagingService } from '@mail/services/messaging_service';
 import { systrayService } from '@mail/services/systray_service';
 import { makeMessagingToLegacyEnv } from '@mail/utils/make_messaging_to_legacy_env';
 
 import { registry } from '@web/core/registry';
+import { Items as legacySystrayItems } from 'web.SystrayMenu';
+import { registerCleanup } from '@web/../tests/helpers/cleanup';
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 
 const WEBCLIENT_LOAD_ROUTES = [
     '/web/webclient/load_menus',
     '/web/dataset/call_kw/res.users/load_views',
+    '/web/dataset/call_kw/res.users/systray_get_activities'
 ];
 const WEBCLIENT_PARAMETER_NAMES = new Set(['legacyParams', 'mockRPC', 'serverData', 'target', 'webClientClass']);
 const SERVICES_PARAMETER_NAMES = new Set([
@@ -129,6 +133,14 @@ function setupMessagingServiceRegistries({
  */
  async function getWebClientReady(param0) {
     setupMainComponentRegistry();
+
+    legacySystrayItems.push(ActivityMenu);
+    registerCleanup(() => {
+        const activityMenuIndex = legacySystrayItems.indexOf(ActivityMenu);
+        if (activityMenuIndex !== -1) {
+            legacySystrayItems.splice(activityMenuIndex, 1);
+        }
+    });
 
     const servicesParameters = {};
     const param0Entries = Object.entries(param0);

--- a/addons/note/static/tests/systray_activity_menu_tests.js
+++ b/addons/note/static/tests/systray_activity_menu_tests.js
@@ -1,20 +1,14 @@
 /** @odoo-module **/
 
-import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 import { start } from '@mail/../tests/helpers/test_utils';
 
-import { Items as legacySystrayItems } from 'web.SystrayMenu';
 import testUtils from 'web.test_utils';
-import { registerCleanup } from '@web/../tests/helpers/cleanup';
 
 QUnit.module('note', {}, function () {
 QUnit.module("ActivityMenu");
 
 QUnit.test('note activity menu widget: create note from activity menu', async function (assert) {
     assert.expect(15);
-
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => legacySystrayItems.pop());
 
     await start();
     assert.containsOnce(document.body, '.o_mail_systray_item',

--- a/addons/test_mail/static/tests/systray_activity_menu_tests.js
+++ b/addons/test_mail/static/tests/systray_activity_menu_tests.js
@@ -1,16 +1,13 @@
 /** @odoo-module **/
 
-import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 import {
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
 
 import session from 'web.session';
-import { Items as legacySystrayItems } from 'web.SystrayMenu';
 import testUtils from 'web.test_utils';
 import { date_to_str } from 'web.time';
-import { registerCleanup } from '@web/../tests/helpers/cleanup';
 import { patchWithCleanup } from '@web/../tests/helpers/utils';
 
 
@@ -37,8 +34,6 @@ QUnit.module('systray_activity_menu_tests.js', {
 QUnit.test('activity menu widget: menu with no records', async function (assert) {
     assert.expect(1);
 
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => legacySystrayItems.pop());
     await start({
         mockRPC: function (route, args) {
             if (args.method === 'systray_get_activities') {
@@ -53,8 +48,6 @@ QUnit.test('activity menu widget: menu with no records', async function (assert)
 QUnit.test('activity menu widget: activity menu with 2 models', async function (assert) {
     assert.expect(10);
 
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => legacySystrayItems.pop());
     const { env } = await start();
 
     await testUtils.nextTick();
@@ -108,8 +101,6 @@ QUnit.test('activity menu widget: activity view icon', async function (assert) {
     assert.expect(14);
 
     patchWithCleanup(session, { uid: 10 });
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => legacySystrayItems.pop());
     const { env } = await start();
     await testUtils.nextTick();
     assert.containsN(document.body, '.o_mail_activity_action', 2,
@@ -160,8 +151,6 @@ QUnit.test('activity menu widget: activity view icon', async function (assert) {
 QUnit.test('activity menu widget: close on messaging menu click', async function (assert) {
     assert.expect(2);
 
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => legacySystrayItems.pop());
     const { click } = await start();
     await testUtils.nextTick();
 


### PR DESCRIPTION
*: calendar, note, test_mail.

In order to ease testing and to prepare for the ActivityMenu widget to be
converted into a component, let's add the sytray menu item into the registry
systematically when using the start helper.

enterprise: https://github.com/odoo/enterprise/pull/29529