### PR TITLE
[FIX] hr_timesheet: fix fields were not displaying in list view

### DIFF
--- a/addons/hr_timesheet/views/project_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_sharing_views.xml
@@ -147,11 +147,11 @@
                 <field name="allow_subtasks" invisible="1"/>
                 <field name="allow_timesheets" invisible="1"/>
                 <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
-                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
+                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" attrs="{'invisible': [('allow_timesheets', '=', False)]}"/>
                 <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}"/>
                 <field name="subtask_effective_hours" widget="timesheet_uom" attrs="{'column_invisible' : ['|', ('allow_subtasks', '=', False), ('allow_timesheets', '=', False)]}" optional="hide"/>
                 <field name="total_hours_spent" widget="timesheet_uom" attrs="{'column_invisible' : ['|', ('allow_subtasks', '=', False), ('allow_timesheets', '=', False)]}" optional="hide"/>
-                <field name="progress" widget="progressbar" attrs="{'column_invisible': [('allow_timesheets', '=', False)]}" optional="show"/>
+                <field name="progress" widget="progressbar" attrs="{'invisible': [('allow_timesheets', '=', False)]}" optional="show"/>
             </field>
         </field>
     </record>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -686,7 +686,7 @@
                     <field name="last_update_color"/>
                     <field name="last_update_status"/>
                     <field name="tag_ids"/>
-                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info"}'/>
+                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "to_define": "muted"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
                         <t t-name="kanban-box">


### PR DESCRIPTION
Before This Commit:  when we open a project sharing portal and open a list view
Then back to kanban view and again back to list view than fields are not
 longer display.

After This Commit: The fields are  properly displayed in list view  when switch
 between the views few times.

Task ID -  2920824






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
