### PR TITLE
[IMP] mail, mass_mailing, base_setup: always apply blacklist + option to bypass

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -45,6 +45,7 @@ class TestImLivechatMessage(TransactionCase):
             % (record_rating.rating_image_url, record_rating.rating, record_rating.feedback),
             rating_id=record_rating.id,
         )
+        self.maxDiff = None
         self.assertEqual(message.message_format(), [{
             'attachment_ids': [],
             'author': {
@@ -63,6 +64,7 @@ class TestImLivechatMessage(TransactionCase):
             'is_discussion': False,
             'is_note': True,
             'linkPreviews': [],
+            'mass_mode': False,
             'message_type': 'notification',
             'messageReactionGroups': [],
             'model': 'discuss.channel',

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -52,6 +52,7 @@ class TestImLivechatMessage(TransactionCase):
                 'name': "test1",
             },
             'body': message.body,
+            'bypassed_blacklist': False,
             'date': message.date,
             'write_date': message.write_date,
             'create_date': message.create_date,

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Discuss',
-    'version': '1.13',
+    'version': '1.14',
     'category': 'Productivity/Discuss',
     'sequence': 145,
     'summary': 'Chat, mail gateway and private channels',

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -141,6 +141,7 @@ class Message(models.Model):
         'Need Action', compute='_compute_needaction', search='_search_needaction')
     has_error = fields.Boolean(
         'Has error', compute='_compute_has_error', search='_search_has_error')
+    bypassed_blacklist = fields.Boolean('Blacklist Included')
     # notifications
     notification_ids = fields.One2many(
         'mail.notification', 'mail_message_id', 'Notifications',
@@ -1035,12 +1036,15 @@ class Message(models.Model):
         return vals_list
 
     def _get_message_format_fields(self):
-        return [
+        res = [
             'id', 'body', 'date', 'email_from',  # base message fields
             'message_type', 'subtype_id', 'subject',  # message specific
             'model', 'res_id', 'record_name',  # document related
             'starred_partner_ids',  # list of partner ids for whom the message is starred
         ]
+        if self.env.user._is_internal():  # Only display that the blacklist was bypassed to internal user
+            res.append('bypassed_blacklist')
+        return res
 
     def _message_notification_format(self):
         """Returns the current messages and their corresponding notifications in

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -142,6 +142,7 @@ class Message(models.Model):
     has_error = fields.Boolean(
         'Has error', compute='_compute_has_error', search='_search_has_error')
     bypassed_blacklist = fields.Boolean('Blacklist Included')
+    mass_mode = fields.Boolean('Mass send mode enabled')
     # notifications
     notification_ids = fields.One2many(
         'mail.notification', 'mail_message_id', 'Notifications',
@@ -1038,7 +1039,7 @@ class Message(models.Model):
     def _get_message_format_fields(self):
         res = [
             'id', 'body', 'date', 'email_from',  # base message fields
-            'message_type', 'subtype_id', 'subject',  # message specific
+            'message_type', 'subtype_id', 'subject', 'mass_mode',  # message specific
             'model', 'res_id', 'record_name',  # document related
             'starred_partner_ids',  # list of partner ids for whom the message is starred
         ]

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2596,7 +2596,7 @@ class MailThread(models.AbstractModel):
                            author_id=None, email_from=None,
                            message_type='notification',
                            attachment_ids=False, tracking_value_ids=False,
-                           bypassed_blacklist=False):
+                           bypassed_blacklist=False, mass_mode=False):
         """ Shortcut allowing to post notes on a batch of documents. It does not
         perform any notification and pre-computes some values to have a short code
         as optimized as possible. This method is private as it does not check
@@ -2631,6 +2631,7 @@ class MailThread(models.AbstractModel):
             # recipients
             'bypassed_blacklist': bypassed_blacklist,
             'email_add_signature': False,  # False as no notification -> no need to compute signature
+            'mass_mode': mass_mode,
             'message_id': tools.generate_tracking_message_id('message-notify'),  # why? this is all but a notify
             'reply_to': self.env['mail.thread']._notify_get_reply_to(default=email_from)[False],
         }
@@ -2753,6 +2754,7 @@ class MailThread(models.AbstractModel):
             'is_internal',
             'mail_activity_type_id',
             'mail_server_id',
+            'mass_mode',
             'message_id',
             'message_type',
             'model',

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2595,7 +2595,8 @@ class MailThread(models.AbstractModel):
     def _message_log_batch(self, bodies, subject=False,
                            author_id=None, email_from=None,
                            message_type='notification',
-                           attachment_ids=False, tracking_value_ids=False):
+                           attachment_ids=False, tracking_value_ids=False,
+                           bypassed_blacklist=False):
         """ Shortcut allowing to post notes on a batch of documents. It does not
         perform any notification and pre-computes some values to have a short code
         as optimized as possible. This method is private as it does not check
@@ -2628,6 +2629,7 @@ class MailThread(models.AbstractModel):
             'subtype_id': self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
             'tracking_value_ids': tracking_value_ids,
             # recipients
+            'bypassed_blacklist': bypassed_blacklist,
             'email_add_signature': False,  # False as no notification -> no need to compute signature
             'message_id': tools.generate_tracking_message_id('message-notify'),  # why? this is all but a notify
             'reply_to': self.env['mail.thread']._notify_get_reply_to(default=email_from)[False],
@@ -2742,6 +2744,7 @@ class MailThread(models.AbstractModel):
             'author_guest_id',
             'author_id',
             'body',
+            'bypassed_blacklist',
             'create_date',  # anyway limited to admins
             'date',
             'email_add_signature',

--- a/addons/mail/static/src/core/message_model.js
+++ b/addons/mail/static/src/core/message_model.js
@@ -43,6 +43,8 @@ export class Message {
     parentMessage;
     /** @type {MessageReactions[]} */
     reactions = [];
+    /** @type {boolean} */
+    mass_mode;
     /** @type {Notification[]} */
     notifications = [];
     /** @type {import("@mail/core/persona_model").Persona[]} */

--- a/addons/mail/static/src/core/message_model.js
+++ b/addons/mail/static/src/core/message_model.js
@@ -19,6 +19,8 @@ export class Message {
     author;
     /** @type {string} */
     body;
+    /** @type {boolean} */
+    bypassed_blacklist;
     /** @type {string} */
     defaultSubject;
     /** @type {number|string} */

--- a/addons/mail/static/src/core_ui/message.xml
+++ b/addons/mail/static/src/core_ui/message.xml
@@ -54,6 +54,9 @@
                                 <t t-if="shouldDisplayAuthorName">- </t>
                                 <RelativeTime datetime="message.datetime"/>
                             </small>
+                            <small t-if="message.bypassed_blacklist" class="mt-3 mx-1 text-muted opacity-50">
+                                (Blacklist Included)
+                            </small>
                             <MessageSeenIndicator
                                 t-if="props.message.isSelfAuthored and !props.squashed and props.thread"
                                 className="'ms-1'"

--- a/addons/mail/static/src/core_ui/message.xml
+++ b/addons/mail/static/src/core_ui/message.xml
@@ -54,6 +54,9 @@
                                 <t t-if="shouldDisplayAuthorName">- </t>
                                 <RelativeTime datetime="message.datetime"/>
                             </small>
+                            <small t-if="message.mass_mode" class="mt-3 text-muted opacity-50">
+                                - sent in mass
+                            </small>
                             <small t-if="message.bypassed_blacklist" class="mt-3 mx-1 text-muted opacity-50">
                                 (Blacklist Included)
                             </small>

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -832,6 +832,7 @@ class MailComposer(models.TransientModel):
 
         values = {
             'author_id': self.author_id.id,
+            'bypassed_blacklist': self.bypass_blacklist,
             'mail_activity_type_id': self.mail_activity_type_id.id,
             'mail_server_id': self.mail_server_id.id,
             'message_type': 'email' if email_mode else self.message_type,

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -833,6 +833,7 @@ class MailComposer(models.TransientModel):
         values = {
             'author_id': self.author_id.id,
             'bypassed_blacklist': self.bypass_blacklist,
+            'mass_mode': email_mode,
             'mail_activity_type_id': self.mail_activity_type_id.id,
             'mail_server_id': self.mail_server_id.id,
             'message_type': 'email' if email_mode else self.message_type,

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -29,7 +29,6 @@
                         <field name="scheduled_date" invisible="1"/>
                         <field name="subtype_id" invisible="1"/>
                         <field name="subtype_is_log" invisible="1"/>
-                        <field name="use_exclusion_list" invisible="1"/>
                         <!-- visible wizard -->
                         <field name="email_from"
                             attrs="{'invisible':[('composition_mode', '!=', 'mass_mail')]}"/>
@@ -69,6 +68,9 @@
                                 <field name="reply_to" string="Reply-to Address" placeholder='e.g: "info@mycompany.odoo.com"'
                                     attrs="{'invisible':['|', ('reply_to_mode', '=', 'update'), ('composition_mode', '!=', 'mass_mail')],
                                             'required':[('reply_to_mode', '!=', 'update'), ('composition_mode', '=', 'mass_mail')]}"/>
+                                <group string="Advanced" groups="base.group_no_one">
+                                    <field name="bypass_blacklist"/>
+                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -173,6 +173,10 @@ class MassMailing(models.Model):
         domain="[('mailing_model_name', '=', mailing_model_name)]")
     mailing_filter_domain = fields.Char('Favorite filter domain', related='mailing_filter_id.mailing_domain')
     mailing_filter_count = fields.Integer('# Favorite Filters', compute='_compute_mailing_filter_count')
+    bypass_blacklist = fields.Boolean('Include Blacklist',
+                                      help='Include all recipients, even the blacklisted ones. '
+                                           'To use with caution and for non-marketing-related issues '
+                                           '(shortage of service, emergencies, …)')
     # A/B Testing
     ab_testing_completed = fields.Boolean(related='campaign_id.ab_testing_completed')
     ab_testing_description = fields.Html('A/B Testing Description', compute="_compute_ab_testing_description")
@@ -1076,6 +1080,7 @@ class MassMailing(models.Model):
                 'reply_to_force_new': mailing.reply_to_mode == 'new',
                 'subject': mailing.subject,
                 'template_id': False,
+                'bypass_blacklist': mailing.bypass_blacklist,
             }
             if mailing.reply_to_mode == 'new':
                 composer_values['reply_to'] = mailing.reply_to

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1052,7 +1052,12 @@ class MassMailing(models.Model):
         return url
 
     def action_send_mail(self, res_ids=None):
-        author_id = self.env.user.partner_id.id
+        current_partner_id = self.env.user.partner_id.id
+        if self.env['ir.model.data']._xmlid_to_res_id('base.partner_root') == current_partner_id:
+            # If current user is odoobot, take mailing responsible as author
+            author_id = self.user_id.partner_id.id
+        else:
+            author_id = current_partner_id
 
         for mailing in self:
             context_user = mailing.user_id or mailing.write_uid or self.env.user

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1301,10 +1301,6 @@ class MassMailing(models.Model):
         mailing_domain = []
         if hasattr(self.env[self.mailing_model_name], '_mailing_get_default_domain'):
             mailing_domain = self.env[self.mailing_model_name]._mailing_get_default_domain(self)
-
-        if self.mailing_type == 'mail' and 'is_blacklisted' in self.env[self.mailing_model_name]._fields:
-            mailing_domain = expression.AND([[('is_blacklisted', '=', False)], mailing_domain])
-
         return mailing_domain
 
     def _parse_mailing_domain(self):

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -78,8 +78,7 @@ class TestMassMailValues(MassMailCommon):
         self.assertEqual(mailing.mailing_model_real, 'res.partner')
         self.assertEqual(mailing.reply_to_mode, 'new')
         self.assertEqual(mailing.reply_to, self.user_marketing.email_formatted)
-        # default for partner: remove blacklisted
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('is_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
         # update domain
         mailing.write({
             'mailing_domain': [('email', 'ilike', 'test.example.com')]
@@ -122,8 +121,7 @@ class TestMassMailValues(MassMailCommon):
             'body_html': '<p>Hello <t t-out="object.name"/></p>',
             'mailing_model_id': self.env['ir.model']._get('res.partner').id,
         })
-        # default for partner: remove blacklisted
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('is_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
 
         # prepare initial data
         filter_1, filter_2, filter_3 = self.env['mailing.filter'].create([

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -364,6 +364,8 @@
                                     <group string="Advanced" groups="base.group_no_one">
                                         <field name="mail_server_available" invisible="1"/>
                                         <field name="name" required="False" string="Name" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                        <field name="bypass_blacklist"
+                                               attrs="{'readonly': [('state', 'not in', ('draft', ))]}"/>
                                         <field name="mail_server_id" attrs="{'readonly': [('state', 'in', ('sending', 'done'))],
                                          'invisible': [('mail_server_available', '=', False)]}"/>
                                         <field name="keep_archives" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -98,4 +98,5 @@ class MailComposeMessage(models.TransientModel):
             'sent_date': now,
             'state': 'done',
             'subject': self.subject,
+            'bypass_blacklist': self.bypass_blacklist,
         }

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -309,13 +309,6 @@ class Mailing(models.Model):
     # TOOLS
     # --------------------------------------------------
 
-    def _get_default_mailing_domain(self):
-        mailing_domain = super(Mailing, self)._get_default_mailing_domain()
-        if self.mailing_type == 'sms' and 'phone_sanitized_blacklisted' in self.env[self.mailing_model_name]._fields:
-            mailing_domain = expression.AND([mailing_domain, [('phone_sanitized_blacklisted', '=', False)]])
-
-        return mailing_domain
-
     def convert_links(self):
         sms_mailings = self.filtered(lambda m: m.mailing_type == 'sms')
         res = {}

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -236,7 +236,7 @@ class Mailing(models.Model):
             'mailing_id': self.id,
             'mass_keep_log': self.keep_archives,
             'mass_force_send': self.sms_force_send,
-            'mass_use_blacklist': not self.bypass_blacklist,
+            'mass_bypass_blacklist': self.bypass_blacklist,
             'mass_sms_allow_unsubscribe': self.sms_allow_unsubscribe,
         }
 

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -236,6 +236,7 @@ class Mailing(models.Model):
             'mailing_id': self.id,
             'mass_keep_log': self.keep_archives,
             'mass_force_send': self.sms_force_send,
+            'mass_use_blacklist': not self.bypass_blacklist,
             'mass_sms_allow_unsubscribe': self.sms_allow_unsubscribe,
         }
 

--- a/addons/mass_mailing_sms/tests/test_mailing_internals.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_internals.py
@@ -35,8 +35,7 @@ class TestMassMailValues(MassSMSCommon):
         self.assertEqual(mailing.medium_id, self.env.ref('mass_mailing_sms.utm_medium_sms'))
         self.assertEqual(mailing.mailing_model_name, 'res.partner')
         self.assertEqual(mailing.mailing_model_real, 'res.partner')
-        # default for partner: remove blacklisted
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('phone_sanitized_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
         # update template -> update body
         mailing.write({'sms_template_id': self.sms_template_partner.id})
         self.assertEqual(mailing.body_plaintext, self.sms_template_partner.body)

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'SMS gateway',
-    'version': '2.4',
+    'version': '2.5',
     'category': 'Hidden/Tools',
     'summary': 'SMS Text Messaging',
     'description': """

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -342,6 +342,7 @@ class SendSMS(models.TransientModel):
             'bodies': self._prepare_log_body_values(sms_records_values),
             'message_type': 'sms',
             'bypassed_blacklist': self.mass_bypass_blacklist,
+            'mass_mode': self.composition_mode == 'mass',
         }
 
     # ------------------------------------------------------------

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -47,7 +47,11 @@ class SendSMS(models.TransientModel):
     # options for comment and mass mode
     mass_keep_log = fields.Boolean('Keep a note on document', default=True)
     mass_force_send = fields.Boolean('Send directly', default=False)
-    mass_use_blacklist = fields.Boolean('Use blacklist', default=True)
+    mass_bypass_blacklist = fields.Boolean('Include Blacklist',
+                                           help='Include all recipients, even the blacklisted ones. '
+                                                'To use with caution and for non-marketing-related issues '
+                                                '(shortage of service, emergencies, …)'
+                                           )
     # recipients
     recipient_valid_count = fields.Integer('# Valid recipients', compute='_compute_recipients', compute_sudo=False)
     recipient_invalid_count = fields.Integer('# Invalid recipients', compute='_compute_recipients', compute_sudo=False)
@@ -253,7 +257,7 @@ class SendSMS(models.TransientModel):
     def _get_blacklist_record_ids(self, records, recipients_info):
         """ Get a list of blacklisted records. Those will be directly canceled
         with the right error code. """
-        if self.mass_use_blacklist:
+        if not self.mass_bypass_blacklist:
             bl_numbers = self.env['phone.blacklist'].sudo().search([]).mapped('number')
             return [r.id for r in records if recipients_info[r.id]['sanitized'] in bl_numbers]
         return []

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -239,11 +239,12 @@ class SendSMS(models.TransientModel):
         records = records if records is not None else self._get_records()
 
         sms_record_values = self._prepare_mass_sms_values(records)
-        sms_all = self._prepare_mass_sms(records, sms_record_values)
-
-        if sms_all and self.mass_keep_log and records and issubclass(type(records), self.pool['mail.thread']):
+        if sms_record_values and self.mass_keep_log and records and issubclass(type(records), self.pool['mail.thread']):
             log_values = self._prepare_mass_log_values(records, sms_record_values)
-            records._message_log_batch(**log_values)
+            messages = records._message_log_batch(**log_values)
+            for record, message in zip(records, messages):
+                sms_record_values[record.id]['mail_message_id'] = message.id
+        sms_all = self._prepare_mass_sms(records, sms_record_values)
 
         if sms_all and self.mass_force_send:
             sms_all.filtered(lambda sms: sms.state == 'outgoing').send(auto_commit=False, raise_exception=False)
@@ -340,6 +341,7 @@ class SendSMS(models.TransientModel):
         return {
             'bodies': self._prepare_log_body_values(sms_records_values),
             'message_type': 'sms',
+            'bypassed_blacklist': self.mass_bypass_blacklist,
         }
 
     # ------------------------------------------------------------

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -49,7 +49,7 @@
                         <field name="body" widget="sms_widget" attrs="{'invisible': [('comment_single_recipient', '=', True), ('recipient_single_valid', '=', False)]}" default_focus="1"/>
                         <group string="Advanced" groups="base.group_no_one"
                                attrs="{'invisible':[('composition_mode', '!=', 'mass')]}">
-                            <field name="mass_use_blacklist"/>
+                            <field name="mass_bypass_blacklist"/>
                         </group>
                         <field name="mass_keep_log" invisible="1"/>
                     </group>

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -47,6 +47,10 @@
                         </div>
                         <field name="body" widget="sms_widget" attrs="{'invisible': ['|', ('comment_single_recipient', '=', False), ('recipient_single_valid', '=', True)]}"/>
                         <field name="body" widget="sms_widget" attrs="{'invisible': [('comment_single_recipient', '=', True), ('recipient_single_valid', '=', False)]}" default_focus="1"/>
+                        <group string="Advanced" groups="base.group_no_one"
+                               attrs="{'invisible':[('composition_mode', '!=', 'mass')]}">
+                            <field name="mass_use_blacklist"/>
+                        </group>
                         <field name="mass_keep_log" invisible="1"/>
                     </group>
                 </sheet>

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2411,7 +2411,7 @@ class TestComposerResultsMassStatus(TestMailComposer):
         composer_form = Form(self.env['mail.compose.message'].with_context(
             self._get_web_context(test_records, add_web=True,
                                   default_template_id=self.template.id,
-                                  default_use_exclusion_list=False)
+                                  default_bypass_blacklist=True)
         ))
         composer = composer_form.save()
         with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_mail_app():

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -310,6 +310,7 @@ class TestMessageNotify(TestMessagePostCommon):
              'notified_partner_ids': self.partner_1 | self.partner_employee_2 | self.partner_admin,
              'res_id': test_record.id,
              'subtype_id': self.env.ref('mail.mt_note'),
