### PR TITLE
[IMP] Mode hash can be activated for cash account journals

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -102,7 +102,7 @@
                                         <div class="text-muted" colspan="2">Keep empty for no control</div>
                                         <field name="type_control_ids" widget="many2many_tags" options="{'no_create': True}"/>
                                         <field name="account_control_ids" widget="many2many_tags"/>
-                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" attrs="{'invisible': [('type', 'in', ['bank', 'cash'])]}"/>
+                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" attrs="{'invisible': [('type', '=', 'bank')]}"/>
                                     </group>
                                     <!-- email alias -->
                                     <group class="oe_read_only" name="group_alias_ro" string="Create Invoices upon Emails" attrs="{'invisible': ['|', ('type', 'not in',  ('sale' ,'purchase')), ('alias_domain', '=', False)]}">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Cash posted journal entries should be secured because employees could steel some cash if not

Current behavior before PR:
- the tick box 'mode hash' is not available in cash journals

Desired behavior after PR is merged:
- we can select 'mode hash' in cash journals




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
