### PR TITLE
[IMP] mrp,mrp_*,repair: MRP back to basics 6

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -19,6 +19,7 @@
         'wizard/change_production_qty_views.xml',
         'wizard/mrp_workcenter_block_view.xml',
         'wizard/stock_warn_insufficient_qty_views.xml',
+        'wizard/stock_unbuild_greater_than_produced.xml',
         'wizard/mrp_production_backorder.xml',
         'wizard/mrp_consumption_warning_views.xml',
         'wizard/mrp_immediate_production_views.xml',

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -101,9 +101,9 @@ class MrpUnbuild(models.Model):
             self.product_id = self.mo_id.product_id.id
             self.bom_id = self.mo_id.bom_id
             self.product_uom_id = self.mo_id.product_uom_id
+            self.lot_id = self.mo_id.lot_producing_id
             if self.has_tracking == 'serial':
                 self.product_qty = 1
-                self.lot_id = self.mo_id.lot_producing_id
             else:
                 self.product_qty = self.mo_id.product_qty
 

--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -50,6 +50,7 @@ access_mrp_document_mrp_manager,mrp.document group_user,model_mrp_document,group
 access_mrp_document_mrp_user,mrp.document group_user,model_mrp_document,group_mrp_user,1,1,1,1
 access_change_production_qty,access.change.production.qty,model_change_production_qty,mrp.group_mrp_user,1,1,1,0
 access_stock_warn_insufficient_qty_unbuild,access.stock.warn.insufficient.qty.unbuild,model_stock_warn_insufficient_qty_unbuild,mrp.group_mrp_user,1,1,1,0
+access_stock_unbuild_greater_than_produced,access.stock.unbuild.greater.than.produced,model_stock_unbuild_greater_than_produced,mrp.group_mrp_user,1,1,1,0
 access_mrp_production_backorder,access.mrp.production.backorder,model_mrp_production_backorder,mrp.group_mrp_user,1,1,1,0
 access_mrp_production_backorder_line,access.mrp.production.backorder.line,model_mrp_production_backorder_line,mrp.group_mrp_user,1,1,1,0
 access_mrp_consumption_warning,access.mrp.consumption.warning,model_mrp_consumption_warning,mrp.group_mrp_user,1,1,1,0

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -349,7 +349,6 @@ class TestTraceability(TestMrpCommon):
 
         unbuild_form = Form(self.env['mrp.unbuild'])
         unbuild_form.mo_id = mo
-        unbuild_form.lot_id = lot
         unbuild_form.save().action_unbuild()
 
         mo_form = Form(self.env['mrp.production'])

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -230,7 +230,9 @@ class TestUnbuild(TestMrpCommon):
         x.bom_id = bom
         x.mo_id = mo
         x.product_qty = 5
-        x.save().action_unbuild()
+        res_dict = x.save().action_unbuild()
+        greater_then_produced = Form(self.env[res_dict['res_model']].with_context(res_dict['context'])).save()
+        greater_then_produced.action_done()
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, allow_negative=True), -5, 'You should have negative quantity for final product in stock')
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p1, self.stock_location, lot_id=lot), 120, 'You should have 80 products in stock')

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -307,13 +307,6 @@ class TestUnbuild(TestMrpCommon):
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, lot_id=lot_final), 5, 'You should have consumed 3 final product in stock')
 
-        with self.assertRaises(AssertionError):
-            x.product_id = p_final
-            x.bom_id = bom
-            x.mo_id = mo
-            x.product_qty = 3
-            x.save()
-
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, lot_id=lot_final), 5, 'You should have consumed 3 final product in stock')
 
         x = Form(self.env['mrp.unbuild'])

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -319,7 +319,6 @@ class TestUnbuild(TestMrpCommon):
         x.bom_id = bom
         x.mo_id = mo
         x.product_qty = 3
-        x.lot_id = lot_final
         x.save().action_unbuild()
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, lot_id=lot_final), 2, 'You should have consumed 3 final product in stock')
@@ -331,7 +330,6 @@ class TestUnbuild(TestMrpCommon):
         x.bom_id = bom
         x.mo_id = mo
         x.product_qty = 2
