### PR TITLE
[FIX] CRM: Unable to choose portal user when assigning an opportunity

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -104,7 +104,7 @@ class Lead(models.Model):
         compute='_compute_name', readonly=False, store=True)
     user_id = fields.Many2one(
         'res.users', string='Salesperson', default=lambda self: self.env.user,
-        domain="['&', ('share', '=', False), ('company_ids', 'in', user_company_ids)]",
+        domain="['&', ('share', '=', True), ('company_ids', 'in', user_company_ids)]",
         check_company=True, index=True, tracking=True)
     user_company_ids = fields.Many2many(
         'res.company', compute='_compute_user_company_ids',


### PR DESCRIPTION
Issue: When setting a portal user as a salesperson for the creation of an opportunity in the website form, we cannot retrieve him/her if we edit the opportunity in the CRM module.

Solution: The "user_id" fields for salesperson in the crm_lead.py model has a domain set to 'share'='False'. Setting it to True resolve the problem.

Signed-off-by: Eteil Djoumatchoua (etdj) <etdj@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
