### PR TITLE
[IMP] bus, *: introduce multi tab service

### DIFF
--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -28,7 +28,7 @@ export class BusService extends CrossTab {
      */
     sendNotification(options, callback) {
         if (window.Notification && Notification.permission === "granted") {
-            if (this.isMasterTab()) {
+            if (this.env.services['multiTab'].isOnMainTab()) {
                 try {
                     this._sendNativeNotification(options.title, options.message, callback);
                 } catch (error) {
@@ -45,7 +45,7 @@ export class BusService extends CrossTab {
             }
         } else {
             this.env.services['notification'].add(options.message, options);
-            if (this.isMasterTab()) {
+            if (this.env.services['multiTab'].isOnMainTab()) {
                 this._beep();
             }
         }
@@ -113,7 +113,7 @@ export class BusService extends CrossTab {
 }
 
 export const busService = {
-    dependencies: ['notification', 'presence', 'rpc'],
+    dependencies: ['notification', 'presence', 'rpc', 'multiTab'],
     start(env, services) {
         return new BusService(env, services);
     },

--- a/addons/bus/static/src/services/legacy/make_multi_tab_to_legacy_env.js
+++ b/addons/bus/static/src/services/legacy/make_multi_tab_to_legacy_env.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+export function makeMultiTabToLegacyEnv(legacyEnv) {
+    return {
+        dependencies: ['multiTab'],
+        start(_, { multiTab }) {
+            legacyEnv.services['multiTab'] = multiTab;
+        },
+    };
+}
+
+registry.category('wowlToLegacyServiceMappers').add('multi_tab_to_legacy_env', makeMultiTabToLegacyEnv);

--- a/addons/bus/static/src/services/multi_tab_service.js
+++ b/addons/bus/static/src/services/multi_tab_service.js
@@ -1,0 +1,213 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+import { browser } from '@web/core/browser/browser';
+import session from 'web.session';
+
+/**
+ * This class uses a Master/Slaves with Leader Election architecture in
+ * order to keep track of the main tab. Tabs are synchronized thanks to the
+ * localStorage.
+ *
+ * localStorage used keys are:
+ * - {LOCAL_STORAGE_PREFIX}.{sanitizedOrigin}.lastPresenceByTab:
+ *   mapping of tab ids to their last recorded presence.
+ * - {LOCAL_STORAGE_PREFIX}.{sanitizedOrigin}.main : id of the current
+ *   main tab.
+ * - {LOCAL_STORAGE_PREFIX}.{sanitizedOrigin}.heartbeat : last main tab
+ *   heartbeat time.
+ *
+ * trigger on env.bus:
+ * - become_main_tab : when this tab became the main.
+ * - no_longer_main_tab : when this tab is no longer the main.
+ */
+export class MultiTab {
+    constructor(env) {
+        this.env = env;
+
+        // CONSTANTS
+        this.TAB_HEARTBEAT_PERIOD = 10000; // 10 seconds
+        this.MAIN_TAB_HEARTBEAT_PERIOD = 1500; // 1.5 seconds
+        this.HEARTBEAT_OUT_OF_DATE_PERIOD = 5000; // 5 seconds
+        this.HEARTBEAT_KILL_OLD_PERIOD = 15000; // 15 seconds
+        this.LOCAL_STORAGE_PREFIX = 'multiTabService';
+
+        // PROPERTIES
+        this._isOnMainTab = false;
+        this._sanitizedOrigin = session.origin.replace(/:\/{0,2}/g, '_');
+
+        const now = new Date().getTime();
+        this._id = _.uniqueId(this.LOCAL_STORAGE_PREFIX) + ':' + now;
+        browser.addEventListener('unload', this._onUnload.bind(this));
+        browser.addEventListener('storage', this._onStorage.bind(this));
+        // REGISTER THIS TAB
+        const lastPresenceByTab = this._callLocalStorage('getItem', 'lastPresenceByTab', {});
+        lastPresenceByTab[this._id] = now;
+        this._callLocalStorage('setItem', 'lastPresenceByTab', lastPresenceByTab);
+
+        if (!this._callLocalStorage('getItem', 'main')) {
+            this._startElection();
+        }
+        this._heartbeat();
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    isOnMainTab() {
+        return this._isOnMainTab;
+    }
+
+    getAllTabIds() {
+        return Object.keys(this._callLocalStorage('getItem', 'lastPresenceByTab', {}));
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Call browser localStorage.
+     *
+     * @private
+     * @param {string} method (getItem, setItem, removeItem)
+     * @param {string} key
+     * @param {any} param
+     * @returns Result of the called method, parsed.
+     */
+    _callLocalStorage(method, key, param) {
+        if (method === 'setItem') {
+            param = JSON.stringify(param);
+        }
+        const result = browser.localStorage[method](this._generateKey(key), param);
+        if (method === 'getItem') {
+            return result ? JSON.parse(result) : param;
+        }
+    }
+
+    /**
+     * Generates localStorage keys prefixed by LOCAL_STORAGE_PREFIX and
+     * the sanitized origin, to prevent keys from conflicting when
+     * several multi tab services co-exist.
+     *
+     * @private
+     * @param {string} key
+     * @returns Key prefixed with the origin.
+     */
+    _generateKey(key) {
+        return this.LOCAL_STORAGE_PREFIX + '.' + this._sanitizedOrigin + '.' + key;
+    }
+
+    /**
+     * Check all the time (according to the constants) if the tab is the main tab and
+     * check if it is active. Use the local storage for this checks.
+     *
+     * @private
+     * @see _startElection method
+     */
+    _heartbeat() {
+        const now = new Date().getTime();
+        let heartbeatValue = this._callLocalStorage('getItem', 'heartbeat', 0);
+        const lastPresenceByTab = this._callLocalStorage('getItem', 'lastPresenceByTab', {});
+        if (heartbeatValue + this.HEARTBEAT_OUT_OF_DATE_PERIOD < now) {
+            // Heartbeat is out of date. Electing new main.
+            this._startElection();
+            heartbeatValue = this._callLocalStorage('getItem', 'heartbeat', 0);
+        }
+        if (this._isOnMainTab) {
+            // Walk through all tabs and kill old ones.
+            const cleanedTabs = {};
+            for (const [tabId, lastPresence] of Object.entries(lastPresenceByTab)) {
+                if (lastPresence + this.HEARTBEAT_KILL_OLD_PERIOD > now) {
+                    cleanedTabs[tabId] = lastPresence;
+                }
+            }
+            if (heartbeatValue !== this.lastHeartbeat) {
+                // Someone else is also main...
+                // It should not happen, except in some race condition situation.
+                this._isOnMainTab = false;
+                this.lastHeartbeat = 0;
+                lastPresenceByTab[this._id] = now;
+                this._callLocalStorage('setItem', 'lastPresenceByTab', lastPresenceByTab);
+                this.env.bus.trigger('no_longer_main_tab');
+            } else {
+                this.lastHeartbeat = now;
+                this._callLocalStorage('setItem', 'heartbeat', now);
+                this._callLocalStorage('setItem', 'lastPresenceByTab', cleanedTabs);
+            }
+        } else {
+            // Update own heartbeat.
+            lastPresenceByTab[this._id] = now;
+            this._callLocalStorage('setItem', 'lastPresenceByTab', lastPresenceByTab);
+        }
+        const hbPeriod = this._isOnMainTab ? this.MAIN_TAB_HEARTBEAT_PERIOD : this.TAB_HEARTBEAT_PERIOD;
+        this._heartbeatTimeout = browser.setTimeout(this._heartbeat.bind(this), hbPeriod);
+    }
+
+    /**
+     * Check with the local storage if the current tab is the main tab.
+     * If this tab became the main, trigger 'become_main_tab' event.
+     *
+     * @private
+     */
+    _startElection() {
+        if (this._isOnMainTab) {
+            return;
+        }
+        // Check who's next.
+        const now = new Date().getTime();
+        const lastPresenceByTab = this._callLocalStorage('getItem', 'lastPresenceByTab', {});
+        const heartbeatKillOld = now - this.HEARTBEAT_KILL_OLD_PERIOD;
+        let newMain;
+        for (const [tab, lastPresence] of Object.entries(lastPresenceByTab)) {
+            // Check for dead tabs.
+            if (lastPresence < heartbeatKillOld) {
+                continue;
+            }
+            newMain = tab;
+            break;
+        }
+        if (newMain === this._id) {
+            // We're next in queue. Electing as main.
+            this.lastHeartbeat = now;
+            this._callLocalStorage('setItem', 'heartbeat', this.lastHeartbeat);
+            this._callLocalStorage('setItem', 'main', true);
+            this._isOnMainTab = true;
+            this.env.bus.trigger('become_main_tab');
+            // Removing main peer from queue.
+            delete lastPresenceByTab[newMain];
+            this._callLocalStorage('setItem', 'lastPresenceByTab', lastPresenceByTab);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    _onStorage({ key, newValue }) {
+        if (key === this._generateKey('main') && !newValue) {
+            // Main was unloaded.
+            this._startElection();
+        }
+    }
+
+    _onUnload() {
+        const lastPresenceByTab = this._callLocalStorage('getItem', 'lastPresenceByTab', {});
+        delete lastPresenceByTab[this._id];
+        this._callLocalStorage('setItem', 'lastPresenceByTab', lastPresenceByTab);
+
+        // Unload main.
+        if (this._isOnMainTab) {
+            this._callLocalStorage('removeItem', 'main');
+        }
+    }
+}
+
+export const multiTabService = {
+    start(env) {
+        return new MultiTab(env);
+    },
+};
+
+registry.category('services').add('multiTab', multiTabService);

--- a/addons/bus/static/tests/assets_watchdog_tests.js
+++ b/addons/bus/static/tests/assets_watchdog_tests.js
@@ -2,6 +2,7 @@
 
 import { busService } from "@bus/services/bus_service";
 import { presenceService } from "@bus/services/presence_service";
+import { multiTabService } from "@bus/services/multi_tab_service";
 
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
@@ -17,6 +18,7 @@ QUnit.module("Bus Assets WatchDog", (hooks) => {
         serviceRegistry.add("assetsWatchdog", assetsWatchdogService);
         serviceRegistry.add("bus_service", busService);
         serviceRegistry.add("presence", presenceService);
+        serviceRegistry.add("multiTab", multiTabService);
         patchWithCleanup(browser, {
             setTimeout(fn) {
                 return this._super(fn, 0);

--- a/addons/calendar/static/tests/calendar_notification_tests.js
+++ b/addons/calendar/static/tests/calendar_notification_tests.js
@@ -2,6 +2,7 @@
 
 import { busService } from "@bus/services/bus_service";
 import { presenceService } from "@bus/services/presence_service";
+import { multiTabService } from "@bus/services/multi_tab_service";
 
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { calendarNotificationService } from "@calendar/js/services/calendar_notification_service";
@@ -20,6 +21,7 @@ QUnit.module("Calendar Notification", (hooks) => {
         serviceRegistry.add("calendarNotification", calendarNotificationService);
         serviceRegistry.add("bus_service", busService);
         serviceRegistry.add("presence", presenceService);
+        serviceRegistry.add("multiTab", multiTabService);
         patchWithCleanup(browser, {
             setTimeout(fn) {
                 this._super(fn, 0);

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -185,6 +185,7 @@ Help your customers with this chat, and analyse their feedback.
             'bus/static/src/longpolling_bus.js',
             'bus/static/src/crosstab_bus.js',
             'bus/static/src/services/bus_service.js',
+            'bus/static/src/services/multi_tab_service.js',
             'mail/static/src/js/utils.js',
             'im_livechat/static/src/legacy/public_livechat_history_tracking.js',
             'im_livechat/static/src/legacy/public_livechat_chatbot.js',

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -98,6 +98,7 @@
             'bus/static/src/*.js',
             'bus/static/src/services/bus_service.js',
             'bus/static/src/services/presence_service.js',
+            'bus/static/src/services/multi_tab_service.js',
             'bus/static/src/services/legacy/make_bus_service_to_legacy_env.js',
             'web/static/lib/luxon/luxon.js',
             'web/static/src/core/**/*',

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -1,7 +1,9 @@
 /** @odoo-module **/
 
 import { busService } from '@bus/services/bus_service';
+import { multiTabService } from '@bus/services/multi_tab_service';
 import { makeBusServiceToLegacyEnv } from '@bus/services/legacy/make_bus_service_to_legacy_env';
+import { makeMultiTabToLegacyEnv } from '@bus/services/legacy/make_multi_tab_to_legacy_env';
 import { makeFakePresenceService } from '@bus/../tests/helpers/mock_services';
 
 import { ChatWindowManagerContainer } from '@mail/components/chat_window_manager_container/chat_window_manager_container';
@@ -82,6 +84,7 @@ function setupMessagingServiceRegistries({
     };
 
     const customBusService = {
+        ...busService,
         start() {
             const originalService = busService.start(...arguments);
             Object.assign(originalService, {
@@ -102,6 +105,7 @@ function setupMessagingServiceRegistries({
             isOdooFocused: () => true,
         }),
         systrayService,
+        multiTab: multiTabService,
         ...services,
     };
 
@@ -110,6 +114,7 @@ function setupMessagingServiceRegistries({
     });
 
     registry.category('wowlToLegacyServiceMappers').add('bus_service_to_legacy_env', makeBusServiceToLegacyEnv);
+    registry.category('wowlToLegacyServiceMappers').add('multi_tab_to_legacy_env', makeMultiTabToLegacyEnv);
     registry.category('wowlToLegacyServiceMappers').add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv);
 }
 

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -934,10 +934,10 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
             this.call('bus_service', 'addChannel', this.options.surveyToken);
             this.call('bus_service', 'startPolling');
 
-            if (!this._checkIsMasterTab()) {
+            if (!this._checkisOnMainTab()) {
                 this.shouldReloadMasterTab = true;
                 this.masterTabCheckInterval = setInterval(function () {
-                     if (self._checkIsMasterTab()) {
+                     if (self._checkisOnMainTab()) {
                         clearInterval(self.masterTabCheckInterval);
                      }
                 }, 2000);
@@ -1077,10 +1077,10 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
     *
     * @private
     */
-    _checkIsMasterTab: function () {
-        var isMasterTab = this.call('bus_service', 'isMasterTab');
+    _checkisOnMainTab: function () {
+        var isOnMainTab = this.call('multiTab', 'isOnMainTab');
         var $errorModal = this.$('#MasterTabErrorModal');
-        if (isMasterTab) {
+        if (isOnMainTab) {
             // Force reload the page when survey is ready to be followed, to force restart long polling
             if (this.shouldReloadMasterTab) {
                 window.location.reload();


### PR DESCRIPTION
*: calendar, survey.

In order to ease the PR introducing websockets in Odoo, introduce
the tab manager service. Indeed, the cross tab bus won't be necessary
anymore but there will still be a need to elect a master tab: some actions
should only be triggered once. To achieve this, the code electing the master
tab has been split with the one handling the longpolling. The crosstab
bus now relies on the tab manager service to known whether or not the
current tab is the master tab.

task-2053917

enterprise: https://github.com/odoo/enterprise/pull/29573