### PR TITLE
[FIX] base: fix autoresize and exclude gif

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -289,7 +289,7 @@ class IrAttachment(models.Model):
 
     def _postprocess_contents(self, values):
         ICP = self.env['ir.config_parameter'].sudo().get_param
-        supported_subtype = ICP('base.image_autoresize_extensions', 'png,jpeg,gif,bmp,tif').split(',')
+        supported_subtype = ICP('base.image_autoresize_extensions', 'png,jpeg,bmp,tiff').split(',')
 
         mimetype = values['mimetype'] = self._compute_mimetype(values)
         _type, _subtype = mimetype.split('/')
@@ -306,16 +306,15 @@ class IrAttachment(models.Model):
                         img = ImageProcess(False, verify_resolution=False)
                         img.image = Image.open(io.BytesIO(values['raw']))
                         img.original_format = (img.image.format or '').upper()
-                        fn_quality = img.image_quality
                     else:  # datas
                         img = ImageProcess(values['datas'], verify_resolution=False)
-                        fn_quality = img.image_base64
 
                     w, h = img.image.size
                     nw, nh = map(int, max_resolution.split('x'))
                     if w > nw or h > nh:
-                        img.resize(nw, nh)
+                        img = img.resize(nw, nh)
                         quality = int(ICP('base.image_autoresize_quality', 80))
+                        fn_quality = img.image_quality if is_raw else img.image_base64
                         values[is_raw and 'raw' or 'datas'] = fn_quality(quality=quality)
                 except UserError as e:
                     # Catch error during test where we provide fake image

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -206,6 +206,12 @@ class TestIrAttachment(TransactionCase):
         attach.raw = img_bin
         self.assertApproximately(attach.raw, fullsize)
 
+        # no resize of gif
+        self.env['ir.config_parameter'].set_param('base.image_autoresize_max_px', '0x0')
+        gif_bin = b'GIF89a\x01\x00\x01\x00\x00\xff\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x00;'
+        attach.raw = gif_bin
+        self.assertEqual(attach.raw, gif_bin)
+
     def test_11_copy(self):
         """
         Copying an attachment preserves the data


### PR DESCRIPTION
Odoo may resize attachment image with side larger than 1920 pixels.

But for animated gifs, this resizement seems to in general increase size
file which is not what we want (in some case making it grow from 3MB to
60 MB).

So with this change, we only resize and optimize images that are not
gifs.

Reasoning: pillow doesn't seem to resize GIF (and seems to only increase
their size, especially animated GIF, because each frame is not
optimized) so we should just not touch them.

Note:

- currently tiff were not resized (because of a mimetype typo)
- currently image dimensions were not resized (from our test, resizing
  on the dimension does not change the size much, quality is most
  important).

both of these issue have been solved in this commit.

opw-[2897291](https://www.odoo.com/web#id=2897291&view_type=form&model=project.task)

Note: In the ticket case, a 4MB gif would grow to 60 MB. Here is an example of a 300 KB gif that is getting saved as 3 MB:

![bignyan](https://user-images.githubusercontent.com/9977887/179728314-8255e120-dedd-4457-93a7-c4d025ca984f.gif)
