### PR TITLE
[FIX] payulatam: error when amount is more than 2 decimals

### DIFF
--- a/addons/payment_payulatam/models/payment.py
+++ b/addons/payment_payulatam/models/payment.py
@@ -10,7 +10,7 @@ from werkzeug import urls
 
 from odoo import api, fields, models, _
 from odoo.addons.payment.models.payment_acquirer import ValidationError
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_round
 
 
 _logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class PaymentAcquirerPayulatam(models.Model):
             accountId=self.payulatam_account_id,
             description=values.get('reference'),
             referenceCode=tx.reference,
-            amount=values['amount'],
+            amount=float_round(values['amount'], 2),
             tax='0',  # This is the transaction VAT. If VAT zero is sent the system, 19% will be applied automatically. It can contain two decimals. Eg 19000.00. In the where you do not charge VAT, it should should be set as 0.
             taxReturnBase='0',
             currency=values['currency'].name,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When redirected to the payment acquirer PayuLatam, if the amount have more than 2
decimals we can have two errors (invalid sign and unique reference).
Even with the decimal accuracy set to 2, we still can have a rounding issue and get
an amount like 1661.340000001

fixes opw-2900105

Current behavior before PR:

The rounding issue is not happening on every amount with decimals.
To get it I use a SO with a total amounr of 1661.34 

Error on PayuLatam page, either 
- invalid sign / order_not_processed_by_sign
TX_VALUE: the additional value exceeds the maximum number of decimal digits (2) / UNIQUE REFERENCE 

Desired behavior after PR is merged:
Amount round to 2 decimal to not get the error.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
