### PR TITLE
[FIX] web: Add missing class `text-body`

### DIFF
--- a/addons/web/static/src/libs/bootstrap/utilities_custom.scss
+++ b/addons/web/static/src/libs/bootstrap/utilities_custom.scss
@@ -79,6 +79,7 @@ $utilities: map-merge(
                 "text-opacity": 1
             ),
             values: (
+                "body": $body-color,
                 "black": $black,
                 "white": $white,
                 "muted": $text-muted,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Since bootstrap 5 `text-body` class is missing.

Current behavior before PR:
`text-body` class was missing.

Desired behavior after PR is merged:
Add `text-body` class.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
