### PR TITLE
[IMP] sale, pos_sale: only consider 'paid' order state when defined

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -10,7 +10,7 @@ class SaleReport(models.Model):
     @api.model
     def _get_done_states(self):
         done_states = super()._get_done_states()
-        done_states.extend(['pos_done', 'invoiced'])
+        done_states.extend(['paid', 'pos_done', 'invoiced'])
         return done_states
 
     state = fields.Selection(

--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -13,7 +13,7 @@ class SaleReport(models.Model):
 
     @api.model
     def _get_done_states(self):
-        return ['sale', 'done', 'paid']
+        return ['sale', 'done']
 
     name = fields.Char('Order Reference', readonly=True)
     date = fields.Datetime('Order Date', readonly=True)


### PR DESCRIPTION
The `sale.report` `paid` state is added in `pos_sale` and shouldn't be considered in the standard `sale` code.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr