### PR TITLE
[FIX] loyalty : coupon ui

### DIFF
--- a/addons/loyalty/data/loyalty_demo.xml
+++ b/addons/loyalty/data/loyalty_demo.xml
@@ -3,8 +3,10 @@
     <!-- 10 percent with code -->
     <record id="10_percent_with_code" model="loyalty.program">
         <field name="name">Code for 10% on orders</field>
-        <field name="program_type">promotion</field>
+        <field name="program_type">promo_code</field>
         <field name="trigger">with_code</field>
+        <field name="portal_visible">False</field>
+        <field name="portal_point_name">Discount point(s)</field>
     </record>
 
     <record id="10_percent_with_code_rule" model="loyalty.rule">
@@ -16,17 +18,19 @@
     <record id="10_percent_with_code_reward" model="loyalty.reward">
         <field name="reward_type">discount</field>
         <field name="discount">10</field>
+        <field name="active">1</field>
         <field name="discount_mode">percent</field>
         <field name="discount_applicability">order</field>
         <field name="program_id" ref="loyalty.10_percent_with_code"/>
     </record>
-
-
     <!-- 3 cabinet + 1 free -->
     <record id="3_cabinets_plus_1_free" model="loyalty.program">
         <field name="name">Buy 3 large cabinets, get one for free</field>
-        <field name="program_type">promotion</field>
+        <field name="program_type">buy_two_get_one</field>
+        <field name="applies_on">current</field>
         <field name="trigger">auto</field>
+        <field name="portal_visible">False</field>
+        <field name="portal_point_name">Credit(s)</field>
     </record>
 
     <record id="3_cabinets_plus_1_free_rule" model="loyalty.rule">
@@ -35,7 +39,7 @@
         <field name="reward_point_amount">1</field>
         <field name="product_ids" eval="[(4, ref('product.product_product_6'))]"/>
         <field name="program_id" ref="loyalty.3_cabinets_plus_1_free"/>
-    </record>    
+    </record>
 
     <record id="3_cabinets_plus_1_free_reward" model="loyalty.reward">
         <field name="reward_type">product</field>
@@ -43,12 +47,13 @@
         <field name="required_points">3</field>
         <field name="program_id" ref="loyalty.3_cabinets_plus_1_free"/>
     </record>    
-
     <!-- 10 percent coupons -->
     <record id="10_percent_coupon" model="loyalty.program">
         <field name="name">10% Discount</field>
-        <field name="applies_on">future</field>
+        <field name="program_type">coupons</field>
+        <field name="applies_on">current</field>
         <field name="trigger">with_code</field>
+        <field name="portal_point_name">Coupon points</field>
     </record>
 
     <record id="10_percent_coupon_rule" model="loyalty.rule">
@@ -68,13 +73,13 @@
         <field name="mail_template_id" ref="loyalty.mail_template_loyalty_card"/>
         <field name="program_id" ref="loyalty.10_percent_coupon"/>
     </record>
-
     <!-- Gift Cards -->
     <record id="gift_card_program" model="loyalty.program">
         <field name="name">Gift Cards</field>
         <field name="program_type">gift_card</field>
         <field name="applies_on">future</field>
         <field name="trigger">auto</field>
+        <field name="portal_visible">True</field>
     </record>
 
     <record id="gift_card_program_rule" model="loyalty.rule">
@@ -93,5 +98,4 @@
         <field name="required_points">1</field>
         <field name="program_id" ref="loyalty.gift_card_program"/>
     </record>
-
 </odoo>

--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -29,6 +29,7 @@ class LoyaltyCard(models.Model):
     partner_id = fields.Many2one('res.partner', index=True)
     points = fields.Float(tracking=True)
     point_name = fields.Char(related='program_id.portal_point_name', readonly=True)
+    concatenate_points = fields.Char(compute='_compute_concatenate_points')
 
     code = fields.Char(default=lambda self: self._generate_code(), required=True, readonly=True, index=True)
     expiration_date = fields.Date()
@@ -44,6 +45,11 @@ class LoyaltyCard(models.Model):
         # Prevent a coupon from having the same code a program
         if self.env['loyalty.rule'].search_count([('mode', '=', 'with_code'), ('code', 'in', self.mapped('code'))]):
             raise ValidationError(_('A trigger with the same code as one of your coupon already exists.'))
+
+    @api.depends('points', 'point_name')
+    def _compute_concatenate_points(self):
+        for card in self:
+            card.concatenate_points = "%.2f %s" % (card.points or 0, card.point_name or '')
 
     # Meant to be overriden
     def _compute_use_count(self):

--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -24,21 +24,30 @@ class LoyaltyProgram(models.Model):
 
     total_order_count = fields.Integer("Total Order Count", compute="_compute_total_order_count")
 
-    rule_ids = fields.One2many('loyalty.rule', 'program_id', 'Triggers', copy=True,
+    rule_ids = fields.One2many('loyalty.rule', 'program_id', 'Conditional rules', copy=True,
          compute='_compute_from_program_type', readonly=False, store=True)
     reward_ids = fields.One2many('loyalty.reward', 'program_id', 'Rewards', copy=True,
          compute='_compute_from_program_type', readonly=False, store=True)
     communication_plan_ids = fields.One2many('loyalty.mail', 'program_id', copy=True,
          compute='_compute_from_program_type', readonly=False, store=True)
+
+    mail_template_id = fields.Many2one('mail.template', compute='_compute_mail_template_id', inverse='_inverse_mail_template_id', string="Email template", readonly=False)
+    product_gift = fields.Many2many(related='rule_ids.product_ids', readonly=False)
+
     coupon_ids = fields.One2many('loyalty.card', 'program_id')
     coupon_count = fields.Integer(compute='_compute_coupon_count')
+    concatenate_count = fields.Char(compute='_compute_concatenate_count', string="Items")
 
     program_type = fields.Selection([
         ('coupons', 'Coupons'),
         ('gift_card', 'Gift Card'),
         ('loyalty', 'Loyalty Cards'),
         ('promotion', 'Promotions'),
-        ('ewallet', 'eWallet')], default='promotion', required=True,
+        ('ewallet', 'eWallet'),
+        ('promo_code', 'Discount Code'),
+        ('buy_two_get_one', 'Buy X Get Y'),
+        ('next_order_coupons', 'Next Order Coupons'),
+        ], default='promotion', required=True,
     )
     date_to = fields.Date(string='Validity')
     limit_usage = fields.Boolean(string='Limit Usage')
@@ -51,12 +60,12 @@ class LoyaltyProgram(models.Model):
         ('current', 'Current order'),
         ('future', 'Future orders'),
         ('both', 'Current & Future orders')], default='current', required=True,
