### PR TITLE
[FIX] bus: poll different channels in different tabs

### DIFF
--- a/addons/bus/static/src/js/crosstab_bus.js
+++ b/addons/bus/static/src/js/crosstab_bus.js
@@ -296,10 +296,9 @@ var CrossTabBus = Longpolling.extend({
         }
 
         const peerChannelsAfter = JSON.stringify(peerChannels);
-        if (peerChannelsBefore === peerChannelsAfter) {
-            return false;
+        if (peerChannelsBefore !== peerChannelsAfter) {
+            this._callLocalStorage('setItem', 'channels', peerChannels);
         }
-        this._callLocalStorage('setItem', 'channels', peerChannels);
 
         const allChannels = new Set();
         for (const channels of Object.values(peerChannels)) {
@@ -312,8 +311,13 @@ var CrossTabBus = Longpolling.extend({
         for (const channel of this._currentTabChannels) {
             allChannels.add(channel);
         }
-        this._channels = Array.from(allChannels);
-        return true;
+        const allChannelsSorted = Array.from(allChannels).sort();
+        if (JSON.stringify(allChannelsSorted) === JSON.stringify(this._channels.sort())) {
+            return false;
+        } else {
+            this._channels = allChannelsSorted;
+            return true;
+        };
     },
     //--------------------------------------------------------------------------
     // Handlers

--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -430,6 +430,55 @@ QUnit.module('Bus', {
         parentTab1.destroy();
         parentTab2.destroy();
     });
+
+    QUnit.test('two tabs adding channels', async function (assert) {
+        assert.expect(4);
+        const parentTab1 = new Widget();
+        let pollPromise;
+        await testUtils.mock.addMockEnvironment(parentTab1, {
+            data: {},
+            services: {
+                local_storage: LocalStorageServiceMock,
+            },
+            mockRPC: function (route, args) {
+                if (route === '/longpolling/poll') {
+                    assert.step(args.channels.join())
+                    pollPromise = testUtils.makeTestPromise();
+                    pollPromise.abort = (function () {
+                        this.reject({message: 'XmlHttpRequestError abort'});
+                    }).bind(pollPromise);
+                    return pollPromise;
+                }
+                return this._super.apply(this, arguments);
+            }
+        });
+        const parentTab2 = new Widget();
+        await testUtils.mock.addMockEnvironment(parentTab2, {
+            data: {},
+            services: {
+                local_storage: LocalStorageServiceMock,
+            },
+            mockRPC: function (route, args) {
+                if (route === '/longpolling/poll') {
+                    throw new Error("slave tab should not use the polling route")
+                }
+                return this._super.apply(this, arguments);
+            }
+        });
+
+        const tab1 = new CrossTabBus(parentTab1);
+        const tab2 = new CrossTabBus(parentTab2);
+        tab1.addChannel("alpha");
+        await nextTick();
+        assert.verifySteps(["alpha"]);
+
+        tab2.addChannel("beta");
+        await nextTick();
+        assert.verifySteps(["alpha,beta"]);
+
+        parentTab1.destroy();
+        parentTab2.destroy();
+    });
 });
 
 });

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -165,7 +165,7 @@ var MockServer = Class.extend({
         }, function (result) {
             var message = result && result.message;
             var event = result && result.event;
-            var errorString = JSON.stringify(message || false);
+            var errorString = typeof message !== "string" ? JSON.stringify(message || false) : message;
             if (debug) {
                 console.warn(
                     '%c[rpc] response (error) %s%s, during test %s',


### PR DESCRIPTION
Commit b743fda doesn't seem to work properly.
Steps to reproduce:
- Open a spreadsheet A in one tab
- Open a spreadsheet B in another tab
=> the master tab should poll both spreadsheet channels but it
does not.

The condition here seems wrong
https://github.com/odoo/odoo/blob/bf2ce0aa0c7d45c90d7ff104d5af5f99b29d59ae/addons/bus/static/src/js/crosstab_bus.js#L299
`peerChannelsBefore` is not really "before".
It already contains the new channel added to local storage by the slave tab!

This commit adds a test showing the issue.
Every attempt I make to fix the issue breaks everything. I don't know the
inner workings well enough.
Too many side effects I don't know of.

Small comment on the change in the mock server:
Cross tab bus tests were not working properly.
The error message string `"XmlHttpRequestError abort"` was stringified (stringifying a string), leading
to `"\"XmlHttpRequestError abort\""`. Since the implementation depends on the
exact error message, tests didn't propely reflect reality


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
