### PR TITLE
[IMP] mail: Emoji border need to be softly

### DIFF
--- a/addons/mail/static/src/components/message_reaction_group/message_reaction_group.scss
+++ b/addons/mail/static/src/components/message_reaction_group/message_reaction_group.scss
@@ -3,8 +3,8 @@
 // ------------------------------------------------------------------
 
 .o_MessageReactionGroup {
-    border-radius: $o-mail-rounded-rectangle-border-radius-sm;
     cursor: pointer;
+    border-radius: 1rem;
 }
 
 // ------------------------------------------------------------------
@@ -19,7 +19,7 @@
 
     &.o-hasUserReacted, &.o-hasUserReacted:hover {
         border-color: $o-brand-primary;
-        background-color: rgba($o-brand-primary, .1);
+        background-color: $white;
     }
 
     &:hover {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

From 15.0, Odoo adding new feature - allow user having reaction on
message, it's a great thing.
But the border of this emoji's group looks a bit rough, even though it
has the `rounded-rectangle` style.

This PR make the border of this group feel sotfly and more friendly with
user.

Before:

![Screenshot from 2022-07-21 09-23-41](https://user-images.githubusercontent.com/90305443/180118153-ada19da5-b1a2-4dc2-a5e6-c41735397f03.png)


After:
- On Discuss

![Screenshot from 2022-07-21 09-25-51](https://user-images.githubusercontent.com/90305443/180118197-1ec68ade-dca1-4cfa-a9e6-b850a344cb78.png)


- On Log Note

![Screenshot from 2022-07-21 09-40-11](https://user-images.githubusercontent.com/90305443/180118287-33f5693f-c8d6-4e56-9700-32b47701470d.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
