### PR TITLE
[FIX] web,base: switch to newly installed lang button color

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -1,7 +1,6 @@
 .modal.o_technical_modal .modal-footer {
     // FIXME: These selectors should not be necessary if we used buttons
     // as direct children of the modal-footer as normally required
-    div,
     footer {
         display: flex;
         flex-wrap: wrap;

--- a/odoo/addons/base/wizard/base_language_install_views.xml
+++ b/odoo/addons/base/wizard/base_language_install_views.xml
@@ -17,7 +17,7 @@
                     <footer>
                         <button name="reload" string="Close" type="object" class="btn-primary" data-hotkey="q"/>
                         <button name="switch_lang" type="object" class="btn-primary ms-1" data-hotkey="w">
-                            Switch to <field name="first_lang_id" class="text-white" style="pointer-events: none;"/> &amp; Close
+                            Switch to <field name="first_lang_id" readonly="True" options="{'no_open': True}"/> &amp; Close
                         </button>
                     </footer>
                 </form>


### PR DESCRIPTION
Steps to reproduce:
- Open Settings
- Add Languages
- Select a language
- Click Add
=> Text in the "Switch to..." button is miss-aligned and color is
unreadable.

This commit fixes the alignment by removing an exception to the dialog
footer's buttons alignment selector which is no longer needed and to
avoid confusion between inner-fields and buttons container.

Also, it fixes the color by rendering the language name as a readonly
text instead of a link inside a button (sic).
