### PR TITLE
[FIX] l10n_in: studio: Unable to edit the GST Treatment field

### DIFF
--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -3,7 +3,7 @@
     <record id="l10n_in_view_partner_form" model="ir.ui.view">
         <field name="name">l10n.in.res.partner.vat.inherit</field>
         <field name="model">res.partner</field>
-        <field name="priority" eval="100"/>
+        <field name="priority" eval="90"/>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="attributes">


### PR DESCRIPTION
Steps to reproduce:

  - Install Studio, Contacts, l10n_in
  - Go to Contacts, open studio on the form view
  - Edit the GST Treatment field name
  -> No changes are made

Cause of the issue:

  When combinings views to generate the final arch, extensions are
  ordered by priority. Studio edits have a priority of 99 but in this
  case, there is an override with a priority of 100.

opw-2899654