### PR TITLE
[FIX] web: list exports its resIds and  form can use them for pager

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -381,7 +381,11 @@ export class ViewAdapter extends ActionAdapter {
         if (ev.name === "switch_view") {
             if (payload.view_type === "form") {
                 if (payload.res_id) {
-                    return this.props.selectRecord(payload.res_id, { mode: payload.mode });
+                    const activeIds = this.__widget.model.get(this.__widget.handle).res_ids;
+                    return this.props.selectRecord(payload.res_id, {
+                        mode: payload.mode,
+                        activeIds,
+                    });
                 } else {
                     return this.props.createRecord();
                 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
