### PR TITLE
[IMP] mail: move mark_all_as_read into message_fetch

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -839,7 +839,7 @@ class Channel(models.Model):
         domain = ["&", ("model", "=", "mail.channel"), ("res_id", "in", self.ids)]
         if last_id:
             domain.append(("id", "<", last_id))
-        return self.env['mail.message']._message_fetch(domain=domain, limit=limit)
+        return self.env['mail.message']._message_fetch(domain=domain, limit=limit).message_format()
 
     # User methods
     @api.model

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -898,13 +898,13 @@ class Message(models.Model):
             :param min_id: messages must be more recent than this id
             :param max_id: message must be less recent than this id
             :param limit: the maximum amount of messages to get;
-            :returns list(dict).
+            :returns: record set of mail.message
         """
         if max_id:
             domain = expression.AND([domain, [('id', '<', max_id)]])
         if min_id:
             domain = expression.AND([domain, [('id', '>', min_id)]])
-        return self.search(domain, limit=limit).message_format()
+        return self.search(domain, limit=limit)
 
     def message_format(self, format_reply=True):
         """ Get the message values in the format for web client. Since message values can be broadcasted,

--- a/addons/mail/static/src/models/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache.js
@@ -245,43 +245,6 @@ registerModel({
             this.update(this._computeHasToLoadMessages());
         },
         /**
-         * Calls "mark all as read" when this thread becomes displayed in a
-         * view (which is notified by `isMarkAllAsReadRequested` being `true`),
-         * but delays the call until some other conditions are met, such as the
-         * messages being loaded.
-         * The reason to wait until messages are loaded is to avoid a race
-         * condition because "mark all as read" will change the state of the
-         * messages in parallel to fetch reading them.
-         *
-         * @private
-         */
-        _onChangeMarkAllAsRead() {
-            if (this.messaging.currentGuest) {
-                return;
-            }
-            if (
-                !this.isMarkAllAsReadRequested ||
-                !this.isLoaded ||
-                this.isLoading
-            ) {
-                // wait for change of state before deciding what to do
-                return;
-            }
-            this.update({ isMarkAllAsReadRequested: false });
-            if (
-                this.thread.isTemporary ||
-                this.thread.model === 'mail.box' ||
-                this.threadViews.length === 0
-            ) {
-                // ignore the request
-                return;
-            }
-            this.messaging.models['Message'].markAllAsRead([
-                ['model', '=', this.thread.model],
-                ['res_id', '=', this.thread.id],
-            ]);
-        },
-        /**
          * Loads this thread cache, by fetching the most recent messages in this
          * conversation.
          *
@@ -355,16 +318,6 @@ registerModel({
             default: false,
         }),
         /**
-         * Determines whether this cache should consider calling "mark all as
-         * read" on this thread.
-         *
-         * This field is a hint that may or may not lead to an actual call.
-         * @see `_onChangeMarkAllAsRead`
-         */
-        isMarkAllAsReadRequested: attr({
-            default: false,
-        }),
-        /**
          * Last message that has been fetched by this thread cache.
          *
          * This DOES NOT necessarily mean the last message linked to this thread
@@ -421,10 +374,6 @@ registerModel({
         new OnChange({
             dependencies: ['hasLoadingFailed', 'isCacheRefreshRequested', 'isLoaded', 'isLoading', 'thread.isTemporary', 'threadViews'],
             methodName: '_onChangeForHasToLoadMessages',
-        }),
-        new OnChange({
-            dependencies: ['isLoaded', 'isLoading', 'isMarkAllAsReadRequested', 'thread.isTemporary', 'thread.model', 'threadViews'],
-            methodName: '_onChangeMarkAllAsRead',
         }),
         new OnChange({
             dependencies: ['hasToLoadMessages'],

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -21,9 +21,10 @@ registerModel({
                 // handled in `_onClickMarkAsRead`
                 return;
             }
+            const messaging = this.messaging;
             this.thread.open();
-            if (!this.messaging.device.isSmall) {
-                this.messaging.messagingMenu.close();
+            if (!messaging.device.isSmall) {
+                messaging.messagingMenu.close();
             }
         },
         /**

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -237,7 +237,6 @@ registerModel({
             if (this.threadCache) {
                 this.threadCache.update({
                     isCacheRefreshRequested: true,
-                    isMarkAllAsReadRequested: true,
                 });
             }
             this.update({ lastVisibleMessage: clear() });

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
@@ -67,7 +67,7 @@ QUnit.test('mark as read', async function (assert) {
 });
 
 QUnit.test('click on preview should mark as read and open the thread', async function (assert) {
-    assert.expect(6);
+    assert.expect(4);
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({});
@@ -83,21 +83,7 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click } = await start({
-        async mockRPC(route, args) {
-            if (route.includes('mark_all_as_read')) {
-                assert.step('mark_all_as_read');
-                assert.deepEqual(
-                    args.kwargs.domain,
-                    [
-                        ['model', '=', 'res.partner'],
-                        ['res_id', '=', resPartnerId1],
-                    ],
-                    "should mark all as read the correct thread"
-                );
-            }
-        },
-    });
+    const { afterEvent, click } = await start();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
         func: () => document.querySelector('.o_MessagingMenu_toggler').click(),
@@ -118,14 +104,16 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
     );
 
     await click('.o_ThreadNeedactionPreview');
-    assert.verifySteps(
-        ['mark_all_as_read'],
-        "should have marked the message as read on clicking on the preview"
-    );
     assert.containsOnce(
         document.body,
         '.o_ChatWindow',
         "should have opened the thread on clicking on the preview"
+    );
+    await click('.o_MessagingMenu_toggler');
+    assert.containsNone(
+        document.body,
+        '.o_ThreadNeedactionPreview',
+        "should have no preview because the message should be marked as read after opening its thread"
     );
 });
 

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -228,7 +228,7 @@ class TestDiscuss(TestMailCommon, TestRecipients):
         message1.with_user(user1).set_message_done()
         messages = self.env['mail.message'].with_user(user1)._message_fetch(domain=[['needaction', '=', True]])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(messages[0].get('id'), message2.id)
+        self.assertEqual(messages[0].id, message2.id)
         messages = self.env['mail.message'].with_user(user2)._message_fetch(domain=[['needaction', '=', True]])
         self.assertEqual(len(messages), 2)
 


### PR DESCRIPTION
This removes an extra request, targets fetched messages more reliably and
simplifies the code.

task-2847909