### PR TITLE
[FIX] account_edi: Cannot cancel invoice even with appropriate access

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -151,7 +151,7 @@ class AccountEdiDocument(models.Model):
                 move = document.move_id
                 move_result = edi_result.get(move, {})
                 if move_result.get('success') is True:
-                    old_attachment = document.attachment_id
+                    old_attachment = document.sudo().attachment_id
                     document.write({
                         'state': 'cancelled',
                         'error': False,
@@ -180,7 +180,7 @@ class AccountEdiDocument(models.Model):
 
             # Attachments that are not explicitly linked to a business model could be removed because they are not
             # supposed to have any traceability from the user.
-            attachments_to_unlink.unlink()
+            attachments_to_unlink.sudo().unlink()
 
         documents.edi_format_id.ensure_one()  # All account.edi.document of a job should have the same edi_format_id
         documents.move_id.company_id.ensure_one()  # All account.edi.document of a job should be from the same company


### PR DESCRIPTION
Issue: When a user create -> confirm and then set the invoice to draft, Another user even
with right access (in the case Billing right on the accounting access) cannot cancel it

Steps to reproduce the bug:
1) Login with admin user having administration rights set as ‘setting’.
2) Inside Customer Invoices Journal Electronic Data Interchange -> Electronic invoicing -> Set/Enable to ‘Factur-X (FR)’
3) Create an invoice ( Ex. INV/2022/00001) with admin user -> Confirm -> Reset to draft.
4) Login with the billing user (Accounting rights set to ‘Only billing rights’)
5) invoicing -> Open Invoice ( Ex. INV/2022/00001) -> Try Cancel invoice ( Ex. INV/2022/00001) without confirming it.
6) Access Error will be reproduced.
7) Go to Customer Invoices Journal -> Electronic Data Interchange -> Electronic Invoicing -> Uncheck ‘Factur-X (FR)’ -> Save.
8) Repeat above mentioned steps again -> No Access error came this time.

Solution: Give the right access to unlink an attachment from set to draft invoice.

