### PR TITLE
[REF][IMP] crm, event, test_mail(_full): make performance tests post-…

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -5,7 +5,7 @@ from odoo.addons.crm.tests import common as crm_common
 from odoo.tests.common import tagged, users
 
 
-@tagged('lead_manage', 'crm_performance')
+@tagged('lead_manage', 'crm_performance', 'post_install', '-at_install')
 class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
 
     @classmethod
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=176):  # crm only: 170 (often), sometimes +3 on runbot // 176 on community ?
+        with self.assertQueryCount(user_sales_manager=543):  # crm 537 / com 543 / ent 537
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=141):  # crm only: 137 (often), sometimes +2/+3 on runbot // extra queries ~1/week
+        with self.assertQueryCount(user_sales_manager=524):  # crm 521 / com 524
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -166,7 +166,8 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         test_leads = self._create_leads_batch(count=50, user_ids=[False])
         user_ids = self.assign_users.ids
 
-        with self.assertQueryCount(user_sales_manager=1038):  # 1033 - crm only: 1029
+        # randomness: at least 1 query
+        with self.assertQueryCount(user_sales_manager=1704):  # crm 1410 / com 1697
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -8,7 +8,7 @@ from odoo.tests.common import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('lead_assign', 'crm_performance')
+@tagged('lead_assign', 'crm_performance', 'post_install', '-at_install')
 class TestLeadAssignPerf(TestLeadAssignCommon):
     """ Test performances of lead assignment feature added in saas-14.2
 
@@ -47,9 +47,10 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
+        # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
             self.env['res.users'].has_group('base.group_user')  # warmup the cache to avoid inconsistency between community an enterprise
-            with self.assertQueryCount(user_sales_manager=1265):
+            with self.assertQueryCount(user_sales_manager=1188):  # crm 1187
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -92,8 +93,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
+        # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=584):  # +1 on nightly
+            with self.assertQueryCount(user_sales_manager=585):  # crm 584
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -174,8 +176,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
+        # randomness
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6280):
+            with self.assertQueryCount(user_sales_manager=6280):  # crm 6226 / com 6276 / ent 6278
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -42,7 +42,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=196):  # -1 tcf
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=194):  # tcf 193 / com 194
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -70,7 +70,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be = self.env['res.lang']._lang_get('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=179):  # com 166 - -2 tcf
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=178):  # tcf 164 / com 166
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.country_id = country_be
@@ -89,7 +89,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_form_partner(self):
         """ Test a single lead creation using Form with a partner """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=187):  # com 175 - -2 tcf
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=186):  # tcf 173 / com 175
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with self.debug_mode():
                 # {'invisible': ['|', ('type', '=', 'opportunity'), ('is_partner_visible', '=', False)]}
@@ -107,7 +107,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=33):  # -1 tcf
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=31):  # tcf 30 / com 31
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -127,7 +127,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_single_partner(self):
         """ Test multiple lead creation (import) """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=34):  # -1 tcf
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=32):  # tcf 31 / com 32
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'partner_id': self.partners[0].id,

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -36,7 +36,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=341):  # 335 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=335):  # tef 335
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -52,7 +52,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5368):  # com runbot: 4943 - +1 tef - ent runbot 5368
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5368):  # tef 4944 / com 4943
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -70,7 +70,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=445):  # 439 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=439):  # 439
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -89,7 +89,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5480):  # com runbot: 5055 - +1 tef - ent runbot 5480
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5480):  # tef 5056 / com 5055
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -107,7 +107,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, no website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=206):  # com runbot: 160
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=206):  # tef 160 / com 160
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             # Require for `website_menu` to be visible
             # <div name="event_menu_configuration" groups="base.group_no_one">
@@ -128,7 +128,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=667):  # com runbot: 566 - -1 tef - ent runbot: 666
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=666):  # tef 565 / com 566
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             # Require for `website_menu` to be visible
             # <div name="event_menu_configuration" groups="base.group_no_one">
@@ -150,7 +150,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # type and website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=693):  # tef only: 593 - com runbot: 596 - ent runbot: 692
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=692):  # tef 593 / com 596
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             # Require for `website_menu` to be visible
             # <div name="event_menu_configuration" groups="base.group_no_one">
@@ -168,7 +168,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype(self):
         """ Test a single event creation """
         # simple without type involved
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=37):  # 31 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=31):  # 31
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -181,7 +181,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype_website(self):
         """ Test a single event creation """
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=352):  # com runbot: 326 - +1 tef - ent runbot 352
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=352):  # tef 327 / com 326
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -196,7 +196,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=64):  # 58 (sometimes +6)
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=58):  # 58
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -212,7 +212,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=387):  # com runbot: 361 - +1 tef - ent runbot 387
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=387):  # tef 362 / com 361
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -234,7 +234,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=687):  # tef only: 640 - com runbot 682
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=684):  # tef 639 / com 681
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -258,7 +258,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=211):  # tef only: 168 - com runbot 207
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=210):  # tef 167 / com runbot 206
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -280,7 +280,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         form like) """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=698):  # tef only: 651 - com runbot 693
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=698):  # tef 652 - com 694
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -301,7 +301,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=203):  # tef only: 185 - com runbot: 190
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=202):  # tef 185 / com 190
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -317,7 +317,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=210):  # tef only: 189 - com runbot: 194
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=209):  # tef 190 / com 195
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -330,7 +330,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=125):  # tef only: 121? - com runbot 109
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=124):  # tef 107 / com 109
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration'].with_context(event_lead_rule_skip=True)) as reg_form:
                 reg_form.event_id = event
