### PR TITLE
[FIX] project: insert in spreadsheet not showing

### DIFF
--- a/addons/project/static/src/js/project_pivot_view.js
+++ b/addons/project/static/src/js/project_pivot_view.js
@@ -4,6 +4,11 @@ import { ProjectControlPanel } from "@project/project_control_panel/project_cont
 import { registry } from "@web/core/registry";
 import { pivotView } from "@web/views/pivot/pivot_view";
 
-const projectPivotView = {...pivotView, ControlPanel: ProjectControlPanel};
+export const projectPivotView = pivotView.extend({
+    config: {
+        ...pivotView.prototype.config,
+        ControlPanel: ProjectControlPanel,
+    },
+});
 
 registry.category("views").add("project_pivot", projectPivotView);


### PR DESCRIPTION
Earlier, project pivot view was not able to render "Insert in spreadsheet"
button. The issue appears to be in the method of appending pivotView in code.
It was using deep copy technique while referring to pivotView,
resulting in avoiding the changes made by our button template. Changing
the following to shallow copy mode solved the issue, as now it's loading
the changes of custom panel on top as well as the button template.

Task-2871852

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
