### PR TITLE
[IMP] web_editor: add "hide controls" option to vimeo video

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -1169,7 +1169,7 @@ var VideoWidget = MediaWidget.extend({
             var videoSrc = _.str.sprintf('%s&loop=1', $video.attr('src'));
             $video.attr('src', ytMatch ? _.str.sprintf('%s&playlist=%s', videoSrc, ytMatch[2]) : videoSrc);
         }
-        if (options.hide_controls && (ytMatch || dmMatch)) {
+        if (options.hide_controls && (ytMatch || dmMatch || vimMatch)) {
             $video.attr('src', $video.attr('src') + '&controls=0');
         }
         if (options.hide_fullscreen && ytMatch) {

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -398,7 +398,7 @@
                     <div class="o_yt_option o_vim_option">
                         <label class="o_switch mb0"><input id="o_video_loop" type="checkbox"/><span/>Loop</label>
                     </div>
-                    <div class="o_yt_option o_dm_option">
+                    <div class="o_yt_option o_dm_option o_vim_option">
                         <label class="o_switch mb0"><input id="o_video_hide_controls" type="checkbox"/><span/>Hide player controls</label>
                     </div>
                     <div class="o_yt_option">


### PR DESCRIPTION
Only youtube and dailymotion were able to add this property to their
video. Maybe it was not supported by vimeo back then, but it seems to be
supported now.

It improves the vimeo youtube in two ways:
1. For background video, the controls are now hidden. There were visible
   for a few seconds before this PR which is not ideal
2. For non background video, there were no way to hide the controls
   which might be problematic to some users as in mobile there is the
   controls display but also an ugly "Tap to unmute" in the middle of
   the video.

Step to reproduce (background video):
- Drag & drop a "Text - Image" snippet and add it the biggest possible
  padding, also add padding to the image (so you see the full video and
  not just part of it)
- Double click on the image, then on the video tab insert a vimeo url
- Save, you will see the controls for a few seconds (progress bar, video
  title, link to vimeo, etc)

Step to reproduce (non background video):
- Drag & drop a "Text - Image" snippet and double click on the image
- On the video tab, insert a vimeo url
- Select "Auto Play"
- Save and go to mobile, you will see the controls and an ugly "Tap to
  mute" in the middle of the video.

The "Tap to mute" is a browser feature, not a vimeo feature. Browsers
are muting video by default when auto play.

Still, some people want to have a nice auto play video shown to users
without sounds and don't want that overlay/controls.

opw-2901256