-         compute='_compute_from_program_type', readonly=False, store=True,
+         compute='_compute_from_program_type', readonly=True, store=True,
     )
     trigger = fields.Selection([
         ('auto', 'Automatic'),
         ('with_code', 'Use a code')],
-        compute='_compute_from_program_type', readonly=False, store=True,
+        compute='_compute_from_program_type', readonly=True, store=True,
         help="""
         Automatic: Customers will be eligible for a reward automatically in their cart.
         Use a code: Customers will be eligible for a reward if they enter a code.
@@ -67,7 +76,7 @@ class LoyaltyProgram(models.Model):
         Show in web portal, PoS customer ticket, eCommerce checkout, the number of points available and used by reward.
         """)
     portal_point_name = fields.Char(default='Points', translate=True,
-         compute='_compute_from_program_type', readonly=False, store=True)
+        compute='_compute_from_program_type', readonly=False, store=True)
     is_nominative = fields.Boolean(compute='_compute_is_nominative')
 
     _sql_constraints = [
@@ -82,6 +91,38 @@ class LoyaltyProgram(models.Model):
 
     def _compute_total_order_count(self):
         self.total_order_count = 0
+
+    @api.depends('coupon_count', 'program_type')
+    def _compute_concatenate_count(self):
+        program_items_name = self._program_items_name()
+        for program in self:
+            program.concatenate_count = "%i %s" % (program.coupon_count or 0, program_items_name[program.program_type] or '')
+
+    @api.depends("communication_plan_ids.mail_template_id")
+    def _compute_mail_template_id(self):
+        for program in self:
+            program.mail_template_id = program.communication_plan_ids.mail_template_id[:1]
+
+    def _inverse_mail_template_id(self):
+        for program in self:
+            if program.program_type not in ("gift_card", "ewallet"):
+                continue
+            if not program.communication_plan_ids:
+                program.communication_plan_ids = self.env['loyalty.mail'].create({
+                    'program_id': program.id,
+                    'trigger': 'create',
+                    'mail_template_id': program.mail_template_id.id,
+                })
+            if self.env['loyalty.mail'].search_count([('program_id', '=', program.id)]) > 1:
+                temp_communication_plan = {
+                    'program_id': program.id,
+                    'trigger': program.communication_plan_ids[0].trigger,
+                    'mail_template_id': program.mail_template_id.id,
+                }
+                program.communication_plan_ids = [(5, 0, 0)]
+                program.communication_plan_ids = self.env['loyalty.mail'].create(temp_communication_plan)
+            else:
+                program.communication_plan_ids.mail_template_id = program.mail_template_id
 
     @api.depends('company_id')
     def _compute_currency_id(self):
@@ -102,6 +143,19 @@ class LoyaltyProgram(models.Model):
                 (program.program_type == 'ewallet' and program.applies_on == 'future')
 
     @api.model
+    def _program_items_name(self):
+        return {
+            'coupons': 'Coupons',
+            'promotion': 'Promos',
+            'gift_card': 'Gift Cards',
+            'loyalty': 'Loyalty Cards',
+            'ewallet': 'eWallets',
+            'promo_code': 'Discounts',
+            'buy_two_get_one': 'Promos',
+            'next_order_coupons': 'Coupons',
+        }
+
+    @api.model
     def _program_type_default_values(self):
         # All values to change when program_type changes
         # NOTE: any field used in `rule_ids`, `reward_ids` and `communication_plan_ids` MUST be present in the kanban view for it to work properly.
@@ -110,9 +164,11 @@ class LoyaltyProgram(models.Model):
                 'applies_on': 'current',
                 'trigger': 'with_code',
                 'portal_visible': False,
-                'portal_point_name': _('Points'),
-                # Coupons don't use rules by default
-                'rule_ids': [(5, 0, 0)],
+                'portal_point_name': _('Coupon points'),
+                'rule_ids': [(5, 0, 0), (0, 0, {
+                    'reward_point_amount': 1,
+                    'reward_point_mode': 'order',
+                })],
                 'reward_ids': [(5, 0, 0), (0, 0, {
                     'required_points': 1,
                     'discount': 10,
@@ -126,7 +182,7 @@ class LoyaltyProgram(models.Model):
                 'applies_on': 'current',
                 'trigger': 'auto',
                 'portal_visible': False,
-                'portal_point_name': _('Points'),
+                'portal_point_name': _('Promo point(s)'),
                 'rule_ids': [(5, 0, 0), (0, 0, {
                     'reward_point_amount': 1,
                     'reward_point_mode': 'order',
@@ -155,7 +211,7 @@ class LoyaltyProgram(models.Model):
                     'discount': 1,
                     'discount_applicability': 'order',
                     'required_points': 1,
-                    'description': _('Pay With Gift Card'),
+                    'description': _('Gift Card'),
                 })],
                 'communication_plan_ids': [(5, 0, 0), (0, 0, {
                     'trigger': 'create',
@@ -166,7 +222,7 @@ class LoyaltyProgram(models.Model):
                 'applies_on': 'both',
                 'trigger': 'auto',
                 'portal_visible': True,
-                'portal_point_name': _('Loyalty Points'),
+                'portal_point_name': _('Loyalty points'),
                 'rule_ids': [(5, 0, 0), (0, 0, {
                     'reward_point_mode': 'money',
                 })],
@@ -192,10 +248,61 @@ class LoyaltyProgram(models.Model):
                     'discount': 1,
                     'discount_applicability': 'order',
                     'required_points': 1,
+                    'description': _('eWallet'),
+                })],
+                'communication_plan_ids': [(5, 0, 0)],
+            },
+            'promo_code': {
+                'applies_on': 'current',
+                'trigger': 'with_code',
+                'portal_visible': False,
+                'portal_point_name': _('Discount point(s)'),
+                'rule_ids': [(5, 0, 0), (0, 0, {
+                    'mode': 'with_code',
+                    'code': 'PROMO_CODE',
+                })],
+                'reward_ids': [(5, 0, 0), (0, 0, {
+                    'discount_applicability': 'specific',
+                    'discount_product_ids': self.env['product.product'].search([('sale_ok', '=', True)], limit=1),
+                    'discount_mode': 'percent',
+                    'discount': 10,
+                })],
+                'communication_plan_ids': [(5, 0, 0)],
+            },
+            'buy_two_get_one': {
+                'applies_on': 'current',
+                'trigger': 'auto',
+                'portal_visible': False,
+                'portal_point_name': _('Credit(s)'),
+                'rule_ids': [(5, 0, 0), (0, 0, {
+                    'reward_point_mode': 'unit',
+                    'product_ids': self.env['product.product'].search([('sale_ok', '=', True)], limit=1),
+                })],
+                'reward_ids': [(5, 0, 0), (0, 0, {
+                    'reward_type': 'product',
+                    'reward_product_id': self.env['product.product'].search([('sale_ok', '=', True)], limit=1) and self.env['product.product'].search([('sale_ok', '=', True)], limit=1).id or False,
+                    'required_points': 2,
+                })],
+                'communication_plan_ids': [(5, 0, 0)],
+            },
+            'next_order_coupons': {
+                'applies_on': 'future',
+                'trigger': 'auto',
+                'portal_visible': True,
+                'portal_point_name': _('Coupon point(s)'),
+                'rule_ids': [(5, 0, 0), (0, 0, {
+                    'minimum_amount': 100,
+                })],
+                'reward_ids': [(5, 0, 0), (0, 0, {
+                    'reward_type': 'discount',
+                    'discount_mode': 'percent',
+                    'discount': 15,
+                    'discount_applicability': 'order',
                 })],
                 'communication_plan_ids': [(5, 0, 0)],
             },
         }
+
 
     @api.depends('program_type')
     def _compute_from_program_type(self):
@@ -280,6 +387,11 @@ class LoyaltyProgram(models.Model):
                 'description': _('Fill in your eWallet, and use it to pay future orders'),
                 'icon': 'ewallet',
             },
+            'next_order_coupons': {
+                'title': _('Next Order Coupons'),
+                'description': _('Send unique, single-use coupon code for the next purchase'),
+                'icon': 'coupons',
+            },
         }
 
     @api.model
@@ -334,20 +446,19 @@ class LoyaltyProgram(models.Model):
                 **program_type_defaults['promotion'],
             },
             'promo_code': {
-                'name': _('Promo Code'),
-                'program_type': 'promotion',
-                'applies_on': 'current',
-                'trigger': 'with_code',
-                'rule_ids': [(0, 0, {
-                    'mode': 'with_code',
-                    'code': '10PERCENT_' + str(uuid4())[:4], # Require a random code in case a user creates multiple program using this template
-                })],
-                'reward_ids': [(0, 0, {
-                    'discount_applicability': 'specific',
-                    'discount_product_ids': product,
-                    'discount_mode': 'percent',
-                    'discount': 10,
-                })]
+                'name': _('Discount code'),
+                'program_type': 'promo_code',
+                **program_type_defaults['promo_code'],
+            },
+            'buy_two_get_one': {
+                'name': _('2+1 Free'),
+                'program_type': 'buy_two_get_one',
+                **program_type_defaults['buy_two_get_one'],
+            },
+            'next_order_coupons': {
+                'name': _('Next Order Coupons'),
+                'program_type': 'next_order_coupons',
+                **program_type_defaults['next_order_coupons'],
             },
             'fidelity': {
                 'name': _('Fidelity Cards'),
@@ -364,21 +475,6 @@ class LoyaltyProgram(models.Model):
                     'discount_applicability': 'specific',
                     'discount_product_ids': product,
                     'discount': 10,
-                })]
-            },
-            'buy_two_get_one': {
-                'name': _('2+1 Free'),
-                'program_type': 'promotion',
-                'applies_on': 'current',
-                'trigger': 'auto',
-                'rule_ids': [(0, 0, {
-                    'reward_point_mode': 'unit',
-                    'product_ids': product,
-                })],
-                'reward_ids': [(0, 0, {
-                    'reward_type': 'product',
-                    'reward_product_id': product and product.id or False,
-                    'required_points': 2,
                 })]
             },
         }

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -27,6 +27,7 @@ class LoyaltyReward(models.Model):
 
     active = fields.Boolean(default=True)
     program_id = fields.Many2one('loyalty.program', required=True, ondelete='cascade')
