### PR TITLE
[IMP] payment_stripe: allow passing contextual request data to the proxy

### DIFF
--- a/addons/payment_stripe/models/payment_acquirer.py
+++ b/addons/payment_stripe/models/payment_acquirer.py
@@ -313,7 +313,10 @@ class PaymentAcquirer(models.Model):
             'jsonrpc': '2.0',
             'id': uuid.uuid4().hex,
             'method': 'call',
-            'params': {'payload': payload},
+            'params': {
+                'payload': payload,  # Stripe data.
+                'proxy_data': self._stripe_prepare_proxy_data(stripe_payload=payload),
+            },
         }
         url = url_join(PROXY_URL, f'{version}/{endpoint}')
         try:
@@ -336,3 +339,17 @@ class PaymentAcquirer(models.Model):
             raise ValidationError(_("Stripe Proxy error: %(error)s", error=error_data['message']))
 
         return response_content.get('result', {})
+
+    def _stripe_prepare_proxy_data(self, stripe_payload=None):
+        """ Prepare the contextual data passed to the proxy when making a request.
+
+        Note: This method serves as a hook for modules that would fully implement Stripe Connect.
+        Note: self.ensure_one()
+
+        :param dict stripe_payload: The part of the request payload to be forwarded to Stripe.
+        :return: The proxy data.
+        :rtype: dict
+        """
+        self.ensure_one()
+
+        return {}


### PR DESCRIPTION
For modules that fully implement Stripe Connect, i.e. that sign requests
with their own API keys, there was no way to pass contextual data to the
proxy when making those requests.

This commit addresses the issue by populating the `proxy_data` param
present in all proxy's routes' signatures with an extendable `dict`.

task-2917229

See also:
- https://github.com/odoo/iap-apps/pull/514
- https://github.com/odoo/internal/pull/1776
- https://github.com/odoo/saas-automation/pull/293