### PR TITLE
[FIX] point_of_sale: Improve information over customer displays settings

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -63,7 +63,7 @@ class PosConfig(models.Model):
     iface_electronic_scale = fields.Boolean(string='Electronic Scale', help="Enables Electronic Scale integration.")
     iface_customer_facing_display = fields.Boolean(compute='_compute_customer_facing_display')
     iface_customer_facing_display_via_proxy = fields.Boolean(string='Customer Facing Display', help="Show checkout to customers with a remotely-connected screen.")
-    iface_customer_facing_display_local = fields.Boolean(string='Local Customer Facing Display', help="Show checkout to customers.")
+    iface_customer_facing_display_local = fields.Boolean(string='Local Customer Facing Display', help="Show customers checkout in a pop-up window. Recommend to be moved to a second screen visible to the client.")
     iface_print_via_proxy = fields.Boolean(string='Print via Proxy', help="Bypass browser printing and prints via the hardware proxy.")
     iface_scan_via_proxy = fields.Boolean(string='Scan via Proxy', help="Enable barcode scanning with a remotely connected barcode scanner and card swiping with a Vantiv card reader.")
     iface_big_scrollbars = fields.Boolean('Large Scrollbars', help='For imprecise industrial touchscreens.')

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -198,6 +198,7 @@
                             </div>
                             <div class="o_setting_right_pane">
                                 <label for="is_posbox" string="IoT Box"/>
+                                <a href="https://www.odoo.com/documentation/15.0/applications/productivity/iot/config/pos.html" title="Documentation" class="ml-1 o_doc_link" target="_blank"></a>
                                 <div class="text-muted mb16">
                                     Connect devices using an IoT Box
                                 </div>
@@ -247,7 +248,7 @@
                             <div class="o_setting_right_pane">
                                 <label for="iface_customer_facing_display_local" string="Customer Display"/>
                                 <div class="text-muted">
-                                    Show checkout to customers through a second display
+                                    Show customers checkout in a pop-up window. Can be moved to a second screen.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Before this commit:
Ambiguity about the dual presence of 'Customer Display' option in IoT Box and without IoT Box. Customers don't really know which one to use in which circumstances.

After this commit:
Customer Display moved to PoS Interface and improved help message.
Link to documentation for IoT Box.

OPW-2809698

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
