### PR TITLE
[FIX] core: complex flushing when searching on one2many fields

### DIFF
--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -70,7 +70,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be = self.env['res.lang']._lang_get('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=177):  # com 166
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=178):  # com 167
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.country_id = country_be


### PR DESCRIPTION
Consider two models A and B, where
 - model A has a many2one_reference field `res_id` with model field `res_model`;
 - model B has an auto-join one2many field `stuff_ids` to A using field `res_id`;
 - the field `res_model` is not flushed on some record.
```
      model     | A                 | B
     -----------+-------------------+-------------------
      memory    | res_model = B     |
     -----------+-------------------+-------------------
      database  | res_model = NULL  | id = 42
                | res_id = 42       |
                | foo = 'bar'       |
```
Now, perform a search on model B that should return record with id=42 by matching some condition on the unflushed record in model A, like:
```py
B.search([('stuff_ids.foo', '=', 'bar')])
```
Before this patch, the search method would not flush the field `res_model`, which causes the method to return incorrect results.  This patch fixes the issue by ensuring that searches on one2many fields flush all the fields on which the one2many field depends.