### PR TITLE
[IMP] hr_expense: add can_be_expensed field in product view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -489,6 +489,20 @@
             <field name="act_window_id" ref="hr_expense_actions_my_all"/>
         </record>
 
+        <record id="view_product_hr_expense_form" model="ir.ui.view">
+            <field name="name">product.template.expense.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <div name="options" position="inside">
+                    <span class="d-inline-block">
+                        <field name="can_be_expensed"/>
+                        <label for="can_be_expensed"/>
+                    </span>
+                </div>
+            </field>
+        </record>
+
         <record id="product_template_search_view_inherit_hr_expense" model="ir.ui.view">
             <field name="name">product.template.search.view.inherit.hr_expense</field>
             <field name="model">product.template</field>


### PR DESCRIPTION
Purpose: Allow users to make product 'expense available'
(or the opposite, unset them as expense products) by making the
field 'can_be_Expensed' available in the base product view.

task - 2909067