### PR TITLE
[FIX] website_sale: fix tests

### DIFF
--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import common
 from . import test_customize
 from . import test_sale_process
 from . import test_sitemap

--- a/addons/website_sale/tests/common.py
+++ b/addons/website_sale/tests/common.py
@@ -1,0 +1,23 @@
+from odoo.tests.common import TransactionCase
+
+class TestWebsiteSaleCommon(TransactionCase):
+
+    def setUp(self):
+        super(TestWebsiteSaleCommon, self).setUp()
+        # Reset country and fiscal country, so that fields added by localizations are
+        # hidden and non-required.
+        # Also remove default taxes from the company and its accounts, to avoid inconsistencies
+        # with empty fiscal country.
+        self.env.company.write({
+            'country_id': None, # Also resets account_fiscal_country_id
+            'account_sale_tax_id': None,
+            'account_purchase_tax_id': None,
+        })
+        account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_id', '=', self.env.company.id)])
+        account_with_taxes.write({
+            'tax_ids': [(5, 0, 0)],
+        })
+        # Update website pricelist to ensure currency is same as env.company
+        website = self.env['website'].get_current_website()
+        pricelist = website.get_current_pricelist()
+        pricelist.write({'currency_id': self.env.company.currency_id.id})

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -6,11 +6,12 @@ import odoo.tests
 from odoo import api
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, TransactionCaseWithUserDemo
 from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website_sale.tests.common import TestWebsiteSaleCommon
 from odoo.addons.website.tools import MockRequest
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestUi(HttpCaseWithUserDemo):
+class TestUi(HttpCaseWithUserDemo, TestWebsiteSaleCommon):
 
     def setUp(self):
         super(TestUi, self).setUp()

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -3,13 +3,14 @@
 import base64
 import io
 
+from odoo.addons.website_sale.tests.common import TestWebsiteSaleCommon
 from PIL import Image
 
 import odoo.tests
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
-class TestWebsiteSaleImage(odoo.tests.HttpCase):
+class TestWebsiteSaleImage(odoo.tests.HttpCase, TestWebsiteSaleCommon):
 
     # registry_test_mode = False  # uncomment to save the product to test in browser
 

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -4,6 +4,7 @@
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
 from odoo.tests import tagged
 from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.tests.common import TestWebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
@@ -148,7 +149,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         self.assertEqual(combination_info['price_extra'], 173.91, "173.91$ + 0% tax (mapped from fp 15% -> 0% for BE)")
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleProductPricelist(TestSaleProductAttributeValueCommon):
+class TestWebsiteSaleProductPricelist(TestSaleProductAttributeValueCommon, TestWebsiteSaleCommon):
     def test_cart_update_with_fpos(self):
         # We will test that the mapping of an 10% included tax by a 0% by a fiscal position is taken into account when updating the cart 
         self.env.user.partner_id.country_id = False


### PR DESCRIPTION
Steps to reproduce:

  Create a new DB with `-i l10n_ar_website_sale` and `--test-enable`

Issue:

  Multiple test fails.

Cause:

  By installing only a l10n module, main company will be altered
  (especially the fiscal country and currency, among other things).
  By doing so, it will raise at least 2 issue:
  - Previous pricelists linked to main company got the previous currency
  - Some fields can be required (depending on company fiscal country)

Solution:

  - Alter company's website pricelist currency to match company currency
  - Reset country and fiscal country, so that fields added by
    localizations are hidden and non-required.
    Also remove default taxes from the company and its accounts,
    to avoid inconsistencies with empty fiscal country.

opw-2767684