@@ -344,7 +344,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # simple customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=126):  # tef only: 107 - com runbot: 123
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=125):  # tef 119 / com 123
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.customer_data[0],
@@ -358,7 +358,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=130):  # tef only: 119 - com runbot: 126
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=129):  # tef 122 / com 127
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -373,7 +373,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=47):  # tef only: 40 - com runbot: 42
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=46):  # tef 41 / com 43
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -388,7 +388,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # website customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=136):  # tef only: 125 - com runbot: 129
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=135):  # tef 126 / com 130
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.website_customer_data[0],
@@ -437,7 +437,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate('user_eventmanager', 'user_eventmanager')
-            with self.assertQueryCount(default=36):
+            with self.assertQueryCount(default=36):  # tef 35
                 self._test_url_open('/event/%i' % self.test_event.id)
 
     @warmup
@@ -453,7 +453,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate('user_eventmanager', 'user_eventmanager')
-            with self.assertQueryCount(default=39):
+            with self.assertQueryCount(default=39):  # tef 38
                 self._test_url_open('/event')
 
     @warmup

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -10,7 +10,7 @@ from odoo.tests import tagged
 from odoo.tools import mute_logger, formataddr
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class BaseMailPerformance(MailCommon, TransactionCaseWithUserDemo):
 
     @classmethod
@@ -38,7 +38,7 @@ class BaseMailPerformance(MailCommon, TransactionCaseWithUserDemo):
         self.flush_tracking()
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestBaseMailPerformance(BaseMailPerformance):
 
     def setUp(self):
@@ -179,7 +179,7 @@ class TestBaseMailPerformance(BaseMailPerformance):
             })
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMailAPIPerformance(BaseMailPerformance):
 
     def setUp(self):
@@ -243,7 +243,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(__system__=16, employee=18):
+        with self.assertQueryCount(__system__=17, employee=19):  # com+tm 16/18
             activity.action_feedback(feedback='Zizisse Done !')
 
     @users('__system__', 'employee')
@@ -260,7 +260,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(__system__=17, employee=20):
+        with self.assertQueryCount(__system__=18, employee=21):  # com+tm 17/20
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -286,7 +286,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(__system__=19, employee=23):
+        with self.assertQueryCount(__system__=21, employee=25):  # com+tm 19/23
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications
@@ -313,7 +313,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(__system__=25, employee=31):
+        with self.assertQueryCount(__system__=27, employee=33):  # tm 26/32
             composer._action_send_mail()
 
     @users('__system__', 'employee')
@@ -335,7 +335,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer.id)],
             })
 
-        with self.assertQueryCount(__system__=28, employee=36):
+        with self.assertQueryCount(__system__=32, employee=40):  # tm 29/37
             composer._action_send_mail()
 
     @users('__system__', 'employee')
@@ -346,7 +346,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(__system__=17, employee=17):
+        with self.assertQueryCount(__system__=20, employee=20):  # tm 17/17 / com 18/18
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -360,7 +360,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=37, employee=45):
+        with self.assertQueryCount(__system__=42, employee=50):  # tm 38/46 / com 41/49
             composer._action_send_mail()
 
         # notifications
@@ -386,7 +386,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(__system__=25, employee=31):
+        with self.assertQueryCount(__system__=27, employee=33):  # tm 26/32
             composer._action_send_mail()
 
     @users('__system__', 'employee')
@@ -399,7 +399,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
 
