### PR TITLE
[FIX] mrp: mo split and merge fix

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2000,10 +2000,10 @@ class MrpProduction(models.Model):
         for move in self.move_finished_ids:
             dests.setdefault(move.byproduct_id.id, []).extend(move.move_dest_ids.ids)
 
-        production = self.env['mrp.production'].create({
+        production = self.env['mrp.production'].with_context(default_picking_type_id=self.picking_type_id.id).create({
             'product_id': product_id.id,
             'bom_id': bom_id.id,
-            'picking_type_id': bom_id.picking_type_id or self._get_default_picking_type(),
+            'picking_type_id': self.picking_type_id.id,
             'product_qty': sum(production.product_uom_qty for production in self),
             'product_uom_id': product_id.uom_id.id,
             'user_id': user_id.id,

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -609,3 +609,43 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.assertEqual(mo.mrp_production_child_count, 0, "Children MOs counted as existing where there should be none")
         self.assertEqual(mo.mrp_production_source_count, 0, "Source MOs counted as existing where there should be none")
         self.assertEqual(mo.mrp_production_backorder_count, 2)
+
+    def test_source_location_on_merge_mo_3_steps(self):
+        """Check that default values are correct after merging mos when 3-step manufacturing"""
+
+        with Form(self.warehouse) as warehouse:
+            warehouse.manufacture_steps = 'pbm_sam'
+
+        # picking with non default location
+        picking_type = self.env['stock.picking.type'].create({
+            'name': 'Manufacturing',
+            'code': 'mrp_operation',
+            'warehouse_id': warehouse.id,
+            'default_location_src_id': self.warehouse.pbm_loc_id.copy().id,
+            'default_location_dest_id': self.warehouse.sam_loc_id.copy().id,
+            'sequence_code': 'TMP',
+            'sequence_id': self.env['ir.sequence'].create({
+                'code': 'mrp.production',
+                'name': 'tmp_production_sequence',
+            }).id,
+        })
+
+        mo1_form = Form(self.env['mrp.production'])
+        mo1_form.product_id = self.finished_product
+        mo1_form.picking_type_id = picking_type
+        mo1 = mo1_form.save()
+        mo1.action_confirm()
+
+        mo2_form = Form(self.env['mrp.production'])
+        mo2_form.product_id = self.finished_product
+        mo2_form.picking_type_id = picking_type
+        mo2 = mo2_form.save()
+        mo2.action_confirm()
+
+        action = (mo1 + mo2).action_merge()
+        mo = self.env[action['res_model']].browse(action['res_id'])
+
+        self.assertEqual(picking_type.default_location_src_id, mo.move_raw_ids.location_id,
+            "The default source location of the merged mo should be the same as the 1st of the original MOs")
+        self.assertEqual(picking_type, mo.picking_type_id,
+            "The operation type of the merged mo should be the same as the 1st of the original MOs")

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -97,6 +97,6 @@ class MrpProductionSplitLine(models.TransientModel):
         'mrp.production.split', 'Split Production', required=True, ondelete="cascade")
     quantity = fields.Float('Quantity To Produce', digits='Product Unit of Measure', required=True)
     user_id = fields.Many2one(
-        'res.users', 'Responsible', required=True,
+        'res.users', 'Responsible',
         domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)])
     date = fields.Datetime('Schedule Date')

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -38,7 +38,7 @@ class MrpProduction(models.Model):
     def action_merge(self):
         if any(production._get_subcontract_move() for production in self):
             raise ValidationError(_("Subcontracted manufacturing orders cannot be merged."))
-        super().action_merge()
+        return super().action_merge()
 
     def subcontracting_record_component(self):
         self.ensure_one()


### PR DESCRIPTION
This commit fixes two bugs:
1) Wrong source location

    Before this commit:
    - Source location is incorrect after merging MOs and 3-step manufacturing is selected.
    - Operation type is incorrect after merging MOs

    After this commit:
    - Set the source location from the correct picking_type's value while merging MO.
    - Set the Operation type for the merged MO to be the same as the original MOs';

2) Traceback when splitting mo

    Before this commit:
    - When splitting a MO without a "responsible user" set then boom it's throwing traceback

    After this commit:
    - The "responsible user" is no longer required which matches the existing MO behavior

TaskID - 2754217

