### PR TITLE
[FIX] stock_account: fix anglo saxon stockvaluationlayer tests

### DIFF
--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -3,6 +3,7 @@
 
 """ Implementation of "INVENTORY VALUATION TESTS (With valuation layers)" spreadsheet. """
 
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
@@ -986,13 +987,77 @@ class TestStockValuationChangeValuation(TestStockValuationCommon):
         self.assertEqual(len(self.product1.stock_valuation_layer_ids), 3)
 
 @tagged('post_install', '-at_install')
-class TestAngloSaxonAccounting(TestStockValuationCommon):
+class TestAngloSaxonAccounting(AccountTestInvoicingCommon):
     @classmethod
-    def setUpClass(cls):
-        super(TestAngloSaxonAccounting, cls).setUpClass()
-        cls.env.company.anglo_saxon_accounting = True
-        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.stock_journal = _create_accounting_data(cls.env)
-        cls.product1.write({
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.env.ref('base.EUR').active = True
+        cls.company_data['company'].anglo_saxon_accounting = True
+        cls.stock_location = cls.env['stock.location'].create({
+            'name': 'stock location',
+            'usage': 'internal',
+        })
+        cls.customer_location = cls.env['stock.location'].create({
+            'name': 'customer location',
+            'usage': 'customer',
+        })
+        cls.supplier_location = cls.env['stock.location'].create({
+            'name': 'supplier location',
+            'usage': 'supplier',
+        })
+        cls.warehouse_in = cls.env['stock.warehouse'].create({
+            'name': 'warehouse in',
+            'company_id': cls.company_data['company'].id,
+            'code': '1',
+        })
+        cls.warehouse_out = cls.env['stock.warehouse'].create({
+            'name': 'warehouse out',
+            'company_id': cls.company_data['company'].id,
+            'code': '2',
+        })
+        cls.picking_type_in = cls.env['stock.picking.type'].create({
+            'name': 'pick type in',
+            'sequence_code': '1',
+            'code': 'incoming',
+            'company_id': cls.company_data['company'].id,
+            'warehouse_id': cls.warehouse_in.id,
+        })
+        cls.picking_type_out = cls.env['stock.picking.type'].create({
+            'name': 'pick type in',
+            'sequence_code': '2',
+            'code': 'outgoing',
+            'company_id': cls.company_data['company'].id,
+            'warehouse_id': cls.warehouse_out.id,
+        })
+        cls.stock_input_account = cls.env['account.account'].create({
+            'name': 'Stock Input',
+            'code': 'StockIn',
+            'account_type': 'asset_current',
+            'reconcile': True,
+        })
+        cls.stock_output_account = cls.env['account.account'].create({
+            'name': 'Stock Output',
+            'code': 'StockOut',
+            'account_type': 'asset_current',
+            'reconcile': True,
+        })
+        cls.stock_valuation_account = cls.env['account.account'].create({
+            'name': 'Stock Valuation',
+            'code': 'Stock Valuation',
+            'account_type': 'asset_current',
+            'reconcile': True,
+        })
+        cls.expense_account = cls.env['account.account'].create({
+            'name': 'Expense Account',
+            'code': 'Expense Account',
+            'account_type': 'expense',
+            'reconcile': True,
+        })
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.product1 = cls.env['product.product'].create({
+            'name': 'product1',
+            'type': 'product',
+            'categ_id': cls.env.ref('product.product_category_all').id,
             'property_account_expense_id': cls.expense_account.id,
         })
         cls.product1.categ_id.write({
@@ -1000,12 +1065,40 @@ class TestAngloSaxonAccounting(TestStockValuationCommon):
             'property_stock_account_input_categ_id': cls.stock_input_account.id,
             'property_stock_account_output_categ_id': cls.stock_output_account.id,
             'property_stock_valuation_account_id': cls.stock_valuation_account.id,
-            'property_stock_journal': cls.stock_journal.id,
+            'property_stock_journal': cls.company_data['default_journal_misc'].id,
         })
-        cls.default_journal_purchase = cls.env['account.journal'].search([
-            ('company_id', '=', cls.env.company.id),
-            ('type', '=', 'purchase')
-        ], limit=1)
+
+    def _make_in_move(self, product, quantity, unit_cost=None, create_picking=False, loc_dest=None, pick_type=None):
+        """ Helper to create and validate a receipt move.
+        """
+        unit_cost = unit_cost or product.standard_price
+        loc_dest = loc_dest or self.stock_location
+        pick_type = pick_type or self.picking_type_in
+        in_move = self.env['stock.move'].create({
+            'name': 'in %s units @ %s per unit' % (str(quantity), str(unit_cost)),
+            'product_id': product.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': loc_dest.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': quantity,
+            'price_unit': unit_cost,
+            'picking_type_id': pick_type.id,
+        })
+
+        if create_picking:
+            picking = self.env['stock.picking'].create({
+                'picking_type_id': in_move.picking_type_id.id,
+                'location_id': in_move.location_id.id,
+                'location_dest_id': in_move.location_dest_id.id,
+            })
+            in_move.write({'picking_id': picking.id})
+
+        in_move._action_confirm()
+        in_move._action_assign()
+        in_move.move_line_ids.qty_done = quantity
+        in_move._action_done()
+
+        return in_move.with_context(svl=True)
 
     def test_avco_and_credit_note(self):
         """
@@ -1023,7 +1116,8 @@ class TestAngloSaxonAccounting(TestStockValuationCommon):
             invoice_line_form.product_id = self.product1
             invoice_line_form.quantity = 2
             invoice_line_form.price_unit = 25
-            invoice_line_form.account_id = self.default_journal_purchase.default_account_id
+            invoice_line_form.account_id = self.company_data['default_journal_purchase'].default_account_id
+            invoice_line_form.tax_ids.clear()
         invoice = invoice_form.save()
         invoice.action_post()
 


### PR DESCRIPTION
Currently the test in stock_account/tests/test_stockvaluationlayer.py for Anglo-Saxon accounting is slightly wrong as it uses a company that can change depending on which l10n is installed (mainly coming from the company's country_id and account_fiscalcountry_id). This means that the test might be running with different settings from one time to another (= non-deterministic) and fail in some circumstances.

This commit fixes this issue by making this test an AccountTestInvoicingCommon test instead. This allows for the use of a test company, always the same. Of course, a few items have to be re-created since they can't be inherited.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
