### PR TITLE
[REF] mrp_subcontracting: update move list view to owl

### DIFF
--- a/addons/mrp_subcontracting/static/src/subcontracting_portal/move_list_view.js
+++ b/addons/mrp_subcontracting/static/src/subcontracting_portal/move_list_view.js
@@ -1,12 +1,11 @@
-/** @odoo-module**/
+/** @odoo-module **/
 
-import ListView from 'web.ListView';
-import viewRegistry from 'web.view_registry';
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
 
-const MoveListView = ListView.extend({
+const MoveListView = {
+    ...listView,
     searchMenuTypes: [],
-});
+};
 
-viewRegistry.add('subcontracting_portal_move_list_view', MoveListView);
-
-export default MoveListView;
+registry.category("views").add('subcontracting_portal_move_list_view', MoveListView);


### PR DESCRIPTION
It now uses the new owl code, instead of the legacy list view, which
will be removed in the future.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
