### PR TITLE
[FIX] mrp: Lot/serial column in MO form view

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -616,7 +616,7 @@ class MrpProduction(models.Model):
     @api.depends('state', 'move_raw_ids')
     def _compute_show_lot_ids(self):
         for order in self:
-            order.show_lot_ids = order.state != 'draft' and any(m.product_id.tracking == 'serial' for m in order.move_raw_ids)
+            order.show_lot_ids = order.state != 'draft' and any(m.product_id.tracking != 'none' for m in order.move_raw_ids)
 
     @api.depends('state', 'move_raw_ids')
     def _compute_show_serial_mass_produce(self):

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -321,9 +321,10 @@
                                     <field name="manual_consumption" invisible="1" force_save="1"/>
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
-                                        groups="stock.group_production_lot" optional="hide"
-                                        attrs="{'invisible': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')],
-                                                'readonly': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')],
+                                        string="Lot/Serial Numbers"
+                                        help="Displays the consumed Lot/Serial Numbers consumed."
+                                        groups="stock.group_production_lot" readonly="1"
+                                        attrs="{'invisible': ['|', ('show_details_visible', '=', False), ('parent.state', '=', 'draft')],
                                                 'column_invisible': [('parent.show_lot_ids', '=',  False)]}"
                                         options="{'create': [('parent.use_create_components_lots', '!=', False)]}"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id}"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
task-2925474
MRP Back to Basics 7

4. Lot/serial column in MO form view : https://tinyurl.com/2c25udwx
+ add tooltip : 'Displays the consumed Lot/Serial Numbers consumed.'

Current behavior before PR:
- the column Serial Numbers only display serial number
- its name was "Serial Numbers"
- no tool tips
- editable 

Desired behavior after PR is merged:
- Change the column Serial Numbers to also display lot number
- Make the column read-only
- add tooltips
- invisible if none of the components has tracking



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
