### PR TITLE
[IMP] web: focus trap on the dialog

### DIFF
--- a/addons/web/static/tests/core/ui_service_tests.js
+++ b/addons/web/static/tests/core/ui_service_tests.js
@@ -2,9 +2,10 @@
 
 import { registry } from "@web/core/registry";
 import { uiService, useActiveElement } from "@web/core/ui/ui_service";
+import { useAutofocus } from "@web/core/utils/hooks";
 import { makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService } from "../helpers/mock_services";
-import { getFixture, mount, nextTick } from "../helpers/utils";
+import { getFixture, mount, nextTick, triggerEvent } from "../helpers/utils";
 
 const { Component, xml } = owl;
 const serviceRegistry = registry.category("services");
@@ -90,4 +91,179 @@ QUnit.test("a component can be the  UI active element: with t-ref delegation", a
     await nextTick();
 
     assert.deepEqual(ui.activeElement, document);
+});
+
+QUnit.test("UI active element: trap focus", async (assert) => {
+    class MyComponent extends Component {
+        setup() {
+            useActiveElement("delegatedRef");
+        }
+    }
+    MyComponent.template = xml`
+        <div>
+            <h1>My Component</h1>
+            <input type="text" placeholder="outerUIActiveElement"/>
+            <div t-ref="delegatedRef">
+                <input type="text" placeholder="withFocus"/>
+            </div>
+        </div>
+    `;
+
+    const env = await makeTestEnv({ ...baseConfig });
+    await mount(MyComponent, target, { env });
+
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("input[placeholder=withFocus]"),
+        "The focus is on the first 'focusable' element of the UI active element"
+    );
+
+    // Pressing 'Tab'
+    let event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab" },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, true);
+    await nextTick();
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("input[placeholder=withFocus]")
+    );
+
+    // Pressing 'Shift + Tab'
+    event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab", shiftKey: true },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, true);
+    await nextTick();
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("input[placeholder=withFocus]")
+    );
+});
+
+QUnit.test("UI active element: trap focus - default focus with autofocus", async (assert) => {
+    class MyComponent extends Component {
+        setup() {
+            useActiveElement("delegatedRef");
+            useAutofocus();
+        }
+    }
+    MyComponent.template = xml`
+        <div>
+            <h1>My Component</h1>
+            <input type="text" placeholder="outerUIActiveElement"/>
+            <div t-ref="delegatedRef">
+                <input type="text" placeholder="withoutFocus"/>
+                <input type="text" t-ref="autofocus" placeholder="withAutoFocus"/>
+            </div>
+        </div>
+    `;
+
+    const env = await makeTestEnv({ ...baseConfig });
+    await mount(MyComponent, target, { env });
+
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("input[placeholder=withAutoFocus]"),
+        "The focus is on the autofocus element of the UI active element"
+    );
+
+    // Pressing 'Tab'
+    let event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab" },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, true);
+    await nextTick();
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("input[placeholder=withoutFocus]")
+    );
+
+    // Pressing 'Shift + Tab'
+    event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab", shiftKey: true },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, true);
+    await nextTick();
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("input[placeholder=withAutoFocus]")
+    );
+
+    // Pressing 'Shift + Tab' (default)
+    event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab", shiftKey: true },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, false);
+});
+
+QUnit.test("UI active element: trap focus - no focus element", async (assert) => {
+    class MyComponent extends Component {
+        setup() {
+            useActiveElement("delegatedRef");
+        }
+    }
+    MyComponent.template = xml`
+        <div>
+            <h1>My Component</h1>
+            <input type="text" placeholder="outerUIActiveElement"/>
+            <div id="idActiveElement" t-ref="delegatedRef">
+                <div>
+                    <span> No focus element </span>
+                </div>
+            </div>
+        </div>
+    `;
+
+    const env = await makeTestEnv({ ...baseConfig });
+    await mount(MyComponent, target, { env });
+
+    assert.strictEqual(
+        document.activeElement,
+        target.querySelector("div[id=idActiveElement]"),
+        "when there is not other element, the focus is on the UI active element itself"
+    );
+    // Pressing 'Tab'
+    let event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab" },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, true);
+    await nextTick();
+    assert.strictEqual(document.activeElement, target.querySelector("div[id=idActiveElement]"));
+
+    // Pressing 'Shift + Tab'
+    event = triggerEvent(
+        document.activeElement,
+        null,
+        "keydown",
+        { key: "Tab", shiftKey: true },
+        { fast: true }
+    );
+    assert.strictEqual(event.defaultPrevented, true);
+    await nextTick();
+    assert.strictEqual(document.activeElement, target.querySelector("div[id=idActiveElement]"));
 });

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -171,7 +171,7 @@ function findElement(el, selector) {
 }
 
 function keyboardEventBubble(args) {
-    return Object.assign({}, args, { bubbles: true, keyCode: args.which });
+    return Object.assign({}, args, { bubbles: true, keyCode: args.which, cancelable: true });
 }
 
 function mouseEventMapping(args) {
@@ -278,7 +278,7 @@ function _makeEvent(eventType, eventAttrs) {
     return event;
 }
 
-export async function triggerEvent(el, selector, eventType, eventAttrs = {}, options = {}) {
+export function triggerEvent(el, selector, eventType, eventAttrs = {}, options = {}) {
     const event = _makeEvent(eventType, eventAttrs);
     const target = findElement(el, selector);
     if (!target) {
@@ -296,7 +296,7 @@ export async function triggerEvent(el, selector, eventType, eventAttrs = {}, opt
     }
     target.dispatchEvent(event);
     if (!options.fast) {
-        await nextTick();
+        return nextTick().then(() => event);
     }
     return event;
 }


### PR DESCRIPTION
This commit will trap the focus on the dialog, this will avoid modifying
a background record when a dialog is open. Trapping the focus on the
dialog is a well-known technique for modals (dialog).
