### PR TITLE
[FIX] web: fix enterprise badge in settings being hidden and wrong color

### DIFF
--- a/addons/web/static/src/legacy/js/fields/upgrade_fields.js
+++ b/addons/web/static/src/legacy/js/fields/upgrade_fields.js
@@ -94,7 +94,7 @@ var AbstractFieldUpgrade = {
         this._super.apply(this, arguments);
         this._insertEnterpriseLabel($("<span>", {
             text: "Enterprise",
-            'class': "badge bg-primary oe_inline o_enterprise_label"
+            'class': "badge text-bg-primary oe_inline o_enterprise_label"
         }));
     },
     /**

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1036,39 +1036,3 @@ $o-form-label-margin-right: 0px;
         clear: left;
     }
 }
-
-.o_setting_box {
-    margin-bottom: 8px;
-    margin-top: 8px;
-    .o_setting_left_pane {
-        width: 24px;
-        float: left;
-        .o_enterprise_label {
-            position: absolute;
-            top: 0px;
-            right: 40px;
-        }
-    }
-    .o_setting_right_pane {
-        margin-left: 24px;
-        border-left: 1px solid $border-color;
-        padding-left: 12px;
-        .o_input_dropdown > .o_input {
-            width: 100%;
-        }
-        .o_field_widget {
-            width: 50%;
-            flex: 0 0 auto;
-
-            &.o_field_many2manytags > .o_field_widget {
-                flex: 1 0 50px;
-            }
-        }
-        button.btn-link:first-child {
-            padding: 0;
-        }
-        a.oe-link {
-            font-size: 12px;
-        }
-    }
-}

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
@@ -1,18 +1,59 @@
-.o-settings-form-view {
-   .o_base_settings {
-      height: 100%;
+.o-settings-form-view .o_view_nocontent {
+   position: static;
+}
+
+.o_base_settings {
+   height: 100%;
+   overflow: auto;
+}
+
+.o_setting_container {
+   height: 100%;
+   > * {
       overflow: auto;
+      flex: 1 0 auto;
+   }
+}
+
+.o_setting_box {
+   margin-bottom: 8px;
+   margin-top: 8px;
+}
+
+.o_setting_left_pane {
+   width: 24px;
+   float: left;
+}
+
+.o_setting_right_pane {
+   margin-left: 24px;
+   border-left: 1px solid $border-color;
+   padding-left: 12px;
+
+   .o_input_dropdown > .o_input {
+      width: 100%;
    }
 
-   .o_setting_container {
-      height: 100%;
-         > * {
-            overflow: auto;
-            flex: 1 0 auto;
-         }
+   .o_field_widget {
+      width: 50%;
+      flex: 0 0 auto;
+
+      &.o_field_many2manytags > .o_field_widget {
+         flex: 1 0 50px;
+      }
    }
 
-   .o_view_nocontent {
-      position: static;
+   button.btn-link:first-child {
+      padding: 0;
    }
+
+   a.oe-link {
+      font-size: 12px;
+   }
+}
+
+.o_enterprise_label {
+   position: absolute;
+   top: 0px;
+   right: 40px;
 }

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
@@ -18,6 +18,7 @@
 .o_setting_box {
    margin-bottom: 8px;
    margin-top: 8px;
+   position: relative;
 }
 
 .o_setting_left_pane {


### PR DESCRIPTION
After the bootstrap migration, the enterprise badge in the settings view
were the wrong color because the class bg-primary was not adapted. This
commit fixes that.

After the wowl views merge, the badge has become hidden behind the
navbar, because it can no longer modify the DOM of its label as it is
managed by owl. When there is no label, the widget appends the badge to
its own $el, and uses position: absolute to position it. This didn't
work because the closest parent that was positioned was the view itself.
This commit fixes that by giving a position: relative to the settings
box.