### PR TITLE
[FIX] point_of_sale: popup behavior on text fields

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/PosPopupController.js
+++ b/addons/point_of_sale/static/src/js/Popups/PosPopupController.js
@@ -62,7 +62,10 @@ odoo.define('point_of_sale.PosPopupController', function(require) {
             }
         }
         _onWindowKeyup(event) {
-            if (!this.topPopup) return;
+            const eventIsFromInputField = event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA';
+            const shouldHandleKey = this.topPopup && !eventIsFromInputField;
+            if (!shouldHandleKey) return;
+
             if (event.key === this.topPopup.props.cancelKey) {
                 this.env.posbus.trigger(`cancel-popup-${this.topPopup.props.id}`);
             } else if (event.key === this.topPopup.props.confirmKey) {


### PR DESCRIPTION
The top popup, by default, confirm/cancel when Enter/Esc key is
pressed. This behaviour should be ignored when the focus is in
text input fields.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
