### PR TITLE
[FIX] web: ignore allowed company from session storage 

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -311,6 +311,11 @@ function makeActionManager(env) {
                 const storedAction = browser.sessionStorage.getItem("current_action");
                 const lastAction = JSON.parse(storedAction || "{}");
                 if (lastAction.res_model === state.model) {
+                    if (lastAction.context) {
+                        // If this method is called because of a company switch, the
+                        // stored allowed_company_ids is incorrect.
+                        delete lastAction.context.allowed_company_ids;
+                    }
                     actionRequest = lastAction;
                     options.viewType = state.view_type;
                 }


### PR DESCRIPTION
This PR was an attempt to bring another approach for odoo/odoo#94039 that was fw-ported from 15.0 up to saas-15.4

Finally, it just adds a test.