### PR TITLE
[FIX] point_of_sale, pos_{loyalty,mercury}: restricting key to confir…

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -248,7 +248,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
 
         openCashControl() {
             if (this.shouldShowCashControl()) {
-                this.showPopup('CashOpeningPopup', { cancelKey: false });
+                this.showPopup('CashOpeningPopup');
             }
         }
 

--- a/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
@@ -16,6 +16,11 @@ odoo.define('point_of_sale.CashOpeningPopup', function(require) {
                 displayMoneyDetailsPopup: false,
             });
         }
+        //@override
+        async confirm() {
+            this.startSession();
+            super.confirm();
+        }
         openDetailsPopup() {
             this.state.openingCash = 0;
             this.state.notes = "";
@@ -31,8 +36,7 @@ odoo.define('point_of_sale.CashOpeningPopup', function(require) {
                    model: 'pos.session',
                     method: 'set_cashbox_pos',
                     args: [this.env.pos.pos_session.id, this.state.openingCash, this.state.notes],
-                });
-            this.cancel(); // close popup
+            });
         }
         updateCashOpening({ total, moneyDetailsNotes }) {
             this.state.openingCash = total;
@@ -49,6 +53,7 @@ odoo.define('point_of_sale.CashOpeningPopup', function(require) {
     }
 
     CashOpeningPopup.template = 'CashOpeningPopup';
+    CashOpeningPopup.defaultProps = { cancelKey: false };
     Registries.Component.add(CashOpeningPopup);
 
     return CashOpeningPopup;

--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -64,6 +64,15 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                 }
             }
         }
