### PR TITLE
[FIX] sale: stop changing salesperson to default when not needed

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -395,7 +395,7 @@ class SaleOrder(models.Model):
             'partner_invoice_id': addr['invoice'],
             'partner_shipping_id': addr['delivery'],
         }
-        user_id = partner_user.id
+        user_id = partner_user.id or self.user_id.id
         if not self.env.context.get('not_self_saleperson'):
             user_id = user_id or self.env.context.get('default_user_id', self.env.uid)
         if user_id and self.user_id.id != user_id:


### PR DESCRIPTION
Current behavior:
In a sale order if you select a partner that has no salesperson
defined, the default one is selected. If you select another
salesperson and then modify the partner (e.g. modify the street
name of the partner), the salesperson will go back to default.

Steps to reproduce:
- Create a quotation
- Select a partner that has no salesperson defined
- Select another salesperson in the quotaion
- Modify the partner adress, and save it
- The salesperson is back to the default one

opw-2920694
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
