### PR TITLE
[FIX] web: ImageUrlField without value

### DIFF
--- a/addons/web/static/src/views/fields/image_url/image_url_field.xml
+++ b/addons/web/static/src/views/fields/image_url/image_url_field.xml
@@ -3,6 +3,7 @@
 
     <t t-name="web.ImageUrlField" owl="1">
         <img
+            t-if="props.value"
             class="img img-fluid"
             alt="Image"
             t-att-src="state.src"

--- a/addons/web/static/tests/views/fields/image_url_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_url_field_tests.js
@@ -212,4 +212,30 @@ QUnit.module("Fields", (hooks) => {
         await click(target.querySelector(".o_kanban_record"));
         assert.verifySteps(["open record"]);
     });
+
+    QUnit.test("image fields with empty value", async function (assert) {
+        serverData.models.partner.records[0].foo = false;
+
+        await makeView({
+            serverData,
+            type: "form",
+            resModel: "partner",
+            arch: `
+                <form>
+                    <field name="foo" widget="image_url" options="{'size': [90, 90]}"/>
+                </form>`,
+            resId: 1,
+        });
+
+        assert.hasClass(
+            target.querySelector('div[name="foo"].o_field_empty'),
+            "o_field_image_url",
+            "the widget should have the correct class"
+        );
+        assert.containsNone(
+            target,
+            'div[name="foo"] > img',
+            "the widget should not contain an image"
+        );
+    });
 });


### PR DESCRIPTION
This commit fixes an issue with the ImageUrlField
widget. When no value was given, the image displayed
a broken file instead of being empty. A test
has been added.