### PR TITLE
[UPD] crm, event, _*: update query counters (again)

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=173):  # crm only: 170 (often), sometimes +3 on runbot
+        with self.assertQueryCount(user_sales_manager=173):  # 170 / sometimes +3 on runbot
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=141):  # crm only: 137 (often), sometimes +2/+3 on runbot // extra queries ~1/week
+        with self.assertQueryCount(user_sales_manager=141):  # crm only: 136 - com 137 - ent 138 /  sometimes +2/+3 on runbot
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -166,7 +166,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         test_leads = self._create_leads_batch(count=50, user_ids=[False])
         user_ids = self.assign_users.ids
 
-        with self.assertQueryCount(user_sales_manager=1038):  # 1034-35 - crm only: 1029
+        with self.assertQueryCount(user_sales_manager=1041):  # crm only: 1025 - com 1034 - ent 1035 - sometimes +5/+6 (nightly ?)
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -49,7 +49,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
 
         with self.with_user('user_sales_manager'):
             self.env['res.users'].has_group('base.group_user')  # warmup the cache to avoid inconsistency between community an enterprise
-            with self.assertQueryCount(user_sales_manager=1269):
+            with self.assertQueryCount(user_sales_manager=1275):  # crm: 1191
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -93,7 +93,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush_recordset()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=583):
+            with self.assertQueryCount(user_sales_manager=584):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -175,7 +175,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush_recordset()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6433):
+            with self.assertQueryCount(user_sales_manager=6433):  # crm 6382
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -42,7 +42,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=241):  # 235, sometimes +6
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=243):  # 235, sometimes +6  / 243 local tests ?
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -70,7 +70,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be = self.env['res.lang']._lang_get('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=184):  # tcf only: 175 - com runbot: 167
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=178):  # tcf only: 165 - com runbot: 167
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.country_id = country_be
@@ -89,7 +89,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_form_partner(self):
         """ Test a single lead creation using Form with a partner """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=189):  # tcf only: 180 - com runbot: 172
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=187):  # tcf only: 174 - com runbot: 176
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.partner_id = self.partners[0]
@@ -104,7 +104,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=41):
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=41):  # tcf 40
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -124,7 +124,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_single_partner(self):
         """ Test multiple lead creation (import) """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=47):
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=47):  # tcf 46
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'partner_id': self.partners[0].id,

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -52,7 +52,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5462):  # tef only: 5068? (5064?) - com runbot: 5037 - ent runbot 5462
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5462):  # tef only: 5038 - com runbot: 5037
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -89,7 +89,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5576):  # tef only: 5178 - com runbot: 5151 - ent runbot 5576
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5576):  # tef only: 5152 - com runbot: 5151
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -107,7 +107,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, no website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=206):  # tef only: 179? - com runbot: 160
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=206):  # tef only: 160 - com runbot: 160
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -125,7 +125,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=671):  # tef only: 638? - com runbot: 571 - ent runbot: 671
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=671):  # tef only: 570 - com runbot: 571
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -144,7 +144,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # type and website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=700):  # tef only: 673 - com runbot: 604 - ent runbot: 700
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=700):  # tef only: 601 - com runbot: 604
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -172,7 +172,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype_website(self):
         """ Test a single event creation """
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=370):  # tef only: 347? (342?) - com runbot: 344 - ent runbot 370
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=370):  # tef only: 345 - com runbot: 344
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -203,7 +203,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=407):  # tef only: 395 (389) - com runbot: 381 - ent runbot 407
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=407):  # tef only: 382 - com runbot: 381
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -225,7 +225,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=713):  # tef only: 672? - com runbot 710 - ent runbot 713
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=713):  # tef only: 669 - com runbot 710
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -249,7 +249,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=239):  # tef only: 197? - com runbot 235
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=239):  # tef only: 196 - com runbot 235
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -271,7 +271,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         form like) """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=724):  # tef only: 683? - com runbot 721 - ent runbot: 725
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=724):  # tef only: 678 - com runbot 721
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -292,7 +292,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=210):  # tef only: 208? - com runbot: 198 - ent runbot: 210
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=210):  # tef only: 192 - com runbot: 198
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -308,7 +308,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=212):  # tef only: 211? - com runbot: 199 - ent runbot: 212
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=212):  # tef only: 194 - com runbot: 199
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -321,7 +321,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=123):  # tef only: 120? - com runbot 109
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=123):  # tef only: 107 - com runbot 109
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration'].with_context(event_lead_rule_skip=True)) as reg_form:
                 reg_form.event_id = event
@@ -335,7 +335,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # simple customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=136):  # tef only: 133? - com runbot: 134 - ent runbot: 136
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=136):  # tef only: 129 - com runbot: 134
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.customer_data[0],
@@ -349,7 +349,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=142):  # tef only: 141? - com runbot: 141 - ent runbot: 142
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=142):  # tef only: 136 - com runbot: 141
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -364,7 +364,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=55):  # tef only: 54? - com runbot: 53 - ent runbot: 55
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=55):  # tef only: 51 - com runbot: 53
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -379,7 +379,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # website customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=144):  # tef only: 140? - com runbot: 140 - ent runbot: 144
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=144):  # tef only: 135 - com runbot: 140
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.website_customer_data[0],
@@ -428,7 +428,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate('user_eventmanager', 'user_eventmanager')
-            with self.assertQueryCount(default=49):  # tef only: 48 (+1 ent)
+            with self.assertQueryCount(default=47):  # tde only: 46
                 self._test_url_open('/event/%i' % self.test_event.id)
 
     @warmup

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -103,7 +103,6 @@ class TestRatingFlow(TestRatingCommon):
     @users('__system__')
     @warmup
     def test_rating_last_value_perfs(self):
-
         record_rating = self.env['mail.test.rating'].browse(self.record_rating.ids)
 
         # prepare rating token
@@ -122,35 +121,34 @@ class TestRatingFlow(TestRatingCommon):
         self.assertEqual(record_rating.rating_last_value, 5, "The last rating is kept.")
         self.assertEqual(record_rating.rating_avg, 3, "The average should be equal to 3")
 
-        with self.profile():
-            RECORD_COUNT = 100
-            partners = self.env['res.partner'].create([
-                {'name': 'Jean-Luc %s' % (idx), 'email': 'jean-luc-%s@opoo.com' % (idx)} for idx in range(RECORD_COUNT)])
-            # 3713 requests if only test_mail_full is installed
-            # 4511 runbot community
-            # 4911 runbot enterprise
-            with self.assertQueryCount(__system__=4912):
-                record_ratings = self.env['mail.test.rating'].create([{
-                    'customer_id': partners[idx].id,
-                    'name': 'Test Rating',
-                    'user_id': self.user_admin.id,
-                } for idx in range(RECORD_COUNT)])
-                for record in record_ratings:
-                    access_token = record._rating_get_access_token()
-                    record.rating_apply(1, token=access_token)
+        RECORD_COUNT = 100
+        partners = self.env['res.partner'].create([
+            {'name': 'Jean-Luc %s' % (idx), 'email': 'jean-luc-%s@opoo.com' % (idx)} for idx in range(RECORD_COUNT)])
+        # 3713 requests if only test_mail_full is installed
+        # 4511 runbot community
+        # 4911 runbot enterprise
+        with self.assertQueryCount(__system__=4911):
+            record_ratings = self.env['mail.test.rating'].create([{
+                'customer_id': partners[idx].id,
+                'name': 'Test Rating',
+                'user_id': self.user_admin.id,
+            } for idx in range(RECORD_COUNT)])
+            for record in record_ratings:
+                access_token = record._rating_get_access_token()
+                record.rating_apply(1, token=access_token)
 
-                record_ratings.rating_ids.write_date = datetime(2022, 1, 1, 14, 00)
-                for record in record_ratings:
-                    access_token = record._rating_get_access_token()
-                    record.rating_apply(5, token=access_token)
+            record_ratings.rating_ids.write_date = datetime(2022, 1, 1, 14, 00)
+            for record in record_ratings:
+                access_token = record._rating_get_access_token()
+                record.rating_apply(5, token=access_token)
 
-            new_ratings = record_ratings.rating_ids.filtered(lambda r: r.rating == 1)
-            new_ratings.write_date = datetime(2022, 2, 1, 14, 00)
-            new_ratings.flush_model(['write_date'])
-            with self.assertQueryCount(__system__=1):
-                record_ratings._compute_rating_last_value()
-                vals = [val == 5 for val in record_ratings.mapped('rating_last_value')]
-                self.assertTrue(all(vals), "The last rating is kept.")
+        new_ratings = record_ratings.rating_ids.filtered(lambda r: r.rating == 1)
+        new_ratings.write_date = datetime(2022, 2, 1, 14, 00)
+        new_ratings.flush_model(['write_date'])
+        with self.assertQueryCount(__system__=1):
+            record_ratings._compute_rating_last_value()
+            vals = [val == 5 for val in record_ratings.mapped('rating_last_value')]
+            self.assertTrue(all(vals), "The last rating is kept.")
 
 
 @tagged('rating')


### PR DESCRIPTION
Trying to depatouille the runbot, once again. In this commit we

  * fix a failing test (one additional query since a few days) in crm;
  * remove an unnecessary profiler;
  * update some internal query counters (addong only, community / enterprise
    counters, ...);
