### PR TITLE
[FIX] web: fix tooltip rendering crashing because of lack of env

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip.xml
+++ b/addons/web/static/src/core/tooltip/tooltip.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.Tooltip" owl="1">
         <div class="o-tooltip px-2 py-1">
-            <t t-if="props.template" t-call="{{props.template}}" t-call-context="props.info"/>
+            <t t-if="props.template" t-call="{{props.template}}" t-call-context="{ env, ...props.info }"/>
             <small t-else="" t-esc="props.tooltip"/>
         </div>
     </t>


### PR DESCRIPTION
With the merge of the new views, we introduced an owl directive which is
t-call-context, that allows a t-call to execute in a controlled context
that is not the context of the component itself. In doing so, we forgot
that some existing templates rely on the presence of the env in the
rendering context for things like knowing if we are in debug mode or if
the device is small/mobile.