-        x.lot_id = lot_final
         x.save().action_unbuild()
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, lot_id=lot_final), 0, 'You should have 0 finalproduct in stock')
@@ -343,7 +341,6 @@ class TestUnbuild(TestMrpCommon):
         x.bom_id = bom
         x.mo_id = mo
         x.product_qty = 5
-        x.lot_id = lot_final
         x.save().action_unbuild()
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, lot_id=lot_final, allow_negative=True), -5, 'You should have negative quantity for final product in stock')
@@ -814,7 +811,6 @@ class TestUnbuild(TestMrpCommon):
         #unbuild order
         unbuild_form = Form(self.env['mrp.unbuild'])
         unbuild_form.mo_id = mo
-        unbuild_form.lot_id = product_1_sn
         unbuild_form.save().action_unbuild()
 
         #mo2

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -7,17 +7,14 @@
             <field name="model">mrp.production</field>
             <field name="arch" type="xml">
                 <tree string="Manufacturing Orders" default_order="priority desc, date_planned_start desc" multi_edit="1" sample="1" decoration-info="state == 'draft'">
-                    <header>
-                        <button name="button_plan" type="object" string="Plan"/>
-                        <button name="do_unreserve" type="object" string="Unreserve"/>
-                        <button name="action_cancel" type="object" string="Cancel"/>
-                    </header>
+                    <header/>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="message_needaction" invisible="1"/>
                     <field name="name" decoration-bf="1"/>
-                    <field name="date_planned_start" readonly="1" optional="show" widget="remaining_days"/>
+                    <field name="date_planned_start" optional="show" widget="remaining_days"/>
                     <field name="date_deadline" widget="remaining_days" attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}" optional="hide"/>
                     <field name="product_id" readonly="1" optional="show"/>
+                    <field name="product_category_id" optional="hide"/>
                     <field name="lot_producing_id" optional="hide"/>
                     <field name="bom_id" readonly="1" optional="hide"/>
                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show"/>
@@ -29,10 +26,10 @@
                         optional="show"
                         decoration-success="reservation_state == 'assigned' or components_availability_state == 'available'"
                         decoration-warning="reservation_state != 'assigned' and components_availability_state in ('expected', 'available')"
-                        decoration-danger="reservation_state != 'assigned' and components_availability_state == 'late'"/>
+                        decoration-danger="reservation_state != 'assigned' and components_availability_state in ('late','not_available')"/>
                     <field name="reservation_state" optional="hide" decoration-danger="reservation_state == 'confirmed'" decoration-success="reservation_state == 'assigned'"/>
                     <field name="product_qty" sum="Total Qty" string="Quantity" readonly="1" optional="show"/>
-                    <field name="product_uom_id" string="UoM" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" optional="show"/>
+                    <field name="product_uom_id" string="UoM" readonly="1" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" optional="show"/>
                     <field name="production_duration_expected" attrs="{'invisible': [('production_duration_expected', '=', 0)]}" groups="mrp.group_mrp_routings" widget="float_time" sum="Total expected duration" optional="show"/>
                     <field name="production_real_duration" attrs="{'invisible': [('production_real_duration', '=', 0)]}" groups="mrp.group_mrp_routings" widget="float_time" sum="Total real duration" optional="show"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
@@ -49,6 +46,21 @@
                 </tree>
             </field>
         </record>
+
+        <record id="mrp_production_tree_view_inherit_with_button" model="ir.ui.view">
+        <field name="name">mrp.production.tree.view.inherit</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_tree_view"/>
+        <field name="mode">primary</field>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="button_plan" type="object" string="Plan"/>
+                <button name="do_unreserve" type="object" string="Unreserve"/>
+                <button name="action_cancel" type="object" string="Cancel"/>
+            </xpath>
+        </field>
+    </record>
 
         <record id="action_production_order_split" model="ir.actions.server">
             <field name="name">Split</field>
