### PR TITLE
[FIX] account_edi, base: Cannot cancel invoice even with appropriate access

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -164,7 +164,7 @@ class AccountEdiDocument(models.Model):
                         # can be safely cancelled.
                         invoice_ids_to_cancel.add(move.id)
 
-                    if not old_attachment.res_model or not old_attachment.res_id:
+                    if not old_attachment.sudo().res_model or not old_attachment.sudo().res_id:
                         attachments_to_unlink |= old_attachment
 
                 else:

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -444,10 +444,11 @@ class IrAttachment(models.Model):
             for res_model, res_id, create_uid, public, res_field in self._cr.fetchall():
                 if public and mode == 'read':
                     continue
-                if not self.env.is_system() and (res_field or (not res_id and create_uid != self.env.uid)):
-                    raise AccessError(_("Sorry, you are not allowed to access this document."))
                 if not (res_model and res_id):
                     continue
+                if not self.env.is_system() and (res_field or (not res_id and create_uid != self.env.uid)):
+                    raise AccessError(_("Sorry, you are not allowed to access this document."))
+
                 model_ids[res_model].add(res_id)
         if values and values.get('res_model') and values.get('res_id'):
             model_ids[values['res_model']].add(values['res_id'])


### PR DESCRIPTION
Issue: When a user create -> confirm and then set the invoice to draft, Another user even
 with right access (in the case Billing right on the accounting access)  cannot cancel it

Solution: When the creator of the invoice set to draft, the ir.attachment file linked to it is unlinked
 but not deleted from the database. But when another user unlink it again with the cancel action he can't because
he doesn't have the right access (res_id, res_model and res_field are empty).

To solve it, in the account_edi_document.py we use sudo to get the the res_model and res_id, and in the check()
in ir.attachment we place the verification of res_model and res_id (the attachment is already unlinked) before the others.

opw-2925207