### PR TITLE
[FIX] point_of_sale: BlockUI malfunctioning

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -76,6 +76,7 @@
 
         'web.assets_backend': [
             'point_of_sale/static/src/scss/pos_dashboard.scss',
+            'point_of_sale/static/src/scss/pos_block_ui.scss',
             'point_of_sale/static/src/backend/tours/point_of_sale.js',
             'point_of_sale/static/src/backend/debug_manager.js',
             'point_of_sale/static/src/backend/web_overrides/**/*.js',

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1242,6 +1242,23 @@ td {
     padding-top:15px;
 }
 
+/*  ********* The BlockUI Component (frontend)  ********* */
+.o_blockUI {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1100;
+  
+    background: #000000;
+    opacity: 0.6;
+    height: 100vh;
+    width: 100vw;
+  
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}
 
 /*  ********* The Screens  ********* */
 

--- a/addons/point_of_sale/static/src/scss/pos_block_ui.scss
+++ b/addons/point_of_sale/static/src/scss/pos_block_ui.scss
@@ -1,0 +1,4 @@
+/*  ********* The BlockUI Component (backend)  ********* */
+.o_blockUI {
+    z-index: 1100;
+}


### PR DESCRIPTION
Before this commit, the BlockUI component from
the web module was not rendered properly. The
reason for this is that after PR #83811 was merged,
the css from `web/static/src/core/ui/block_ui.scss`
was replaced with non-semantic Bootstrap css classes
(e.g. .d-flex, .justify-content-center). Those css
classes were inaccessible to PoS, both the frontend
and the backend, because the `point_of_sale` module
does not load Bootstrap code (a design decision).

In this commit, we restore the proper rendering
of the BlockUI component both for the "frontend"
and the "backend" of the PoS App.

task-2924335
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
