### PR TITLE
[FIX] account: fpo map account is not used

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -97,6 +97,12 @@ class AccruedExpenseRevenue(models.TransientModel):
                     'columns': preview_columns,
                 },
             })
+    def _get_computed_account(self, order, product, is_purchase):
+        accounts = product.with_company(order.company_id).product_tmpl_id.get_product_accounts(fiscal_pos=order.fiscal_position_id)
+        if is_purchase:
+            return accounts['expense']
+        else:
+            return accounts['income']
 
     def _compute_move_vals(self):
         def _get_aml_vals(order, balance, amount_currency, account_id, label=""):
@@ -136,10 +142,7 @@ class AccruedExpenseRevenue(models.TransientModel):
             if len(orders) == 1 and self.amount:
                 total_balance = self.amount
                 order_line = order.order_line[0]
-                if is_purchase:
-                    account = order_line.product_id.property_account_expense_id or order_line.product_id.categ_id.property_account_expense_categ_id
-                else:
-                    account = order_line.product_id.property_account_income_id or order_line.product_id.categ_id.property_account_income_categ_id
+                account = self._get_computed_account(order, order_line.product_id, is_purchase)
                 values = _get_aml_vals(order, self.amount, 0, account.id, label=_('Manual entry'))
                 move_lines.append(Command.create(values))
             else:
@@ -166,13 +169,13 @@ class AccruedExpenseRevenue(models.TransientModel):
                 )
                 for order_line in lines:
                     if is_purchase:
-                        account = order_line.product_id.property_account_expense_id or order_line.product_id.categ_id.property_account_expense_categ_id
+                        account = self._get_computed_account(order, order_line.product_id, is_purchase)
                         amount = self.company_id.currency_id.round(order_line.qty_to_invoice * order_line.price_unit / rate)
                         amount_currency = order_line.currency_id.round(order_line.qty_to_invoice * order_line.price_unit)
                         fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'invoice_lines']
                         label = _('%s - %s; %s Billed, %s Received at %s each', order.name, _ellipsis(order_line.name, 20), order_line.qty_invoiced, order_line.qty_received, formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id))
                     else:
-                        account = order_line.product_id.property_account_income_id or order_line.product_id.categ_id.property_account_income_categ_id
+                        account = self._get_computed_account(order, order_line.product_id, is_purchase)
                         amount = self.company_id.currency_id.round(order_line.untaxed_amount_to_invoice / rate)
                         amount_currency = order_line.untaxed_amount_to_invoice
                         fnames = ['qty_to_invoice', 'untaxed_amount_to_invoice', 'qty_invoiced', 'qty_delivered', 'invoice_lines']


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this commit, the fiscal position is not used to determine account.

@oco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
