### PR TITLE
[FIX] website: correctly show language dropdown in rtl langs

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1286,10 +1286,14 @@ header {
 }
 
 // Language selector
-.js_language_selector {
-    .dropdown-menu {
-        min-width: 0;
+#wrapwrap:not(.o_rtl) {
+    .js_language_selector {
+        .dropdown-menu {
+            min-width: 0;
+        }
     }
+}
+.js_language_selector {
     a.list-inline-item {
         padding: 3px 0;
 


### PR DESCRIPTION
Before this commit, the lang entries in the language switcher's dropdown
would overflow the dropdown (which was way too small).

There were no issue in 13.0 as the issue seems to have appeared since
commit [1] which was merged in 14.0 (13.5 at the time).
That commit added a `min-width: 0;` on the `.dropdown-menu` making the
dropdown visually broken in rtl languages.

There is no issue in saas-15.5 (current master) as it was converted to
BS5 where the issue do not appear.

There is probably a cleaner solution to be found to have a full
understanding of the real issue and probably make a generic solution
instead of only fixing footer language selector, but this would need to
spend more time investigating the issue.
As the error seems gone with BS5 anyway, and only this dropdown seems to
be impacted, this is a reasonable fix.

[1]: https://github.com/odoo/odoo/commit/745ef9de97544d5c1a97e03be67e903feca40c2a

Fixes #64774, fixes #63764
opw-2904798

