### PR TITLE
[FIX] hr_timesheet: set the correct user in the timesheet 

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -17,6 +17,11 @@ class AccountAnalyticLine(models.Model):
         result = super(AccountAnalyticLine, self).default_get(field_list)
         if 'encoding_uom_id' in field_list:
             result['encoding_uom_id'] = self.env.company.timesheet_encode_uom_id.id
+        employee_id = self._context.get('default_employee_id')
+        if employee_id:
+            employee = self.env['hr.employee'].browse(employee_id)
+            if 'user_id' not in result or employee.user_id.id != result.get('user_id'):
+                result['user_id'] = employee.user_id.id
         if not self.env.context.get('default_employee_id') and 'employee_id' in field_list and result.get('user_id'):
             result['employee_id'] = self.env['hr.employee'].search([('user_id', '=', result['user_id']), ('company_id', '=', result.get('company_id', self.env.company.id))], limit=1).id
         return result

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -458,3 +458,35 @@ class TestTimesheet(TestCommonTimesheet):
 
         with self.assertRaises(UserError):
             timesheet.employee_id = self.empl_employee2
+
+    def test_check_timesheet_user(self):
+        """ Test Check whether the timesheet user is correct or not.
+
+            Part 1: Test Case:
+            ----------
+                1) Create employee without user
+                2) Create timesheet
+                3) Check the user of the timesheet
+
+            Part 2:  Test Case:
+            ----------
+                3) Create a timesheet of the employee linked to the user
+                4) Check the user of the timesheet
+        """
+
+        Timesheet = self.env['account.analytic.line']
+
+        emp_without_user = self.env['hr.employee'].create({
+            'name': 'Empl Employee',
+        })
+        without_user_timesheet = Timesheet.with_context(default_employee_id=emp_without_user.id).create({
+            'project_id': self.project_customer.id,
+            'unit_amount': 8.0,
+        })
+        self.assertFalse(without_user_timesheet.user_id, 'User is not set in timesheet.')
+
+        with_user_timesheet = Timesheet.with_context(default_employee_id=self.empl_employee.id).create({
+            'project_id': self.project_customer.id,
+            'unit_amount': 8.0,
+        })
+        self.assertEqual(with_user_timesheet.user_id, self.user_employee, 'User Employee is set in timesheet.')


### PR DESCRIPTION
Currently, if the employee is not linked with the user, then the current user is
set in the timesheet.Now it will be fixed.

  Steps to reproduce:

1. Install hr_timesheet
2. Go To Employee
3. Create employee
4. Open the timesheets (Click on the 'Timesheets' stat button)
5. Create the timesheet
6. Check the user

Task-2924292