### PR TITLE
[FIX] website: linkable image should not disappear while clicking

### DIFF
--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -63,6 +63,10 @@
     }
 }
 
+.o_footer_logo.oe_edited_link {
+    display: block;
+}
+
 #oe_snippets {
     top: 0;
     .oe-toolbar {


### PR DESCRIPTION
**Current behavior before PR:**

Edit mode in website, the linkable image(logo in footer template) disappears
after clicking on it.

**Desired behavior after PR is merged:**

The linkable image will not disappear after clicking.

**Task**-2862870
