### PR TITLE
[FIX] account: fix test_01_account_tour

### DIFF
--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -21,6 +21,19 @@ class TestUi(odoo.tests.HttpCase):
         account_with_taxes.write({
             'tax_ids': [Command.clear()],
         })
+        # Since the company's country might have changed with COA installation,
+        # must create a new Jounal with a lower sequence since journals linked
+        # to the company might not be compatible anymore.
+        user_type = self.env.ref('account.data_account_type_current_assets')
+        account = self.env['account.account'].create({'name': 'test', 'code': 'test', 'user_type_id': user_type.id})
+        self.env['account.journal'].create({
+            'sequence': 0,
+            'name': 'test_out_invoice_journal',
+            'code': 'XXXXX',
+            'type': 'sale',
+            'default_account_id': account.id,
+            'company_id':  self.env.company.id,
+        })
         # This tour doesn't work with demo data on runbot
         all_moves = self.env['account.move'].search([('move_type', '!=', 'entry')])
         all_moves.button_draft()


### PR DESCRIPTION
Steps to reproduce:

  - Install l10n_ar or l10n_cl module
  - Run the test_01_account_tour test

Issue:

  Fields `Document Type` and `Document Number` are required, while they
  should not.

Cause:

  Both fields are required if l10n_latam_use_documents is set to `True`
  Before running the test, we remove the country on the env.company.
  However, since l10n_latam_use_documents does not depend on country_id
  fields, is l10n_latam_use_documents not updated and therefore still
  `True` (while it should not).

Solution:

  Don't change country of company.
  Before running the test, create a sale journal with a lower sequence
  so it will took first and since it's a new journal, the value
  of l10n_latam_use_documents will be `False` by default.

opw-2899680