### PR TITLE
[FIX] point_of_sale,*pos*: remove 'pos' field attribute

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -26,7 +26,15 @@ class PosConfig(models.Model):
         return self.env['account.journal'].search([('type', '=', 'sale'), ('company_id', '=', self.env.company.id)], limit=1)
 
     def _default_payment_methods(self):
-        return self.env['pos.payment.method'].search([('split_transactions', '=', False), ('company_id', '=', self.env.company.id)])
+        """ Should only default to payment methods that are compatible to this config's company and currency.
+        """
+        return self.env['pos.payment.method'].search([
+            ('split_transactions', '=', False),
+            ('company_id', '=', self.env.company.id),
+            '|',
+                ('journal_id', '=', False),
+                ('journal_id.currency_id', 'in', (False, self.env.company.currency_id.id)),
+        ])
 
     def _default_pricelist(self):
         return self.env['product.pricelist'].search([('company_id', 'in', (False, self.env.company.id)), ('currency_id', '=', self.env.company.currency_id.id)], limit=1)
@@ -294,18 +302,18 @@ class PosConfig(models.Model):
         for config in self:
             if config.use_pricelist and config.pricelist_id not in config.available_pricelist_ids:
                 raise ValidationError(_("The default pricelist must be included in the available pricelists."))
+
+            # Check if the config's payment methods are compatible with its currency
+            for pm in config.payment_method_ids:
+                if pm.journal_id and pm.journal_id.currency_id and pm.journal_id.currency_id != config.currency_id:
+                    raise ValidationError(_("All payment methods must be in the same currency as the Sales Journal or the company currency if that is not set."))
+
         if any(self.available_pricelist_ids.mapped(lambda pricelist: pricelist.currency_id != self.currency_id)):
             raise ValidationError(_("All available pricelists must be in the same currency as the company or"
                                     " as the Sales Journal set on this point of sale if you use"
                                     " the Accounting application."))
         if self.invoice_journal_id.currency_id and self.invoice_journal_id.currency_id != self.currency_id:
             raise ValidationError(_("The invoice journal must be in the same currency as the Sales Journal or the company currency if that is not set."))
-        if any(
-            self.payment_method_ids\
-                .filtered(lambda pm: pm.is_cash_count)\
-                .mapped(lambda pm: self.currency_id not in (self.company_id.currency_id | pm.journal_id.currency_id))
-        ):
-            raise ValidationError(_("All payment methods must be in the same currency as the Sales Journal or the company currency if that is not set."))
 
     @api.constrains('iface_start_categ_id', 'iface_available_categ_ids')
     def _check_start_categ(self):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -44,7 +44,7 @@ class ResConfigSettings(models.TransientModel):
 
     pos_allowed_pricelist_ids = fields.Many2many('product.pricelist', compute='_compute_pos_allowed_pricelist_ids')
     pos_amount_authorized_diff = fields.Float(related='pos_config_id.amount_authorized_diff', readonly=False)
-    pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_available_pricelist_ids', readonly=False, store=True)
+    pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_pricelist_id', readonly=False, store=True)
     pos_barcode_nomenclature_id = fields.Many2one(related='pos_config_id.barcode_nomenclature_id', readonly=False)
     pos_cash_control = fields.Boolean(related='pos_config_id.cash_control')
     pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Cash Rounding (PoS)")
@@ -238,22 +238,24 @@ class ResConfigSettings(models.TransientModel):
             else:
                 res_config.pos_tip_product_id = False
 
-    @api.depends('pos_use_pricelist', 'pos_available_pricelist_ids', 'pos_config_id')
+    @api.depends('pos_use_pricelist', 'pos_config_id', 'pos_journal_id')
     def _compute_pos_pricelist_id(self):
         for res_config in self:
-            res_config.is_default_pricelist_displayed = len(res_config.pos_available_pricelist_ids) != 1
-
+            currency_id = res_config.pos_journal_id.currency_id.id if res_config.pos_journal_id.currency_id else res_config.pos_config_id.company_id.currency_id.id
+            pricelists_in_current_currency = self.env['product.pricelist'].search([('company_id', 'in', (False, res_config.pos_config_id.company_id.id)), ('currency_id', '=', currency_id)])
             if not res_config.pos_use_pricelist:
-                res_config.pos_pricelist_id = self.pos_config_id._default_pricelist()
-                continue
-
-            if res_config.is_default_pricelist_displayed:
-                res_config.pos_pricelist_id = res_config.pos_config_id.pricelist_id
+                res_config.pos_available_pricelist_ids = pricelists_in_current_currency[:1]
+                res_config.pos_pricelist_id = pricelists_in_current_currency[:1]
             else:
-                if len(res_config.pos_available_pricelist_ids) == 1:
-                    res_config.pos_pricelist_id = res_config.pos_available_pricelist_ids._origin
+                if any([p.currency_id.id != currency_id for p in res_config.pos_available_pricelist_ids]):
+                    res_config.pos_available_pricelist_ids = pricelists_in_current_currency
+                    res_config.pos_pricelist_id = pricelists_in_current_currency[:1]
                 else:
-                    res_config.pos_pricelist_id = self.pos_config_id._default_pricelist()
+                    res_config.pos_available_pricelist_ids = res_config.pos_config_id.available_pricelist_ids
+                    res_config.pos_pricelist_id = res_config.pos_config_id.pricelist_id
+
+            # TODO: Remove this field in master because it's always True.
+            res_config.is_default_pricelist_displayed = True
 
     @api.depends('pos_available_pricelist_ids', 'pos_use_pricelist')
     def _compute_pos_allowed_pricelist_ids(self):
@@ -262,14 +264,6 @@ class ResConfigSettings(models.TransientModel):
                 res_config.pos_allowed_pricelist_ids = res_config.pos_available_pricelist_ids.ids
             else:
                 res_config.pos_allowed_pricelist_ids = self.env['product.pricelist'].search([]).ids
-
-    @api.depends('pos_use_pricelist', 'pos_config_id')
-    def _compute_pos_available_pricelist_ids(self):
-        for res_config in self:
-            if not res_config.pos_use_pricelist:
-                res_config.pos_available_pricelist_ids = res_config.pos_config_id._default_pricelist()
-            else:
-                res_config.pos_available_pricelist_ids = res_config.pos_config_id.available_pricelist_ids
 
     @api.depends('pos_is_posbox', 'pos_config_id')
     def _compute_pos_proxy_ip(self):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -10,10 +10,9 @@ _logger = logging.getLogger(__name__)
 class ResConfigSettings(models.TransientModel):
     """
     NOTES
-    1. Fields with 'pos' attributes are removed from the vals before super call to `create`.
+    1. Fields with name starting with 'pos_' are removed from the vals before super call to `create`.
        Values of these fields are written to `pos_config_id` record after the super call.
-       So, if we want to make an atomic write to some set of fields, we need to redefine those
-       fields to have compute, readonly=False, store=True, and pos='<pos.config.field.name>'.
+       This is done so that these fields are written at the same time to the active pos.config record.
     2. During `creation` of this record, each related field is written to the source record
        *one after the other*, so constraints on the source record that are based on multiple
        fields might not work properly. However, only the *modified* related fields are written
@@ -22,10 +21,6 @@ class ResConfigSettings(models.TransientModel):
        super call, then the number of fields is reduced after.
     """
     _inherit = 'res.config.settings'
-
-    def _valid_field_parameter(self, field, name):
-        """Introduce 'pos' attribute to allow atomic write for the destination pos.config record."""
-        return name == 'pos' or super()._valid_field_parameter(field, name)
 
     def _default_pos_config(self):
         # Default to the last modified pos.config.
