### PR TITLE
[FIX] hr_expense: set quantity to 1 when choosing 0-cost-product

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -129,6 +129,12 @@ class HrExpense(models.Model):
         for expense in self.filtered("product_has_cost"):
             expense.currency_id = expense.company_currency_id
 
+    @api.onchange('product_has_cost')
+    def _onchange_product_has_cost(self):
+        # Reset quantity to 1, in case of 0-cost product
+        if not self.product_has_cost:
+            self.quantity = 1
+
     @api.depends('date', 'currency_id', 'company_currency_id', 'company_id')
     def _compute_currency_rate(self):
         date_today = fields.Date.context_today(self.env.user)


### PR DESCRIPTION
Scenario:

Open expense, choose product with cost, set quantity to 5, now choose
any 0-cost product. Save the expense.

Behavior: quantity is 5

Expected behavior: quantity should be set to 1

Implications: As a result, in the list view on expenses, we see incorrect quantity.
Moreover, in SO, price_unit will be incorrectly computed.

task - 2867723


