### PR TITLE
[FIX] mail: fix the traceback on schedule activity view 

### DIFF
--- a/addons/mail/static/src/js/views/activity/activity_controller.js
+++ b/addons/mail/static/src/js/views/activity/activity_controller.js
@@ -68,7 +68,7 @@ var ActivityController = BasicController.extend({
             disable_multiple_selection: true,
             context: state.context,
             on_selected: function (record) {
-                var fakeRecord = state.getKanbanActivityData({}, record[0]);
+                var fakeRecord = state.getKanbanActivityData({}, record[0].id);
                 var widget = new KanbanActivity(self, 'activity_ids', fakeRecord, {});
                 widget.scheduleActivity();
             },

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -367,7 +367,7 @@ QUnit.test('activity view: search more to schedule an activity for a record of a
             assert.step('doAction');
             var expectedAction = {
                 context: {
-                    default_res_id: { id: mailTestActivityId1, display_name: undefined },
+                    default_res_id: mailTestActivityId1,
                     default_res_model: "mail.test.activity",
                 },
                 name: "Schedule Activity",


### PR DESCRIPTION
Before this commit, when we open the activity view and click on schedule activity >> select a record there is a trackback due to the invalid default_res_id passed in context.

So in this commit, fixes the issue by passing the valid res_id in instead of the object with id and display_name.

task-2927335