### PR TITLE
[FIX] mass_mailing: fix traceback on picking shape

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -133,7 +133,8 @@ options.registry.ImageOptimize.include({
         // feature.
         const imgShapeContainerEl = this.el.querySelector('.o_we_image_shape');
         if (imgShapeContainerEl) {
-            imgShapeContainerEl.classList.toggle('d-none', !odoo.debug);
+            // Hidden from view as the feature is not yet supported in emails
+            imgShapeContainerEl.classList.add('d-none');
         }
     },
 


### PR DESCRIPTION
Picking a shape for an image in mass_mailing (when in developer mode)
would result in a sudden error due to a None
being passed to _getCSSColorValue

The shape picker is completely hidden in  the mass_mailing
templates editor as essentially no mail
client supports it in this version up to 15.3

Feature properly reintroduced in:
https://github.com/odoo/odoo/pull/84926

Task-2937490
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
