### PR TITLE
[FIX] sale: set correct invoice status

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1072,6 +1072,7 @@ class SaleOrderLine(models.Model):
             elif not float_is_zero(line.qty_to_invoice, precision_digits=precision):
                 line.invoice_status = 'to invoice'
             elif line.state == 'sale' and line.product_id.invoice_policy == 'order' and\
+                    line.product_uom_qty >= 0.0 and\
                     float_compare(line.qty_delivered, line.product_uom_qty, precision_digits=precision) == 1:
                 line.invoice_status = 'upselling'
             elif float_compare(line.qty_invoiced, line.product_uom_qty, precision_digits=precision) >= 0:

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -159,6 +159,20 @@ class TestSaleOrder(TestCommonSaleNoChart):
         self.assertEqual(invoice3.amount_total, 8 * self.product_map['serv_order'].list_price, 'Sale: second invoice total amount is wrong')
         self.assertTrue(self.sale_order.invoice_status == 'invoiced', 'Sale: SO status after invoicing everything (including the upsel) should be "invoiced"')
 
+    def test_invoice_state_when_ordered_quantity_is_negative(self):
+        """When you invoice a SO line with a product that is invoiced on ordered quantities and has negative ordered quantity,
+        this test ensures that the  invoicing status of the SO line is 'invoiced' (and not 'upselling')."""
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_customer_usd.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_order.id,
+                'product_uom_qty': -1,
+            })]
+        })
+        sale_order.action_confirm()
+        sale_order._create_invoices(final=True)
+        self.assertTrue(sale_order.invoice_status == 'invoiced', 'Sale: The invoicing status of the SO should be "invoiced"')
+
     def test_sale_sequence(self):
         self.env['ir.sequence'].search([
             ('code', '=', 'sale.order'),


### PR DESCRIPTION
Steps to reproduce:
- Create a quotation
- Add a product that is invoiced on "ordered quantities" and set the quantity to a negative number.
- Leave 'delivered' to 0
- Confirm the quotation
- Create the Invoice and validate it.
- Go to the SO list view (Orders > Orders)

You should see that the Invoice Status of the order you just created is 'Upselling Opportunity', which is not correct.

Why this is happening:

Here's an explanation on the 'Upselling Opportunity' state (found in the code):

> upselling: this is possible only for a product invoiced on ordered quantities for which **we delivered more than expected.**

In our case, the invoice line's state is set to 'upselling' because we have a negative ordered quantity and a zero delivered quantity (i.e. we delivered more than expected).

opw-2895218