### PR TITLE
[IMP] purchase, sale, stock: add packaging in reports

### DIFF
--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -64,3 +64,17 @@ class ProductPackaging(models.Model):
             if new_qty == product_qty:
                 return packaging
         return self.env['product.packaging']
+
+    def _compute_qty(self, qty, qty_uom=False):
+        """Returns the qty of this packaging that qty converts to.
+        A float is returned because there are edge cases where some users use
+        "part" of a packaging
+
+        :param qty: float of product quantity (given in product UoM if no qty_uom provided)
+        :param qty_uom: Optional uom of quantity
+        :returns: float of packaging qty
+        """
+        self.ensure_one()
+        if qty_uom:
+            qty = qty_uom._compute_quantity(qty, self.product_uom_id)
+        return float_round(qty / self.qty, precision_rounding=self.product_uom_id.rounding)

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1298,13 +1298,11 @@ class PurchaseOrderLine(models.Model):
 
     @api.depends('product_packaging_id', 'product_uom', 'product_qty')
     def _compute_product_packaging_qty(self):
+        self.product_packaging_qty = 0
         for line in self:
             if not line.product_packaging_id:
-                line.product_packaging_qty = 0
-            else:
-                packaging_uom = line.product_packaging_id.product_uom_id
-                packaging_uom_qty = line.product_uom._compute_quantity(line.product_qty, packaging_uom)
-                line.product_packaging_qty = float_round(packaging_uom_qty / line.product_packaging_id.qty, precision_rounding=packaging_uom.rounding)
+                continue
+            line.product_packaging_qty = line.product_packaging_id._compute_qty(line.product_qty, line.product_uom)
 
     @api.depends('product_packaging_qty')
     def _compute_product_qty(self):

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -81,6 +81,9 @@
                                 <td class="text-end">
                                     <span t-field="line.product_qty"/>
                                     <span t-field="line.product_uom.name" groups="uom.group_uom"/>
