### PR TITLE
[FIX] pos: search for paid order in pos bar not working when a table …

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -25,8 +25,13 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     TipScreen: 'TIPPING',
                 });
             }
-            getTable(order) {
-                return `${order.table.floor.name} (${order.table.name})`;
+           getTable(order) {
+                if (typeof order.table != "undefined") {
+                    return `${order.table.floor.name} (${order.table.name})`;
+                    }
+                else {
+                    return this.env._t("The table was deleted")
+                }
             }
             //@override
             _getSearchFields() {


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
In the pos restaurant/bar the orders are linked to a table.
The tables can be deleted but the order still exists.
In the POS, when we go to "orders" and search for paid orders, it will not work if a table was deleted before.
It's because in the code we search for order.table.floor.name.
As the table does not exist anymore, we can't find the floor

So if the table is undifined we return a string saying that the table was deleted

fixes opw-2835603

Current behavior before PR:

error in console and the search does not return a result if there was a table that was deleted in it

Desired behavior after PR is merged:
It now return a result for the search even if a table was deleted.
If a table was deleted, it return a string saying "The table was deleted"



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
