### PR TITLE
[FIX] mrp: mo split and merge fix

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -36,6 +36,9 @@
                         </group>
                         <group>
                             <field name="product_id"/>
+                            <field name="product_tracking" invisible="1"/>
+                            <field name="company_id" invisible="1"/>
+                            <field name="state" invisible="1"/>
                             <label for="product_qty"/>
                             <div class="o_row">
                                 <span><field name="product_qty"/></span>
@@ -58,6 +61,8 @@
                             <field name="quantity"/>
                             <field name="user_id"/>
                             <field name="date"/>
+                            <field name="lot_producing_id" context="{'default_product_id': parent.product_id, 'default_company_id': parent.company_id}"
+                            domain="[('company_id','=',parent.company_id),('product_id','=',parent.product_id)]" attrs="{'column_invisible': ['|',('parent.state','=','draft'),('parent.product_tracking','in',(None,False))]}"/>
                         </tree>
                     </field>
                     <field name="production_split_multi_id" invisible="1"/>


### PR DESCRIPTION
1) When splitting mo expected duration comes wrong
current behavior:
    -When we are splitting mo in multiple quantities the expected duration for
     the first backorder calculating wrong and the rest is okay.
After this commit:
    -The problem is while splitting mo at the time of recalculating the
     "expected duration"  we are getting already divided by the quantity
     for the first work order.
    -So we get that "expected duration" before it calculates. And use it in
     recalculating formula while splitting mo.

2) Added a field lot/serial number for backorder & log-note when mo is splitted
    -With this commit, we can give a lot/serial number to each backorder
     at the time of splitting mo. We have added a lot/serial no field in
     split wizard too.
    -After splitting mo I have added a log note in main mo like
     "This manufacture order is splited to"(splited backorder names)

TaskId - 2754217