### PR TITLE
[FIX] mrp: workorder kanban view match qty field

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -403,7 +403,7 @@
                 <field name="working_state"/>
                 <field name="workcenter_id"/>
                 <field name="product_id"/>
-                <field name="qty_production"/>
+                <field name="qty_remaining"/>
                 <field name="product_uom_id" force_save="1"/>
                 <templates>
                     <t t-name="kanban-box">
@@ -424,7 +424,7 @@
                             </div>
                             <div class="o_kanban_record_bottom">
                                 <h5 class="oe_kanban_bottom_left">
-                                    <span><t t-esc="record.product_id.value"/>, </span> <span><t t-esc="record.qty_production.value"/> <t t-esc="record.product_uom_id.value"/></span>
+                                    <span><t t-esc="record.product_id.value"/>, </span> <span><t t-esc="record.qty_remaining.value"/> <t t-esc="record.product_uom_id.value"/></span>
                                 </h5>
                                 <div class="oe_kanban_bottom_right" t-if="record.state.raw_value == 'progress'">
                                     <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0"><i class="fa fa-play" role="img" aria-label="Run" title="Run"/></span>


### PR DESCRIPTION
task-2925474
MRP Back to Basics 7

Description of the issue/feature this PR addresses:
5. In the work orders kanban views, show. the work order quantity and not the MO
quantity : https://tinyurl.com/2xoqyub2

Current behavior before PR:
- Currently the kanban view show qty_production. However the Listview show the qty_remaining.
So I match the field for 2 views (qty_remaining)

Desired behavior after PR is merged:
Both List view and kanban view show the same quantity field now (qty_remaining)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
