### PR TITLE
[FIX] web_editor: allow to reset background color

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -551,9 +551,9 @@ export const editorCommands = {
         // Get the <font> nodes to color
         const selectedNodes = getSelectedNodes(editor.editable);
         const fonts = selectedNodes.flatMap(node => {
-            let font = closestElement(node, 'font');
+            let font = closestElement(node, 'font') || closestElement(node, 'span');
             const children = font && descendants(font);
-            if (font && font.nodeName === 'FONT') {
+            if (font && (font.nodeName === 'FONT' || (font.nodeName === 'SPAN' && font.style[mode]))) {
                 // Partially selected <font>: split it.
                 const selectedChildren = children.filter(child => selectedNodes.includes(child));
                 if (selectedChildren.length) {


### PR DESCRIPTION
**Current behavior before PR:**

When copy-pasting from Discord into Notes, get a text with color and background
color. But when clicking on the trash icon inside the toolbar to remove the
background color, it doesn't remove the background color.

**Desired behavior after PR is merged:**

Allowed to remove background color from text using trash icon.

Task-2889682



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
