### PR TITLE
[FIX] web: BasicRelationalModel bad rpc

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -1337,7 +1337,7 @@ export class RelationalModel extends Model {
             if (payload.service === "ajax" && payload.method === "rpc") {
                 // ajax service uses an extra 'target' argument for rpc
                 args = args.concat(ev.target);
-                return payload.callback(owl.Component.env.session.rpc(...args));
+                return payload.callback(owl.Component.env.services.rpc(...args));
             } else if (payload.service === "notification") {
                 return this.notificationService.add(payload.message, {
                     className: payload.className,


### PR DESCRIPTION
There is an error using RPC in the BasicRelationalModel, we try to call
the rpc function from session. This function does not exist in session
but in services.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
