### PR TITLE
[FIX] point_of_sale: use taxed prices in discount comparison

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2268,6 +2268,16 @@ exports.Orderline = Backbone.Model.extend({
             return this.get_base_price();
         }
     },
+    get_taxed_lst_unit_price: function(){
+        var lst_price = this.get_lst_price();
+        if (this.pos.config.iface_tax_included === 'total') {
+            var product =  this.get_product();
+            var taxes_ids = product.taxes_id;
+            var product_taxes = this.get_taxes_after_fp(taxes_ids);
+            return this.compute_all(product_taxes, lst_price, 1, this.pos.currency.rounding).total_included;
+        }
+        return lst_price;
+    },
     get_price_without_tax: function(){
         return this.get_all_prices().priceWithoutTax;
     },

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -37,9 +37,9 @@
                         <span> </span><t t-esc="props.line.get_unit().name" />
                         at
                         <t t-if="props.line.display_discount_policy() == 'without_discount' and
-                            props.line.get_unit_display_price() &lt; props.line.get_lst_price()">
+                            props.line.get_unit_display_price() &lt; props.line.get_taxed_lst_unit_price()">
                             <s>
-                                <t t-esc="env.pos.format_currency(props.line.get_fixed_lst_price(),'Product Price')" />
+                                <t t-esc="env.pos.format_currency(props.line.get_taxed_lst_unit_price(),'Product Price')" />
                             </s>
                             <t t-esc="env.pos.format_currency(props.line.get_unit_display_price(),'Product Price')" />
                         </t>


### PR DESCRIPTION
Before this commit, If "Show public price & discount to the customer"
discount display policy is selected, taxed prices in the pricelist with
discounts are compared with untaxed prices in the public pricelist,
which leads to not showing the discounted values when the pricelist
value is less than untaxed list price, but the taxed value is more than
untaxed list price.

Steps to reproduce:

1. Create a product, add it to a pricelist with a lower price in a way
 that if the tax is added the price is more than its sale price, add a
 tax option to the product
2. Set the pricelist discount display policy as `Show public price &
discount to the customer`
3. Set the PoS to use tax-included prices, and to use the discounted
pricelist
4. start the PoS session, add the product, you will see that the
public price isn't shown (with a strike-through)

To fix, we can use a different function that computes the taxed public
price, so it could be compared with the pricelist price.

opw-2919734

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
