### PR TITLE
[FIX] hr_timesheet: fixed domain for project and employee

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -21,7 +21,7 @@ class AccountAnalyticLine(models.Model):
         return result
 
     def _domain_project_id(self):
-        domain = [('allow_timesheets', '=', True)]
+        domain = [('allow_timesheets', '=', True), ('company_id', '=', self.env.company.id)]
         if not self.user_has_groups('hr_timesheet.group_timesheet_manager'):
             return expression.AND([domain,
                 ['|', ('privacy_visibility', '!=', 'followers'), ('allowed_internal_user_ids', 'in', self.env.user.ids)]
@@ -29,9 +29,12 @@ class AccountAnalyticLine(models.Model):
         return domain
 
     def _domain_employee_id(self):
+        domain = [('company_id', '=', self.env.company.id)]
         if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
-            return [('user_id', '=', self.env.user.id)]
-        return []
+            return expression.AND([domain,
+                [('user_id', '=', self.env.user.id)]
+            ])
+        return domain
 
     def _domain_task_id(self):
         if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):


### PR DESCRIPTION
earlier in multiple company it is given employee and
project of all company

now it is giving project and employee of environmnet
company only

Task_id : 2925187

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
