### PR TITLE
[FIX] web_editor: remove copy paste unwanted newline

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -38,6 +38,7 @@ import {
     startPos,
     nodeSize,
     allowsParagraphRelatedElements,
+    isEmptyBlock,
     isUnbreakable,
     makeContentsInline,
 } from '../utils/utils.js';
@@ -168,6 +169,9 @@ function insert(editor, data, isText = true) {
                 if (offset) {
                     const [left, right] = splitElement(currentNode.parentElement, offset);
                     currentNode = insertBefore ? right : left;
+                    if (isEmptyBlock(right)) {
+                        right.remove();
+                    }
                 } else {
                     currentNode = currentNode.parentElement;
                 }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1041,6 +1041,7 @@ const paragraphRelatedElements = [
     'H4',
     'H5',
     'H6',
+    'PRE',
 ];
 
 /**


### PR DESCRIPTION
**Current behavior before PR:**

- When you try to paste text beside a text which is in code formate it
  puts the new text in new line with smaller font.

- When we try to paste text in code formate in new line then it will
  give a blank space below the pasted text

**Desired behavior after PR is merged:**

- when you try to paste text beside a text which is in code formate it
  puts the pasted text in new line with original fontsize.

- When we paste the text in code formate in new line then it will not give
  a empty line below it,

Task-2683455


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
