### PR TITLE
[FIX] web: list renderer: clicking on something else than a data row …

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1473,14 +1473,20 @@ export class ListRenderer extends Component {
 
         this.tableRef.el.querySelector("tbody").classList.remove("o_keyboard_navigation");
 
-        if (this.tableRef.el.contains(ev.target)) {
-            return; // ignore clicks inside the table, they are handled directly by the renderer
+        const target = ev.target;
+        if (
+            this.tableRef.el.contains(target) &&
+            (target.closest(".o_data_row") || target.closest(".o_column_sortable"))
+        ) {
+            // ignore clicks inside the table that are originating from a record row
+            // as they are handled directly by the renderer.
+            return;
         }
         if (this.activeElement !== this.uiService.activeElement) {
             return;
         }
         // Legacy DatePicker
-        if (ev.target.closest(".daterangepicker")) {
+        if (target.closest(".daterangepicker")) {
             return;
         }
         this.props.list.unselectRecord(true);

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -13964,4 +13964,41 @@ QUnit.module("Views", (hooks) => {
             ["yop", "gnap", "blip", "blip"]
         );
     });
+
+    QUnit.test("editable list header click should unselect record", async (assert) => {
+        await makeView({
+            resModel: "foo",
+            type: "list",
+            arch: `<list editable="top"><field name="display_name" /></list>`,
+            serverData,
+        });
+
+        await click(target.querySelector(".o_data_cell"));
+        assert.containsOnce(target, ".o_selected_row");
+        await editInput(target, ".o_data_cell input", "someInput");
+        await click(target.querySelector("thead th:nth-child(2)"));
+        await triggerEvent(target.querySelector("thead th"), null, "keydown", { key: "ArrowDown" });
+
+        assert.containsNone(target, ".o_selected_row");
+    });
+
+    QUnit.test("editable list group header click should unselect record", async (assert) => {
+        await makeView({
+            resModel: "foo",
+            type: "list",
+            arch: `<list editable="top"><field name="display_name" /></list>`,
+            serverData,
+            groupBy: ["bar"],
+        });
+
+        await click(target.querySelector(".o_group_header"));
+        await click(target.querySelector(".o_group_header:not(.o_group_open)"));
+
+        await click(target.querySelector(".o_data_cell"));
+        assert.containsOnce(target, ".o_selected_row");
+        await editInput(target, ".o_data_cell input", "someInput");
+        await click(target.querySelectorAll(".o_group_header")[1]);
+
+        assert.containsNone(target, ".o_selected_row");
+    });
 });


### PR DESCRIPTION
…unselects the current record

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