+    program_type = fields.Selection(related="program_id.program_type")
     # Stored for security rules
     company_id = fields.Many2one(related='program_id.company_id', store=True)
     currency_id = fields.Many2one(related='program_id.currency_id')
@@ -116,9 +117,13 @@ class LoyaltyReward(models.Model):
     def _compute_description(self):
         for reward in self:
             reward_string = ""
-            if reward.reward_type == 'product':
+            if reward.description == _('Gift Card') or reward.description == _('eWallet'):
+                return
+            elif reward.reward_type == 'product':
                 products = reward.reward_product_ids
-                if len(products) == 1:
+                if len(products) == 0:
+                    reward_string = _('Free Product')
+                elif len(products) == 1:
                     reward_string = _('Free Product - %s', reward.reward_product_id.name)
                 else:
                     reward_string = _('Free Product - [%s]', ', '.join(products.mapped('name')))

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -23,6 +23,7 @@ class LoyaltyRule(models.Model):
 
     active = fields.Boolean(default=True)
     program_id = fields.Many2one('loyalty.program', required=True, ondelete='cascade')
+    program_type = fields.Selection(related="program_id.program_type")
     # Stored for security rules
     company_id = fields.Many2one(related='program_id.company_id', store=True)
     currency_id = fields.Many2one(related='program_id.currency_id')
@@ -52,7 +53,7 @@ class LoyaltyRule(models.Model):
         ('auto', 'Automatic'),
         ('with_code', 'With a promotion code'),
     ], string="Application", default="auto")
-    code = fields.Char(string='Promotion Code', compute='_compute_code', store=True, readonly=False)
+    code = fields.Char(string='Discount code', compute='_compute_code', store=True, readonly=False)
 
     _sql_constraints = [
         ('reward_point_amount_positive', 'CHECK (reward_point_amount > 0)', 'Rule points reward must be strictly positive.'),

--- a/addons/loyalty/static/src/js/loyalty_control_panel_widget.js
+++ b/addons/loyalty/static/src/js/loyalty_control_panel_widget.js
@@ -7,3 +7,4 @@ export class LoyaltyX2ManyField extends X2ManyField {};
 LoyaltyX2ManyField.template = "loyalty.LoyaltyX2ManyField";
 
 registry.category("fields").add("loyalty_one2many", LoyaltyX2ManyField);
+

--- a/addons/loyalty/static/src/scss/loyalty.scss
+++ b/addons/loyalty/static/src/scss/loyalty.scss
@@ -12,6 +12,17 @@
         height: auto !important;
         background-color: none !important;
     }
+
+    .o_loyalty_kanban_card_left {
+        float: left;
+        width: 70%;
+    }
+
+    .o_loyalty_kanban_card_right {
+        float: right;
+        width: 30%;
+        text-align: center;
+    }
 }
 
 .loyalty-templates-container {

--- a/addons/loyalty/views/loyalty_card_views.xml
+++ b/addons/loyalty/views/loyalty_card_views.xml
@@ -7,10 +7,17 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="code"/>
-                        <field name="expiration_date"/>
-                        <field name="partner_id"/>
-                        <field name="points"/>
+                        <group>
+                            <field name="code"/>
+                            <field name="expiration_date"/>
+                            <field name="partner_id"/>
+                            <label string="Balance" for="points"/>
+                            <div class="o_row">
+                                <field name="points" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
+                                <field name="points" class="oe_read_only"/>                                    
+                                <field name="point_name" no_label="1"/>
+                            </div>
+                        </group>
                     </group>
                 </sheet>
                 <div class="oe_chatter">
@@ -26,7 +33,8 @@
         <field name="arch" type="xml">
             <tree string="Coupons" create="false" edit="false" delete="false">
                 <field name="code"/>
-                <field name="points" string="Balance"/>
+                <field name="create_date" optional="hide"/>
+                <field name="concatenate_points" string="Balance"/>
                 <field name="expiration_date"/>
                 <field name="program_id"/>
                 <field name="partner_id"/>
@@ -35,8 +43,19 @@
         </field>
     </record>
 
+    <record id="loyalty_card_view_search" model="ir.ui.view">
+        <field name="name">loyalty.card.view.search</field>
+        <field name="model">loyalty.card</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter name="active" string="Active" domain="['&amp;', ('points', '>', 0), '|', ('expiration_date', '>=', context_today().strftime('%Y-%m-%d 00:00:00')), ('expiration_date', '=', False)]"/>
+                <filter name="inactive" string="Inactive" domain="['|', ('points', '&lt;=', 0), ('expiration_date', '&lt;', context_today().strftime('%Y-%m-%d 23:59:59'))]"/>
+            </search>
+        </field>
+    </record>
+
     <record id="loyalty_card_action" model="ir.actions.act_window">
-        <field name="name">Coupons</field>
+        <field name="name">Items</field>
         <field name="res_model">loyalty.card</field>
         <field name="view_mode">tree,form</field>
         <field name="domain">[('program_id', '=', active_id)]</field>

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -20,11 +20,12 @@
                                 <span class="o_stat_value">
                                     <field name="coupon_count"/>
                                 </span>
-                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'coupons')]}">Coupons</span>
+                                <span class="o_stat_text" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'coupons'), ('program_type', '!=', 'next_order_coupons')]}">Coupons</span>
                                 <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}">Gift Cards</span>
                                 <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}">eWallets</span>
                                 <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}">Loyalty Cards</span>
-                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'promotion')]}">Promos</span>
+                                <span class="o_stat_text" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'promotion'), ('program_type', '!=', 'buy_two_get_one')]}">Promos</span>
+                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'promo_code')]}">Discount</span>
                             </div>
                         </button>
                     </div>
@@ -33,69 +34,112 @@
                     <div class="oe_title">
                         <label for="name" string="Program Name"/>
                         <h1>
-                            <field name="name" class="text-break" placeholder="e.g. 10% discount on laptops"/>
+                            <field name="name" placeholder="e.g. 10% discount on laptops"/>
                         </h1>
                     </div>
-                    <group>
-                        <group>
-                            <label for="program_type"/>
-                            <div>
-                                <field name="program_type" widget="selection"/>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'coupons')]}" colspan="2">
-                                    Generate &amp; share coupon code manually.
-                                    <br/>
-                                    Rewards are provided when the user provides a coupon code in the eCommerce, Point of Sale or regular orders.
-                                    <br/>
-                                    Add triggers for constraints on coupon usage.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}" colspan="2">
-                                    Once a sale order is validated, the customers get Loyalty Points that can be used in the current order, or accumulated in future orders.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}" colspan="2">
-                                    Gift Cards are created and sent by email when the customer orders a product defined in your triggers.
-                                    <br/>
-                                    Then, Gift Cards can be used to pay orders.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'promotion')]}" colspan="2">
-                                    Set up triggers based on a promotional code and/or products purchased, that give access to reward on the current order.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" colspan="2">
-                                    Personal eWallet are created when the customer orders a product defined in the triggers.
-                                    <br/>
-                                    Then, eWallets are proposed during the checkout, to pay orders.
-                                </p>
-                            </div>
-                            <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="currency_id"/>
-                            <field name="currency_symbol" invisible="1"/>
-                        </group>
-                        <group>
-                            <field name="date_to"/>
-                            <label for="limit_usage"/>
-                            <span>
-                                <field name="limit_usage" class="oe_inline"/>
-                                <span attrs="{'invisible': [('limit_usage', '=', False)]}"> to <field name="max_usage" class="oe_inline"/> usages</span>
-                            </span>
-                            <label for="portal_visible" string="Show points"/>
-                            <span>
-                                <field name="portal_visible" class="oe_inline"/>
-                                <span attrs="{'invisible': [('portal_visible', '=', False)]}"> as <field name="portal_point_name" class="oe_inline"/></span>
-                            </span>
-                            <field name="applies_on" widget="radio" groups="base.group_no_one"/>
-                            <field name="trigger" widget="radio" groups="base.group_no_one" attrs="{'invisible': [('applies_on', '!=', 'current')]}"/>
-                        </group>
-                    </group>
 
