### PR TITLE
[FIX] mrp: fix workorders duration expected

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1691,9 +1691,6 @@ class MrpProduction(models.Model):
         self.env['stock.move.line'].browse(move_lines_to_unlink).unlink()
         self.env['stock.move.line'].create(move_lines_vals)
 
-        # We need to adapt `duration_expected` on both the original workorders and their
-        # backordered workorders. To do that, we use the original `duration_expected` and the
-        # ratio of the quantity produced and the quantity to produce.
         for production in self:
             initial_qty = initial_qty_by_production[production]
             initial_workorder_remaining_qty = []
@@ -1701,7 +1698,7 @@ class MrpProduction(models.Model):
 
             # Adapt duration
             for workorder in (production | bo).workorder_ids:
-                workorder.duration_expected = workorder.duration_expected * workorder.production_id.product_qty / initial_qty
+                workorder.duration_expected = workorder._get_duration_expected()
 
             # Adapt quantities produced
             for workorder in production.workorder_ids:


### PR DESCRIPTION
_split_productions wrongly compute duration expected.

task: 2925901
related to task 2884562

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
