### PR TITLE
Saas 15 fix pos bar search paid order table deleted

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -31,7 +31,12 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 });
             }
             getTable(order) {
-                return `${order.table.floor.name} (${order.table.name})`;
+                if (typeof order.table != "undefined") {
+                    return `${order.table.floor.name} (${order.table.name})`;
+                    }
+                else {
+                    return this.env._t("The table was deleted")
+                }
             }
             //@override
             _getSearchFields() {


### PR DESCRIPTION
[FIX] pos: search for paid order in pos bar not working when a table was deleted

In the pos restaurant/bar the orders are linked to a table.
The tables can be deleted but the order still exists.
In the POS, when we go to "orders" and search for paid orders, it will not work if a table was deleted before.
It's because in the code we search for order.table.floor.name.
As the table does not exist anymore, we can't find the floor

So if the table is undifined we return a string saying that the table was deleted

fixes opw-2835603
