### PR TITLE
[FIX] requirements: use certificate on SSL connection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
 psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
-pyopenssl==19.0.0
+pyopenssl==21.0.0
 PyPDF2==1.26.0
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.4
@@ -37,8 +37,8 @@ pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
-requests==2.25.1 # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
-urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
+requests==2.22.0 # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
+urllib3==1.25.8 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1
 Werkzeug==0.16.1 ; python_version <= '3.9'
 Werkzeug==2.0.2 ; python_version > '3.9'  # (Jammy)


### PR DESCRIPTION
It's not possible to use a certificate

Steps to reproduce:
1. Install l10n_es_edi_sii module
2. Switch to company 'ES Company'
3. Go to Settings > Invoicing > Spain Localization > Registro de Libros
   connection SII and select 'Hacienda Foral de Gipuzkoa'
4. Go to Invoicing > Configuration > Accounting > Journals and open
   'Customer Invoices'. In the 'Advanced Settings' tab, enable EDI
   functionality 'SII IVA Llevanza de libros registro (ES)'
5. Go to Invoicing > Configuration > Spain > Certificate (ES) and import
   the certificate (file named sello_entidad_act.p12 in
   l10n_es_edi_sii/demo/certificates/) with password "IZDesa2021"
6. Create an invoice with any customer and product and confirm it
7. Click on 'Send now', an error is raised

Solution:
Revert to previously used package versions

Problem:
With the version 2.25 of requests, SSLContext object has no attribute
`_ctx`