### PR TITLE
[FIX] pos_coupon: convert string date to accept by all browsers

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -761,6 +761,9 @@ odoo.define('pos_coupon.pos', function (require) {
                     return program.promo_applicability === 'on_next_order';
                 });
         },
+        _convertToDate: function (stringDate) {
+            return new Date(stringDate.replace(/ /g, 'T').concat('Z'))
+        },
         /**
          * @param {coupon.program} program
          * @returns {{ successful: boolean, reason: string | undefined }}
@@ -814,8 +817,8 @@ odoo.define('pos_coupon.pos', function (require) {
             }
 
             // Check rule date
-            const ruleFrom = program.rule_date_from ? new Date(program.rule_date_from) : new Date(-8640000000000000);
-            const ruleTo = program.rule_date_to ? new Date(program.rule_date_to) : new Date(8640000000000000);
+            const ruleFrom = program.rule_date_from ? this._convertToDate(program.rule_date_from) : new Date(-8640000000000000);
+            const ruleTo = program.rule_date_to ? this._convertToDate(program.rule_date_to) : new Date(8640000000000000);
             const orderDate = new Date();
             if (!(orderDate >= ruleFrom && orderDate <= ruleTo)) {
                 return {


### PR DESCRIPTION
Before this commit: `new Date(stringDate)` in the safari browser doesn't
accept this date format:
	"2020-08-26 12:29:33"
Instate it should be:
	"2020-08-26T12:29:33Z"

The solution is to convert it to the accepted format.

opw-2901785

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
