### PR TITLE
[IMP] base: ir_attachment add index

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1641,7 +1641,7 @@ class StockMove(models.Model):
                 precision_rounding=rounding,
                 rounding_method='HALF-UP')
             extra_move_vals = self._prepare_extra_move_vals(extra_move_quantity)
-            extra_move = self.copy(default=extra_move_vals)
+            extra_move = self.copy(default=extra_move_vals).with_context(avoid_putaway_rules=True)
 
             merge_into_self = all(self[field] == extra_move[field] for field in self._prepare_merge_moves_distinct_fields())
 

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -226,6 +226,8 @@ class StockMoveLine(models.Model):
                 packaging=self.move_id.product_packaging_id)
 
     def _apply_putaway_strategy(self):
+        if self._context.get('avoid_putaway_rules'):
+            return
         self = self.with_context(do_not_unreserve=True)
         for package, smls in groupby(self, lambda sml: sml.result_package_id):
             smls = self.env['stock.move.line'].concat(*smls)

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5771,3 +5771,26 @@ class StockMove(TransactionCase):
         })
         self.assertEqual(move.move_line_ids.location_id, self.stock_location)
         self.assertEqual(move.move_line_ids.location_dest_id, self.customer_location)
+
+    def test_receive_more_and_in_child_location(self):
+        """
+        Ensure that, when receiving more than expected, and when the destination
+        location of the SML is different from the SM one, the SM validation will
+        not change the destination location of the SML
+        """
+        move = self.env['stock.move'].create({
+            'name': self.product.name,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+        })
+        move._action_confirm()
+        move.move_line_ids.write({
+            'location_dest_id': self.stock_location.child_ids[0].id,
+            'qty_done': 3,
+        })
+        move._action_done()
+        self.assertEqual(move.move_line_ids.qty_done, 3)
+        self.assertEqual(move.move_line_ids.location_dest_id, self.stock_location.child_ids[0])

--- a/addons/web/static/src/libs/bootstrap/utilities_custom.scss
+++ b/addons/web/static/src/libs/bootstrap/utilities_custom.scss
@@ -79,6 +79,7 @@ $utilities: map-merge(
                 "text-opacity": 1
             ),
             values: (
+                "body": $body-color,
                 "black": $black,
                 "white": $white,
                 "muted": $text-muted,

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1237,6 +1237,7 @@ export class SearchModel extends EventBus {
                     [category.fieldName],
                     {
                         category_domain: this._getCategoryDomain(category.id),
+                        context: this.globalContext,
                         enable_counters: category.enableCounters,
                         expand: category.expand,
                         filter_domain: filterDomain,
@@ -1272,6 +1273,7 @@ export class SearchModel extends EventBus {
                     {
                         category_domain: categoryDomain,
                         comodel_domain: new Domain(filter.domain).toList(evalContext),
+                        context: this.globalContext,
                         enable_counters: filter.enableCounters,
                         filter_domain: this._getFilterDomain(filter.id),
                         expand: filter.expand,

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -3402,4 +3402,36 @@ QUnit.module("Search", (hooks) => {
 
         assert.deepEqual(getCategoriesContent(target), ["All", "gold", "silver"]);
     });
+
+    QUnit.test("Category with counters and filter with domain", async (assert) => {
+        serverData.views["partner,false,search"] = /* xml */ `
+            <search>
+                <searchpanel>
+                    <field name="category_id"/>
+                    <field name="company_id" select="multi" domain="[['category_id', '=', category_id]]"/>
+                </searchpanel>
+            </search>`;
+
+        const { TestComponent } = makeTestComponent();
+        await makeWithSearch({
+            serverData,
+            Component: TestComponent,
+            resModel: "partner",
+            searchViewId: false,
+            mockRPC: (route, args) => {
+                if (
+                    ["search_panel_select_range", "search_panel_select_multi_range"].includes(
+                        args.method
+                    )
+                ) {
+                    assert.step(args.kwargs.context.special_key);
+                }
+            },
+            context: {
+                special_key: "special_key",
+            },
+        });
+
+        assert.verifySteps(["special_key", "special_key"]);
+    });
 });

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -398,7 +398,7 @@ class IrAttachment(models.Model):
     raw = fields.Binary(string="File Content (raw)", compute='_compute_raw', inverse='_inverse_raw')
     datas = fields.Binary(string='File Content (base64)', compute='_compute_datas', inverse='_inverse_datas')
     db_datas = fields.Binary('Database Data', attachment=False)
-    store_fname = fields.Char('Stored Filename')
+    store_fname = fields.Char('Stored Filename', index=True)
     file_size = fields.Integer('File Size', readonly=True)
     checksum = fields.Char("Checksum/SHA1", size=40, index=True, readonly=True)
     mimetype = fields.Char('Mime Type', readonly=True)
@@ -645,7 +645,7 @@ class IrAttachment(models.Model):
                 ))
 
             # 'check()' only uses res_model and res_id from values, and make an exists.
-            # We can group the values by model, res_id to make only one query when 
+            # We can group the values by model, res_id to make only one query when
             # creating multiple attachments on a single record.
             record_tuple = (values.get('res_model'), values.get('res_id'))
             record_tuple_set.add(record_tuple)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Improves the odoo garbage collector for large amounts of attachments.

**Current behavior before PR:**
The odoo garbage collector takes around 20 sec to process 1000 records. In one of our deployed projects with production data, there are 790,000 records. According to our tests, each batch of 1000 records takes 20 seconds and hence the whole process is currently taking around 4 hours to complete, as shown below:

 (790,000 records / 1000) * 20 sec *(1 min / 60 sec) * (1 hour / 60 min)  = 4.38 hours. 

Since the Odoo garbage collector routine runs periodically and currently takes more than 4 hours, this behavior **is not acceptable in this application**, because if there is any other app that tries to use attachments at the same time (for instance invoicing), it will not be able to do it since the Odoo garbage collector will lock the table, leading to a deadlock.

**Desired behavior after PR is merged:**
After adding the index parameter to the store_fname field in our local patch, we noticed that the total time decreased drastically from 4 hours to 10 seconds since now each batch of 1000 k records takes only 13 ms.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
