### PR TITLE
[FIX] web_editor: error while changing background color of button

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1544,7 +1544,9 @@ const Wysiwyg = Widget.extend({
                             oldColorpicker.destroy();
                         }
                         manualOpening = true;
-                        $dropdown.children('.dropdown-toggle').dropdown('show');
+                        const $childElement = $dropdown.children('.dropdown-toggle');
+                        const dropdownToggle = new Dropdown($childElement);
+                        dropdownToggle.show();
                         const $colorpicker = $dropdown.find('.colorpicker');
                         const colorpickerHeight = $colorpicker.outerHeight();
                         const toolbarContainerTop = dom.closestScrollable(this.toolbar.el).getBoundingClientRect().top;


### PR DESCRIPTION
**Current behavior before PR:**

When we want to change the background color of a button, clicking on that button
will occur traceback(dropdown is not a function).

**Desired behavior after PR is merged:**

Traceback will not occur by initializing the dropdown component as it has
converted into the OWL component.

**Task**-2916277
