### PR TITLE
[IMP] web: debug_items: a menu to view a dynamic owl template

### DIFF
--- a/addons/web/static/src/core/utils/xml.js
+++ b/addons/web/static/src/core/utils/xml.js
@@ -158,3 +158,35 @@ export function setAttributes(node, attributes) {
         node.setAttribute(name, value);
     }
 }
+
+function indentXML(node, spaces = 2, level = 0) {
+    // trim existing spaces and new lines, as owl would anyway
+    for (const child of node.childNodes) {
+        if (child.nodeType === 3 && !(child.innerText && child.innerText.trim())) {
+            child.remove();
+        } else if (child.nodeType === 3) {
+            child.innerText = child.innerText.trim();
+        }
+    }
+
+    for (const c of node.children) {
+        c.before(xmlDocument.createTextNode("\n"));
+        indentXML(c, spaces, level + 1);
+    }
+    const actualSpaces = new Array(spaces * level).join(" ");
+    if (actualSpaces) {
+        node.before(xmlDocument.createTextNode(actualSpaces));
+    }
+
+    if (node.children.length) {
+        node.append(xmlDocument.createTextNode("\n"));
+        node.append(xmlDocument.createTextNode(actualSpaces));
+    }
+    return node;
+}
+
+export function indentFromString(string, spaces = 2) {
+    const doc = parser.parseFromString(string, "text/xml");
+    const indented = indentXML(doc.firstChild, spaces);
+    return new XMLSerializer().serializeToString(indented);
+}

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -379,10 +379,10 @@ class ViewOwlTemplateDialog extends Component {
         for (const [name, xml] of Object.entries(this.props.templates)) {
             pages.push({
                 Component: DisplayIndentedTemplate,
+                isVisible: true,
+                title: name,
                 props: {
                     xml,
-                    isVisible: true,
-                    title: name,
                 },
             });
         }

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -34,10 +34,10 @@ export class FormRenderer extends Component {
         useBounceButton(useRef("compiled_view_root"), () => {
             return !record.isInEdition;
         });
-        this.uiService = useService('ui');
+        this.uiService = useService("ui");
         this.onResize = useDebounced(this.render, 200);
-        onMounted(() => browser.addEventListener('resize', this.onResize));
-        onWillUnmount(() => browser.removeEventListener('resize', this.onResize));
+        onMounted(() => browser.addEventListener("resize", this.onResize));
+        onWillUnmount(() => browser.removeEventListener("resize", this.onResize));
     }
 
     evalDomainFromRecord(record, expr) {

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -8,7 +8,7 @@ import {
     getTag,
 } from "@web/core/utils/xml";
 import { toStringExpression } from "./utils";
-import { useDebugCategory } from "@web/core/debug/debug_context";
+import { useDebugCategory, useEnvDebugContext } from "@web/core/debug/debug_context";
 
 /**
  * @typedef Compiler
@@ -450,6 +450,17 @@ export class ViewCompiler {
     }
 }
 
+function debugViewCompiler(templates) {
+    const debugContext = useEnvDebugContext();
+    const contexts = debugContext.categories.get("view_compiler");
+    const nextTemplates = {};
+    if (contexts) {
+        contexts.forEach(({ templates }) => Object.assign(nextTemplates, templates));
+    }
+    Object.assign(nextTemplates, templates);
+    useDebugCategory("view_compiler", { templates: nextTemplates });
+}
+
 /**
  * @param {typeof ViewCompiler} ViewCompiler
  * @param {string} rawArch
@@ -469,7 +480,7 @@ export function useViewCompiler(ViewCompiler, rawArch, templates, params) {
             compiledTemplates[key] = xml`${compiledDoc.outerHTML}`;
         }
     }
-    useDebugCategory("view_compiler", { templates: compiledTemplates });
+    debugViewCompiler(compiledTemplates);
 
     return { ...compiledTemplates };
 }

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -8,6 +8,7 @@ import {
     getTag,
 } from "@web/core/utils/xml";
 import { toStringExpression } from "./utils";
+import { useDebugCategory } from "@web/core/debug/debug_context";
 
 /**
  * @typedef Compiler
@@ -468,5 +469,7 @@ export function useViewCompiler(ViewCompiler, rawArch, templates, params) {
             compiledTemplates[key] = xml`${compiledDoc.outerHTML}`;
         }
     }
+    useDebugCategory("view_compiler", { templates: compiledTemplates });
+
     return { ...compiledTemplates };
 }


### PR DESCRIPTION
Some views must compile an OWL template on the basis of an arch (Form and Kanban).
Since those templates are dynamic, it is hard to see them as readable XML, for debugging
or even development purposes.

This commit adds a little debug menu that, when clicked, displays an naively indented XML of the "compiled" template
Compiled here refers to the process of transforming an arch to a valid OWL template.

For now, only the form renderer activates that item.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
