### PR TITLE
[MERGE] web: fix issues in domain selector

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_leaf_node.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_leaf_node.js
@@ -24,24 +24,12 @@ export class DomainSelectorLeafNode extends Component {
     }
 
     get displayedOperator() {
-        let op = this.getOperatorInfo(this.props.node.operator);
-        if (op) {
-            return op.label;
-        }
-        op = registry
-            .category("domain_selector/operator")
-            .getAll()
-            .find((op) =>
-                op.matches({
-                    field: this.fieldInfo,
-                    operator: this.props.node.operator,
-                    value: this.props.node.operands[1],
-                })
-            );
+        const op = this.getOperatorInfo(this.props.node.operator);
         return op ? op.label : "?";
     }
     get isValueHidden() {
-        return this.getOperatorInfo(this.props.node.operator).hideValue;
+        const op = this.getOperatorInfo(this.props.node.operator);
+        return op ? op.hideValue : false;
     }
 
     async loadField(resModel, fieldName) {
@@ -61,12 +49,25 @@ export class DomainSelectorLeafNode extends Component {
         return registry.category("domain_selector/fields").get(type, null);
     }
     getOperatorInfo(operator) {
-        return this.getFieldComponent(this.fieldInfo.type)
+        let op = this.getFieldComponent(this.fieldInfo.type)
             .getOperators()
             .find((op) =>
                 op.matches({
                     field: this.fieldInfo,
                     operator,
+                    value: this.props.node.operands[1],
+                })
+            );
+        if (op) {
+            return op;
+        }
+        return registry
+            .category("domain_selector/operator")
+            .getAll()
+            .find((op) =>
+                op.matches({
+                    field: this.fieldInfo,
+                    operator: this.props.node.operator,
                     value: this.props.node.operands[1],
                 })
             );

--- a/addons/web/static/src/core/model_field_selector/model_field_hook.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_hook.js
@@ -3,14 +3,20 @@
 import { useService } from "@web/core/utils/hooks";
 
 export function useModelField() {
-    const orm = useService("orm");
+    const view = useService("view");
 
     const loadModelFields = (resModel) => {
-        // should be cached
-        return orm.call(resModel, "fields_get", [
-            false,
-            ["store", "searchable", "type", "string", "relation", "selection", "related"],
-        ]);
+        return view.loadFields(resModel, {
+            attributes: [
+                "store",
+                "searchable",
+                "type",
+                "string",
+                "relation",
+                "selection",
+                "related",
+            ],
+        });
     };
 
     const loadChain = async (resModel, fieldName) => {

--- a/addons/web/static/tests/core/domain_selector_tests.js
+++ b/addons/web/static/tests/core/domain_selector_tests.js
@@ -351,4 +351,28 @@ QUnit.module("Components", (hooks) => {
 
         assert.strictEqual(target.querySelector(".o_domain_leaf").textContent, `Foo like "kikou"`);
     });
+
+    QUnit.test("operator fallback in edit mode", async (assert) => {
+        registry.category("domain_selector/operator").add("test", {
+            category: "test",
+            label: "test",
+            value: "test",
+            onDidChange: () => null,
+            matches: ({ operator }) => operator === "test",
+            hideValue: true,
+        });
+
+        await mount(DomainSelector, target, {
+            env,
+            props: {
+                readonly: false,
+                resModel: "partner",
+                value: "[['foo', 'test', 'kikou']]",
+            },
+        });
+
+        // check that the DomainSelector does not crash
+        assert.containsOnce(target, ".o_domain_selector");
+        assert.containsN(target, ".o_domain_leaf_edition > div", 2, "value should be hidden");
+    });
 });

--- a/addons/web/static/tests/views/view_service_tests.js
+++ b/addons/web/static/tests/views/view_service_tests.js
@@ -108,4 +108,77 @@ QUnit.module("View service", (hooks) => {
 
         assert.verifySteps(["get_views", "get_views"]);
     });
+
+    QUnit.test("loadViews stores fields in cache", async (assert) => {
+        assert.expect(2);
+
+        const mockRPC = (route, args) => {
+            if (route.includes("get_views")) {
+                assert.step("get_views");
+            }
+            if (route.includes("fields_get")) {
+                assert.step("fields_get");
+            }
+        };
+
+        await makeMockServer(serverData, mockRPC);
+        const env = await makeTestEnv();
+
+        await env.services.views.loadViews(
+            {
+                resModel: "take.five",
+                views: [[99, "list"]],
+                context: {default_field_value: 1},
+            },
+            {}
+        );
+        await env.services.views.loadFields("take.five");
+
+        assert.verifySteps(["get_views"]);
+    });
+
+    QUnit.test("store loadFields calls in cache in success", async (assert) => {
+        assert.expect(2);
+
+        const mockRPC = (route, args) => {
+            if (route.includes("fields_get")) {
+                assert.step("fields_get");
+            }
+        };
+
+        await makeMockServer(serverData, mockRPC);
+        const env = await makeTestEnv();
+
+        await env.services.views.loadFields("take.five");
+        await env.services.views.loadFields("take.five");
+
+        assert.verifySteps(["fields_get"]);
+    });
+
+    QUnit.test("store loadFields calls in cache when failed", async (assert) => {
+        assert.expect(5);
+
+        const mockRPC = (route, args) => {
+            if (route.includes("fields_get")) {
+                assert.step("fields_get");
+                return Promise.reject("my little error");
+            }
+        };
+
+        await makeMockServer(serverData, mockRPC);
+        const env = await makeTestEnv();
+
+        try {
+            await env.services.views.loadFields("take.five");
+        } catch (error) {
+            assert.strictEqual(error, "my little error");
+        }
+        try {
+            await env.services.views.loadFields("take.five");
+        } catch (error) {
+            assert.strictEqual(error, "my little error");
+        }
+
+        assert.verifySteps(["fields_get", "fields_get"]);
+    });
 });


### PR DESCRIPTION
## [FIX] web: get correct operator in DomainSelector

Before this commit, giving an unknown operator for a
certain field type made the DomainSelector crash.
Now the component lists all existing operators to find
one that matches and prevent crashing.

---

## [IMP] web: add loadFields fn to view service

This commit adds a function `loadFields` to the view
service to load the fields of a given model and cache them.

---

## [IMP] web: cache fields_get in DomainSelector

Before this commit, the DomainSelector did a lot of
RPCs to fields_get each time it was rendering.
Now, we use the view_service.loadFields which does the
RPCs and caches the results.