### PR TITLE
[FIX] point_of_sale, web: `BlockUI` component malfuctioning

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1266,6 +1266,22 @@ td {
     padding-top:15px;
 }
 
+/*  ********* The BlockUI Component (frontend)  ********* */
+.o_blockUI {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1100;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    height: 100vh;
+    width: 100vw;
+    background: #000000;
+    color: white;
+    opacity: 0.6;
+}
 
 /*  ********* The Screens  ********* */
 

--- a/addons/web/static/src/core/ui/block_ui.scss
+++ b/addons/web/static/src/core/ui/block_ui.scss
@@ -2,4 +2,6 @@
 	cursor: wait;
 	-webkit-backdrop-filter: blur(2px);
 	backdrop-filter: blur(2px);
+	// NOTE: The value of the z-index below mirrors the $zindex-tooltip one
+	z-index: 1070 !important;
 }


### PR DESCRIPTION
In this PR we restore the proper rendering of the `BlockUI` component:
- at the PoS frontend, where css rules where not applied after some recent changes
- at the PoS backend, where the component was hidden under other components with a higher z-index. 

task-2924335
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
