### PR TITLE
[IMP] check for then forbid requests at tour success

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1241,6 +1241,7 @@ class ChromeBrowser:
             except CancelledError:
                 ...
             except InvalidStateError:
+                print(args, stackTrace, kw, flush=True)
                 self._logger.warning(
                     "Trying to set result to failed (%s) but found the future settled (%s)",
                     message, self._result


### PR DESCRIPTION
If a tour launches requests then terminates without waiting for their return, things can get rather wonky, leading to errors during cleanup (as the request might come back in the middle of the browser cleanup triggering strange errors).

If a tour claims to be done while it has requests in flight, trigger an error instead.

Outstanding issue: concurrent long polling, this seems to be active during tours.

A possible alternative would be to wait for the requests to complete, however requests can "cascade" in ways which are difficult to chain & predict so that's a much more complicated thing to reliably ensure.