### PR TITLE
[IMP] web_tour: require a check last step

### DIFF
--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -40,6 +40,7 @@ var RunningTourActionHelper = core.Class.extend({
     keydown: function (keyCodes, element) {
         this._keydown(this._get_action_values(element), keyCodes.split(/[,\s]+/));
     },
+    check() {},
     auto: function (element) {
         var values = this._get_action_values(element);
         if (values.consume_event === "input") {

--- a/addons/web_tour/static/src/js/tour_manager.js
+++ b/addons/web_tour/static/src/js/tour_manager.js
@@ -90,7 +90,7 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
         var options = args.length === 2 ? {} : args[1];
         var steps = last_arg instanceof Array ? last_arg : [last_arg];
         const last_step = steps[steps.length - 1];
-        if (!(last_step.run === 'check' || /\{\s*\}$/.test(last_step.run))) {
+        if (!(last_step.run === 'check' || /null|\{\s*\}$/.test(last_step.run))) {
             const step_json = JSON.stringify(
                 last_step,
                 (k, v) => typeof v === 'function' ? v.toString() : v,


### PR DESCRIPTION
Improvement of 9733f6e: it attempted to hide incorrect last steps but that was probably the wrong choice (as hiding stuff usually is).

Instead, the last step of a tour should be an explicit check/wait step.

Questions:

- wait or check? "check" seems to be the usual comment next to empty function, but for end-of-tour "wait" would also make sense, makes sense that the final step would be waiting for some thing
- should all functions be allowed as last step or only empty ones? On the one hand all functions means non-trivial final checks, on the other hand all functions means the last step can still have side-effects, which is exactly what some tours already do to bypass 9733f6e e.g. https://github.com/odoo/odoo/blob/51ff8b09dbadf8c0f15a62d2b26e6df6d6630f31/addons/crm/static/src/js/tours/crm.js#L84-L89
