### PR TITLE
[FIX] point_of_sale: fix calling set_quantity_by_lot function

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1531,7 +1531,7 @@ class Orderline extends PosModel {
 
         // Set the quantity of the line based on number of pack lots.
         if(!this.product.to_weight){
-            this.pack_lot_lines.set_quantity_by_lot();
+            this.set_quantity_by_lot();
         }
     }
     set_product_lot(product){


### PR DESCRIPTION
There is a mistake in forward-port of this PR (8cfc2bdcadff72bee9400c8893677d35e551b92d)
on version saas-15.2 (007e7e1563b89ebd2eef51e48303a5af1348d024).

This is the traceback when using the lot number in PoS:

	TypeError: this.pack_lot_lines.set_quantity_by_lot is not afunction at Proxy.setPackLotLines (https://17609393-saas-15-2-all.runbot70.odoo.com/web/assets/1996-322b17a/point_of_sale.assets.min.js:1424:49) at Proxy.add_product (https://17609393-saas-15-2-all.runbot70.odoo.com/web/assets/1996-322b17a/point_of_sale.assets.min.js:1566:55) at Proxy.add_product (https://17609393-saas-15-2-all.runbot70.odoo.com/web/assets/1996-322b17a/point_of_sale.assets.min.js:1772:36) at Proxy.add_product (https://17609393-saas-15-2-all.runbot70.odoo.com/web/assets/1996-322b17a/point_of_sale.assets.min.js:2358:883) at Proxy.add_product (https://17609393-saas-15-2-all.runbot70.odoo.com/web/assets/1996-322b17a/point_of_sale.assets.min.js:2749:359) at ProductScreen._clickProduct (https://17609393-saas-15-2-all.runbot70.odoo.com/web/assets/1996-322b17a/point_of_sale.assets.min.js:931:121)

The currect format is "this.set_quantity_by_lot();", but it's
"this.pack_lot_lines.set_quantity_by_lot();".

opw-2919419

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
