### PR TITLE
[FIX] product: Setting variant image to template

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -285,7 +285,7 @@ class ProductProduct(models.Model):
         # This is needed because when there is only one variant, the user
         # doesn't know there is a difference between template and variant, he
         # expects both images to be the same.
-        if self.product_tmpl_id.image and self.product_variant_count > 1:
+        if self.product_variant_count > 1:
             self.image_variant = image
         else:
             self.image_variant = False


### PR DESCRIPTION
When there is only one variant, the image should be assigned to template regardless the image in the template.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
