### PR TITLE
[FIX] web: fix buttonbox crash when it receives a class

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.js
+++ b/addons/web/static/src/views/form/button_box/button_box.js
@@ -31,4 +31,8 @@ ButtonBox.template = "web.Form.ButtonBox";
 ButtonBox.components = { Dropdown, DropdownItem };
 ButtonBox.props = {
     slots: Object,
+    class: { type: String, optional: true },
+};
+ButtonBox.defaultProps = {
+    class: "",
 };

--- a/addons/web/static/src/views/form/button_box/button_box.xml
+++ b/addons/web/static/src/views/form/button_box/button_box.xml
@@ -5,7 +5,7 @@
     <t t-set="allButtons" t-value="getButtons()" />
     <t t-set="visibleButtons" t-value="allButtons['visible']" />
     <t t-set="additionalButtons" t-value="allButtons['additional']" />
-    <div class="o-form-buttonbox oe_button_box" t-attf-class="{{ visibleButtons.length >= getMaxButtons() ? 'o_full' : 'o_not_full' }}">
+    <div class="o-form-buttonbox oe_button_box" t-attf-class="{{ visibleButtons.length >= getMaxButtons() ? 'o_full' : 'o_not_full'}} {{this.props.class}}">
         <t t-slot="{{ button_value }}" t-foreach="visibleButtons" t-as="button" t-key="button_value" />
 
         <t t-if="additionalButtons.length" >

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -5889,6 +5889,21 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o-form-buttonbox");
     });
 
+    QUnit.test("button box accepts extra classes", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <div class="oe_button_box my_class" name="button_box"><div/></div>
+                </form>`,
+            resId: 2,
+        });
+
+        assert.containsOnce(target, ".o-form-buttonbox.my_class");
+    });
+
     QUnit.test("one2many default value creation", async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
Previously, attempting to add a class to a button box would crash
because the button box divs are compiled to ButtonBox component which
did not accept a class prop. This commit fixes that.