### PR TITLE
[FIX] web: makes the logo route return the correct image

### DIFF
--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -234,7 +234,8 @@ class Binary(http.Controller):
                         imgext = '.' + mimetype.split('/')[1]
                         if imgext == '.svg+xml':
                             imgext = '.svg'
-                        response = send_file(image_data, filename=imgname + imgext, mimetype=mimetype, mtime=row[1])
+                        response = send_file(image_data, request.httprequest.environ,
+                                             download_name=imgname + imgext, mimetype=mimetype, last_modified=row[1])
                     else:
                         response = http.Stream.from_path(placeholder('nologo.png')).get_response()
             except Exception:


### PR DESCRIPTION
This solves the problem of emails that gets the odoo logo even after the
company logo has been changed.

The cause was that the wrong method was imported to send the file to the
client causing an exception (invalid parameters) which caused the default
logo to be sent instead of the current one.
This quick fix changes the import to use the method with the correct
signature (but deprecated).

Task-2920690

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
