### PR TITLE
[FIX] purchase: incorrect order total

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -950,7 +950,7 @@ class PurchaseOrderLine(models.Model):
         for line in self:
             taxes = line.taxes_id.compute_all(**line._prepare_compute_all_values())
             line.update({
-                'price_tax': taxes['total_included'] - taxes['total_excluded'],
+                'price_tax': sum(t.get('amount', 0.0) for t in taxes.get('taxes', [])),
                 'price_total': taxes['total_included'],
                 'price_subtotal': taxes['total_excluded'],
             })


### PR DESCRIPTION
With Rounding Method: Round Globally
Create a Purchase order as follows:
Product A, qty 1, price 10.74, tax 21% not included
Product B, qty 2, price 0.83, tax 21% not included

The order amounts will be calculated as:

Untaxed Amount  $ 12.40
Taxes   $ 2.61
Total $ 15.00

Issue: The total is not the sum of the previous values

opw-2919517

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
