### PR TITLE
[FIX] website: restore inline SVG on steps snippet start

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -135,6 +135,8 @@
             # to archive and not load that JS file if we have to create a 001.js
             # and the DB has no snippet using the 000.js left.
             'website/static/src/snippets/s_map/000.js',
+            'website/static/src/snippets/s_process_steps/000.js',
+            'website/static/src/snippets/s_process_steps/utils.js',
         ],
         'web.assets_frontend_minimal': [
             'website/static/src/js/content/inject_dom.js',

--- a/addons/website/static/src/snippets/s_process_steps/000.js
+++ b/addons/website/static/src/snippets/s_process_steps/000.js
@@ -1,0 +1,34 @@
+/** @odoo-module */
+
+import {qweb} from 'web.core';
+import publicWidget from 'web.public.widget';
+import StepsConnectorsBuilder from './utils';
+
+const ProcessStepsWidget = publicWidget.Widget.extend({
+    selector: '.s_process_steps',
+    xmlDependencies: ['/website/static/src/snippets/s_process_steps/000.xml'],
+
+    /**
+     * @override
+     */
+    start() {
+        if (!this.el.querySelector('svg.s_process_step_svg_defs defs')) {
+            // The inline SVGs inside the snippet are empty. This is probably due
+            // the sanitization of a field during the save, like in a product
+            // description field.
+            // In such cases, reconstruct the steps connectors.
+            this.el.querySelector('svg.s_process_step_svg_defs').innerHTML = qweb.render(
+                'website.s_process_steps.defs', {
+                    color: this.el.dataset.arrowColor,
+                    id: 's_process_steps_arrow_head' + Date.now(),
+                }
+            );
+            new StepsConnectorsBuilder(this.el).rebuildStepsConnectors();
+        }
+        return this._super(...arguments);
+    },
+});
+
+publicWidget.registry.processSteps = ProcessStepsWidget;
+
+export default ProcessStepsWidget;

--- a/addons/website/static/src/snippets/s_process_steps/000.xml
+++ b/addons/website/static/src/snippets/s_process_steps/000.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-name="website.s_process_steps.defs">
+    <defs>
+        <marker class="s_process_steps_arrow_head" markerWidth="15" markerHeight="10" refX="6" refY="6" orient="auto" t-att-id="id">
+            <path d="M 2,2 L10,6 L2,10 L6,6 L2,2" vector-effect="non-scaling-size" t-attf-style="fill: #{color};"></path>
+        </marker>
+    </defs>
+</t>
+
+<t t-name="website.s_process_steps.connectorPath">
+    <t t-if="arrowHeadId">
+        <path t-att-d="path" vector-effect="non-scaling-stroke" t-attf-marker-end="url(##{arrowHeadId})" t-attf-style="stroke: #{color};"></path>
+    </t>
+    <t t-else="">
+        <path t-att-d="path" vector-effect="non-scaling-stroke" t-attf-style="stroke: #{color};"></path>
+    </t>
+</t>
+
+</templates>

--- a/addons/website/static/src/snippets/s_process_steps/options.js
+++ b/addons/website/static/src/snippets/s_process_steps/options.js
@@ -2,6 +2,7 @@
 
 import options from 'web_editor.snippets.options';
 import weUtils from 'web_editor.utils';
+import StepsConnectorsBuilder from './utils';
 
 options.registry.StepsConnector = options.Class.extend({
 
@@ -15,7 +16,7 @@ options.registry.StepsConnector = options.Class.extend({
     selectClass: function (previewMode, value, params) {
         this._super(...arguments);
         if (params.name === 'connector_type') {
-            this._reloadConnectors();
+            new StepsConnectorsBuilder(this.$target[0]).rebuildStepsConnectors();
             let markerEnd = '';
             if (['s_process_steps_connector_arrow', 's_process_steps_connector_curved_arrow'].includes(value)) {
                 const arrowHeadEl = this.$target[0].querySelector('.s_process_steps_arrow_head');
@@ -36,7 +37,9 @@ options.registry.StepsConnector = options.Class.extend({
     changeColor(previewMode, widgetValue, params) {
         const htmlPropColor = weUtils.getCSSVariableValue(widgetValue);
         const arrowHeadEl = this.$target[0].closest('.s_process_steps').querySelector('.s_process_steps_arrow_head');
-        arrowHeadEl.querySelector('path').style.fill = htmlPropColor || widgetValue;
+        const color = htmlPropColor || widgetValue;
+        arrowHeadEl.querySelector('path').style.fill = color;
+        this.$target[0].closest('.s_process_steps').dataset.arrowColor = color;
     },
 
     //--------------------------------------------------------------------------
@@ -48,114 +51,9 @@ options.registry.StepsConnector = options.Class.extend({
      */
     notify(name) {
         if (['change_column_size', 'change_container_width', 'change_columns', 'move_snippet'].includes(name)) {
-            this._reloadConnectors();
+            new StepsConnectorsBuilder(this.$target[0]).rebuildStepsConnectors();
         } else {
             this._super(...arguments);
-        }
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * Width and position of the connectors should be updated when one of the
-     * steps is modified.
-     *
-     * @private
-     */
-    _reloadConnectors() {
-        const possibleTypes = this._requestUserValueWidgets('connector_type')[0].getMethodsParams().optionsPossibleValues.selectClass;
-        const type = possibleTypes.find(possibleType => possibleType && this.$target[0].classList.contains(possibleType)) || '';
-        const steps = this.$target[0].querySelectorAll('.s_process_step');
-
-        for (let i = 0; i < steps.length - 1; i++) {
-            const connectorEl = steps[i].querySelector('.s_process_step_connector');
-            const stepMainElementRect = this._getStepMainElementRect(steps[i]);
-            const nextStepMainElementRect = this._getStepMainElementRect(steps[i + 1]);
-            const stepSize = this._getStepColSize(steps[i]);
-            const nextStepSize = this._getStepColSize(steps[i + 1]);
-            const nextStepPadding = this._getStepColPadding(steps[i + 1]);
-
-            connectorEl.style.left = `calc(50% + ${stepMainElementRect.width / 2}px)`;
-            connectorEl.style.height = `${stepMainElementRect.height}px`;
-            connectorEl.style.width = `calc(${100 * (stepSize / 2 + nextStepPadding + nextStepSize / 2) / stepSize}% - ${stepMainElementRect.width / 2}px - ${nextStepMainElementRect.width / 2}px)`;
-            connectorEl.classList.toggle('d-none', nextStepMainElementRect.top > stepMainElementRect.bottom);
-            const {height, width} = connectorEl.getBoundingClientRect();
-            connectorEl.setAttribute('viewBox', `0 0 ${width} ${height}`);
-            connectorEl.querySelector('path').setAttribute('d', this._getPath(type, width, height));
-        }
-    },
-    /**
-     * Returns the step's icon or content bounding rectangle.
-     *
-     * @private
-     * @param {HTMLElement}
-     * @returns {object}
-     */
-    _getStepMainElementRect(stepEl) {
-        const iconEl = stepEl.querySelector('i');
-        if (iconEl) {
-            return iconEl.getBoundingClientRect();
-        }
-        const contentEls = stepEl.querySelectorAll('.s_process_step_content > *');
-        // If there is no icon, the biggest text bloc in the content container
-        // will be chosen.
-        if (contentEls.length) {
-            const contentRects = [...contentEls].map(contentEl => {
-                const range = document.createRange();
-                range.selectNodeContents(contentEl);
-                return range.getBoundingClientRect();
-            });
-            return contentRects.reduce((previous, current) => {
-                return current.width > previous.width ? current : previous;
-            });
-        }
-        return {};
-    },
-    /**
-     * Returns the size of the step, as a number of bootstrap lg-col.
-     *
-     * @private
-     * @param {HTMLElement}
-     * @returns {integer}
-     */
-    _getStepColSize(stepEl) {
-        const colClass = stepEl.className.split(' ').find(cl => cl.startsWith('col-lg'));
-        return parseInt(colClass[colClass.length - 1]);
-    },
-    /**
-     * Returns the padding of the step, as a number of bootstrap lg-col.
-     *
-     * @private
-     * @param {HTMLElement}
-     * @returns {integer}
-     */
-    _getStepColPadding(stepEl) {
-        const paddingClass = stepEl.className.split(' ').find(cl => cl.startsWith('offset-lg'));
-        return paddingClass ? parseInt(paddingClass[paddingClass.length - 1]) : 0;
-    },
-    /**
-     * Returns the svg path based on the type of connector.
-     *
-     * @private
-     * @param {string} type
-     * @param {integer} width
-     * @param {integer} height
-     * @returns {string}
-     */
-    _getPath(type, width, height) {
-        const hHeight = height / 2;
-        switch (type) {
-            case 's_process_steps_connector_line': {
-                return `M 0 ${hHeight} L ${width} ${hHeight}`;
-            }
-            case 's_process_steps_connector_arrow': {
-                return `M ${0.05 * width} ${hHeight} L ${0.95 * width - 6} ${hHeight}`;
-            }
-            case 's_process_steps_connector_curved_arrow': {
-                return `M ${0.05 * width} ${hHeight * 1.2} Q ${width / 2} ${hHeight * 1.8}, ${0.95 * width - 6} ${hHeight * 1.2}`;
-            }
         }
     },
 });

--- a/addons/website/static/src/snippets/s_process_steps/utils.js
+++ b/addons/website/static/src/snippets/s_process_steps/utils.js
@@ -1,0 +1,126 @@
+/** @odoo-module */
+
+import {qweb} from 'web.core';
+
+class StepsConnectorsBuilder {
+    /**
+     * Creates a steps connectors builder for a given steps element.
+     *
+     * @param {element} el steps element
+     */
+    constructor(el) {
+        this.el = el;
+    }
+
+    /**
+     * Rebuilds the steps connectors.
+     * Width and position of the connectors should be updated when one of the
+     * steps is modified or if they were lost after a sanitization.
+     */
+    rebuildStepsConnectors() {
+        const steps = this.el.querySelectorAll('.s_process_step');
+        for (let i = 0; i < steps.length - 1; i++) {
+            const connectorEl = steps[i].querySelector('.s_process_step_connector');
+            const stepMainElementRect = this._getStepMainElementRect(steps[i]);
+            const nextStepMainElementRect = this._getStepMainElementRect(steps[i + 1]);
+            const stepSize = this._getStepColSize(steps[i]);
+            const nextStepSize = this._getStepColSize(steps[i + 1]);
+            const nextStepPadding = this._getStepColPadding(steps[i + 1]);
+    
+            connectorEl.style.left = `calc(50% + ${stepMainElementRect.width / 2}px)`;
+            connectorEl.style.height = `${stepMainElementRect.height}px`;
+            connectorEl.style.width = `calc(${100 * (stepSize / 2 + nextStepPadding + nextStepSize / 2) / stepSize}% - ${stepMainElementRect.width / 2}px - ${nextStepMainElementRect.width / 2}px)`;
+            connectorEl.classList.toggle('d-none', nextStepMainElementRect.top > stepMainElementRect.bottom);
+            const {height, width} = connectorEl.getBoundingClientRect();
+            connectorEl.setAttribute('viewBox', `0 0 ${width} ${height}`);
+            let pathEl = connectorEl.querySelector('path');
+            const pathAttr = this._getPath(width, height) || '';
+            if (pathEl) {
+                pathEl.setAttribute('d', pathAttr);
+            } else {
+                const defsSvgEl = this.el.querySelector('svg.s_process_step_svg_defs');
+                connectorEl.innerHTML = qweb.render('website.s_process_steps.connectorPath', {
+                    path: pathAttr,
+                    arrowHeadId: this.el.classList.contains('s_process_steps_connector_arrow') ||
+                        this.el.classList.contains('s_process_steps_connector_curved_arrow') ?
+                        defsSvgEl.querySelector('marker').id : '',
+                    color: defsSvgEl.querySelector('path').style.fill,
+                });
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the step's icon or content bounding rectangle.
+     *
+     * @private
+     * @param {HTMLElement}
+     * @returns {object}
+     */
+    _getStepMainElementRect(stepEl) {
+        const iconEl = stepEl.querySelector('i');
+        if (iconEl) {
+            return iconEl.getBoundingClientRect();
+        }
+        const contentEls = stepEl.querySelectorAll('.s_process_step_content > *');
+        // If there is no icon, the biggest text bloc in the content container
+        // will be chosen.
+        if (contentEls.length) {
+            const contentRects = [...contentEls].map(contentEl => {
+                const range = document.createRange();
+                range.selectNodeContents(contentEl);
+                return range.getBoundingClientRect();
+            });
+            return contentRects.reduce((previous, current) => {
+                return current.width > previous.width ? current : previous;
+            });
+        }
+        return {};
+    }
+    /**
+     * Returns the size of the step, as a number of bootstrap lg-col.
+     *
+     * @private
+     * @param {HTMLElement}
+     * @returns {integer}
+     */
+    _getStepColSize(stepEl) {
+        const colClass = stepEl.className.split(' ').find(cl => cl.startsWith('col-lg'));
+        return parseInt(colClass[colClass.length - 1]);
+    }
+    /**
+     * Returns the padding of the step, as a number of bootstrap lg-col.
+     *
+     * @private
+     * @param {HTMLElement}
+     * @returns {integer}
+     */
+    _getStepColPadding(stepEl) {
+        const paddingClass = stepEl.className.split(' ').find(cl => cl.startsWith('offset-lg'));
+        return paddingClass ? parseInt(paddingClass[paddingClass.length - 1]) : 0;
+    }
+    /**
+     * Returns the svg path based on the type of connector.
+     *
+     * @private
+     * @param {integer} width
+     * @param {integer} height
+     * @returns {string}
+     */
+    _getPath(width, height) {
+        const hHeight = height / 2;
+        if (this.el.classList.contains('s_process_steps_connector_line')) {
+            return `M 0 ${hHeight} L ${width} ${hHeight}`;
+        } else if (this.el.classList.contains('s_process_steps_connector_arrow')) {
+            return `M ${0.05 * width} ${hHeight} L ${0.95 * width - 6} ${hHeight}`;
+        } else if (this.el.classList.contains('s_process_steps_connector_curved_arrow')) {
+            return `M ${0.05 * width} ${hHeight * 1.2} Q ${width / 2} ${hHeight * 1.8}, ${0.95 * width - 6} ${hHeight * 1.2}`;
+        }
+    }
+}
+
+export default StepsConnectorsBuilder;


### PR DESCRIPTION
Since [1] when a process steps snippet is sanitized, the content of the
inline SVGs involved in drawing the connectors is lost.

This commit restores those SVGs in case they are not present when the
snippet is started.

Steps to reproduce:
- Drop a steps snippet in the product-specific part of a product page.
- Configure its arrow type and its color.
- Save.
=> The connectors were not displayed anymore.

[1]: https://github.com/odoo/odoo/commit/aba31e9f2d8a44ce1586403f2a621a6caeed57b4

task-2829961

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
