### PR TITLE
[FIX] purchase_stock: update price_unit from purch line to stock move

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -333,6 +333,10 @@ class PurchaseOrderLine(models.Model):
         lines = self.filtered(lambda l: l.order_id.state == 'purchase')
         previous_product_qty = {line.id: line.product_uom_qty for line in lines}
         result = super(PurchaseOrderLine, self).write(values)
+        if 'price_unit' in values:
+            for line in lines:
+                moves = line.move_ids.filtered(lambda s: s.state not in ('cancel', 'done'))
+                moves.write({'price_unit': line._get_stock_move_price_unit()})
         if 'product_qty' in values:
             lines.with_context(previous_product_qty=previous_product_qty)._create_or_update_picking()
         return result

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -41,6 +41,19 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
                 })],
         }
 
+    def test_update_price_unit(self):
+        self.po_vals["order_line"] = [self.po_vals["order_line"][0]]
+        # we only need one purchase line for this test
+        po = self.env['purchase.order'].create(self.po_vals)
+        pol = po.order_line[0]
+        po.button_confirm()
+        self.assertEqual(len(pol.move_ids), 1)
+        self.assertEqual(pol.move_ids[0].price_unit, 500)
+        pol.price_unit = 1
+        self.assertEqual(pol.price_unit, 1)
+        # line below shouldn't fail
+        self.assertEqual(pol.move_ids[0].price_unit, 1)
+
     def test_00_purchase_order_flow(self):
         # Ensure product_id_2 doesn't have res_partner_1 as supplier
         if self.partner_a in self.product_id_2.seller_ids.mapped('name'):

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -87,8 +87,8 @@ class TestStockValuation(TransactionCase):
         # update the unit price on the purchase order line
         po1.order_line.price_unit = 200
 
-        # the unit price on the stock move is not directly updated
-        self.assertEqual(move1.price_unit, 100)
+        # the unit price on the stock move is updated
+        self.assertEqual(move1.price_unit, 200)
 
         # validate the receipt
         res_dict = picking1.button_validate()


### PR DESCRIPTION
## Description of the issue this PR addresses:

purchase price_unit updates should be propagated on stock.move



## Current behavior before PR:
When a price_unit is updated on confirmed purchase.order, this price is not propagated on related stock.move

## Desired behavior after PR is merged:
purchase price_unit is propagated on not done/cancel stock.move




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
