### PR TITLE
[FIX] hr_timesheet: ambiguous columns error

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -12,17 +12,20 @@ class ReportProjectTaskUser(models.Model):
     remaining_hours = fields.Float('Remaining Hours', readonly=True)
     progress = fields.Float('Progress', group_operator='avg', readonly=True)
 
+
     def _select(self):
-        return super(ReportProjectTaskUser, self)._select() + """,
-            progress as progress,
-            t.effective_hours as hours_effective,
-            t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
-            planned_hours as hours_planned"""
+        select_to_append = """,
+                (t.effective_hours * 100) / NULLIF(t.planned_hours, 0) as progress,
+                t.effective_hours as hours_effective,
+                t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
+                NULLIF(t.planned_hours, 0) as hours_planned
+        """
+        return super(ReportProjectTaskUser, self)._select() + select_to_append
 
     def _group_by(self):
-        return super(ReportProjectTaskUser, self)._group_by() + """,
-            remaining_hours,
-            t.effective_hours,
-            progress,
-            planned_hours
-            """
+        group_by_append = """,
+                t.effective_hours,
+                t.subtask_effective_hours,
+                t.planned_hours
+        """
+        return super(ReportProjectTaskUser, self)._group_by() + group_by_append


### PR DESCRIPTION
Steps to reproduce:

- Add a custom field to a table with a column name already used in another table and 
ensure that both tables are called in a query. The query doesn't specify which table the column
column is coming from using an ALIAS.

Current Behavior:
The query fails when a column in different tables have the same name(can have because of custom fields).

Expected Behavior:
The query shouldn't fail when a column with same name is in two tables.

Explanation:
When selecting from two tables, columns in two tables
can have the same name,when its not specificied in a query
which table that column is coming from it raises an
ambiguous column error. Since we support addition of custom
modules/fields to standard these errors are likely so it
should be specified in the queries which table columns
come from.
upg-361968

