### PR TITLE
[IMP] mail: legacy activity menu to wowl registry

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -88,11 +88,13 @@
             'mail/static/src/components/*/*',
             # Unused by guests and depends on ViewDialogs, better to remove it instead of pulling the whole view dependency tree
             ('remove', 'mail/static/src/components/composer_suggested_recipient/*'),
+            ('remove', 'mail/static/src/components/activity_menu_container/*'),
             'mail/static/src/js/emojis.js',
             'mail/static/src/js/utils.js',
             ('include', 'mail.assets_messaging'),
             'mail/static/src/public/*',
             'mail/static/src/services/*.js',
+            ('remove', 'mail/static/src/services/systray_service.js'),
             'mail/static/src/utils/*.js',
             # Framework JS
             'bus/static/src/*.js',

--- a/addons/mail/static/src/components/activity_menu_container/activity_menu_container.js
+++ b/addons/mail/static/src/components/activity_menu_container/activity_menu_container.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
+
+import { ComponentAdapter } from "web.OwlCompatibility";
+
+const { Component } = owl;
+
+class ActivityMenuAdapter extends ComponentAdapter {
+    setup() {
+        this.env = owl.Component.env;
+        super.setup();
+    }
+}
+
+export class ActivityMenuContainer extends Component {
+    get activityMenuWidget() {
+        return ActivityMenu;
+    }
+}
+
+
+Object.assign(ActivityMenuContainer, {
+    components: { ActivityMenuAdapter },
+    template: 'mail.ActivityMenuContainer',
+});

--- a/addons/mail/static/src/components/activity_menu_container/activity_menu_container.xml
+++ b/addons/mail/static/src/components/activity_menu_container/activity_menu_container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.ActivityMenuContainer" owl="1">
+        <ActivityMenuAdapter Component="activityMenuWidget"/>
+    </t>
+</templates>

--- a/addons/mail/static/src/js/systray/systray_activity_menu.js
+++ b/addons/mail/static/src/js/systray/systray_activity_menu.js
@@ -3,7 +3,6 @@
 import { qweb as QWeb } from 'web.core';
 import config from "web.config";
 import session  from 'web.session';
-import SystrayMenu from 'web.SystrayMenu';
 import Widget from 'web.Widget';
 import Time from 'web.time';
 
@@ -196,7 +195,5 @@ var ActivityMenu = Widget.extend({
         document.body.classList.remove('modal-open');
     },
 });
-
-SystrayMenu.Items.push(ActivityMenu);
 
 export default ActivityMenu;

--- a/addons/mail/static/src/services/systray_service.js
+++ b/addons/mail/static/src/services/systray_service.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { ActivityMenuContainer } from '@mail/components/activity_menu_container/activity_menu_container';
 import { MessagingMenuContainer } from '@mail/components/messaging_menu_container/messaging_menu_container';
 import { CallSystrayMenuContainer } from '@mail/components/call_systray_menu_container/call_systray_menu_container';
 
@@ -10,7 +11,8 @@ const systrayRegistry = registry.category('systray');
 export const systrayService = {
     dependencies: ['messaging'],
     start() {
-        systrayRegistry.add('mail.MessagingMenuContainer', { Component: MessagingMenuContainer });
+        systrayRegistry.add('mail.ActivityMenu', { Component: ActivityMenuContainer }, { sequence: 20 });
+        systrayRegistry.add('mail.MessagingMenuContainer', { Component: MessagingMenuContainer }, { sequence: 25 });
         systrayRegistry.add('mail.CallSystrayMenuContainer', { Component: CallSystrayMenuContainer }, { sequence: 100 });
     },
 };

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -10,14 +10,11 @@ import { ChatWindowManagerContainer } from '@mail/components/chat_window_manager
 import { DialogManagerContainer } from '@mail/components/dialog_manager_container/dialog_manager_container';
 import { DiscussContainer } from '@mail/components/discuss_container/discuss_container';
 import { PopoverManagerContainer } from '@mail/components/popover_manager_container/popover_manager_container';
-import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 import { messagingService } from '@mail/services/messaging_service';
 import { systrayService } from '@mail/services/systray_service';
 import { makeMessagingToLegacyEnv } from '@mail/utils/make_messaging_to_legacy_env';
 
 import { registry } from '@web/core/registry';
-import { Items as legacySystrayItems } from 'web.SystrayMenu';
-import { registerCleanup } from '@web/../tests/helpers/cleanup';
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 
@@ -138,14 +135,6 @@ function setupMessagingServiceRegistries({
  */
  async function getWebClientReady(param0) {
     setupMainComponentRegistry();
-
-    legacySystrayItems.push(ActivityMenu);
-    registerCleanup(() => {
-        const activityMenuIndex = legacySystrayItems.indexOf(ActivityMenu);
-        if (activityMenuIndex !== -1) {
-            legacySystrayItems.splice(activityMenuIndex, 1);
-        }
-    });
 
     const servicesParameters = {};
     const param0Entries = Object.entries(param0);


### PR DESCRIPTION
To prepare for the introduction of the wowl ActivityMenuContainer and to ease testing,
let's already make the ActivityMenu widget use the systray registry.