-        with self.assertQueryCount(__system__=11, employee=12):
+        with self.assertQueryCount(__system__=28, employee=29):  # tm 13/14 / com 27/28
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -408,7 +408,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=25, employee=31):
+        with self.assertQueryCount(__system__=26, employee=32):  # tm 25/31
             composer._action_send_mail()
 
         # notifications
@@ -426,7 +426,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
-        with self.assertQueryCount(__system__=12, employee=13):
+        with self.assertQueryCount(__system__=31, employee=32):  # tm 14/15 / com 30/31
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -435,7 +435,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=33, employee=44):
+        with self.assertQueryCount(__system__=38, employee=49):  # tm 33/44
             composer._action_send_mail()
 
         # notifications
@@ -458,7 +458,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(__system__=27, employee=29):
+        with self.assertQueryCount(__system__=42, employee=44):  # tm 29/31 / com 39/41
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -469,7 +469,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=34, employee=40):
+        with self.assertQueryCount(__system__=36, employee=42):  # tm 35/41
             composer._action_send_mail()
 
         # notifications
@@ -490,7 +490,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(__system__=28, employee=30):
+        with self.assertQueryCount(__system__=43, employee=45):  # tm 30/32 / com 40/42
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -501,7 +501,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=46, employee=63):
+        with self.assertQueryCount(__system__=52, employee=69):  # tm 47/64
             composer._action_send_mail()
 
         # notifications
@@ -522,7 +522,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_assignation_email(self):
         self.user_test.write({'notification_type': 'email'})
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=27, employee=28):
+        with self.assertQueryCount(__system__=28, employee=29):  # tm 27/28
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -531,7 +531,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=18, employee=20):
+        with self.assertQueryCount(__system__=19, employee=21):
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -575,7 +575,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=24, employee=28):
+        with self.assertQueryCount(__system__=25, employee=29):  # tm 24/28
             record.message_post(
                 body='<p>Test Post Performances with an email ping</p>',
                 partner_ids=self.customer.ids,
@@ -587,7 +587,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=13, employee=17):
+        with self.assertQueryCount(__system__=14, employee=18):
             record.message_post(
                 body='<p>Test Post Performances with an inbox ping</p>',
                 partner_ids=self.user_test.partner_id.ids,
@@ -662,7 +662,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMailComplexPerformance(BaseMailPerformance):
 
     def setUp(self):
@@ -768,7 +768,8 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.container.message_subscribe(self.user_portal.partner_id.ids)
         record = self.container.with_user(self.env.user)
 
-        with self.assertQueryCount(__system__=36, employee=37):  # about 20 (19?) queries per additional customer group
+        # about 20 (19?) queries per additional customer group
+        with self.assertQueryCount(__system__=38, employee=39):  # tm 36/37
             record.message_post(
                 body='<p>Test Post Performances</p>',
                 message_type='comment',
@@ -785,7 +786,8 @@ class TestMailComplexPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
         template_id = self.env.ref('test_mail.mail_test_container_tpl').id
 
-        with self.assertQueryCount(__system__=43, employee=44):  # about 20 (19 ?) queries per additional customer group
+        # about 20 (19 ?) queries per additional customer group
+        with self.assertQueryCount(__system__=47, employee=48):  # tm 43/44
             record.message_post_with_template(template_id, message_type='comment', composition_mode='comment')
 
         self.assertEqual(record.message_ids[0].body, '<p>Adding stuff on %s</p>' % record.name)
@@ -848,7 +850,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
-        with self.assertQueryCount(__system__=24, employee=25):
+        with self.assertQueryCount(__system__=25, employee=26):  # tm 24/25
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -868,7 +870,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=56, employee=57):
+        with self.assertQueryCount(__system__=59, employee=60):  # tm 56/57
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -897,7 +899,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
-        with self.assertQueryCount(__system__=36, employee=36):
+        with self.assertQueryCount(__system__=38, employee=38):  # tm 36/36
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -934,7 +936,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(__system__=36, employee=36):
+        with self.assertQueryCount(__system__=38, employee=38):  # tm 36/36
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -967,7 +969,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(__system__=19, employee=20):
+        with self.assertQueryCount(__system__=20, employee=21):  # tm 19/20
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,
@@ -1083,7 +1085,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             ]
         }])
 
-        with self.assertQueryCount(employee=5):
+        with self.assertQueryCount(employee=6):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1092,7 +1094,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=17):
+        with self.assertQueryCount(employee=18):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1113,19 +1115,19 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'res_id': record.id
         } for record in records])
 
