### PR TITLE
[FIX] account : remove QR code method for credit note

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -294,7 +294,7 @@ class AccountMove(models.Model):
         default=_get_default_invoice_incoterm,
         help='International Commercial Terms are a series of predefined commercial terms used in international transactions.')
     display_qr_code = fields.Boolean(string="Display QR-code", related='company_id.qr_code')
-    qr_code_method = fields.Selection(string="Payment QR-code",
+    qr_code_method = fields.Selection(string="Payment QR-code", copy=False,
         selection=lambda self: self.env['res.partner.bank'].get_available_qr_methods_in_sequence(),
         help="Type of QR-code to be generated for the payment of this invoice, when printing it. If left blank, the first available and usable method will be used.")
 

--- a/addons/account_qr_code_sepa/tests/test_sepa_qr.py
+++ b/addons/account_qr_code_sepa/tests/test_sepa_qr.py
@@ -3,7 +3,7 @@
 from odoo.exceptions import UserError
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
-
+from odoo import fields
 
 @tagged('post_install', '-at_install')
 class TestSEPAQRCode(AccountTestInvoicingCommon):
@@ -62,3 +62,16 @@ class TestSEPAQRCode(AccountTestInvoicingCommon):
         """
         self.sepa_qr_invoice.generate_qr_code()
         self.assertEqual(self.sepa_qr_invoice.qr_code_method, 'sct_qr', "SEPA QR-code generator should have been chosen for this invoice.")
+
+    def test_out_invoice_create_refund_qr_code(self):
+        self.sepa_qr_invoice.generate_qr_code()
+        self.sepa_qr_invoice.action_post()
+        move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.sepa_qr_invoice.ids).create({
+            'date': fields.Date.from_string('2019-02-01'),
+            'reason': 'no reason',
+            'refund_method': 'refund',
+        })
+        reversal = move_reversal.reverse_moves()
+        reverse_move = self.env['account.move'].browse(reversal['res_id'])
+
+        self.assertFalse(reverse_move.qr_code_method, "qr_code_method for credit note should be None")


### PR DESCRIPTION
To reproduce
============

Enable "Qr Codes" under Accounting Settings > Create Invoice > set "Payment QR-code" method (tab "More Info")
> issue Credit Note > try to "Send and Print" credit note > Error:

` The chosen QR-code type is not eligible for this invoice. `

Specification
=============

Generating QR code on Credit Note doesn't make sense, so the field `qr_code_method` is set to `False`
when creating a Credit Note.

opw-2900112