@@ -49,26 +44,26 @@ class ResConfigSettings(models.TransientModel):
 
     pos_allowed_pricelist_ids = fields.Many2many('product.pricelist', compute='_compute_pos_allowed_pricelist_ids')
     pos_amount_authorized_diff = fields.Float(related='pos_config_id.amount_authorized_diff', readonly=False)
-    pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_available_pricelist_ids', readonly=False, store=True, pos='available_pricelist_ids')
+    pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_available_pricelist_ids', readonly=False, store=True)
     pos_barcode_nomenclature_id = fields.Many2one(related='pos_config_id.barcode_nomenclature_id', readonly=False)
     pos_cash_control = fields.Boolean(related='pos_config_id.cash_control')
     pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Cash Rounding (PoS)")
     pos_company_has_template = fields.Boolean(related='pos_config_id.company_has_template')
     pos_default_bill_ids = fields.Many2many(related='pos_config_id.default_bill_ids', readonly=False)
-    pos_default_fiscal_position_id = fields.Many2one('account.fiscal.position', string='Default Fiscal Position', compute='_compute_pos_fiscal_positions', readonly=False, store=True, pos='default_fiscal_position_id')
-    pos_fiscal_position_ids = fields.Many2many('account.fiscal.position', string='Fiscal Positions', compute='_compute_pos_fiscal_positions', readonly=False, store=True, pos='fiscal_position_ids')
+    pos_default_fiscal_position_id = fields.Many2one('account.fiscal.position', string='Default Fiscal Position', compute='_compute_pos_fiscal_positions', readonly=False, store=True)
+    pos_fiscal_position_ids = fields.Many2many('account.fiscal.position', string='Fiscal Positions', compute='_compute_pos_fiscal_positions', readonly=False, store=True)
     pos_has_active_session = fields.Boolean(related='pos_config_id.has_active_session')
-    pos_iface_available_categ_ids = fields.Many2many('pos.category', string='Available PoS Product Categories', compute='_compute_pos_iface_available_categ_ids', readonly=False, store=True, pos='iface_available_categ_ids')
+    pos_iface_available_categ_ids = fields.Many2many('pos.category', string='Available PoS Product Categories', compute='_compute_pos_iface_available_categ_ids', readonly=False, store=True)
     pos_iface_big_scrollbars = fields.Boolean(related='pos_config_id.iface_big_scrollbars', readonly=False)
-    pos_iface_cashdrawer = fields.Boolean(string='Cashdrawer', compute='_compute_pos_iface_cashdrawer', readonly=False, store=True, pos='iface_cashdrawer')
+    pos_iface_cashdrawer = fields.Boolean(string='Cashdrawer', compute='_compute_pos_iface_cashdrawer', readonly=False, store=True)
     pos_iface_customer_facing_display_local = fields.Boolean(related='pos_config_id.iface_customer_facing_display_local', readonly=False)
-    pos_iface_customer_facing_display_via_proxy = fields.Boolean(string='Customer Facing Display', compute='_compute_pos_iface_customer_facing_display_via_proxy', readonly=False, store=True, pos='iface_customer_facing_display_via_proxy')
-    pos_iface_electronic_scale = fields.Boolean(string='Electronic Scale', compute='_compute_pos_iface_electronic_scale', readonly=False, store=True, pos='iface_electronic_scale')
+    pos_iface_customer_facing_display_via_proxy = fields.Boolean(string='Customer Facing Display', compute='_compute_pos_iface_customer_facing_display_via_proxy', readonly=False, store=True)
+    pos_iface_electronic_scale = fields.Boolean(string='Electronic Scale', compute='_compute_pos_iface_electronic_scale', readonly=False, store=True)
     pos_iface_print_auto = fields.Boolean(related='pos_config_id.iface_print_auto', readonly=False)
     pos_iface_print_skip_screen = fields.Boolean(related='pos_config_id.iface_print_skip_screen', readonly=False)
