### PR TITLE
[IMP] hr_holiday: Ensure persistence of number_of_hours_display

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -205,15 +205,10 @@ class HolidaysAllocation(models.Model):
         for allocation in self:
             allocation.number_of_days_display = allocation.number_of_days
 
-    @api.depends('number_of_days', 'employee_id')
+    @api.depends('number_of_days', 'holiday_status_id')
     def _compute_number_of_hours_display(self):
         for allocation in self:
-            if allocation.parent_id and allocation.parent_id.type_request_unit == "hour":
-                allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
-            elif allocation.number_of_days:
-                allocation.number_of_hours_display = allocation.number_of_days * (allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY)
-            else:
-                allocation.number_of_hours_display = 0.0
+            allocation.number_of_hours_display = allocation.number_of_days * (allocation.holiday_status_id.company_id.resource_calendar_id.hours_per_day or HOURS_PER_DAY)
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):


### PR DESCRIPTION
Purpose
=======

Base the number_of_hours_display on the company calendar instead of the
employee calendar to avoid modifying the informative allocated value
in case of a working schedule change.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
