### PR TITLE
[FIX] account: Remove useless check on bank statement button post.

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -297,42 +297,58 @@ class AccountBankStatement(models.Model):
             st_line.currency_id = self.journal_id.currency_id or self.company_id.currency_id
 
     def _check_balance_end_real_same_as_computed(self):
-        ''' Check the balance_end_real (encoded manually by the user) is equals to the balance_end (computed by odoo).
-        In case of a cash statement, the different is set automatically to a profit/loss account.
-        '''
-        for stmt in self:
-            if not stmt.currency_id.is_zero(stmt.difference):
-                if stmt.journal_type == 'cash':
-                    st_line_vals = {
-                        'statement_id': stmt.id,
-                        'journal_id': stmt.journal_id.id,
-                        'amount': stmt.difference,
-                        'date': stmt.date,
-                    }
+        """ Check the balance_end_real (encoded manually by the user) is equals to the balance_end (computed by odoo). """
+        return self._check_cash_balance_end_real_same_as_computed() and self._check_bank_balance_end_real_same_as_computed()
 
-                    if stmt.difference < 0.0:
-                        if not stmt.journal_id.loss_account_id:
-                            raise UserError(_('Please go on the %s journal and define a Loss Account. This account will be used to record cash difference.', stmt.journal_id.name))
+    def _check_cash_balance_end_real_same_as_computed(self):
+        """ Check the balance_end_real (encoded manually by the user) is equals to the balance_end (computed by odoo).
+            For a cash statement, if there is a difference, the different is set automatically to a profit/loss account.
+        """
+        for statement in self.filtered(lambda stmt: stmt.journal_type == 'cash'):
+            if not statement.currency_id.is_zero(statement.difference):
+                st_line_vals = {
+                    'statement_id': statement.id,
+                    'journal_id': statement.journal_id.id,
+                    'amount': statement.difference,
+                    'date': statement.date,
+                }
 
-                        st_line_vals['payment_ref'] = _("Cash difference observed during the counting (Loss)")
-                        st_line_vals['counterpart_account_id'] = stmt.journal_id.loss_account_id.id
-                    else:
-                        # statement.difference > 0.0
-                        if not stmt.journal_id.profit_account_id:
-                            raise UserError(_('Please go on the %s journal and define a Profit Account. This account will be used to record cash difference.', stmt.journal_id.name))
+                if statement.currency_id.compare_amounts(statement.difference, 0.0) < 0.0:
+                    if not statement.journal_id.loss_account_id:
+                        raise UserError(_(
+                            "Please go on the %s journal and define a Loss Account. "
+                            "This account will be used to record cash difference.",
+                            statement.journal_id.name
+                        ))
 
-                        st_line_vals['payment_ref'] = _("Cash difference observed during the counting (Profit)")
-                        st_line_vals['counterpart_account_id'] = stmt.journal_id.profit_account_id.id
-
-                    self.env['account.bank.statement.line'].create(st_line_vals)
+                    st_line_vals['payment_ref'] = _("Cash difference observed during the counting (Loss)")
+                    st_line_vals['counterpart_account_id'] = statement.journal_id.loss_account_id.id
                 else:
-                    balance_end_real = formatLang(self.env, stmt.balance_end_real, currency_obj=stmt.currency_id)
-                    balance_end = formatLang(self.env, stmt.balance_end, currency_obj=stmt.currency_id)
-                    raise UserError(_(
-                        'The ending balance is incorrect !\nThe expected balance (%(real_balance)s) is different from the computed one (%(computed_balance)s).',
-                        real_balance=balance_end_real,
-                        computed_balance=balance_end
-                    ))
+                    # statement.difference > 0.0
+                    if not statement.journal_id.profit_account_id:
+                        raise UserError(_(
+                            "Please go on the %s journal and define a Profit Account. "
+                            "This account will be used to record cash difference.",
+                            statement.journal_id.name
+                        ))
+
+                    st_line_vals['payment_ref'] = _("Cash difference observed during the counting (Profit)")
+                    st_line_vals['counterpart_account_id'] = statement.journal_id.profit_account_id.id
+
+                self.env['account.bank.statement.line'].create(st_line_vals)
+        return True
+
+    def _check_bank_balance_end_real_same_as_computed(self):
+        """ Check the balance_end_real (encoded manually by the user) is equals to the balance_end (computed by odoo). """
+        for statement in self.filtered(lambda stmt: stmt.journal_type == 'bank'):
+            if not statement.currency_id.is_zero(statement.difference):
+                balance_end_real = formatLang(self.env, statement.balance_end_real, currency_obj=statement.currency_id)
+                balance_end = formatLang(self.env, statement.balance_end, currency_obj=statement.currency_id)
+                raise UserError(_(
+                    'The ending balance is incorrect !\nThe expected balance (%(real_balance)s) is different from the computed one (%(computed_balance)s).',
+                    real_balance=balance_end_real,
+                    computed_balance=balance_end
+                ))
         return True
 
     def unlink(self):
@@ -399,7 +415,7 @@ class AccountBankStatement(models.Model):
         if any(statement.state != 'open' for statement in self):
             raise UserError(_("Only new statements can be posted."))
 
-        self._check_balance_end_real_same_as_computed()
+        self._check_cash_balance_end_real_same_as_computed()
 
         for statement in self:
             if not statement.name:


### PR DESCRIPTION
As we allow editing balances in processing state, we do not want to check balances before the validation of the bank statement
(only in case of a bank journal).

Commit about editing balances: 03f83eb87da00938b9d2df78651c1e06cf8a6d58

This fix split the `_check_balance_end_real_same_as_computed` into 2 functions. One to check "bank" bank statement and one to check "cash" bank statement. It allows to keep the same behavior for a "cash" bank statement when we post the bank statement, and having the right behavior for a "bank" bank statement.

opw-2835728

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
