### PR TITLE
[IMP] l10n_sg: Box Mapping for Purchase Tax

### DIFF
--- a/addons/l10n_sg/data/account_tax_data.xml
+++ b/addons/l10n_sg/data/account_tax_data.xml
@@ -635,7 +635,7 @@
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'base',
-                        'plus_report_line_ids': [ref('account_tax_report_line_applicable_goods_imported_value')],
+                        'plus_report_line_ids': [ref('account_tax_report_line_applicable_goods_imported_value'), ref('account_tax_report_line_total_taxable_purchases')],
                     }),
                     (0,0, {
                         'factor_percent': 100,
@@ -646,7 +646,7 @@
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'base',
-                        'minus_report_line_ids': [ref('account_tax_report_line_applicable_goods_imported_value')],
+                        'minus_report_line_ids': [ref('account_tax_report_line_applicable_goods_imported_value'), ref('account_tax_report_line_total_taxable_purchases')],
                     }),
                     (0,0, {
                         'factor_percent': 100,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As required from Singaporean tax regulation, we need to add Box 5 on the tax grid to make sure the amount is correctly mapped in both boxes.

Task ID: [2854163](https://www.odoo.com/web#id=2854163&cids=5&menu_id=4720&action=333&active_id=1822&model=project.task&view_type=form)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
