### PR TITLE
[FIX] website_sale: fix test_05_google_analytics

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -28,6 +28,7 @@ tour.register('google_analytics_view_item', {
     {
         content: "wait until `_getCombinationInfo()` rpc is done",
         trigger: 'body[view-event-id]',
+        timeout: 25000,
         run: () => {
             const $body = $('body');
             itemId = $body.attr('view-event-id');
@@ -43,6 +44,7 @@ tour.register('google_analytics_view_item', {
         content: 'wait until `_getCombinationInfo()` rpc is done (2)',
         // a new view event should have been generated, for another variant
         trigger: `body[view-event-id][view-event-id!=${itemId}]`,
+        timeout: 25000,
         run: () => {}, // it's a check
     },
 ]);
@@ -64,6 +66,7 @@ tour.register('google_analytics_add_to_cart', {
         content: 'check add to cart event',
         extra_trigger: 'body[cart-event-id]',
         trigger: 'a:has(.my_cart_quantity:containsExact(1))',
+        timeout: 25000,
         run: () => {}, // it's a check
     },
 ]);


### PR DESCRIPTION
This commit increases the timeout for some steps in the
`google_analytics_view_item` tour.
The step would time out semi-regularly due to a timeout.

TaskId-2925407
