### PR TITLE
[FIX] web: take into account invisible buttons

### DIFF
--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -59,22 +59,25 @@ export class ListArchParser extends XMLParser {
                 buttonGroup = undefined;
             }
             if (node.tagName === "button") {
-                const button = {
-                    ...processButton(node),
-                    defaultRank: "btn-link",
-                    type: "button",
-                    id: buttonId++,
-                };
-                if (buttonGroup) {
-                    buttonGroup.buttons.push(button);
-                } else {
-                    buttonGroup = {
-                        id: `column_${nextId++}`,
-                        type: "button_group",
-                        buttons: [button],
-                        hasLabel: false,
+                const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+                if (modifiers.column_invisible !== true) {
+                    const button = {
+                        ...processButton(node),
+                        defaultRank: "btn-link",
+                        type: "button",
+                        id: buttonId++,
                     };
-                    columns.push(buttonGroup);
+                    if (buttonGroup) {
+                        buttonGroup.buttons.push(button);
+                    } else {
+                        buttonGroup = {
+                            id: `column_${nextId++}`,
+                            type: "button_group",
+                            buttons: [button],
+                            hasLabel: false,
+                        };
+                        columns.push(buttonGroup);
+                    }
                 }
             } else if (node.tagName === "field") {
                 const fieldInfo = Field.parseFieldNode(node, models, modelName, "list");

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -290,7 +290,8 @@ export class MockServer {
                     const v = evaluateExpr(mod, context) ? true : false;
                     if (inTreeView && !inListHeader && attr === "invisible") {
                         modifiers.column_invisible = v;
-                    } else if (v || !(attr in modifiers) || !Array.isArray(modifiers[attr])) {
+                    }
+                    if (v || !(attr in modifiers) || !Array.isArray(modifiers[attr])) {
                         modifiers[attr] = v;
                     }
                 }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -485,29 +485,45 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target.querySelector(".o_data_row:first-child"), "td.o_list_button", 2);
     });
 
-    QUnit.test("list view with adjacent buttons and invisible field", async function (assert) {
-        await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: `
+    QUnit.test(
+        "list view with adjacent buttons and invisible field and button",
+        async function (assert) {
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: `
                 <tree>
                     <button name="a" type="object" icon="fa-car"/>
                     <field name="foo" invisible="1"/>
+                    <!--Here the invisible=1 is used to simulate a group on the case that the user
+                        don't have the rights to see the button.-->
+                    <button name="b" type="object" icon="fa-car" invisible="1"/>
                     <button name="x" type="object" icon="fa-star"/>
                     <button name="y" type="object" icon="fa-refresh"/>
                     <button name="z" type="object" icon="fa-exclamation"/>
                 </tree>`,
-        });
+            });
 
-        assert.containsN(
-            target,
-            "th",
-            3,
-            "adjacent buttons in the arch must be grouped in a single column"
-        );
-        assert.containsN(target.querySelector(".o_data_row:first-child"), "td.o_list_button", 2);
-    });
+            assert.containsN(
+                target,
+                "th",
+                3,
+                "adjacent buttons in the arch must be grouped in a single column"
+            );
+            assert.containsN(
+                target,
+                "tr:first-child button",
+                4,
+                "Only 4 buttons should be visible"
+            );
+            assert.containsN(
+                target.querySelector(".o_data_row:first-child"),
+                "td.o_list_button",
+                2
+            );
+        }
+    );
 
     QUnit.test(
         "list view with adjacent buttons and invisible field (modifier)",


### PR DESCRIPTION
Before this commit, an error was raised when an invisible button was
found on a list view (for example, if it has a group).

Now, the invisible buttons are correctly managed.
