### PR TITLE
[FIX] mrp: add color to warning multi-lot mass produce

### DIFF
--- a/addons/mrp/wizard/stock_assign_serial_numbers.xml
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.xml
@@ -27,7 +27,7 @@
                 </group>
                 <field name="multiple_lot_components_names" invisible="1"/>
                 <group col="1">
-                    <p class="o_form_label oe_inline" attrs="{'invisible': [('multiple_lot_components_names', '=', False)]}">
+                    <p class="o_form_label oe_inline text-danger" attrs="{'invisible': [('multiple_lot_components_names', '=', False)]}">
                         Note that components <field name="multiple_lot_components_names" readonly="True"/> have multiple lot reservations.<br/>
                         Do you want to confirm anyway ?
                     </p>


### PR DESCRIPTION
task-2925474
MRP Back to Basics 7

3. When mass producing from several reserved lots, we display a warning message that the lot reservation is
'multiple'. Display that message in red.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
