### PR TITLE
[FIX] website: prevent click on scroll btn to remove it in edit mode

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2778,18 +2778,6 @@ options.registry.ScrollButton = options.Class.extend({
         await this._super(...arguments);
         this.$button = this.$('.o_scroll_button');
     },
-    /**
-     * Removes button if the option is not displayed (for example in "fit
-     * content" height).
-     *
-     * @override
-     */
-    updateUIVisibility: async function () {
-        await this._super(...arguments);
-        if (this.$button.length && this.el.offsetParent === null) {
-            this.$button.detach();
-        }
-    },
 
     //--------------------------------------------------------------------------
     // Options


### PR DESCRIPTION
Step to reproduce:
- Enter edit mode
- Drag & drop Cover snippet
- Select height 100% in the right panel
- It will now show the "Scroll btn" option (toggle), enable it
- Now click on footer (to focus out of the Cover snippet options)
- Click on the scroll btn, it will disappear

opw-2920287
