### PR TITLE
[FIX] payment[_transfer]: enable qr code for portal payments

### DIFF
--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -127,13 +127,7 @@
                     <div class="row">
                         <div class="col-lg-6">
                             <div>
-                                <!-- message is the content of either the HTML field describing the
-                                transaction state computed while processing feedback data, or the
-                                HTML field associated with the transaction state, defined on the
-                                acquirer.  -->
-                                <div t-attf-class="alert alert-#{status}"
-                                     t-out="message"
-                                     role="status"/>
+                                <t t-call="payment.transaction_status"/>
                                 <div class="form-group row">
                                     <label for="form_partner_name" class="col-md-3 col-form-label">
                                         From

--- a/addons/payment_transfer/views/payment_transfer_templates.xml
+++ b/addons/payment_transfer/views/payment_transfer_templates.xml
@@ -14,7 +14,7 @@
                     <strong>Communication: </strong><span t-esc="tx.reference"/>
                 </div>
                 <div t-if="tx.acquirer_id.sudo().qr_code">
-                    <t t-set="qr_code" t-value="tx.acquirer_id.sudo().journal_id.bank_account_id.build_qr_code_base64(tx.amount, tx.reference, None, tx.currency_id, tx.partner_id)"/>
+                    <t t-set="qr_code" t-value="tx.company_id.sudo().partner_id.bank_ids[:1].build_qr_code_base64(tx.amount, tx.reference, None, tx.currency_id, tx.partner_id)"/>
                     <div t-if="qr_code" class="mt-2">
                         <h3>Or scan me with your banking app.</h3>
                         <img class="border border-dark rounded" t-att-src="qr_code"/>


### PR DESCRIPTION
Steps to reproduce:
- configure a qr-code set up for a belgian company
https://www.odoo.com/documentation/15.0/applications/finance/accounting/receivables/customer_invoices/epc_qr_code.html?highlight=bank%20account
- activate acquirer "wire transfer" and activate qr-code
- create an invoice
- generate a payment link
- open the link and select wire transfer

Issue:
The qr-code will not be displayed

Cause:
- missing qr code template
- incorrect info fetching for the qr code

Solution:
- correct info fetching for the qr code such as in
https://github.com/odoo/odoo/blob/15a5bc956ad865d4a6ebb001b5767a5009533782/addons/website_sale/views/templates.xml#L1852
commit : https://github.com/odoo-dev/odoo/commit/15a5bc956ad865d4a6ebb001b5767a5009533782

opw-2903527