@@ -243,7 +255,7 @@
                             <field name="components_availability" attrs="{'invisible': [('state', 'not in', ['confirmed', 'progress'])]}"
                                 decoration-success="reservation_state == 'assigned' or components_availability_state == 'available'"
                                 decoration-warning="reservation_state != 'assigned' and components_availability_state in ('expected', 'available')"
-                                decoration-danger="reservation_state != 'assigned' and components_availability_state == 'late'"/>
+                                decoration-danger="reservation_state != 'assigned' and components_availability_state in ('late','not_available')"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}" force_save="1"/>
                             <field name="show_final_lots" invisible="1"/>
@@ -556,6 +568,11 @@
                         domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter name="filter_date_planned_start" string="Scheduled Date" date="date_planned_start"/>
                     <separator/>
+                    <filter string="Components Available" name="components_available" domain="[('components_availability_state', '=', 'available')]"/>
+                    <filter string="Components Scheduled" name="components_expected" domain="[('components_availability_state', '=', 'expected')]"/>
+                    <filter string="Components Late" name="components_late" domain="[('components_availability_state', '=', 'late')]"/>
+                    <filter string="Components Unavailable" name="components_not_available" domain="[('components_availability_state', '=', 'not_available')]"/>
+                    <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>
                     <group expand="0" string="Group By...">
@@ -574,7 +591,7 @@
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">mrp.production</field>
             <field name="view_mode">tree,kanban,form,calendar,pivot,graph</field>
-            <field name="view_id" eval="False"/>
+            <field name="view_id" ref="mrp_production_tree_view_inherit_with_button"/>
             <field name="search_view_id" ref="view_mrp_production_filter"/>
             <field name="context">{'search_default_todo': True, 'default_company_id': allowed_company_ids[0]}</field>
             <field name="domain">[('picking_type_id.active', '=', True)]</field>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -48,7 +48,7 @@
                     <attribute name="attrs">{'column_invisible': [('parent.product_id', '!=', False)]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='bom_product_template_attribute_value_ids']" position="after">
-                    <button name="action_archive" class="btn-link" type="object" string="Archive Operation" icon="fa-times"/>
+                    <button name="action_archive" class="oe_right" type="object" string="Archive Operation"/>
                 </xpath>
                 <xpath expr="//field[@name='blocked_by_operation_ids']" position="replace">
                 </xpath>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -117,7 +117,7 @@
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="has_tracking" invisible="1"/>
-                                <field name="lot_id" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
+                                <field name="lot_id" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')], 'readonly':['|', ('mo_id','!=',False), ('state', '=', 'done')]}" groups="stock.group_production_lot" force_save="1"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                         </group>
@@ -156,7 +156,7 @@
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="has_tracking" invisible="1"/>
-                                <field name="lot_id" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
+                                <field name="lot_id" readonly="1" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
                                 <field name="company_id" groups="base.group_multi_company" readonly="1"/>
                             </group>
                         </group>

--- a/addons/mrp/wizard/__init__.py
+++ b/addons/mrp/wizard/__init__.py
@@ -8,3 +8,4 @@ from . import mrp_consumption_warning
 from . import mrp_immediate_production
 from . import stock_assign_serial_numbers
 from . import mrp_production_split
+from . import stock_unbuild_greater_than_produced

--- a/addons/mrp/wizard/mrp_immediate_production_views.xml
+++ b/addons/mrp/wizard/mrp_immediate_production_views.xml
@@ -6,7 +6,8 @@
         <field name="arch" type="xml">
             <form string="Immediate production?">
                 <group>
-                    <p>You have not recorded <i>produced</i> quantities yet, by clicking on <i>apply</i> Odoo will produce all the finished products and consume all components.</p>
+                    <p>You have not recorded <i>produced</i> quantities yet, by clicking on <i>apply</i> Odoo will produce all the finished products and consume all components and untouched work orders.
+                    </p>
                 </group>
 
                 <field name="show_productions" invisible="1"/>

