### PR TITLE
[FIX] website_sale_gift_card: correctly compute gift card with taxcloud

### DIFF
--- a/addons/website_sale_gift_card/controllers/gift_card_controller.py
+++ b/addons/website_sale_gift_card/controllers/gift_card_controller.py
@@ -18,8 +18,9 @@ class GiftCardController(main.WebsiteSale):
     @http.route()
     def shop_payment(self, **post):
         order = request.website.sale_get_order()
+        res = super().shop_payment(**post)
         order._recompute_gift_card_lines()
-        return super().shop_payment(**post)
+        return res
 
     @http.route(['/shop/cart'], type='http', auth="public", website=True)
     def cart(self, **post):


### PR DESCRIPTION
Current behavior:
When using taxcloud for tax computation and using a giftcard on the
website shop, the giftcard amount is incorrect.

Steps to reproduce:
- Setup taxcloud for user A
- Setup EasyPost or any other not free shipping methods
- Activate giftcards for website
- Login as user A in the website shop
- Add an article to the cart
- Process to checkout and pay with giftcard
- The amount due is incorrect (negative value)

See this video for full explanation on how to setup taxcloud and
EasyPost :
https://drive.google.com/file/d/1E5ADDDwr_UbjYq-0t4whllFaQlkRBUCD/view

opw-2883592
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
