### PR TITLE
[IMP] purchase: speed up dashboard rfq sent computation.

### DIFF
--- a/addons/purchase/data/purchase_data.xml
+++ b/addons/purchase/data/purchase_data.xml
@@ -17,6 +17,11 @@
             <field name="default" eval="False"/>
             <field name="res_model">purchase.order</field>
         </record>
+        <record id="mt_rfq_sent" model="mail.message.subtype">
+            <field name="name">RFQ Sent</field>
+            <field name="default" eval="False"/>
+            <field name="res_model">purchase.order</field>
+        </record>
 
         <!-- Sequences for purchase.order -->
         <record id="seq_purchase_order" model="ir.sequence">

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -385,6 +385,8 @@ class PurchaseOrder(models.Model):
             return self.env.ref('purchase.mt_rfq_confirmed')
         elif 'state' in init_values and self.state == 'done':
             return self.env.ref('purchase.mt_rfq_done')
+        elif 'state' in init_values and self.state == 'sent':
+            return self.env.ref('purchase.mt_rfq_sent')
         return super(PurchaseOrder, self)._track_subtype(init_values)
 
     # ------------------------------------------------------------
@@ -689,30 +691,17 @@ class PurchaseOrder(models.Model):
 
         one_week_ago = fields.Datetime.to_string(fields.Datetime.now() - relativedelta(days=7))
 
-        # Get list of translation values
-        Translation = self.env['ir.translation']
-        list_old_value_char = []
-        list_new_value_char = []
-        field_name = 'ir.model.fields.selection,name'
-        for lang in self.env['res.lang'].search_read([], ['code']):
-            list_old_value_char.append(Translation._get_source(field_name, 'model', lang['code'], source='RFQ'))
-            list_new_value_char.append(Translation._get_source(field_name, 'model', lang['code'], source='RFQ Sent'))
-
-        # This query is brittle since it depends on the label values of a selection field
-        # not changing, but we don't have a direct time tracker of when a state changes
         query = """SELECT COUNT(1)
-                   FROM mail_tracking_value v
-                   LEFT JOIN mail_message m ON (v.mail_message_id = m.id)
+                   FROM mail_message m
                    JOIN purchase_order po ON (po.id = m.res_id)
                    WHERE m.create_date >= %s
                      AND m.model = 'purchase.order'
                      AND m.message_type = 'notification'
-                     AND v.old_value_char IN %s
-                     AND v.new_value_char IN %s
+                     AND m.subtype_id = %s
                      AND po.company_id = %s;
                 """
 
-        self.env.cr.execute(query, (one_week_ago, tuple(list_old_value_char), tuple(list_new_value_char), self.env.company.id))
+        self.env.cr.execute(query, (one_week_ago, self.env.ref('purchase.mt_rfq_sent').id, self.env.company.id))
         res = self.env.cr.fetchone()
         result['all_sent_rfqs'] = res[0] or 0
 

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_purchase_invoice
 from . import test_access_rights
 from . import test_accrued_purchase_orders
 from . import test_purchase_tax_totals
+from . import test_purchase_dashboard

