### PR TITLE
[FIX] mail: correct window focus wrong listeners

### DIFF
--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -18,7 +18,7 @@ registerModel({
             odoo.__DEBUG__.messaging = this;
         },
         _willDelete() {
-            this.env.services['bus_service'].off('window_focus', null, this._handleGlobalWindowFocus);
+            this.env.bus.off('window_focus', null, this._handleGlobalWindowFocus);
             delete odoo.__DEBUG__.messaging;
         },
     },


### PR DESCRIPTION
The messaging service was still subscribing to bus_service window focus while
this service does not trigger this event anymore. This PR fixes this issue.
