### PR TITLE
[FIX] point_of_sale: stuck when offline

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -6,7 +6,7 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
     const { identifyError } = require('point_of_sale.utils');
     const { ConnectionLostError, ConnectionAbortedError} = require('@web/core/network/rpc_service')
 
-    const { onWillStart, onMounted, useState } = owl;
+    const { onWillStart, useState } = owl;
 
     /**
      * This popup needs to be self-dependent because it needs to be called from different place.
@@ -22,7 +22,6 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                 displayMoneyDetailsPopup: false,
             });
             onWillStart(this.onWillStart);
-            onMounted(this.onMounted);
         }
         async onWillStart() {
             try {
@@ -54,22 +53,14 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                 }
                 Object.assign(this.state, state);
             } catch (error) {
-                this.error = error;
-            }
-        }
-        /*
-         * Since this popup need to be self dependent, in case of an error, the popup need to be closed on its own.
-         */
-        onMounted() {
-            if (this.error) {
                 this.cancel();
-                if (identifyError(this.error) instanceof ConnectionLostError) {
+                if (identifyError(error) instanceof ConnectionLostError) {
                     this.showPopup('ErrorPopup', {
                         title: this.env._t('Network Error'),
                         body: this.env._t('Please check your internet connection and try again.'),
                     });
                 } else {
-                    throw this.error;
+                    throw error;
                 }
             }
         }


### PR DESCRIPTION
This only happens after the introduction of PosPopupController.
ProductInfoPopup and ClosePosPopup manages their own error but it's
not compatible with the new controller. Basically after the error
in onWillStart, the renderer will attempt to render the component
but there will be error which results to *not* being able to call
onMounted hook which is responsible in calling error popup.

Furthermore, the PosPopupController is unable to cleanup the original
popup that failed. So the connection returns, all the unshown popups
will show up again.

In this change, we clear the problematic popup by immediately calling
`cancel` and showing the proper error in the onWillStart call stack,
no need for the onMounted hook.

IMPROVEMENT: Perhaps it's better to delegate the management of error
to the component that requests for showing the popup, such that the
popup popup is more or less dumb which only receives props, and not
make it's own rpc during mounting.

To reproduce: https://watch.screencastify.com/v/1LE31gapmkIjTfkB7dTY

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
