### PR TITLE
[IMP] project,**: improve generic UX for project

### DIFF
--- a/addons/hr_timesheet/views/project_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_sharing_views.xml
@@ -6,9 +6,11 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.project_sharing_project_task_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='child_ids']/tree/field[@name='kanban_state']" position="after">
+            <xpath expr="//field[@name='child_ids']/tree/field[@name='portal_user_names']" position="after">
                 <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide"/>
                 <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
+                <field name="subtask_effective_hours" string="Sub-tasks Hours Spent" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide"/>
+                <field name="total_hours_spent" string="Total Hours" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
                 <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100"/>
                 <field name="progress" widget="progressbar" optional="hide"/>
             </xpath>
@@ -146,12 +148,24 @@
                 <field name="allow_subtasks" invisible="1"/>
                 <field name="allow_timesheets" invisible="1"/>
                 <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
-                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
-                <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
+                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
                 <field name="subtask_effective_hours" widget="timesheet_uom" attrs="{'column_invisible' : ['|', ('allow_subtasks', '=', False), ('allow_timesheets', '=', False)]}" optional="hide"/>
                 <field name="total_hours_spent" widget="timesheet_uom" attrs="{'column_invisible' : ['|', ('allow_subtasks', '=', False), ('allow_timesheets', '=', False)]}" optional="hide"/>
-                <field name="progress" widget="progressbar" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}" optional="show"/>
+                <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
+                <field name="progress" widget="progressbar" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}" optional="hide"/>
             </field>
+        </field>
+    </record>
+
+    <record id="project_sharing_project_task_view_search_inherit_timesheet" model="ir.ui.view">
+        <field name="name">project.sharing.project.task.view.search.inherit.timesheet</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.project_sharing_project_task_view_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='late']" position='after'>
+                <filter string="Tasks in Overtime" name="overtime" domain="[('overtime', '&gt;', 0)]"/>
+                <filter string="Tasks Soon in Overtime" name="remaining_hours_percentage" domain="[('remaining_hours_percentage', '&lt;=', 0.2)]"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -227,9 +227,13 @@
                                    attrs="{'invisible' : ['|', ('allow_subtasks', '=', False), ('subtask_effective_hours', '=', 0.0)]}" />
                             <span>
                                 <label class="fw-bold" for="remaining_hours" string="Remaining Hours"
-                                       attrs="{'invisible': ['|', ('planned_hours', '=', 0.0), ('encode_uom_in_days', '=', True)]}"/>
+                                       attrs="{'invisible': ['|', '|', ('planned_hours', '=', 0.0), ('encode_uom_in_days', '=', True), ('remaining_hours', '&lt;', 0)]}"/>
                                 <label class="fw-bold" for="remaining_hours" string="Remaining Days"
-                                       attrs="{'invisible': ['|', ('planned_hours', '=', 0.0), ('encode_uom_in_days', '=', False)]}"/>
+                                       attrs="{'invisible': ['|', '|', ('planned_hours', '=', 0.0), ('encode_uom_in_days', '=', False), ('remaining_hours', '&lt;', 0)]}"/>
+                                <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Hours"
+                                       attrs="{'invisible': ['|', '|', ('planned_hours', '=', 0.0), ('encode_uom_in_days', '=', True), ('remaining_hours', '&gt;=', 0)]}"/>
+                                <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Days"
+                                       attrs="{'invisible': ['|', '|', ('planned_hours', '=', 0.0), ('encode_uom_in_days', '=', False), ('remaining_hours', '&gt;=', 0)]}"/>
                             </span>
                             <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
                                    attrs="{'invisible' : [('planned_hours', '=', 0.0)]}" nolabel="1"/>
@@ -271,11 +275,11 @@
                     <field name="allow_subtasks" invisible="1"/>
                     <field name="progress" invisible="1"/>
                     <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
                     <field name="subtask_effective_hours" widget="timesheet_uom" attrs="{'invisible' : [('allow_subtasks', '=', False)]}" optional="hide"/>
                     <field name="total_hours_spent" widget="timesheet_uom" attrs="{'invisible' : [('allow_subtasks', '=', False)]}" optional="hide"/>
                     <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100"/>
-                    <field name="progress" widget="progressbar" optional="show" groups="hr_timesheet.group_hr_timesheet_user" attrs="{'invisible' : [('planned_hours', '=', 0)]}"/>
+                    <field name="progress" widget="progressbar" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" attrs="{'invisible' : [('planned_hours', '=', 0)]}"/>
                 </field>
             </field>
         </record>
