### PR TITLE
[REF] payment: reuse the transaction status template wherever possible

### DIFF
--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -36,6 +36,7 @@
     'assets': {
         'web.assets_frontend': [
             'payment/static/src/scss/portal_payment.scss',
+            'payment/static/src/scss/payment_templates.scss',
             'payment/static/src/scss/payment_form.scss',
             'payment/static/lib/jquery.payment/jquery.payment.js',
             'payment/static/src/js/checkout_form.js',

--- a/addons/payment/static/src/scss/payment_templates.scss
+++ b/addons/payment/static/src/scss/payment_templates.scss
@@ -1,0 +1,3 @@
+div#o_payment_status_alert > p {
+    margin-bottom: 0;
+}

--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -113,8 +113,6 @@
     <template id="confirm">
         <!-- Variables description:
             - 'tx' - The transaction to display
-            - 'message' - The acquirer message configured for the given transaction state
-            - 'status' - The alert class to use for the message
         -->
         <t t-call="portal.frontend_layout">
             <t t-set="page_title" t-value="'Payment Confirmation'"/>
@@ -127,13 +125,7 @@
                     <div class="row">
                         <div class="col-lg-6">
                             <div>
-                                <!-- message is the content of either the HTML field describing the
-                                transaction state computed while processing feedback data, or the
-                                HTML field associated with the transaction state, defined on the
-                                acquirer.  -->
-                                <div t-attf-class="alert alert-#{status}"
-                                     t-out="message"
-                                     role="status"/>
+                                <t t-call="payment.transaction_status"/>
                                 <div class="form-group row">
                                     <label for="form_partner_name" class="col-md-3 col-form-label">
                                         From
@@ -168,7 +160,7 @@
                                     </div>
                                     <div class="col-md-4 offset-md-3 mt-2 ps-0">
                                         <a role="button"
-                                           t-attf-class="btn btn-#{status} float-end"
+                                           t-attf-class="btn btn-primary float-end"
                                            href="/my/home">
                                             <i class="fa fa-arrow-circle-right"/> Back to My Account
                                         </a>

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -368,27 +368,44 @@
         <!-- Variables description:
             - 'tx' - The transaction whose status must be displayed
         -->
-        <div t-if="tx.state == 'pending' and not is_html_empty(tx.acquirer_id.sudo().pending_msg)"
-             class="alert alert-warning alert-dismissible">
-            <span t-out="tx.acquirer_id.sudo().pending_msg"/>
-            <button class="btn-close" data-bs-dismiss="alert" title="Dismiss"></button>
+        <t t-if="tx.state == 'draft'">
+            <t t-set="alert_style">info</t>
+            <t t-set="status_message">
+                <p>Your payment has not been processed yet.</p>
+            </t>
+        </t>
+        <t t-elif="tx.state == 'pending'">
+            <t t-set="alert_style">warning</t>
+            <t t-set="status_message" t-value="tx.acquirer_id.sudo().pending_msg"/>
+        </t>
+        <t t-elif="tx.state == 'authorized'">
+            <t t-set="alert_style">success</t>
+            <t t-set="status_message" t-value="tx.acquirer_id.sudo().auth_msg"/>
+        </t>
+        <t t-elif="tx.state == 'done'">
+            <t t-set="alert_style">success</t>
+            <t t-set="status_message" t-value="tx.acquirer_id.sudo().done_msg"/>
+        </t>
+        <t t-elif="tx.state == 'cancel'">
+            <t t-set="alert_style">danger</t>
+            <t t-set="status_message" t-value="tx.acquirer_id.sudo().cancel_msg"/>
+        </t>
+        <t t-elif="tx.state == 'error'">
+            <t t-set="alert_style">danger</t>
+            <t t-set="status_message">
+                <p>An error occurred during the processing of your payment.</p>
+            </t>
+        </t>
+
+        <t t-if="is_html_empty(status_message)" t-set="status_message" t-value="''"/>
+
+        <div t-if="status_message or tx.state_message"
+             id="o_payment_status_alert"
+             t-attf-class="alert alert-{{alert_style}} alert-dismissible">
+            <button class="btn-close" data-bs-dismiss="alert" title="Dismiss"/>
+            <t t-if="status_message" t-out="status_message"/>
+            <t t-if="tx.state_message" t-out="tx.state_message"/>
         </div>
-        <div t-elif="tx.state == 'authorized' and not is_html_empty(tx.acquirer_id.sudo().auth_msg)"
-             class="alert alert-success alert-dismissible">
-            <span t-out="tx.acquirer_id.sudo().auth_msg"/>
-            <button class="btn-close" data-bs-dismiss="alert" title="Dismiss"></button>
-        </div>
-        <div t-elif="tx.state == 'done' and not is_html_empty(tx.acquirer_id.sudo().done_msg)"
-             class="alert alert-success alert-dismissible">
-            <span t-out="tx.acquirer_id.sudo().done_msg"/>
-            <button class="btn-close" data-bs-dismiss="alert" title="Dismiss"></button>
-        </div>
-        <div t-elif="tx.state == 'cancel' and not is_html_empty(tx.acquirer_id.sudo().cancel_msg)"
-             class="alert alert-danger alert-dismissible">
-            <span t-out="tx.acquirer_id.sudo().cancel_msg"/>
-            <button class="btn-close" data-bs-dismiss="alert" title="Dismiss"></button>
-        </div>
-        <span t-if="tx.state_message" t-esc="tx.state_message"/>
     </template>
 
 </odoo>

--- a/addons/payment_transfer/views/payment_transfer_templates.xml
+++ b/addons/payment_transfer/views/payment_transfer_templates.xml
@@ -8,7 +8,7 @@
     </template>
 
     <template id="transfer_transaction_status" inherit_id="payment.transaction_status">
-        <xpath expr="//span[@t-out='tx.acquirer_id.sudo().pending_msg']" position="after">
+        <xpath expr="//div[@id='o_payment_status_alert']" position="inside">
             <t t-if="tx.acquirer_id.sudo().provider == 'transfer'">
                 <div t-if="tx.reference">
                     <strong>Communication: </strong><span t-esc="tx.reference"/>


### PR DESCRIPTION
The alert block content and style for the transaction status after
payment were computed in two different places: In the dedicated
`payment.transaction_status` QWeb template, and in the
/payment/confirmation` route's controller which, for some reason, was
re-inventing the wheel instead of relying on the dedicated template.
This commit combines the slightly different behaviors in the template
and gets rid of the duplicated logic in the controller to:
- Handle the states 'draft' and 'error'.
- Always show the transaction's state message, and not only when the
  transaction was in a state for which there exists no pre-defined
  message (`draft` and `error`).

task-2924873
