### PR TITLE
[FIX] web: weird modal effect on backdrop click

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -221,6 +221,8 @@ $modal-md: $o-modal-md !default;
 
 $modal-content-border-radius: $border-radius !default;
 
+$modal-scale-transform: none !default;
+
 // Breadcrumbs
 
 $breadcrumb-padding-y: 0 !default;


### PR DESCRIPTION
Since BS5 migration, clicking on the backdrop of a "static" modal
triggers a weird scaling-up/down effect on the modal.

Steps to reproduce:
- Open Livechat Channels
- Open a channel
- Click on operator which opens a modal
- click on backdrop
=> scale-up/down effect

This commit fixes it by disabling the scaling transform effect on
modals.