### PR TITLE
[FIX] board: Allow users to add mrp and stock view to dashboard

### DIFF
--- a/addons/board/static/src/js/board_view.js
+++ b/addons/board/static/src/js/board_view.js
@@ -246,7 +246,7 @@ var BoardRenderer = FormRenderer.extend({
                     // the action does not exist anymore
                     return Promise.resolve();
                 }
-                var evalContext = new Context(params.context).eval();
+                var evalContext = new Context(session.user_context, params.context).eval();
                 if (evalContext.group_by && evalContext.group_by.length === 0) {
                     delete evalContext.group_by;
                 }


### PR DESCRIPTION
Steps:
- Go to inventory
- Transfers
- Add to dashboard
- Open dashboard
- traceback

These views use allowed_company_ids but this key is not present in
params/action context.

Instead of adding it in the window action like here https://github.com/odoo/odoo/pull/88851
we can use the `session.user_context`.

opw-2908348