### PR TITLE
[FIX] web: fix file downloading button in firefox

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1360,7 +1360,7 @@
         <div class="o_attachment_wrap">
             <t t-set="ext" t-value="file.name.replace(/^.*\./, '')"/>
             <div class="o_image_box float-left" t-att-data-id="file.id">
-                <a t-att-href="url" t-att-title="'Download ' + file.name" aria-label="Download">
+                <a target="_blank" t-att-href="url" t-att-title="'Download ' + file.name" aria-label="Download">
                     <span class="o_image o_hover" t-att-data-mimetype="mimetype" t-att-data-ext="ext" role="img"/>
                 </a>
             </div>


### PR DESCRIPTION
Mail composer may have attachment to preview (e.g. open PO/SO form and click
"send by email"). The attachment has url `/web/content/123456?download=true`,
which returns following header: `Content-Disposition: attachment;
filename*=UTF-8''PO_P12345.pdf`.

Somehow, firefox doesn't process such links. In Odoo v15 (but not v14), user
is navigated to new tab, while original tab shows loading screen.

Adding target="_blank" fixes the issue.

opw-2922947
opw-2907679

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
