### PR TITLE
[FIX][15.0]project: fix access right project_collaborator

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -339,7 +339,7 @@ class Project(models.Model):
 
     # Project Sharing fields
     collaborator_ids = fields.One2many('project.collaborator', 'project_id', string='Collaborators', copy=False)
-    collaborator_count = fields.Integer('# Collaborators', compute='_compute_collaborator_count')
+    collaborator_count = fields.Integer('# Collaborators', compute='_compute_collaborator_count', compute_sudo=True)
 
     # rating fields
     rating_request_deadline = fields.Datetime(compute='_compute_rating_request_deadline', store=True)


### PR DESCRIPTION
- We should grant access right project.collaborator to internal user group, i think it only is typing mistake.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