-                    <notebook>
-                        <page string="Triggers &amp; Rewards" name="rules_rewards">
+                    <group col="2">
+                        <group col="1">
+                            <group col="1">
+                                <group>
+                                    <label for="program_type"/>
+                                    <div>
+                                        <field name="program_type" widget="selection" attrs="{'readonly': [('coupon_count', '!=', 0)]}"/>                                   
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'coupons')]}" colspan="2">
+                                            Generate &amp; share coupon codes manually. It can be used in eCommerce, Point of Sale or regular orders to claim the Reward. You can define constraints on its usage through conditional rule.
+                                            <div groups="base.group_no_one">
+                                                When generating coupon, you can define a specific points value that can be exchanged for rewards. 
+                                            </div>
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}" colspan="2">
+                                            When customers make an order, they accumulate points they can exchange for rewards on the current order or on a future one.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}" colspan="2">
+                                            Gift Cards are created manually or automatically sent by email when the customer orders a gift card product.
+                                            <br/>
+                                            Then, Gift Cards can be used to pay orders.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'promotion')]}" colspan="2">
+                                            Set up conditional rules on the order that will give access to rewards for customers                                            
+                                            <div groups="base.group_no_one">
+                                                Each rule can grant points to the customer he will be able to exchange against rewards
+                                            </div>
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" colspan="2">
+                                            eWallets are created manually or automatically when the customer orders a eWallet product.
+                                            <br/>
+                                            Then, eWallets are proposed during the checkout, to pay orders.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'promo_code')]}" colspan="2">
+                                            Define Discount codes on conditional rules then share it with your customers for rewards.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'buy_two_get_one')]}" colspan="2">
+                                            Grant 1 credit for each item bought then reward the customer with Y items in exchange of X credits.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'next_order_coupons')]}" colspan="2">
+                                            Drive repeat purchases by sending a unique, single-use coupon code for the next purchase when a customer buys something in your store.
+                                        </p>
+                                    </div>
+                                </group>
+
+                                <group>
+                                    <field name="currency_id"/>
+                                    <field name="currency_symbol" invisible="1"/>
+                                </group>
+
+                                <group colspan="2" col="1" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'ewallet'), ('program_type', '!=', 'gift_card')]}">
+                                    <field name="mail_template_id" widget="many2one_tags"/>
+                                    <field name="product_gift" string="Gift Card Products" widget="many2many_tags" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}"/>
+                                    <field name="product_gift" string="eWallet Products" widget="many2many_tags" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}"/>
+                                </group>
+                            </group>
+                            <group attrs="{'invisible': ['&amp;', ('program_type', '!=', 'coupons'), 
+                                                         '&amp;', ('program_type', '!=', 'promotion'), 
+                                                         '&amp;', ('program_type', '!=', 'loyalty'), 
+                                                         '&amp;', ('program_type', '!=', 'promo_code'),
+                                                         '&amp;', ('program_type', '!=', 'buy_two_get_one'),
+                                                         ('program_type', '!=', 'next_order_coupons')]}">
+                                <field name="portal_point_name" attrs="{'invisible': [('program_type', '=', 'loyalty')]}" string="Points Unit" groups="base.group_no_one"/>
+                                <field name="portal_point_name" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}" string="Points Unit"/>
+                                <field name="portal_visible" groups="base.group_no_one" string="Show points Unit"/>
+                                <field name="trigger" string="Program trigger" groups="base.group_no_one" widget="selection" readonly="1" force_save="1"/>                            
+                                <field name="applies_on" string="Use points on" groups="base.group_no_one" widget="radio" readonly="1" force_save="1"/>
+                            </group>
+                        </group>
+
+                        <group col="1">
+                            <group attrs="{'invisible': ['&amp;', ('program_type', '!=', 'gift_card'), ('program_type', '!=', 'ewallet')]}">
+                                <field name="currency_symbol" string="Displayed as" groups="base.group_no_one"/>
+                            </group>
+                            <group attrs="{'invisible': ['&amp;', ('program_type', '!=', 'coupons'), 
+                                                         '&amp;', ('program_type', '!=', 'promotion'), 
+                                                         '&amp;', ('program_type', '!=', 'loyalty'), 
+                                                         '&amp;', ('program_type', '!=', 'promo_code'), 
+                                                         '&amp;', ('program_type', '!=', 'buy_two_get_one'),
+                                                         ('program_type', '!=', 'next_order_coupons')]}">
+                                <field name="date_to"/>
+                                <label for="limit_usage"/>
+                                <span>
+                                    <field name="limit_usage" class="oe_inline"/>
+                                    <span attrs="{'invisible': [('limit_usage', '=', False)]}"> to <field name="max_usage" class="oe_inline"/> usages</span>
+                                </span>
+                            </group>
+                            <group>
+                                <field name="company_id" groups="base.group_multi_company"/>
+                            </group>
+                        </group>  
+                    </group>
+                    
+                    <notebook attrs="{ 'invisible': ['|',('program_type', '=', 'gift_card'),('program_type', '=', 'ewallet')]}">
+                        <page string="Rules &amp; Rewards" name="rules_rewards">
                             <group>
                                 <group>
-                                    <field name="rule_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a trigger"
+                                    <field name="rule_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a rule"
                                         class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol}"/>
                                 </group>
                                 <group>
                                     <field name="reward_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a reward"
-                                        class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol}"/>
+                                      class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol}"/>
                                 </group>
                             </group>
                         </page>
@@ -116,7 +160,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="program_type"/>
-                <field name="active"/>
+                <field name="concatenate_count"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -141,7 +185,7 @@
         <field name="help" type="html">
             <div class="o_loyalty_not_found container">
                 <h1>No loyalty program found.</h1>
-                <p class="lead fw-light">Create a new one from scratch, or use one of the templates below.</p>
+                <p class="lead">Create a new one from scratch, or use one of the templates below.</p>
             </div>
         </field>
     </record>

--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -5,51 +5,80 @@
         <field name="model">loyalty.reward</field>
         <field name="arch" type="xml">
             <form>
+                <field name="program_type" invisible="1"/>
                 <sheet>
-                    <group>
-                        <group>
-                            <field name="reward_type" widget="radio"/>
+                    <group col="2">
+                        <group string="Reward" id="reward_type_group" col="1">
+                            <group>
+                                <field name="reward_type" widget="selection" attrs="{'readonly' : [('program_type', '=', 'buy_two_get_one')]}"/>
+                            </group>
+                            
+                            <group attrs="{'invisible': [('reward_type', '!=', 'discount')]}">
+                                <label for="discount"/>
+                                <div class="o_row">
+                                    <field name="discount" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
+                                    <field name="discount_mode" class="oe_edit_only col-4 oe_inline pe-2"/>
+                                    <field name="discount" class="oe_read_only"/>
+                                    <field name="discount_mode" class="oe_read_only"/>
+                                    <span>on</span>
+                                </div>
+                                <field name="multi_product" invisible="1"/>
+                                <label for="discount_applicability" string=""/>
+                                <field name="discount_applicability" nolabel="1" widget="radio"/>
+                                <field name="clear_wallet" invisible="1"/>
+                            </group>
                         </group>
