### PR TITLE
[FIX] hr_holidays: no leave in list view for multiple employee

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -662,7 +662,10 @@
             'search_default_active_time_off': 4,
             'hide_employee_name': 1}
         </field>
-        <field name="domain">[('employee_id.company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain">['|', ('employee_id.company_id', 'in', allowed_company_ids),
+                                    '&amp;', ('multi_employee', '=', True),
+                                    '&amp;', ('state', 'in', ['draft', 'confirm', 'validate1']),
+                                    ('employee_ids.company_id', 'in', allowed_company_ids)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Meet the time off dashboard.


### PR DESCRIPTION
Steps to reproduce:
- Create a leave request for multiple employees
- Go in the employee list

Current behavior:
The leave request is not visible in the list view

Expected behavior:
The leave request is visible in the list view

Explanation:
Previously a domain on the list view restricted the
records to the one that had an employee_id with the
right company but this condition was never met by the
the multi_employee leaves as they have no employee_id.
To solve the issue we add to the domain a condition to
accept multi_domain employee that have the right state
and the right company.

opw-2917291