### PR TITLE
[FIX] account: payment method for different payment types

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -910,3 +910,74 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'partner_bank_id': self.comp_bank_account2.id,
             },
         ])
+
+    def test_payment_method_different_type_single_batch_not_grouped(self):
+        """ Test payment methods when paying a bill and a refund with separated payments (1000 + -2000)."""
+        in_refund = self.env['account.move'].create({
+            'move_type': 'in_refund',
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 1600.0})],
+        })
+        in_refund.action_post()
+
+        active_ids = (self.in_invoice_1 + in_refund).ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'group_payment': False,
+        })._create_payments()
+
+        self.assertRecordValues(payments[0], [
+            {
+                'ref': 'BILL/2017/01/0001',
+                'payment_method_id': self.bank_journal_1.outbound_payment_method_ids[0].id,
+                'payment_type': 'outbound',
+            }
+        ])
+
+        self.assertRecordValues(payments[1], [
+            {
+                'ref': 'RBILL/2017/01/0001',
+                'payment_method_id': self.bank_journal_1.inbound_payment_method_ids[0].id,
+                'payment_type': 'inbound',
+            },
+        ])
+
+        self.assertRecordValues(payments[0].line_ids.sorted('balance'), [
+            # == Payment 1: to pay in_invoice_1 ==
+            # Liquidity line:
+            {
+                'debit': 0.0,
+                'credit': 1000.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': -1000.0,
+                'reconciled': False,
+            },
+            # Payable line:
+            {
+                'debit': 1000.0,
+                'credit': 0.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': 1000.0,
+                'reconciled': True,
+            },
+        ])
+        self.assertRecordValues(payments[1].line_ids.sorted('balance'), [
+            # == Payment 2: to pay in_refund_1 ==
+            # Payable line:
+            {
+                'debit': 0.0,
+                'credit': 1600.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': -1600.0,
+                'reconciled': True,
+            },
+            # Liquidity line:
+            {
+                'debit': 1600.0,
+                'credit': 0.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': 1600.0,
+                'reconciled': False,
+            },
+        ])


### PR DESCRIPTION
This commit fix a bug noticed when fixing this other
one in v15 https://github.com/odoo/odoo/pull/93943.

We notice that, in addition to not set correctly
the payment type, the payment method was wrong too.

With this commit, when creating payments from batch,
we check for each payment if its type is the same
as the one set on the wizard. If not (which means
that there are payments of differents types), we set
the payment method regarding the payment type.

opw-2852186