@@ -347,7 +351,7 @@
                     <filter string="My Team's Tasks" name="my_team_tasks" domain="[('user_ids.employee_parent_id.user_id', '=', uid)]"/>
                     <filter string="My Department's Tasks" name="my_department" domain="[('user_ids.employee_id.member_of_department', '=', True)]"/>
                 </xpath>
-                <xpath expr="//filter[@name='late']" position='after'>
+                <xpath expr="//filter[@name='tasks_due_today']" position='after'>
                     <filter string="Tasks in Overtime" name="overtime" domain="[('overtime', '&gt;', 0)]"/>
                     <filter string="Tasks Soon in Overtime" name="remaining_hours_percentage" domain="[('remaining_hours_percentage', '&lt;=', 0.2)]"/>
                 </xpath>

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -135,7 +135,7 @@
                 <field name="portal_user_names" string="Assignees" optional="show"/>
                 <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible': [('is_closed', '=', True)]}"/>
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
-                <field name="kanban_state" widget="state_selection" optional="hide"/>
+                <field name="kanban_state" widget="state_selection" options="{'hide_label': True}" nolabel="1" optional="show"/>
                 <field name="legend_blocked" invisible="1"/>
                 <field name="legend_normal" invisible="1"/>
                 <field name="legend_done" invisible="1"/>
@@ -220,6 +220,7 @@
                                     <field name="project_id" invisible="1"/>
                                     <field name="is_closed" invisible="1"/>
                                     <field name="sequence" widget="handle"/>
+                                    <field name="priority" widget="priority" optional="show" nolabel="1"/>
                                     <field name="name"/>
                                     <field name="display_project_id" string="Project" optional="hide" invisible="1"/>
                                     <field name="allow_milestones" invisible="1"/>
@@ -231,10 +232,10 @@
                                     <field name="company_id" invisible="1"/>
                                     <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide"/>
                                     <field name="user_ids" invisible="1" />
-                                    <field name="portal_user_names" string="Assignees"/>
+                                    <field name="portal_user_names" string="Assignees" optional="show"/>
                                     <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}" optional="show"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
-                                    <field name="kanban_state" widget="state_selection" optional="hide"/>
+                                    <field name="kanban_state" widget="state_selection" options="{'hide_label': True}" nolabel="1" optional="show"/>
                                     <field name="stage_id" optional="show"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link float-end"
                                             context="{'form_view_ref': 'project.project_sharing_project_task_view_form'}"
@@ -258,16 +259,23 @@
                 <field name="name" string="Task"/>
                 <field name="tag_ids"/>
                 <field name="portal_user_names" string="Assignees"/>
-                <field name="partner_id" operator="child_of"/>
-                <field name="stage_id"/>
                 <field string="Project" name="display_project_id"/>
                 <field name="milestone_id" groups="project.group_project_milestone"/>
+                <field name="stage_id"/>
+                <field name="partner_id" operator="child_of"/>
                 <filter string="Unassigned" name="unassigned" domain="[('user_ids', '=', False)]"/>
                 <separator/>
                 <filter string="High Priority" name="high_priority" domain="[('priority', '=', 1)]"/>
                 <filter string="Low Priority" name="low_priority" domain="[('priority', '=', 0)]"/>
                 <separator/>
                 <filter string="Late Tasks" name="late" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d')), ('is_closed', '=', False)]"/>
+                <filter string="Tasks Due Today" name="tasks_due_today" domain="[('date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
+                <filter string="Late Milestones" name="late_milestone" domain="[('is_closed', '=', False), ('has_late_and_unreached_milestone', '=', True)]" groups="project.group_project_milestone"/>
+                <separator/>
+                <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', False)]"/>
+                <filter string="Closed Tasks" name="closed_tasks" domain="[('is_closed', '=', True)]"/>
+                <filter string="Closed Last 7 Days" name="closed_last_7_days" domain="[('is_closed', '=', True), ('date_last_stage_update', '&gt;', datetime.datetime.now() - relativedelta(days=7))]"/>
+                <filter string="Closed Last 30 Days" name="closed_last_30_days" domain="[('is_closed', '=', True), ('date_last_stage_update', '&gt;', datetime.datetime.now() - relativedelta(days=30))]"/>
                 <separator/>
                 <filter invisible="1" string="Today Activities" name="activities_today"
                     domain="[('activity_ids.date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -33,18 +33,15 @@
                     <filter string="High Priority" name="high_priority" domain="[('priority', '=', 1)]"/>
                     <filter string="Low Priority" name="low_priority" domain="[('priority', '=', 0)]"/>
                     <separator/>
