### PR TITLE
[FIX] stock: impossible to search easly location

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -348,7 +348,8 @@
                 <search string="Stock Moves">
                     <field name="origin" filter_domain="['|', '|', ('origin', 'ilike', self), ('name', 'ilike', self), ('picking_id', 'ilike', self)]" string="Reference"/>
                     <field name="product_id"/>
-                    <field name="name" string="Location" filter_domain="['|',('location_id', 'ilike', self),('location_dest_id', 'ilike', self)]"/>
+                    <field name="location_id" string="Source Location" groups="stock.group_stock_multi_locations"/> 
+                    <field name="location_dest_id" string="Destination Location" groups="stock.group_stock_multi_locations"/> 
                     <field name="partner_id" string="Partner" filter_domain="[('picking_id.partner_id', 'child_of', self)]"/>
                     <filter string="Ready" name="ready" domain="[('state','=','assigned')]" help="Stock moves that are Available (Ready to process)"/>
                     <filter string="To Do" name="future" domain="[('state','in',('assigned','confirmed','waiting'))]" help="Stock moves that are Confirmed, Available or Waiting"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this PR Odoo don't pre-search on location.

Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/181525087-945b7f1a-bac8-4cbe-be96-f9e15cb5f2fe.png)

Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/16716992/181525168-28ded319-bbd6-4cba-b6a2-172e26e1b398.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
