### PR TITLE
[FIX] mass_mailing: Create mass mailing without logo

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -108,7 +108,7 @@
             <div class="row">
                 <div class="col-lg-8 pt16 pb16">
                     <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;float:none;">
-                         <img border="0" t-att-src="image_data_uri(company_id.logo)" style="height:auto;max-width:200px;max-height:48px;" />
+                         <img t-if="company_id.logo" border="0" t-att-src="image_data_uri(company_id.logo)" style="height:auto;max-width:200px;max-height:48px;" />
                     </a>
                 </div>
                 <div class="col-lg-4 text-right o_mail_no_resize">
@@ -168,7 +168,7 @@
                 <div class="col-lg-4"/>
                 <div class="col-lg-4 text-center pt16 pb16">
                     <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;">
-                        <img border="0" t-att-src="image_data_uri(company_id.logo)" style="height:auto;max-width:200px;max-height:48px;width:auto"/>
+                        <img t-if="company_id.logo" border="0" t-att-src="image_data_uri(company_id.logo)" style="height:auto;max-width:200px;max-height:48px;width:auto"/>
                     </a>
                 </div>
                 <div class="col-lg-4 text-right"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Let's consider a company c and a user in this company u.
- Delete the logo of c
- Go to mass mailing > Create

Bug:
Traceback is raised

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
