### PR TITLE
[FIX] mrp: allow multi-edit workorder

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -62,7 +62,7 @@
         <field name="model">mrp.workorder</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <tree editable="bottom">
+            <tree editable="bottom" multi_edit="1">
                 <field name="consumption" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="is_produced" invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
task-2925474 
MRP Back to Basics 7
Allow mass editing in mrp work orders tree view



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
