### PR TITLE
14.0 FIX stock: price_unit propagated on move of return picking

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -132,6 +132,8 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
 
         # Validate picking
         return_pick.move_line_ids.write({'qty_done': 2})
+        # price is propagated on the return move
+        self.assertEqual(return_pick.move_lines[0].price_unit, 500)
 
         return_pick.button_validate()
 

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -96,6 +96,7 @@ class ReturnPicking(models.TransientModel):
     def _prepare_move_default_values(self, return_line, new_picking):
         vals = {
             'product_id': return_line.product_id.id,
+            'price_unit': return_line.move_id.price_unit,
             'product_uom_qty': return_line.quantity,
             'product_uom': return_line.product_id.uom_id.id,
             'picking_id': new_picking.id,


### PR DESCRIPTION
## Description of the issue this PR addresses:

price_unit of the stock.move is not propagated to the return picking

## Current behavior before PR:

stock move price_unit  of the return picking is 0

## Desired behavior after PR is merged:

stock move price_unit of the return picking is = to the orginal move

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