+        //@override
+        async confirm() {
+            await this.closeSession();
+            super.confirm();
+        }
+        //@override
+        async cancel() {
+            this.cancelPopup();
+        }
         openDetailsPopup() {
             this.state.payments[this.defaultCashDetails.id].counted = 0;
             this.state.payments[this.defaultCashDetails.id].difference = -this.defaultCashDetails.amount;

--- a/addons/point_of_sale/static/src/js/Popups/ControlButtonPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ControlButtonPopup.js
@@ -18,7 +18,8 @@ odoo.define('point_of_sale.ControlButtonPopup', function(require) {
     ControlButtonPopup.template = 'ControlButtonPopup';
     ControlButtonPopup.defaultProps = {
         cancelText: _lt('Back'),
-        controlButtons: []
+        controlButtons: [],
+        confirmKey: false,
     };
 
     Registries.Component.add(ControlButtonPopup);

--- a/addons/point_of_sale/static/src/js/Popups/ErrorPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ErrorPopup.js
@@ -18,9 +18,9 @@ odoo.define('point_of_sale.ErrorPopup', function(require) {
     ErrorPopup.template = 'ErrorPopup';
     ErrorPopup.defaultProps = {
         confirmText: _lt('Ok'),
-        cancelText: _lt('Cancel'),
         title: _lt('Error'),
         body: '',
+        cancelKey: false,
     };
 
     Registries.Component.add(ErrorPopup);

--- a/addons/point_of_sale/static/src/js/Popups/ErrorTracebackPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ErrorTracebackPopup.js
@@ -32,6 +32,7 @@ odoo.define('point_of_sale.ErrorTracebackPopup', function(require) {
     ErrorTracebackPopup.defaultProps = {
         confirmText: _lt('Ok'),
         cancelText: _lt('Cancel'),
+        confirmKey: false,
         title: _lt('Error with Traceback'),
         body: '',
         exitButtonIsShown: false,

--- a/addons/point_of_sale/static/src/js/Popups/OrderImportPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/OrderImportPopup.js
@@ -18,7 +18,7 @@ odoo.define('point_of_sale.OrderImportPopup', function(require) {
     OrderImportPopup.template = 'OrderImportPopup';
     OrderImportPopup.defaultProps = {
         confirmText: _lt('Ok'),
-        cancelText: _lt('Cancel'),
+        cancelKey: false,
         body: '',
     };
 

--- a/addons/point_of_sale/static/src/js/Popups/ProductInfoPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ProductInfoPopup.js
@@ -71,5 +71,6 @@ odoo.define('point_of_sale.ProductInfoPopup', function(require) {
     }
 
     ProductInfoPopup.template = 'ProductInfoPopup';
+    ProductInfoPopup.defaultProps= { confirmKey: false };
     Registries.Component.add(ProductInfoPopup);
 });

--- a/addons/point_of_sale/static/src/js/Popups/SelectionPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/SelectionPopup.js
@@ -46,11 +46,11 @@ odoo.define('point_of_sale.SelectionPopup', function (require) {
     }
     SelectionPopup.template = 'SelectionPopup';
     SelectionPopup.defaultProps = {
-        confirmText: _lt('Confirm'),
         cancelText: _lt('Cancel'),
         title: _lt('Select'),
         body: '',
         list: [],
+        confirmKey: false,
     };
 
     Registries.Component.add(SelectionPopup);

--- a/addons/point_of_sale/static/src/xml/Popups/CashOpeningPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashOpeningPopup.xml
@@ -18,7 +18,7 @@
                     <textarea placeholder="Notes" class="opening-cash-notes" t-model="state.notes"/>
                 </main>
                 <footer class="footer">
-                    <div class="button" t-on-click="startSession">Open session</div>
+                    <div class="button" t-on-click="confirm">Open session</div>
                 </footer>
             </div>
             <MoneyDetailsPopup

--- a/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
@@ -93,9 +93,9 @@
                     </div>
                 </main>
                 <footer class="footer">
-                    <div class="button" t-att-class="{'disabled': !canCancel()}" t-on-click="cancelPopup">Continue Selling</div>
+                    <div class="button" t-att-class="{'disabled': !canCancel()}" t-on-click="cancel">Continue Selling</div>
                     <div class="button" t-on-click="closePos">Keep Session Open</div>
-                    <div class="button" t-att-class="{'disabled': !canCloseSession()}" t-on-click="closeSession">Close Session</div>
+                    <div class="button" t-att-class="{'disabled': !canCloseSession()}" t-on-click="confirm">Close Session</div>
                 </footer>
             </div>
             <MoneyDetailsPopup

--- a/addons/point_of_sale/static/src/xml/Popups/OfflineErrorPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/OfflineErrorPopup.xml
@@ -9,7 +9,7 @@
                     </header>
                     <main class="body traceback"><t t-esc="props.body"/></main>
                     <footer class="footer">
-                        <div class="button cancel" t-on-click="cancel">
+                        <div class="button confirm" t-on-click="confirm">
                             Ok
                         </div>
                         <div class="button dont-show-again" t-on-click="dontShowAgain">

--- a/addons/point_of_sale/static/src/xml/Popups/OrderImportPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/OrderImportPopup.xml
@@ -26,7 +26,7 @@
                         </t>
                     </ul>
                     <footer class="footer">
-                        <div class="button cancel" t-on-click="cancel">
+                        <div class="button cancel" t-on-click="confirm">
                             <t t-esc="props.confirmText" />
                         </div>
                     </footer>

--- a/addons/pos_loyalty/static/src/js/Popups/GiftCardPopup.js
+++ b/addons/pos_loyalty/static/src/js/Popups/GiftCardPopup.js
@@ -36,6 +36,13 @@ export class GiftCardPopup extends AbstractAwaitablePopup {
         this.useAutoFocus(this.state);
     }
 
+    //@override
+    async confirm() {
+        if (!this.state.showMenu) {
+            this.clickConfirm();
+        }
+    }
+
     clickConfirm() {
         this.confirmFunctions[this.state.context]();
     }

--- a/addons/pos_loyalty/static/src/xml/Popups/GiftCardPopup.xml
+++ b/addons/pos_loyalty/static/src/xml/Popups/GiftCardPopup.xml
@@ -95,7 +95,7 @@
                     <div t-if="!state.showMenu" class="button cancel gift-card-footer-button" t-on-click="switchToMenu">
                         Back
                     </div>
-                    <div t-if="!state.showMenu" class="button confirm gift-card-footer-button" t-on-click="clickConfirm">
+                    <div t-if="!state.showMenu" class="button confirm gift-card-footer-button" t-on-click="confirm">
                         Confirm
                     </div>
                 </footer>

--- a/addons/pos_mercury/static/src/js/PaymentTransactionPopup.js
+++ b/addons/pos_mercury/static/src/js/PaymentTransactionPopup.js
@@ -28,9 +28,9 @@ odoo.define('pos_mercury.PaymentTransactionPopup', function(require) {
     PaymentTransactionPopup.template = 'PaymentTransactionPopup';
     PaymentTransactionPopup.defaultProps = {
         confirmText: _lt('Ok'),
-        cancelText: _lt('Cancel'),
         title: _lt('Online Payment'),
         body: '',
+        cancelKey: false,
     };
 
     Registries.Component.add(PaymentTransactionPopup);


### PR DESCRIPTION
…m or cancel popup

The "pressing a specific key to confirm/cancel a popup" behavior was added but the problem was that
some popups only had one button which was either confirm or cancel. It was thus possible to close
those popups by bypassing the default behavior (e.g. possible to "cancel" a popup which only
has one button linked to an overridden confirm method and vice-versa). Also, we normalize the use of
`confirm` and `cancel` methods in the popups so that when the specifics keys are pressed, the right
behavior is executed.