-                        <group id="discount_group" attrs="{'invisible': [('reward_type', '!=', 'discount')]}">
-                            <label for="discount"/>
+
+                        <group string="Among" attrs="{'invisible': [('reward_type', '!=', 'product')]}">
+                            <field name="reward_product_qty" string="Quantity rewarded"/>
+                            <field name="reward_product_id"/>
+                            <field name="reward_product_tag_id"/>
+                        </group>
+
+                        <group string="Discount" col="1" attrs="{'invisible': [('reward_type', '!=', 'discount')]}">
+                            <group>
+                                <field name="discount_max_amount"/>
+                            </group>                            
+                            <group attrs="{'invisible': [('discount_applicability', '!=', 'specific')]}">
+                                <field name="all_discount_product_ids" invisible="1"/>
+                                <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}"/>
+                                <field name="discount_product_ids" widget="many2many_tags"/>
+                                <field name="discount_product_category_id"/>
+                                <field name="discount_product_tag_id"/>
+                            </group>
+                        </group>
+
+                        <group string="Points" colspan="2" col="1" groups="base.group_no_one" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'coupons'), '&amp;', ('program_type', '!=', 'promotion'), '&amp;', ('program_type', '!=', 'promo_code'), ('program_type', '!=', 'next_order_coupons')]}">
                             <div class="o_row">
-                                <field name="discount" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
-                                <field name="discount_mode" class="oe_edit_only col-4 oe_inline pe-2"/>
-                                <field name="discount" class="oe_read_only"/>
-                                <field name="discount_mode" class="oe_read_only"/>
-                                <span>on</span>
+                                <span>In exchange of</span>
+                                <field name="required_points" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
+                                <field name="required_points" class="oe_read_only"/>                                    
+                                <field name="point_name" no_label="1"/>
+                                <span attrs="{'invisible': [('clear_wallet', '!=', True)]}"> (or more)</span>
                             </div>
-                            <!-- Align right -->
-                            <field name="all_discount_product_ids" invisible="1"/>
-                            <label for="discount_applicability" string=""/>
-                            <field name="discount_applicability" nolabel="1" widget="radio"/>
-                            <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}"/>
-                            <field name="discount_product_ids" widget="many2many_tags"
-                                attrs="{'invisible': [('discount_applicability', '!=', 'specific')]}"/>
-                            <field name="discount_product_category_id" attrs="{'invisible': [('discount_applicability', '!=', 'specific')]}"/>
-                            <field name="discount_product_tag_id" attrs="{'invisible': [('discount_applicability', '!=', 'specific')]}"/>
-                            <field name="discount_max_amount"/>
+                            <div class="o_row">
+                                <span>Clear all promo point(s)</span>
+                                <field name="clear_wallet"/>
+                            </div>                            
                         </group>
-                        <group id="product_group" attrs="{'invisible': [('reward_type', '!=', 'product')]}">
-                            <field name="multi_product" invisible="1"/>
-                            <field name="reward_product_ids" invisible="1"/>
-                            <field name="reward_product_id" attrs="{'required': [('reward_type', '=', 'product'), ('reward_product_ids', '=', [])]}"/>
-                            <field name="reward_product_tag_id" attrs="{'required': [('reward_type', '=', 'product'), ('reward_product_ids', '=', [])]}"/>
-                            <label for="reward_product_qty"/>
-                            <div class="row m-0">
-                                <field name="reward_product_qty" class="oe_inline"/>
-                                <field name="reward_product_uom_id" class="oe_inline" attrs="{'invisible': [('multi_product', '=', True)]}"/>
+
+                        <group string="Points" colspan="2" col="1" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'loyalty'), ('program_type', '!=', 'buy_two_get_one')]}">
+                            <div class="o_row">
+                                <span>In exchange of</span>
+                                <field name="required_points" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
+                                <field name="required_points" class="oe_read_only"/>                                    
+                                <field name="point_name" no_label="1"/>
+                                <span attrs="{'invisible': [('clear_wallet', '!=', True)]}"> (or more)</span>
+                            </div>
+                            <div class="o_row" groups="base.group_no_one">
+                                <span>Clear all promo point(s)</span>
+                                <field name="clear_wallet"/>
                             </div>
                         </group>
-                        <group>
-                            <field name="required_points"/>
-                            <field name="clear_wallet"/>
-                        </group>
-                    </group>
-                    <group>
-                        <group>
-                            <field name="description"/>
-                        </group>
+
+                        <group colspan="2">
+                            <field name="description" string="Description on order"/>
+                        </group> 
                     </group>
                 </sheet>
             </form>
@@ -70,6 +99,8 @@
                 <field name="discount_mode"/>
                 <field name="discount_applicability"/>
                 <field name="discount_product_domain"/>
+                <field name="discount_product_category_id"/>
+                <field name="discount_product_tag_id"/>
                 <field name="discount_max_amount"/>
                 <field name="discount_line_product_id"/>
                 <field name="reward_product_id"/>
@@ -77,30 +108,96 @@
                 <field name="multi_product"/>
                 <field name="reward_product_qty"/>
                 <field name="reward_product_uom_id"/>
-                <field name="required_points"/>
-                <field name="point_name"/>
-                <field name="clear_wallet"/>
+                <field name="required_points" groups="base.group_no_one"/>
+                <field name="point_name" groups="base.group_no_one"/>
+                <field name="clear_wallet" groups="base.group_no_one"/>
+                <field name="program_type" invisible="1"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click_edit mx-0">
-                            <field name="description"/>
-                            <t t-if="record.reward_type.raw_value === 'discount' &amp;&amp; record.discount_applicability.raw_value === 'specific'">
-                                <t t-if="record.discount_product_domain.raw_value &amp;&amp; record.discount_product_domain.raw_value !== '[]'" groups="base.group_no_one">
-                                    <a><i class="fa fa-search fa-fw" title="Product Domain"/> <field name="discount_product_domain"/></a>
+                            <div class="o_loyalty_kanban_card_left" id="reward_info">
+                                <t t-if="record.reward_type.raw_value === 'discount'">
+
+                                    <t t-if="record.discount">
+                                        <a><field name="discount"/><field name="discount_mode"/> discount <t t-if="record.discount_max_amount.raw_value > 0">( Max <field name="discount_max_amount"/> )</t></a>
+                                    </t> 
+
+                                    <t t-if="record.discount_applicability.raw_value === 'specific'">
+                                        <br/>
+                                        <br/>
+
+                                        <span style="text-decoration: underline; font-weight: bold">Applied to:</span>
+
+                                        <t t-if="record.discount_product_ids.raw_value.length > 0">
+                                            <div class="d-flex"><i class="fa fa-cube fa-fw" title="Products"/> <field name="discount_product_ids" widget="many2many_tags" class="d-inline"/></div>
+                                        </t>
+                                        <t t-if="record.discount_product_category_id.raw_value">
+                                            <div class="d-flex"><i class="fa fa-cubes fa-fw" title="Product Categories"/> <field name="discount_product_category_id" class="d-inline"/></div>
+                                        </t>
+                                        <t t-if="record.discount_product_tag_id.raw_value">
+                                            <div class="d-flex"><i class="fa fa-tags fa-fw" title="Product Tags"/> <field name="discount_product_tag_id" class="d-inline"/></div>
+                                        </t>  
+                                        <t t-if="record.discount_product_domain.raw_value &amp;&amp; record.discount_product_domain.raw_value !== '[]'" groups="base.group_no_one">
+                                            <div class="d-flex"><i class="fa fa-search fa-fw" title="Product Domain"/> <field name="discount_product_domain" class="d-inline"/></div>
+                                        </t>
+                                    </t>
+
+                                    <t t-if="record.discount_applicability.raw_value === 'cheapest'">
+                                        on the cheapest product
+                                        <br/>
+                                    </t>
+
+                                    <t t-if="record.discount_applicability.raw_value === 'order'">
+                                        on your order
+                                        <br/>
+                                    </t>
                                 </t>
-                                <t t-if="record.discount_product_ids.raw_value.length > 0">
-                                    <div class="d-flex"><i class="fa fa-cube fa-fw" title="Products"/> <field name="discount_product_ids" widget="many2many_tags" class="d-inline"/></div>
-                                </t>
-                                <t t-if="record.discount_product_category_id.raw_value">
-                                    <a><i class="fa fa-cubes fa-fw" title="Product Categories"/> <field name="discount_product_category_id"/></a>
+
+                                <t t-if="record.reward_type.raw_value === 'product'" t-attf-style="display: -webkit-box; -webkit-box-pack: center; -webkit-box-orient: vertical;">
+
+                                    <a>Free product</a>                                    
                                     <br/>
