### PR TITLE
[REV] point_of_sale: res.partner doesn't belong to a specific company

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
@@ -56,9 +56,6 @@ odoo.define('point_of_sale.ClientDetailsEdit', function(require) {
                 });
             }
             processedChanges.id = this.props.partner.id || false;
-            if (!this.props.partner.id) {
-                processedChanges.company_id = this.env.pos.company.id;
-            }
             this.trigger('save-changes', { processedChanges });
         }
         async uploadImage(event) {


### PR DESCRIPTION
This reverts commit 3aa03eb65d431cb9749a2b31a9a09d6b41cd34a4.

based on:

https://github.com/odoo/odoo/pull/94153#issuecomment-1194580295
