### PR TITLE
[ADD] core: error if a test finishes with a form being edited

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -82,12 +82,11 @@ tour.register('account_tour', {
         content: _t("Set a price"),
         position: "bottom",
         run: 'text 100',
-    }, {
+    },
+    ...tour.stepUtils.saveForm(),
+    {
         trigger: "button[name=action_post]",
-        // FIXME WOWL: this selector needs to work in both legacy and non-legacy views
-        // because account_invoice_extracts *adds* a js_class on the base view which forces
-        // the use of a legacy view in enterprise only
-        extra_trigger: "[name=move_type] [raw-value=out_invoice], [name=move_type][raw-value=out_invoice]",
+        extra_trigger: "button.o_form_button_edit",
         content: _t("Once your invoice is ready, press CONFIRM."),
     }, {
         trigger: "button[name=action_invoice_sent]",
@@ -121,6 +120,14 @@ tour.register('account_tour', {
         extra_trigger: "[name=move_type] [raw-value=out_invoice], [name=move_type][raw-value=out_invoice]",
         content: _t("Let's send the invoice."),
         position: "top"
+    }, {
+        trigger: "button[name=action_invoice_sent].btn-secondary",
+        content: _t("The invoice having been sent, the button has changed priority."),
+        run() {},
+    }, {
+        trigger: "button[name=action_register_payment]",
+        content: _t("The next step is payment registration."),
+        run() {},
     }
 ]);
 

--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -80,6 +80,7 @@ tour.register('event_configurator_tour', {
 }, {
     trigger: 'textarea[name="name"].tour_success_2',
     run: function () {} // check
-}]);
+}, ...tour.stepUtils.discardForm()
+]);
 
 });

