### PR TITLE
[FIX] web: search panel: use action context when fetching data

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1236,6 +1236,7 @@ export class SearchModel extends EventBus {
                     [category.fieldName],
                     {
                         category_domain: this._getCategoryDomain(category.id),
+                        context: this.globalContext,
                         enable_counters: category.enableCounters,
                         expand: category.expand,
                         filter_domain: filterDomain,
@@ -1271,6 +1272,7 @@ export class SearchModel extends EventBus {
                     {
                         category_domain: categoryDomain,
                         comodel_domain: new Domain(filter.domain).toList(evalContext),
+                        context: this.globalContext,
                         enable_counters: filter.enableCounters,
                         filter_domain: this._getFilterDomain(filter.id),
                         expand: filter.expand,

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -3402,4 +3402,36 @@ QUnit.module("Search", (hooks) => {
 
         assert.deepEqual(getCategoriesContent(target), ["All", "gold", "silver"]);
     });
+
+    QUnit.test("Category with counters and filter with domain", async (assert) => {
+        serverData.views["partner,false,search"] = /* xml */ `
+            <search>
+                <searchpanel>
+                    <field name="category_id"/>
+                    <field name="company_id" select="multi" domain="[['category_id', '=', category_id]]"/>
+                </searchpanel>
+            </search>`;
+
+        const { TestComponent } = makeTestComponent();
+        await makeWithSearch({
+            serverData,
+            Component: TestComponent,
+            resModel: "partner",
+            searchViewId: false,
+            mockRPC: (route, args) => {
+                if (
+                    ["search_panel_select_range", "search_panel_select_multi_range"].includes(
+                        args.method
+                    )
+                ) {
+                    assert.step(args.kwargs.context.special_key);
+                }
+            },
+            context: {
+                special_key: "special_key",
+            },
+        });
+
+        assert.verifySteps(["special_key", "special_key"]);
+    });
 });


### PR DESCRIPTION
In SearchModel, the calls to search_panel_select_range and
search_panel_select_multi_range were done without using the global
context (e.g. the action context), contrarily to what is done in the
legacy SearchPanelModelExtension. We fix that.