### PR TITLE
[FIX] web: less bounce edit form button

### DIFF
--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -31,8 +31,8 @@ export class FormRenderer extends Component {
             this.compileParams
         );
         useSubEnv({ model: record.model });
-        useBounceButton(useRef("compiled_view_root"), () => {
-            return !record.isInEdition;
+        useBounceButton(useRef("compiled_view_root"), (target) => {
+            return !record.isInEdition && !!target.closest(".oe_title, .o_inner_group");
         });
         this.uiService = useService('ui');
         this.onResize = useDebounced(this.render, 200);

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -9109,11 +9109,17 @@ QUnit.module("Views", (hooks) => {
                     <div class="oe_title">
                         <field name="display_name"/>
                     </div>
+                    <notebook>
+                        <page name="a" string="A"></page>
+                    </notebook>
                 </form>`,
             resId: 1,
         });
 
         // in readonly
+        await click(target.querySelector(".nav-tabs .nav-item"));
+        assert.containsNone(target, ".o_catch_attention");
+
         await click(target.querySelector("div.oe_title"));
         assert.hasClass(target.querySelector(".o_form_button_edit"), "o_catch_attention");
 


### PR DESCRIPTION
Before this commit, the edit button in form view bounced on any click.
Now, the button bounces only when clicking in the area of a field or its label.