### PR TITLE
[FIX] web: correctly add o_xxl_formview class

### DIFF
--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -139,7 +139,11 @@ export const uiService = {
 
         // listen to media query status changes
         const updateSize = () => {
+            const prevSize = ui.size;
             ui.size = this.getSize();
+            if (ui.size !== prevSize) {
+                bus.trigger("resize");
+            }
         };
         browser.addEventListener("resize", debounce(updateSize, 100));
 

--- a/addons/web/static/src/legacy/scss/secondary_variables.scss
+++ b/addons/web/static/src/legacy/scss/secondary_variables.scss
@@ -27,6 +27,12 @@ $o-statusbar-disabled-bg: lighten($o-brand-lightsecondary, 7%) !default;
 
 $o-datepicker-week-bg-color: lighten($o-datepicker-week-color, 30%) !default;
 
+// Form
+
+// Safest for the next value would be map-get($container-max-widths, lg) as it
+// is the minimal width of the default form view design for md/lg sizes
+$o-form-sheet-min-width: 990px !default;
+
 // Kanban
 
 $o-kanban-record-margin: $o-horizontal-padding / 2 !default;

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -5,7 +5,7 @@ import { makeContext } from "@web/core/context";
 import { useDebugCategory } from "@web/core/debug/debug_context";
 import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
-import { useService } from "@web/core/utils/hooks";
+import { useService, useBus } from "@web/core/utils/hooks";
 import { createElement } from "@web/core/utils/xml";
 import { ActionMenus } from "@web/search/action_menus/action_menus";
 import { Layout } from "@web/search/layout";
@@ -15,6 +15,7 @@ import { standardViewProps } from "@web/views/standard_view_props";
 import { useSetupView } from "@web/views/view_hook";
 import { isX2Many } from "@web/views/utils";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
+import { SIZES } from "@web/core/ui/ui_service";
 
 const { Component, onWillStart, useEffect, useRef, onRendered, useState, toRaw } = owl;
 
@@ -93,6 +94,8 @@ export class FormController extends Component {
         this.router = useService("router");
         this.user = useService("user");
         this.viewService = useService("view");
+        this.ui = useService("ui");
+        useBus(this.ui.bus, "resize", this.render);
 
         this.archInfo = this.props.archInfo;
         const activeFields = this.archInfo.activeFields;
@@ -416,9 +419,16 @@ export class FormController extends Component {
     }
 
     get className() {
+        const { size } = this.ui;
+        let sizeClass = "";
+        if (size <= SIZES.XS) {
+            sizeClass = "o_xxs_form_view";
+        } else if (size === SIZES.XXL) {
+            sizeClass = "o_xxl_form_view";
+        }
         return {
             [this.props.className]: true,
-            o_xxs_form_view: this.env.isSmall,
+            [sizeClass]: true,
         };
     }
 }

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1010,6 +1010,31 @@ $o-form-label-margin-right: 0px;
         }
     }
 }
+
+.o_xxl_form_view {
+    flex-flow: row nowrap;
+    height: 100%;
+
+    .o_form_sheet_bg {
+        flex: 1 1 auto; // Side chatter is disabled if this has to shrink but this was added for safety
+        width: $o-form-sheet-min-width + 2 * $o-horizontal-padding;
+        // max-width: map-get($container-max-widths, xl) + 2 * $o-horizontal-padding; // would be logical but breaks no-chatter form views
+        padding: 0 $o-horizontal-padding;
+        overflow: auto;
+        border-bottom: none;
+
+        > .o_form_statusbar, > .alert {
+            margin-left: -$o-horizontal-padding;
+            margin-right: -$o-horizontal-padding;
+        }
+
+        > .o_form_sheet {
+            width: 100%;
+            max-width: map-get($container-max-widths, xl);
+        }
+    }
+}
+
 .o_form_view.o_xxs_form_view {
     .oe_title {
         word-break: break-all;

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -255,7 +255,7 @@ export class ListRenderer extends Component {
     computeColumnWidthsFromContent() {
         const table = this.tableRef.el;
 
-        // Toggle a className used to remove style that could interfer with the ideal width
+        // Toggle a className used to remove style that could interfere with the ideal width
         // computation algorithm (e.g. prevent text fields from being wrapped during the
         // computation, to prevent them from being completely crushed)
         table.classList.add("o_list_computing_widths");
@@ -735,7 +735,7 @@ export class ListRenderer extends Component {
 
     getOptionalActiveFields() {
         this.optionalActiveFields = {};
-        let optionalActiveFields = browser.localStorage.getItem(this.keyOptionalFields);
+        const optionalActiveFields = browser.localStorage.getItem(this.keyOptionalFields);
         if (optionalActiveFields) {
             this.allColumns.forEach((col) => {
                 this.optionalActiveFields[col.name] = optionalActiveFields.includes(col.name);

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -15,6 +15,8 @@ import {
 } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
+const { EventBus } = owl;
+
 let serverData;
 let target;
 
@@ -175,6 +177,7 @@ QUnit.module("Fields", (hooks) => {
                         value: true,
                     });
                     return {
+                        bus: new EventBus(),
                         size: 0,
                         isSmall: true,
                     };


### PR DESCRIPTION
With the conversion of views to the new webclient, the o_xxl_formview
class was no longer applied as expected, which broke the layout and the
width calculation in embedded list views (as the chatter would take up
more space than intended during the width computation). This commit
fixes that by adding the class when needed.