### PR TITLE
[15.0][FIX] website: Cannot read properties of undefined (reading 'trim') when defaultTitle is empty

### DIFF
--- a/addons/website/static/src/js/menu/seo.js
+++ b/addons/website/static/src/js/menu/seo.js
@@ -362,7 +362,7 @@ var MetaTitleDescription = Widget.extend({
         if (!this.canEditDescription) {
             this.$description.attr('disabled', true);
         }
-        if (this.htmlPage.title().trim() !== this.htmlPage.defaultTitle.trim()) {
+        if (!this.htmlPage.defaultTitle || this.htmlPage.title().trim() !== this.htmlPage.defaultTitle.trim()) {
             this.$title.val(this.htmlPage.title());
         }
         if (this.htmlPage.description().trim() !== this.previewDescription) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