-                                </t>
-                                <t t-if="record.discount_product_tag_id.raw_value">
-                                    <a><i class="fa fa-tags fa-fw" title="Product Tags"/> <field name="discount_product_tag_id"/></a>
                                     <br/>
+
+                                    <div>
+                                        <span style="text-decoration: underline; font-weight: bold">Among:</span>
+                                    </div>
+
+                                    
+                                    <t t-if="record.reward_product_id.raw_value">
+                                        <div class="d-flex"><i class="fa fa-cube fa-fw" title="Product Domain"/><field name="reward_product_id"/> <t t-if="record.reward_product_qty.raw_value > 1">x <field name="reward_product_qty"/></t></div>
+                                    </t>
+                                    <t t-if="record.reward_product_tag_id.raw_value">
+                                        <div class="d-flex"><i class="fa fa-tags fa-fw" title="Product Tags"/> <field name="reward_product_tag_id" class="d-inline"/></div>
+                                    </t> 
                                 </t>
-                            </t>
-                            <p class="m-0">With <field name="required_points"/> <field name="point_name"/><t t-if="record.clear_wallet.raw_value"> (or more)</t></p>
+                            </div>
+
+                            <div class="o_loyalty_kanban_card_right" groups="base.group_no_one" attrs="{'invisible': ['|', ('program_type', '=', 'loyalty'), ('program_type', '=', 'buy_two_get_one')]}">
+                                <p class="text-muted">
+                                    <span style="text-decoration: underline; font-weight: bold">In exchange of</span>
+                                    <br/>
+                                    <t t-if="record.clear_wallet.raw_value">
+                                        all <field name="point_name" class="oe_read_only"/> (if at least <field name="required_points" class="oe_read_only"/> <field name="point_name" class="oe_read_only"/>)
+                                    </t>
+                                    <t t-else="">
+                                        <field name="required_points" class="oe_read_only"/> <field name="point_name" class="oe_read_only"/>
+                                    </t>
+                                </p>
+                            </div>
+
+                            <div class="o_loyalty_kanban_card_right" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'loyalty'), ('program_type', '!=', 'buy_two_get_one')]}">
+                                <p class="text-muted">
+                                    <span style="text-decoration: underline; font-weight: bold">In exchange of</span>
+                                    <br/>
+                                    <t t-if="record.clear_wallet.raw_value">
+                                        all <field name="point_name" class="oe_read_only"/> (if at least <field name="required_points" class="oe_read_only"/> <field name="point_name" class="oe_read_only"/>)
+                                    </t>
+                                    <t t-else="">
+                                        <field name="required_points" class="oe_read_only"/> <field name="point_name" class="oe_read_only"/>
+                                    </t>
+                                </p>
+                            </div>
                         </div>
                     </t>
                 </templates>

--- a/addons/loyalty/views/loyalty_rule_views.xml
+++ b/addons/loyalty/views/loyalty_rule_views.xml
@@ -5,38 +5,66 @@
         <field name="model">loyalty.rule</field>
         <field name="arch" type="xml">
             <form class="loyalty-rule-form">
+                <field name="program_type" invisible="1"/> 
                 <sheet>
-                    <group>
-                        <group>
-                            <field name="product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}"/>
-                            <field name="product_ids" widget="many2many_tags"/>
-                            <field name="product_category_id"/>
-                            <field name="product_tag_id"/>
+                    <group col="2">
+                        <group colspan="2" attrs="{ 'invisible' : [('program_type' ,'!=', 'promo_code')]}">
+                            <field name="code" attrs="{ 'required' : [('program_type', '=', 'promo_code')]}"/>
                         </group>
-                        <group>
-                            <label for="reward_point_amount"/>
-                            <span>
-                                <field name="reward_point_amount" class="oe_inline"/>
-                                <field name="reward_point_name" class="oe_inline"/>
-                            </span>
-                            <label for="reward_point_mode" string=""/>
-                            <field name="reward_point_mode" widget="radio" nolabel="1"/>
+                        <group colspan="1" col="1" string="Conditions">
+                            <group>
+                                <field name="minimum_qty"/>
+                            </group>
+                            <group attrs="{'invisible': [('program_type', '=', 'buy_two_get_one')]}">
+                                <label for="minimum_amount"/>
+                                <div class="o_row">
+                                    <field name="minimum_amount" class="oe_inline pe-2"/>
+                                    <field name="currency_id"/>
+                                    <span>tax</span>
+                                    <field name="minimum_amount_tax_mode" class="oe_inline"/>
+                                </div>
+                            </group>
+                        </group>  
+                        <group col="1" string="Among">
+                            <group>
+                                <field name="product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}"/>
+                                <field name="product_ids" widget="many2many_tags"/>                            
+                            </group>
+                            <group>
+                                <field name="product_category_id"/>
+                                <field name="product_tag_id"/>
+                            </group> 
                         </group>
-                        <group>
-                            <field name="minimum_qty"/>
-                            <label for="minimum_amount"/>
-                            <div class="o_row">
-                                <field name="minimum_amount" class="oe_inline pe-2"/>
-                                <span>tax</span>
-                                <field name="minimum_amount_tax_mode" class="oe_inline"/>
-                            </div>
-                        </group>
-                        <group>
-                            <field name="mode" widget="radio"/>
-                            <field name="code"
-                                attrs="{'invisible': [('mode', '!=', 'with_code')],
-                                    'required': [('mode', '=', 'with_code')]}"/>
-                        </group>
+                        <group col="1" colspan="2">
+                            <group string="Point(s)" attrs="{'invisible': [('program_type', '!=', 'coupons')]}" groups="base.group_no_one">
+                                <a>Grant the amount of coupon points defined as the coupon value</a> 
+                            </group>
+                            <group string="Point(s)" attrs="{'invisible': ['&amp;' ,('program_type', '!=', 'promotion'), '&amp;', ('program_type', '!=', 'promo_code'), ('program_type', '!=', 'next_order_coupons')]}" groups="base.group_no_one">
+                                <group>
+                                    <div class="o_row">
+                                        Grant
+                                        <field name="reward_point_amount" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
+                                        <field name="reward_point_name" class="oe_edit_only col-4 oe_inline pe-2"/>
+                                        <field name="reward_point_amount" class="oe_read_only"/>
+                                        <field name="reward_point_name" class="oe_read_only"/>
+                                    </div>
+                                    <field name="reward_point_mode" widget="radio" nolabel="1"/>                                    
+                                </group>
+                            </group>                            
+                            <group string="Point(s)" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'loyalty'), ('program_type', '!=', 'buy_two_get_one')]}">
+                                <group>
+                                    <div class="o_row">
+                                        Grant
+                                        <field name="reward_point_amount" class="oe_edit_only col-2 oe_inline text-center pe-2"/>
+                                        <field name="reward_point_name" class="oe_edit_only col-4 oe_inline pe-2"/>
+                                        <field name="reward_point_amount" class="oe_read_only"/>
+                                        <field name="reward_point_name" class="oe_read_only"/>
+                                    </div>
+                                    <field name="reward_point_mode" widget="radio" nolabel="1"/>                                
+                                </group>
+                            </group>
+                        </group> 
+
                     </group>
                 </sheet>
             </form>
@@ -64,43 +92,67 @@
                 <field name="minimum_amount_tax_mode"/>
                 <field name="mode"/>
                 <field name="code"/>
+                <field name="program_type" invisible="1"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click_edit mx-0">
-                            <t t-if="record.product_domain.raw_value &amp;&amp; record.product_domain.raw_value !== '[]'" groups="base.group_no_one">
-                                <a><i class="fa fa-search fa-fw" title="Product Domain"/> <field name="product_domain"/></a>
-                            </t>
-                            <t t-if="record.product_ids.raw_value.length > 0">
-                                <div class="d-flex"><i class="fa fa-cube fa-fw" title="Products"/> <field name="product_ids" widget="many2many_tags" class="d-inline"/></div>
-                            </t>
-                            <t t-if="record.product_category_id.raw_value">
-                                <a><i class="fa fa-cubes fa-fw" title="Product Categories"/> <field name="product_category_id"/></a>
+                            <div class="o_loyalty_kanban_card_left">
+                                <t t-if="record.code.raw_value"><span>Discount code <field name="code"/></span><br/></t>
+                                <t t-if="record.minimum_qty.raw_value > 0"><span>If minimum <field name="minimum_qty"/> item(s) bought</span><br/></t>
+                                <t t-if="record.minimum_amount.raw_value > 0"><span>If minimum <field name="minimum_amount"/> spent<t t-if="record.minimum_amount_tax_mode.raw_value === 'excl'"> (tax excluded)</t></span><br/></t>
                                 <br/>
