### PR TITLE
[FIX] base,account,account_edi: revamp send & print wizard

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -54,7 +54,7 @@
 </div>
             </field>
             <field name="report_template" ref="account_invoices"/>
-            <field name="report_name">Invoice_{{ (object.name or '').replace('/','_') }}{{ object.state == 'draft' and '_draft' or '' }}</field>
+            <field name="report_name">{{ (object.name or '').replace('/','_') }}{{ object.state == 'draft' and '_draft' or '' }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>
@@ -127,7 +127,7 @@
 </div>
             </field>
             <field name="report_template" ref="account_invoices"/>
-            <field name="report_name">Credit_note_{{ (object.name or '').replace('/','_') }}{{ object.state == 'draft' and '_draft' or '' }}</field>
+            <field name="report_name">{{ (object.name or '').replace('/','_') }}{{ object.state == 'draft' and '_draft' or '' }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3222,6 +3222,7 @@ class AccountMove(models.Model):
             default_email_layout_xmlid="mail.mail_notification_paynow",
             model_description=self.with_context(lang=lang).type_name,
             force_email=True,
+            is_origin_send_and_print=True,
         )
         return {
             'name': _('Send Invoice'),

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -3,14 +3,75 @@ import io
 from collections import OrderedDict
 
 from odoo import models, _
-from odoo.exceptions import UserError
 from odoo.tools import pdf
+from odoo.exceptions import UserError
+from PyPDF2 import PdfFileReader, PdfFileWriter
+from reportlab.pdfgen import canvas
 
 
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
+    def _add_watermark_streams(self, streams, text):
+        """ Add a watermark 'duplicated' to the PDF
+        :param pdf_stream
+        :return (BytesIO):  The modified PDF stream
+        """
+        for invoice_id, stream_dict in streams.items():
+            input_pdf = PdfFileReader(stream_dict['stream'])
+
+            packet = io.BytesIO()
+            can = canvas.Canvas(packet)
+
+            page = input_pdf.getPage(0)
+            width = float(abs(page.mediaBox.getWidth()))
+            height = float(abs(page.mediaBox.getHeight()))
+
+            can.translate(width / 3.7, height / 1.4)
+
+            # Set rotation angle
+            can.rotate(-45)
+
+            can.setFontSize(70)
+            can.setFillAlpha(0.2)
+            can.drawString(0, 0, text)
+
+            # Save watermark pdf file
+            can.save()
+
+            # merge the two pages
+            # Merge the old pages with the watermark
+            watermark_pdf = PdfFileReader(packet, overwriteWarnings=False)
+            new_pdf = PdfFileWriter()
+            for p in range(input_pdf.getNumPages()):
+                new_page = input_pdf.getPage(p)
+                # Remove annotations (if any), to prevent errors in PyPDF2
+                if '/Annots' in new_page:
+                    del new_page['/Annots']
+                new_page.mergePage(watermark_pdf.getPage(p))
+                new_pdf.addPage(new_page)
+
+            # Write the new pdf into a new output stream
+            output = io.BytesIO()
+            new_pdf.write(output)
+
+            # debug
+            with open("/home/odoo/Downloads/example-drafted.pdf", "wb") as output_file:
+                new_pdf.write(output_file)
+
+            new_stream = io.BytesIO()
+            new_pdf.write(new_stream)
+            stream_dict['stream'] = new_stream
+        return streams
+
     def _render_qweb_pdf_prepare_streams(self, data, res_ids=None):
+        # Add watermark
+        # TODO: when do we want it to appear ? handle multiple invoices, handle original bills...
+        if res_ids and self.report_name in ['account.report_invoice_with_payments', 'account.report_invoice']:
+            old_streams = super()._render_qweb_pdf_prepare_streams(data, res_ids=res_ids)
+            new_streams = self._add_watermark_streams(old_streams, _("DUPLICATED"))
+            return new_streams
+
         # Custom behavior for 'account.report_original_vendor_bill'.
         if self.report_name != 'account.report_original_vendor_bill':
             return super()._render_qweb_pdf_prepare_streams(data, res_ids=res_ids)

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -86,19 +86,9 @@
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
 
                         <table class="table table-sm o_main_table" name="invoice_line_table">
-                            <div style="position: fixed;
-                        top: 0;
-                        bottom: 0;
-                        left: 0;
-                        right: 0;
-                        color: #503047;
-                        font-size: 100px;
-                        font-weight: 500px;
-                        display: grid;
-                        justify-content: center;
-                        align-content: center;
-                        opacity: 0.3;
-                        transform: rotate(-40deg);">DUPLICATED</div>
+                            <!--<div style="position: fixed; top: 0; bottom: 0; left: 0; right: 0; color: #503047;
+                            font-size: 100px; font-weight: 500px; display: grid; justify-content: center;
+                            align-content: center; opacity: 0.3; transform: rotate(-40deg);">TODI LE MEME</div>-->
                             <thead>
                                 <tr>
                                     <th name="th_description" class="text-start"><span>Description</span></th>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -86,6 +86,19 @@
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
 
                         <table class="table table-sm o_main_table" name="invoice_line_table">
+                            <div style="position: fixed;
+                        top: 0;
+                        bottom: 0;
+                        left: 0;
+                        right: 0;
+                        color: #503047;
+                        font-size: 100px;
+                        font-weight: 500px;
+                        display: grid;
+                        justify-content: center;
+                        align-content: center;
+                        opacity: 0.3;
+                        transform: rotate(-40deg);">DUPLICATED</div>
                             <thead>
                                 <tr>
                                     <th name="th_description" class="text-start"><span>Description</span></th>

--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -8,6 +8,7 @@
             <field name="groups_id" eval="[(4,ref('base.group_user'))]"/>
             <field name="arch" type="xml">
                 <form string="Invoice send &amp; Print">
+                    <field name="model" invisible="1"/>
                     <div class="alert alert-warning" role="alert"
                          attrs="{'invisible': [('move_types', '=', False)]}">
                         You have selected the following document types at the same time:

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -183,6 +183,7 @@ class AccountPayment(models.Model):
         self.action_cancel()
 
     def do_print_checks(self):
+        # TODO JUVR, when clicking on the button to print the checks, it triggers this function
         check_layout = self.company_id.account_check_printing_layout
         redirect_action = self.env.ref('account.action_account_config')
         if not check_layout or check_layout == 'disabled':

--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -8,14 +8,26 @@ class MailTemplate(models.Model):
 
     def _get_edi_attachments(self, document):
         """
-        Will return the information about the attachment of the edi document for adding the attachment in the mail.
+        Will either return the information about the attachment of the edi document for adding the attachment in the
+        mail, or the attachment id to be linked to the 'send & print' wizard.
         Can be overridden where e.g. a zip-file needs to be sent with the individual files instead of the entire zip
+
+        IMPORTANT:
+        * If the attachment's id is returned, no new attachment will be created, the existing one on the move is linked
+        to the wizard (see _onchange_template_id in mail.compose.message).
+        * If the attachment's content is returned, a new one is created and linked to the wizard. Thus, when sending
+        the mail (clicking on 'send & print' in the wizard), a new attachment is added to the move (see
+        _action_send_mail in mail.compose.message).
+
         :param document: an edi document
-        :return: list with a tuple with the name and base64 content of the attachment
+        :return: dict:
+            {'attachments': tuple with the name and base64 content of the attachment}
+            OR
+            {'attachment_ids': list containing the id of the attachment}
         """
         if not document.attachment_id:
-            return []
-        return [(document.attachment_id.name, document.attachment_id.datas)]
+            return {}
+        return {'attachment_ids': [document.attachment_id.id]}
 
     def generate_email(self, res_ids, fields):
         res = super().generate_email(res_ids, fields)
@@ -33,6 +45,8 @@ class MailTemplate(models.Model):
             record_data = (res[record.id] if multi_mode else res)
             for doc in record.edi_document_ids:
                 record_data.setdefault('attachments', [])
-                record_data['attachments'] += self._get_edi_attachments(doc)
+                attachments = self._get_edi_attachments(doc)
+                record_data['attachment_ids'] += attachments.get('attachment_ids', [])
+                record_data['attachments'] += attachments.get('attachments', [])
 
         return res

--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -25,8 +25,7 @@ class MailTemplate(models.Model):
             OR
             {'attachment_ids': list containing the id of the attachment}
         """
-        # TODO put it in a file mail_template in ubl_cii
-        if not document.attachment_id or document.edi_format_id.code == 'facturx_1_0_05':
+        if not document.attachment_id:
             return {}
         return {'attachment_ids': [document.attachment_id.id]}
 

--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -25,7 +25,8 @@ class MailTemplate(models.Model):
             OR
             {'attachment_ids': list containing the id of the attachment}
         """
-        if not document.attachment_id:
+        # TODO put it in a file mail_template in ubl_cii
+        if not document.attachment_id or document.edi_format_id.code == 'facturx_1_0_05':
             return {}
         return {'attachment_ids': [document.attachment_id.id]}
 

--- a/addons/account_edi_ubl_cii/models/__init__.py
+++ b/addons/account_edi_ubl_cii/models/__init__.py
@@ -10,3 +10,4 @@ from . import account_edi_xml_ubl_xrechnung
 from . import account_edi_xml_ubl_nlcius
 from . import account_edi_xml_ubl_efff
 from . import ir_actions_report
+from . import mail_template

--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -140,9 +140,10 @@ class AccountEdiFormat(models.Model):
         if self.code != 'facturx_1_0_05':
             return super()._prepare_invoice_report(pdf_writer, edi_document)
 
-        # regenerate Facturx everytime a pdf is created
-        edi_document.filtered(lambda doc: doc.edi_format_id.code == 'facturx_1_0_05').state = 'to_send'
-        edi_document.filtered(lambda doc: doc.edi_format_id.code == 'facturx_1_0_05')._process_documents_no_web_services()
+        # regenerate Factur-X everytime a pdf is created
+        edi_document.state = 'to_send'
+        edi_document._process_documents_no_web_services()
+
         if not edi_document.attachment_id:
             return
 

--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -162,13 +162,6 @@ class AccountEdiFormat(models.Model):
                 })
                 pdf_writer.add_file_metadata(content.encode())
 
