### PR TITLE
[IMP] project_timesheet_holidays: add redirect warning

### DIFF
--- a/addons/project_timesheet_holidays/__manifest__.py
+++ b/addons/project_timesheet_holidays/__manifest__.py
@@ -17,6 +17,7 @@ on leaves. Project and task can be configured company-wide.
     'data': [
         'views/res_config_settings_views.xml',
         'views/hr_holidays_views.xml',
+        'views/project_task_views.xml',
         'security/ir.model.access.csv',
 
     ],

--- a/addons/project_timesheet_holidays/views/project_task_views.xml
+++ b/addons/project_timesheet_holidays/views/project_task_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="leave_task_form_view">
+        <field name="name">project.task.leave.form.view</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+        <field name="arch" type="xml">
+            <xpath expr="/form" position="inside">
+                <field name="is_timeoff_task" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']" position="attributes">
+                <attribute name="attrs">{'invisible': [('analytic_account_active', '=', False)], 'readonly': [('is_timeoff_task', '=', True)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR add redirect warning with view time off button when
user try to delete timesheets that are linked to time off which
redirect to timesheet related time off and make timesheet page
readonly for tasks that are linked to leave type

task-2888607