-    pos_iface_print_via_proxy = fields.Boolean(string='Print via Proxy', compute='_compute_pos_iface_print_via_proxy', readonly=False, store=True, pos='iface_print_via_proxy')
-    pos_iface_scan_via_proxy = fields.Boolean(string='Scan via Proxy', compute='_compute_pos_iface_scan_via_proxy', readonly=False, store=True, pos='iface_scan_via_proxy')
-    pos_iface_start_categ_id = fields.Many2one('pos.category', string='Initial Category', compute='_compute_pos_iface_start_categ_id', readonly=False, store=True, pos='iface_start_categ_id')
+    pos_iface_print_via_proxy = fields.Boolean(string='Print via Proxy', compute='_compute_pos_iface_print_via_proxy', readonly=False, store=True)
+    pos_iface_scan_via_proxy = fields.Boolean(string='Scan via Proxy', compute='_compute_pos_iface_scan_via_proxy', readonly=False, store=True)
+    pos_iface_start_categ_id = fields.Many2one('pos.category', string='Initial Category', compute='_compute_pos_iface_start_categ_id', readonly=False, store=True)
     pos_iface_tax_included = fields.Selection(related='pos_config_id.iface_tax_included', readonly=False)
     pos_iface_tipproduct = fields.Boolean(related='pos_config_id.iface_tipproduct', readonly=False)
     pos_invoice_journal_id = fields.Many2one(related='pos_config_id.invoice_journal_id', readonly=False)
@@ -88,11 +83,11 @@ class ResConfigSettings(models.TransientModel):
     pos_payment_method_ids = fields.Many2many(related='pos_config_id.payment_method_ids', readonly=False)
     pos_picking_policy = fields.Selection(related='pos_config_id.picking_policy', readonly=False)
     pos_picking_type_id = fields.Many2one(related='pos_config_id.picking_type_id', readonly=False)
-    pos_pricelist_id = fields.Many2one('product.pricelist', string='Default Pricelist', compute='_compute_pos_pricelist_id', readonly=False, store=True, pos='pricelist_id')
+    pos_pricelist_id = fields.Many2one('product.pricelist', string='Default Pricelist', compute='_compute_pos_pricelist_id', readonly=False, store=True)
     pos_product_load_background = fields.Boolean(related='pos_config_id.product_load_background', readonly=False)
-    pos_proxy_ip = fields.Char(string='IP Address', compute='_compute_pos_proxy_ip', readonly=False, store=True, pos='proxy_ip')
-    pos_receipt_footer = fields.Text(string='Receipt Footer', compute='_compute_pos_receipt_header_footer', readonly=False, store=True, pos='receipt_footer')
-    pos_receipt_header = fields.Text(string='Receipt Header', compute='_compute_pos_receipt_header_footer', readonly=False, store=True, pos='receipt_header')
+    pos_proxy_ip = fields.Char(string='IP Address', compute='_compute_pos_proxy_ip', readonly=False, store=True)
+    pos_receipt_footer = fields.Text(string='Receipt Footer', compute='_compute_pos_receipt_header_footer', readonly=False, store=True)
+    pos_receipt_header = fields.Text(string='Receipt Header', compute='_compute_pos_receipt_header_footer', readonly=False, store=True)
     pos_restrict_price_control = fields.Boolean(related='pos_config_id.restrict_price_control', readonly=False)
     pos_rounding_method = fields.Many2one(related='pos_config_id.rounding_method', readonly=False)
     pos_route_id = fields.Many2one(related='pos_config_id.route_id', readonly=False)
@@ -102,7 +97,7 @@ class ResConfigSettings(models.TransientModel):
     pos_ship_later = fields.Boolean(related='pos_config_id.ship_later', readonly=False)
     pos_start_category = fields.Boolean(related='pos_config_id.start_category', readonly=False)
     pos_tax_regime_selection = fields.Boolean(related='pos_config_id.tax_regime_selection', readonly=False)
