### PR TITLE
[FIX] l10n_fi: Default account payable for Finland localization

### DIFF
--- a/addons/l10n_fi/data/l10n_fi_chart_post_data.xml
+++ b/addons/l10n_fi/data/l10n_fi_chart_post_data.xml
@@ -3,7 +3,7 @@
     <record id="fi_chart_template" model="account.chart.template">
         <field name="code_digits">4</field>
         <field name="property_account_receivable_id" ref="account_1700"/>
-        <field name="property_account_payable_id" ref="account_2700"/>
+        <field name="property_account_payable_id" ref="account_2870"/>
         <field name="property_account_expense_categ_id" ref="account_4000"/>
         <field name="property_account_income_categ_id" ref="account_3000"/>
         <field name="property_account_expense_id" ref="account_4000"/>


### PR DESCRIPTION
Issue:
In finnish localization, partners have by default account payable "2700 Velat saman konsernin yrityksille, pitkäaikaiset" which is incorrect
Expected behaviour: The default account payable for finnich localization should be "2870 Ostovelat"

Solution:
In l1On_fi/data/l10n_fi_chart_post_data.xml, the "property_account_payable_id" is set to "account_2700". Just change  it to "account_2870"

opw-2936893

Eteil Djoumatchoua <etdj@odoo.com>
