### PR TITLE
[FIX] web_editor: restore margin on `we-selection-items`

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -65,6 +65,7 @@ $o-we-item-standup-color-dark: $o-we-bg-darkest;
 $o-we-item-standup-top: inset 0 1px 0;
 $o-we-item-standup-bottom: inset 0 -1px 0;
 
+$o-we-dropdown-spacing: $o-we-item-spacing !default;
 $o-we-dropdown-bg: $o-we-bg-darker !default;
 $o-we-dropdown-border-width: 1px !default;
 $o-we-dropdown-border-color: $o-we-bg-darkest !default;
@@ -139,6 +140,7 @@ $o-we-sidebar-content-field-clickable-spacing: $o-we-sidebar-content-field-label
 $o-we-sidebar-content-field-pressed-bg: $o-we-item-pressed-bg !default;
 $o-we-sidebar-content-field-pressed-color: $o-we-item-pressed-color !default;
 
+$o-we-sidebar-content-field-dropdown-spacing: $o-we-dropdown-spacing !default;
 $o-we-sidebar-content-field-dropdown-bg: $o-we-dropdown-bg !default;
 $o-we-sidebar-content-field-dropdown-border-width: $o-we-dropdown-border-width !default;
 $o-we-sidebar-content-field-dropdown-border-color: $o-we-dropdown-border-color !default;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -997,6 +997,9 @@ body.editor_enable.editor_has_snippets {
             we-selection-items {
                 @include o-position-absolute(100%, 0, auto, 0);
                 z-index: $zindex-dropdown;
+                &:not(.dropdown-menu) {
+                    margin-top: $o-we-sidebar-content-field-dropdown-spacing !important;
+                }
 
                 &:not(.o_we_has_pager) {
                     max-height: 600px;


### PR DESCRIPTION
Margin top of `we-selection-items` was removed during the migration of
BS5 to avoid warning on runbot, but we have to restore it for non BS
`dropdown-menu`.

Ref:
odoo/odoo@e1ea58c941c64c4ed0e9d5c6a6d09767c9a83647

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
