### PR TITLE
[FIX] product: add product_tmpl_id to allow easy view inherit

### DIFF
--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -120,6 +120,7 @@
             <field name="item_ids" position="replace">
                 <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}" groups="product.group_product_pricelist">
                     <tree string="Pricelist Rules">
+                        <field name="product_tmpl_id" invisible="1"/>
                         <field name="name" string="Applicable On"/>
                         <field name="min_quantity"/>
                         <field name="price" string="Price"/>


### PR DESCRIPTION
Before this commit, the product_tmpl_id field was present in the
product_pricelist_view but not the product_pricelist_view_inherit.

This changes allows to have a simple solution to modify the product_tmpl_id attributes
in other modules.

taskid: 2886054



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
