### PR TITLE
[FIX] l10n_it_edi_*: ImportoTotaleDocumento must include ReverseCharge taxes  

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -132,7 +132,7 @@
                     <BolloVirtuale>SI</BolloVirtuale>
                     <ImportoBollo t-esc="format_numbers(record.l10n_it_stamp_duty)"/>
                 </DatiBollo>
-                <ImportoTotaleDocumento t-esc="format_monetary(record.amount_total, currency)"/>
+                <ImportoTotaleDocumento t-esc="format_monetary(document_total, currency)"/>
             </DatiGeneraliDocumento>
             <DatiOrdineAcquisto t-if="record.ref">
                 <IdDocumento t-esc="format_alphanumeric(record.ref[:20])"/>

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -183,6 +183,12 @@ class AccountMove(models.Model):
             or (partner.country_id.code == 'IT' and '0000000')
             or 'XXXXXXX')
 
+        # Self-invoices are technically -100%/+100% repartitioned
+        # but functionally need to be exported as 100%
+        document_total = self.amount_total
+        if is_self_invoice:
+            document_total += sum([v['tax_amount_currency'] for k, v in tax_details['tax_details'].items()])
+
         # Create file content.
         template_values = {
             'record': self,
@@ -196,6 +202,7 @@ class AccountMove(models.Model):
             'seller': seller,
             'seller_partner': company.partner_id if not is_self_invoice else partner,
             'currency': self.currency_id or self.company_currency_id,
+            'document_total': document_total,
             'representative': company.l10n_it_tax_representative_partner_id,
             'codice_destinatario': codice_destinatario,
             'regime_fiscale': company.l10n_it_tax_system if not is_self_invoice else 'RF01',

--- a/addons/l10n_it_edi_sdicoop/tests/expected_xmls/reverse_charge_bill.xml
+++ b/addons/l10n_it_edi_sdicoop/tests/expected_xmls/reverse_charge_bill.xml
@@ -54,7 +54,7 @@
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
                 <Numero>BILL/2022/03/0001</Numero>
-                <ImportoTotaleDocumento>1600.80</ImportoTotaleDocumento>
+                <ImportoTotaleDocumento>1808.91</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>
         <DatiBeniServizi>


### PR DESCRIPTION
In the XML, on the field <ImportoTotaleDocumento> holds the untaxed amount but it should have the taxed amount.
The field inside the xml correctly takes the total amount of the invoice, but on the invoice in Odoo when using a RC tax, the tax amount is 0 in Odoo, so the total amount will be as it is untaxed on the XML. That's because the repartition lines are +100%/-100% distributed, but in the self-invoice they must be exported as +100%, so we re-add them to the total.

Task link: https://www.odoo.com/web#id=2936967&model=project.task
opw-2936967