### PR TITLE
[FIX] mrp: mo split and merge fix

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1743,6 +1743,11 @@ class MrpProduction(models.Model):
         workorders_to_cancel.action_cancel()
         backorders.workorder_ids._action_confirm()
 
+        if amounts:
+            refs = [backorder._get_html_link() for backorder in backorders]
+            message = _("This Manufacturing Orders is splited to: %s") % ', '.join(refs)
+            self.message_post(body=message)
+
         return self.env['mrp.production'].browse(production_ids)
 
     def button_mark_done(self):

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -36,6 +36,9 @@
                         </group>
                         <group>
                             <field name="product_id"/>
+                            <field name="product_tracking" invisible="1"/>
+                            <field name="company_id" invisible="1"/>
+                            <field name="state" invisible="1"/>
                             <label for="product_qty"/>
                             <div class="o_row">
                                 <span><field name="product_qty"/></span>
@@ -58,6 +61,8 @@
                             <field name="quantity"/>
                             <field name="user_id"/>
                             <field name="date"/>
+                            <field name="lot_producing_id" context="{'default_product_id': parent.product_id, 'default_company_id': parent.company_id}"
+                            domain="[('company_id','=',parent.company_id),('product_id','=',parent.product_id)]" attrs="{'column_invisible': ['|',('parent.state','=','draft'),('parent.product_tracking', 'in', ('none', False))]}"/>
                         </tree>
                     </field>
                     <field name="production_split_multi_id" invisible="1"/>


### PR DESCRIPTION
  With this commit
   =============
  - Added a field lot/serial number for backorder & log-note when mo is splited
   we can give a lot/serial number to each backorder
   at the time of splitting mo. We have added a lot/serial no field in
   split wizard too, same as like mo.
  - After splitting mo I have added a log note in main mo like
   "This manufacture order is splited to" (splited backorder names)

TaskId - 2754217