### PR TITLE
[FIX] payment: allow payment for internal user even if not same company

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -443,7 +443,10 @@ class PaymentPortal(portal.CustomerPortal):
         :return: None
         :raise UserError: If the companies don't match.
         """
-        if partner.company_id and partner.company_id != document_company:
+        allowed_companies = partner.company_id
+        if partner.user_ids:
+            allowed_companies |= partner.user_ids.mapped('company_ids')
+        if document_company not in allowed_companies:
             raise UserError(
                 _("Please switch to company '%s' to make this payment.", document_company.name)
             )


### PR DESCRIPTION
Steps to reproduce:

  - Install `l10n_lu` and `account_payment` modules
  - Login with Admin User
  - Switch to LU company
  - Create and confirm a new invoice
  - Click on Preview

Issue:

  Error: `Please switch to company Odoo - Lu to make this payment`.

Cause:

  In payment module, we ensure that the partner company is matching the
  invoice company. However, in this case, this is an internal user and
  his partner is linked to a different company A but user has
  access to company A & B.

Solution:

  If partner is linked to an internal user, add to allowed companies
  the companies that user has access to.

opw-2922633