-    pos_tip_product_id = fields.Many2one('product.product', string='Tip Product', compute='_compute_pos_tip_product_id', readonly=False, store=True, pos='tip_product_id')
+    pos_tip_product_id = fields.Many2one('product.product', string='Tip Product', compute='_compute_pos_tip_product_id', readonly=False, store=True)
     pos_use_pricelist = fields.Boolean(related='pos_config_id.use_pricelist', readonly=False)
     pos_warehouse_id = fields.Many2one(related='pos_config_id.warehouse_id', readonly=False, string="Warehouse (PoS)")
 
@@ -116,26 +111,30 @@ class ResConfigSettings(models.TransientModel):
             pos_config_id = vals.get('pos_config_id')
             if pos_config_id:
                 pos_fields_vals = {}
-                for field in self._fields.values():
-                    val = vals.get(field.name)
-
-                    # Add only to pos_fields_vals if
-                    #   1. _field is in vals -- meaning, the _field is in view.
-                    #   2. _field has 'pos' attribute
-                    if hasattr(field, 'pos') and val is not None:
-                        pos_config_field_name = field.pos
-                        if not pos_config_field_name in self.env['pos.config']._fields:
-                            _logger.warning("The value of '%s' is not properly saved to the pos_config_id field because the destination"
-                                " field '%s' is not a valid field in the pos.config model.", field.name, pos_config_field_name)
-                        else:
-                            pos_fields_vals[pos_config_field_name] = val
-                            del vals[field.name]
 
                 if vals.get('pos_cash_rounding'):
                     vals['group_cash_rounding'] = True
 
                 if vals.get('pos_use_pricelist'):
                     vals['group_product_pricelist'] = True
+
+                for field in self._fields.values():
+                    if field.name == 'pos_config_id':
+                        continue
+
+                    val = vals.get(field.name)
+
+                    # Add only to pos_fields_vals if
+                    #   1. _field is in vals -- meaning, the _field is in view.
+                    #   2. _field starts with 'pos_' -- meaning, the _field is a pos field.
+                    if field.name.startswith('pos_') and val is not None:
+                        pos_config_field_name = field.name[4:]
+                        if not pos_config_field_name in self.env['pos.config']._fields:
+                            _logger.warning("The value of '%s' is not properly saved to the pos_config_id field because the destination"
+                                " field '%s' is not a valid field in the pos.config model.", field.name, pos_config_field_name)
+                        else:
+                            pos_fields_vals[pos_config_field_name] = val
+                            del vals[field.name]
 
                 pos_config_id_to_fields_vals_map[pos_config_id] = pos_fields_vals
 

--- a/addons/pos_adyen/models/res_config_settings.py
+++ b/addons/pos_adyen/models/res_config_settings.py
@@ -8,7 +8,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     # pos.config fields
-    pos_adyen_ask_customer_for_tip = fields.Boolean(compute='_compute_pos_adyen_ask_customer_for_tip', store=True, readonly=False, pos='adyen_ask_customer_for_tip')
+    pos_adyen_ask_customer_for_tip = fields.Boolean(compute='_compute_pos_adyen_ask_customer_for_tip', store=True, readonly=False)
 
     @api.depends('pos_iface_tipproduct', 'pos_config_id')
     def _compute_pos_adyen_ask_customer_for_tip(self):

--- a/addons/pos_discount/models/res_config_settings.py
+++ b/addons/pos_discount/models/res_config_settings.py
@@ -9,7 +9,7 @@ class ResConfigSettings(models.TransientModel):
 
     # pos.config fields
     pos_discount_pc = fields.Float(related='pos_config_id.discount_pc', readonly=False)
-    pos_discount_product_id = fields.Many2one('product.product', compute='_compute_pos_discount_product_id', store=True, readonly=False, pos='discount_product_id')
+    pos_discount_product_id = fields.Many2one('product.product', compute='_compute_pos_discount_product_id', store=True, readonly=False)
 
     @api.depends('company_id', 'pos_module_pos_discount', 'pos_config_id')
     def _compute_pos_discount_product_id(self):

