### PR TITLE
[FIX] website_slides: Impossible to delete a slide

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -80,7 +80,7 @@ class EmbeddedSlide(models.Model):
     _description = 'Embedded Slides View Counter'
     _rec_name = 'slide_id'
 
-    slide_id = fields.Many2one('slide.slide', string="Presentation", required=True, index=True)
+    slide_id = fields.Many2one('slide.slide', string="Presentation", required=True, index=True, ondelete='cascade')
     url = fields.Char('Third Party Website URL', required=True)
     count_views = fields.Integer('# Views', default=1)
 


### PR DESCRIPTION
Steps to reproduce the issue:

- Create a presentation in a course (model `slide.slide`)
- Create an entry referencing the presentation in `slide_embed` table
- Remove the presentation from the course and save the changes

Bug:

A validation error was raised

opw:2902062