### PR TITLE
hr_timesheet,*_*: improve generic UX of timesheet

### DIFF
--- a/addons/hr_timesheet/models/res_config_settings.py
+++ b/addons/hr_timesheet/models/res_config_settings.py
@@ -12,7 +12,7 @@ class ResConfigSettings(models.TransientModel):
     module_project_timesheet_holidays = fields.Boolean("Time Off",
         compute="_compute_timesheet_modules", store=True, readonly=False)
     reminder_user_allow = fields.Boolean(string="Employee Reminder")
-    reminder_manager_allow = fields.Boolean(string="Manager Reminder")
+    reminder_allow = fields.Boolean(string="Approver Reminder")
     project_time_mode_id = fields.Many2one(
         'uom.uom', related='company_id.project_time_mode_id', string='Project Time Unit', readonly=False,
         help="This will set the unit of measure used in projects and tasks.\n"

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -82,14 +82,17 @@ class TestCommonTimesheet(TransactionCase):
         cls.empl_employee = cls.env['hr.employee'].create({
             'name': 'User Empl Employee',
             'user_id': cls.user_employee.id,
+            'employee_type': 'freelance',  # Avoid searching the contract if hr_contract module is installed before this module.
         })
         cls.empl_employee2 = cls.env['hr.employee'].create({
             'name': 'User Empl Employee 2',
             'user_id': cls.user_employee2.id,
+            'employee_type': 'freelance',
         })
         cls.empl_manager = cls.env['hr.employee'].create({
             'name': 'User Empl Officer',
             'user_id': cls.user_manager.id,
+            'employee_type': 'freelance',
         })
 
     def assert_get_view_timesheet_encode_uom(self, expected):

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -88,13 +88,13 @@
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane">
-                                <field name="reminder_manager_allow" widget="upgrade_boolean"/>
+                                <field name="reminder_allow" widget="upgrade_boolean"/>
                             </div>
-                            <div class="o_setting_right_pane" id="reminder_manager_allow">
-                                <label for="reminder_manager_allow"/>
+                            <div class="o_setting_right_pane" id="reminder_allow">
+                                <label for="reminder_allow"/>
                                 <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
-                                    Send a periodical email reminder to timesheets managers<br/>
+                                    Send a periodical email reminder to timesheets approvers<br/>
                                     that still have timesheets to validate
                                 </div>
                             </div>

--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
@@ -7,6 +7,9 @@
             <field name="arch" type="xml">
                 <search string="Timesheet Attendance">
                     <field name="user_id" string="Employee"/>
+                    <filter string="My Team" name="my_team" domain="[('user_id.employee_parent_id.user_id', '=', uid)]"/>
+                    <filter string="My Department" name="my_department" domain="[('user_id.employee_id.member_of_department', '=', True)]"/>
+                    <separator/>
                     <filter name="month" string="Date" date="date"/>
                     <filter name="group_by_user" string="Employee" context="{'group_by': 'user_id'}"/>
                     <filter name="group_by_month" string="Date" date="date" context="{'group_by': 'date'}"/>

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -24,7 +24,7 @@ class SaleOrderLine(models.Model):
 
     def name_get(self):
         res = super().name_get()
-        with_price_unit = self.env.context.get('with_price_unit')
+        with_price_unit = self._context.get('with_price_unit', self._context.get('is_timesheet'))
         if with_price_unit:
             names = dict(res)
             result = []

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -77,7 +77,7 @@
             <xpath expr="//field[@name='partner_phone']" position="after">
                 <field name="sale_order_id" attrs="{'invisible': True}" groups="sales_team.group_sale_salesman"/>
                 <field name="sale_line_id" groups="!sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}"/>
-                <field name="sale_line_id" groups="sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_create": True}' readonly="0" context="{'create': False, 'edit': False, 'delete': False}"/>
+                <field name="sale_line_id" groups="sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_create": True}' readonly="0" context="{'create': False, 'edit': False, 'delete': False}" placeholder="Non-billable"/>
                 <field name="commercial_partner_id" invisible="1" />
             </xpath>
         </field>

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -35,6 +35,7 @@ class AccountAnalyticLine(models.Model):
     # we needed to store it only in order to be able to groupby in the portal
     order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=True, index=True)
     is_so_line_edited = fields.Boolean("Is Sales Order Item Manually Edited")
+    allow_billable = fields.Boolean(related="project_id.allow_billable")
 
     @api.depends('project_id.commercial_partner_id', 'task_id.commercial_partner_id')
     def _compute_commercial_partner(self):

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -59,7 +59,7 @@
                 <field name="commercial_partner_id" invisible="1" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" invisible="1" groups="sales_team.group_sale_salesman"/>
                 <field name="allow_billable" invisible="1" groups="sales_team.group_sale_salesman"/>
-                <field name="so_line" widget="so_line_field" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False}" attrs="{'invisible': [('allow_billable', '=', False)]}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" widget="so_line_field" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False, 'with_price_unit': True}" attrs="{'invisible': [('allow_billable', '=', False)]}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -44,7 +44,8 @@
             <xpath expr="//tree/field[@name='name']" position="after">
                 <field name="commercial_partner_id" invisible="1" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" invisible="1" groups="sales_team.group_sale_salesman"/>
-                <field name="so_line" widget="so_line_field" optional="hide" options="{'no_create': True}" context="{'create': False, 'edit': False, 'delete': False}" groups="sales_team.group_sale_salesman"/>
+                <field name="allow_billable" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" widget="so_line_field" optional="hide" options="{'no_create': True}" context="{'create': False, 'edit': False, 'delete': False}" attrs="{'invisible': [('allow_billable', '=', False)]}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>
@@ -57,7 +58,8 @@
             <xpath expr="//field[@name='task_id']" position="after">
                 <field name="commercial_partner_id" invisible="1" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" invisible="1" groups="sales_team.group_sale_salesman"/>
-                <field name="so_line" widget="so_line_field" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False}" groups="sales_team.group_sale_salesman"/>
+                <field name="allow_billable" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" widget="so_line_field" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False}" attrs="{'invisible': [('allow_billable', '=', False)]}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
*_* = hr_timesheet_attendance, sale_management, sale_project, sale_timesheet

Purpose of this PR to improve generic UX of timesheet app.

So in this PR done following changes:
- hide the SOL field if there is no project set or if the project is non billable.
- add the `My Team` and `My Department` filters in Timesheet/Attendance
report.
- add the placeholders for SOL field in timesheets,project.task.
- update the test to avoid searching the contract if hr_contract module is
installed before this hr_timesheet module.
- indicate the unit price of the SOL if the same service is present multiple
times in the SO.
- move nane_get method of SOL from sale_project to sale_management
so it we don't need to overide name_get in sale_planning to do same thing.

task-2893556