### PR TITLE
[FIX] point_of_sale: sell products with lot or serial number

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1531,7 +1531,7 @@ class Orderline extends PosModel {
 
         // Set the quantity of the line based on number of pack lots.
         if(!this.product.to_weight){
-            this.pack_lot_lines.set_quantity_by_lot();
+            this.set_quantity_by_lot();
         }
     }
     set_product_lot(product){


### PR DESCRIPTION
In point of sale, adding a product with a lot or serial number to an
order raises an error.

Steps to reproduce:
1. Install Point of Sale
2. Go to Point of Sale > Products and create a product 'Product A' of
   type 'Storable Product' and tracked by serial number
3. Open a session in POS 'Shop' and add 'Product A' to the order (give
   any serial number): an error is thrown

Solution:
Call `set_quantity_by_lot` from `this`

Problem:
This PR https://github.com/odoo/odoo/pull/82461 modified the class in
which `set_quantity_by_lot` is defined, hence we do not need to call it
from `pack_lot_lines` anymore

opw-2919414