-    def _get_edi_attachments(self, document):
-        # EXTENDS account_edi
-        # do not attach the factur-x.xml in the 'send & print' wizard
-        if document.edi_format_id.code == 'facturx_1_0_05':
-            return {}
-        return super()._get_edi_attachments(document)
-
     ####################################################
     # Import: Account.edi.format override
     ####################################################

--- a/addons/account_edi_ubl_cii/models/mail_template.py
+++ b/addons/account_edi_ubl_cii/models/mail_template.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class MailTemplate(models.Model):
+    _inherit = "mail.template"
+
+    def _get_edi_attachments(self, document):
+        # EXTENDS account_edi
+        # Avoid having factur-x.xml in the 'send & print' wizard
+        if document.edi_format_id.code == 'facturx_1_0_05':
+            return {}
+        return super()._get_edi_attachments(document)

--- a/addons/l10n_it_edi/models/mail_template.py
+++ b/addons/l10n_it_edi/models/mail_template.py
@@ -14,5 +14,5 @@ class MailTemplate(models.Model):
         :return: list with a tuple with the name and base64 content of the attachment
         """
         if document.edi_format_id.code == 'fattura_pa':
-            return []
+            return {}
         return super()._get_edi_attachments(document)

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -283,6 +283,9 @@
                 </script>
             </head>
             <body class="container" t-att-data-report-id="report_xml_id" t-att-onload="subst and 'subst()'" style="overflow:hidden">
+                <!--<div style="position: fixed; top: 0; bottom: 0; left: 0; right: 0; color: #503047; font-size: 100px;
+                font-weight: 500px; display: grid; justify-content: center; align-content: center; opacity: 0.3;
+                transform: rotate(-45deg);">DUPLICATED</div>-->
                 <t t-out="body"/>
             </body>
         </html>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -283,9 +283,6 @@
                 </script>
             </head>
             <body class="container" t-att-data-report-id="report_xml_id" t-att-onload="subst and 'subst()'" style="overflow:hidden">
-                <!--<div style="position: fixed; top: 0; bottom: 0; left: 0; right: 0; color: #503047; font-size: 100px;
-                font-weight: 500px; display: grid; justify-content: center; align-content: center; opacity: 0.3;
-                transform: rotate(-45deg);">DUPLICATED</div>-->
                 <t t-out="body"/>
             </body>
         </html>

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -686,7 +686,7 @@ class IrActionsReport(models.Model):
 
             html = self_sudo.with_context(**additional_context)._render_qweb_html(res_ids_wo_stream, data=data)[0]
 
-            # TODO JUVR add watermark
+            # TODO JUVR add watermark (bodies = html)
             bodies, html_ids, header, footer, specific_paperformat_args = self._prepare_html(html, report_model=self_sudo.model)
 
             if self_sudo.attachment and set(res_ids_wo_stream) != set(html_ids):

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -686,6 +686,7 @@ class IrActionsReport(models.Model):
 
             html = self_sudo.with_context(**additional_context)._render_qweb_html(res_ids_wo_stream, data=data)[0]
 
+            # TODO JUVR add watermark
             bodies, html_ids, header, footer, specific_paperformat_args = self._prepare_html(html, report_model=self_sudo.model)
 
             if self_sudo.attachment and set(res_ids_wo_stream) != set(html_ids):
@@ -795,6 +796,7 @@ class IrActionsReport(models.Model):
 
                 attachment_vals_list.append({
                     'name': attachment_name,
+                    # TODO JUVR here: add watermark if duplicated, in the _render_qweb_pdf in account ?
                     'raw': stream_data['stream'].getvalue(),
                     'res_model': self.model,
                     'res_id': record.id,

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -801,7 +801,8 @@ class IrActionsReport(models.Model):
                     'type': 'binary',
                 })
 
-            if attachment_vals_list:
+            # Avoid creating a PDF attachment when opening the 'send & print' wizard
+            if attachment_vals_list and not self.env.context.get('is_origin_send_and_print'):
                 attachment_names = ', '.join(x['name'] for x in attachment_vals_list)
                 try:
                     self.env['ir.attachment'].create(attachment_vals_list)

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -345,7 +345,8 @@
                                 <group string="Purchase" name="purchase" priority="2">
                                 </group>
                                 <group name="misc" string="Misc">
-                                    <field name="company_registry" attrs="{'invisible': [('parent_id','!=',False)]}"/>
+                                    <field name="company_registry" string="KVK-nummer" help="A" attrs="{'invisible': ['|', ('parent_id','!=',False), ('country_code', '!=', 'NL')]}"/>
+                                    <field name="company_registry" help="B" attrs="{'invisible': ['|', ('parent_id','!=',False), ('country_code', '==', 'NL')]}"/>
                                     <field name="ref" string="Reference"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('parent_id', '!=', False)]}" force_save="1"/>
                                     <field name="industry_id" attrs="{'invisible': [('is_company', '=', False)]}" options="{'no_create': True}"/>


### PR DESCRIPTION
This commit revamps the 'send & print' wizard.

Previously when opening the wizard, 2 PDF were rendered, 1 was added to the move.
When clicking "Send & Print" in the wizard, another PDF was added to the move,
and the other attachments were also duplicated on the move.

Now:

We avoid creating a PDF on the move when opening the wizard, using a context key.

In addition, when opening the wizard, the move's attachments
are *linked* to the wizard rather than recreated, s.t. when closing the
wizard, the attachments (except the PDF) are not duplicated on the move.

When using the context key, a weird bug occured (template was
not loaded directly, empty wizard, as reported in
3ae25d62bb25569cbe5adb809e394b6427fe6b40).
Changing account.invoice.send from delegation inheritance to
classical inheritance solved it.

It also prevents us from generating 2 times a PDF when opening
the wizard (it was the case previously).

If we choose the option 'Print' in the wizard, we will still have a duplicated
PDF if the filename in the email template is different from:
{{ (object.name or '').replace('/','_') }}{{ object.state == 'draft' and '_draft' or '' }}
Indeed, the ir.actions.reports triggers the _render_qweb_pdf, which by default
regenerate a new PDF and creates a new attachment on the move if it doesn't already
exists (see retrieve_attachment in ir.actions.report).

Add watermark "DUPLICATED" to pdf, but when exactly ? To be precised

task-???

Enterprise PR: https://github.com/odoo/enterprise/pull/29816