### PR TITLE
[IMP] web: update owl from 2.0.0-beta-14 to 2.0.0-beta-16

### DIFF
--- a/addons/web/static/tests/core/main_components_container_tests.js
+++ b/addons/web/static/tests/core/main_components_container_tests.js
@@ -66,6 +66,7 @@ QUnit.module("Components", (hooks) => {
 
         const handler = (ev) => {
             assert.step(ev.reason.message);
+            assert.step(ev.reason.cause.message);
             // need to preventDefault to remove error from console (so python test pass)
             ev.preventDefault();
         };
@@ -78,7 +79,10 @@ QUnit.module("Components", (hooks) => {
         window.removeEventListener("unhandledrejection", handler);
         // unpatch QUnit asap so any other errors can be caught by it
         unpatch(QUnit, "MainComponentsContainer QUnit patch");
-        assert.verifySteps(["BOOM"]);
+        assert.verifySteps([
+            "An error occured in the owl lifecycle (see this Error's \"cause\" property)",
+            "BOOM"
+        ]);
 
         assert.equal(
             target.querySelector(".o-main-components-container").innerHTML,
@@ -115,6 +119,7 @@ QUnit.module("Components", (hooks) => {
 
         const handler = (ev) => {
             assert.step(ev.reason.message);
+            assert.step(ev.reason.cause.message);
             // need to preventDefault to remove error from console (so python test pass)
             ev.preventDefault();
         };
@@ -127,8 +132,10 @@ QUnit.module("Components", (hooks) => {
         window.removeEventListener("unhandledrejection", handler);
         // unpatch QUnit asap so any other errors can be caught by it
         unpatch(QUnit, "MainComponentsContainer QUnit patch");
-        assert.verifySteps(["BOOM"]);
-
+        assert.verifySteps([
+            "An error occured in the owl lifecycle (see this Error's \"cause\" property)",
+            "BOOM"
+        ]);
         assert.equal(
             target.querySelector(".o-main-components-container").innerHTML,
             "<span>MainComponentA</span>"

--- a/addons/web/static/tests/webclient/actions/close_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/close_action_tests.js
@@ -9,6 +9,7 @@ import {
     patchWithCleanup,
 } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
+import { registerCleanup } from "../../helpers/cleanup";
 import FormController from "web.FormController";
 import { makeFakeUserService } from "@web/../tests/helpers/mock_services";
 import ListController from "web.ListController";
@@ -230,7 +231,18 @@ QUnit.module("ActionManager", (hooks) => {
     );
 
     QUnit.test("web client is not deadlocked when a view crashes", async function (assert) {
-        assert.expect(3);
+        assert.expect(6);
+        const handler = (ev) => {
+            assert.step("error");
+            // need to preventDefault to remove error from console (so python test pass)
+            ev.preventDefault();
+        };
+        window.addEventListener("unhandledrejection", handler);
+        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
+        patchWithCleanup(QUnit, {
+            onUnhandledRejection: () => {},
+        });
+
         const readOnFirstRecordDef = testUtils.makeTestPromise();
         const mockRPC = (route, args) => {
             if (args.method === "read" && args.args[0][0] === 1) {
@@ -242,9 +254,11 @@ QUnit.module("ActionManager", (hooks) => {
         // open first record in form view. this will crash and will not
         // display a form view
         await testUtils.dom.click($(target).find(".o_list_view .o_data_row:first"));
+        assert.verifySteps([]);
         await legacyExtraNextTick();
-        readOnFirstRecordDef.reject("not working as intended");
+        readOnFirstRecordDef.reject(new Error("not working as intended"));
         await nextTick();
+        assert.verifySteps(["error"])
         assert.containsOnce(target, ".o_list_view", "there should still be a list view in dom");
         // open another record, the read will not crash
         await testUtils.dom.click($(target).find(".o_list_view .o_data_row:eq(2)"));

--- a/addons/web/static/tests/webclient/actions/error_handling_tests.js
+++ b/addons/web/static/tests/webclient/actions/error_handling_tests.js
@@ -34,7 +34,7 @@ QUnit.module("ActionManager", (hooks) => {
         try {
             await doAction(webClient, "Boom");
         } catch (e) {
-            assert.ok(e instanceof TypeError);
+            assert.ok(e.cause instanceof TypeError);
         }
         assert.strictEqual(target.querySelector(".o_action_manager").innerHTML, contents);
     });

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -361,7 +361,7 @@ QUnit.module("ActionManager", (hooks) => {
                         { onClose: () => assert.step("failing dialog closed") }
                     );
                 } catch (e) {
-                    assert.strictEqual(e.message, "my error");
+                    assert.strictEqual(e.cause.message, "my error");
                 }
             }
         }


### PR DESCRIPTION
Release notes:

https://github.com/odoo/owl/releases/tag/v2.0.0-beta-14

Details:

- fix: lifecyle_hooks: correctly wrap errors in async code
- imp: use a custom error class for all errors thrown by owl
- fix: package.json: remove browser value
- ref: component_node: slightly simplify code

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
