### PR TITLE
[IMP] l10n_ar: group by on IIBB-Sales report

### DIFF
--- a/addons/l10n_ar/report/invoice_report.py
+++ b/addons/l10n_ar/report/invoice_report.py
@@ -6,11 +6,11 @@ class AccountInvoiceReport(models.Model):
 
     _inherit = 'account.invoice.report'
 
-    l10n_ar_state_id = fields.Many2one('res.country.state', 'State', readonly=True)
+    l10n_ar_state_id = fields.Many2one('res.country.state', 'Delivery Province', readonly=True)
     date = fields.Date(readonly=True, string="Accounting Date")
 
     _depends = {
-        'account.move': ['partner_id', 'date'],
+        'account.move': ['partner_shipping_id', 'date'],
         'res.partner': ['state_id'],
     }
 
@@ -18,4 +18,4 @@ class AccountInvoiceReport(models.Model):
         return super()._select() + ", contact_partner.state_id as l10n_ar_state_id, move.date"
 
     def _from(self):
-        return super()._from() + " LEFT JOIN res_partner contact_partner ON contact_partner.id = move.partner_id"
+        return super()._from() + " LEFT JOIN res_partner contact_partner ON contact_partner.id = move.partner_shipping_id"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The report "IIBB-Sales by jurisdiction" group invoice subtotal amounts by partner address instead of the delivery address set on customers invoices.

Current behavior before PR:

The report "IIBB-Sales by jurisdiction" group amounts by partner address.

Desired behavior after PR is merged:

The report "IIBB-Sales by jurisdiction" group amounts by delivery address.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
