### PR TITLE
[FIX] web_editor: preventing traceback on quote icon click

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1732,9 +1732,9 @@ const Wysiwyg = Widget.extend({
                 // Tooltips need to be cleared before leaving the editor.
                 this.saving_mutex.exec(() => {
                     $target.tooltip({title: _t('Double-click to edit'), trigger: 'manual', container: 'body'}).tooltip('show');
+                    this.tooltipTimeouts.push(setTimeout(() => $target.tooltip('dispose'), 800));
                 });
                 this.odooEditor.observerActive();
-                this.tooltipTimeouts.push(setTimeout(() => $target.tooltip('dispose'), 800));
             }, 400));
         }
         // Update color of already opened colorpickers.


### PR DESCRIPTION
**Current behavior before PR:**

Clicking on the quote icon of BlockQuote generates traceback.

**Desired behavior after PR is merged:**

Now clicking on the quote icon doesn't generate a traceback.


Task-2920794

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