--- a/addons/pos_epson_printer/models/res_config_settings.py
+++ b/addons/pos_epson_printer/models/res_config_settings.py
@@ -7,7 +7,7 @@ from odoo import fields, models, api
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    pos_epson_printer_ip = fields.Char(compute='_compute_pos_epson_printer_ip', store=True, readonly=False, pos='epson_printer_ip')
+    pos_epson_printer_ip = fields.Char(compute='_compute_pos_epson_printer_ip', store=True, readonly=False)
 
     @api.depends('pos_epson_printer_ip', 'pos_other_devices')
     def _compute_pos_iface_cashdrawer(self):

--- a/addons/pos_loyalty/models/res_config_settings.py
+++ b/addons/pos_loyalty/models/res_config_settings.py
@@ -6,7 +6,7 @@ from odoo import fields, models, api
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    pos_loyalty_program_id = fields.Many2one('loyalty.program', compute='_compute_pos_loyalty_id', store=True, readonly=False, pos='loyalty_program_id')
+    pos_loyalty_program_id = fields.Many2one('loyalty.program', compute='_compute_pos_loyalty_id', store=True, readonly=False)
 
     pos_use_coupon_programs = fields.Boolean(related='pos_config_id.use_coupon_programs', readonly=False)
     pos_coupon_program_ids = fields.Many2many(related='pos_config_id.coupon_program_ids', readonly=False)

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -110,9 +110,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.write({
             'tax_regime_selection': False,
             'use_pricelist': False,
-            'pricelist_id': self.env["product.pricelist"].create(
-                {"name": "PoS Default Pricelist",}
-            ),
             'use_coupon_programs': True,
             'coupon_program_ids': [Command.link(self.coupon_program.id)],
             'promo_program_ids': [Command.link(prog.id) for prog in self.promo_programs],

--- a/addons/pos_restaurant/models/res_config_settings.py
+++ b/addons/pos_restaurant/models/res_config_settings.py
@@ -10,13 +10,13 @@ class ResConfigSettings(models.TransientModel):
         return ['|', ('pos_config_id', 'in', self.pos_config_id.ids), ('pos_config_id', '=', False)]
 
     pos_floor_ids = fields.One2many(related='pos_config_id.floor_ids', readonly=False, domain=lambda self: self._get_floors_domain())
-    pos_iface_orderline_notes = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False, pos='iface_orderline_notes')
-    pos_iface_printbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False, pos='iface_printbill')
-    pos_iface_splitbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False, pos='iface_splitbill')
-    pos_is_order_printer = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False, pos='is_order_printer')
-    pos_is_table_management = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False, pos='is_table_management')
+    pos_iface_orderline_notes = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
+    pos_iface_printbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
+    pos_iface_splitbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
+    pos_is_order_printer = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
+    pos_is_table_management = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
     pos_printer_ids = fields.Many2many(related='pos_config_id.printer_ids', readonly=False)
-    pos_set_tip_after_payment = fields.Boolean(compute='_compute_pos_set_tip_after_payment', store=True, readonly=False, pos='set_tip_after_payment')
+    pos_set_tip_after_payment = fields.Boolean(compute='_compute_pos_set_tip_after_payment', store=True, readonly=False)
 
     @api.depends('pos_module_pos_restaurant', 'pos_config_id')
     def _compute_pos_module_pos_restaurant(self):


### PR DESCRIPTION
With this change, we are now assuming each field that starts with
'pos_' to be a 'pos.config' field that has value that will be saved
to 'pos_config_id'.

This fixes the issue of the constraint functions being called at wrong
timings resulting to invalid error messages such as when changing the
currency of the config by setting a journal_id with currency_id that
is different from the company's currency.

To reproduce: https://drive.google.com/file/d/1qEWQ3nRn9MSBbQoDWi_tZXeGlW0sGnnm/view?usp=sharing
After this patch: https://drive.google.com/file/d/1ipyzRcnEkX44gcDpalLyYspVeV45xlRt/view?usp=sharing

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
