### PR TITLE
[FIX] mass_mailing: should not land on top

### DIFF
--- a/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
+++ b/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
@@ -59,7 +59,11 @@ const MassMailingFullWidthFormController = FormController.extend({
         } else {
             const ref = $iframeDoc.find('#iframe_target')[0];
             if (ref) {
-                this.$iframe.height(Math.max(ref.scrollHeight + VERTICAL_OFFSET, minHeight));
+                this.$iframe.css({
+                    height: this._isFullScreen()
+                        ? $(window).height()
+                        : Math.max(ref.scrollHeight + VERTICAL_OFFSET, minHeight),
+                });
             }
         }
     },
@@ -77,7 +81,6 @@ const MassMailingFullWidthFormController = FormController.extend({
         const isFullscreen =  this._isFullScreen();
         if (isFullscreen) {
             $sidebar.height(windowHeight);
-            this.$iframe.height(windowHeight);
             $sidebar.css({
                 top: '',
                 bottom: '',


### PR DESCRIPTION
**Current behavior before PR:**

When the page is expanded and try to add any block with an image, try to change
the image using replace button. It lands the user at the top of the page instead
of staying image place.

**Desired behavior after PR is merged:**

The user will stay at the image place after clicking on replace button.

**Task**-2753302


