### PR TITLE
[FIX] l10n_pe: Missing purchase tax groups added

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -274,15 +274,19 @@ class AccountMove(models.Model):
         for rec in self.filtered(
                 lambda x: x.name and x.name != '/' and x.is_purchase_document() and x.l10n_latam_use_documents
                             and x.commercial_partner_id):
-            domain = [
-                ('move_type', '=', rec.move_type),
-                # by validating name we validate l10n_latam_document_type_id
-                ('name', '=', rec.name),
-                ('company_id', '=', rec.company_id.id),
-                ('id', '!=', rec.id),
-                ('commercial_partner_id', '=', rec.commercial_partner_id.id),
-                # allow to have to equal if they are cancelled
-                ('state', '!=', 'cancel'),
-            ]
+            domain = rec._get_domain_unique_vendor_number()
             if rec.search(domain):
                 raise ValidationError(_('Vendor bill number must be unique per vendor and company.'))
+
+    def _get_domain_unique_vendor_number(self):
+        self.ensure_one()
+        return [
+            ('move_type', '=', self.move_type),
+            # by validating name we validate l10n_latam_document_type_id
+            ('name', '=', self.name),
+            ('company_id', '=', self.company_id.id),
+            ('id', '!=', self.id),
+            ('commercial_partner_id', '=', self.commercial_partner_id.id),
+            # allow to have to equal if they are cancelled
+            ('state', '!=', 'cancel'),
+        ]

--- a/addons/l10n_pe/__manifest__.py
+++ b/addons/l10n_pe/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Peru - Accounting',
-    "version": "2.0",
+    "version": "3.0",
     'summary': "PCGE Simplified",
     'category': 'Accounting/Localizations/Account Charts',
     'author': 'Vauxoo, Odoo',

--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -8,6 +8,14 @@
         <field name="name">IGV</field>
         <field name="sequence">0</field>
     </record>
+    <record id="tax_group_igv_g_ng" model="account.tax.group">
+        <field name="name">IGV GyNG</field>
+        <field name="sequence">0</field>
+    </record>
+    <record id="tax_group_igv_ng" model="account.tax.group">
+        <field name="name">IGV NG</field>
+        <field name="sequence">0</field>
+    </record>
     <record id="tax_group_ivap" model="account.tax.group">
         <field name="name">IVAP</field>
         <field name="sequence">0</field>
@@ -40,7 +48,11 @@
         <field name="name">DET</field>
         <field name="sequence">100</field>
     </record>
-    
+    <record id="tax_group_ret" model="account.tax.group">
+        <field name="name">RET</field>
+        <field name="sequence">100</field>
+    </record>
+
     <!-- VAT for sales -->
     <record id="sale_tax_igv_18" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
@@ -298,6 +310,124 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('chart40111'),
+            }),
+        ]"/>
+    </record>
+    <record id="sale_tax_igv_18g_ng" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">18% Gravadas y No Gravadas</field>
+        <field name="description">IGV</field>
+        <field name="l10n_pe_edi_tax_code">1000</field>
+        <field name="l10n_pe_edi_unece_category">S</field>
+        <field name="amount">18.0</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="sequence">1</field>
+        <field name="include_base_amount">1</field>
+        <field name="tax_group_id" ref="tax_group_igv_g_ng"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart40117'),
+            }),
+            (0,0, {
+                'factor_percent': 0,
+                'repartition_type': 'tax',
+                'account_id': ref('chart6411'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart40117'),
+            }),
+            (0,0, {
+                'factor_percent': 0,
+                'repartition_type': 'tax',
+                'account_id': ref('chart6411'),
+            }),
+        ]"/>
+    </record>
+    <record id="sale_tax_igv_18_ng" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">18% No Gravadas</field>
+        <field name="description">IGV NG</field>
+        <field name="l10n_pe_edi_tax_code">1000</field>
+        <field name="l10n_pe_edi_unece_category">S</field>
+        <field name="amount">18.0</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="sequence">1</field>
+        <field name="include_base_amount">1</field>
+        <field name="tax_group_id" ref="tax_group_igv_ng"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart40116'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart40116'),
+            }),
+        ]"/>
+    </record>
+    <record id="purchase_tax_exp_0" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">0% EXP</field>
+        <field name="description">EXP</field>
+        <field name="l10n_pe_edi_tax_code">9995</field>
+        <field name="l10n_pe_edi_unece_category">S</field>
+        <field name="amount">0</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="sequence">1</field>
+        <field name="include_base_amount">1</field>
+        <field name="tax_group_id" ref="tax_group_exp"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart40115'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart40115'),
             }),
         ]"/>
     </record>


### PR DESCRIPTION
The IGV (Impuesto General alas Ventas), is a tax used on the customer
bills for the SO generated, and only is used the group IGV.

But, when you receive an invoice that has applied the IGV, you can to
distribute the tax on 3 cases:

- Taxed operations
- Taxed and not taxed operations
- No taxed operations

This was established by the SUNAT, and indicates that must be accounted
by separated, so, is necessary a tax by each type and for the purchase
reports also are necessary 3 groups to allow split each amount on their
correct column.

More info:
https://www.sunat.gob.pe/legislacion/igv/regla/cap5.htm
http://forseti.pe/periodico/articulos/con-respecto-al-igv-operaciones-gravadas-y-no-gravadas-que-sucede-con-el-credito-fiscal/
https://www.youtube.com/watch?v=OUXeDEggNOw




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