-                            </t>
-                            <t t-if="record.product_tag_id.raw_value">
-                                <a><i class="fa fa-tags fa-fw" title="Product Tags"/> <field name="product_tag_id"/></a>
-                                <br/>
-                            </t>
-                            <t t-if="record.product_ids.raw_value.length === 0 &amp;&amp; !record.product_category_id.raw_value &amp;&amp; !record.product_tag_id.raw_value">
-                                <a><i class="fa fa-cube fa-fw" title="Products"/> All Products</a>
-                                <br/>
-                            </t>
-                            <a>
-                                <t t-if="record.minimum_qty.raw_value > 1 || record.minimum_amount.raw_value">
-                                    <t t-set="qty" t-value="record.minimum_qty.raw_value"/>
-                                    <t t-set="amt" t-value="record.minimum_amount.raw_value"/>
-                                    <t t-set="tax_mode" t-value="record.minimum_amount_tax_mode.raw_value"/>
-                                    <span>If<t t-if="qty > 1"> minimum <field name="minimum_qty"/> PCE</t>
-                                        <t t-if="amt"><t t-if="qty > 1">and</t> minimum <field name="minimum_amount"/><t t-if="tax_mode === 'excl'"> (tax excluded)</t></t>
-                                    </span>
+
+                                <t t-if="record.product_ids.raw_value.length != 0 || record.product_category_id.raw_value || record.product_tag_id.raw_value">
+                                    <span style="text-decoration: underline; font-weight: bold">Among:</span>
                                     <br/>
+
+                                    <t t-if="record.product_ids.raw_value.length > 0">
+                                        <div class="d-flex"><i class="fa fa-cube fa-fw" title="Products"/> <field name="product_ids" widget="many2many_tags" class="d-inline"/></div>
+                                    </t>
+                                    <t t-if="record.product_category_id.raw_value">
+                                        <div class="d-flex"><i class="fa fa-cubes fa-fw" title="Product Categories"/> <field name="product_category_id" class="d-inline"/></div>
+                                    </t>
+                                    <t t-if="record.product_tag_id.raw_value">
+                                        <div class="d-flex"><i class="fa fa-tags fa-fw" title="Product Tags"/> <field name="product_tag_id" class="d-inline"/></div>
+                                    </t>
+                                    <t t-if="record.product_ids.raw_value.length === 0 &amp;&amp; !record.product_category_id.raw_value &amp;&amp; !record.product_tag_id.raw_value">
+                                        <div class="d-flex"><i class="fa fa-cube fa-fw" title="Products"/><span>All Products</span></div>
+                                    </t>
+                                    <t t-if="record.product_domain.raw_value &amp;&amp; record.product_domain.raw_value !== '[]'" groups="base.group_no_one">
+                                        <div class="d-flex"><i class="fa fa-search fa-fw" title="Product Domain"/> <field name="product_domain" class="d-inline"/></div>
+                                    </t>
                                 </t>
-                            </a>
-                            <t t-if="record.code.raw_value">
-                                <a><i class="fa fa-pencil-square-o fa-fw" title="Code"/>With Code: <field name="code"/></a>
-                                <br/>
-                            </t>
-                            <i class="fa fa-gift fa-fw" title="conditions"/> <span>Reward <field name="reward_point_amount"/> <field name="reward_point_name"/> <field name="reward_point_mode"/></span>
+                            </div>
+                            
+                            <div class="o_loyalty_kanban_card_right" groups="base.group_no_one" attrs="{'invisible': [('program_type', '!=', 'coupons')]}">
+                                <p class="text-muted">
+                                    <span style="text-decoration: underline; font-weight: bold">Grant</span>
+                                    <br/>
+                                    the value of the coupon
+                                </p>
+                            </div>
+                            <div class="o_loyalty_kanban_card_right" groups="base.group_no_one" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'promotion'), '&amp;', ('program_type', '!=', 'promo_code'), ('program_type', '!=', 'next_order_coupons')]}">
+                                <p class="text-muted">
+                                    <span style="text-decoration: underline; font-weight: bold">Grant</span>
+                                    <br/>
+                                    <field name="reward_point_amount" class="oe_read_only"/>
+                                    <soan> </soan>
+                                    <field name="reward_point_name" class="oe_read_only"/>
+                                    <soan> </soan>
+                                    <field name="reward_point_mode" class="oe_read_only"/>
+                                </p>
+                            </div>
+                            <div class="o_loyalty_kanban_card_right" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'loyalty'), ('program_type', '!=', 'buy_two_get_one')]}">
+                                <p class="text-muted">
+                                    <span style="text-decoration: underline; font-weight: bold">Grant</span>   
+                                    <br/>
+                                    <field name="reward_point_amount" class="oe_read_only"/>
+                                    <soan> </soan>
+                                    <field name="reward_point_name" class="oe_read_only"/>
+                                    <soan> </soan>                                    
+                                    <field name="reward_point_mode" class="oe_read_only"/>
+                                </p>
+                            </div>
                         </div>
                     </t>
                 </templates>

--- a/addons/loyalty/wizard/loyalty_generate_wizard.py
+++ b/addons/loyalty/wizard/loyalty_generate_wizard.py
@@ -25,6 +25,7 @@ class LoyaltyGenerateWizard(models.TransientModel):
         compute='_compute_coupon_qty', readonly=False, store=True)
     points_granted = fields.Float('Grant', required=True, default=1)
     points_name = fields.Char(related='program_id.portal_point_name', readonly=True)
+    currency_symbol = fields.Char(related='program_id.currency_symbol', readonly=True)
     valid_until = fields.Date()
 
     def _get_partners(self):

--- a/addons/loyalty/wizard/loyalty_generate_wizard_views.xml
+++ b/addons/loyalty/wizard/loyalty_generate_wizard_views.xml
@@ -4,26 +4,48 @@
         <field name="name">loyalty.generate.wizard.view.form</field>
         <field name="model">loyalty.generate.wizard</field>
         <field name="arch" type="xml">
-            <form string="Generate Coupons">
+            <form string="Generate">
                 <sheet>
-                    <group>
-                        <field name="program_id" invisible="1"/>
-                        <field name="program_type" invisible="1"/>
-                        <field name="mode" widget="radio" attrs="{'invisible': [('program_type', '=', 'ewallet')]}"/>
-                        <field name="customer_ids" widget="many2many_tags_avatar" attrs="{'invisible': [('mode', '=', 'anonymous')]}"/>
-                        <field name="customer_tag_ids" widget="many2many_tags" attrs="{'invisible': [('mode', '=', 'anonymous')]}" options="{'color_field': 'color'}"/>
-                        <separator/>
-                        <field name="coupon_qty" attrs="{'readonly': [('mode', '=', 'selected')], 'required': [('mode', '=', 'anonymous')]}"/>
-                        <label for="points_granted"/>
-                        <span>
-                            <field name="points_granted" class="oe_inline"/>
-                            <field name="points_name" class="oe_inline"/>
-                        </span>
-                        <field name="valid_until"/>
+                    <group col="1">
+                        <group>
+                            <field name="program_id" invisible="1"/>
+                            <field name="program_type" invisible="1"/>
+                            <field name="mode" widget="radio" attrs="{'invisible': [('program_type', '=', 'ewallet')]}"/>
+                            <field name="customer_ids" widget="many2many_tags" attrs="{'invisible': [('mode', '=', 'anonymous')]}"/>
+                            <field name="customer_tag_ids" widget="many2many_tags" attrs="{'invisible': [('mode', '=', 'anonymous')]}" options="{'color_field': 'color'}"/>
+                            <field name="coupon_qty" string="Quantity to generate" attrs="{'readonly': [('mode', '=', 'selected')], 'required': [('mode', '=', 'anonymous')]}"/>
+                        </group>
+                        <group groups="base.group_no_one" attrs="{'invisible': [('program_type', '!=', 'coupons')]}">
+                            <label string="Coupon value" for="points_granted"/>
+                            <span>
+                                <field name="points_granted" class="oe_inline"/>
+                                <field name="points_name" class="oe_inline"/>
+                            </span>
+                        </group>
+                        <group attrs="{'invisible': [('program_type', '!=', 'gift_card')]}">
+                            <label string="Gift Card value" for="points_granted"/>
+                            <span>
+                                <field name="points_granted" class="oe_inline"/>
+                                <field name="currency_symbol" class="oe_inline"/>
+                            </span>
+                        </group>
+                        <group attrs="{'invisible': [('program_type', '!=', 'ewallet')]}">
+                            <label string="eWallet value" for="points_granted"/>
+                            <span>
+                                <field name="points_granted" class="oe_inline"/>
+                                <field name="currency_symbol" class="oe_inline"/>
+                            </span>
+                        </group>
+                        <group>
+                            <field name="valid_until"/>
+                        </group>
                     </group>
                 </sheet>
                 <footer>
