### PR TITLE
[FIX] barcode: allow multiple buttons with the same string and action

### DIFF
--- a/addons/barcodes/static/src/js/barcode_form_view.js
+++ b/addons/barcodes/static/src/js/barcode_form_view.js
@@ -436,7 +436,7 @@ FormRenderer.include({
         };
         var name = node.attrs.name;
         if (node.attrs.string) {
-            name = name + '_' + node.attrs.string;
+            name = JSON.stringify(node.attrs);
         }
 
         this.trigger_up('activeBarcode', {

--- a/addons/barcodes/static/tests/barcode_tests.js
+++ b/addons/barcodes/static/tests/barcode_tests.js
@@ -89,6 +89,44 @@ QUnit.test('Button with barcode_trigger', async function (assert) {
     form.destroy();
 });
 
+QUnit.test('Two buttons with same barcode_trigger and the same string and action', async function (assert) {
+    assert.expect(2);
+
+    var form = await createView({
+        View: FormView,
+        model: 'product',
+        data: this.data,
+        arch: '<form>' +
+                '<header>' +
+                    '<button name="do_something" string="Validate" type="object" invisible="0" barcode_trigger="doit"/>' +
+                    '<button name="do_something" string="Validate" type="object" invisible="1" barcode_trigger="doit"/>' +
+                '</header>' +
+            '</form>',
+        res_id: 2,
+
+        services: {
+            notification: {
+                notify: function (params) {
+                    assert.step(params.type);
+                }
+            },
+        },
+        intercepts: {
+            execute_action: function (event) {
+                assert.strictEqual(event.data.action_data.name, 'do_something',
+                    "do_something method call verified");
+            },
+        },
+    });
+
+    // O-BTN.doit should call execute_action as the first button is visible
+    _.each(['O','-','B','T','N','.','d','o','i','t','Enter'], triggerKeypressEvent);
+    await testUtils.nextTick();
+    assert.verifySteps([], "no warning should be displayed");
+
+    form.destroy();
+});
+
 QUnit.test('edit, save and cancel buttons', async function (assert) {
     assert.expect(6);
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable work order option in manufacturing settings
- Create a manufacturing order and use the product Table
- Open the tablet view
- with the JS instruction, try to simulate the scan of the command
`CONTINUE CONSUMPTION` with this value: `O-BTN.continue`

Problem:
The action continue is not executed because when the tablet view
is loaded, the function _barcodeButtonHandler is triggered in which
we try to call the `activeBarcode` function for all the buttons:
https://github.com/odoo/odoo/blob/c6716847aa5d694650bfe046657f052a03f9ca39/addons/barcodes/static/src/js/barcode_form_view.js#L437-L445
To add each button in a dictionary, we use as key the name + the string
of the button, but as multiple buttons can have the same name and
the same action, only the last button is saved:
https://github.com/odoo/enterprise/blob/2c9d2c5738d378f6f5cdc2ceec00b89cb5fa9536/mrp_workorder/views/mrp_workorder_views.xml#L137-L150

https://github.com/odoo/odoo/blob/c6716847aa5d694650bfe046657f052a03f9ca39/addons/barcodes/static/src/js/barcode_form_view.js#L252-L255

Solution:
To allow having multiple buttons with a similar name and action,
we must add in the key the attrs hash of the button

opw-2899297
