### PR TITLE
Batch of "website in backend" fixes: toolbar visibility, context from params, anchor and background options, keyboard shortcuts, ui fixes, nearest dropzone

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1001,7 +1001,8 @@ var SnippetEditor = Widget.extend({
 
         // TODO lot of this is duplicated code of the d&d feature of snippets
         if (!this.dropped) {
-            var $el = $.nearest({x: ui.position.left, y: ui.position.top}, '.oe_drop_zone', {container: document.body}).first();
+            const { nearest } = this.$body[0].ownerDocument.defaultView.$;
+            let $el = nearest({x: ui.position.left, y: ui.position.top}, '.oe_drop_zone', {container: document.body}).first();
             // Some drop zones might have been disabled.
             $el = $el.filter(this.$dropZones);
             if ($el.length) {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1973,6 +1973,7 @@ body.editor_enable.editor_has_snippets {
         border-color: $o-we-handles-accent-color;
         background: transparent;
         text-align: center;
+        font-size: 16px;
         transition: opacity 400ms linear 0s;
 
         &.o_overlay_hidden {

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -76,6 +76,14 @@ export class WebsitePreview extends Component {
 
         useEffect(() => {
             this.websiteService.currentWebsiteId = this.websiteId;
+
+            // The params used to configure the context should be ignored when
+            // the action is restored (example: click on the breadcrumb).
+            const isRestored = this.props.action.jsId === this.websiteService.actionJsId;
+            this.websiteService.actionJsId = this.props.action.jsId;
+            if (isRestored) {
+                return;
+            }
             this.websiteService.context.showNewContentModal = this.props.action.context.params && this.props.action.context.params.display_new_content;
             this.websiteService.context.edition = this.props.action.context.params && !!this.props.action.context.params.enable_editor;
             this.websiteService.context.translation = this.props.action.context.params && !!this.props.action.context.params.edit_translations;

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -3,6 +3,7 @@
 import legacyEnv from 'web.commonEnv';
 import { useService } from '@web/core/utils/hooks';
 import { WysiwygAdapterComponent } from '../wysiwyg_adapter/wysiwyg_adapter';
+import { useActiveElement } from '@web/core/ui/ui_service';
 
 const { markup, Component, useState, useChildSubEnv, useEffect, onWillStart, onMounted } = owl;
 
@@ -39,6 +40,8 @@ export class WebsiteEditorComponent extends Component {
                 this.publicRootReady();
             }
         });
+
+        useActiveElement('wysiwyg-adapter');
     }
     /**
      * Starts the wysiwyg or disable edition if currently

--- a/addons/website/static/src/components/editor/editor.xml
+++ b/addons/website/static/src/components/editor/editor.xml
@@ -4,7 +4,9 @@
     <div t-if="state.reloading" class="o_loading_dummy">
         <t t-out="this.loadingDummy"/>
     </div>
-    <div t-if="state.showWysiwyg" t-att-class="{ o_w_wysiwyg_transition: !this.state.reloading, o_w_wysiwyg: this.websiteContext.snippetsLoaded }">
+    <div t-if="state.showWysiwyg"
+        t-ref="wysiwyg-adapter"
+        t-att-class="{ o_w_wysiwyg_transition: !this.state.reloading, o_w_wysiwyg: this.websiteContext.snippetsLoaded }">
         <WysiwygAdapterComponent Component="this.Wysiwyg"
             snippetSelector="this.reloadSelector"
             willReload.bind="this.willReload"

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1261,7 +1261,7 @@ options.registry.OptionsTab = options.Class.extend({
      */
     async _computeWidgetState(methodName, params) {
         if (methodName === 'customizeBodyBgType') {
-            const bgImage = $('#wrapwrap').css('background-image');
+            const bgImage = getComputedStyle(this.ownerDocument.querySelector('#wrapwrap'))['background-image'];
             if (bgImage === 'none') {
                 return "NONE";
             }

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2458,7 +2458,7 @@ options.registry.anchor = options.Class.extend({
             }
             this._setAnchorName(anchorName + n);
         }
-        return `${window.location.pathname}#${this.$target[0].id}`;
+        return `${this.ownerDocument.location.pathname}#${this.$target[0].id}`;
     },
     /**
      * Creates a safe id/anchor from text.

--- a/addons/website/static/src/js/editor/wysiwyg.js
+++ b/addons/website/static/src/js/editor/wysiwyg.js
@@ -271,14 +271,6 @@ snippetsEditor.SnippetsMenu.include({
         const _super = this._super(...arguments);
         if (this.$body[0].ownerDocument !== this.ownerDocument) {
             this.$body.on('click.snippets_menu', '*', this._onClick);
-
-            // As there is now one document for the SnippetsMenu and another one
-            // for the snippets, clicking on one should blur and remove the
-            // selection of the other one.
-            this._blurSnippetsSelection = this._blurSnippetsSelection.bind(this);
-            this._blurSnippetsMenuSelection = this._blurSnippetsMenuSelection.bind(this);
-            this.$body[0].ownerDocument.addEventListener('click', this._blurSnippetsMenuSelection);
-            this.$el[0].addEventListener('click', this._blurSnippetsSelection);
         }
         return _super;
     },
@@ -288,8 +280,6 @@ snippetsEditor.SnippetsMenu.include({
     destroy() {
         if (this.$body[0].ownerDocument !== this.ownerDocument) {
             this.$body.off('.snippets_menu');
-            this.$body[0].ownerDocument.removeEventListener('click', this._blurSnippetsMenuSelection);
-            this.$el[0].removeEventListener('click', this._blurSnippetsSelection);
         }
         return this._super(...arguments);
     },
@@ -308,38 +298,6 @@ snippetsEditor.SnippetsMenu.include({
         $dropzone.attr('data-editor-sub-message', $hookParent.attr('data-editor-sub-message'));
         return $dropzone;
     },
-    /**
-     * @private
-     */
-     _blurDocumentSelection(document) {
-        const selection = document.getSelection();
-        selection.removeAllRanges();
-    },
-
-    //--------------------------------------------------------------------------
-    // Handler
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _blurSnippetsSelection(ev) {
-        // The selection should be kept for the toolbar buttons, as they are
-        // related to the text's style edition. It should be blurred for the
-        // link tools, as they modify the element itself.
-        const shouldKeepFocus = ev.target.closest('.oe-toolbar') && !ev.target.closest('#create-link');
-        if (shouldKeepFocus) {
-            return;
-        }
-        this._blurDocumentSelection(this.$body[0].ownerDocument);
-    },
-    /**
-     * @private
-     */
-    _blurSnippetsMenuSelection(ev) {
-        this._blurDocumentSelection(this.ownerDocument);
-    },
-
 });
 
 return WebsiteWysiwyg;

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -61,7 +61,7 @@ export const websiteService = {
                 document.body.classList.toggle('o_website_fullscreen', fullscreen);
                 bus.trigger((fullscreen ? 'FULLSCREEN-INDICATION-SHOW' : 'FULLSCREEN-INDICATION-HIDE'));
             }
-        });
+        }, { global: true });
         registry.category('main_components').add('FullscreenIndication', {
             Component: FullscreenIndication,
             props: { bus },

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -38,6 +38,7 @@ export const websiteService = {
         let isPublisher;
         let isDesigner;
         let hasMultiWebsites;
+        let actionJsId;
         const context = reactive({
             showNewContentModal: false,
             showAceEditor: false,
@@ -150,6 +151,12 @@ export const websiteService = {
             },
             get hasMultiWebsites() {
                 return hasMultiWebsites === true;
+            },
+            get actionJsId() {
+                return actionJsId;
+            },
+            set actionJsId(jsId) {
+                actionJsId = jsId;
             },
             openMenuDialog(Component, props) {
                 return dialog.add(Component, props);

--- a/addons/website/static/src/systray_items/publish.js
+++ b/addons/website/static/src/systray_items/publish.js
@@ -34,7 +34,7 @@ class PublishSystray extends Component {
     }
 }
 PublishSystray.template = xml`
-<div t-on-click="publishContent" class="o_menu_systray_item d-md-flex ms-auto">
+<div t-on-click="publishContent" class="o_menu_systray_item d-md-flex ms-auto" data-hotkey="p">
     <a href="#">
         <Switch value="state.published" extraClasses="'mb-0 o_switch_danger_success'"/>
         <t t-esc="this.label"/>

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -42,4 +42,35 @@ wTourUtils.dragNDrop({
             console.error("The paragraph text selection was lost.");
         }
     },
+}, {
+    content: "Click on the anchor option",
+    trigger: '#oe_snippets .snippet-option-anchor we-button',
+    run() {
+        // The clipboard cannot be accessed from a script.
+        // https://w3c.github.io/editing/docs/execCommand/#dfn-the-copy-command
+        // The execCommand is patched for that step so that ClipboardJS still
+        // sends the 'success' event.
+        const oldExecCommand = document.execCommand;
+        document.execCommand = () => true;
+        this.$anchor[0].click();
+        document.execCommand = oldExecCommand;
+    }
+}, {
+    content: "Check the copied url from the notification toast",
+    trigger: '.o_notification_manager .o_notification_content',
+    run() {
+        const { textContent } = this.$anchor[0];
+        const url = textContent.substring(textContent.indexOf('/'));
+
+        // The url should not target the client action
+        if (url.startsWith('/@')) {
+            console.error('The anchor option should target the frontend');
+        }
+
+        const iframeDocument = document.querySelector('.o_iframe').contentDocument;
+        const snippetId = iframeDocument.querySelector('.s_text_image').id;
+        if (!url || url.indexOf(snippetId) < 0) {
+            console.error('The anchor option does not target the correct snippet.');
+        }
+    },
 }]);

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -1,0 +1,45 @@
+/** @odoo-module */
+
+import wTourUtils from 'website.tour_utils';
+
+wTourUtils.registerEditionTour('snippet_editor_panel_options', {
+    test: true,
+    url: '/',
+    edition: true,
+}, [
+wTourUtils.dragNDrop({
+    id: 's_text_image',
+    name: 'Text - Image',
+}), {
+    content: "Click on the first paragraph.",
+    trigger: 'iframe .s_text_image p',
+}, {
+    content: "The text toolbar should be visible. The paragraph should be selected.",
+    trigger: '#oe_snippets .o_we_customize_panel > #o_we_editor_toolbar_container',
+    run() {
+        const iframeDocument = document.querySelector('.o_iframe').contentDocument;
+        const pText = iframeDocument.querySelector('.s_text_image p').textContent;
+        const selection = iframeDocument.getSelection().toString();
+        if (pText !== selection) {
+            console.error("The paragraph was not correctly selected.");
+        }
+    },
+}, {
+    content: "Click on the width option.",
+    trigger: '[data-select-class="o_container_small"]',
+}, {
+    content: "The snippet should have the correct class.",
+    trigger: 'iframe .s_text_image > .o_container_small',
+    run: () => {}, // It's a check.
+}, {
+    content: "The text toolbar should still be visible, and the text still selected.",
+    trigger: '#oe_snippets .o_we_customize_panel > #o_we_editor_toolbar_container',
+    run() {
+        const iframeDocument = document.querySelector('.o_iframe').contentDocument;
+        const pText = iframeDocument.querySelector('.s_text_image p').textContent;
+        const selection = iframeDocument.getSelection().toString();
+        if (pText !== selection) {
+            console.error("The paragraph text selection was lost.");
+        }
+    },
+}]);

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -17,10 +17,8 @@ wTourUtils.registerEditionTour("website_style_edition", {
     content: "Change font size",
     trigger: '[data-variable="font-size-base"] input',
     run: `text_blur ${TARGET_FONT_SIZE}`,
-}, {
-    content: "Save",
-    trigger: '[data-action="save"]',
-}, {
+},
+...wTourUtils.clickOnSave(), {
     content: "Check the font size was properly adapted",
     trigger: 'iframe body:not(.editor_enable) #wrapwrap',
     run: function (actions) {
@@ -29,5 +27,15 @@ wTourUtils.registerEditionTour("website_style_edition", {
             console.error(`Expected the font-size to be equal to ${TARGET_FONT_SIZE}px but found ${style.fontSize} instead`);
         }
     },
+},
+wTourUtils.clickOnEdit(),
+wTourUtils.goToTheme(), {
+    content: "Click on the Background Image selection",
+    trigger: '[data-customize-body-bg-type="\'image\'"]:not(.active)',
+    extra_trigger: '[data-customize-body-bg-type="NONE"].active',
+}, {
+    content: "The media dialog should open",
+    trigger: '.o_select_media_dialog',
+    run: () => {}, // It's a check.
 }]);
 });

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -305,3 +305,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_19_website_page_options(self):
         self.start_tour("/web", "website_page_options", login="admin")
+
+    def test_20_snippet_editor_panel_options(self):
+        self.start_tour("/@/?enable_editor=1", "snippet_editor_panel_options", login="admin")


### PR DESCRIPTION
[FIX] web_editor: fix nearest dropzone when moving a snippet

Before this commit, when a snippet was moved, and dropped outside of a
dropzone, the nearest dropzone was not found and the snippet would
return to its initial position.

This commit fixes it by using the editable document instead of the
global one.

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: copy frontend link when using the anchor option

Before this commit, clicking on the "anchor" icon from a snippet editor
would copy the client action's url (introduced in [1]).

This commit changes the snippet's path computation to use the target's
ownerDocument location instead of the global one.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: fix editor keyboard shortcuts

Before this commit, the shortcuts that were registered for both the
navbar and the editor would not work.
Example: "alt+1", or "alt+2" that would open a menu item of the navbar,
or switch tab of the editor.

This commit regiters the editor as the active element, so that keyboard
shortcuts registered on that element are given priority at the hotkey
service level. The "escape" shortcut to go fullscreen is adapted with
the global option to be independent from the active element.

This commit also adds the "alt+p" keyboard shortcut on the publish
systray item.

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: ignore context params when client action is restored

Before this commit, the website context was configured with the params
of the client action, at all times. This was leading to weird
behaviours:
- Go to the website client action
- Install the "Blogs" module from the new content systray item
- Navigate on a blog post from the client action
- Click on the "Settings" systray item (last one from the right)
- Click on the "Website Preview" breadcrumb item
=> The "New Content" modal is displayed, again, when it should not.

Another flow, on enterprise:
- Start the client action with /@/?enable_editor=1
- Click on the top left icon to go back to the home screen
- Click on the top left icon to go back to the website
=> The editor is launched when it should not.

To prevent that, the action jsId key is registered at the website
service level. If the action is restored, the jsId will be the same, and
the params used to configure the context will be ignored.

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] web_editor: fix snippets overlay buttons ui

After [1] was merged, the delete/move buttons of the snippets overlay
reduced in size, because of the font-size difference between the backend
and the frontend.

This commit fixes it by setting a fixed font-size of 16px (this restores
the same size as before, as the button was using 1rem on the frontend,
and most browsers use 16px as a default font size).

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: fix theme options background widget state

Before this commit, the Page Layout > Background option's widget of the
Theme section of the SnippetsMenu was not updated correctly after using
the option.
The #wrapwrap was queried in the global document when it should be
queried in the target's ownerDocument.

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: keep focus on text when using snippet options

Before [1] was merged, for this flow:
- Drop a snippet in the page
- Click on some paragraph
- Click on a snippet option's widget
=> The text selection was lost on Chrome, but kept on Firefox.

With [1] instantiating the SnippetsMenu on a different document than the
snippets one, it was possible to keep the text selection (the snippets
document selection) when clicking on the snippets options (on the global
document).
Some code was added to preserve the Chrome behaviour and lose the text
selection. This code is reverted to keep the Firefox behaviour.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
