### PR TITLE
[REF][IMP] crm, event, test_mail(_full): make performance tests post-…

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -5,7 +5,7 @@ from odoo.addons.crm.tests import common as crm_common
 from odoo.tests.common import tagged, users
 
 
-@tagged('lead_manage', 'crm_performance')
+@tagged('lead_manage', 'crm_performance', 'post_install', '-at_install')
 class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
 
     @classmethod
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=173):  # crm only: 170 (often), sometimes +3 on runbot
+        with self.assertQueryCount(user_sales_manager=506):  # crm 504
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=141):  # crm only: 136 (often), sometimes +2/+3 on runbot // extra queries ~1/week
+        with self.assertQueryCount(user_sales_manager=487):  # crm 482
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -166,7 +166,8 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         test_leads = self._create_leads_batch(count=50, user_ids=[False])
         user_ids = self.assign_users.ids
 
-        with self.assertQueryCount(user_sales_manager=1041):  # 1038 generally on runbot - crm only: 1029 // 1040/41 about once / day on runbot (22h build ?)
+        # randomness: at least 1 query
+        with self.assertQueryCount(user_sales_manager=1667):  # crm 1376 - com 1662
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -8,7 +8,7 @@ from odoo.tests.common import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('lead_assign', 'crm_performance')
+@tagged('lead_assign', 'crm_performance', 'post_install', '-at_install')
 class TestLeadAssignPerf(TestLeadAssignCommon):
     """ Test performances of lead assignment feature added in saas-14.2
 
@@ -47,8 +47,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush()
 
+        # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=1289):  # 1281-1289 generally - crm only: 1204
+            with self.assertQueryCount(user_sales_manager=1206):  # crm 1205
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -91,8 +92,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush()
 
+        # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=589):  # 584-585 generally, sometimes 589
+            with self.assertQueryCount(user_sales_manager=586):  # crm 585
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -173,8 +175,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush()
 
+        # randomness: at least 17 queries
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6549):  # 6540-6547 generally / sometimes +1/+2 on nightly
+            with self.assertQueryCount(user_sales_manager=6546):  # crm 6501 - com 6546
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -42,7 +42,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=245):  # 236, sometimes +6
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=236):  # 236
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -70,7 +70,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be = self.env['res.lang']._lang_get('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=188):  # tcf only: 173 - com runbot: 174/175
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=188):  # tcf 173 / com 175
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.country_id = country_be
@@ -89,7 +89,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_form_partner(self):
         """ Test a single lead creation using Form with a partner """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=197):  # tcf only: 178 - com runbot: 179/180
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=197):  # tcf 182 / com 184
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.partner_id = self.partners[0]
@@ -104,7 +104,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=42):  # tcf only: 41 - com runbot: 42
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=42):  # tcf only: 41
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -124,7 +124,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_single_partner(self):
         """ Test multiple lead creation (import) """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=48):  # tcf only: 47 - com runbot: 48
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=48):  # tcf only: 47
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'partner_id': self.partners[0].id,

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -36,7 +36,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=343):  # 337 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=337):  # 337
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -52,7 +52,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5488):  # tef only: 5062 (5058) - com runbot: 5062 - ent runbot 5482-5487
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5487):  # tef 5058 / com 5062 / ent 5487
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -70,7 +70,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=449):  # 443 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=443):  # 443
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -89,7 +89,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5601):  # tef only: 5171 - com runbot: 5175 - ent runbot 5595-5600
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5600):  # tef 5171 / com 5175 / ent 5600
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -107,7 +107,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, no website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=228):  # tef only: 176 - com runbot: 176 - ent runbot: 228
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=226):  # tef 176 / com 176
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -125,7 +125,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=737):  # tef only: 622 - com runbot: 623 - ent runbot: 737
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=736):  # tef 624 / com 625
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -144,7 +144,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # type and website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=772):  # tef only: 660 - com runbot: 663 - ent runbot: 772
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=772):  # tef 662 / com 665
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'
@@ -159,7 +159,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype(self):
         """ Test a single event creation """
         # simple without type involved
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=39):  # 33 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=33):  # 33
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -172,7 +172,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype_website(self):
         """ Test a single event creation """
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=377):  # tef only: 351 (346) - com runbot: 350 - ent runbot 376
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=376):  # tef 346 / com 350
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -187,7 +187,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=69):  # 62 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=62):  # 62
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -203,7 +203,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=413):  # tef only: 388 (382) - com runbot: 386 - ent runbot 412
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=412):  # tef 382 / com 386
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -225,7 +225,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=719):  # tef only: 674? - com runbot 716 - ent runbot 719
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=719):  # tef 673 / com 716
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -249,7 +249,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=242):  # tef only: 200 - com runbot 238 - ent runbot 242
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=242):  # tef 199 / com 238
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -271,7 +271,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         form like) """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=730):  # tef only: 685? - com runbot 727
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=730):  # tef 684 / com 727
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -292,7 +292,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=230):  # tef only: 210? - com runbot 216
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=230):  # tef 210 / com 216
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -308,7 +308,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=232):  # tef only: 213? - com runbot 217
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=232):  # tef 212 / com 217
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -321,7 +321,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=140):  # tef only: 123 - com runbot 124
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=140):  # tef 122 / com 124
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration'].with_context(event_lead_rule_skip=True)) as reg_form:
                 reg_form.event_id = event
