### PR TITLE
[IMP] account: provide bank statement info instead of payment

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -95,7 +95,7 @@
                     </table>
                 </div>
                 <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" t-if="!props.is_exchange" style="margin-top:5px; margin-bottom:5px;" groups="account.group_account_invoice" t-on-click="() => props._onRemoveMoveReconcile(props.move_id, props.partial_id)">Unreconcile</button>
-                <button class="btn btn-sm btn-secondary js_open_payment float-end" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onOpenMove(props.move_id)">View</button>
+                <button class="btn btn-sm btn-secondary js_open_payment float-end" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onOpenMove(props.move_id, props.has_statement, props.account_payment_id)">View</button>
             </div>
         </div>
     </t>

--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -82,8 +82,9 @@ export class AccountPaymentField extends Component {
         this.props.record.model.notify();
     }
 
-    async openMove(moveId) {
-        const action = await this.orm.call(this.props.record.resModel, 'action_open_business_doc', [moveId], {});
+    async openMove(moveId, hasStatement, paymentId) {
+        const actionParams = hasStatement ? ['account.payment', 'button_open_statement_lines', [paymentId], {}] : [this.props.record.resModel, 'action_open_business_doc', [moveId], {}];
+        const action = await this.orm.call(...actionParams);
         this.action.doAction(action);
     }
 }


### PR DESCRIPTION
When a payment is registered manually and reconciled with a
bank statement, the payment widget on the invoice still displays payment data.
Clicking the "View" button also redirects to the `account.payment` form.
Once a bank statement is posted, it is preferred to show the bank statement
information and redirect to a bank reconciliation widget view,
filtered by the bank statement line reconciled with the payment.

In a very unlikely case that a payment is reconciled with more than one
bank statement line, we display the last statement's data and filter the
reconciliation widget by the last statement line posted.

task-2928299

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