+                                    <span t-if="line.product_packaging_id">
+                                        (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.product_packaging_id"/>)
+                                    </span>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_unit"/>

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -41,6 +41,9 @@
                                 <td class="text-end">
                                     <span t-field="order_line.product_qty"/>
                                     <span t-field="order_line.product_uom" groups="uom.group_uom"/>
+                                    <span t-if="order_line.product_packaging_id">
+                                        (<span t-field="order_line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="order_line.product_packaging_id"/>)
+                                    </span>
                                 </td>
                             </t>
                             <t t-else="">

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -649,15 +649,11 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_packaging_id', 'product_uom', 'product_uom_qty')
     def _compute_product_packaging_qty(self):
+        self.product_packaging_qty = 0
         for line in self:
             if not line.product_packaging_id:
-                line.product_packaging_qty = False
-            else:
-                packaging_uom = line.product_packaging_id.product_uom_id
-                packaging_uom_qty = line.product_uom._compute_quantity(line.product_uom_qty, packaging_uom)
-                line.product_packaging_qty = float_round(
-                    packaging_uom_qty / line.product_packaging_id.qty,
-                    precision_rounding=packaging_uom.rounding)
+                continue
+            line.product_packaging_qty = line.product_packaging_id._compute_qty(line.product_uom_qty, line.product_uom)
 
     # This computed default is necessary to have a clean computation inheritance
     # (cf sale_stock) instead of simply removing the default and specifying

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -104,6 +104,9 @@
                                 <td name="td_quantity" class="text-end">
                                     <span t-field="line.product_uom_qty">3</span>
                                     <span t-field="line.product_uom">units</span>
+                                    <span t-if="line.product_packaging_id">
+                                        (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.product_packaging_id"/>)
+                                    </span>
                                 </td>
                                 <td name="td_priceunit" class="text-end">
                                     <span t-field="line.price_unit">3</span>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -78,10 +78,16 @@
                                 <td>
                                     <span t-field="move.product_uom_qty">3.00</span>
                                     <span t-field="move.product_uom">units</span>
+                                    <span t-if="move.product_packaging_id">
+                                        (<span t-field="move.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="move.product_packaging_id"/>)
+                                    </span>
                                 </td>
                                 <td>
                                     <span t-field="move.quantity_done">3.00</span>
                                     <span t-field="move.product_uom">units</span>
+                                    <span t-if="move.product_packaging_id">
+                                        (<span t-field="move.product_packaging_qty_done" t-options='{"widget": "integer"}'/> <span t-field="move.product_packaging_id"/>)
+                                    </span>
                                 </td>
                             </tr>
                         </tbody>
@@ -240,12 +246,18 @@
                 <span t-esc="aggregated_lines[line]['qty_ordered']"
                     t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
                 <span t-esc="aggregated_lines[line]['product_uom'].name"/>
+                <span t-if="aggregated_lines[line]['packaging'].name">
+                    (<span t-out="aggregated_lines[line]['packaging_qty']" t-options='{"widget": "integer"}'/> <span t-out="aggregated_lines[line]['packaging'].name"/>)
+                </span>
             </td>
             <td class="text-center" name="move_line_aggregated_qty_done">
                 <t t-if="aggregated_lines[line]['qty_done']">
                     <span t-esc="aggregated_lines[line]['qty_done']"
                         t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
                     <span t-esc="aggregated_lines[line]['product_uom'].name"/>
+                    <span t-if="aggregated_lines[line]['packaging'].name">
+                        (<span t-out="aggregated_lines[line]['packaging_qty_done']" t-options='{"widget": "integer"}'/> <span t-out="aggregated_lines[line]['packaging'].name"/>)
+                    </span>
                 </t>
             </td>
         </tr>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -118,6 +118,14 @@
                                             <span t-if="o.state != 'done'" t-field="ml.reserved_uom_qty">3.00</span>
                                             <span t-else="" t-field="ml.qty_done">3.00</span>
                                             <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
+                                            <span t-if="ml.move_id.product_packaging_id">
+                                                <span t-if="o.state != 'done'">
+                                                    (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
+                                                </span>
+                                                <span t-if="o.state == 'done'">
+                                                    (<span t-field="ml.product_packaging_qty_done" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
+                                                </span>
+                                            </span>
                                         </td>
                                         <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations">
                                             <span t-esc="ml.location_id.display_name">WH/Stock</span>

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5649,8 +5649,8 @@ class StockMove(TransactionCase):
         self.assertEqual(len(aggregate_values), 2)
         sml1 = delivery.move_line_ids.filtered(lambda ml: ml.product_id == self.product)
         sml2 = delivery.move_line_ids.filtered(lambda ml: ml.product_id == product2)
-        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}']
-        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}']
+        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}_']
+        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}_']
         self.assertEqual(aggregate_val_1['qty_ordered'], 10)
         self.assertEqual(aggregate_val_1['qty_done'], 6)
         self.assertEqual(aggregate_val_2['qty_ordered'], 10)
@@ -5671,8 +5671,8 @@ class StockMove(TransactionCase):
         self.assertEqual(len(aggregate_values), 2)
         sml1 = delivery.move_line_ids.filtered(lambda ml: ml.product_id == self.product)
         sml2 = delivery.move_line_ids.filtered(lambda ml: ml.product_id == product2)
-        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}']
-        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}']
+        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}_']
+        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}_']
         self.assertEqual(aggregate_val_1['qty_ordered'], 10)
         self.assertEqual(aggregate_val_1['qty_done'], 6)
         self.assertEqual(aggregate_val_2['qty_ordered'], 10)
@@ -5683,9 +5683,9 @@ class StockMove(TransactionCase):
         sml1 = first_backorder.move_line_ids.filtered(lambda ml: ml.product_id == self.product)
         sml2 = first_backorder.move_line_ids.filtered(lambda ml: ml.product_id == product2)
         sml3 = first_backorder.move_line_ids.filtered(lambda ml: ml.product_id == product3)
-        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}']
-        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}']
-        aggregate_val_3 = aggregate_values[f'{product3.id}_{product3.name}__{sml3.product_uom_id.id}']
+        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}_']
+        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}_']
+        aggregate_val_3 = aggregate_values[f'{product3.id}_{product3.name}__{sml3.product_uom_id.id}_']
         self.assertEqual(aggregate_val_1['qty_ordered'], 4)
         self.assertEqual(aggregate_val_1['qty_done'], 4)
         self.assertEqual(aggregate_val_2['qty_ordered'], 8)
@@ -5704,8 +5704,8 @@ class StockMove(TransactionCase):
         self.assertEqual(len(aggregate_values), 2)
         sml1 = delivery.move_line_ids.filtered(lambda ml: ml.product_id == self.product)
         sml2 = delivery.move_line_ids.filtered(lambda ml: ml.product_id == product2)
