### PR TITLE
[FIX] web: fix make fake rpc service

### DIFF
--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -66,7 +66,9 @@ export function makeFakeRPCService(mockRPC) {
                 let rejectFn;
                 const rpcProm = new Promise((resolve, reject) => {
                     rejectFn = reject;
-                    resolve(rpcService(...arguments));
+                    rpcService(...arguments)
+                        .then(result => resolve(result))
+                        .catch(err => reject(err));
                 });
                 rpcProm.abort = () => rejectFn(new ConnectionAbortedError("XmlHttpRequestError abort"));
                 return rpcProm;


### PR DESCRIPTION
Fake rpc service abort is incorrect because it resolves to rpcService(...arguments).
Since it is resolve immediately, it can't be aborted. This commit fixes this issue.
