### PR TITLE
[FIX] website: navigate forward in configurator

### DIFF
--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -468,6 +468,12 @@ const actions = {
         state.selectedType = id;
     },
     selectWebsitePurpose({state}, id) {
+        // Keep track or the former selection in order to be able to keep
+        // the auto-advance navigation scheme while being able to use the
+        // browser's back and forward buttons.
+        if (!id && state.selectedPurpose) {
+            state.formerSelectedPurpose = state.selectedPurpose;
+        }
         Object.values(state.features).filter((feature) => feature.module_state !== 'installed').forEach((feature) => {
             // need to check id, since we set to undefined in mount() to avoid the auto next screen on back button
             feature.selected |= id && feature.website_config_preselection.includes(WEBSITE_PURPOSES[id].name);
@@ -588,6 +594,7 @@ async function getInitialState(services) {
     return Object.assign(r, {
         selectedType: undefined,
         selectedPurpose: undefined,
+        formerSelectedPurpose: undefined,
         selectedIndustry: undefined,
         selectedPalette: undefined,
         recommendedPalette: undefined,
@@ -635,7 +642,9 @@ async function applyConfigurator(self, themeName) {
             industry_id: self.state.selectedIndustry.id,
             selected_palette: selectedPalette,
             theme_name: themeName,
-            website_purpose: WEBSITE_PURPOSES[self.state.selectedPurpose].name,
+            website_purpose: WEBSITE_PURPOSES[
+                self.state.selectedPurpose || self.state.formerSelectedPurpose
+            ].name,
             website_type: WEBSITE_TYPES[self.state.selectedType].name,
             logo_attachment_id: self.state.logoAttachmentId,
         };
@@ -660,6 +669,7 @@ async function makeEnvironment() {
         const newState = {
             selectedType: store.state.selectedType,
             selectedPurpose: store.state.selectedPurpose,
+            formerSelectedPurpose: store.state.formerSelectedPurpose,
             selectedIndustry: store.state.selectedIndustry,
             selectedPalette: store.state.selectedPalette,
             recommendedPalette: store.state.recommendedPalette,


### PR DESCRIPTION
When navigating backward to step 2, the website purpose is reset in
order for the navigation to not automatically advance to step 3.
Because of this, when navigating to further steps with the browser's
forward button, that field remains empty. This ultimately produces
an error when the configurator state is extracted to generate the
website.

After this commit the former selected purpose is kept when no purpose
is selected anymore. It is then used when collecting the configurator
details if there is no selected purpose.

task-2789075

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
