### PR TITLE
[FIX] web: fix ratio in `many2many_avatar` widget

### DIFF
--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -315,6 +315,7 @@
             &.avatar.o_clickable_m2x_avatar {
                 img.o_m2m_avatar {
                     margin-right: 0px;
+                    object-fit: cover;
                 }
             }
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently in many2many_avatar widget, image shrink with their container,
make avatar user looking weird. Specially with vertical portrait image

This PR will fix this kind of bug UI.

Before:

![Screenshot from 2022-07-20 09-47-00](https://user-images.githubusercontent.com/90305443/179886283-3320af64-0b84-41cb-af52-008e5278cdeb.png)

After:



![Screenshot from 2022-07-20 09-47-17](https://user-images.githubusercontent.com/90305443/179886296-efddaea6-0f7e-48f4-a527-4e1330ef9254.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
