### PR TITLE
[FIX] website: use registerEditionTour for edition tours

### DIFF
--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -1,12 +1,12 @@
 odoo.define("website.tour.default_shape_gets_palette_colors", function (require) {
 "use strict";
 
-var tour = require("web_tour.tour");
 const wTourUtils = require('website.tour_utils');
 
-tour.register("default_shape_gets_palette_colors", {
+wTourUtils.registerEditionTour("default_shape_gets_palette_colors", {
     test: true,
-    url: wTourUtils.getClientActionUrl('/', true),
+    url: '/',
+    edition: true,
 }, [
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -1,7 +1,6 @@
 odoo.define("website.tour.edit_link_popover", function (require) {
 "use strict";
 
-const tour = require('web_tour.tour');
 const wTourUtils = require('website.tour_utils');
 
 const FIRST_PARAGRAPH = 'iframe #wrap .s_text_image p:nth-child(2)';
@@ -25,9 +24,10 @@ const clickEditLink = [{
     in_modal: false,
 }];
 
-tour.register('edit_link_popover', {
+wTourUtils.registerEditionTour('edit_link_popover', {
     test: true,
-    url: wTourUtils.getClientActionUrl('/', true),
+    url: '/',
+    edition: true,
 }, [
     // 1. Test links in page content (web_editor)
     wTourUtils.dragNDrop({

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -15,7 +15,7 @@ class TestSnippets(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_empty_parent_autoremove', login='admin')
 
     def test_02_default_shape_gets_palette_colors(self):
-        self.start_tour("/web", "default_shape_gets_palette_colors", login='admin')
+        self.start_tour('/@/?enable_editor=1', "default_shape_gets_palette_colors", login='admin')
 
     def test_03_snippets_all_drag_and_drop(self):
         with MockRequest(self.env, website=self.env['website'].browse(1)):

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -216,7 +216,7 @@ class TestUi(odoo.tests.HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')
 
     def test_09_website_edit_link_popover(self):
-        self.start_tour("/web", "edit_link_popover", login="admin")
+        self.start_tour('/@/?enable_editor=1', "edit_link_popover", login="admin")
 
     def test_10_website_conditional_visibility(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_1', login='admin')


### PR DESCRIPTION
Before this commit, the tours default_shape_gets_palette_colors and
edit_link_popover were not using the tour utils function
registerEditionTour, that starts a tour on the iframe, in edit mode,
with a timeout on the first step.

Because this timeout was not there, loading the iframe and the snippets
menu could take longer than the default timeout and the test would fail
inconsistently.

task-2687506



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
