### PR TITLE
[FIX] mrp, purchase, sale: correct domain for quantity counters

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -55,7 +55,7 @@ class ProductTemplate(models.Model):
         action['domain'] = [('state', '=', 'done'), ('product_tmpl_id', 'in', self.ids)]
         action['context'] = {
             'graph_measure': 'product_uom_qty',
-            'time_ranges': {'field': 'date_planned_start', 'range': 'last_365_days'}
+            'search_default_filter_date_planned_start_365days': 1,
         }
         return action
 

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -330,6 +330,8 @@
                         domain="[('activity_ids.date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_ids.date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
+                    <filter name="filter_date_planned_start_365days" string="Planned Date: Last 365 Days" domain="[
+                        ('date_planned_start', '&gt;', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -44,7 +44,7 @@ class ProductTemplate(models.Model):
         action['context'] = {
             'graph_measure': 'qty_ordered',
             'search_default_orders': 1,
-            'time_ranges': {'field': 'date_approve', 'range': 'last_365_days'}
+            'search_default_filter_date_order_365days': 1,
         }
         return action
 
@@ -62,7 +62,6 @@ class ProductProduct(models.Model):
             ('product_id', 'in', self.ids),
             ('date_order', '>', date_from)
         ]
-        PurchaseOrderLines = self.env['purchase.order.line'].search(domain)
         order_lines = self.env['purchase.order.line'].read_group(domain, ['product_id', 'product_uom_qty'], ['product_id'])
         purchased_data = dict([(data['product_id'][0], data['product_uom_qty']) for data in order_lines])
         for product in self:
@@ -75,7 +74,7 @@ class ProductProduct(models.Model):
         action = self.env.ref('purchase.action_purchase_order_report_all').read()[0]
         action['domain'] = ['&', ('state', 'in', ['purchase', 'done']), ('product_id', 'in', self.ids)]
         action['context'] = {
-            'search_default_last_year_purchase': 1,
+            'search_default_filter_date_order_365days': 1,
             'search_default_status': 1, 'search_default_order_month': 1,
             'graph_measure': 'qty_ordered'
         }

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -53,6 +53,10 @@
             <search string="Purchase Orders">
                 <filter string="Requests for Quotation" name="quotes" domain="[('state','in',('draft','sent'))]"/>
                 <filter string="Purchase Orders" name="orders" domain="[('state','!=','draft'), ('state','!=','sent'), ('state','!=','cancel')]"/>
+                <separator/>
+                <filter string="Order Date: Last 365 Days" name="filter_date_order_365days" domain="[
+                    ('date_order', '&gt;', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                <separator/>
                 <field name="partner_id"/>
                 <field name="product_id"/>
                 <group expand="0" string="Extended Filters">

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -50,7 +50,7 @@ class ProductProduct(models.Model):
             'active_id': self._context.get('active_id'),
             'search_default_Sales': 1,
             'active_model': 'sale.report',
-            'time_ranges': {'field': 'date', 'range': 'last_365_days'},
+            'search_default_filter_date_365days': 1,
         }
         return action
 

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -89,7 +89,7 @@ class ProductTemplate(models.Model):
             'active_id': self._context.get('active_id'),
             'active_model': 'sale.report',
             'search_default_Sales': 1,
-            'time_ranges': {'field': 'date', 'range': 'last_365_days'}
+            'search_default_filter_date_365days': 1,
         }
         return action
 

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -34,6 +34,9 @@
                 <filter name="Quotations" string="Quotations" domain="[('state','in', ('draft', 'sent'))]"/>
                 <filter name="Sales" string="Sales Orders" domain="[('state','not in',('draft', 'cancel', 'sent'))]"/>
                 <separator/>
+                <filter name="filter_date_365days" string="Order Date: Last 365 Days" domain="[
+                    ('date', '&gt;=', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                <separator/>
                 <field name="user_id"/>
                 <field name="team_id"/>
                 <field name="product_id"/>


### PR DESCRIPTION
Steps to reproduce:

- Go to sales. Create a new product. Then create a sale order with that product with 1 quantity and validate.
- Go to that product variant form. Button "X units sold" shows "1 units sold."
- Click on the button to go to the pivot view.
  => No records are shown in the pivot view (because today is excluded in the domain).

We need to assure button shows same quantity as the one in the pivot view.

In https://github.com/odoo/odoo/pull/96051 I tried to modify the web js domain, but it seems that was wrong, as the web domain was intended as it is now (counting full days). So I try now the other way around, that is, to correct the quantity shown in the button.

Error:
![](https://user-images.githubusercontent.com/25005517/179019431-c4bbdf62-b639-4f86-af5e-af849160f551.gif)

And this is the web domain:
![Selection_488](https://user-images.githubusercontent.com/25005517/179550190-4131d3da-3f32-4369-ab5b-f823dbf4bee4.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr