### PR TITLE
[FIX] website_slides: add style to the side bar container

### DIFF
--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -253,7 +253,7 @@
                         <t t-else="">Join Course</t>
                     </span>
                 </a>
-                
+
                 <div t-if="not channel.is_member and channel.enroll == 'invite'" class="text-center">
                     <div t-attf-class="alert my-0 bg-100 p-2 #{'o_wslides_js_channel_enroll' if not is_public_user else ''}"
                          t-att-data-channel-id="channel.id">
@@ -310,7 +310,7 @@
             <table class="table table-sm mt-3">
                 <tr t-if="channel.user_id">
                     <th class="border-top-0">Responsible</th>
-                    <td class="border-top-0"><span t-field="channel.user_id"/></td>
+                    <td class="border-top-0 text-break"><span t-field="channel.user_id"/></td>
                 </tr>
                 <tr>
                     <th class="border-top-0">Last Update</th>


### PR DESCRIPTION
Reproduction:
1. Install Website and eLearning
2. Add new language Dutch
3. Modify the course responsible’s name as “Gertjan Kleinbloesem” in
eLearning
4. Open the course page in the website app and switch to Dutch, the
responsible name is overflowed

Reason: The background container doesn’t adapt to the length of the text

Fix: Add text break to the responsible's name so it won't break the
style

opw-2862250

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
