### PR TITLE
[FIX] website: tone on tone invisible button in the sign app

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -1135,7 +1135,7 @@ $o-color-palettes: map-merge($o-color-palettes,
             'copyright': 2,
         ),
         'kiddo-3': (
-            'o-color-1': #684672,
+            'o-color-1': #a68baf,
             'o-color-2': #639C8E,
             'o-color-3': #f8ebd6,
             'o-color-4': #FFFFFF,


### PR DESCRIPTION
Steps to reproduce:
1. Install website and choose the kiddo theme
2. Install Sign
3. In Sign, click on the "Share" of "Non disclosure Agreement.pdf"
4. In another window (not log in), access the shared sign document. Make sure to be in "mobile" mode in this view (using the browser dev tools)
5. Choose a field to fill in the document
6. The space under the field value looks empty rather than having the "Next" button

Issue:
The next button is there but it's color is purple and the background is purple too -> barely visible

Solution:
We change the color of the kiddo for a lighter purple so that the writing becomes visible.

opw-2871042