### PR TITLE
[FIX] website: prevent js recursion error with form visibility

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -9157,6 +9157,13 @@ msgid "There is no data currently available."
 msgstr ""
 
 #. module: website
+#. openerp-web
+#: code:addons/website/static/src/snippets/s_website_form/options.js:0
+#, python-format
+msgid "There is no field available for this option."
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.res_config_settings_view_form
 msgid ""
 "There is no website available for this company. You could create a new one."

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1068,10 +1068,14 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      */
     setVisibility(previewMode, widgetValue, params) {
         if (widgetValue === 'conditional') {
-            // Set a default visibility dependency
-            const firstInputOfForm = this.formEl.querySelector('.s_website_form_field:not(.s_website_form_dnone) input');
-            this._setVisibilityDependency(firstInputOfForm.name);
-            return;
+            const widget = this.findWidget('hidden_condition_opt');
+            const firstValue = widget.getMethodsParams('setVisibilityDependency').possibleValues.find(el => el !== '');
+            if (firstValue) {
+                // Set a default visibility dependency
+                this._setVisibilityDependency(firstValue);
+                return;
+            }
+            Dialog.confirm(this, _t("There is no field available for this option."));
         }
         this._deleteConditionalVisibility(this.$target[0]);
     },
@@ -1197,10 +1201,11 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         fieldEl.classList.remove('s_website_form_field_hidden_if', 'd-none');
     },
     /**
+     * @param {HTMLElement} [fieldEl]
      * @returns {HTMLElement} The visibility dependency of the field
      */
-    _getDependencyEl() {
-        const dependencyName = this.$target[0].dataset.visibilityDependency;
+    _getDependencyEl(fieldEl = this.$target[0]) {
+        const dependencyName = fieldEl.dataset.visibilityDependency;
         return this.formEl.querySelector(`.s_website_form_input[name="${dependencyName}"]`);
     },
     /**
@@ -1214,6 +1219,16 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 <we-button data-select-data-attribute="!fileSet">${_t("Is not set")}</we-button>
             </we-select>
         `)[0]);
+        const recursiveFindCircular = (el) => {
+            if (el.dataset.visibilityDependency === this._getFieldName()) {
+                return true;
+            }
+            const dependencyInputEl = this._getDependencyEl(el);
+            if (!dependencyInputEl) {
+                return false;
+            }
+            return recursiveFindCircular(dependencyInputEl.closest('.s_website_form_field'));
+        };
 
         // Update available visibility dependencies
         const selectDependencyEl = uiFragment.querySelector('we-select[data-name="hidden_condition_opt"]');
@@ -1223,7 +1238,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 const inputEl = el.querySelector('.s_website_form_input');
                 if (el.querySelector('.s_website_form_label_content') && inputEl && inputEl.name
                         && inputEl.name !== this.$target[0].querySelector('.s_website_form_input').name
-                        && !existingDependencyNames.includes(inputEl.name)) {
+                        && !existingDependencyNames.includes(inputEl.name) && !recursiveFindCircular(el)) {
                     const button = document.createElement('we-button');
                     button.textContent = el.querySelector('.s_website_form_label_content').textContent;
                     button.dataset.setVisibilityDependency = inputEl.name;


### PR DESCRIPTION
Before this commit, it was possible to make the JS crash due to maximum
call stack reached due to some recursion between 2 field visibility.
It was then preventing the page to even be accessed as it is the 000.js
(public file) which is failing.
The only way to fix that is then to go through the backend.

Step to reproduce:
- Enter edit mode and drag & drop a form snippet on the page
- Select a field, let's call it field_a
- Set it's visibility option in the right panel to "Visible only if" and
  select another field as value, let's call it field_b
- Now select field_b and do the same operation and set field_a as value
- Save

After save, the 000.js file will be executed and the traceback will
occur, preventing the page to work at all.

opw-2889860
