### PR TITLE
[FIX] pos: search paid orders in bar not working if table is deleted

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -202,6 +202,8 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
                 if (this.state.selectedTableId === originalSelectedTableId) {
                     this.state.selectedTableId = null;
                 }
+                delete this.env.pos.tables_by_id[originalSelectedTableId];
+                this.env.pos.TICKET_SCREEN_STATE.syncedOrders.cache = {};
             } catch (error) {
                 if (error.message.code < 0) {
                     await this.showPopup('OfflineErrorPopup', {

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -122,6 +122,12 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 }
                 return result;
             }
+            async _onDoRefund() {
+                if(this.env.pos.config.iface_floorplan) {
+                    this.env.pos.set_table(this.getSelectedSyncedOrder().table ? this.getSelectedSyncedOrder().table : Object.values(this.env.pos.tables_by_id)[0]);
+                }
+                super._onDoRefund();
+            }
         };
 
     Registries.Component.extend(TicketScreen, PosResTicketScreen);

--- a/addons/pos_restaurant/static/src/xml/Screens/TicketScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/TicketScreen.xml
@@ -8,8 +8,10 @@
         </xpath>
         <xpath expr="//div[hasclass('order-row')]//div[@name='delete']" position="before">
             <div t-if="env.pos.config.iface_floorplan" class="col" name="table">
-                <div t-if="env.isMobile">Table</div>
-                <div><t t-esc="getTable(order)"></t></div>
+                <t t-if="order.table">
+                    <div t-if="env.isMobile">Table</div>
+                    <div><t t-esc="getTable(order)"></t></div>
+                </t>
             </div>
             <div t-if="_state.ui.filter == 'TIPPING'" class="col end narrow" name="tip">
                 <div t-if="env.isMobile">Tip</div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In the pos restaurant/bar the orders are linked to a table.
The tables can be deleted but the order still exists.
In the POS, when we go to "orders" and search for paid orders, it will not work if a table was deleted before.
As the table does not exist anymore, we can't find the floor on which was the table

fixes opw-2835603

Current behavior before PR:

The order doesn't show because we have an error in the console

Desired behavior after PR is merged:

the orders are showing normally




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
