### PR TITLE
[FIX] project: fix project kanban view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -686,7 +686,7 @@
                     <field name="last_update_color"/>
                     <field name="last_update_status"/>
                     <field name="tag_ids"/>
-                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info"}'/>
+                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "to_define": "muted"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
                         <t t-name="kanban-box">


### PR DESCRIPTION
Before this commit: project kanban view: when filtering on projects with no
status, the kanban cards of the matching projects are mute.

After this commit: project kanban view: when filtering on projects with no
status, the kanban cards of the matching projects are not mute.

Task ID: 2920824

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
