### PR TITLE
[13.0][FIX] base_vat: Handle properly VIES check with Greek VATs

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -107,7 +107,7 @@ _ref_vat = {
 }
 
 _region_specific_vat_codes = {
-    'xi',
+    'xi', 'el',
 }
 
 
@@ -533,4 +533,3 @@ class ResPartner(models.Model):
             country_id = values.get('country_id', self.country_id.id)
             values['vat'] = self._fix_vat_number(values['vat'], country_id)
         return super(ResPartner, self).write(values)
-


### PR DESCRIPTION
Steps to reproduce the problem:

- Mark "Verify VAT Numbers" in Invoicing configuration
- Create a partner with country = Greece and vat number like `EL012345678`.
- Save.

Current behavior:

The vat number that is passed to the library for VIES check is `GREL012345678`. As there's a fallback to perform the simple check with the suitable data, the error depends only on the format, but it's not a proper behavior.

Expected behavior:

The VIES check is done with proper data.

We only need to add the vat code `el` to the list of region specific codes for being handled the same as Ireland.

This has been highlighted by the OCA module `base_vat_optional_vies`:

https://odoo-community.org/shop/3265#attr=8401

Extension of 14a7bc9db1564d074c35c0fc344c1ac9821520b9

@Tecnativa TT38107