### PR TITLE
[IMP] delivery: printing multiple shipping labels

### DIFF
--- a/addons/delivery/controllers/__init__.py
+++ b/addons/delivery/controllers/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import wizard
+from . import main

--- a/addons/delivery/controllers/main.py
+++ b/addons/delivery/controllers/main.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request, content_disposition
+from odoo.tools import pdf
+
+
+class DeliveryController(http.Controller):
+
+    @http.route('/print/shipping/<picking_ids>', type='http', auth='user')
+    def print_shipping_lables(self, picking_ids):
+        pickings = request.env['stock.picking'].browse([int(picking_id) for picking_id in picking_ids.split(',')])
+        content = pdf.merge_pdf([attachment.raw for attachment in pickings.picking_label_ids])
+        headers = [
+            ('Content-Type', 'application/pdf'),
+            ('Content-Disposition', content_disposition('shippingLabels.pdf'))
+        ]
+        return request.make_response(content, headers)

--- a/addons/delivery/data/delivery_data.xml
+++ b/addons/delivery/data/delivery_data.xml
@@ -24,5 +24,12 @@
             <field name="delivery_type">fixed</field>
             <field name="product_id" ref="delivery.product_product_delivery"/>
         </record>
+        <record id="print_shipping_label" model="ir.actions.server">
+            <field name="name">Print Shipping Labels</field>
+            <field name="model_id" ref="delivery.model_stock_picking"/>
+            <field name="binding_model_id" ref="delivery.model_stock_picking"/>
+            <field name="state">code</field>
+            <field name="code">action = records.print_shipping_labels()</field>
+        </record>
     </data>
 </odoo>

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -213,6 +213,9 @@ class DeliveryCarrier(models.Model):
         if self.can_generate_return:
             return getattr(self, '%s_get_return_label' % self.delivery_type)(pickings, tracking_number, origin_date)
 
+    def get_label_prefix(self):
+        return "Label"
+
     def get_return_label_prefix(self):
         return 'ReturnLabel-%s' % self.delivery_type
 


### PR DESCRIPTION
Purpose
=======
printing multiple shipping labels at once in inventory transfer, provided by third-party shippers like FedEx, ups, etc.

So in this commit, added the 'Print Shipping Lables' action in the inventory transfer list view.
this method gets all shipping labels from the transfer's attachment and gets it in a single PDF file.

TaskId - 2447447