### PR TITLE
[FIX] web: fix crash in form view when saving with no changes

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -286,9 +286,8 @@ export class Record extends DataPoint {
     }
 
     get dirtyFields() {
-        return Object.keys(this.model.__bm__.localData[this.__bm_handle__]._changes).map(
-            (change) => this.activeFields[change]
-        );
+        const changes = this.model.__bm__.localData[this.__bm_handle__]._changes || {};
+        return Object.keys(changes).map((change) => this.activeFields[change]);
     }
 
     get translatableFields() {


### PR DESCRIPTION
Previously, when saving a form view without having changed anything,
there could be a crash because the _changes were null, because we try to
enumarate the keys to find dirty fields. This commit fixes that by
returning an empty array when the _changes are null.