### PR TITLE
[FIX] website: fix restricted editor warnings

### DIFF
--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -30,7 +30,7 @@ patch(NavBar.prototype, 'website_navbar', {
         this.websiteEditingMenus = {
             'website.menu_edit_menu': {
                 Component: EditMenuDialog,
-                isDisplayed: () => !!this.websiteService.currentWebsite,
+                isDisplayed: () => !!this.websiteService.currentWebsite && this.websiteService.isDesigner,
             },
             'website.menu_optimize_seo': {
                 Component: OptimizeSEODialog,

--- a/addons/website/static/src/js/content/website_root_instance.js
+++ b/addons/website/static/src/js/content/website_root_instance.js
@@ -7,7 +7,7 @@ import { loadWysiwyg } from "web_editor.loader";
 export default createPublicRoot(WebsiteRoot).then(rootInstance => {
     // This data attribute is set by the WebsitePreview client action for a
     // publisher user.
-    if (window.frameElement && window.frameElement.dataset.loadWysiwyg) {
+    if (window.frameElement && window.frameElement.dataset.loadWysiwyg === 'true') {
         loadWysiwyg(['website.compiled_assets_wysiwyg']).then(() => {
             window.dispatchEvent(new CustomEvent('PUBLIC-ROOT-READY', {detail: {rootInstance}}));
         });


### PR DESCRIPTION
Before this commit, the "Edit Menu" was displayed for the restricted
editors, even if they didn't have the right to access the website pages.
This was leading to a warning in the "click_all" test with the demo
user, and didn't make sense for the real user (who was prompted an
"access denied" modal).

Now, this menu is displayed only for the website designers.

Additionally to that, the website root instance would load the wysiwyg
assets if it is created inside an iframe which has the "load-wysiwyg"
data-attribute. But the test was not correctly written (as
data-load-wysiwyg was the string 'false'). This would lead to a warning
in the console when a user with no website rights was accessing the
website client action, introduced in [1].

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