+             'mass_mode': False,
             }
         )
         self.assertNotIn(new_notification, self.test_record.message_ids)

--- a/addons/test_mail_sms/tests/test_sms_composer.py
+++ b/addons/test_mail_sms/tests/test_sms_composer.py
@@ -346,7 +346,7 @@ class TestSMSComposerMass(SMSCommon):
             ).create({
                 'body': self._test_body,
                 'mass_keep_log': False,
-                'mass_use_blacklist': True,
+                'mass_bypass_blacklist': False,
             })
 
             with self.mockSMSGateway():
@@ -378,7 +378,7 @@ class TestSMSComposerMass(SMSCommon):
             ).create({
                 'body': self._test_body,
                 'mass_keep_log': False,
-                'mass_use_blacklist': False,
+                'mass_bypass_blacklist': True,
             })
 
             with self.mockSMSGateway():
@@ -409,7 +409,7 @@ class TestSMSComposerMass(SMSCommon):
             ).create({
                 'body': self._test_body,
                 'mass_keep_log': False,
-                'mass_use_blacklist': True,
+                'mass_bypass_blacklist': False,
             })
 
             with self.mockSMSGateway():

--- a/addons/test_mail_sms/tests/test_sms_post.py
+++ b/addons/test_mail_sms/tests/test_sms_post.py
@@ -33,6 +33,13 @@ class TestSMSPost(SMSCommon, TestSMSRecipients):
         self.assertEqual(messages.subtype_id, self.env.ref('mail.mt_note'))
         self.assertSMSNotification([{'partner': self.partner_1}], 'Mega SMS\nTop moumoutte', messages)
 
+    def test_message_sms_internals_mass_mode_flag(self):
+        with self.with_user('employee'), self.mockSMSGateway():
+            test_record = self.env['mail.test.sms'].browse(self.test_record.id)
+            messages = test_record._message_sms('<p>Mega SMS<br/>Top moumoutte</p>', partner_ids=self.partner_1.ids)
+
+        self.assertFalse(messages.mass_mode)
+
     def test_message_sms_internals_resend_existingd(self):
         with self.with_user('employee'), self.mockSMSGateway(sim_error='wrong_number_format'):
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -258,6 +258,7 @@ class TestMassMailing(TestMassMailCommon):
         self.assertFalse(any(message.get('bypassed_blacklist', False) for message in messages_sent.message_format()))
         self.assertTrue(all('bypassed_blacklist' not in message
                             for message in messages_sent.with_user(self.user_portal).sudo().message_format()))
+        self.assertTrue(all(message.get('mass_mode', False) for message in messages_sent.message_format()))
 
         # Same test but with the option bypass_blacklist set to True
         mailing = mailing.copy()
@@ -279,6 +280,7 @@ class TestMassMailing(TestMassMailCommon):
         self.assertTrue(all(message.get('bypassed_blacklist', False) for message in messages_sent.message_format()))
         self.assertTrue(all('bypassed_blacklist' not in message
                             for message in messages_sent.with_user(self.user_portal).sudo().message_format()))
