### PR TITLE
[FIX] web_editor: fix display of double overlays in edit mode

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1986,7 +1986,6 @@ var SnippetsMenu = Widget.extend({
                         if (editor.isSticky()) {
                             editor.toggleOverlay(true, false);
                             customize$Elements = await editor.toggleOptions(true);
-                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Steps to reproduce the bug:

1. Drag and drop the "image - text" snippet.
2. Click on the image => you have a double overlay which appears (one on
the column with handles and one on the image without handles), this is
good, that's what we want: the ability to control the column width but
as the image has options, it should be framed with an overlay too to
indicate what you are editing in the right panel.
3. Hover the column options => good, only the overlay of the column
remains in preview mode (without handles / buttons).
4. Hover the image options => good, only the overlay of the image
remains in preview mode (without handles / buttons).
5. Stop hovering the panel => the double overlay should be restored but
that's not the case: only the column one remains, even though the image
options are still displayed in the panel.

When we introduced the possibility to display 2 overlays at the same
time in this commit [1], we added a loop to search for the overlays to
display since there can now be several.

But in a later commit [2], we added a `break` in this loop, which no
longer allows displaying more than one overlay when necessary.

[1]: https://github.com/odoo/odoo/commit/9bbe5be3fb0d995374a369851df3641979d8e553
[2]: https://github.com/odoo/odoo/commit/806a8db35b5e0e6a461422f5bba7c97180c3ef29

task-2919164

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
