### PR TITLE
[FIX] account: block automatic entry creation from 0 balance lines

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -334,7 +334,7 @@ class AutomaticEntryWizard(models.TransientModel):
                 destination_move_offset += 2
                 accrual_move_lines = accrual_move.mapped('line_ids').filtered(lambda line: line.account_id == accrual_account)[accrual_move_offsets[accrual_move]:accrual_move_offsets[accrual_move]+2]
                 accrual_move_offsets[accrual_move] += 2
-                (accrual_move_lines + destination_move_lines).reconcile()
+                (accrual_move_lines + destination_move_lines).filtered(lambda line: not line.currency_id.is_zero(line.balance)).reconcile()
             move.message_post(body=self._format_strings(_('Adjusting Entries have been created for this invoice:<ul><li>%(link1)s cancelling '
                                                           '{percent:.2f}%% of {amount}</li><li>%(link0)s postponing it to {new_date}</li></ul>',
                                                           link0=self._format_move_link(destination_move),


### PR DESCRIPTION
Open Accounting>Journal Items
Select 1+ items with 0 credit/debit
Hit Actions>Automatic Entries
In the wizard choose 'Change Period', select an Accrued Account with
'reconcile' flag and confirm

Error will raise 'You are trying to reconcile some entries that are
already reconciled.'
It is not clear to the user, but the issue is that lines with 0 balance
are considered as reconciled. New entries, with 0 balance, will be
created to match the selected one, but on reconciliation the issue will
raise

opw-2909058

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
