### PR TITLE
[FIX] website: avoid double-escape of pages search results

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -365,6 +365,9 @@ class WebsiteSearchableMixin(models.AbstractModel):
             for result, data in zip(self, results_data):
                 for html_field in html_fields:
                     if data[html_field]:
+                        if html_field == 'arch':
+                            # Undo second escape of text nodes from wywsiwyg.js _getEscapedElement.
+                            data[html_field] = re.sub(r'&amp;(?=\w+;)', '&', data[html_field])
                         text = text_from_html(data[html_field])
                         text = re.sub('\\s+', ' ', text).strip()
                         data[html_field] = text


### PR DESCRIPTION
Since [1] when the search bar was refactored, a search facility was
added on website pages and the rendering of those search results did
not correctly handle some of the HTML escaping.

This is related to the fact that the `ir_ui_view`'s `arch_db` field is
stored with this double escaping on text nodes, which is done by
`wysiwyg.js` through the `_getEscapedElement` method since [2].

This commit unescapes the last layer of `&amp;` before extracting the
page's text for generating the search results.

Steps to reproduce:
- Add some "&", "<" or ">" characters in a page.
- Use the search snippet to lookup for the page.
=> The results in both autocomplete and the results pages display the
content with an extra unwanted escaping (&amp;...)

[1]: https://github.com/odoo/odoo/commit/9f9c4bb7e40233e633f97c60fb00ae191e9077af
[2]: https://github.com/odoo/odoo/commit/f5acea7f9ce232773ec3adf1828a3d18bbedee1e

opw-2908645

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
