### PR TITLE
[FIX] web: Kanban small column & quick create column width

### DIFF
--- a/addons/web/static/src/legacy/scss/kanban_view.scss
+++ b/addons/web/static/src/legacy/scss/kanban_view.scss
@@ -440,7 +440,7 @@
         }
 
         &.o_kanban_small_column .o_kanban_group:not(.o_column_folded) {
-            width: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
+            flex-basis: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
         }
     }
 
@@ -538,7 +538,7 @@
 
     // Kanban Grouped Layout - "Create new column" column
     .o_column_quick_create {
-        flex-basis: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
+        flex: 0 0 $o-kanban-small-record-width + 2*$o-kanban-group-padding;
 
         .o_quick_create_folded {
             cursor: pointer;

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -448,7 +448,7 @@
         }
 
         &.o_kanban_small_column .o_kanban_group:not(.o_column_folded) {
-            width: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
+            flex-basis: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
         }
     }
 
@@ -538,7 +538,7 @@
 
     // Kanban Grouped Layout - "Create new column" column
     .o_column_quick_create {
-        flex-basis: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
+        flex: 0 0 $o-kanban-small-record-width + 2*$o-kanban-group-padding;
 
         .o_quick_create_folded {
             cursor: pointer;


### PR DESCRIPTION
Since odoo/odoo@2dd37982e61964f0d922892011af192c903623b4 , Kanban
column's width is flex based. But sadly two types of columns were not
adapted properly:
- Kanban small column didn't reduce the column width
- Quick create kanban column shrinked too much

This commit fixes both these issues by properly setting the flex-basis
size for one and disabling shrinking for the other.