### PR TITLE
[FIX] account, stock: time to unlink a move is to long

### DIFF
--- a/addons/account/models/account_full_reconcile.py
+++ b/addons/account/models/account_full_reconcile.py
@@ -9,7 +9,7 @@ class AccountFullReconcile(models.Model):
     name = fields.Char(string='Number', required=True, copy=False, default=lambda self: self.env['ir.sequence'].next_by_code('account.reconcile'))
     partial_reconcile_ids = fields.One2many('account.partial.reconcile', 'full_reconcile_id', string='Reconciliation Parts')
     reconciled_line_ids = fields.One2many('account.move.line', 'full_reconcile_id', string='Matched Journal Items')
-    exchange_move_id = fields.Many2one('account.move')
+    exchange_move_id = fields.Many2one('account.move', index=True)
 
     def unlink(self):
         """ When removing a full reconciliation, we need to revert the eventual journal entries we created to book the

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -28,7 +28,7 @@ class StockValuationLayer(models.Model):
     stock_valuation_layer_id = fields.Many2one('stock.valuation.layer', 'Linked To', readonly=True, check_company=True)
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'stock_valuation_layer_id')
     stock_move_id = fields.Many2one('stock.move', 'Stock Move', readonly=True, check_company=True, index=True)
-    account_move_id = fields.Many2one('account.move', 'Journal Entry', readonly=True, check_company=True)
+    account_move_id = fields.Many2one('account.move', 'Journal Entry', readonly=True, check_company=True, index=True)
 
     def init(self):
         tools.create_index(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this commit, in large database the time to unlink is very long.
Before 700 ms after a few ms


@Williambraecky
@rco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
