### PR TITLE
[FIX] website_sale_delivery: keep delivery method when using giftcards

### DIFF
--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -13,10 +13,13 @@ class WebsiteSaleDelivery(WebsiteSale):
     def shop_payment(self, **post):
         order = request.website.sale_get_order()
         carrier_id = post.get('carrier_id')
+        keep_carrier = post.get('keep_carrier', False)
+        if keep_carrier:
+            keep_carrier = bool(int(keep_carrier))
         if carrier_id:
             carrier_id = int(carrier_id)
         if order:
-            order._check_carrier_quotation(force_carrier_id=carrier_id)
+            order.with_context(keep_carrier=keep_carrier)._check_carrier_quotation(force_carrier_id=carrier_id)
             if carrier_id:
                 return request.redirect("/shop/payment")
 

--- a/addons/website_sale_delivery/models/sale_order.py
+++ b/addons/website_sale_delivery/models/sale_order.py
@@ -38,8 +38,9 @@ class SaleOrder(models.Model):
             return True
         else:
             self = self.with_company(self.company_id)
+            keep_carrier = self.env.context.get('keep_carrier', False)
             # attempt to use partner's preferred carrier
-            if not force_carrier_id and self.partner_shipping_id.property_delivery_carrier_id:
+            if not force_carrier_id and self.partner_shipping_id.property_delivery_carrier_id and not keep_carrier:
                 force_carrier_id = self.partner_shipping_id.property_delivery_carrier_id.id
 
             carrier = force_carrier_id and DeliveryCarrier.browse(force_carrier_id) or self.carrier_id

--- a/addons/website_sale_delivery/static/tests/tours/website_sale_delivery_gift_card.js
+++ b/addons/website_sale_delivery/static/tests/tours/website_sale_delivery_gift_card.js
@@ -1,0 +1,58 @@
+odoo.define('website_sale_delivery.test', function (require) {
+    'use strict';
+
+    require("website_sale.tour");
+    var tour = require("web_tour.tour");
+    const tourUtils = require('website_sale.tour_utils');
+
+    tour.register('shop_sale_giftcard_delivery', {
+        test: true,
+        url: '/shop?search=Accoustic',
+    },
+        [
+            {
+                content: "select Small Cabinet",
+                trigger: '.oe_product a:contains("Acoustic Bloc Screens")',
+            },
+            {
+                content: "add 1 Small Cabinet into cart",
+                trigger: '#product_details input[name="add_qty"]',
+                run: "text 1",
+            },
+            {
+                content: "click on 'Add to Cart' button",
+                trigger: "a:contains(ADD TO CART)",
+            },
+            tourUtils.goToCart(1),
+            {
+                content: "go to checkout",
+                trigger: 'a[href="/shop/checkout?express=1"]',
+                run: 'click'
+            },
+            {
+                content: "select free delivery method",
+                trigger: "li label:contains(delivery1)",
+                run: 'click'
+            },
+            {
+                content: "click on 'Pay with gift card'",
+                trigger: '.js_show_gift_card',
+                run: 'click'
+            },
+            {
+                content: "Enter gift card code",
+                trigger: "input[name='gift_card_code']",
+                run: 'text 044c-7c9c-432f-810e-dcff'
+            },
+            {
+                content: "click on 'Pay'",
+                trigger: "button[type='submit'].a-submit:contains(Pay)",
+                run: 'click'
+            },
+            {
+                content: "check if delivery price is correct'",
+                trigger: "#order_delivery .oe_currency_value:contains(5.00)",
+            },
+        ]
+    );
+});

--- a/addons/website_sale_delivery/tests/__init__.py
+++ b/addons/website_sale_delivery/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_ui
 from . import test_controller
+from . import test_website_sale_delivery

--- a/addons/website_sale_delivery/tests/test_website_sale_delivery.py
+++ b/addons/website_sale_delivery/tests/test_website_sale_delivery.py
@@ -1,0 +1,50 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests.common import HttpCase
+from odoo.tests import tagged
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleDelivery(HttpCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.gift_card = self.env['gift.card'].create({
+            'initial_amount': 10000,
+            'code': '123456',
+        })
+
+        self.product_delivery_normal1 = self.env['product.product'].create({
+            'name': 'Normal Delivery Charges',
+            'invoice_policy': 'order',
+            'type': 'service',
+        })
+
+        self.product_delivery_normal2 = self.env['product.product'].create({
+            'name': 'Normal Delivery Charges',
+            'invoice_policy': 'order',
+            'type': 'service',
+        })
+
+        self.normal_delivery = self.env['delivery.carrier'].create({
+            'name': 'delivery1',
+            'fixed_price': 5,
+            'delivery_type': 'fixed',
+            'website_published': True,
+            'product_id': self.product_delivery_normal1.id,
+        })
+
+        self.normal_delivery2 = self.env['delivery.carrier'].create({
+            'name': 'delivery2',
+            'fixed_price': 10,
+            'delivery_type': 'fixed',
+            'website_published': True,
+            'product_id': self.product_delivery_normal2.id,
+        })
+
+    def test_shop_sale_gift_card_keep_delivery(self):
+
+        #get admin user and set his preferred shipping method to normal delivery
+        admin_user = self.env.ref('base.user_admin')
+        admin_user.partner_id.write({'property_delivery_carrier_id': self.normal_delivery.id})
+
+        self.start_tour("/", 'shop_sale_giftcard_delivery', login='admin')

--- a/addons/website_sale_gift_card/controllers/gift_card_controller.py
+++ b/addons/website_sale_gift_card/controllers/gift_card_controller.py
@@ -13,7 +13,7 @@ class GiftCardController(main.WebsiteSale):
         gift_card = request.env["gift.card"].sudo().search([('code', '=', gift_card_code.strip())], limit=1)
         order = request.env['website'].get_current_website().sale_get_order()
         gift_card_status = order._pay_with_gift_card(gift_card)
-        return request.redirect('/shop/payment' + ('?gift_card_error=%s' % gift_card_status if gift_card_status else ''))
+        return request.redirect('/shop/payment' + '?keep_carrier=1' + ('&gift_card_error=%s' % gift_card_status if gift_card_status else ''))
 
     @http.route()
     def shop_payment(self, **post):


### PR DESCRIPTION
Current behavior:
If you have atleast 2 delivery methods available on the website,
and try to pay with a giftcard the selected delivery method will
always switch to the first method of the list.

Steps to reproduce:
- Activate giftcards for website
- Publish atleast 2 delivery methods (one free and one not free)
- Go on the website shop, and add product to the cart
- Process checkout and select the not free delivery method
- Pay with giftcard
- The delivery price is 0 so the delivery method has been
  modified

opw-2883592
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
