### PR TITLE
[IMP] website: remove the iframefallback in test mode

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -152,6 +152,7 @@
         ],
         'web.assets_tests': [
             'website/static/tests/tours/**/*',
+            'website/static/src/client_actions/website_preview/website_preview_test_mode.js',
         ],
         'web.assets_backend': [
             ('include', 'website.assets_editor'),
@@ -168,6 +169,7 @@
             'website/static/src/js/theme_preview_kanban.js',
             'website/static/src/js/theme_preview_form.js',
             'website/static/src/client_actions/*/*.js',
+            ('remove', 'website/static/src/client_actions/website_preview/website_preview_test_mode.js'),
             'website/static/src/client_actions/*/*.scss',
             'website/static/src/components/fields/fields.js',
             'website/static/src/components/fullscreen_indication/fullscreen_indication.js',

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -151,6 +151,10 @@ export class WebsitePreview extends Component {
         return path;
     }
 
+    get testMode() {
+        return false;
+    }
+
     reloadIframe(url) {
         return new Promise((resolve, reject) => {
             this.iframe.el.addEventListener('OdooFrameContentLoaded', resolve, { once: true });
@@ -215,7 +219,8 @@ export class WebsitePreview extends Component {
         // This is needed for the registerThemeHomepageTour tours
         const { editable, viewXmlid } = this.websiteService.currentWebsite.metadata;
         this.container.el.dataset.viewXmlid = viewXmlid;
-        if (!editable) {
+        // The iframefallback is hidden in test mode
+        if (!editable && this.iframefallback.el) {
             this.iframefallback.el.classList.add('d-none');
         }
 
@@ -280,7 +285,8 @@ export class WebsitePreview extends Component {
         // Chrome Windows/Linux).
         // If the iframe is currently displaying an XML file, the body does not
         // exist, so we do not replace the iframefallback content.
-        if (!this.websiteContext.edition && this.iframe.el.contentDocument.body) {
+        // The iframefallback is hidden in test mode
+        if (!this.websiteContext.edition && this.iframe.el.contentDocument.body && this.iframefallback.el) {
             this.iframefallback.el.contentDocument.body.replaceWith(this.iframe.el.contentDocument.body.cloneNode(true));
             this.iframefallback.el.classList.remove('d-none');
             $().getScrollingElement(this.iframefallback.el.contentDocument)[0].scrollTop = $().getScrollingElement(this.iframe.el.contentDocument)[0].scrollTop;

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -15,7 +15,8 @@
     <div class="o_website_preview" t-att-class="{ 'editor_enable editor_has_snippets': this.websiteContext.snippetsLoaded }" t-ref="container">
         <div class="o_iframe_container" t-att-class="{ 'o_is_mobile': this.websiteContext.isMobile }">
             <BlockIframe/>
-            <iframe t-att-src="iframeFallbackUrl"
+            <iframe t-if="!testMode"
+                t-att-src="iframeFallbackUrl"
                 class="o_ignore_in_tour"
                 t-att-class="{ 'd-none': this.websiteContext.edition }"
                 t-ref="iframefallback"/>

--- a/addons/website/static/src/client_actions/website_preview/website_preview_test_mode.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview_test_mode.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+import { patch } from 'web.utils';
+import { WebsitePreview } from '@website/client_actions/website_preview/website_preview';
+
+patch(WebsitePreview.prototype, 'website_preview_test_mode', {
+    /**
+     * @override
+     */
+    get testMode() {
+        return true;
+    }
+});

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -298,7 +298,8 @@ function registerEditionTour(name, options, steps) {
     let tourSteps = steps;
     let url = getClientActionUrl(options.url, !!options.edition);
     if (options.edition) {
-       tourSteps = [{
+        tourSteps = [{
+            content: "Wait for the edit mode to be started",
             trigger: '.o_website_preview.editor_enable.editor_has_snippets',
             timeout: 30000,
             run: () => {}, // It's a check

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -1,0 +1,23 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+
+tour.register('client_action_iframe_fallback', {
+    test: true,
+    url: '/@/',
+},
+[
+    {
+        content: "Ensure we are on the expected page",
+        trigger: 'body iframe html[data-view-xmlid="website.homepage"]',
+        run: () => {}, // It's a check.
+    }, {
+        content: "Ensure the iframe fallback is not loaded in test mode",
+        trigger: 'body',
+        run: () => {
+            if (document.querySelector('iframe[src="/website/iframefallback"]')) {
+                console.error("The iframe fallback shouldn't be inside the DOM.");
+            }
+        },
+    },
+]);

--- a/addons/website/tests/test_client_action.py
+++ b/addons/website/tests/test_client_action.py
@@ -22,3 +22,6 @@ class TestClientAction(odoo.tests.HttpCase):
             'is_published': True,
         })
         self.start_tour(page.url, 'client_action_redirect', login='admin')
+
+    def test_02_client_action_iframe_fallback(self):
+        self.start_tour('/@/', 'client_action_iframe_fallback', login='admin')


### PR DESCRIPTION
This commit gets rid of the iframefallback in test mode. It is not
helpful there and slows down the tests as it involves some HTTP
requests.
Its purpose is only for the end users to have a smoother UX during page
transition. It is irrelevant in tests. Note that it means the tests
wouldn't break if that iframe fallback was to be breaking something in
real use cases.

task-2687506
