### PR TITLE
[FIX] base_setup: replace `id` for `module_microsoft_calendar` in configuration

### DIFF
--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -221,7 +221,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="sync_google_calendar_setting">
+                            <div class="col-12 col-lg-6 o_setting_box" id="sync_outlook_calendar_setting">
                                 <div class="o_setting_left_pane">
                                     <field name="module_microsoft_calendar" />
                                 </div>


### PR DESCRIPTION
Currently, Outlook and Google calendar having same container `id` in view.
This PR will fix that problem

https://github.com/odoo/odoo/blob/5edff67b88c60649af592556e7088f1630625168/addons/base_setup/views/res_config_settings_views.xml#L224-L256

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
