### PR TITLE
[FIX] test_mass_mailing, {test_}mail: always apply blacklist for mass…

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -481,7 +481,7 @@ class MailComposer(models.TransientModel):
 
     def _process_state(self, mail_values_dict):
         recipients_info = self._process_recipient_values(mail_values_dict)
-        blacklist_ids = self._get_blacklist_record_ids(mail_values_dict)
+        blacklist_ids = self._get_blacklist_record_ids(mail_values_dict, recipients_info)
         optout_emails = self._get_optout_emails(mail_values_dict)
         done_emails = self._get_done_emails(mail_values_dict)
         # in case of an invoice e.g.
@@ -523,17 +523,31 @@ class MailComposer(models.TransientModel):
 
         return mail_values_dict
 
-    def _get_blacklist_record_ids(self, mail_values_dict):
+    def _get_blacklist_record_ids(self, mail_values_dict, recipients_info=None):
+        """Get record ids for which at least one recipient is black listed.
+
+        :param dict mail_values_dict: mail values per record id
+        :param dict recipients_info: optional dict of recipients info per record id
+            Optional for backward compatibility but without, result can be incomplete.
+        :return set: record ids with at least one black listed recipient.
+        """
         blacklisted_rec_ids = set()
-        if self.composition_mode == 'mass_mail' and issubclass(type(self.env[self.model]), self.pool['mail.thread.blacklist']):
+        if self.composition_mode == 'mass_mail':
             self.env['mail.blacklist'].flush(['email'])
             self._cr.execute("SELECT email FROM mail_blacklist WHERE active=true")
             blacklist = {x[0] for x in self._cr.fetchall()}
-            if blacklist:
+            if not blacklist:
+                return blacklisted_rec_ids
+            if issubclass(type(self.env[self.model]), self.pool['mail.thread.blacklist']):
                 targets = self.env[self.model].browse(mail_values_dict.keys()).read(['email_normalized'])
                 # First extract email from recipient before comparing with blacklist
                 blacklisted_rec_ids.update(target['id'] for target in targets
                                            if target['email_normalized'] in blacklist)
+            elif recipients_info:
+                # Note that we exclude the record if at least one recipient is blacklisted (-> even if not all)
+                # But as commented above: Mass mailing should always have a single recipient per record.
+                blacklisted_rec_ids.update(res_id for res_id, recipient_info in recipients_info.items()
+                                           if blacklist & set(recipient_info['mail_to_normalized']))
         return blacklisted_rec_ids
 
     def _get_done_emails(self, mail_values_dict):

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -750,7 +750,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(__system__=30, emp=31):  # tm 29/30
+        with self.assertQueryCount(__system__=31, emp=32):  # tm 30/31
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -62,7 +62,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +151 compared to local
-        with self.assertQueryCount(__system__=1671, marketing=1672):  # tmm 1520/1521
+        with self.assertQueryCount(__system__=1672, marketing=1673):  # tmm 1521/1522
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
… mailing

Always apply the blacklist in mass_mail composition mode regardless of the
recipient model implementing mail.thread.blacklist or not.

This solves the problem of mail sent to black listed address for model not
inheriting from mail.thread.blacklist.

Technical notes:
- it has been done in mail.compose.message _get_blacklist_record_ids ignoring
the mixin mail.thread.blacklist to avoid model change in stable.
- some tests have one added query because the blacklist is now queried for each
batch mail sends even if the model of the recipient doesn't implement
mail.thread.blacklist.

Task-2834862

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
