### PR TITLE
[FIX] web: fix useService binding service methods when it should not

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -161,12 +161,12 @@ export function useListener(eventName, querySelector, handler, options = {}) {
 // useService
 // -----------------------------------------------------------------------------
 
-function _protectMethod(component, caller, fn) {
-    return async (...args) => {
+function _protectMethod(component, fn) {
+    return async function (...args) {
         if (status(component) === "destroyed") {
             throw new Error("Component is destroyed");
         }
-        const result = await fn.call(caller, ...args);
+        const result = await fn.call(this, ...args);
         return status(component) === "destroyed" ? new Promise(() => {}) : result;
     };
 }
@@ -186,12 +186,12 @@ export function useService(serviceName) {
     const service = services[serviceName];
     if (serviceName in SERVICES_METADATA) {
         if (service instanceof Function) {
-            return _protectMethod(component, null, service);
+            return _protectMethod(component, service);
         } else {
             const methods = SERVICES_METADATA[serviceName];
             const result = Object.create(service);
             for (let method of methods) {
-                result[method] = _protectMethod(component, service, service[method]);
+                result[method] = _protectMethod(component, service[method]);
             }
             return result;
         }


### PR DESCRIPTION
Previously, the useService hook would call _protectMethod, which wraps
async methods so that any call to them after the component has been
destroyed throws an error, and any call that was started while the
component was alive but returned after the component was destroyed would
return a pending promise such that no more component code is executed.

In doing so, it would for some reason bind all the methods to the
service, this prevents some functionalities where a method would return
a differently configured version of that same service, on which you can
call the methods again (eg: orm.silent), as the modified service's
methods would not be bound to that modified service.

This commit fixes this issue by not binding the methods eagerly, and
introduces a test for all these behaviours.