### PR TITLE
[FIX] project: fixes missing stage changed notifications

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2038,10 +2038,10 @@ class Task(models.Model):
             'done': 'project.mt_task_ready',
             'normal': 'project.mt_task_progress',
         }
-        if 'kanban_state_label' in init_values and self.kanban_state in mail_message_subtype_per_kanban_state:
-            return self.env.ref(mail_message_subtype_per_kanban_state[self.kanban_state])
-        elif 'stage_id' in init_values:
+        if 'stage_id' in init_values:
             return self.env.ref('project.mt_task_stage')
+        elif 'kanban_state_label' in init_values and self.kanban_state in mail_message_subtype_per_kanban_state:
+            return self.env.ref(mail_message_subtype_per_kanban_state[self.kanban_state])
         return super(Task, self)._track_subtype(init_values)
 
     def _mail_get_message_subtypes(self):


### PR DESCRIPTION
Steps :
When the user is subscribed to the `Stage changed` subtype but not `Task in progress` and when the stage is changed users only subscribed to stage changed will not receive stage changed notification.

Cause :
When the stage is changed it will also change the kanban_state to in progress and due to that, it will track the kanban_state from _track_subtype, and the user who subscribed only stage_changed will not get notified.

Fix :
So in this commit, prioritize the stage_id changed notification so that when the stage_id is changed we use that one, and the in-progress won't be triggered, but when we change the kanban state back to progress it will be triggered. As in progress is implicit when changing the stage_id.

Task -2818058