--- a/addons/mrp/wizard/stock_unbuild_greater_than_produced.py
+++ b/addons/mrp/wizard/stock_unbuild_greater_than_produced.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class StockUnbuildGreaterThanProduced(models.TransientModel):
+    _name = 'stock.unbuild.greater.than.produced'
+    _description = 'Stock Unbuild Greater Than Produced'
+
+    unbuild_id = fields.Many2one('mrp.unbuild', 'Unbuild')
+    produced_quantity = fields.Float("Produced Quantity")
+    old_unbuild_quantity = fields.Float("Already Unbuild")
+    unbuild_quantity = fields.Float("Unbuild Qty")
+
+    def action_done(self):
+        self.ensure_one()
+        return self.unbuild_id.with_context(skip_more_then_produced_check=True).action_unbuild()

--- a/addons/mrp/wizard/stock_unbuild_greater_than_produced.xml
+++ b/addons/mrp/wizard/stock_unbuild_greater_than_produced.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_unbuild_greater_than_produced_form_view" model="ir.ui.view">
+        <field name="name">stock.unbuild.greater.than.produced</field>
+        <field name="model">stock.unbuild.greater.than.produced</field>
+        <field name="arch" type="xml">
+            <form>
+                <div string="description">
+                    <div>
+                        Note that the total unbuild quantity for this MO is greater than the produced quantity.
+                    </div>
+                    <footer>
+                        <button name="cancel_button" string="Discard" class="btn-primary" special="cancel" data-hotkey="z"/>
+                        <button string="Confirm" name="action_done" type="object" class="btn-secondary" data-hotkey="q"/>
+                    </footer>
+                </div>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -131,13 +131,15 @@ class Repair(models.Model):
     invoice_state = fields.Selection(string='Invoice State', related='invoice_id.state')
     priority = fields.Selection([('0', 'Normal'), ('1', 'Urgent')], default='0', string="Priority")
 
+    @api.depends('product_id')
     def _compute_allowed_picking_type_ids(self):
         '''
             computes the ids of return picking types
         '''
         out_picking_types = self.env['stock.picking.type'].search_read(domain=[('code', '=', 'outgoing')],
                                                                           fields=['return_picking_type_id'], load='')
-        self.allowed_picking_type_ids = [pick_type['return_picking_type_id'] for pick_type in out_picking_types]
+        self.allowed_picking_type_ids = [
+            pt['return_picking_type_id'] for pt in out_picking_types if pt['return_picking_type_id']]
 
     @api.depends('partner_id')
     def _compute_default_address_id(self):

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -88,7 +88,7 @@
                             <field name="address_id" groups="account.group_delivery_invoice_address"/>
                             <field name="sale_order_id"/>
                             <field name="allowed_picking_type_ids" invisible="1"/>
-                            <field name="picking_id" domain="[('picking_type_id','in', allowed_picking_type_ids)]" options="{'no_create': True}"/>
+                            <field name="picking_id" domain="[('picking_type_id','in', allowed_picking_type_ids), ('product_id','=',product_id)]" options="{'no_create': True}"/>
                         </group>
                         <group>
                             <field name="schedule_date"/>


### PR DESCRIPTION
mrp
===
- Remove 3 buttons (plan, unreserve, cancel) when open manufacturing orders from any many2many field.

- no time has been recorded on operations then give warning with apply button

- do not allow to mass edit UOM in any manufacturing state

- Track the MO quantity unbuild vs quantity produced and add non blocking warning message when unbuild quantity is more then produced quantity

- Add product category of final product as optional=hide in MO list

- Add component status filters and allow to select between these 4 options

- Available

- Expected on Time

- Late

- Not Available

- Add Planned (tickbox) as optional=hide in MO list

- make lot/serial field read only on unbuilding MO wizard

repair
======
Currently it is not possible to select a return on a repair order unless save it first. so after this commit user can able to select it without save it.

mrp_subcontracting
==================
MO form view fix https://tinyurl.com/2cmrpvre

task - 2845380

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
