### PR TITLE
[FIX] sale_loyalty: fix invalid invoice status

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -413,7 +413,7 @@ class SaleOrder(models.Model):
         # if the created invoice will only contain the promotion line
         super()._get_invoice_status()
         for order in self:
-            if order.invoice_status != 'to_invoice':
+            if order.invoice_status != 'to invoice':
                 continue
             if not any(not line.is_reward_line and line.invoice_status == 'to invoice' for line in order.order_line):
                 order.invoice_status = 'no'

--- a/addons/sale_loyalty/tests/test_sale_invoicing.py
+++ b/addons/sale_loyalty/tests/test_sale_invoicing.py
@@ -49,12 +49,16 @@ class TestSaleInvoicing(TestSaleCouponCommon):
         invoiceable_lines = order._get_invoiceable_lines()
         # Product was not delivered, we cannot invoice
         # the product line nor the promotion line
+        order._get_invoice_status()
+        self.assertEqual(order.invoice_status, 'no')
         self.assertEqual(len(invoiceable_lines), 0)
         with self.assertRaises(UserError):
             order._create_invoices()
 
         order.order_line[0].qty_delivered = 1
         # Product is delivered, the two lines can be invoiced.
+        order._get_invoice_status()
+        self.assertEqual(order.invoice_status, 'to invoice')
         invoiceable_lines = order._get_invoiceable_lines()
         self.assertEqual(order.order_line, invoiceable_lines)
         account_move = order._create_invoices()


### PR DESCRIPTION
The invoice status was badly computed since the loyalty refactor due to
the use of the wrong value when comparing to the previous state.
(to_invoice instead of to invoice)

TaskId-2936708