### PR TITLE
[IMP] delivery: set weight for shipping rate

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -104,7 +104,11 @@ class ProviderGrid(models.Model):
         total = (order.amount_total or 0.0) - total_delivery
 
         total = self._compute_currency(order, total, 'pricelist_to_company')
-
+        # weight is either,
+        # 1- weight chosen by user in choose.delivery.carrier wizard passed by context
+        # 2- saved weight to use on sale order
+        # 3- total order line weight as fallback
+        weight = self.env.context.get('order_weight') or order.shipping_weight or weight
         return self._get_price_from_picking(total, weight, volume, quantity)
 
     def _get_price_dict(self, total, weight, volume, quantity):

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -129,7 +129,7 @@ class TestDeliveryCost(common.TransactionCase):
                 'name': 'On Site Assistance',
                 'product_id': self.product_2.id,
                 'product_uom_qty': 30,
-                'product_uom': self.product_uom_hour.id,
+                'product_uom': self.product_uom_unit.id,
                 'price_unit': 38.25,
             })],
         })

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -353,7 +353,11 @@
                     <xpath expr="//field[@name='order_line']/tree" position="attributes">
                         <attribute name="decoration-warning">recompute_delivery_price and is_delivery</attribute>
                     </xpath>
+                    <field name="picking_policy" position="after">
+                        <field name="shipping_weight" readonly="True"/>
+                    </field>
                 </data>
+                
             </field>
         </record>
 

--- a/addons/delivery/wizard/choose_delivery_carrier_views.xml
+++ b/addons/delivery/wizard/choose_delivery_carrier_views.xml
@@ -9,6 +9,11 @@
                 <group>
                     <group>
                         <field name="carrier_id" domain="[('id', 'in', available_carrier_ids)]"/>
+                        <label for="total_weight"/>
+                        <div class="o_row">
+                            <field name="total_weight" />
+                            <field name="weight_uom_name" />
+                        </div>
                         <field name="delivery_type" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
                         <field name="order_id" invisible="1"/>


### PR DESCRIPTION
Previously, when adding shipment to sale order, the user did not know
the total weight of the order when getting rate of shipping method.
This commit shows the total order weight to the user with the ability to
set it to any value to get the rate with.

TaskId: 2797613


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
