### PR TITLE
[FIX] sale_stock: lot number not shown in refund invoices

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -30,13 +30,27 @@ class AccountMove(models.Model):
             return []
 
         current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: not aml.display_type and aml.product_id and aml.quantity)
-        all_invoices_amls = current_invoice_amls.sale_line_ids.invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.move_name, aml.id))
+        all_invoices_amls = current_invoice_amls.sale_line_ids.invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.id))
         index = all_invoices_amls.ids.index(current_invoice_amls[:1].id) if current_invoice_amls[:1] in all_invoices_amls else 0
         previous_amls = all_invoices_amls[:index]
 
         previous_qties_invoiced = previous_amls._get_invoiced_qty_per_product()
         invoiced_qties = current_invoice_amls._get_invoiced_qty_per_product()
         invoiced_products = invoiced_qties.keys()
+
+        if self.move_type == 'out_invoice':
+            return_source_usage = 'customer'
+        else:
+            # This is a refund, let's swap the "actors" like if the customer is invoicing the company, so:
+            # - We take the opposite of each (previous) invoiced quantity
+            # - We reverse the stock logic:
+            #   - a delivery is now from the customer to an internal location
+            #   - a return is now from an internal location to the customer
+            for p in previous_qties_invoiced:
+                previous_qties_invoiced[p] = -previous_qties_invoiced[p]
+            for p in invoiced_qties:
+                invoiced_qties[p] = -invoiced_qties[p]
+            return_source_usage = 'internal'
 
         qties_per_lot = defaultdict(float)
         previous_qties_delivered = defaultdict(float)
@@ -48,7 +62,7 @@ class AccountMove(models.Model):
             product_uom = product.uom_id
             qty_done = sml.product_uom_id._compute_quantity(sml.qty_done, product_uom)
 
-            if sml.location_id.usage == 'customer':
+            if sml.location_id.usage == return_source_usage:
                 returned_qty = min(qties_per_lot[sml.lot_id], qty_done)
                 qties_per_lot[sml.lot_id] -= returned_qty
                 qty_done = returned_qty - qty_done
@@ -60,7 +74,7 @@ class AccountMove(models.Model):
             # try to reach the previous_qty_invoiced
             if float_compare(qty_done, 0, precision_rounding=product_uom.rounding) < 0 or \
                     float_compare(previous_qty_delivered, previous_qty_invoiced, precision_rounding=product_uom.rounding) < 0:
-                previously_done = qty_done if sml.location_id.usage == 'customer' else min(previous_qty_invoiced - previous_qty_delivered, qty_done)
+                previously_done = qty_done if sml.location_id.usage == return_source_usage else min(previous_qty_invoiced - previous_qty_delivered, qty_done)
                 previous_qties_delivered[product] += previously_done
                 qty_done -= previously_done
 

--- a/addons/sale_stock/tests/test_report.py
+++ b/addons/sale_stock/tests/test_report.py
@@ -281,3 +281,169 @@ class TestSaleStockInvoices(TestSaleCommon):
         self.assertRegex(text, r'Product By Lot\n6.00\nUnits\nLOT0002', "There should be a line that specifies 6 x LOT0002")
         self.assertRegex(text, r'Product By Lot\n2.00\nUnits\nLOT0003', "There should be a line that specifies 2 x LOT0003")
         self.assertNotIn('LOT0001', text)
