### PR TITLE
[IMP] account: remove the Unreconcile button on Exchange Difference items

### DIFF
--- a/addons/account/static/src/xml/account_payment.xml
+++ b/addons/account/static/src/xml/account_payment.xml
@@ -102,7 +102,7 @@
                 </tr>
             </table>
         </div>
-        <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" t-att-partial-id="partial_id" t-att-payment-id="payment_id" t-att-move-id="move_id" style="margin-top:5px; margin-bottom:5px;" groups="account.group_account_invoice">Unreconcile</button>
+        <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" t-if="!is_exchange" t-att-partial-id="partial_id" t-att-payment-id="payment_id" t-att-move-id="move_id" style="margin-top:5px; margin-bottom:5px;" groups="account.group_account_invoice">Unreconcile</button>
         <button class="btn btn-sm btn-secondary js_open_payment float-end" t-att-move-id="move_id" style="margin-top:5px; margin-bottom:5px;">View</button>
     </t>
 


### PR DESCRIPTION
This PR removes the Unreconcile button on Exchange Difference items

When an invoice has led to the creation of an Exchange Difference Entry, it is shown on the invoice view form.
The info button allows to see more information on that entry, however in the case of an exchange difference,
the "Unreconcile" button should not be displayed. This commit fixes this.
![image](https://user-images.githubusercontent.com/91618364/181505815-f31454b5-391e-414f-85b0-ccede48d1a20.png)