--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -45,12 +45,14 @@ const commonSteps = [tour.stepUtils.showAppsMenuItem(), {
  tour.register('im_livechat_chatbot_steps_sequence_tour', {
     test: true,
     url: '/web',
-}, [].concat(commonSteps, [{
+}, [
+    ...commonSteps, {
     trigger: 'button:contains("Save & Close")'
 }, {
     trigger: 'body.o_web_client:not(.modal-open)',
-    run: () => {}
-}]));
+    run() {},
+}, ...tour.stepUtils.discardForm()
+]);
 
 /**
  * Same as above, with an extra drag&drop at the end.
@@ -58,7 +60,8 @@ const commonSteps = [tour.stepUtils.showAppsMenuItem(), {
 tour.register('im_livechat_chatbot_steps_sequence_with_move_tour', {
     test: true,
     url: '/web',
-}, [].concat(commonSteps, [{
+}, [
+    ...commonSteps, {
     trigger: 'button:contains("Save & New")'
 }, {
     trigger: 'tr:contains("Step 3")',
@@ -135,4 +138,5 @@ tour.register('im_livechat_chatbot_steps_sequence_with_move_tour', {
     trigger: 'tr:contains("Step 6")',
     in_modal: false,
     run: () => {}
-}]));
+}, ...tour.stepUtils.discardForm(),
+]);

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_snippets_menu_tabs.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_snippets_menu_tabs.js
@@ -48,4 +48,5 @@ tour.register('mass_mailing_snippets_menu_tabs', {
         trigger: 'iframe .o_we_customize_panel .snippet-option-DesignTab',
         run: () => null, // it's a check
     },
+    ...tour.stepUtils.discardForm(),
 ]);

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -101,11 +101,7 @@ tour.register('purchase_matrix_tour', {
 }, {
     trigger: 'span:contains("Confirm")',
     run: 'click' // apply the matrix
-}, {
-    trigger: '.o_form_button_save:contains("Save")',
-    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("8.20")',
-    run: 'click' // SAVE Sales Order, after matrix has been applied (extra_trigger).
-},
+}, ...tour.stepUtils.saveForm('.o_field_cell.o_data_cell.o_list_number:contains("8.20")')
 ]);
 
 

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -113,9 +113,5 @@ tour.register('event_sale_with_product_configurator_tour', {
     in_modal: false,
 }, {
     trigger: '.o_event_sale_js_event_configurator_ok',
-}, {
-    trigger: '.o_form_button_save:contains("Save")',
-    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("60.00")',
-    run: 'click' // SAVE Sales Order, after the last ticket has been applied.
-}
+}, ...tour.stepUtils.saveForm('.o_field_cell.o_data_cell.o_list_number:contains("60.00")'),
 ]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -116,4 +116,5 @@ tour.register('sale_product_configurator_advanced_tour', {
     extra_trigger: 'div[name="order_line"]',
     in_modal: false,
     run: function (){} //check
-}]);
+}, ...tour.stepUtils.discardForm()
+]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -141,13 +141,7 @@ tour.register('sale_product_configurator_edition_tour', {
 }, {
     trigger: 'td.o_data_cell:contains("tour success")',
     extra_trigger: 'div[name="order_line"]',
-    run: function (){}
-}, {
-    trigger: 'td.o_data_cell',
-    run: function () {
-        window.location.href = window.location.origin + '/web';
-    },  // Avoid race condition at the end of the tour by returning to the home page.
-}, {
-    trigger: '.o_navbar',
-    run: function() {},  // Check the home page is loaded
-}]);
+    run: function() {},
+},
+    ...tour.stepUtils.discardForm(),
+]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -58,4 +58,5 @@ tour.register('sale_product_configurator_optional_products_tour', {
     trigger: 'tr:has(td.o_data_cell:contains("Chair floor protection")):nth(1) td.o_data_cell:contains("1.0")',
     extra_trigger: 'div[name="order_line"]',
     run: function () {}, // check added product
-}]);
+}, ...tour.stepUtils.discardForm()
+]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -72,5 +72,5 @@ tour.stepUtils.showAppsMenuItem(),
 }, {
     content: "verify SO final price included",
     trigger: 'span[name="amount_total"]:contains("1,437.00")',
-}
+}, ...tour.stepUtils.discardForm()
 ]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -73,5 +73,5 @@ tour.register('sale_product_configurator_tour', {
     trigger: 'span[name=amount_total]:contains("0.00")',
     in_modal: false,
     run: function (){}
-}
+}, ...tour.stepUtils.discardForm()
 ]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -139,9 +139,5 @@ tour.register('sale_matrix_tour', {
     }
 }, {
     trigger: 'span:contains("Confirm")',  // apply the matrix
-}, {
-    trigger: '.o_form_button_save:contains("Save")',
-    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("8.20")',
-    run: 'click', // SAVE Sales Order, after matrix has been applied (extra_trigger).
-},
+}, ...tour.stepUtils.saveForm('.o_field_cell.o_data_cell.o_list_number:contains("8.20")'),
 ]);

--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -443,12 +443,11 @@
                 }
                 await testApp(app);
             } else {
-                app = await getNextApp();
-                while (app) {
+                while (app = await getNextApp()) {
                     await testApp(app);
-                    app = await getNextApp();
                 }
             }
+
             console.log("Test took", (performance.now() - startTime) / 1000, "seconds");
             console.log("Successfully tested", testedApps.length, " apps");
             console.log("Successfully tested", testedMenus.length - testedApps.length, "menus");

--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -8,7 +8,7 @@ _logger = logging.getLogger(__name__)
 
 @odoo.tests.tagged('click_all', 'post_install', '-at_install', '-standard')
 class TestMenusAdmin(odoo.tests.HttpCase):
-
+    allow_end_on_form = True
     def test_01_click_everywhere_as_admin(self):
         menus = self.env['ir.ui.menu'].load_menus(False)
         for app_id in menus['root']['children']:
@@ -20,7 +20,7 @@ class TestMenusAdmin(odoo.tests.HttpCase):
 
 @odoo.tests.tagged('click_all', 'post_install', '-at_install', '-standard')
 class TestMenusDemo(odoo.tests.HttpCase):
-
+    allow_end_on_form = True
     def test_01_click_everywhere_as_demo(self):
         user_demo = self.env.ref("base.user_demo")
         menus = self.env['ir.ui.menu'].with_user(user_demo.id).load_menus(False)
@@ -32,12 +32,12 @@ class TestMenusDemo(odoo.tests.HttpCase):
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestMenusAdminLight(odoo.tests.HttpCase):
-
+    allow_end_on_form = True
     def test_01_click_apps_menus_as_admin(self):
         self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere'](undefined, true);", "odoo.isReady === true", login="admin", timeout=120)
 
 @odoo.tests.tagged('post_install', '-at_install',)
 class TestMenusDemoLight(odoo.tests.HttpCase):
-
+    allow_end_on_form = True
     def test_01_click_apps_menus_as_demo(self):
         self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere'](undefined, true);", "odoo.isReady === true", login="demo", timeout=120)

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1686,7 +1686,7 @@ export class OdooEditor extends EventTarget {
      */
     _computeHistorySelection() {
         const sel = this.document.getSelection();
-        if (!sel.anchorNode) {
+        if (!(sel && sel.anchorNode)) {
             return this._latestComputedSelection;
         }
         this._latestComputedSelection = {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -123,7 +123,8 @@ class Sanitize {
                 node = nodeP;
             }
 
-            const anchor = this.root.ownerDocument.getSelection().anchorNode;
+            const selection = this.root.ownerDocument.getSelection();
+            const anchor = selection && selection.anchorNode;
             const anchorEl = anchor && closestElement(anchor);
             // Remove zero-width spaces added by `fillEmpty` when there is
             // content and the selection is not next to it.

--- a/addons/web_tour/static/src/js/tour_step_utils.js
+++ b/addons/web_tour/static/src/js/tour_step_utils.js
@@ -157,5 +157,43 @@ return Class.extend({
             },
         ].map(this.addDebugHelp(this._getHelpMessage('mobileKanbanSearchMany2X', modalTitle, valueSearched)));
     },
+    /**
+     * Utility steps to save a form and wait for the save to complete
+     *
+     * @param extra_trigger additional save-condition selector
+     */
+    saveForm(extra_trigger) {
+        return [{
+            content: "save form",
+            trigger: '.o_form_button_save:contains("Save")',
+            extra_trigger,
+            run: 'click',
+            auto: true,
+        }, {
+            content: "wait for save completion",
+            trigger: '.o_form_readonly',
+            run() {},
+            auto: true,
+        }];
+    },
+    /**
+     * Utility steps to cancel a form creation or edition.
+     *
+     * Supports creation/edition from either a form or a list view (so checks
+     * for both states).
+     */
+    discardForm() {
+        return [{
+            content: "exit the form",
+            trigger: ".o_form_button_cancel",
+            run: 'click',
+            auto: true,
+        }, {
+            content: "wait for cancellation to complete",
+            trigger: ".o_list_renderer, .o_form_readonly",
+            run() {},
+            auto: true,
+        }];
+    }
 });
 });

