### PR TITLE
[REF] web: changes to the Notebook API

### DIFF
--- a/addons/web/static/src/core/notebook/notebook.js
+++ b/addons/web/static/src/core/notebook/notebook.js
@@ -15,25 +15,27 @@ const { Component, onWillDestroy, onWillUpdateProps, useEffect, useRef, useState
  *
  *      e.g.:
  *          PageTemplate.template = xml`
-                    <h1 t-esc="props.title" />
+                    <h1 t-esc="props.heading" />
                     <p t-esc="props.text" />`;
 
  *      `pages` could be:
  *      [
  *          {
  *              Component: PageTemplate,
+ *              id: 'unique_id' // optional: can be given as defaultPage props to the notebook
+ *              index: 1 // optional: page position in the notebook
+ *              name: 'some_name' // optional
+ *              title: "Some Title 1", // title displayed on the tab pane
  *              props: {
- *                  title: "Some Title 1",
- *                  isVisible: bool,
+ *                  heading: "Page 1",
  *                  text: "Text Content 1",
  *              },
- *              name: 'some_name' // optional
  *          },
  *          {
  *              Component: PageTemplate,
+ *              title: "Some Title 2",
  *              props: {
- *                  title: "Some Title 2",
- *                  isVisible: bool,
+ *                  heading: "Page 2",
  *                  text: "Text Content 2",
  *              },
  *          },
@@ -108,14 +110,14 @@ export class Notebook extends Component {
         if (!props.slots && !props.pages) {
             return [];
         }
+        if (props.pages) {
+            for (const page of props.pages) {
+                page.isVisible = true;
+            }
+        }
         const pages = [];
         const pagesWithIndex = [];
         for (const [k, v] of Object.entries({ ...props.slots, ...props.pages })) {
-            if (v.props) {
-                v.isVisible = v.props.isVisible;
-                v.title = v.props.title;
-                v.index = v.props.index;
-            }
             const id = v.id || k;
             if (v.index) {
                 pagesWithIndex.push([id, v]);

--- a/addons/web/static/src/views/kanban/kanban_column_examples_dialog.js
+++ b/addons/web/static/src/views/kanban/kanban_column_examples_dialog.js
@@ -35,11 +35,8 @@ export class KanbanColumnExamplesDialog extends Component {
         this.props.examples.forEach((eg) => {
             this.pages.push({
                 Component: KanbanExamplesNotebookTemplate,
-                props: {
-                    ...eg,
-                    isVisible: true,
-                    title: eg.name,
-                },
+                title: eg.name,
+                props: eg,
                 id: eg.name,
             });
         });

--- a/addons/web/static/tests/core/notebook_tests.js
+++ b/addons/web/static/tests/core/notebook_tests.js
@@ -193,31 +193,35 @@ QUnit.module("Components", (hooks) => {
 
         class NotebookPageRenderer extends Component {}
         NotebookPageRenderer.template = xml`
-                <h3 t-esc="props.title"></h3>
+                <h3 t-esc="props.heading"></h3>
                 <p t-esc="props.text" />
             `;
+        NotebookPageRenderer.props = {
+            heading: String,
+            text: String,
+        };
 
         class Parent extends Component {
             setup() {
                 this.pages = [
                     {
                         Component: NotebookPageRenderer,
+                        index: 1,
+                        title: "Page 2",
                         props: {
-                            index: 1,
-                            isVisible: true,
-                            title: "Page 2",
+                            heading: "Page 2",
                             text: "Second page rendered by a template component",
                         },
                     },
                     {
                         Component: NotebookPageRenderer,
+                        id: "page_three", // required to be set as default page
+                        index: 2,
+                        title: "Page 3",
                         props: {
-                            index: 2,
-                            isVisible: true,
-                            title: "Page 3",
+                            heading: "Page 3",
                             text: "Third page rendered by a template component",
                         },
-                        id: "page_three", // required to be set as default page
                     },
                 ];
             }
@@ -261,19 +265,13 @@ QUnit.module("Components", (hooks) => {
                 this.pages = [
                     {
                         Component: Page,
-                        props: {
-                            index: 1,
-                            isVisible: true,
-                            title: "Page 1",
-                        },
+                        index: 1,
+                        title: "Page 1",
                     },
                     {
                         Component: Page,
-                        props: {
-                            index: 2,
-                            isVisible: true,
-                            title: "Page 2",
-                        },
+                        index: 2,
+                        title: "Page 2",
                     },
                 ];
             }


### PR DESCRIPTION
This commit fixes the API of the Notebook component
that mixed props of page templates with its attributes
(isVisible, title and index). Mixing page props and
attributes was confusing. Tests have been adapted
to reflect those changes.