### PR TITLE
[FIX] web: views: relational_model: correctly handle limits changed b…

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -2123,8 +2123,8 @@ export class DynamicGroupList extends DynamicList {
     }
 
     async load(params = {}) {
-        this.limit = params.limit || this.limit;
-        this.offset = params.offset || this.offset;
+        this.limit = params.limit !== undefined ? params.limit : this.limit;
+        this.offset = params.offset !== undefined ? params.offset : this.offset;
         /** @type {[Group, number][]} */
         const previousGroups = this.groups.map((g, i) => [g, i]);
         this.groups = await this._loadGroups();

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -14342,6 +14342,30 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
+    QUnit.test("grouped list return to page 1 with pager", async (assert) => {
+        await makeView({
+            resModel: "foo",
+            type: "list",
+            arch: `<list limit="1"><field name="display_name" /></list>`,
+            serverData,
+            groupBy: ["bar"],
+            mockRPC(route, args) {
+                if (args.method === "web_read_group") {
+                    assert.step(
+                        `${args.method} limit: ${args.kwargs.limit}; offset: ${args.kwargs.offset}`
+                    );
+                }
+            },
+        });
+        assert.verifySteps(["web_read_group limit: 80; offset: 0"]);
+        await editPager(target, "1-1");
+        assert.verifySteps(["web_read_group limit: 1; offset: 0"]);
+        await pagerNext(target);
+        assert.verifySteps(["web_read_group limit: 1; offset: 1"]);
+        await pagerPrevious(target);
+        assert.verifySteps(["web_read_group limit: 1; offset: 0"]);
+    });
+
     QUnit.test("renders banner_route", async (assert) => {
         await makeView({
             type: "list",


### PR DESCRIPTION
…y user

Have a list view, modify by hand the limit in the pager, modify the search domain,
or, activate a group by, or deactivate a group by.

Before this commit, none of these three use cases was handled. The limit was lost all the time.

After this commit, the limits are kept form a transition to the next.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