-        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}']
-        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}']
+        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}_']
+        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}_']
         self.assertEqual(aggregate_val_1['qty_ordered'], 10)
         self.assertEqual(aggregate_val_1['qty_done'], 6)
         self.assertEqual(aggregate_val_2['qty_ordered'], 10)
@@ -5716,9 +5716,9 @@ class StockMove(TransactionCase):
         sml1 = first_backorder.move_line_ids.filtered(lambda ml: ml.product_id == self.product)
         sml2 = first_backorder.move_line_ids.filtered(lambda ml: ml.product_id == product2)
         sml3 = first_backorder.move_line_ids.filtered(lambda ml: ml.product_id == product3)
-        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}']
-        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}']
-        aggregate_val_3 = aggregate_values[f'{product3.id}_{product3.name}__{sml3.product_uom_id.id}']
+        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{sml1.product_uom_id.id}_']
+        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sml2.product_uom_id.id}_']
+        aggregate_val_3 = aggregate_values[f'{product3.id}_{product3.name}__{sml3.product_uom_id.id}_']
         self.assertEqual(aggregate_val_1['qty_ordered'], 4)
         self.assertEqual(aggregate_val_1['qty_done'], 4)
         self.assertEqual(aggregate_val_2['qty_ordered'], 8)
@@ -5730,8 +5730,8 @@ class StockMove(TransactionCase):
         self.assertEqual(len(aggregate_values), 2)
         sml1 = second_backorder.move_line_ids.filtered(lambda ml: ml.product_id == product3)
         sm2 = second_backorder.move_ids.filtered(lambda ml: ml.product_id == product2)
-        aggregate_val_1 = aggregate_values[f'{product3.id}_{product3.name}__{sml1.product_uom_id.id}']
-        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sm2.product_uom.id}']
+        aggregate_val_1 = aggregate_values[f'{product3.id}_{product3.name}__{sml1.product_uom_id.id}_']
+        aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}__{sm2.product_uom.id}_']
         self.assertEqual(aggregate_val_1['qty_ordered'], 3)
         self.assertEqual(aggregate_val_1['qty_done'], 3)
         self.assertEqual(aggregate_val_2['qty_ordered'], 2)
@@ -5788,7 +5788,7 @@ class StockMove(TransactionCase):
             'location_dest_id': move2.location_dest_id.id,
         })
         aggregate_values = picking.move_line_ids._get_aggregated_product_quantities()
-        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}']
+        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
         self.assertEqual(aggregated_val['qty_ordered'], 15)
         picking.button_validate()
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 10)
@@ -5833,11 +5833,11 @@ class StockMove(TransactionCase):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.customer_location), 15)
 
         aggregate_values1 = picking.move_line_ids[0]._get_aggregated_product_quantities(strict=True)
-        aggregated_val = aggregate_values1[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}']
+        aggregated_val = aggregate_values1[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
         self.assertEqual(aggregated_val['qty_ordered'], 10)
 
         aggregate_values2 = picking.move_line_ids[1]._get_aggregated_product_quantities(strict=True)
-        aggregated_val = aggregate_values2[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}']
+        aggregated_val = aggregate_values2[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
         self.assertEqual(aggregated_val['qty_ordered'], 5)
 
     def test_move_line_aggregated_product_quantities_incomplete_package(self):
@@ -5874,22 +5874,95 @@ class StockMove(TransactionCase):
         backorder.action_cancel()  # Cancels the automatically created backorder.
 
         aggregate_values = picking.move_line_ids._get_aggregated_product_quantities()
-        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}']
+        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
         self.assertEqual(aggregated_val['qty_ordered'], 15)
         self.assertEqual(aggregated_val['qty_done'], 5)
 
         aggregate_values = picking.move_line_ids._get_aggregated_product_quantities(strict=True)
-        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}']
+        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
         self.assertEqual(aggregated_val['qty_ordered'], 5)
         self.assertEqual(aggregated_val['qty_done'], 5)
 
         aggregate_values = picking.move_line_ids._get_aggregated_product_quantities(except_package=True)
