### PR TITLE
[FIX] stock: history back on the forecast report

### DIFF
--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -101,7 +101,7 @@ const ReplenishReport = clientAction.extend({
         // Hack to put the res_model on the url. This way, the report always know on with res_model it refers.
         if (location.href.indexOf('active_model') === -1) {
             const url = window.location.href + `&active_model=${this.resModel}`;
-            window.history.pushState({}, "", url);
+            window.history.replaceState({}, "", url);
         }
     },
 


### PR DESCRIPTION
Steps to reproduce:

  - Go to stock > Replenishment
  - Click on a forecast report widget
  - Go back using the browser arrows
  -> The page is redirected to another forecast report and the
  breadcrumbs are cleared

Cause of the issue:

  The forecast report action uses the `window.history.pushState` to
  add the active model in the url.
  When going back, the new url is the same one but without the active
  model.
  We can get the correct behavior by doing `window.history.go(-2)` in
  the console.

Solution:

  Use `history.replaceState` instead

opw-2917725