### PR TITLE
[FIX] stock: count request sets the wrong user

### DIFF
--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -18,10 +18,10 @@ class StockRequestCount(models.TransientModel):
 
     def action_request_count(self):
         for count_request in self:
-            count_request.quant_ids.with_context(inventory_mode=True).write(
-                count_request._get_values_to_write())
             if count_request.set_count == 'set':
                 count_request.quant_ids.filtered(lambda q: not q.inventory_quantity_set).action_set_inventory_quantity()
+            count_request.quant_ids.with_context(inventory_mode=True).write(
+                count_request._get_values_to_write())
 
     def _get_values_to_write(self):
         values = {


### PR DESCRIPTION
Steps to reproduce:
- go to Inventory > Operations > Inventory Adjustments
- Select at least one product
- Click on Request a count; A dialog box containing a form should appear
- Select a user other than the current user
- Make sure to check "Set Current Value"
- Click "Confirm"

You should see that the user you selected is not the one assigned for the count. Instead, the count is assigned to the current user.

This is happening because currently, calling `action_set_inventory_quantity` also sets the user as the current one if the quantity is not already set.

opw-2924694