-                    <button name="generate_coupons" type="object" string="Generate Coupons" class="btn-primary" data-hotkey="q"/>
+                    <button name="generate_coupons" type="object" class="btn-primary" data-hotkey="q">
+                        <span>Generate </span>
+                        <field name="program_type" nolabel="1"/>
+                    </button>
                     <button special="cancel" data-hotkey="z" string="Cancel"/>
                 </footer>
             </form>
@@ -31,7 +53,7 @@
     </record>
 
     <record id="loyalty_generate_wizard_action" model="ir.actions.act_window">
-        <field name="name">Generate Coupons</field>
+        <field name="name">Generate</field>
         <field name="res_model">loyalty.generate.wizard</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>

--- a/addons/loyalty_delivery/views/loyalty_reward_views.xml
+++ b/addons/loyalty_delivery/views/loyalty_reward_views.xml
@@ -5,10 +5,28 @@
         <field name="model">loyalty.reward</field>
         <field name="inherit_id" ref="loyalty.loyalty_reward_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@id='product_group']" position="after">
-                <group id="shipping" attrs="{'invisible': [('reward_type', '!=', 'shipping')]}">
+            <xpath expr="//group[@id='reward_type_group']" position="after">
+                <group string="Free shipping" attrs="{'invisible': [('reward_type', '!=', 'shipping')]}">
                     <field name="discount_max_amount"/>
                 </group>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="loyalty_reward_view_kanban_inherit_loyalty_delivery" model="ir.ui.view">
+        <field name="name">loyalty.reward.view.kanban.inherit.loyalty.delivery</field>
+        <field name="model">loyalty.reward</field>
+        <field name="inherit_id" ref="loyalty.loyalty_reward_view_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='reward_info']" position="inside">
+                <t t-if="record.reward_type.raw_value === 'shipping'" t-attf-style="display: -webkit-box; -webkit-box-pack: center; -webkit-box-orient: vertical;">
+                    
+                    <a>Free shipping <t t-if="record.discount_max_amount.raw_value > 0">( Max <field name="discount_max_amount"/> )</t></a>
+                    <br/><br/>
+
+                    <div class="o_kanban_record_title">Applied to:<br/></div>
+                    <a>Order</a>    
+                </t>                    
             </xpath>
         </field>
     </record>

--- a/addons/pos_loyalty/data/pos_loyalty_demo.xml
+++ b/addons/pos_loyalty/data/pos_loyalty_demo.xml
@@ -4,9 +4,11 @@
         <!-- 15% next order -->
         <record id="15_pc_on_next_order" model="loyalty.program">
             <field name="name">15% on next order</field>
-            <field name="program_type">promotion</field>
+            <field name="program_type">next_order_coupons</field>
             <field name="trigger">auto</field>
             <field name="applies_on">future</field>
+            <field name="portal_visible">True</field>
+            <field name="portal_point_name">Coupon point(s)</field>
         </record>
 
         <record id="15_pc_on_next_order_rule" model="loyalty.rule">
@@ -62,8 +64,10 @@
     <record id="loyalty_program" model="loyalty.program">
         <field name="name">Loyalty Program</field>
         <field name="program_type">loyalty</field>
-        <field name="trigger">auto</field>
         <field name="applies_on">both</field>
+        <field name="trigger">auto</field>
+        <field name="portal_visible">True</field>
+        <field name="portal_point_name">Loyalty Points</field>
     </record>
 
     <record id="loyalty_program_rule" model="loyalty.rule">

--- a/addons/website_sale_loyalty/models/loyalty_card.py
+++ b/addons/website_sale_loyalty/models/loyalty_card.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import fields, models
 
 class LoyaltyCard(models.Model):
     _inherit = 'loyalty.card'
+
+    website_id = fields.Many2one('website', 'Website')
 
     def action_coupon_share(self):
         self.ensure_one()

--- a/addons/website_sale_loyalty/views/loyalty_program_views.xml
+++ b/addons/website_sale_loyalty/views/loyalty_program_views.xml
@@ -14,9 +14,9 @@
         <field name="model">loyalty.program</field>
         <field name="inherit_id" ref="loyalty.loyalty_program_view_form"/>
         <field name="arch" type="xml">
-            <field name="currency_id" position="after">
+            <field name="company_id" position="after">
                 <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
-            </field>
+            </field>            
         </field>
     </record>
 
@@ -25,9 +25,10 @@
         <field name="model">loyalty.program</field>
         <field name="inherit_id" ref="loyalty.loyalty_program_view_tree"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <field name="company_id" position="after">
                 <field name="website_id" groups="website.group_multi_website"/>
-                <button name="action_program_share" string="Share" type="object" icon="fa-share-alt"/>
+                <button name="action_program_share" string="Share" type="object" icon="fa-share-alt" 
+                    attrs="{'invisible': [('program_type', '!=', 'promo_code')]}"/>
             </field>
         </field>
     </record>

--- a/addons/website_sale_loyalty/wizard/sale_coupon_share.py
+++ b/addons/website_sale_loyalty/wizard/sale_coupon_share.py
@@ -68,7 +68,7 @@ class SaleCouponShare(models.TransientModel):
 
     def action_generate_short_link(self):
         return {
-            'name': _('Share Coupon'),
+            'name': _('Share'),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'coupon.share',
@@ -85,7 +85,7 @@ class SaleCouponShare(models.TransientModel):
             raise UserError(_("Provide either a coupon or a program."))
 
         return {
-            'name': _('Share Coupon'),
+            'name': _('Share') + ' %s' % (program and dict(program._fields['program_type'].selection).get(program.program_type) or 'Coupon'),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'coupon.share',

--- a/addons/website_sale_loyalty/wizard/sale_coupon_share_views.xml
+++ b/addons/website_sale_loyalty/wizard/sale_coupon_share_views.xml
@@ -14,13 +14,13 @@
                             It will be applied at checkout when the customer uses this link.
                         </p>
                     </div>
-                    <field name="share_link" widget="CopyClipboardURL" nolabel="1"/>
                 </group>
                 <hr attrs="{'invisible': ['|', ('website_id', '=', False), ('id', '!=', False)]}"/>
-                <group attrs="{'invisible': [('id', '!=', False)]}">
+                <group>
                     <field name="website_id" groups="website.group_multi_website" widget="selection"
-                           attrs="{'invisible': [('program_website_id', '!=', False)]}"/>
+                        attrs="{'invisible': [('program_website_id', '!=', False)]}"/>
                     <field name="redirect"/>
+                    <field name="share_link" widget="CopyClipboardURL"/>
                 </group>
                 <footer>
                     <button string="Done" class="btn-primary" special="cancel" data-hotkey="z"/>


### PR DESCRIPTION
task-2855656

Description of the issue/feature this PR addresses: Improvements for the coupon view (meaningless properties hidden, confusing properties renamed, check properties which should not be editable)

Current behavior before PR: 

Desired behavior after PR is merged: less confusing presentation (points name hidden, coupon trigger not editable, clearer presentation of conditional rules and rewards, adding static information, already used coupon not editable)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
