### PR TITLE
[FIX] point_of_sale: fix traceback when selling tracked product in PoS

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1531,7 +1531,7 @@ class Orderline extends PosModel {
 
         // Set the quantity of the line based on number of pack lots.
         if(!this.product.to_weight){
-            this.pack_lot_lines.set_quantity_by_lot();
+            this.set_quantity_by_lot();
         }
     }
     set_product_lot(product){


### PR DESCRIPTION
Current behavior:
When selling a trackedd product in the PoS you had a traceback when
entering the product serial number.

Steps to reproduce:
- Create a product tracked by serial numbers
- Update the product quantity
- Open PoS session and add the product to the order
- Enter the product serial number
- An error appears

note: the error was introduced by this forwardport #94601

opw-2924405
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
