### PR TITLE
[FIX] sale_stock_margin: do not recompute purchase_price on confirm

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    @api.depends('move_ids', 'move_ids.stock_valuation_layer_ids', 'order_id.picking_ids.state')
+    @api.depends('move_ids', 'move_ids.stock_valuation_layer_ids', 'move_ids.picking_id.state')
     def _compute_purchase_price(self):
         lines_without_moves = self.browse()
         for line in self:


### PR DESCRIPTION
The cost (purchase_price) of a sale order line is recomputed when the
sale order is confirmed, overwriting the potentially edited value

Steps to reproduce:
1. Install sale_stock_margin module
2. Create a quotation, add any customer and two lines: a service (e.g.
   Deposit) and any other storable product (e.g. Large Cabinet)
3. Activate 'Cost (purchase_price)' column in the order lines view
4. Edit the cost of Deposit and confirm the quotation
5. The cost resets to the original product cost

Solution:
Modify the dependency of `_compute_purchase_price` to trigger it only
when the sale order line's related picking has changed state

Problem:
The dependency on order_id.picking_ids.state makes it that the purchase
price is recomputed for all sale order lines when any of the picking of
the related sale order has a modified state (but we want to recompute it
only for the sale order line that had its picking's state modified)

opw-2904500