### PR TITLE
[FIX] coupon: fix missing french translation causing error

### DIFF
--- a/addons/coupon/i18n/fr.po
+++ b/addons/coupon/i18n/fr.po
@@ -1265,7 +1265,7 @@ msgstr "de remise sur %s"
 #. module: coupon
 #: model_terms:ir.ui.view,arch_db:coupon.report_coupon
 msgid "off on %s"
-msgstr "de remise sur"
+msgstr "de remise sur %s"
 
 #. module: coupon
 #: model_terms:ir.ui.view,arch_db:coupon.report_coupon


### PR DESCRIPTION
Steps to reproduce:
- Install French language
- Go to Sales/Products/Coupon Programs
- Create a new coupon, making sure you set Discount Apply On = On Specific Products
- Save and generate a coupon
- Make sure to be in French
- Go to one coupon and click Send By Email button.
You should be presented with a Traceback saying 'TypeError: not all arguments converted during string formatting'
Note that this only happens  if odoo is set to french.

This is happening because one string used in the coupon email template was not translated correctly in french.
The translation is missing  the specifier '%s', which causes an error when python tries to format the string.

opw-2922594