--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -15,7 +15,7 @@ class TestHttpCase(HttpCase):
                 with patch('odoo.tests.common.ChromeBrowser.take_screenshot', return_value=None):
                     self.browser_js(url_path='about:blank', code=code)
             # second line must contains error message
-            self.assertEqual(error_catcher.exception.args[0].splitlines()[1], "test error message")
+            self.assertEqual(error_catcher.exception.args[0].splitlines()[-1], "test error message")
         self.assertEqual(len(log_catcher.output), 1)
         self.assertIn('test error message', log_catcher.output[0])
 
@@ -26,7 +26,7 @@ class TestHttpCase(HttpCase):
                 with patch('odoo.tests.common.ChromeBrowser.take_screenshot', return_value=None):
                     self.browser_js(url_path='about:blank', code=code)
             # second line must contains error message
-            self.assertEqual(error_catcher.exception.args[0].splitlines()[1:3],
+            self.assertEqual(error_catcher.exception.args[0].splitlines()[-2:],
             ['TypeError: test error message', '    at <anonymous>:1:15'])
         self.assertEqual(len(log_catcher.output), 1)
         self.assertIn('TypeError: test error message\n    at <anonymous>:1:15', log_catcher.output[0])

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -973,6 +973,12 @@ tour.stepUtils.autoExpandMoreButtons('.o_control_panel .breadcrumb:contains("the
     content: _t("Validate"),
     position: "bottom",
 }, {
+    edition: "community",
+    content: "wait for payment registration to succeed",
+    trigger: "span.bg-success:contains('Paid')",
+    auto: true,
+    run() {}
+},{
     edition: "enterprise",
     trigger: '.o_menu_toggle',
     content: _t('Go back to the home menu'),
@@ -1055,5 +1061,31 @@ tour.stepUtils.autoExpandMoreButtons('.o_control_panel .breadcrumb:contains("the
     trigger: "button[name='button_validate']",
     content: Markup(_t('<p><b>Click on Reconcile</p>')),
     position: "right",
+},
+{
+    mobile: false,
+    edition: "enterprise",
+    trigger: ".o_tag_badge_text:contains('Matched')",
+    auto: true,
+},
+// exit reconciliation widget
+{
+    ...tour.stepUtils.toggleHomeMenu(),
+    mobile: false,
+    auto: true,
+},
+{
+    trigger: `.o_app[data-menu-xmlid="account_accountant.menu_accounting"]`,
+    edition: 'enterprise',
+    mobile: false,
+    auto: true,
+},
+{
+    mobile: false,
+    edition: "enterprise",
+    content: "check that we're back on the dashboard",
+    trigger: 'a:contains("Customer Invoices")',
+    auto: true,
+    run() {}
 }]);
 });

