### PR TITLE
[FIX] stock_accountant: filter input/output account in reco widget

### DIFF
--- a/addons/stock_account/models/account_reconciliation_widget.py
+++ b/addons/stock_account/models/account_reconciliation_widget.py
@@ -9,29 +9,22 @@ class AccountReconciliation(models.AbstractModel):
 
     @api.model
     def _domain_move_lines_for_reconciliation(self, st_line, aml_accounts, partner_id, excluded_ids=None, search_str=False, mode='rp'):
-        def to_int(val):
-            try:
-                return int(val)
-            except (ValueError, TypeError):
-                return None
-
         domain = super()._domain_move_lines_for_reconciliation(
             st_line, aml_accounts, partner_id, excluded_ids=excluded_ids, search_str=search_str, mode=mode
         )
-        acc_props = (
+        account_stock_properties_names = [
             "property_stock_account_input",
             "property_stock_account_output",
             "property_stock_account_input_categ_id",
             "property_stock_account_output_categ_id",
-        )
-        acc_ids = [
-            (acc["value_reference"] or "").split(",")[-1]
-            for acc in self.env["ir.property"]
-            .sudo()
-            .search([("name", "in", acc_props), ("value_reference", "!=", False)])
-            .read(["value_reference"])
-            if to_int((acc["value_reference"] or "").split(",")[-1])
         ]
-        if acc_ids:
-            domain = expression.AND([domain, [("account_id.id", "not in", acc_ids)]])
+        properties = self.env['ir.property'].sudo().search([
+            ('name', 'in', account_stock_properties_names),
+            ('company_id', '=', self.env.company.id),
+            ('value_reference', '!=', False),
+        ])
+
+        if properties:
+            accounts = properties.mapped(lambda p: p.get_by_record())
+            domain.append(('account_id', 'not in', tuple(accounts.ids)))
         return domain

--- a/addons/stock_account/tests/__init__.py
+++ b/addons/stock_account/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_anglo_saxon_valuation_reconciliation_common
 from . import test_stockvaluation
 from . import test_stockvaluationlayer
+from . import test_reconciliation_widget

--- a/addons/stock_account/tests/test_reconciliation_widget.py
+++ b/addons/stock_account/tests/test_reconciliation_widget.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCase
+from odoo.tests.common import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReconciliationWidget(ValuationReconciliationTestCase):
+
+    def test_no_stock_account_in_reconciliation_proposition(self):
+        """
+        We check if no stock interim account is present in the reconcialiation proposition,
+        with both standard and custom stock accounts
+        """
+        avco_1 = self._create_product_category().copy({'property_cost_method': 'average'})
+
+        # We need a product category with custom stock accounts
+        avco_2 = self._create_product_category().copy({
+            'property_cost_method': 'average',
+            'property_stock_account_input_categ_id': self.input_account.copy().id,
+            'property_stock_account_output_categ_id': self.output_account.copy().id,
+            'property_stock_journal': avco_1.property_stock_journal.copy(),
+            'property_stock_valuation_account_id': self.valuation_account.copy().id
+        })
+
+        move_1, move_2 = self.env['account.move'].create([
+            {
+                'type': 'entry',
+                'name': 'Entry 1',
+                'journal_id': avco_1.property_stock_journal.id,
+                'line_ids': [
+                    (0, 0, {
+                        'account_id': avco_1.property_stock_account_input_categ_id.id,
+                        'debit': 0.0,
+                        'credit': 100.0
+                    }),
+                    (0, 0, {
+                        'account_id': avco_1.property_stock_valuation_account_id.id,
+                        'debit': 100.0,
+                        'credit': 0.0
+                    })
+                ]
+            },
+            {
+                'type': 'entry',
+                'name': 'Entry 2',
+                'journal_id': avco_2.property_stock_journal.id,
+                'line_ids': [
+                    (0, 0, {
+                        'account_id': avco_2.property_stock_account_input_categ_id.id,
+                        'debit': 0.0,
+                        'credit': 100.0
+                    }),
+                    (0, 0, {
+                        'account_id': avco_2.property_stock_valuation_account_id.id,
+                        'debit': 100.0,
+                        'credit': 0.0
+                    })
+                ]
+            },
+        ])
+
+        (move_1 + move_2).action_post()
+
+        bank_journal = self.env['account.journal'].create({'name': 'Test Bank Journal', 'type': 'bank'})
+
+        statement = self.env['account.bank.statement'].create({
+            'journal_id': bank_journal.id,
+            'balance_start': 0.0,
+            'balance_end': -100.0,
+            'balance_end_real': -100.0,
+            'line_ids': [(0, 0, {'name': 'test', 'ref': 'test', 'amount': -100.0})]
+        })
+
+        statement.button_open()
+
+        res = self.env['account.reconciliation.widget'].get_move_lines_for_bank_statement_line(statement.line_ids.id, excluded_ids=[])
+        stock_accounts_code = (
+            avco_1.property_stock_account_input_categ_id + avco_2.property_stock_account_input_categ_id
+            + avco_1.property_stock_account_output_categ_id + avco_2.property_stock_account_output_categ_id
+        ).mapped('code')
+        stock_res = [line for line in res if line['account_code'] in stock_accounts_code]
+        self.assertEqual(len(stock_res), 0)


### PR DESCRIPTION
Backport of [0a8aa0d48b17d2d428941b3bd11aca5d0a3422e9](https://github.com/odoo/enterprise/commit/0a8aa0d48b17d2d428941b3bd11aca5d0a3422e9)

Don't show the stock input/output accounts
in the reconciliation widget.

Steps to reproduce:

- A product category PC, costing method AVCO,
  automated valuation and custom stock input(STI)/output(STO)
  account (reconcile = True)
- A Journal Entry with the STI
  Move line :
  | Account | Debit | Credit |
  |---------|-------|--------|
  |   STI   |  0.0  |  50.0  |
  | XXXXXXX |  50.0 |   0.0  |

- Create a bank statement with amount corresponding with
  the journal entry then reconcile
-> Line for custom stock input STI account shows up in misc tab
   on reconciliation widget

Fetch all accounts relative to stock accounts properties, then
filter them in the domain.

opw-2792862

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
