### PR TITLE
[FIX] base: address operation context keys in calendar view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -904,7 +904,7 @@ actual arch.
         Model = self.env[model].sudo(False)
         is_base_model = self.env.context.get('base_model_name', model) == model
 
-        if node.tag in ('kanban', 'tree', 'form', 'activity'):
+        if node.tag in ('kanban', 'tree', 'form', 'activity', 'calendar'):
             for action, operation in (('create', 'create'), ('delete', 'unlink'), ('edit', 'write')):
                 if (not node.get(action) and
                         not Model.check_access_rights(operation, raise_exception=False) or


### PR DESCRIPTION
Prior this fix, creating an action with (e.g.)
additional_context : {create: 0} wouldn't have any effect
on calendar view.

Now, if this context key is added, the user won't be able to create.
Also true for delete and write.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