@@ -335,7 +335,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # simple customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=142):  # tef only: 135? - com runbot 140
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=142):  # tef 135 / com 140
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.customer_data[0],
@@ -349,7 +349,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=148):  # tef only: 142? - com runbot 146
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=148):  # tef 142 / com 147
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -364,7 +364,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=58):  # tef only: 55 - com runbot 56
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=58):  # tef 54 / com 56
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -379,7 +379,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # website customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=150):  # tef only: 142? - com runbot 146
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=150):  # tef 141 / com 146
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.website_customer_data[0],
@@ -428,7 +428,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate('user_eventmanager', 'user_eventmanager')
-            with self.assertQueryCount(default=60):  # tef only: 59 (+1 ent)
+            with self.assertQueryCount(default=59):  # tef 58
                 self._test_url_open('/event/%i' % self.test_event.id)
 
     @warmup
@@ -444,7 +444,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate('user_eventmanager', 'user_eventmanager')
-            with self.assertQueryCount(default=50):  # tef only: 49 (+1 ent)
+            with self.assertQueryCount(default=50):  # tef 49
                 self._test_url_open('/event')
 
     @warmup

--- a/addons/test_mail_full/tests/test_sms_performance.py
+++ b/addons/test_mail_full/tests/test_sms_performance.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
 
     def setUp(self):
@@ -75,7 +75,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
         self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages, sent_unlink=True)
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
 
     def setUp(self):

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -36,7 +36,7 @@ class TestMassMailPerformanceBase(TransactionCase):
         self.patch(self.env.registry, 'ready', True)
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMassMailPerformance(TestMassMailPerformanceBase):
 
     def setUp(self):
@@ -61,14 +61,14 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +101 compared to local (1568)
-        with self.assertQueryCount(__system__=1670, marketing=1671):
+        with self.assertQueryCount(__system__=1670, marketing=1671):  # tmm 1569/1570
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMassMailBlPerformance(TestMassMailPerformanceBase):
 
     def setUp(self):
@@ -101,7 +101,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +125 compared to local (1834)
-        with self.assertQueryCount(__system__=1960, marketing=1961):
+        with self.assertQueryCount(__system__=1960, marketing=1961):  # tmm 1835/1836
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
…install

PURPOSE

Have more reliable tests.
Better spot side effects coming from sub addons.
Lessen non deterministic counters due to local db.

SPECIFICATIONS

Make crm, event and mail performance tests post install.

Update query counters with
  * local values (install module only with enterprise activated);
  * community / enterprise runbots (if value is different);
  * some notes on non deterministic issue if known;

Task-2925606
