### PR TITLE
[IMP] website_slides: reword article edition message to match new edit

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -299,11 +299,11 @@
             <t t-out="slide.embed_code"/>
         </div>
         <div t-if="slide.slide_category == 'article'">
-            <div t-if="is_html_empty(slide.html_content)" class="alert alert-info">
-                Click on the "Edit" button on the top-right of the screen to edit your slide content.
+            <div t-if="is_html_empty(slide.html_content)" class="alert alert-info o_not_editable">
+                Click on the "Edit" button in the top corner of the screen to edit your slide content.
             </div>
             <div class="bg-white p-3">
-                <div t-field="slide.html_content"/>
+                <div t-field="slide.html_content" placeholder="Add your content here..."/>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adapt the wording since the edit button is not always on the top
right corner but can also be on the top left one. Also make the
info alert non editable, and add a placeholder to indicate the
editable area.

Task-2924229