### PR TITLE
[FIX] purchase: do not update the unit price if the PO is validated

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -701,7 +701,7 @@ class PurchaseOrderLine(models.Model):
 
     @api.onchange('product_qty', 'product_uom')
     def _onchange_quantity(self):
-        if not self.product_id:
+        if not self.product_id or self.state in ('purchase', 'done'):
             return
         params = {'order_id': self.order_id}
         seller = self.product_id._select_seller(


### PR DESCRIPTION
Steps to reproduce the bug:
- create a storable product “P1”:
    - Go to  purchase tab > add vendor “azure interior” with price of
    $10 per unit
- Create a PO:
    - Select Azure interior as vendor
    - add 3 units of P1:
         - update the price from $10 to $5 unit price
    - Confirm the PO
   - Receive order
   - Create a Bill and confirm it
- Go back to the Po:
    - The unit price is readonly
    - Change the quantity from 3 to 5
   
Problem:
The price is updated to 10 in the onchange_quantity

Solution:
If the PO is in the invoiced status, it's useless to update the unit
price, because anyway, the field is readonly, it will not be saved
when the user saves the PO

opw-2920050
