### PR TITLE
[FIX] product: fix inconsistency of computed barcode field

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -224,23 +224,18 @@ class ProductTemplate(models.Model):
     @api.depends('product_variant_ids.barcode')
     def _compute_barcode(self):
         self.barcode = False
-        for template in self:
-            # TODO master: update product_variant_count depends and use it instead
-            variant_count = len(template.product_variant_ids)
-            if variant_count == 1:
+        for template in self.with_context(active_test=False):
+            if len(template.product_variant_ids) == 1:
                 template.barcode = template.product_variant_ids.barcode
-            elif variant_count == 0:
-                archived_variants = template.with_context(active_test=False).product_variant_ids
-                if len(archived_variants) == 1:
-                    template.barcode = archived_variants.barcode
 
     def _search_barcode(self, operator, value):
         templates = self.with_context(active_test=False).search([('product_variant_ids.barcode', operator, value)])
         return [('id', 'in', templates.ids)]
 
     def _set_barcode(self):
-        if len(self.product_variant_ids) == 1:
-            self.product_variant_ids.barcode = self.barcode
+        product = self.with_context(active_test=False).product_variant_ids
+        if len(product) == 1:
+            product.barcode = self.barcode
 
     @api.model
     def _get_weight_uom_id_from_ir_config_parameter(self):

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -286,7 +286,8 @@ class TestVariants(common.TestProductCommon):
                 ],
             })]
         })
-        self.assertFalse(template.barcode)  # 2 active variants --> no barcode on template
+        # no barcode is set when there are more than 1 variant
+        self.assertFalse(template.barcode)
 
         variant_1 = template.product_variant_ids[0]
         variant_2 = template.product_variant_ids[1]
@@ -296,11 +297,11 @@ class TestVariants(common.TestProductCommon):
 
         variant_1.action_archive()
         template.invalidate_model(['barcode'])
-        self.assertEqual(template.barcode, variant_2.barcode)  # 1 active variant --> barcode on template
+        self.assertFalse(template.barcode)
 
         variant_1.action_unarchive()
         template.invalidate_model(['barcode'])
-        self.assertFalse(template.barcode)  # 2 active variants --> no barcode on template
+        self.assertFalse(template.barcode)
 
     def test_archive_all_variants(self):
         template = self.env['product.template'].create({


### PR DESCRIPTION
`product.template` has a computed field `barcode` which is not empty only when
there is just one product variant. However, it was inconsistent with
`_search_barcode` which always searches on archived variants too.

STEPS:
* create product with two variants
* archive one of the variants
* set product barcode on the template
* search "barcode is not set"

BEFORE this commit the search results include the product which computed barcode
is not empty

AFTER this commit, the barcode is linked to the single variant (archived or not)

The field was introduced in v14:
https://github.com/odoo/odoo/commit/42e6396d4a62340540a14f6252032f64d315be86
And updated in v15: https://github.com/odoo/odoo/commit/f0c7cde3938c01df5fc10bb8dcd72fd3bb18afdb

opw-2921537

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
