### PR TITLE
[FIX] contacts: menu "Configuration" set sequence 100

### DIFF
--- a/addons/contacts/views/contact_views.xml
+++ b/addons/contacts/views/contact_views.xml
@@ -51,7 +51,7 @@
         name="Configuration"
         parent="menu_contacts"
         groups="base.group_system"
-        sequence="2"/>
+        sequence="100"/>
 
     <menuitem id="menu_partner_category_form"
         action="base.action_partner_category_form"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Menu "Configuration" set sequence 100

Current behavior before PR:
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/5561864/180392156-a8007243-69c0-4a94-919b-4ab448bed26b.png">


Desired behavior after PR is merged:
To make it easier for adding new menus between Contacts and Configuration



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