--- a/odoo/addons/test_new_api/static/tests/tours/constraint.js
+++ b/odoo/addons/test_new_api/static/tests/tours/constraint.js
@@ -27,6 +27,11 @@ odoo.define('web.test.constraint', function (require) {
     }, { // check popup content
         content: "check notification box",
         trigger: '.o_dialog_warning:contains(The color code must be positive !)',
-        run: function () {}, // it's a check
-    }]);
+        run() {}
+    }, {
+        content: "close notification box",
+        trigger: '.modal-footer .o-default-button',
+    },
+    ...tour.stepUtils.discardForm(),
+    ]);
 });

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -472,13 +472,11 @@ odoo.define('web.test.x2many', function (require) {
         trigger: '.o_field_widget[name=name] input',
         run:     'text {generate_dummy_message}',
     }, {
-        content: "chuck update and new dummy message happened",
+        content: "check update and new dummy message happened",
         trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:containsExact(22)',
         extra_trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:containsExact(22)',
         run: function () {}, // it's a check
-    }, { // cancel
-        content: "cancel change",
-        trigger: '.o_cp_buttons .o_form_button_cancel',
-        run: 'click',
-    }]);
+    },
+    ...tour.stepUtils.discardForm(),
+    ]);
 });

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1514,7 +1514,7 @@ which leads to stray network requests and inconsistencies."""))
             )
         """, 'awaitPromise': True})
         # wait for the screenshot or whatever
-        wait(self._responses.values())
+        wait(self._responses.values(), 10)
         self._logger.info('Deleting cookies and clearing local storage')
         self._websocket_request('Network.clearBrowserCache')
         self._websocket_request('Network.clearBrowserCookies')
@@ -1523,7 +1523,7 @@ which leads to stray network requests and inconsistencies."""))
         # hopefully after navigating to about:blank there's no event left
         self._frames.clear()
         # wait for the clearing requests to finish in case the browser is re-used
-        wait(self._responses.values())
+        wait(self._responses.values(), 10)
         self._responses.clear()
         self._result.cancel()
         self._result = Future()


### PR DESCRIPTION
Since 54ea9564905f6c140b4892357657e763d21b4fa5 the form view has an
"urgentSave" fallback when the page is unloaded (tab closed, page
navigated away from, ...).

In tours, this translates to new network requests being performed
during the browser cleanup, possibly chaining further into more
network events.

Flag these tours as incorrect.