### PR TITLE
[IMP] web_editor: rename Auto width to Default

### DIFF
--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -186,7 +186,7 @@
             </div>
 
             <div id="image-width" class="btn-group">
-                <div title="Resize Auto" class="btn editor-ignore">Auto</div>
+                <div title="Resize Default" class="btn editor-ignore">Default</div>
                 <div id="100%" title="Resize Full" class="btn editor-ignore">100%</div>
                 <div id="50%" title="Resize Half" class="btn editor-ignore">50%</div>
                 <div id="25%" title="Resize Quarter" class="btn editor-ignore">25%</div>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -571,7 +571,7 @@
         </we-row>
 
         <we-button-group string="Width" data-css-property="width">
-            <we-button data-select-style="" title="Resize Auto">Auto</we-button>
+            <we-button data-select-style="" title="Resize Default">Default</we-button>
             <we-button data-select-style="25%" title="Resize Quarter">25%</we-button>
             <we-button data-select-style="50%" title="Resize Half">50%</we-button>
             <we-button data-select-style="100%" title="Resize Full">100%</we-button>


### PR DESCRIPTION
This nomenclature was taken straight from the old Summernote options
when the new editor was merged in 15.0.

While perfectly correct from a technical point of view, the use of the
word "Auto" in this context is confusing because the user might think
that the system is going to choose an optimal size for them while this
is not what this option does at all. What it does is simply removing any
width style property that might be set on the image, thus letting the
image be sized appropriately by the browser in accordance with active
CSS rules at that position in the page, hence "Default".
