### PR TITLE
[IMP] project: restrict sending rating mails when changing stage

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1546,7 +1546,8 @@ class Task(models.Model):
     def _send_task_rating_mail(self, force_send=False):
         for task in self:
             rating_template = task.stage_id.rating_template_id
-            if rating_template:
+            partner = task.partner_id
+            if rating_template and partner and partner != self.env.user.partner_id:
                 task.rating_send_request(rating_template, lang=task.partner_id.lang, force_send=force_send)
 
     def _rating_get_partner(self):


### PR DESCRIPTION
The rating email template should not be sent if:
there is no partner set on the task
or if the current user is set as the partner of the task

task-2924559

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