-        with self.assertQueryCount(employee=4):
+        with self.assertQueryCount(employee=5):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=12):
+        with self.assertQueryCount(employee=13):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMailHeavyPerformancePost(BaseMailPerformance):
 
     def setUp(self):
@@ -1195,7 +1197,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
             ('attach tuple 3', "attachement tupple content 3", {'cid': 'cid2'}),
         ]
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(employee=49):
+        with self.assertQueryCount(employee=54):  # tm 50
             self.cr.sql_log = self.warm and self.cr.sql_log_count
             record_container.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMailPerformance(BaseMailPerformance):
 
     @classmethod
@@ -81,7 +81,7 @@ class TestMailPerformance(BaseMailPerformance):
         record_ticket = self.env['mail.test.ticket.mc'].browse(self.record_ticket.ids)
         attachments = self.env['ir.attachment'].create(self.test_attachments_vals)
 
-        with self.assertQueryCount(employee=68):  # tmf: 68 / com: 68
+        with self.assertQueryCount(employee=68):  # tmf: 61 / com: 68
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body='<p>Test Content</p>',

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -101,6 +101,10 @@ class TestRatingFlow(TestRatingCommon):
         self.assertEqual(rating.rating, 1)
         self.assertEqual(record_rating.rating_last_value, 1)
 
+
+@tagged('rating', 'mail_performance', 'post_install', '-at_install')
+class TestRatingPerformance(TestRatingCommon):
+
     @users('__system__')
     @warmup
     def test_rating_last_value_perfs(self):
@@ -126,10 +130,8 @@ class TestRatingFlow(TestRatingCommon):
         RECORD_COUNT = 100
         partners = self.env['res.partner'].create([
             {'name': 'Jean-Luc %s' % (idx), 'email': 'jean-luc-%s@opoo.com' % (idx)} for idx in range(RECORD_COUNT)])
-        # 3713 requests if only test_mail_full is installed
-        # 4510 runbot community
-        # 4910 runbot enterprise
-        with self.assertQueryCount(__system__=4910):
+
+        with self.assertQueryCount(__system__=5910):  # tmf 4710 / com 5510
             record_ratings = self.env['mail.test.rating'].create([{
                 'customer_id': partners[idx].id,
                 'name': 'Test Rating',

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
 
     def setUp(self):
@@ -35,7 +35,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=26):  # test_mail_enterprise: 26
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=26):
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -73,7 +73,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
         self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages, sent_unlink=True)
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
 
     def setUp(self):

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -22,7 +22,7 @@ class TestMassMailPerformanceBase(BaseMailPerformance):
             signature='--\nMartial'
         )
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMassMailPerformance(TestMassMailPerformanceBase):
 
     def setUp(self):
@@ -47,21 +47,21 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +2 compared to local
-        with self.assertQueryCount(__system__=426, marketing=427):
+        with self.assertQueryCount(__system__=426, marketing=427):  # tm 424/425
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
 
         # runbot needs +3 compared to local
-        with self.assertQueryCount(__system__=69, marketing=67):
+        with self.assertQueryCount(__system__=69, marketing=67):  # tm 65/65
             self.env['mail.mail'].sudo().search([('to_delete', '=', True)]).unlink()
 
         mails = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])
         self.assertFalse(mails, 'Should have auto-deleted the <mail.mail>')
 
 
-@tagged('mail_performance')
+@tagged('mail_performance', 'post_install', '-at_install')
 class TestMassMailBlPerformance(TestMassMailPerformanceBase):
 
     def setUp(self):
@@ -94,14 +94,14 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +2 compared to local
-        with self.assertQueryCount(__system__=488, marketing=489):
+        with self.assertQueryCount(__system__=488, marketing=489):  # tm 486/487
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
 
         # runbot needs +3 compared to local
-        with self.assertQueryCount(__system__=69, marketing=67):
+        with self.assertQueryCount(__system__=69, marketing=67):  # tm 65/65
             self.env['mail.mail'].sudo().search([('to_delete', '=', True)]).unlink()
 
         cancelled_mail_count = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])


### PR DESCRIPTION
…install

PURPOSE

Have more reliable tests.
Better spot side effects coming from sub addons.
Lessen non deterministic counters due to local db.

SPECIFICATIONS

Make crm, event and mail performance tests post install.

Update query counters with
  * local values (install module only with enterprise activated);
  * community / enterprise runbots (if value is different);
  * some notes on non deterministic issue if known;

Task-2925606
