### PR TITLE
[FIX] hr_appraisal: cache miss as demo user

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -186,7 +186,7 @@ class HrEmployeePrivate(models.Model):
         # cache, and interpreted as an access error
         self.flush_recordset(fields)
         public = self.env['hr.employee.public'].browse(self._ids)
-        public._read(fields)
+        public.read(fields)
         for fname in fields:
             values = self.env.cache.get_values(public, public._fields[fname])
             self.env.cache.update(self, self._fields[fname], values)


### PR DESCRIPTION
Since eb67feb5 we had to redo the hack to read fields from public user and set them in hr_employee.
However in this hack we used `_read`, which doesn't fill the cache with fields that are not stored,
which caused a cache miss when reading the field `avatar_128` from hr.employee, to display the image of
the manager in the kanban view of hr_appraisal.

This fix uses `read` instead.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
