### PR TITLE
[FIX] l10n_es: TAI fiscal position fixes

### DIFF
--- a/addons/l10n_es/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_es/data/account_fiscal_position_template_data.xml
@@ -358,7 +358,7 @@
         <record id="fptt_not_subject_tai_4s" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_not_subject_tai"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva4_sc"/>
-            <field name="tax_dest_id" ref="account_tax_template_p_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva4_isp"/>
         </record>
         <record id="fptt_not_subject_tai_4_inv"
             model="account.fiscal.position.tax.template">
@@ -374,7 +374,7 @@
         <record id="fptt_not_subject_tai_10s" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_not_subject_tai"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva10_sc"/>
-            <field name="tax_dest_id" ref="account_tax_template_p_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva10_isp"/>
         </record>
         <record id="fptt_not_subject_tai_10_inv"
             model="account.fiscal.position.tax.template">
@@ -390,7 +390,7 @@
         <record id="fptt_not_subject_tai_21s" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_not_subject_tai"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva21_sc"/>
-            <field name="tax_dest_id" ref="account_tax_template_p_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva21_isp"/>
         </record>
         <record id="fptt_not_subject_tai_21_inv"
             model="account.fiscal.position.tax.template">
@@ -402,7 +402,7 @@
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_not_subject_tai"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva4b"/>
-            <field name="tax_dest_id" ref="account_tax_template_s_iva_ns_b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_e"/>
         </record>
         <record id="fptt_not_subject_tai_ventas_4s"
             model="account.fiscal.position.tax.template">
@@ -414,7 +414,7 @@
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_not_subject_tai"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva10b"/>
-            <field name="tax_dest_id" ref="account_tax_template_s_iva_ns_b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_e"/>
         </record>
         <record id="fptt_not_subject_tai_ventas_10s"
             model="account.fiscal.position.tax.template">
@@ -426,7 +426,7 @@
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_not_subject_tai"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva21b"/>
-            <field name="tax_dest_id" ref="account_tax_template_s_iva_ns_b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_e"/>
         </record>
         <record id="fptt_not_subject_tai_ventas_21s"
             model="account.fiscal.position.tax.template">


### PR DESCRIPTION
- 4% IVA soportado (servicios corrientes) (Purchases) -> apply:  IVA 4% Compra con Inversión del Sujeto Pasivo Nacional

- 10% IVA soportado (servicios corrientes) (Purchases) -> apply: IVA 10% Compra con Inversión del Sujeto Pasivo Nacional

- 21% IVA soportado (servicios corrientes) (Purchases) ->apply: IVA 21% Compra con Inversión del Sujeto Pasivo Nacional

- IVA 4% (Bienes) (Sales) -> apply: IVA 0% Exportaciones (Sales)

- IVA 10% (Bienes) (Sales) -> apply: IVA 0% Exportaciones (Sales)

- IVA 21% (Bienes) (Sales) -> apply: IVA 0% Exportaciones (Sales)

opw-2887294

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
