### PR TITLE
[FIX] mrp: Manual Consumption field on BOM

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -414,6 +414,7 @@ class MrpBomLine(models.Model):
     @api.depends('product_id', 'tracking')
     def _compute_manual_consumption(self):
         self.filtered(lambda m: m.tracking != 'none').manual_consumption = True
+        self.filtered(lambda m: m.operation_id.name).manual_consumption = True
 
     @api.depends('product_id', 'bom_id')
     def _compute_child_bom_id(self):
@@ -452,6 +453,11 @@ class MrpBomLine(models.Model):
     def onchange_product_id(self):
         if self.product_id:
             self.product_uom_id = self.product_id.uom_id.id
+
+    @api.onchange('operation_id')
+    def onchange_operation_id(self):
+        if self.operation_id.name:
+            self.manual_consumption = True
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -97,7 +97,7 @@
                                     <field name="allowed_operation_ids" invisible="1"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" optional="hidden" attrs="{'column_invisible': [('parent.type','not in', ('normal', 'phantom'))]}" options="{'no_quick_create':True,'no_create_edit':True}"/>
                                     <field name="tracking" invisible="1"/>
-                                    <field name="manual_consumption" optional="hide" width="1.0" attrs="{'readonly': [('tracking', '!=', 'none')]}"/>
+                                    <field name="manual_consumption" optional="hide" width="1.0" attrs="{'readonly': ['|', ('tracking', '!=', 'none'), ('operation_id', '!=', False)]}"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
task-2925474
MRP Back to Basics 7

Current behavior before PR:
- User has to manually click to active the manual_consumption and also can modify the field

Desired behavior after PR is merged:
- Auto mark manual_consumption as True and read-only as soon as the component is used in an operation (select an action in Consumed in Operation).




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
