### PR TITLE
[FIX] point_of_sale: limited product loading correctly with IoT box

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -152,13 +152,7 @@ exports.PosModel = Backbone.Model.extend({
         await this.load_product_uom_unit();
         await this.load_orders();
         this.set_start_order();
-        if(this.config.use_proxy){
-            if (this.config.iface_customer_facing_display) {
-                this.on('change:selectedOrder', this.send_current_order_to_customer_facing_display, this);
-            }
 
-            return this.connect_to_proxy();
-        }
         if(this.config.limited_products_loading) {
             await this.loadLimitedProducts();
             if(this.config.product_load_background)
@@ -166,6 +160,15 @@ exports.PosModel = Backbone.Model.extend({
         }
         if(this.config.partner_load_background )
             this.loadPartnersBackground();
+
+        if(this.config.use_proxy){
+            if (this.config.iface_customer_facing_display) {
+                this.on('change:selectedOrder', this.send_current_order_to_customer_facing_display, this);
+            }
+
+            return this.connect_to_proxy();
+        }
+
         return Promise.resolve();
     },
     // releases ressources holds by the model at the end of life of the posmodel


### PR DESCRIPTION
Current behavior:
If you used the IoT box in a PoS and had the "limited product loading"
option activated, there was not any product loaded in the PoS session

Steps to reproduce:
- Go in the Shop setting and activate IoT box
- In the IoT box select any device in the list
- Enable "Limited product loading" and set products to load to a low number
- Save the settings and start a PoS session
- There is no products loaded in the session

opw-2895691
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
