### PR TITLE
[REF] mail: separate the tile model based on the parent view

### DIFF
--- a/addons/mail/static/src/components/call_main_view/call_main_view.scss
+++ b/addons/mail/static/src/components/call_main_view/call_main_view.scss
@@ -6,10 +6,6 @@
     min-width: 0;
 }
 
-.o_CallMainView_mainParticipantContainer {
-    min-width: 0;
-}
-
 .o_CallMainView_gridParticipantCard {
     width: var(--width);
     height: var(--height);
@@ -29,10 +25,6 @@
 // ------------------------------------------------------------------
 // Style
 // ------------------------------------------------------------------
-
-.o_CallMainView_mainParticipantContainer {
-    background-color: black;
-}
 
 .o_CallMainView_sidebarButton {
     color: white;

--- a/addons/mail/static/src/components/call_main_view/call_main_view.xml
+++ b/addons/mail/static/src/components/call_main_view/call_main_view.xml
@@ -3,36 +3,28 @@
 
 <t t-name="mail.CallMainView" owl="1">
     <t t-if="callMainView">
-        <div class="o_CallMainView d-flex flex-grow-1 flex-column align-items-center justify-content-center" t-ref="root" t-on-mouseleave="callMainView.onMouseleave">
+        <div class="o_CallMainView d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative bg-black-50" t-ref="root" t-on-mouseleave="callMainView.onMouseleave">
             <t t-set="dummy" t-value="messaging and messaging.device and messaging.device.globalWindowInnerHeight and messaging.device.globalWindowInnerWidth"/>
-
-            <div class="o_CallMainView_participantContainer d-flex justify-content-between w-100 h-100 overflow-hidden" t-on-click="callMainView.onClick" t-on-mousemove="callMainView.onMouseMove">
-                <t t-if="callMainView.callView.mainParticipantCard">
-                    <div class="o_CallMainView_mainParticipantContainer d-flex flex-grow-1 justify-content-center position-relative mw-100 mh-100">
-                        <CallParticipantCard className="'o_CallMainView_participantCard'" record="callMainView.callView.mainParticipantCard"/>
-                        <t t-if="callMainView.showOverlay and !callMainView.callView.threadView.compact">
-                            <i t-if="callMainView.callView.hasSidebar" class="o_CallMainView_sidebarButton o_cursor_pointer position-absolute fa fa-arrow-right" title="Hide sidebar" t-on-click="callMainView.onClickHideSidebar"/>
-                            <i t-else="" class="o_CallMainView_sidebarButton o_cursor_pointer position-absolute fa fa-arrow-left" title="Show sidebar" t-on-click="callMainView.onClickShowSidebar"/>
-                        </t>
-                    </div>
-                </t>
-                <t t-elif="callMainView.callView.tileParticipantCards.length > 0">
-                    <div
-                        class="o_CallMainView_grid d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
-                        t-ref="tileContainer"
-                        t-attf-style="--height:{{callMainView.tileHeight}}px; --width:{{callMainView.tileWidth}}px;"
-                    >
-                        <t t-foreach="callMainView.callView.tileParticipantCards" t-as="participantCard" t-key="'grid_tile_'+participantCard.localId">
-                            <CallParticipantCard
-                                className="'o_CallMainView_gridParticipantCard'"
-                                record="participantCard"
-                            />
-                        </t>
-                    </div>
+            <div
+                class="o_CallMainView_grid d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
+                t-attf-style="--height:{{callMainView.tileHeight}}px; --width:{{callMainView.tileWidth}}px;"
+                t-on-click="callMainView.onClick"
+                t-on-mousemove="callMainView.onMouseMove"
+                t-ref="tileContainer"
+            >
+                <t t-foreach="callMainView.mainTiles" t-as="tile" t-key="'grid_tile_'+tile.localId">
+                    <CallParticipantCard
+                        className="'o_CallMainView_gridParticipantCard'"
+                        record="tile.participantCard"
+                    />
                 </t>
             </div>
 
             <!-- Buttons -->
+            <t t-if="callMainView.hasSidebarButton">
+                <i t-if="callMainView.callView.isSidebarOpen" class="o_CallMainView_sidebarButton o_cursor_pointer position-absolute fa fa-arrow-right" title="Hide sidebar" t-on-click="callMainView.onClickHideSidebar"/>
+                <i t-else="" class="o_CallMainView_sidebarButton o_cursor_pointer position-absolute fa fa-arrow-left" title="Show sidebar" t-on-click="callMainView.onClickShowSidebar"/>
+            </t>
             <t t-if="callMainView.showOverlay or !callMainView.isControllerFloating">
                 <div class="o_CallMainView_controls d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute bottom-0 pb-3': callMainView.isControllerFloating }">
                     <div class="o_CallMainView_controlsOverlayContainer" t-on-mousemove="callMainView.onMouseMoveOverlay">

--- a/addons/mail/static/src/components/call_sidebar_view/call_sidebar_view.xml
+++ b/addons/mail/static/src/components/call_sidebar_view/call_sidebar_view.xml
@@ -4,10 +4,10 @@
 <t t-name="mail.CallSidebarView" owl="1">
     <t t-if="callSidebarView">
         <div class="o_CallSidebarView d-flex align-items-center h-100 flex-column">
-            <t t-foreach="callSidebarView.callView.tileParticipantCards" t-as="participantCard" t-key="participantCard.localId">
+            <t t-foreach="callSidebarView.sidebarTiles" t-as="tile" t-key="tile.localId">
                 <CallParticipantCard
                     className="'o_CallSidebarView_participantCard w-100'"
-                    record="participantCard"
+                    record="tile.participantCard"
                 />
             </t>
         </div>

--- a/addons/mail/static/src/models/call_main_view_tile.js
+++ b/addons/mail/static/src/models/call_main_view_tile.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { insertAndReplace } from '@mail/model/model_field_command';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'CallMainViewTile',
+    identifyingFields: ['callMainViewOwner', 'channelMember'],
+    fields: {
+        callMainViewOwner: one('CallMainView', {
+            inverse: 'mainTiles',
+            readonly: true,
+            required: true,
+        }),
+        channelMember: one('ChannelMember', {
+            readonly: true,
+            required: true,
+        }),
+        participantCard: one('CallParticipantCard', {
+            default: insertAndReplace(),
+            inverse: 'mainViewTileOwner',
+            isCausal: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/call_sidebar_view.js
+++ b/addons/mail/static/src/models/call_sidebar_view.js
@@ -1,16 +1,31 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { many, one } from '@mail/model/model_field';
+import { insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'CallSidebarView',
     identifyingFields: ['callView'],
+    recordMethods: {
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeSidebarTiles() {
+            return insertAndReplace(this.callView.filteredChannelMembers.map(channelMember => ({ channelMember: replace(channelMember) })));
+        },
+    },
     fields: {
         callView: one('CallView', {
             inverse: 'callSidebarView',
-            required: true,
             readonly: true,
-        })
+            required: true,
+        }),
+        sidebarTiles: many('CallSidebarViewTile', {
+            compute: '_computeSidebarTiles',
+            inverse: 'callSidebarViewOwner',
+            isCausal: true,
+        }),
     },
 });

--- a/addons/mail/static/src/models/call_sidebar_view_tile.js
+++ b/addons/mail/static/src/models/call_sidebar_view_tile.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { insertAndReplace } from '@mail/model/model_field_command';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'CallSidebarViewTile',
+    identifyingFields: ['callSidebarViewOwner', 'channelMember'],
+    fields: {
+        callSidebarViewOwner: one('CallSidebarView', {
+            inverse: 'sidebarTiles',
+            readonly: true,
+            required: true,
+        }),
+        channelMember: one('ChannelMember', {
+            readonly: true,
+            required: true,
+        }),
+        participantCard: one('CallParticipantCard', {
+            default: insertAndReplace(),
+            inverse: 'sidebarViewTileOwner',
+            isCausal: true,
+        }),
+    },
+});


### PR DESCRIPTION
Before this commit, the `callParticipantCard` model was used separately
for both the main session and the multi-tile views
(`CallSidebarView`/`CallMainView`), this commit makes so that each
multi-tile view has its own list of tiles.

part of task-2692836