+        self.assertTrue(all(message.get('mass_mode', False) for message in messages_sent.message_format()))
 
 
     @users('user_marketing')

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -153,6 +153,7 @@ class TestMassSMSInternals(TestMassSMSCommon):
         self.assertEqual(mailing.canceled, 5)
         messages_sent = self.env['sms.sms'].sudo().search([('mailing_id', '=', mailing.id)]).mail_message_id
         self.assertFalse(any(message.get('bypassed_blacklist', False) for message in messages_sent.message_format()))
+        self.assertTrue(all(message.get('mass_mode', False) for message in messages_sent.message_format()))
 
         # Same test using bypass_blacklist = True
         mailing = mailing.copy()
@@ -170,6 +171,7 @@ class TestMassSMSInternals(TestMassSMSCommon):
         self.assertEqual(mailing.canceled, 4)
         messages_sent = self.env['sms.sms'].sudo().search([('mailing_id', '=', mailing.id)]).mail_message_id
         self.assertTrue(all(message.get('bypassed_blacklist', False) for message in messages_sent.message_format()))
+        self.assertTrue(all(message.get('mass_mode', False) for message in messages_sent.message_format()))
 
     @users('user_marketing')
     def test_mass_sms_internals_done_ids(self):

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -147,6 +147,22 @@ class TestMassSMSInternals(TestMassSMSCommon):
              for record in falsy_record_1 + falsy_record_2],
             mailing, falsy_record_1 + falsy_record_2,
         )
