### PR TITLE
[REV] google_calendar: not sending emails to existing event attendees

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -199,8 +199,7 @@ class GoogleSync(models.AbstractModel):
             return
         with google_calendar_token(self.env.user.sudo()) as token:
             if token:
-                send_updates = self._context.get('send_updates', True)
-                google_id = google_service.with_context(send_updates=send_updates).insert(values, token=token, timeout=timeout)
+                google_id = google_service.insert(values, token=token, timeout=timeout)
                 self.write({
                     'google_id': google_id,
                     'need_sync': False,

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -96,14 +96,13 @@ class User(models.Model):
         synced_events = self.env['calendar.event']._sync_google2odoo(events - recurrences, default_reminders=default_reminders)
 
         # Odoo -> Google
-        send_updates = not full_sync
         recurrences = self.env['calendar.recurrence']._get_records_to_sync(full_sync=full_sync)
         recurrences -= synced_recurrences
-        recurrences.with_context(send_updates=send_updates)._sync_odoo2google(calendar_service)
+        recurrences._sync_odoo2google(calendar_service)
         synced_events |= recurrences.calendar_event_ids - recurrences._get_outliers()
         synced_events |= synced_recurrences.calendar_event_ids - synced_recurrences._get_outliers()
         events = self.env['calendar.event']._get_records_to_sync(full_sync=full_sync)
-        (events - synced_events).with_context(send_updates=send_updates)._sync_odoo2google(calendar_service)
+        (events - synced_events)._sync_odoo2google(calendar_service)
 
         return bool(events | synced_events) or bool(recurrences | synced_recurrences)
 

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -58,8 +58,7 @@ class GoogleCalendarService():
 
     @requires_auth_token
     def insert(self, values, token=None, timeout=TIMEOUT):
-        send_updates = self._context.get('send_updates', True)
-        url = "/calendar/v3/calendars/primary/events?sendUpdates=%s" % ("all" if send_updates else "none")
+        url = "/calendar/v3/calendars/primary/events?sendUpdates=all"
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         if not values.get('id'):
             values['id'] = uuid4().hex


### PR DESCRIPTION
There was an issue with this fix. 
[EDIT BY LSE]
The previous fix caused issue when event are created from Odoo's side with the following traceback:
```
...
File "/home/odoo/src/odoo/addons/google_calendar/models/google_sync.py", line 250, in _google_insert
    google_id = google_service.with_context(send_updates=send_updates).insert(values, token=token, timeout=timeout)
AttributeError: 'GoogleCalendarService' object has no attribute 'with_context'
```
which happen because the `GoogleCalendarService` class does not inherit from any class (`with_context` is defined on the Model class).

As a consequences, this events are not synced on Google Calendar side.

[END EDIT]

This reverts commit 8ebb44420c3e2dcc0d990d2646486654b4b2955d.

OPW-2918057

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