--- a/addons/purchase/tests/test_purchase_dashboard.py
+++ b/addons/purchase/tests/test_purchase_dashboard.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.mail.tests.common import MailCase
+from odoo.tests import tagged, Form, new_test_user
+from odoo.tools import mute_logger, format_amount
+from odoo import fields
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseDashboard(AccountTestInvoicingCommon, MailCase):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        # Create two new users
+        cls.user_a = new_test_user(cls.env, login='purchaseusera', groups='purchase.group_purchase_user')
+        cls.user_b = new_test_user(cls.env, login='purchaseuserb', groups='purchase.group_purchase_user')
+
+        # Create two products.
+        product_data = {
+            'name': 'SuperProduct',
+            'type': 'consu',
+        }
+        cls.product_100 = cls.env['product.product'].create({**product_data, 'standard_price': 100})
+        cls.product_250 = cls.env['product.product'].create({**product_data, 'standard_price': 250})
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_purchase_dashboard(self):
+        '''
+        Test purchase dashboard values with multiple users.
+        '''
+
+        # Create 3 Request for Quotations with lines.
+        rfqs = self.env['purchase.order'].create([{
+            'partner_id': self.partner_a.id,
+            'company_id': self.user_a.company_id.id,
+            'currency_id': self.user_a.company_id.currency_id.id,
+            'date_order': fields.Date.today(),
+        } for i in range(3)])
+        for rfq, qty in zip(rfqs, [1, 2, 3]):
+            rfq_form = Form(rfq)
+            with rfq_form.order_line.new() as line_1:
+                line_1.product_id = self.product_100
+                line_1.product_qty = qty
+            with rfq_form.order_line.new() as line_2:
+                line_2.product_id = self.product_250
+                line_2.product_qty = qty
+            rfq_form.save()
+
+        # Create 1 late RFQ without line.
+        self.env['purchase.order'].create([{
+            'partner_id': self.partner_a.id,
+            'company_id': self.user_a.company_id.id,
+            'currency_id': self.user_a.company_id.currency_id.id,
+            'date_order': fields.Date.today() - timedelta(days=7)
+        }])
+
+        # Create 1 draft RFQ for user A.
+        self.env['purchase.order'].with_user(self.user_a).create([{
+            'partner_id': self.partner_a.id,
+            'company_id': self.user_a.company_id.id,
+            'currency_id': self.user_a.company_id.currency_id.id,
+            'date_order': fields.Date().today() + timedelta(days=7)
+        }])
+
+        self.flush_tracking()
+        with self.mock_mail_gateway():
+            rfqs[0].with_user(self.user_a).write({'state': 'sent'})
+            self.flush_tracking()
+        # Sanity checks for rfq state.
+        self.assertEqual(rfqs[0].state, 'sent')
+        with self.mock_mail_gateway():
+            rfqs[1].with_user(self.user_b).write({'state': 'sent'})
+            self.flush_tracking()
+        self.assertEqual(rfqs[1].state, 'sent')
+
+        # Confirm Orders with lines.
+        rfqs.button_confirm()
+        # Retrieve dashboard as User A to check 'my_{to_send, waiting, late}' values.
+        dashboard_result = rfqs.with_user(self.user_a).retrieve_dashboard()
+
+        # Check dashboard values
+        currency_id = self.env.company.currency_id
+        zero_value_keys = ['all_waiting', 'my_waiting', 'my_late']
+        self.assertListEqual([dashboard_result[key] for key in zero_value_keys], [0]*len(zero_value_keys))
+        self.assertEqual(dashboard_result['all_to_send'], 2)
+        self.assertEqual(dashboard_result['my_to_send'], 1)
+        self.assertEqual(dashboard_result['all_late'], 1)
+        self.assertEqual(dashboard_result['all_avg_order_value'], format_amount(self.env, self.tax_purchase_a.compute_all(700.0)['total_included'], currency_id))
+        self.assertEqual(dashboard_result['all_avg_days_to_purchase'], 0)
+        self.assertEqual(dashboard_result['all_total_last_7_days'], format_amount(self.env, self.tax_purchase_a.compute_all(2100.0)['total_included'], currency_id))
+        self.assertEqual(dashboard_result['all_sent_rfqs'], 2)


### PR DESCRIPTION
Add a new subtype_id for 'RFQ Sent' state. This removes
the need to join on mail.tracking.value when computing
'all_sent_rfqs'. Since mail.tracking.value is usually
a big table, removing this join leads to a substantial
speedup when loading the purchase.order dashboard on big
databases.

Add a unit test to check the dashboard values.

#### Speedup

The reported times were obtained using a v15 customer database with 4.5M mail_messages
and 4.75M mail_tracking_values. 2690 tracking_values were for RFQ Sent state. The data
was collected by timing queries in psql directly, so using a v15 DB is fine even if this PR targets master.

The reported times format is `cold cache time (hot cache time)`.

| Mail message and tracking | Before PR | After PR |
|:---------------------------:|:----------:|:---------:|
| 100 000 | 5s (15ms) | 1.1s (2ms) |
| 500 000 | 12s (20ms) | 1.3s (4ms) |
| 2M | 34s (30ms) | 1.6s (11ms) |
| 4.5M | 50s (45ms) | 2s (12ms) |


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