-                    <filter string="Starred" name="starred" domain="[('priority', '=', 1)]"/>
-                    <filter string="Not Starred" name="not_starred" domain="[('priority', '=', 0)]"/>
-                    <separator/>
-                    <filter string="Tasks Due Today" name="tasks_due_today" domain="[('date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
-                    <filter string="Late Milestones" name="late_milestone" domain="[('is_closed', '=', False), ('has_late_and_unreached_milestone', '=', True)]" groups="project.group_project_milestone"/>
                     <filter string="Blocked" name="blocked" domain="[('is_blocked', '=', True)]" groups="project.group_project_task_dependencies"/>
                     <filter string="Not Blocked" name="not_blocked" domain="[('is_blocked', '=', False), ('is_private', '=', False)]" groups="project.group_project_task_dependencies"/>
                     <separator groups="project.group_project_task_dependencies"/>
                     <filter string="Blocking" name="blocking" domain="[('is_closed', '=', False), ('dependent_ids', '!=', False)]" groups="project.group_project_task_dependencies"/>
                     <filter string="Not Blocking" name="not_blocking" domain="['|', ('is_closed', '=', True), ('dependent_ids', '=', False), ('is_private', '=', False)]" groups="project.group_project_task_dependencies"/>
                     <separator groups="project.group_project_task_dependencies"/>
+                    <filter string="Late Milestones" name="late_milestone" domain="[('is_closed', '=', False), ('has_late_and_unreached_milestone', '=', True)]" groups="project.group_project_milestone"/>
                     <filter string="Late Tasks" name="late" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d')), ('is_closed', '=', False)]"/>
+                    <filter string="Tasks Due Today" name="tasks_due_today" domain="[('date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter string="Stalling for 30 Days+" name="stall_last_30_days" domain="[('is_closed', '=', False), ('date_last_stage_update', '&lt;=', datetime.datetime.now() - relativedelta(days=30))]"/>
                     <separator/>
                     <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', False)]"/>

--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -29,7 +29,7 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.project_sharing_project_task_view_search"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='partner_id']" position="before">
+            <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="sale_order_id" string="Sale Order" filter_domain="['|', ('sale_order_id', 'ilike', self), ('sale_line_id', 'ilike', self)]"/>
             </xpath>
             <xpath expr="//group/filter[@name='customer']" position="after">

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -102,8 +102,8 @@
                 <field name="allow_billable" invisible="1"/>
                 <group attrs="{'invisible': [('allow_billable', '=', False)]}">
                     <field name="project_partner_id" invisible="1"/>
-                    <field name="sale_line_id" groups="!sales_team.group_sale_salesman" options="{'no_open': True}" readonly="1"/>
-                    <field name="sale_line_id" groups="sales_team.group_sale_salesman" options="{'no_create': True}" readonly="0"/>
+                    <field name="sale_line_id" groups="!sales_team.group_sale_salesman" placeholder="Non-billable" options="{'no_open': True}" readonly="1"/>
+                    <field name="sale_line_id" groups="sales_team.group_sale_salesman" options="{'no_create': True}" placeholder="Non-billable" readonly="0"/>
                     <field name="quantity_percentage" groups="!sales_team.group_sale_salesman" widget="percentage" readonly="1"/>
                     <field name="quantity_percentage" groups="sales_team.group_sale_salesman" widget="percentage" readonly="0"/>
                 </group>
@@ -120,8 +120,8 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="project_partner_id" invisible="1"/>
                 <field name="allow_billable" invisible="1"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
-                <field name="sale_line_id" optional="hide" options="{'no_create': True}" groups="sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" placeholder="Non-billable" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" optional="hide" options="{'no_create': True}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
                 <field name="quantity_percentage" optional="hide" widget="percentage" readonly="1" groups="!sales_team.group_sale_salesman"/>
                 <field name="quantity_percentage" optional="hide" widget="percentage" groups="sales_team.group_sale_salesman"/>
             </xpath>

--- a/addons/sale_purchase/models/product_template.py
+++ b/addons/sale_purchase/models/product_template.py
@@ -9,23 +9,29 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     service_to_purchase = fields.Boolean(
-        "Subcontract Service",
-        compute='_compute_service_to_purchase', store=True, readonly=False,
+        "Subcontract Service", company_dependent=True,
         help="If ticked, each time you sell this product through a SO, a RfQ is automatically created to buy the product. Tip: don't forget to set a vendor on the product.")
 
-    _sql_constraints = [
-        ('service_to_purchase', "CHECK((type != 'service' AND service_to_purchase != true) or (type = 'service'))", 'Product that is not a service can not create RFQ.'),
-    ]
-
-    @api.constrains('service_to_purchase', 'seller_ids')
+    @api.constrains('service_to_purchase', 'seller_ids', 'type')
     def _check_service_to_purchase(self):
         for template in self:
