### PR TITLE
[FIX] mrp: Workcenter Specific Capacities add fields

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1714,19 +1714,15 @@ class MrpProduction(models.Model):
         self.env['stock.move.line'].browse(move_lines_to_unlink).write({'move_id': False})
         self.env['stock.move.line'].browse(move_lines_to_unlink).unlink()
         self.env['stock.move.line'].create(move_lines_vals)
-
-        # We need to adapt `duration_expected` on both the original workorders and their
-        # backordered workorders. To do that, we use the original `duration_expected` and the
-        # ratio of the quantity produced and the quantity to produce.
         workorders_to_cancel = self.env['mrp.workorder']
         for production in self:
             initial_qty = initial_qty_by_production[production]
             initial_workorder_remaining_qty = []
             bo = production_to_backorders[production]
 
-            # Adapt duration
+            # Adapt duration by triggering the computation function for the duration_expected
             for workorder in bo.workorder_ids:
-                workorder.duration_expected = workorder.duration_expected * workorder.production_id.product_qty / initial_qty
+                workorder.duration_expected = workorder._get_duration_expected()
 
             # Adapt quantities produced
             for workorder in production.workorder_ids:

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -421,6 +421,8 @@ class MrpWorkCenterCapacity(models.Model):
     product_id = fields.Many2one('product.product', string='Product', required=True)
     product_uom_id = fields.Many2one('uom.uom', string='Product UoM', related='product_id.uom_id')
     capacity = fields.Float('Capacity', default=1.0, help="Number of pieces that can be produced in parallel for this product.")
+    time_start = fields.Float('Setup Time (minutes)', help="Time in minutes for the setup.")
+    time_stop = fields.Float('Cleanup Time (minutes)', help="Time in minutes for the cleaning.")
 
     _sql_constraints = [
         ('positive_capacity', 'CHECK(capacity > 0)', 'Capacity should be a positive number.'),

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -393,6 +393,8 @@
                                         <field name="product_id"/>
                                         <field name="product_uom_id" groups="uom.group_uom"/>
                                         <field name="capacity"/>
+                                        <field name="time_start" optional="hide"/>
+                                        <field name="time_stop" optional="hide"/>
                                     </tree>
                                 </field>
                             </page>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
task-2925474
MRP Back to Basics 7

1. Expand Specific Capacities field on Work Center, so that for each product, it is possible to specify discrete set
up and clean up time as well.
UI as such : add both columns as optional=hide in the table : https://tinyurl.com/2nt6euea

Current behavior before PR:
- Can only declare setup/cleanup time for work center

Desired behavior after PR is merged:
- add 2 additional fields for mrp.workcenter.capacity so that it is able to set setup/cleanup time for each of the product as well



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