-        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}']
+        aggregated_val = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
         self.assertEqual(aggregated_val['qty_ordered'], 10)
         self.assertEqual(aggregated_val['qty_done'], False)
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 20)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.customer_location), 5)
+
+    def test_move_line_aggregated_product_quantities_packagings(self):
+        """ Test the `stock.move.line` method `_get_aggregated_product_quantities`,
+        which returns data used to print delivery slips, with product packagings
+        """
+        self.env.user.groups_id += self.env.ref("product.group_stock_packaging")
+        packaging_of_4 = self.env['product.packaging'].create({
+            'name': 'pack of 4',
+            'product_id': self.product.id,
+            'qty': 4
+        })
+        packaging_of_5 = self.env['product.packaging'].create({
+            'name': 'pack of 5',
+            'product_id': self.product.id,
+            'qty': 5
+        })
+        packaging_of_2_dozen = self.env['product.packaging'].create({
+            'name': 'pack of 2 dozen',
+            'product_id': self.product.id,
+            'qty': 24,
+        })
+        self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 25)
+        delivery_form = self.env['stock.picking'].create({
+            'state': 'draft',
+            'immediate_transfer': False,
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+        })
+        delivery_form = Form(delivery_form)
+        with delivery_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom_qty = 4
+        with delivery_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom_qty = 10
+        with delivery_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom = self.uom_dozen
+            move.product_uom_qty = 2
+        with delivery_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom_qty = 3
+        delivery = delivery_form.save()
+        delivery.action_assign()
+
+        self.assertEqual(delivery.move_ids_without_package[0].product_packaging_id, packaging_of_4)
+        self.assertEqual(delivery.move_ids_without_package[1].product_packaging_id, packaging_of_5)
+        self.assertEqual(delivery.move_ids_without_package[2].product_packaging_id, packaging_of_2_dozen)
+        self.assertFalse(delivery.move_ids_without_package[3].product_packaging_id)
+
+        for move in delivery.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        aggregate_values = delivery.move_line_ids._get_aggregated_product_quantities()
+        self.assertEqual(len(aggregate_values), 4, "Each packaging should have their own line")
+        aggregate_val_1 = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_{packaging_of_4}']
+        aggregate_val_2 = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_{packaging_of_5}']
+        aggregate_val_3 = aggregate_values[f'{self.product.id}_{self.product.name}__{self.uom_dozen.id}_{packaging_of_2_dozen}']
+        aggregate_val_4 = aggregate_values[f'{self.product.id}_{self.product.name}__{self.product.uom_id.id}_']
+        self.assertEqual(aggregate_val_1['qty_ordered'], 4)
+        self.assertEqual(aggregate_val_1['qty_done'], 4)
+        self.assertEqual(aggregate_val_1['packaging_qty'], 1)
+        self.assertEqual(aggregate_val_1['packaging_qty_done'], 1)
+        self.assertEqual(aggregate_val_2['qty_ordered'], 10)
+        self.assertEqual(aggregate_val_2['qty_done'], 10)
+        self.assertEqual(aggregate_val_2['packaging_qty'], 2)
+        self.assertEqual(aggregate_val_2['packaging_qty_done'], 2)
+        self.assertEqual(aggregate_val_3['qty_ordered'], 2)
+        self.assertEqual(aggregate_val_3['qty_done'], 2)
+        self.assertEqual(aggregate_val_3['packaging_qty'], 1)
+        self.assertEqual(aggregate_val_3['packaging_qty_done'], 1)
+        self.assertEqual(aggregate_val_4['qty_ordered'], 3)
+        self.assertEqual(aggregate_val_4['qty_done'], 3)
+        self.assertFalse(aggregate_val_4.get('packaging_qty'))
+        self.assertFalse(aggregate_val_4.get('packaging_qty_done'))
 
     def test_move_sn_warning(self):
         """ Check that warnings pop up when duplicate SNs added or when SN isn't in


### PR DESCRIPTION
Several reports don't include product packing info on them. This is
useful for customers to see that what they bought matches what they
expected and for pickers who need to know which product packaging they
should be selecting from stock. Reports this was added to are:
- Sales orders,
- purchase orders (including RFQs),
- picking operations,
- delivery slips.

Note that we purposely exclude backordered moves since they weren't
deemed to be necessary at the time this feature was created.

Also includes light refactoring to remove repeated code for conversion
of product qty to packaging qty and to make it easier to do this
conversion in the future (i.e. can pass product.packaging without
original record that it was assigned to)

Task id 2927379



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