+        self.assertEqual(mailing.canceled, 5)
+
+        # Same test using bypass_blacklist = True
+        mailing = mailing.copy()
+        mailing.bypass_blacklist = True
+        with self.with_user('user_marketing'):
+            with self.mockSMSGateway():
+                mailing.action_send_sms()
+
+        self.assertSMSTraces(
+            [{'partner': bl_record_1.customer_id,
+              'number': phone_validation.phone_format(bl_record_1.phone_nbr, 'BE', '32', force_format='E164'),
+              'content': 'Dear %s this is a mass SMS' % bl_record_1.display_name}],
+            mailing, bl_record_1,
+        )
+        self.assertEqual(mailing.canceled, 4)
 
     @users('user_marketing')
     def test_mass_sms_internals_done_ids(self):

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -30,7 +30,7 @@ class TestMassSMSInternals(TestMassSMSCommon):
             'mailing_model_id': self.env['ir.model']._get('mail.test.sms.bl').id,
             'mailing_type': 'sms',
         })
-        self.assertEqual(literal_eval(mailing.mailing_domain), [('phone_sanitized_blacklisted', '=', False)])
+        self.assertEqual(literal_eval(mailing.mailing_domain), [])
 
     @users('user_marketing')
     def test_mass_sms_internals(self):


### PR DESCRIPTION
Always apply the blacklist in mass_mail composition mode and add an option to
bypass it for example for transactional or incident emails.

Technical note:
- a special test with target model with partner_id has been added because
checking blacklist works slightly differently in that case: blacklisted email
are checked against recipients (instead of email_to).

Task-2834862

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
