### PR TITLE
[FIX] website : one2many fields when no record is found

### DIFF
--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -254,16 +254,17 @@
     <t t-name="website.form_field_selection">
         <t t-set="field.isCheck" t-value="true"/>
         <t t-call="website.form_field">
+            <t t-if="!field.records">
+                <input
+                    class="s_website_form_input"
+                    t-att-name="field.name"
+                    t-att-value="undefined"
+                    t-att-required="field.required || field.modelRequired || None"
+                    placeholder="No matching record !"
+                    disabled=""
+                />
+            </t>
             <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" t-att-data-name="field.name" t-att-data-display="field.formatInfo.multiPosition">
-                <t t-if="!field.records">
-                    <input
-                        class="s_website_form_input"
-                        t-att-name="field.name"
-                        t-att-value="record.id"
-                        t-att-required="field.required || field.modelRequired || None"
-                        placeholder="No matching record !"
-                    />
-                </t>
                 <t t-foreach="field.records" t-as="record">
                     <t t-call="website.form_radio"/>
                 </t>
@@ -327,16 +328,17 @@
         <t t-if="field.relation != 'ir.attachment'">
             <t t-set="field.isCheck" t-value="true"/>
             <t t-call="website.form_field">
+                <t t-if="!field.records || field.records.length == 0">
+                    <input
+                        class="form-control s_website_form_input"
+                        t-att-name="field.name"
+                        t-att-value="undefined"
+                        t-att-required="field.required || field.modelRequired || None"
+                        placeholder="No matching record !"
+                        disabled=""
+                    />
+                </t>
                 <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" t-att-data-name="field.name" t-att-data-display="field.formatInfo.multiPosition">
-                    <t t-if="!field.records">
-                        <input
-                            class="s_website_form_input"
-                            t-att-name="field.name"
-                            t-att-value="record.id"
-                            t-att-required="field.required || field.modelRequired || None"
-                            placeholder="No matching record !"
-                        />
-                    </t>
                     <t t-foreach="field.records" t-as="record">
                         <t t-call="website.form_checkbox"/>
                     </t>


### PR DESCRIPTION
To reproduce
============

1) Website Fronteed > Add a page
2) Drag the form block
4) Add a field
5) for the field type select a one2many field (Reactions for example)

an error will be raised.

Purpose
=======

the issue is caused by the condition :
https://github.com/odoo/odoo/blob/bec7d16eb4f4e8b27093ac73cb4e638456c516ef/addons/website/static/src/xml/website_form_editor.xml#L331

where `field.records` is an empty array but `![]` is `false` in Javascript, so we will end up with a field without an input
then the `querySelector` in this line :
https://github.com/odoo/odoo/blob/44fa95f52eedf9e20b11ffe20209fae499446fe1/addons/website/static/src/snippets/s_website_form/options.js#L1363

will return `null` and trying to get `name` from `null` will occure the error.

Specification
=============

to solve the issue the condition was corrected and some code was moved for styling reasons.

the Selection Field was also changed because it looked the same as One2Many field.

opw-2916396