### PR TITLE
[FIX] mail: fix the follower subtypes order

### DIFF
--- a/addons/mail/static/src/model/model_field_relation_set.js
+++ b/addons/mail/static/src/model/model_field_relation_set.js
@@ -69,6 +69,9 @@ export class RelationSet {
                             const valB = followRelations(b, relatedPath);
                             switch (compareMethod) {
                                 case 'truthy-first': {
+                                    if (valA === valB) {
+                                        break;
+                                    }
                                     if (!valA) {
                                         return 1;
                                     }
@@ -78,6 +81,9 @@ export class RelationSet {
                                     break;
                                 }
                                 case 'falsy-first': {
+                                    if (valA === valB) {
+                                        break;
+                                    }
                                     if (!valA) {
                                         return -1;
                                     }


### PR DESCRIPTION
Before this commit, the subtypes are not correctly ordered when none of the subtypes have a parent model. while it should be ordered by parent model, then by sequence.

So in this commit, we will first check if both their parent model are falsy then we can't order them (A = B). Then we will consider their sequence, and they will be useful to determine the proper order.

task-2904015