### PR TITLE
[FIX] l10n_it_edi: Natura field in DatiRiepilogo should be after Aliq…

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -156,11 +156,11 @@
                 <t t-set="kind_exoneration" t-value="tax.l10n_it_kind_exoneration"/>
                 <DatiRiepilogo>
                     <AliquotaIVA t-esc="format_numbers(tax.amount)"/>
+                    <Natura t-if="has_exoneration" t-esc="kind_exoneration"/>
                     <Arrotondamento t-if="tax_dict.get('rounding')" t-esc="format_numbers(tax_dict['rounding'])"/>
                     <ImponibileImporto t-esc="format_monetary(abs(tax_dict['base_amount_currency']), currency)"/>
                     <Imposta t-esc="format_monetary(abs(tax_dict['tax_amount_currency']), currency)"/>
                     <EsigibilitaIVA t-if="not has_exoneration or kind_exoneration == 'N6'" t-esc="tax.l10n_it_vat_due_date"/>
-                    <Natura t-if="has_exoneration" t-esc="kind_exoneration"/>
                     <RiferimentoNormativo t-if="has_exoneration" t-esc="format_alphanumeric(tax.l10n_it_law_reference[:100])"/>
                 </DatiRiepilogo>
             </t>


### PR DESCRIPTION
…uotaIVA

It was moved by accident in
https://github.com/odoo-dev/odoo/commit/fc211bb65926fe6ab4e11d0f550258235dc029eb#diff-811190e17a6319ef140e8c723545eec04db37d3cad73a7c855f0808aa74131d1

FatturaPA is quite picky in terms of the order of fieldS.

opw-2703669

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
