### PR TITLE
[FIX] product: prevent printing labels for archived products

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -1607,6 +1607,14 @@ msgid "Next Activity Type"
 msgstr ""
 
 #. module: product
+#: code:addons/product/wizard/product_label_layout.py:0
+#, python-format
+msgid ""
+"No product to print, if the product is archived please unarchive it before "
+"printing its label."
+msgstr ""
+
+#. module: product
 #: model_terms:ir.actions.act_window,help:product.product_supplierinfo_type_action
 msgid "No vendor pricelist found"
 msgstr ""

--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -52,6 +52,8 @@ class ProductLabelLayout(models.TransientModel):
         elif self.product_ids:
             products = self.product_ids.ids
             active_model = 'product.product'
+        else:
+            raise UserError(_("No product to print, if the product is archived please unarchive it before printing its label."))
 
         # Build data to pass to the report
         data = {


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product
- Archive it
- Try to print labels

Problem:
A traceback is triggered, Because when we click on print the label
we have to open the wizard, so we load the wizard model
`product.label.layout` via an onchange:
https://github.com/odoo/odoo/blob/15.0/odoo/models.py#L6357-L6360
thanks to the context, it will find the concerned product
(via default_product_id) Except that the product is archived,
so ignored in the result returned by the onchange

Therefore, in the confirmation, we will create the wizard,
but it will not have a product filled, so in the `_prepare_report_data`
function we do not enter in the if or the elif:
https://github.com/odoo/odoo/blob/d9f45ba6941939b3d4b40beb5abbc330be84d695/addons/product/wizard/product_label_layout.py#L49-L54

it will therefore raise a traceback when we want to iterate on it:
https://github.com/odoo/odoo/blob/d9f45ba6941939b3d4b40beb5abbc330be84d695/addons/product/wizard/product_label_layout.py#L60

opw-2855659




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
