### PR TITLE
[FIX] web_editor: allow to insert link at the start of the text/node

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -682,12 +682,8 @@ export function getDeepRange(editable, { range, sel, splitText, select, correctT
         (!beforeEnd || (beforeEnd.nodeType === Node.TEXT_NODE && !isVisibleStr(beforeEnd)))
     ) {
         const previous = previousLeaf(end, editable, true);
-        if (previous && closestElement(previous).isContentEditable) {
-            if (!endOffset && !startOffset && (start === end)) {
-                [end, endOffset] = [end, endOffset];
-            } else {
-                [end, endOffset] = [previous, nodeSize(previous)];
-            }
+        if (previous && closestElement(previous).isContentEditable && start !== end) {
+            [end, endOffset] = [previous, nodeSize(previous)];
         }
     }
 

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -683,7 +683,11 @@ export function getDeepRange(editable, { range, sel, splitText, select, correctT
     ) {
         const previous = previousLeaf(end, editable, true);
         if (previous && closestElement(previous).isContentEditable) {
-            [end, endOffset] = [previous, nodeSize(previous)];
+            if (!endOffset && !startOffset && (start === end)) {
+                [end, endOffset] = [end, endOffset];
+            } else {
+                [end, endOffset] = [previous, nodeSize(previous)];
+            }
         }
     }
 


### PR DESCRIPTION
**Current behavior before PR:**

Inserting the link at the beginning of the text/node creates link on previous
text/node

**Desired behavior after PR is merged:**

It should be possible to insert link at the beginning of the text/node


Task-2786607

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
