### PR TITLE
Creating a email marketing campaign with the 'Event Promo' template breaks the JS of the Email Marketing module.

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -926,7 +926,7 @@ function _getMatchedCSSRules(node, cssRules) {
     }
 
     for (const [key, value] of Object.entries(processedStyle)) {
-        if (value.endsWith('important')) {
+        if (value && value.endsWith('important')) {
             processedStyle[key] = value.replace(/\s*!important\s*$/, '');
         }
     };


### PR DESCRIPTION
Bug seen in ticket: 2774878

Steps to reproduce the issue:
-In 15.0 create an email marketing campaign
-Pick the 'Event Promo' template
-Save
=> js error and unresponsive UI




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
