### PR TITLE
[FIX] account: button 'Journal Entry' being hidden by their container

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -220,7 +220,9 @@
 
                             <!-- Journal Entry  button -->
                             <button name="button_open_journal_entry" type="object" class="oe_stat_button" icon="fa-bars">
-                                Journal Entry
+                                <div class="o_stat_info">
+                                    <span class="o_stat_text">Journal Entry</span>
+                                </div>
                             </button>
                         </div>
 


### PR DESCRIPTION
Currently, button 'Journal Entry' not wrap with `<span>` which make this
text being hidden by their own container.

This PR will fix this problem.

Before

![Screenshot from 2022-07-22 09-02-21](https://user-images.githubusercontent.com/90305443/180346858-50e04eac-0329-4e3e-ac38-3c7b1a4c0cc3.png)

After


![Screenshot from 2022-07-22 09-03-48](https://user-images.githubusercontent.com/90305443/180346886-bdca02e3-c88e-479b-b732-2d22b7e12401.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
