### PR TITLE
[IMP] calendar: do not switch assignation on activities

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -407,13 +407,12 @@ class Meeting(models.Model):
     def create(self, vals_list):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
+        defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
 
         vals_list = [  # Else bug with quick_create when we are filter on an other user
-            dict(vals, user_id=self.env.user.id) if not 'user_id' in vals else vals
+            dict(vals, user_id=defaults.get('user_id', self.env.user.id)) if not 'user_id' in vals else vals
             for vals in vals_list
         ]
-
-        defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
         meeting_activity_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1)
         # get list of models ids and filter out None values directly
         model_ids = list(filter(None, {values.get('res_model_id', defaults.get('res_model_id')) for values in vals_list}))

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -20,6 +20,8 @@ class MailActivity(models.Model):
             'default_name': self.summary or self.res_name,
             'default_description': self.note if not is_html_empty(self.note) else '',
             'default_activity_ids': [(6, 0, self.ids)],
+            'default_partner_ids': self.user_id.partner_id.ids,
+            'default_user_id': self.user_id.id,
         }
         return action
 


### PR DESCRIPTION
Currently, if we create an activity for user other than logged in one and
create a calendar event from the activity, it automatically changes the
attendee on the event and re-assigns the activity to the logged in user
instead of the one originally assigned to the activity during creation.
It happens because default attendees are not passed while creating the
event from activity. ALso, when editing the calendar event, the sync
mechanism changes the activity user to the organizer of the event, which
by default is logged in user.

This commit improves the behavior by passing the appropriate default
values so that the calendar attendees and organizer matches with the
user to whom the activity is assigned initially.

task-2920631


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
