### PR TITLE
[FIX] web: default class for buttons in a button_box

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -144,7 +144,11 @@ export class FormCompiler extends ViewCompiler {
                         ? `!evalDomainFromRecord(props.record,${JSON.stringify(invisible)})`
                         : true,
             });
-            append(mainSlot, this.compileNode(child, params, false));
+            const button = this.compileNode(child, params, false);
+            if (button.tagName === "ViewButton") {
+                button.setAttribute("defaultRank", "'oe_stat_button'");
+            }
+            append(mainSlot, button);
             append(buttonBox, mainSlot);
         }
 

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -1431,6 +1431,34 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".oe_stat_button")); // should not call doActionButton
     });
 
+    QUnit.test("rendering stat buttons without class", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <div name="button_box" class="oe_button_box">
+                            <button>
+                                <field name="int_field"/>
+                            </button>
+                        </div>
+                        <group>
+                            <field name="foo"/>
+                        </group>
+                    </sheet>
+                </form>`,
+            resId: 2,
+        });
+
+        assert.containsOnce(
+            target,
+            "button.oe_stat_button",
+            "button should have oe_stat_button class"
+        );
+    });
+
     QUnit.test("rendering stat buttons without action", async function (assert) {
         await makeView({
             type: "form",


### PR DESCRIPTION
Before this commit, the buttons without classes in a button_box were
assigned the default btn-secondary.

Now, the default class for the buttons without classes in a button_box
is the class oe_stat_button
