### PR TITLE
[FIX][15.0]hr_expense: fix compute tax_ids

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -247,7 +247,7 @@ class HrExpense(models.Model):
             if not expense.attachment_number or (expense.attachment_number and not expense.unit_amount):
                 expense.unit_amount = expense.product_id.price_compute('standard_price')[expense.product_id.id]
             expense.product_uom_id = expense.product_id.uom_id
-            expense.tax_ids = expense.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id == expense.company_id)  # taxes only from the same company
+            expense.tax_ids = expense.product_id.supplier_taxes_id.filtered(lambda tax: tax.price_include and tax.company_id == expense.company_id)  # taxes only from the same company
             account = expense.product_id.product_tmpl_id._get_product_accounts()['expense']
             if account:
                 expense.account_id = account


### PR DESCRIPTION
- Tax on expenses must be price include as of version 15.0; we changed
this on the field and view but not the compute function yet. This PR
corrects it by adding a condition to the filter used to calculate tax
ids.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