+
+    def test_refund_cancel_invoices(self):
+        """
+        Suppose the lots are printed on the invoices.
+        The user sells 2 tracked-by-usn products, he delivers 2 products, he delivers 2 and invoices them
+        Then he adds credit nots and issues a full refund. Recieve the product.
+        The reversed invoice should also have correct USN
+        """
+        usn01 = self.env['stock.production.lot'].search(
+            [('name', '=', 'USN0001')])
+        usn02 = self.env['stock.production.lot'].search(
+            [('name', '=', 'USN0002')])
+
+        report = self.env['ir.actions.report']._get_report_from_name(
+            'account.report_invoice_with_payments')
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write(
+            {'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {'name': self.product_by_usn.name,
+                 'product_id': self.product_by_usn.id, 'product_uom_qty': 2}),
+            ],
+        })
+        so.action_confirm()
+
+        picking = so.picking_ids
+        picking.move_lines.move_line_ids[0].qty_done = 1
+        picking.move_lines.move_line_ids[1].qty_done = 1
+        picking.button_validate()
+
+        invoice01 = so._create_invoices()
+        invoice01.action_post()
+
+        html = report._render_qweb_html(invoice01.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0001',
+                         "There should be a line that specifies 1 x USN0001")
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0002',
+                         "There should be a line that specifies 1 x USN0002")
+
+        # Refund the invoice
+        refund_invoice_wiz = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=[invoice01.id]).create({
+            'refund_method': 'cancel',
+        })
+        refund_invoice = self.env['account.move'].browse(
+            refund_invoice_wiz.reverse_moves()['res_id'])
+
+        # recieve the returned product
+        stock_return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_ids=picking.ids, active_id=picking.sorted().ids[0],
+            active_model='stock.picking'))
+        return_wiz = stock_return_picking_form.save()
+        res = return_wiz.create_returns()
+        pick_return = self.env['stock.picking'].browse(res['res_id'])
+
+        move_form = Form(pick_return.move_lines,
+                         view='stock.view_stock_move_nosuggest_operations')
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = usn01
+            line.qty_done = 1
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = usn02
+            line.qty_done = 1
+        move_form.save()
+        pick_return.button_validate()
+
+        # reversed invoice
+        html = report._render_qweb_html(refund_invoice.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0001',
+                         "There should be a line that specifies 1 x USN0001")
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0002',
+                         "There should be a line that specifies 1 x USN0002")
+
+    def test_refund_modify_invoices(self):
+        """
+        Suppose the lots are printed on the invoices.
+        The user sells 2 tracked-by-usn products, he delivers 2 products, he delivers 2 and invoices them
+        Then he adds credit nots and issues a full refund. Recieve the products.
+        The reversed invoice should also have correct USN
+        """
+
+        usn01 = self.env['stock.production.lot'].search(
+            [('name', '=', 'USN0001')])
+        usn02 = self.env['stock.production.lot'].search(
+            [('name', '=', 'USN0002')])
+
+        report = self.env['ir.actions.report']._get_report_from_name(
+            'account.report_invoice_with_payments')
+        display_lots = self.env.ref('sale_stock.group_lot_on_invoice')
+        display_uom = self.env.ref('uom.group_uom')
+        self.env.user.write(
+            {'groups_id': [(4, display_lots.id), (4, display_uom.id)]})
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {'name': self.product_by_usn.name,
+                 'product_id': self.product_by_usn.id, 'product_uom_qty': 2}),
+            ],
+        })
+        so.action_confirm()
+
+        picking = so.picking_ids
+        picking.move_lines.move_line_ids[0].qty_done = 1
+        picking.move_lines.move_line_ids[1].qty_done = 1
+        picking.button_validate()
+
+        invoice01 = so._create_invoices()
+        invoice01.action_post()
+
+        html = report._render_qweb_html(invoice01.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0001',
+                         "There should be a line that specifies 1 x USN0001")
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0002',
+                         "There should be a line that specifies 1 x USN0002")
+
+        # Refund the invoice
+        refund_invoice_wiz = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=[invoice01.id]).create({
+            'refund_method': 'modify',
+        })
+        invoice02 = self.env['account.move'].browse(
+            refund_invoice_wiz.reverse_moves()['res_id'])
+        invoice02.action_post()
+
+        # new draft invoice
+        html = report._render_qweb_html(invoice02.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0001',
+                         "There should be a line that specifies 1 x USN0001")
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0002',
+                         "There should be a line that specifies 1 x USN0002")
+
+        # recieve the returned product
+        stock_return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_ids=picking.ids, active_id=picking.sorted().ids[0],
+            active_model='stock.picking'))
+        return_wiz = stock_return_picking_form.save()
+        res = return_wiz.create_returns()
+        pick_return = self.env['stock.picking'].browse(res['res_id'])
+
+        move_form = Form(pick_return.move_lines,
+                         view='stock.view_stock_move_nosuggest_operations')
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = usn01
+            line.qty_done = 1
+        with move_form.move_line_nosuggest_ids.new() as line:
+            line.lot_id = usn02
+            line.qty_done = 1
+        move_form.save()
+        pick_return.button_validate()
+
+        # reversed invoice
+        refund_invoice = invoice01.reversal_move_id
+
+        html = report._render_qweb_html(refund_invoice.ids)[0]
+        text = html2plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0001',
+                         "There should be a line that specifies 1 x USN0001")
+        self.assertRegex(text, r'Product By USN\n1.00\nUnits\nUSN0002',
+                         "There should be a line that specifies 1 x USN0002")


### PR DESCRIPTION
Reproduction:
1. Install Sale, Accounting, Inventor. In setting of Inventory, enable
Lots & Serial Numbers, Display Lots & Serial Numbers on Invoices,
Display Lots & Serial Numbers on Delivery Slips.
2. Create a product with lot/serial number
3. Create a order of this product, confirm. Click the delivery and
validate it.
4. Back to the SO, create an invoice, confirm and print it, the serial
number shows.
5. At the invoice, click “Add credit note”, choose “Full refund” (2
invoices for the SO) or “Full refund and new draft invoice” (3 invoices
for the SO), the lot number doesn’t show in new draft invoice or the
refund invoice

Reason: the current lot number tracking workflow focused on invoicing
different numbers of products and making sure it gets the correct
lot/serial number. It doesn’t include the refund invoice case.

Fix: since the current working logic works great with invoicing products
which are delivered from the warehouse to the customer, we can reuse
this logic for refund invoices for products which are returned from the
customer to the warehouse. In the refund and return case, we switch the
calculation of warehouse and customer. Thus, a return can be seen as a
delivery from the customer to the warehouse.
In the code, we set a new variable, return_source_usage, to check if the
account move type is a delivery or a return. If it’s an invoice for
return, we take the opposite of the previous invoiced product quantity.
Because in a refund, previous invoiced is now considered as refunded.
In the original workflow, when sml.location_id.usage is “customer”, it’s
a return and we update the returned_qty and the related quantities. In
the new workflow, if the invoice is a refund one, we do the same steps
when sml.location_id.usage is “internal”, e.g. when the stock move line
is a delivery, we consider it a return.

opw-2879714

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