-            if template.service_to_purchase and not template.seller_ids:
-                raise ValidationError(_(
-                    "Please define the vendor from whom you would like to purchase this service automatically."))
+            if template.service_to_purchase:
+                if template.type != 'service':
+                    raise ValidationError(_("Product that is not a service can not create RFQ."))
+                template._check_vendor_for_service_to_purchase(template.seller_ids)
 
-    @api.depends('type', 'expense_policy')
-    def _compute_service_to_purchase(self):
-        for template in self:
-            if template.type != 'service' or template.expense_policy != 'no':
-                template.service_to_purchase = False
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('service_to_purchase'):
+                self._check_vendor_for_service_to_purchase(vals.get('seller_ids'))
+        return super().create(vals_list)
+
+    def _check_vendor_for_service_to_purchase(self, sellers):
+        if not sellers:
+            raise ValidationError(_("Please define the vendor from whom you would like to purchase this service automatically."))
+
+    @api.onchange('type', 'expense_policy')
+    def _onchange_service_to_purchase(self):
+        products_template = self.filtered(lambda p: p.type != 'service' or p.expense_policy != 'no')
+        products_template.service_to_purchase = False

--- a/addons/sale_purchase/views/product_views.xml
+++ b/addons/sale_purchase/views/product_views.xml
@@ -8,7 +8,11 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='bill']" position="before">
                 <group string="Reordering" attrs="{'invisible': [('type','!=','service')]}">
-                    <field name="service_to_purchase"/>
+                    <div class="o_td_label">
+                        <field name="service_to_purchase"/>
+                        <label for='service_to_purchase'/>
+                        <span class='fa fa-lg fa-building-o fa-fw' title="Service to Purchase"/>
+                    </div>
                 </group>
             </xpath>
         </field>

--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -16,6 +16,9 @@
                     context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
                     optional="hide"/>
             </xpath>
+            <xpath expr="//field[@name='child_ids']/tree/field[@name='remaining_hours']" position="after">
+                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom"/>
+            </xpath>
             <xpath expr="//field[@name='remaining_hours']" position="after">
                 <field name="allow_billable" invisible="1" />
                 <field name="remaining_hours_available" invisible="1"/>
@@ -31,6 +34,17 @@
                             attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&gt;=', 0)]}"/>
                 </span>
                 <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}"></field>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="project_sharing_inherit_project_task_view_tree_sale_timesheet" model="ir.ui.view">
+        <field name="name">project.task.tree.inherit.sale.timesheet</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.project_sharing_inherit_project_task_view_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='remaining_hours']" position="after">
+                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -105,10 +105,10 @@
                     <field name="allow_billable" invisible="1"/>
                 </xpath>
                 <xpath expr="//field[@name='child_ids']/tree//field[@name='remaining_hours']" position="after">
-                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide" groups="base.group_user"/>
+                    <field name="remaining_hours_so" widget="timesheet_uom" optional="hide" groups="base.group_user"/>
                 </xpath>
                 <xpath expr="//field[@name='depend_on_ids']/tree//field[@name='remaining_hours']" position="after">
-                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide" groups="base.group_user"/>
+                    <field name="remaining_hours_so" widget="timesheet_uom" optional="hide" groups="base.group_user"/>
                 </xpath>
 
             </field>
@@ -120,7 +120,7 @@
             <field name="inherit_id" ref="hr_timesheet.view_task_tree2_inherited" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='remaining_hours']" position="after">
-                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide"/>
+                    <field name="remaining_hours_so" widget="timesheet_uom" optional="hide"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
**=project_purchase,sale_project,sale_purchase,sale_timesheet

Purpose of this PR to improve generic usage of project
app.

So, in this PR done following changes:

- move the the filter 'tasks_due_today' and 'late_milestone' above the
 'late' filter.
- change label for 'remaining_hours_on_so' according to timesheet uom.
- add task_view button in task analysis list view.
- add placeholder in milestone wizard
- make remaining_hour field colour red when it's value < 0.
- added filter in project_sharing_view search view 'overtime',
  'remaining_hours_percentage','tasks_due_today','late_milestone',
  'open_tasks','closed_tasks','closed_last_7_days','closed_last_30_days'.
- added optional field in project_sharing_view sub-task list view
  'subtask_effective_hours', 'total_hours_spent','priority','remaining_hours_so'.
- added optional field in portal tree view 'timesheet_uom','progress','priority',
  'portal_user_names','remaining_hours_so'.
- re-arrange quick search options in search view options in portal view.
- project.project form view: added a 'create purchase order' action button
  set by default the AA of the project on the POLs of the PO.
- make the 'subcontract service' field company dependent and add
  fa-building icon on form view.

task - 2889829

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
