### PR TITLE
[FIX] sale, mrp, l10n_ar: correct filter on button to pivot view

### DIFF
--- a/addons/l10n_ar/report/invoice_report_view.xml
+++ b/addons/l10n_ar/report/invoice_report_view.xml
@@ -9,6 +9,10 @@
             <search>
                 <field name="l10n_ar_state_id"/>
                 <filter name="with_document" string="With Document" domain="[('l10n_latam_document_type_id', '!=', False)]"/>
+                <separator/>
+                <filter name="filter_date_this_year" string="Accounting Date: This Year" domain="[
+                    ('date', '&gt;=', '(context_today() + relativedelta(month=1, day=1)).strftime('%Y-%m-%d')'),
+                    ('date', '&lt;', '(context_today() + relativedelta(month=1, day=1, years=1)).strftime('%Y-%m-%d')')]"/>
             </search>
             <filter name="user" position="after">
                 <filter string="State" name="groupby_l10n_ar_state_id" context="{'group_by': 'l10n_ar_state_id'}"/>
@@ -21,7 +25,7 @@
         <field name="name">IIBB - Sales by jurisdiction</field>
         <field name="res_model">account.invoice.report</field>
         <field name="view_mode">pivot</field>
-        <field name="context">{'search_default_current': 1, 'search_default_customer': 1, 'search_default_with_document': 1, 'search_default_company': 1, 'search_default_groupby_l10n_ar_state_id': 2, 'search_default_groupby_account_id': 3, 'time_ranges': {'field': 'date', 'range': 'this_year'}}</field>
+        <field name="context">{'search_default_current': 1, 'search_default_customer': 1, 'search_default_with_document': 1, 'search_default_company': 1, 'search_default_groupby_l10n_ar_state_id': 2, 'search_default_groupby_account_id': 3, 'search_default_filter_date_this_year': 1}</field>
     </record>
 
     <menuitem
@@ -34,7 +38,7 @@
         <field name="name">IIBB - Purchases by jurisdiction</field>
         <field name="res_model">account.invoice.report</field>
         <field name="view_mode">pivot</field>
-        <field name="context">{'search_default_current': 1, 'search_default_supplier': 1, 'search_default_with_document': 1, 'search_default_company': 1, 'search_default_groupby_l10n_ar_state_id': 2, 'search_default_groupby_account_id': 3, 'time_ranges': {'field': 'date', 'range': 'this_year'}}</field>
+        <field name="context">{'search_default_current': 1, 'search_default_supplier': 1, 'search_default_with_document': 1, 'search_default_company': 1, 'search_default_groupby_l10n_ar_state_id': 2, 'search_default_groupby_account_id': 3, 'search_default_filter_date_this_year': 1}</field>
     </record>
 
     <menuitem

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -62,7 +62,7 @@ class ProductTemplate(models.Model):
         action['domain'] = [('state', '=', 'done'), ('product_tmpl_id', 'in', self.ids)]
         action['context'] = {
             'graph_measure': 'product_uom_qty',
-            'time_ranges': {'field': 'date_planned_start', 'range': 'last_365_days'}
+            'search_default_filter_date_planned_start_365days': 1,
         }
         return action
 

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -492,6 +492,8 @@
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter name="filter_date_planned_start" string="Scheduled Date" date="date_planned_start"/>
+                    <filter name="filter_date_planned_start_365days" string="Scheduled Date: Last 365 Days" domain="[
+                        ('date_planned_start', '&gt;', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -30,7 +30,8 @@
             <search string="Purchase Orders">
                 <filter string="Requests for Quotation" name="quotes" domain="[('state','in',('draft','sent'))]"/>
                 <filter string="Purchase Orders" name="orders" domain="[('state','!=','draft'), ('state','!=','sent'), ('state','!=','cancel')]"/>
-                <filter string="Confirmation Date Last Year" name="later_than_a_year_ago" domain="[('date_approve', '&gt;=', ((context_today()-relativedelta(years=1)).strftime('%Y-%m-%d')))]"/>
+                <filter string="Confirmation Date: Last Year" name="later_than_a_year_ago" domain="[
+                    ('date_approve', '&gt;=', (datetime.datetime.combine(context_today() - relativedelta(years=1), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                 <filter name="filter_date_order" date="date_order"/>
                 <filter name="filter_date_approve" date="date_approve" default_period="this_month"/>
                 <field name="partner_id"/>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -96,7 +96,7 @@
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
-                        type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
+                        type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last year">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="mr4"/>
@@ -128,7 +128,7 @@
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
-                        type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
+                        type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last year">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="mr4"/>

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -49,8 +49,8 @@ class ProductProduct(models.Model):
             'pivot_measures': ['product_uom_qty'],
             'active_id': self._context.get('active_id'),
             'search_default_Sales': 1,
+            'search_default_filter_date_365days': 1,
             'active_model': 'sale.report',
-            'time_ranges': {'field': 'date', 'range': 'last_365_days'},
         }
         return action
 

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -89,7 +89,7 @@ class ProductTemplate(models.Model):
             'active_id': self._context.get('active_id'),
             'active_model': 'sale.report',
             'search_default_Sales': 1,
-            'time_ranges': {'field': 'date', 'range': 'last_365_days'}
+            'search_default_filter_date_365days': 1,
         }
         return action
 

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -35,6 +35,8 @@
                 <filter name="Sales" string="Sales Orders" domain="[('state','not in',('draft', 'cancel', 'sent'))]"/>
                 <separator/>
                 <filter name="filter_date" date="date" default_period="this_month"/>
+                <filter name="filter_date_365days" string="Order Date: Last 365 Days" domain="[
+                    ('date', '&gt;=', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                 <separator/>
                 <field name="user_id"/>
                 <field name="team_id"/>


### PR DESCRIPTION
The time_ranges / timeRanges context flag is not supported anymore in pivot view.

**Description of the issue/feature this PR addresses:**

Go to a product variant form view for a product that is saleable. The smart button "X Units Sold" shows a quantity. Then click on the button which will open a pivot view. In the pivot view, not appears the sale orders for this year, but also from past years.

This issue also happens in other modules that still have the time_ranges / timeRanges context flag for pivot view.

**Current behavior before PR:**

**Desired behavior after PR is merged:**


Note: It's difficult to reproduce in a recent database as you need products sold / manufactured / invoiced one or more years ago.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr