### PR TITLE
[FIX] l10n_lu,l10n_lu_reports,l10n_lu_reports_annual_vat: fix translations

### DIFF
--- a/addons/l10n_lu/i18n_extra/de.po
+++ b/addons/l10n_lu/i18n_extra/de.po
@@ -154,7 +154,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
 msgid "012 - Overall turnover"
-msgstr ""
+msgstr "012 - Gesamtumsatz"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
@@ -164,7 +164,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
-msgstr ""
+msgstr "014 - Ausfuhren"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
@@ -174,7 +174,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015 - Other exemptions"
-msgstr ""
+msgstr "015 - Andere Befreiungen"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
@@ -184,7 +184,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
-msgstr ""
+msgstr "016 - Andere Befreiungen"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
@@ -197,6 +197,8 @@ msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
 msgstr ""
+"017 - Tabakwaren, deren Mehrwertsteuer an der Quelle oder am Ausgang des "
+"Steuerlagers gemeinsam mit den Verbrauchsteuern erhoben wurde"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
@@ -209,6 +211,8 @@ msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
 msgstr ""
+"018 - An innergemeinschaftliche Erwerbe anschließende Lieferungen im Rahmen von "
+"Dreiecksgeschäften..."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
@@ -218,17 +222,17 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019 - Supplies other than referred to in 018 and 423 or 424"
-msgstr ""
+msgstr "019 - Andere im Ausland getätigte (steuerpflichtige) Umsätze"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
 msgid "021 - Exemptions and deductible amounts"
-msgstr ""
+msgstr "021 - Steuerbefreiungen und abzugsfähige Beträge"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
 msgid "022 - Taxable turnover"
-msgstr ""
+msgstr "022 - Steuerpflichtiger Umsatz"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
@@ -238,7 +242,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
-msgstr ""
+msgstr "031 - Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
@@ -248,12 +252,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
-msgstr ""
+msgstr "033 - Besteuerungsgrundlage 0%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
-msgstr ""
+msgstr "037 - Steuerpflichtiger Umsatz: Aufteilung - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
@@ -263,12 +267,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
-msgstr ""
+msgstr "040 - MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
-msgstr ""
+msgstr "046 - Steuerpflichtiger Umsatz: Aufteilung - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
@@ -278,12 +282,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
-msgstr ""
+msgstr "049 - Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
-msgstr ""
+msgstr "051 - Innergemeinschaftliche Erwerbe von Gegenständen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
@@ -293,12 +297,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
-msgstr ""
+msgstr "054 - MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
 msgid "056 - Intra-Community acquisitions of goods – tax"
-msgstr ""
+msgstr "056 - Innergemeinschaftliche Erwerbe von Gegenständen - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
@@ -308,7 +312,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
-msgstr ""
+msgstr "059 - für Zwecke des Unternehmens: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
@@ -318,12 +322,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063 - for non-business purposes: base 3%"
-msgstr ""
+msgstr "063 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
 msgid "065 - Importation of goods – base"
-msgstr ""
+msgstr "065 - Einfuhren von Gegenständen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
@@ -333,7 +337,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
-msgstr ""
+msgstr "068 - für Zwecke des Unternehmens: MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
@@ -343,12 +347,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073 - for non-business purposes: tax 3%"
-msgstr ""
+msgstr "073 - für unternehmensfremde Zwecke: MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
 msgid "076 - Total tax due"
-msgstr ""
+msgstr "076 - Gesamtbetrag der Steuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
@@ -359,6 +363,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
 msgstr ""
+"090 - Erklärte Mehrwertsteuer für die Zuordnung von Gegenständen zu Zwecken "
+"des Unternehmens"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
@@ -368,12 +374,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092 - Paid as joint and several guarantee"
-msgstr ""
+msgstr "092 - Als solidarisch haftender Bürge bezahlte MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
 msgid "093 - Total input tax"
-msgstr ""
+msgstr "093 - Gesamtbetrag Vorsteuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
@@ -381,6 +387,8 @@ msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
 msgstr ""
+"094 - Nicht abziehbare Vorsteuer betreffend die gemäß Art. 44 und Art. 56quater "
+"steuerfreien Umsätze"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
@@ -388,31 +396,45 @@ msgid ""
 "095 - where the deductible proportion determined in accordance to article 50 "
 "is applied"
 msgstr ""
+"095 - Nicht abziehbare Vorsteuer in Anwendung der in Art. 50 vorgesehenen "
+"Prorata-Regel"
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+msgid "096"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+msgid ""
+"096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
+"56ter-2(7) (when applying the margin scheme)"
+msgstr "096 - Nicht abziehbare Vorsteuer in Anwendung von Art. 56ter-1/7 und 56ter-2/7 "
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
-msgstr ""
+msgstr "097 - Gesamtbetrag der nicht abziehbaren Vorsteuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
 msgid "102 - Total input tax deductible"
-msgstr ""
+msgstr "102 - Gesamtbetrag der abziehbaren Vorsteuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
 msgid "103 - Total tax due"
-msgstr ""
+msgstr "103 - Gesamtbetrag der Steuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
 msgid "104 - Total input tax deductible"
-msgstr ""
+msgstr "104 - Gesamtbetrag der abziehbaren Vorsteuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
 msgid "105 - Exceeding amount"
-msgstr ""
+msgstr "105 - Überschuss"
 
 #. module: l10n_lu
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-14
@@ -564,7 +586,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152 - Acquisitions, in the context of triangular transactions – base"
-msgstr ""
+msgstr "152 - Im Rahmen von Dreiecksgeschäften getätigte Erwerbe - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-17
@@ -716,7 +738,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194 - base exempt"
-msgstr ""
+msgstr "194 - Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
@@ -726,7 +748,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
-msgstr ""
+msgstr "195 - für Zwecke des Unternehmens: Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
@@ -736,7 +758,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
-msgstr ""
+msgstr "196 - für unternehmensfremde Zwecke: Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
@@ -748,7 +770,7 @@ msgstr ""
 msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
-msgstr ""
+msgstr "226 - Im Rahmen der Sonderregelung von Artikel 56sexies getätigte Umsätze"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
@@ -758,7 +780,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
-msgstr ""
+msgstr "227 - Sonderregelung zur Steueraussetzung: Berichtigung"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
@@ -768,7 +790,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
-msgstr ""
+msgstr "228 - Berichtigte Steuer - Sonderregelung zur Steueraussetzung"
 
 #. module: l10n_lu
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-3
@@ -888,7 +910,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
 msgid "407 - Importation of goods – tax"
-msgstr ""
+msgstr "407 - Einfuhren von Gegenständen - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
@@ -896,6 +918,8 @@ msgid ""
 "409 - Supply of services for which the customer is liable for the payment of "
 "VAT – base"
 msgstr ""
+"409 - Vom Empfänger als Steuerschuldner zu erklärende Dienstleistungen "
+" - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
@@ -903,6 +927,8 @@ msgid ""
 "410 - Supply of services for which the customer is liable for the payment of "
 "VAT – tax"
 msgstr ""
+"410 - Vom Empfänger als Steuerschuldner zu erklärende Dienstleistungen "
+" - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
@@ -914,6 +940,7 @@ msgstr ""
 msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of VAT"
 msgstr ""
+"419 - Umsätze im Inland, für die der Empfänger Steuerschuldner ist"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
@@ -925,6 +952,8 @@ msgstr ""
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
+"423 - Dienstleistungen, die im Mitgliedstaat des Empfängers, der dort für "
+"Zwecke der MwSt. erfasst und Steuerschuldner ist, nicht steuerbefreit sind"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
@@ -935,6 +964,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
 msgstr ""
+"424 - Dienstleistungen, die im Mitgliedstaat des Empfängers, "
+"der dort für Zwecke der MwSt. erfasst ist, steuerbefreit sind"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
@@ -944,7 +975,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
-msgstr ""
+msgstr "431 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
@@ -954,7 +985,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
-msgstr ""
+msgstr "432 - nicht steuerbefreit im Inland: MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
@@ -964,12 +995,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435 - exempt within the territory: exempt"
-msgstr ""
+msgstr "435 - steuerbefreit im Inland: steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
 msgid "436 - base"
-msgstr ""
+msgstr "436 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
@@ -980,6 +1011,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
 msgstr ""
+"441 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
@@ -990,6 +1023,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
 msgstr ""
+"442 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
@@ -1000,11 +1035,13 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
 msgstr ""
+"445 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
-msgstr ""
+msgstr "454 - Gesamtbetrag der Entgelte"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
@@ -1016,6 +1053,8 @@ msgstr ""
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
+"455 - Entnahmen von Gegenständen für Zwecke des Unternehmens und für "
+"unternehmensfremde Zwecke"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
@@ -1025,7 +1064,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
-msgstr ""
+msgstr "456 - Erbringung von Dienstleistungen für unternehmensfremde Zwecke"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
@@ -1038,6 +1077,8 @@ msgid ""
 "457 - Intra-Community supply of goods to persons identified for VAT purposes "
 "in another Member State (MS)"
 msgstr ""
+"457 - Innergemeinschaftliche Lieferungen an Personen, die eine Id.-Nummer in "
+"einem anderen Mitgliedstaat besitzen"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
@@ -1047,7 +1088,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
-msgstr ""
+msgstr "458 - Von anderen Steuerpflichtigen für Warenlieferungen und "
+"Dienstleistungen in Rechnung gestellte Mehrwertsteuer"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
@@ -1058,6 +1100,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
 msgstr ""
+"459 - Erklärte oder bezahlte Mehrwertsteuer für innergemeinschaftliche "
+"Erwerbe von Gegenständen"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
@@ -1067,7 +1111,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
-msgstr ""
+msgstr "460 - Erklärte oder bezahlte Mehrwertsteuer für eingeführte Waren"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
@@ -1077,22 +1121,22 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461 - Due under the reverse charge (see points II.E and F)"
-msgstr ""
+msgstr "461 - Als Schuldner erklärte Mehrwertsteuer (Siehe Punkte II.E und F)"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
 msgid "462 - tax"
-msgstr ""
+msgstr "462 - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
 msgid "463 - base"
-msgstr ""
+msgstr "463 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
 msgid "464 - tax"
-msgstr ""
+msgstr "464 - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
@@ -1104,12 +1148,12 @@ msgstr ""
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
-msgstr ""
+msgstr "471 - Telekommunikationsdienstleistungen, Rundfunk- und Fernsehdienstleistungen..."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
 msgid "472 - Other sales / receipts"
-msgstr ""
+msgstr "472 - Andere Umsätze / Erträge"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
@@ -1119,7 +1163,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701 - base 17%"
-msgstr ""
+msgstr "701 - Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
@@ -1129,7 +1173,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
-msgstr ""
+msgstr "702 - MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
@@ -1139,7 +1183,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703 - base 14%"
-msgstr ""
+msgstr "703 - Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
@@ -1149,7 +1193,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
-msgstr ""
+msgstr "704 - MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
@@ -1159,7 +1203,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705 - base 8%"
-msgstr ""
+msgstr "705 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
@@ -1169,7 +1213,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
-msgstr ""
+msgstr "706 - MwSt. 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
@@ -1179,7 +1223,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711 - base 17%"
-msgstr ""
+msgstr "711 - Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
@@ -1189,7 +1233,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
-msgstr ""
+msgstr "712 - MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
@@ -1199,7 +1243,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713 - base 14%"
-msgstr ""
+msgstr "713 - Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
@@ -1209,7 +1253,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
-msgstr ""
+msgstr "714 - MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
@@ -1219,7 +1263,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715 - base 8%"
-msgstr ""
+msgstr "715 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
@@ -1229,7 +1273,21 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
+msgstr "716 - MwSt. 8%"
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+msgid "719"
 msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+msgid ""
+"719 - of manufactured tobacco (VAT is collected at the exit of the tax "
+"warehouse with excise duties)"
+msgstr ""
+"719 - von Tabakwaren, deren Mehrwertsteuer am Ausgang des Steuerlagers "
+"gemeinsam mit den Verbrauchsteuern erhoben wird"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
@@ -1239,7 +1297,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
-msgstr ""
+msgstr "721 - für Zwecke des Unternehmens: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
@@ -1249,7 +1307,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
-msgstr ""
+msgstr "722 - für Zwecke des Unternehmens: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
@@ -1259,7 +1317,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
-msgstr ""
+msgstr "723 - für Zwecke des Unternehmens: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
@@ -1269,7 +1327,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
-msgstr ""
+msgstr "724 - für Zwecke des Unternehmens: MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
@@ -1279,7 +1337,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
-msgstr ""
+msgstr "725 - für Zwecke des Unternehmens: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
@@ -1289,7 +1347,21 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
+msgstr "726 - für Zwecke des Unternehmens: MwSt. 8%"
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+msgid "729"
 msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+msgid ""
+"729 - of manufactured tobacco (VAT is collected at the exit of the tax "
+"warehouse with excise duties)"
+msgstr ""
+"729 - von Tabakwaren, deren Mehrwertsteuer am Ausgang des Steuerlagers "
+"gemeinsam mit den Verbrauchsteuern erhoben wird"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
@@ -1299,7 +1371,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
-msgstr ""
+msgstr "731 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
@@ -1309,7 +1381,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
-msgstr ""
+msgstr "732 - für unternehmensfremde Zwecke: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
@@ -1319,7 +1391,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
-msgstr ""
+msgstr "733 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
@@ -1329,7 +1401,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
-msgstr ""
+msgstr "734 - für unternehmensfremde Zwecke: MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
@@ -1339,7 +1411,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
-msgstr ""
+msgstr "735 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
@@ -1349,7 +1421,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
-msgstr ""
+msgstr "736 - für unternehmensfremde Zwecke: MwSt. 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
@@ -1359,7 +1431,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
-msgstr ""
+msgstr "741 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
@@ -1369,7 +1441,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
-msgstr ""
+msgstr "742 - nicht steuerbefreit im Inland: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
@@ -1379,7 +1451,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
-msgstr ""
+msgstr "743 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
@@ -1389,7 +1461,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
-msgstr ""
+msgstr "744 - nicht steuerbefreit im Inland: MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
@@ -1399,7 +1471,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
-msgstr ""
+msgstr "745 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
@@ -1409,7 +1481,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
-msgstr ""
+msgstr "746 - nicht steuerbefreit im Inland: MwSt. 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
@@ -1420,6 +1492,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
 msgstr ""
+"751 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
@@ -1430,6 +1504,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
 msgstr ""
+"752 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
@@ -1440,6 +1516,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
 msgstr ""
+"753 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
@@ -1450,6 +1528,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
 msgstr ""
+"754 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
@@ -1460,6 +1540,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
 msgstr ""
+"755 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
@@ -1469,7 +1551,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
-msgstr ""
+msgstr "756 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
+"in der Gemeinschaft ansässig sind: MwSt. 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
@@ -1480,6 +1563,8 @@ msgstr ""
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
 msgstr ""
+"761 - erbracht an den Erklärenden von im Inland ansässigen Steuerpflichtigen: "
+"Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
@@ -1489,7 +1574,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
-msgstr ""
+msgstr "762 - erbracht an den Erklärenden von im Inland ansässigen "
+"Steuerpflichtigen: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
@@ -1499,7 +1585,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
-msgstr ""
+msgstr "763 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
@@ -1509,17 +1595,17 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764 - tax 8%"
-msgstr ""
+msgstr "764 - MwSt. 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
 msgid "765 - base"
-msgstr ""
+msgstr "765 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
 msgid "766 - tax"
-msgstr ""
+msgstr "766 - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
@@ -1527,6 +1613,7 @@ msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
+"767 -Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
@@ -1534,6 +1621,7 @@ msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
 msgstr ""
+"768 -Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-8

--- a/addons/l10n_lu/i18n_extra/fr.po
+++ b/addons/l10n_lu/i18n_extra/fr.po
@@ -154,7 +154,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
 msgid "012 - Overall turnover"
-msgstr ""
+msgstr "012 - Chiffre d'affaires global"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
@@ -164,7 +164,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
-msgstr ""
+msgstr "014 - Exportations"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
@@ -174,7 +174,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015 - Other exemptions"
-msgstr ""
+msgstr "015 - Autres exonérations"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
@@ -184,7 +184,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
-msgstr ""
+msgstr "016 - Autres exonérations"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
@@ -197,6 +197,8 @@ msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
 msgstr ""
+"017 - Tabacs fabriqués dont la TVA a été perçue à la source respectivement "
+"à la sortie de l'entrepôt fiscal..."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
@@ -209,6 +211,8 @@ msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
 msgstr ""
+"018 - Livraisons subséquentes à des acquisitions intracommunautaires dans "
+"le cadre d'opérations triangulaires, lorsque le destinataire identifié à la TVA..."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
@@ -218,17 +222,17 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019 - Supplies other than referred to in 018 and 423 or 424"
-msgstr ""
+msgstr "019 - Autres opérations réalisées (imposables) à l'étranger"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
 msgid "021 - Exemptions and deductible amounts"
-msgstr ""
+msgstr "021 - Exonérations et montants déductibles"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
 msgid "022 - Taxable turnover"
-msgstr ""
+msgstr "022 - Chiffre d'affaires imposable"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
@@ -238,7 +242,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
-msgstr ""
+msgstr "031 - base 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
@@ -248,12 +252,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
-msgstr ""
+msgstr "033 - base 0%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
-msgstr ""
+msgstr "037 - Ventilation du chiffre d'affaires imposable – base"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
@@ -263,12 +267,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
-msgstr ""
+msgstr "040 - taxe 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
-msgstr ""
+msgstr "046 - Ventilation du chiffre d'affaires imposable – taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
@@ -278,12 +282,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
-msgstr ""
+msgstr "049 - base 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
-msgstr ""
+msgstr "051 - Acquisitions intracommunautaires de biens - base"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
@@ -293,12 +297,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
-msgstr ""
+msgstr "054 - taxe 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
 msgid "056 - Intra-Community acquisitions of goods – tax"
-msgstr ""
+msgstr "056 - Acquisitions intracommunautaires de biens - taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
@@ -308,7 +312,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
-msgstr ""
+msgstr "059 - à des fins de l'entreprise: base 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
@@ -318,12 +322,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063 - for non-business purposes: base 3%"
-msgstr ""
+msgstr "063 - à des fins étrangères à l'entreprise: base 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
 msgid "065 - Importation of goods – base"
-msgstr ""
+msgstr "065 - Importations de biens - base"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
@@ -333,7 +337,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
-msgstr ""
+msgstr "068 - à des fins de l'entreprise: taxe de 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
@@ -343,12 +347,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073 - for non-business purposes: tax 3%"
-msgstr ""
+msgstr "073 - à des fins étrangères à l'entreprise: taxe de 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
 msgid "076 - Total tax due"
-msgstr ""
+msgstr "076 - Total de la taxe en aval"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
@@ -358,7 +362,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
-msgstr ""
+msgstr "090 - Taxe déclarée pour l'affectation de biens à l'entreprise"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
@@ -368,12 +372,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092 - Paid as joint and several guarantee"
-msgstr ""
+msgstr "092 - Taxe acquittée comme caution solidaire"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
 msgid "093 - Total input tax"
-msgstr ""
+msgstr "093 - Total de la taxe en amont"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
@@ -381,6 +385,8 @@ msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
 msgstr ""
+"094 - Taxe non déductible en rapport avec des opérations exonérées en vertu "
+"des articles 44 et 56quater"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
@@ -388,31 +394,47 @@ msgid ""
 "095 - where the deductible proportion determined in accordance to article 50 "
 "is applied"
 msgstr ""
+"095 - Taxe non déductible en application du prorata visé à l'article 50"
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+msgid "096"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+msgid ""
+"096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
+"56ter-2(7) (when applying the margin scheme)"
+msgstr ""
+"096 - Taxe non déductible en application des articles 56ter-1/7 et "
+"56ter-2/7 (en cas d'option pour le régime d'imposition de la marge "
+"bénéficiaire)"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
-msgstr ""
+msgstr "097 - Total de la taxe en amont non déductible"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
 msgid "102 - Total input tax deductible"
-msgstr ""
+msgstr "102 - Total de la taxe en amont déductible"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
 msgid "103 - Total tax due"
-msgstr ""
+msgstr "103 - Total de la taxe en aval"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
 msgid "104 - Total input tax deductible"
-msgstr ""
+msgstr "104 - Total de la taxe en amont déductible"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
 msgid "105 - Exceeding amount"
-msgstr ""
+msgstr "105 - Excédent"
 
 #. module: l10n_lu
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-14
@@ -716,7 +738,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194 - base exempt"
-msgstr ""
+msgstr "194 - base exonérée"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
@@ -726,7 +748,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
-msgstr ""
+msgstr "195 - à des fins de l'entreprise: base exonérée"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
@@ -736,7 +758,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
-msgstr ""
+msgstr "196 - à des fins étrangères à l'entreprise: base exonérée"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
@@ -749,6 +771,8 @@ msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
 msgstr ""
+"226 - Opérations réalisées dans le cadre du régime particulier de l'article "
+"56sexies"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
@@ -758,7 +782,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
-msgstr ""
+msgstr "227 - Régime particulier suspensif: régularisation"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
@@ -768,7 +792,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
-msgstr ""
+msgstr "228 - Taxe régularisée - régime particulier suspensif"
 
 #. module: l10n_lu
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-3
@@ -888,7 +912,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
 msgid "407 - Importation of goods – tax"
-msgstr ""
+msgstr "407 - Importations de biens - taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
@@ -896,6 +920,8 @@ msgid ""
 "409 - Supply of services for which the customer is liable for the payment of "
 "VAT – base"
 msgstr ""
+"409 - Prestations de services à déclarer par le preneur redevable de la taxe "
+"- base"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
@@ -903,6 +929,8 @@ msgid ""
 "410 - Supply of services for which the customer is liable for the payment of "
 "VAT – tax"
 msgstr ""
+"410 - Prestations de services à déclarer par le preneur redevable de la taxe "
+"- taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
@@ -914,6 +942,7 @@ msgstr ""
 msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of VAT"
 msgstr ""
+"419 - Opérations à l'intérieur du pays pour lesquelles le preneur est le redevable"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
@@ -925,6 +954,7 @@ msgstr ""
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
+"423 - Prestations de services non exonérées dans l'Etat membre du preneur redevable"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
@@ -934,7 +964,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
-msgstr ""
+msgstr "424 - Prestations de services exonérées dans l'Etat membre du preneur"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
@@ -944,7 +974,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
-msgstr ""
+msgstr "431 - non exonérées à l'intérieur du pays: base 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
@@ -954,7 +984,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
-msgstr ""
+msgstr "432 - non exonérées à l'intérieur du pays: tax 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
@@ -964,7 +994,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435 - exempt within the territory: exempt"
-msgstr ""
+msgstr "435 - exonérées à l'intérieur du pays: exonérées"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
@@ -979,7 +1009,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
-msgstr ""
+msgstr "441 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: base 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
@@ -989,7 +1020,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
-msgstr ""
+msgstr "442 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: tax 3%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
@@ -999,12 +1031,13 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
-msgstr ""
+msgstr "445 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: exonérées"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
-msgstr ""
+msgstr "454 - Total Ventes / Recettes"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
@@ -1016,6 +1049,7 @@ msgstr ""
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
+"455 - Application de biens de l'utilisation privée et à des fins de l'entreprise"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
@@ -1025,7 +1059,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
-msgstr ""
+msgstr "456 - Prestations de services effectuées à des fins étrangères à "
+"l'entreprise"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
@@ -1038,6 +1073,8 @@ msgid ""
 "457 - Intra-Community supply of goods to persons identified for VAT purposes "
 "in another Member State (MS)"
 msgstr ""
+"457 - Livraisons intracommunautaires de biens à des personnes identifiées à "
+"la TVA dans un autre État membre"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
@@ -1047,7 +1084,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
-msgstr ""
+msgstr "458 - Taxe facturée par d'autres assujettis pour des biens et des services fournis"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
@@ -1057,7 +1094,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
-msgstr ""
+msgstr "459 - Taxe déclarée ou payée sur des acquisitions intracommunautaires de biens"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
@@ -1067,7 +1104,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
-msgstr ""
+msgstr "460 - Taxe déclarée ou payée sur des biens importés"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
@@ -1077,12 +1114,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461 - Due under the reverse charge (see points II.E and F)"
-msgstr ""
+msgstr "461 - Taxe déclarée comme débiteur (cf points II.E et F)"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
 msgid "462 - tax"
-msgstr ""
+msgstr "462 - taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
@@ -1092,7 +1129,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
 msgid "464 - tax"
-msgstr ""
+msgstr "464 - taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
@@ -1105,11 +1142,13 @@ msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
 msgstr ""
+"471 - Prestations de services de télécommunication, de radiodiffusion "
+"et de télévision..."
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
 msgid "472 - Other sales / receipts"
-msgstr ""
+msgstr "472 - Autres Ventes / Recettes"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
@@ -1129,7 +1168,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
-msgstr ""
+msgstr "702 - taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
@@ -1149,7 +1188,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
-msgstr ""
+msgstr "704 - taxe 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
@@ -1169,7 +1208,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
-msgstr ""
+msgstr "706 - taxe 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
@@ -1189,7 +1228,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
-msgstr ""
+msgstr "712 - taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
@@ -1209,7 +1248,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
-msgstr ""
+msgstr "714 - taxe 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
@@ -1229,7 +1268,21 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
+msgstr "716 - taxe 8%"
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+msgid "719"
 msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+msgid ""
+"719 - of manufactured tobacco (VAT is collected at the exit of the tax "
+"warehouse with excise duties)"
+msgstr ""
+"719 - de tabacs fabriqués dont la TVA est perçue à la sortie de "
+"l'entrepôt fiscal conjointement avec les accises"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
@@ -1239,7 +1292,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
-msgstr ""
+msgstr "721 - à des fins de l'entreprise: base 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
@@ -1249,7 +1302,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
-msgstr ""
+msgstr "722 - à des fins de l'entreprise: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
@@ -1259,7 +1312,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
-msgstr ""
+msgstr "723 - à des fins de l'entreprise: base 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
@@ -1269,7 +1322,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
-msgstr ""
+msgstr "724 - à des fins de l'entreprise: taxe 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
@@ -1279,7 +1332,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
-msgstr ""
+msgstr "725 - à des fins de l'entreprise: base 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
@@ -1289,7 +1342,21 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
+msgstr "726 - à des fins de l'entreprise: taxe 8%"
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+msgid "729"
 msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+msgid ""
+"729 - of manufactured tobacco (VAT is collected at the exit of the tax "
+"warehouse with excise duties)"
+msgstr ""
+"729 - de tabacs fabriqués dont la TVA est perçue à la sortie de "
+"l'entrepôt fiscal conjointement avec les accises"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
@@ -1299,7 +1366,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
-msgstr ""
+msgstr "731 - à des fins étrangères à l'entreprise: base 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
@@ -1309,7 +1376,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
-msgstr ""
+msgstr "732 - à des fins étrangères à l'entreprise: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
@@ -1319,7 +1386,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
-msgstr ""
+msgstr "733 - à des fins étrangères à l'entreprise: base 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
@@ -1329,7 +1396,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
-msgstr ""
+msgstr "734 - à des fins étrangères à l'entreprise: taxe 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
@@ -1339,7 +1406,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
-msgstr ""
+msgstr "735 - à des fins étrangères à l'entreprise: base 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
@@ -1349,7 +1416,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
-msgstr ""
+msgstr "736 - à des fins étrangères à l'entreprise: taxe 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
@@ -1359,7 +1426,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
-msgstr ""
+msgstr "741 - non exonérées à l'intérieur du pays: base 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
@@ -1369,7 +1436,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
-msgstr ""
+msgstr "742 - non exonérées à l'intérieur du pays: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
@@ -1379,7 +1446,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
-msgstr ""
+msgstr "743 - non exonérées à l'intérieur du pays: base 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
@@ -1389,7 +1456,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
-msgstr ""
+msgstr "744 - non exonérées à l'intérieur du pays: taxe 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
@@ -1399,7 +1466,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
-msgstr ""
+msgstr "745 - non exonérées à l'intérieur du pays: base 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
@@ -1409,7 +1476,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
-msgstr ""
+msgstr "746 - non exonérées à l'intérieur du pays: taxe 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
@@ -1419,7 +1486,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
-msgstr ""
+msgstr "751 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: base 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
@@ -1429,7 +1497,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
-msgstr ""
+msgstr "752 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
@@ -1439,7 +1508,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
-msgstr ""
+msgstr "753 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: base 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
@@ -1449,7 +1519,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
-msgstr ""
+msgstr "754 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: taxe 14%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
@@ -1459,7 +1530,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
-msgstr ""
+msgstr "755 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: base 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
@@ -1469,7 +1541,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
-msgstr ""
+msgstr "756 - effectuées au déclarant par des assujettis établis en dehors "
+"de la Communauté: taxe 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
@@ -1479,7 +1552,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
-msgstr ""
+msgstr "761 - effectuées au déclarant par des assujettis établis "
+"à l'intérieur du pays: base 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
@@ -1489,7 +1563,8 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
-msgstr ""
+msgstr "762 - effectuées au déclarant par des assujettis établis "
+"à l'intérieur du pays: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
@@ -1509,7 +1584,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764 - tax 8%"
-msgstr ""
+msgstr "764 - taxe 8%"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
@@ -1519,7 +1594,7 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
 msgid "766 - tax"
-msgstr ""
+msgstr "766 - taxe"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
@@ -1527,6 +1602,7 @@ msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
+"767 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - base"
 
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
@@ -1534,6 +1610,7 @@ msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
 msgstr ""
+"768 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - taxe"
 
 #. module: l10n_lu
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-8

--- a/addons/l10n_lu/i18n_extra/l10n_lu.pot
+++ b/addons/l10n_lu/i18n_extra/l10n_lu.pot
@@ -389,6 +389,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+msgid "096"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+msgid ""
+"096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
+"56ter-2(7) (when applying the margin scheme)"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
 msgstr ""
@@ -1232,6 +1244,18 @@ msgid "716 - tax 8%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+msgid "719"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+msgid ""
+"719 - of manufactured tobacco (VAT is collected at the exit of the tax "
+"warehouse with excise duties)"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721"
 msgstr ""
@@ -1289,6 +1313,18 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+msgid "729"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+msgid ""
+"729 - of manufactured tobacco (VAT is collected at the exit of the tax "
+"warehouse with excise duties)"
 msgstr ""
 
 #. module: l10n_lu


### PR DESCRIPTION
- Add translations for fr, de
- Add a fix for auto-installation of l10n_lu_reports
Because l10n_lu_reports depends on account_saft and we don't want to
install that for every l10n, account_saft needs to be installed in the
post_init hook only until saas15.3, where this is fixed.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
