### PR TITLE
[FIX] stock: get product qty in specific location

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -259,7 +259,7 @@ class Product(models.Model):
                 if isinstance(item, int):
                     ids.add(item)
                 else:
-                    domain = expression.OR([[('name', 'ilike', item)], domain])
+                    domain = expression.OR([[(self.env[model]._rec_name, 'ilike', item)], domain])
             if domain:
                 if force_company_id:
                     domain = expression.AND([[('company_id', '=', force_company_id)], domain])


### PR DESCRIPTION
When getting the on hand quantity of a product in a specific location,
the result may be incorrect.

To reproduce the issue:
1. In Settings, enable "Storage Locations"
2. Create a storable product P
3. Update its quantity:
    - 5 x P at WH/Stock/Shelf 1
4. Inventory > Reporting > Inventory Report
5. Apply the following filters:
    - Product: P
    - Location: WH/Stock/Shelf 1
    - => There is a line with 5 x P at WH/Stock/Shelf 1, which is
correct
6. Click on Inventory at Date, set \<Today\>, confirm
7. Apply the following filters:
    - Product: P
    - Location: WH/Stock/Shelf 1

Error: There is a line for P but its on hand quantity is 0, which is
incorrect (should be 5)

In the first search, we let the ORM handle the domain conversion. When
searching for `('location_id', 'ilike', 'WH/Stock/Shelf 1')`, it will
use the `_rec_name` of the model to find the record. In case of a stock
location, its `_rec_name` is the field `complete_name`:
https://github.com/odoo/odoo/blob/94a8ad3fae914b046064bb7ce17572be8280f6e0/addons/stock/models/stock_location.py#L19

However, for the second search, when getting the on-hand quantity of the
product, we force the use of the field `name` to find the location.
Because the `name` of the searched location is "Shelf 1", using
"WH/Stock/Shelf 1" as key search will not work.

OPW-2920904