### PR TITLE
[FIX] web: record (quick-)created in grouped kanban are on top

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -2518,7 +2518,7 @@ export class Group extends DataPoint {
         }
         const saved = await record.save();
         if (saved) {
-            this.addRecord(this.removeRecord(record));
+            this.addRecord(this.removeRecord(record), 0);
             this.count++;
             this.list.count++;
             return record;

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -1223,6 +1223,46 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".thisisdeletable", 4, "records should be deletable");
     });
 
+    QUnit.test("quick created records in grouped kanban are on displayed top", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban on_create="quick_create">
+                    <field name="product_id"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="display_name"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["product_id"],
+        });
+
+        assert.containsN(target, ".o_kanban_group", 2);
+        assert.containsN(target.querySelector(".o_kanban_group"), ".o_kanban_record", 2);
+
+        await createRecord();
+        assert.containsN(target.querySelector(".o_kanban_group"), ".o_kanban_record", 2);
+        assert.containsOnce(target.querySelector(".o_kanban_group"), ".o_kanban_quick_create");
+
+        await editInput(target, ".o_field_widget[name=display_name] input", "new record");
+        await click(target, ".o_kanban_add");
+        assert.containsN(target.querySelector(".o_kanban_group"), ".o_kanban_record", 3);
+        assert.containsOnce(target.querySelector(".o_kanban_group"), ".o_kanban_quick_create");
+        // the new record must be the first record of the column
+        assert.strictEqual(target.querySelector(".o_kanban_record").innerText, "new record");
+
+        await editInput(target, ".o_field_widget[name=display_name] input", "another record");
+        await click(target, ".o_kanban_add");
+        assert.containsN(target.querySelector(".o_kanban_group"), ".o_kanban_record", 4);
+        assert.containsOnce(target.querySelector(".o_kanban_group"), ".o_kanban_quick_create");
+        // the new record must be the first record of the column
+        assert.strictEqual(target.querySelector(".o_kanban_record").innerText, "another record");
+        assert.strictEqual(target.querySelectorAll(".o_kanban_record")[1].innerText, "new record");
+    });
+
     QUnit.test("quick create record without quick_create_view", async (assert) => {
         assert.expect(16);
 
@@ -1829,7 +1869,7 @@ QUnit.module("Views", (hooks) => {
             });
 
             assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 5);
-            assert.deepEqual(getCardTexts(0), ["blip", "new partner"]);
+            assert.deepEqual(getCardTexts(0), ["new partner", "blip"]);
         }
     );
 
@@ -7323,7 +7363,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 2);
         assert.deepEqual(
             getCardTexts(),
-            ["record1", "record2"],
+            ["record2", "record1"],
             "records should be correctly ordered"
         );
 
@@ -7332,7 +7372,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 2);
         assert.deepEqual(
             getCardTexts(),
-            ["record2", "record1"],
+            ["record1", "record2"],
             "records should be correctly ordered"
         );
 
@@ -7341,7 +7381,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 2);
         assert.deepEqual(
             getCardTexts(),
-            ["record1", "record2"],
+            ["record2", "record1"],
             "records should be correctly ordered"
         );
         assert.verifySteps(["resequence", "resequence"], "should have resequenced twice");
@@ -9661,7 +9701,7 @@ QUnit.module("Views", (hooks) => {
         def.resolve();
         await nextTick();
 
-        assert.deepEqual(getCardTexts(0), ["0", "1", "0"]);
+        assert.deepEqual(getCardTexts(0), ["0", "0", "1"]);
         assert.verifySteps(["name_create", "read"]);
     });
 


### PR DESCRIPTION
Before this commit, the records created in grouped kanban view via
the quick create feature were displayed in the bottom of the column
where they had been created. They should be on top. This commit
fixes that issue. Note that this only concerns the state of the
kanban view before the next reload, as from that moment onwards,
the default order on the model is used.

Issue introduced by the conversion of the kanban view to owl.
