### PR TITLE
[REF] web: domain: use shallowEqual to compare arrays

### DIFF
--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -206,7 +206,7 @@ function matchCondition(record, condition) {
             return fieldValue === value;
         case "!=":
         case "<>":
-            return JSON.stringify(fieldValue) !== JSON.stringify(value);
+            return !matchCondition(record, [field, "==", value]);
         case "<":
             return fieldValue < value;
         case "<=":


### PR DESCRIPTION
This commit refactors the way we handle the "<>" case in domain
evaluation, for the sake of consistency with the "==" case. Indeed,
we tried to avoid using JSON.stringify as it could have an unwanted
behavior (e.g. it could crash, or it could have been overridden on
the value we manipulate).
