### PR TITLE
[FIX] hr_timesheet : negative remaining hours

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -148,7 +148,8 @@ class Task(models.Model):
     @api.depends('effective_hours', 'subtask_effective_hours', 'planned_hours')
     def _compute_remaining_hours(self):
         for task in self:
-            task.remaining_hours = task.planned_hours - task.effective_hours - task.subtask_effective_hours
+            #do not set remaining hours to negative value
+            task.remaining_hours = max(task.planned_hours - task.effective_hours - task.subtask_effective_hours, 0)
 
     @api.depends('effective_hours', 'subtask_effective_hours')
     def _compute_total_hours_spent(self):

--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -16,7 +16,7 @@ class ReportProjectTaskUser(models.Model):
         return super(ReportProjectTaskUser, self)._select() + """,
             t.progress as progress,
             t.effective_hours as hours_effective,
-            t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
+            GREATEST(t.planned_hours - t.effective_hours - t.subtask_effective_hours, 0) as remaining_hours,
             planned_hours as hours_planned"""
 
     def _group_by(self):


### PR DESCRIPTION
To reproduce
============

1. Create a new Project.
2. Create a Task. Allocate Hours for task (eg: 10 hours)
3. Create a Sub-task. Do NOT allocate hours for the sub-task.
4. Create a timesheet for the subtask with hours (eg: 3 Hours)
5. Click Save.
6. Go to reporting then "Task Analysis".
8. Change to Pivot view.
9. display remainig hours and task titles.

Result: The calculation of the Remaining Hours for the project is incorrect while the calculation
of the Remaining Hours for the parent task is correct, and the sub task has a negative value as
remaining hours.

Purpose
=======

this issue is caused by having negative value as remaining hours, which doesn't make any sense.

Specification
=============

to solve the issue we set remaining hours to 0 if the value is negative.

opw-2847846
