### PR TITLE
[IMP] web_editor: adds a remove button next to the shape selector

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6247,15 +6247,6 @@ registry.BackgroundShape = SnippetOptionWidget.extend({
         return uiFragment;
     },
     /**
-     * @override
-     */
-    async _computeWidgetVisibility(widgetName, params) {
-        if (widgetName === 'shape_none_opt') {
-            return false;
-        }
-        return this._super(...arguments);
-    },
-    /**
      * Flips the shape on its x/y axis.
      *
      * @param {boolean} previewMode

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -234,136 +234,137 @@
              t-att-data-selector="selector"
              t-att-data-exclude="exclude"
              t-att-data-target="target">
-            <we-select-pager string="Shape" class="o_we_sublevel_1 o_we_shape_menu" data-dependencies="!shape_none_opt" data-name="bg_shape_opt">
-                <!-- Invisible None button to be used for select's placeholder text -->
-                <we-button data-shape="" data-name="shape_none_opt"/>
-                <we-select-page string="Origins">
-                    <we-button data-shape="web_editor/Origins/02_001" data-select-label="Origins 01"/>
-                    <we-button data-shape="web_editor/Origins/04_001" data-select-label="Origins 02"/>
-                    <we-button data-shape="web_editor/Origins/05" data-select-label="Origins 03"/>
-                    <we-button data-shape="web_editor/Origins/06_001" data-select-label="Origins 04"/>
-                    <we-button data-shape="web_editor/Origins/07_002" data-select-label="Origins 05"/>
-                    <we-button data-shape="web_editor/Origins/08" data-select-label="Origins 06"/>
-                    <we-button data-shape="web_editor/Origins/09_001" data-select-label="Origins 07"/>
-                    <we-button data-shape="web_editor/Origins/11_001" data-select-label="Origins 08"/>
-                    <we-button data-shape="web_editor/Origins/14_001" data-select-label="Origins 09"/>
-                    <we-button data-shape="web_editor/Origins/16" data-select-label="Origins 10" data-animated="true"/>
-                    <we-button data-shape="web_editor/Origins/17" data-select-label="Origins 11" data-animated="true"/>
-                    <we-button data-shape="web_editor/Origins/18" data-select-label="Origins 12" data-animated="true"/>
-                </we-select-page>
-                <we-select-page string="Blocks &amp; Rainy">
-                    <we-button data-shape="web_editor/Blocks/02_001" data-select-label="Blocks 01"/>
-                    <we-button data-shape="web_editor/Blocks/01_001" data-select-label="Blocks 02"/>
-                    <we-button data-shape="web_editor/Blocks/03" data-select-label="Blocks 03"/>
-                    <we-button data-shape="web_editor/Blocks/04" data-select-label="Blocks 04"/>
-                    <we-button data-shape="web_editor/Rainy/01_001" data-select-label="Rainy 01" data-animated="true"/>
-                    <we-button data-shape="web_editor/Rainy/02_001" data-select-label="Rainy 02" data-animated="true"/>
-                    <we-button data-shape="web_editor/Rainy/06" data-select-label="Rainy 03"/>
-                    <we-button data-shape="web_editor/Rainy/07" data-select-label="Rainy 04"/>
-                    <we-button data-shape="web_editor/Rainy/10" data-select-label="Rainy 05" data-animated="true"/>
-                    <we-button data-shape="web_editor/Rainy/04" data-select-label="Rainy 06"/>
-                    <we-button data-shape="web_editor/Rainy/05_001" data-select-label="Rainy 07"/>
-                    <we-button data-shape="web_editor/Rainy/03_001" data-select-label="Rainy 08" data-animated="true"/>
-                    <we-button data-shape="web_editor/Rainy/08_001" data-select-label="Rainy 09" data-animated="true"/>
-                    <we-button data-shape="web_editor/Rainy/09_001" data-select-label="Rainy 10"/>
-                </we-select-page>
-                <we-select-page string="Wavy">
-                    <we-button data-shape="web_editor/Wavy/01_001" data-select-label="Wavy 01"/>
-                    <we-button data-shape="web_editor/Wavy/02_001" data-select-label="Wavy 02"/>
-                    <we-button data-shape="web_editor/Wavy/03" data-select-label="Wavy 03"/>
-                    <we-button data-shape="web_editor/Wavy/10" data-select-label="Wavy 04"/>
-                    <we-button data-shape="web_editor/Wavy/24" data-select-label="Wavy 05" data-animated="true"/>
-                    <we-button data-shape="web_editor/Wavy/25" data-select-label="Wavy 06" data-animated="true"/>
-                    <we-button data-shape="web_editor/Wavy/26" data-select-label="Wavy 07" data-animated="true"/>
-                    <we-button data-shape="web_editor/Wavy/27" data-select-label="Wavy 08" data-animated="true"/>
-                    <we-button data-shape="web_editor/Wavy/04" data-select-label="Wavy 09"/>
-                    <we-button data-shape="web_editor/Wavy/05" data-select-label="Wavy 10"/>
-                    <we-button data-shape="web_editor/Wavy/06_001" data-select-label="Wavy 11"/>
-                    <we-button data-shape="web_editor/Wavy/07" data-select-label="Wavy 12"/>
-                    <we-button data-shape="web_editor/Wavy/08" data-select-label="Wavy 13"/>
-                    <we-button data-shape="web_editor/Wavy/09" data-select-label="Wavy 14"/>
-                    <we-button data-shape="web_editor/Wavy/11" data-select-label="Wavy 15"/>
-                    <we-button data-shape="web_editor/Wavy/12_001" data-select-label="Wavy 16"/>
-                    <we-button data-shape="web_editor/Wavy/28" data-select-label="Wavy 17" data-animated="true"/>
-                    <we-button data-shape="web_editor/Wavy/13_001" data-select-label="Wavy 18"/>
-                    <we-button data-shape="web_editor/Wavy/14" data-select-label="Wavy 19"/>
-                    <we-button data-shape="web_editor/Wavy/15" data-select-label="Wavy 20"/>
-                    <we-button data-shape="web_editor/Wavy/16" data-select-label="Wavy 21"/>
-                    <we-button data-shape="web_editor/Wavy/17" data-select-label="Wavy 22"/>
-                    <we-button data-shape="web_editor/Wavy/18" data-select-label="Wavy 23"/>
-                    <we-button data-shape="web_editor/Wavy/19" data-select-label="Wavy 24"/>
-                    <we-button data-shape="web_editor/Wavy/20" data-select-label="Wavy 25"/>
-                    <we-button data-shape="web_editor/Wavy/21" data-select-label="Wavy 26"/>
-                    <we-button data-shape="web_editor/Wavy/22" data-select-label="Wavy 27"/>
-                    <we-button data-shape="web_editor/Wavy/23" data-select-label="Wavy 28"/>
-                </we-select-page>
-                <we-select-page string="Blobs">
-                    <we-button data-shape="web_editor/Blobs/01_001" data-select-label="Blobs 01" data-animated="true"/>
-                    <we-button data-shape="web_editor/Blobs/02" data-select-label="Blobs 02"/>
-                    <we-button data-shape="web_editor/Blobs/03" data-select-label="Blobs 03"/>
-                    <we-button data-shape="web_editor/Blobs/04" data-select-label="Blobs 04"/>
-                    <we-button data-shape="web_editor/Blobs/05" data-select-label="Blobs 05"/>
-                    <we-button data-shape="web_editor/Blobs/06" data-select-label="Blobs 06"/>
-                    <we-button data-shape="web_editor/Blobs/07" data-select-label="Blobs 07"/>
-                    <we-button data-shape="web_editor/Blobs/08" data-select-label="Blobs 08"/>
-                    <we-button data-shape="web_editor/Blobs/09" data-select-label="Blobs 09"/>
-                    <we-button data-shape="web_editor/Blobs/10_001" data-select-label="Blobs 10"/>
-                    <we-button data-shape="web_editor/Blobs/11" data-select-label="Blobs 11"/>
-                    <we-button data-shape="web_editor/Blobs/12" data-select-label="Blobs 12"/>
-                </we-select-page>
-                <we-select-page string="Bold">
-                    <we-button data-shape="web_editor/Bold/01" data-select-label="Bold 01"/>
-                    <we-button data-shape="web_editor/Bold/02" data-select-label="Bold 02"/>
-                    <we-button data-shape="web_editor/Bold/03" data-select-label="Bold 03"/>
-                    <we-button data-shape="web_editor/Bold/04" data-select-label="Bold 04"/>
-                    <we-button data-shape="web_editor/Bold/05_001" data-select-label="Bold 05"/>
-                    <we-button data-shape="web_editor/Bold/06_001" data-select-label="Bold 06"/>
-                    <we-button data-shape="web_editor/Bold/07_001" data-select-label="Bold 07"/>
-                    <we-button data-shape="web_editor/Bold/08" data-select-label="Bold 08"/>
-                    <we-button data-shape="web_editor/Bold/09" data-select-label="Bold 09"/>
-                    <we-button data-shape="web_editor/Bold/10_001" data-select-label="Bold 10"/>
-                    <we-button data-shape="web_editor/Bold/11_001" data-select-label="Bold 11"/>
-                    <we-button data-shape="web_editor/Bold/12_001" data-select-label="Bold 12"/>
-                </we-select-page>
-                <we-select-page string="Airy &amp; Zigs">
-                    <we-button data-shape="web_editor/Airy/01" data-select-label="Airy 01"/>
-                    <we-button data-shape="web_editor/Airy/02" data-select-label="Airy 02"/>
-                    <we-button data-shape="web_editor/Airy/03_001" data-select-label="Airy 03" data-animated="true"/>
-                    <we-button data-shape="web_editor/Airy/04_001" data-select-label="Airy 04" data-animated="true"/>
-                    <we-button data-shape="web_editor/Airy/05_001" data-select-label="Airy 05" data-animated="true"/>
-                    <we-button data-shape="web_editor/Airy/06" data-select-label="Airy 06"/>
-                    <we-button data-shape="web_editor/Airy/07" data-select-label="Airy 07"/>
-                    <we-button data-shape="web_editor/Airy/08" data-select-label="Airy 08"/>
-                    <we-button data-shape="web_editor/Airy/09" data-select-label="Airy 09"/>
-                    <we-button data-shape="web_editor/Airy/10" data-select-label="Airy 10"/>
-                    <we-button data-shape="web_editor/Airy/11" data-select-label="Airy 11"/>
-                    <we-button data-shape="web_editor/Airy/12_001" data-select-label="Airy 12" data-animated="true"/>
-                    <we-button data-shape="web_editor/Airy/13_001" data-select-label="Airy 13" data-animated="true"/>
-                    <we-button data-shape="web_editor/Airy/14" data-select-label="Airy 14"/>
-                    <we-button data-shape="web_editor/Zigs/01_001" data-select-label="Zigs 01" data-animated="true"/>
-                    <we-button data-shape="web_editor/Zigs/02_001" data-select-label="Zigs 02" data-animated="true"/>
-                    <we-button data-shape="web_editor/Zigs/03" data-select-label="Zigs 03"/>
-                    <we-button data-shape="web_editor/Zigs/04" data-select-label="Zigs 04"/>
-                    <we-button data-shape="web_editor/Zigs/05" data-select-label="Zigs 05"/>
-                    <we-button data-shape="web_editor/Zigs/06" data-select-label="Zigs 06"/>
-                </we-select-page>
-                <we-select-page string="Floating shapes">
-                    <we-button data-shape="web_editor/Floats/01" data-select-label="Float 01" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/02" data-select-label="Float 02" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/03" data-select-label="Float 03" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/04" data-select-label="Float 04" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/05" data-select-label="Float 05" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/06" data-select-label="Float 06" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/07" data-select-label="Float 07" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/08" data-select-label="Float 08" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/09" data-select-label="Float 09" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/10" data-select-label="Float 10" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/11" data-select-label="Float 11" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/12" data-select-label="Float 12" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/13" data-select-label="Float 13" data-animated="true"/>
-                    <we-button data-shape="web_editor/Floats/14" data-select-label="Float 14" data-animated="true"/>
-                </we-select-page>
-            </we-select-pager>
+            <we-row string="Shape" class="o_we_sublevel_1">
+                <we-select-pager class="o_we_shape_menu" data-dependencies="!shape_none_opt" data-name="bg_shape_opt">
+                    <we-select-page string="Origins">
+                        <we-button data-shape="web_editor/Origins/02_001" data-select-label="Origins 01"/>
+                        <we-button data-shape="web_editor/Origins/04_001" data-select-label="Origins 02"/>
+                        <we-button data-shape="web_editor/Origins/05" data-select-label="Origins 03"/>
+                        <we-button data-shape="web_editor/Origins/06_001" data-select-label="Origins 04"/>
+                        <we-button data-shape="web_editor/Origins/07_002" data-select-label="Origins 05"/>
+                        <we-button data-shape="web_editor/Origins/08" data-select-label="Origins 06"/>
+                        <we-button data-shape="web_editor/Origins/09_001" data-select-label="Origins 07"/>
+                        <we-button data-shape="web_editor/Origins/11_001" data-select-label="Origins 08"/>
+                        <we-button data-shape="web_editor/Origins/14_001" data-select-label="Origins 09"/>
+                        <we-button data-shape="web_editor/Origins/16" data-select-label="Origins 10" data-animated="true"/>
+                        <we-button data-shape="web_editor/Origins/17" data-select-label="Origins 11" data-animated="true"/>
+                        <we-button data-shape="web_editor/Origins/18" data-select-label="Origins 12" data-animated="true"/>
+                    </we-select-page>
+                    <we-select-page string="Blocks &amp; Rainy">
+                        <we-button data-shape="web_editor/Blocks/02_001" data-select-label="Blocks 01"/>
+                        <we-button data-shape="web_editor/Blocks/01_001" data-select-label="Blocks 02"/>
+                        <we-button data-shape="web_editor/Blocks/03" data-select-label="Blocks 03"/>
+                        <we-button data-shape="web_editor/Blocks/04" data-select-label="Blocks 04"/>
+                        <we-button data-shape="web_editor/Rainy/01_001" data-select-label="Rainy 01" data-animated="true"/>
+                        <we-button data-shape="web_editor/Rainy/02_001" data-select-label="Rainy 02" data-animated="true"/>
+                        <we-button data-shape="web_editor/Rainy/06" data-select-label="Rainy 03"/>
+                        <we-button data-shape="web_editor/Rainy/07" data-select-label="Rainy 04"/>
+                        <we-button data-shape="web_editor/Rainy/10" data-select-label="Rainy 05" data-animated="true"/>
+                        <we-button data-shape="web_editor/Rainy/04" data-select-label="Rainy 06"/>
+                        <we-button data-shape="web_editor/Rainy/05_001" data-select-label="Rainy 07"/>
+                        <we-button data-shape="web_editor/Rainy/03_001" data-select-label="Rainy 08" data-animated="true"/>
+                        <we-button data-shape="web_editor/Rainy/08_001" data-select-label="Rainy 09" data-animated="true"/>
+                        <we-button data-shape="web_editor/Rainy/09_001" data-select-label="Rainy 10"/>
+                    </we-select-page>
+                    <we-select-page string="Wavy">
+                        <we-button data-shape="web_editor/Wavy/01_001" data-select-label="Wavy 01"/>
+                        <we-button data-shape="web_editor/Wavy/02_001" data-select-label="Wavy 02"/>
+                        <we-button data-shape="web_editor/Wavy/03" data-select-label="Wavy 03"/>
+                        <we-button data-shape="web_editor/Wavy/10" data-select-label="Wavy 04"/>
+                        <we-button data-shape="web_editor/Wavy/24" data-select-label="Wavy 05" data-animated="true"/>
+                        <we-button data-shape="web_editor/Wavy/25" data-select-label="Wavy 06" data-animated="true"/>
+                        <we-button data-shape="web_editor/Wavy/26" data-select-label="Wavy 07" data-animated="true"/>
+                        <we-button data-shape="web_editor/Wavy/27" data-select-label="Wavy 08" data-animated="true"/>
+                        <we-button data-shape="web_editor/Wavy/04" data-select-label="Wavy 09"/>
+                        <we-button data-shape="web_editor/Wavy/05" data-select-label="Wavy 10"/>
+                        <we-button data-shape="web_editor/Wavy/06_001" data-select-label="Wavy 11"/>
+                        <we-button data-shape="web_editor/Wavy/07" data-select-label="Wavy 12"/>
+                        <we-button data-shape="web_editor/Wavy/08" data-select-label="Wavy 13"/>
+                        <we-button data-shape="web_editor/Wavy/09" data-select-label="Wavy 14"/>
+                        <we-button data-shape="web_editor/Wavy/11" data-select-label="Wavy 15"/>
+                        <we-button data-shape="web_editor/Wavy/12_001" data-select-label="Wavy 16"/>
+                        <we-button data-shape="web_editor/Wavy/28" data-select-label="Wavy 17" data-animated="true"/>
+                        <we-button data-shape="web_editor/Wavy/13_001" data-select-label="Wavy 18"/>
+                        <we-button data-shape="web_editor/Wavy/14" data-select-label="Wavy 19"/>
+                        <we-button data-shape="web_editor/Wavy/15" data-select-label="Wavy 20"/>
+                        <we-button data-shape="web_editor/Wavy/16" data-select-label="Wavy 21"/>
+                        <we-button data-shape="web_editor/Wavy/17" data-select-label="Wavy 22"/>
+                        <we-button data-shape="web_editor/Wavy/18" data-select-label="Wavy 23"/>
+                        <we-button data-shape="web_editor/Wavy/19" data-select-label="Wavy 24"/>
+                        <we-button data-shape="web_editor/Wavy/20" data-select-label="Wavy 25"/>
+                        <we-button data-shape="web_editor/Wavy/21" data-select-label="Wavy 26"/>
+                        <we-button data-shape="web_editor/Wavy/22" data-select-label="Wavy 27"/>
+                        <we-button data-shape="web_editor/Wavy/23" data-select-label="Wavy 28"/>
+                    </we-select-page>
+                    <we-select-page string="Blobs">
+                        <we-button data-shape="web_editor/Blobs/01_001" data-select-label="Blobs 01" data-animated="true"/>
+                        <we-button data-shape="web_editor/Blobs/02" data-select-label="Blobs 02"/>
+                        <we-button data-shape="web_editor/Blobs/03" data-select-label="Blobs 03"/>
+                        <we-button data-shape="web_editor/Blobs/04" data-select-label="Blobs 04"/>
+                        <we-button data-shape="web_editor/Blobs/05" data-select-label="Blobs 05"/>
+                        <we-button data-shape="web_editor/Blobs/06" data-select-label="Blobs 06"/>
+                        <we-button data-shape="web_editor/Blobs/07" data-select-label="Blobs 07"/>
+                        <we-button data-shape="web_editor/Blobs/08" data-select-label="Blobs 08"/>
+                        <we-button data-shape="web_editor/Blobs/09" data-select-label="Blobs 09"/>
+                        <we-button data-shape="web_editor/Blobs/10_001" data-select-label="Blobs 10"/>
+                        <we-button data-shape="web_editor/Blobs/11" data-select-label="Blobs 11"/>
+                        <we-button data-shape="web_editor/Blobs/12" data-select-label="Blobs 12"/>
+                    </we-select-page>
+                    <we-select-page string="Bold">
+                        <we-button data-shape="web_editor/Bold/01" data-select-label="Bold 01"/>
+                        <we-button data-shape="web_editor/Bold/02" data-select-label="Bold 02"/>
+                        <we-button data-shape="web_editor/Bold/03" data-select-label="Bold 03"/>
+                        <we-button data-shape="web_editor/Bold/04" data-select-label="Bold 04"/>
+                        <we-button data-shape="web_editor/Bold/05_001" data-select-label="Bold 05"/>
+                        <we-button data-shape="web_editor/Bold/06_001" data-select-label="Bold 06"/>
+                        <we-button data-shape="web_editor/Bold/07_001" data-select-label="Bold 07"/>
+                        <we-button data-shape="web_editor/Bold/08" data-select-label="Bold 08"/>
+                        <we-button data-shape="web_editor/Bold/09" data-select-label="Bold 09"/>
+                        <we-button data-shape="web_editor/Bold/10_001" data-select-label="Bold 10"/>
+                        <we-button data-shape="web_editor/Bold/11_001" data-select-label="Bold 11"/>
+                        <we-button data-shape="web_editor/Bold/12_001" data-select-label="Bold 12"/>
+                    </we-select-page>
+                    <we-select-page string="Airy &amp; Zigs">
+                        <we-button data-shape="web_editor/Airy/01" data-select-label="Airy 01"/>
+                        <we-button data-shape="web_editor/Airy/02" data-select-label="Airy 02"/>
+                        <we-button data-shape="web_editor/Airy/03_001" data-select-label="Airy 03" data-animated="true"/>
+                        <we-button data-shape="web_editor/Airy/04_001" data-select-label="Airy 04" data-animated="true"/>
+                        <we-button data-shape="web_editor/Airy/05_001" data-select-label="Airy 05" data-animated="true"/>
+                        <we-button data-shape="web_editor/Airy/06" data-select-label="Airy 06"/>
+                        <we-button data-shape="web_editor/Airy/07" data-select-label="Airy 07"/>
+                        <we-button data-shape="web_editor/Airy/08" data-select-label="Airy 08"/>
+                        <we-button data-shape="web_editor/Airy/09" data-select-label="Airy 09"/>
+                        <we-button data-shape="web_editor/Airy/10" data-select-label="Airy 10"/>
+                        <we-button data-shape="web_editor/Airy/11" data-select-label="Airy 11"/>
+                        <we-button data-shape="web_editor/Airy/12_001" data-select-label="Airy 12" data-animated="true"/>
+                        <we-button data-shape="web_editor/Airy/13_001" data-select-label="Airy 13" data-animated="true"/>
+                        <we-button data-shape="web_editor/Airy/14" data-select-label="Airy 14"/>
+                        <we-button data-shape="web_editor/Zigs/01_001" data-select-label="Zigs 01" data-animated="true"/>
+                        <we-button data-shape="web_editor/Zigs/02_001" data-select-label="Zigs 02" data-animated="true"/>
+                        <we-button data-shape="web_editor/Zigs/03" data-select-label="Zigs 03"/>
+                        <we-button data-shape="web_editor/Zigs/04" data-select-label="Zigs 04"/>
+                        <we-button data-shape="web_editor/Zigs/05" data-select-label="Zigs 05"/>
+                        <we-button data-shape="web_editor/Zigs/06" data-select-label="Zigs 06"/>
+                    </we-select-page>
+                    <we-select-page string="Floating shapes">
+                        <we-button data-shape="web_editor/Floats/01" data-select-label="Float 01" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/02" data-select-label="Float 02" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/03" data-select-label="Float 03" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/04" data-select-label="Float 04" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/05" data-select-label="Float 05" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/06" data-select-label="Float 06" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/07" data-select-label="Float 07" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/08" data-select-label="Float 08" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/09" data-select-label="Float 09" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/10" data-select-label="Float 10" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/11" data-select-label="Float 11" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/12" data-select-label="Float 12" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/13" data-select-label="Float 13" data-animated="true"/>
+                        <we-button data-shape="web_editor/Floats/14" data-select-label="Float 14" data-animated="true"/>
+                    </we-select-page>
+                </we-select-pager>
+                <we-button data-shape="" data-name="shape_none_opt" data-dependencies="!shape_none_opt" data-no-preview="true" class="fa fa-fw fa-times"/>
+            </we-row>
             <we-row string="Flip" class="o_we_sublevel_2">
                 <we-button class="fa fa-fw fa-arrows-h" data-flip-x="true" data-no-preview="true" data-dependencies="!shape_none_opt"/>
                 <we-button class="fa fa-fw fa-arrows-v" data-flip-y="true" data-no-preview="true" data-dependencies="!shape_none_opt"/>


### PR DESCRIPTION
This commit aims to make it easier to remove a shape over a background
image.

Before this commit, we could only remove a shape by clicking on the
"shape" button in the background options (it was not easy to find
quickly), but with this commit we can now also remove it thanks to a
"remove" button that has been added next to the shape selector.

task-2827802

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
