### PR TITLE
[FIX] account_payment should not be deleted if account move is posted

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -656,7 +656,7 @@ class AccountPayment(models.Model):
 
     def unlink(self):
         # OVERRIDE to unlink the inherited account.move (move_id field) as well.
-        moves = self.with_context(force_delete=True).move_id
+        moves = self.move_id
         res = super().unlink()
         moves.unlink()
         return res


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Description here : https://github.com/odoo/odoo/issues/75111

A company registers payments before they know if they have an invoice related to. At the end of the story, a lot of payments were mistakes and have to be reimbursed to the customers or transfered to another company.
The payment should not be deleted because if so, there is no trace anymore in the accounting. Some employee could steel the money then (if it's cash or unlabelled check)

Current behavior before PR:
- Posted payments can be deleted and there is no trace anymore

Desired behavior after PR is merged:
- Posted payments should not be deleted




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
