### PR TITLE
[FIX] web: fix form view crash when notebook has name attribute

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -421,7 +421,7 @@ export class FormCompiler extends ViewCompiler {
         const noteBookAnchors = {};
 
         if (el.hasAttribute("class")) {
-            noteBook.setAttribute("className", `"${el.getAttribute("class")}"`);
+            noteBook.setAttribute("className", toStringExpression(el.getAttribute("class")));
             el.removeAttribute("class");
         }
 
@@ -436,11 +436,6 @@ export class FormCompiler extends ViewCompiler {
 
             const pageSlot = createElement("t");
             append(noteBook, pageSlot);
-
-            if (el.hasAttribute("name")) {
-                noteBook.setAttribute("name", `"${el.getAttribute("name")}"`);
-                el.removeAttribute("name");
-            }
 
             const pageId = `page_${this.id++}`;
             const pageTitle = toStringExpression(

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -916,7 +916,7 @@ QUnit.module("Views", (hooks) => {
                     <form>
                         <sheet>
                             <field name="int_field"/>
-                            <notebook class="new_class" attrs='{"invisible": [["int_field", "=", 10]]}'>
+                            <notebook name="test_name" class="new_class" attrs='{"invisible": [["int_field", "=", 10]]}'>
                                 <page string="Foo">
                                     <field name="foo"/>
                                 </page>


### PR DESCRIPTION
Previously, when the name attribute was set on a notebook in a form view
arch, we would pass that as a prop to the Notebook component, but this
prop is not supported by the component, so it would crash in debug mode
when validating the props. This commit fixes that by simply not copying
this attribute to a prop as it is useless.