### PR TITLE
[FIX] notes: push new notes to top of the list

### DIFF
--- a/addons/note/models/note.py
+++ b/addons/note/models/note.py
@@ -35,7 +35,7 @@ class Note(models.Model):
     _name = 'note.note'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = "Note"
-    _order = 'sequence'
+    _order = 'sequence, id desc'
 
     def _get_default_stage_id(self):
         return self.env['note.stage'].search([('user_id', '=', self.env.uid)], limit=1)
@@ -43,7 +43,7 @@ class Note(models.Model):
     name = fields.Text(compute='_compute_name', string='Note Summary', store=True)
     user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid)
     memo = fields.Html('Note Content')
-    sequence = fields.Integer('Sequence')
+    sequence = fields.Integer('Sequence', default=0)
     stage_id = fields.Many2one('note.stage', compute='_compute_stage_id',
         inverse='_inverse_stage_id', string='Stage', default=_get_default_stage_id)
     stage_ids = fields.Many2many('note.stage', 'note_stage_rel', 'note_id', 'stage_id',


### PR DESCRIPTION
Steps to reproduce the issue:

- Notes app > Kanban view > Create a bunch of notes using
the + icon in the kanban view
- (optional) Modify the default order of the notes
- Add a new note using the quick add feature
- Don't modify the order of the notes and refresh the page
- The new note will be sent to the bottom of the note list
(off-screen if the list is long enough)

This happens because new notes have their sequence set to NULL, which
places them at the end of the list after ordering by sequence.

This commit sets the default sequence of a new note to 0, so that it
is placed at the top of the list and adds an additional sort on
'id desc' to consider the case where all notes have the same sequence.

opw-2924615