### PR TITLE
[IMP] product: involve product template in last update computation

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -175,6 +175,15 @@ class ProductProduct(models.Model):
             else:
                 record.image_variant_1920 = record.image_1920
 
+    @api.depends("create_date", "write_date", "product_tmpl_id.create_date", "product_tmpl_id.write_date")
+    def compute_concurrency_field_with_access(self):
+        # Intentionally not calling super() to involve all fields explicitly
+        for record in self:
+            record[self.CONCURRENCY_CHECK_FIELD] = max(filter(None, (
+                record.product_tmpl_id.write_date or record.product_tmpl_id.create_date,
+                record.write_date or record.create_date or fields.Datetime.now(),
+            )))
+
     def _compute_image_1024(self):
         """Get the image from the template if no image is set on the variant."""
         for record in self:

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -3,6 +3,7 @@
 
 import base64
 from collections import OrderedDict
+from datetime import datetime, timedelta
 import io
 import unittest.mock
 
@@ -624,6 +625,20 @@ class TestVariantsImages(common.TestProductCommon):
         """Check that on variant, the image used is the image_variant_1920 if set,
         and defaults to the template image otherwise.
         """
+        # Pretend setup happened in an older transaction by updating on the SQL layer and making sure it gets reloaded
+        # Using _write() instead of write() because write() only allows updating log access fields at boot time
+        before = datetime.now() - timedelta(hours=1)
+        self.template._write({
+            'create_date': before,
+            'write_date': before,
+        })
+        self.variants._write({
+            'create_date': before,
+            'write_date': before,
+        })
+        self.template.invalidate_cache(['create_date', 'write_date'], self.template.ids)
+        self.variants.invalidate_cache(['create_date', 'write_date'], self.variants.ids)
+
         f = io.BytesIO()
         Image.new('RGB', (800, 500), '#000000').save(f, 'PNG')
         f.seek(0)
@@ -633,8 +648,11 @@ class TestVariantsImages(common.TestProductCommon):
         self.assertEqual(len(set(images)), 4)
 
         variant_no_image = self.variants[0]
+        old_last_update = variant_no_image['__last_update']
         self.assertFalse(variant_no_image.image_1920)
         self.template.image_1920 = image_black
+        self.template.write({'write_date': datetime.now()})
+        new_last_update = variant_no_image['__last_update']
 
         # the first has no image variant, all the others do
         self.assertFalse(variant_no_image.image_variant_1920)
@@ -644,6 +662,9 @@ class TestVariantsImages(common.TestProductCommon):
         self.assertEqual(variant_no_image.image_1920, self.template.image_1920)
         # having changed the template image should not have changed these
         self.assertEqual(images[1:], self.variants.mapped('image_1920')[1:])
+
+        # last update changed for the variant without image
+        self.assertLess(old_last_update, new_last_update)
 
     def test_update_images_with_archived_variants(self):
         """Update images after variants have been archived"""


### PR DESCRIPTION
This is a backport of [1].

Since [2] whenever the image of a `product.template` is updated, the
write date of all its related `product.product` is updated.  This was
done to force a change of the unique parameter on image fields, which is
based on the last update field.

After this commit the `product.product`'s last update is instead
computed by also taking the `product.template`'s last update into
account.  This avoids the need for updating the write date when the
image is changed, but on the other hand it also forces product images to
be reloaded whenever any other field of the `product.template` is
changed.

[1]: https://github.com/odoo/odoo/commit/620b0222506a91e73eac6e08f5d17d20e3a23230
[2]: https://github.com/odoo/odoo/pull/71139

Related to https://github.com/odoo/odoo/pull/76309

task-2477438

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
