### PR TITLE
[IMP] mail: remove Record/create

### DIFF
--- a/addons/im_livechat/static/src/models/thread.js
+++ b/addons/im_livechat/static/src/models/thread.js
@@ -58,7 +58,7 @@ patchModelMethods('Thread', {
                  * easier to handle one temporary partner per channel.
                  */
                 data2.members.push(unlink(this.messaging.publicPartners));
-                const partner = this.messaging.models['Partner'].create(
+                const partner = this.messaging.models['Partner'].insert(
                     Object.assign(
                         this.messaging.models['Partner'].convertData(data.livechat_visitor),
                         { id: this.messaging.models['Partner'].getNextPublicId() }

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -11,7 +11,7 @@ import { makeDeferred } from '@mail/utils/deferred';
 /**
  * Object that manage models and records, notably their update cycle: whenever
  * some records are requested for update (either with model static method
- * `create()` or record method `update()`), this object processes them with
+ * `insert()` or record method `update()`), this object processes them with
  * direct field & and computed field updates.
  */
 export class ModelManager {
@@ -174,13 +174,6 @@ export class ModelManager {
             return allRecords.filter(filterFunc);
         }
         return allRecords;
-    }
-
-    /**
-     * @deprecated use insert instead
-     */
-    create(model, data = {}) {
-        return this.insert(model, data);
     }
 
     /**

--- a/addons/mail/static/src/models/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager.js
@@ -113,7 +113,7 @@ registerModel({
             }
             let chatWindow = thread.chatWindow;
             if (!chatWindow) {
-                chatWindow = this.messaging.models['ChatWindow'].create({
+                chatWindow = this.messaging.models['ChatWindow'].insert({
                     isFolded,
                     manager: replace(this),
                     thread: replace(thread),

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -281,7 +281,7 @@ registerModel({
                 });
             } else if (!this.thread || !this.thread.isTemporary) {
                 const currentPartner = this.messaging.currentPartner;
-                const message = this.messaging.models['Message'].create({
+                const message = this.messaging.models['Message'].insert({
                     author: replace(currentPartner),
                     body: this.env._t("Creating a new record..."),
                     id: getMessageNextTemporaryId(),

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -565,7 +565,7 @@ registerModel({
                 0
             );
             const partnerRoot = this.messaging.partnerRoot;
-            const message = this.messaging.models['Message'].create(Object.assign(convertedData, {
+            const message = this.messaging.models['Message'].insert(Object.assign(convertedData, {
                 author: replace(partnerRoot),
                 id: lastMessageId + 0.01,
                 isTransient: true,

--- a/addons/mail/static/src/models/record.js
+++ b/addons/mail/static/src/models/record.js
@@ -58,12 +58,6 @@ registerModel({
             return this.modelManager.all(this, filterFunc);
         },
         /**
-         * @deprecated use insert instead
-         */
-        create(data) {
-            return this.modelManager.create(this, data);
-        },
-        /**
          * Gets the unique record that matches the given identifying data, if it
          * exists.
          *

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -79,7 +79,7 @@ Component.env = legacyEnv;
 
     const messaging = await env.services.messaging.get();
     messaging.models['Thread'].insert(messaging.models['Thread'].convertData(data.channelData));
-    const discussPublicView = messaging.models['DiscussPublicView'].create(data.discussPublicViewData);
+    const discussPublicView = messaging.models['DiscussPublicView'].insert(data.discussPublicViewData);
     if (discussPublicView.shouldDisplayWelcomeViewInitially) {
         discussPublicView.switchToWelcomeView();
     } else {

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
@@ -195,7 +195,7 @@ QUnit.test('click on edit follower', async function (assert) {
         res_model: 'res.partner',
         views: [[false, 'form']],
     });
-    const thread = messaging.models['Thread'].create({
+    const thread = messaging.models['Thread'].insert({
         id: threadId,
         model: 'res.partner',
     });

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/clear_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/clear_tests.js
@@ -10,7 +10,7 @@ QUnit.test('clear: should set attribute field undefined if there is no default v
     assert.expect(1);
 
     const { messaging } = await start();
-    const task = messaging.models['TestTask'].create({
+    const task = messaging.models['TestTask'].insert({
         id: 1,
         title: 'test title 1',
     });
@@ -26,7 +26,7 @@ QUnit.test('clear: should set attribute field the default value', async function
     assert.expect(1);
 
     const { messaging } = await start();
-    const task = messaging.models['TestTask'].create({
+    const task = messaging.models['TestTask'].insert({
         id: 1,
         difficulty: 5,
     });
@@ -42,7 +42,7 @@ QUnit.test('clear: should set x2one field undefined if no default value is given
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 20 }),
     });
@@ -64,7 +64,7 @@ QUnit.test('clear: should set x2one field the default value', async function (as
     assert.expect(1);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         favorite: insertAndReplace({ description: 'pingpong' }),
         id: 10,
     });
@@ -80,7 +80,7 @@ QUnit.test('clear: should set x2many field empty array if no default value is gi
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace({ id: 20 }),
     });
@@ -102,7 +102,7 @@ QUnit.test('clear: should set x2many field the default value', async function (a
     assert.expect(1);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         hobbies: [
             insertAndReplace({ description: 'basketball' }),

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/insert_and_replace_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/insert_and_replace_tests.js
@@ -11,7 +11,7 @@ QUnit.test('insertAndReplace: should create and link a new record for an empty x
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
     contact.update({ address: insertAndReplace({ id: 10 }) });
     const address = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(
@@ -30,7 +30,7 @@ QUnit.test('insertAndReplace: should create and replace a new record for a non-e
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
@@ -58,7 +58,7 @@ QUnit.test('insertAndReplace: should update the existing record for an x2one fie
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({
             id: 10,
@@ -88,7 +88,7 @@ QUnit.test('insertAndReplace: should create and replace the records for an x2man
     assert.expect(4);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace({ id: 10 }),
     });
@@ -121,7 +121,7 @@ QUnit.test('insertAndReplace: should update and replace the records for an x2man
     assert.expect(4);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace([
             { id: 10, title: 'task 10' },

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/insert_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/insert_tests.js
@@ -11,7 +11,7 @@ QUnit.test('insert: should create and link a new record for an empty x2one field
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
     contact.update({ address: insert({ id: 10 }) });
     const address = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(
@@ -30,7 +30,7 @@ QUnit.test('insert: should create and replace a new record for a non-empty x2one
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
@@ -58,7 +58,7 @@ QUnit.test('insert: should update the existing record for an x2one field', async
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({
             id: 10,
@@ -88,7 +88,7 @@ QUnit.test('insert: should create and link a new record for an x2many field', as
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
     contact.update({ tasks: insert({ id: 10 }) });
     const task = messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     assert.strictEqual(
@@ -112,7 +112,7 @@ QUnit.test('insert: should create and add a new record for an x2many field', asy
     assert.expect(4);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace({ id: 10 }),
     });
@@ -145,7 +145,7 @@ QUnit.test('insert: should update existing records for an x2many field', async f
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace({
             id: 10,

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/link_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/link_tests.js
@@ -11,8 +11,8 @@ QUnit.test('link: should link a record to an empty x2one field', async function 
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
-    const address = messaging.models['TestAddress'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
+    const address = messaging.models['TestAddress'].insert({ id: 10 });
     contact.update({ address: replace(address) });
     assert.strictEqual(
         contact.address,
@@ -30,12 +30,12 @@ QUnit.test('link: should replace a record to a non-empty x2one field', async fun
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
     const address10 = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
-    const address20 = messaging.models['TestAddress'].create({ id: 20 });
+    const address20 = messaging.models['TestAddress'].insert({ id: 20 });
     contact.update({ address: replace(address20) });
     assert.strictEqual(
         contact.address,
@@ -58,8 +58,8 @@ QUnit.test('link: should link a record to an empty x2many field', async function
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
-    const task = messaging.models['TestTask'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
+    const task = messaging.models['TestTask'].insert({ id: 10 });
     contact.update({ tasks: link(task) });
     assert.strictEqual(
         contact.tasks.length,
@@ -82,12 +82,12 @@ QUnit.test('link: should link and add a record to a non-empty x2many field', asy
     assert.expect(5);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace({ id: 10 }),
     });
     const task10 = messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
-    const task20 = messaging.models['TestTask'].create({ id: 20 });
+    const task20 = messaging.models['TestTask'].insert({ id: 20 });
     contact.update({ tasks: link(task20) });
     assert.strictEqual(
         contact.tasks.length,

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/replace_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/replace_tests.js
@@ -11,8 +11,8 @@ QUnit.test('replace: should link a record for an empty x2one field', async funct
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
-    const address = messaging.models['TestAddress'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
+    const address = messaging.models['TestAddress'].insert({ id: 10 });
     contact.update({ address: replace(address) });
     assert.strictEqual(
         contact.address,
@@ -30,12 +30,12 @@ QUnit.test('replace: should replace a record for a non-empty x2one field', async
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
     const address10 = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
-    const address20 = messaging.models['TestAddress'].create({ id: 20 });
+    const address20 = messaging.models['TestAddress'].insert({ id: 20 });
     contact.update({ address: replace(address20) });
     assert.strictEqual(
         contact.address,
@@ -58,8 +58,8 @@ QUnit.test('replace: should link a record for an empty x2many field', async func
     assert.expect(4);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({ id: 10 });
-    const task = messaging.models['TestTask'].create({ id: 10 });
+    const contact = messaging.models['TestContact'].insert({ id: 10 });
+    const task = messaging.models['TestTask'].insert({ id: 10 });
     contact.update({ tasks: replace(task) });
     assert.strictEqual(
         contact.tasks.length,
@@ -87,7 +87,7 @@ QUnit.test('replace: should replace all records for a non-empty field', async fu
     assert.expect(5);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace([
             { id: 10 },
@@ -96,7 +96,7 @@ QUnit.test('replace: should replace all records for a non-empty field', async fu
     });
     const task10 = messaging.models['TestTask'].findFromIdentifyingData({ id: 10 });
     const task20 = messaging.models['TestTask'].findFromIdentifyingData({ id: 20 });
-    const task30 = messaging.models['TestTask'].create({ id: 30 });
+    const task30 = messaging.models['TestTask'].insert({ id: 30 });
     contact.update({ tasks: replace(task30) });
     assert.strictEqual(
         contact.tasks.length,
@@ -129,7 +129,7 @@ QUnit.test('replace: should order the existing records for x2many field', async 
     assert.expect(3);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace([
             { id: 10 },

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/set_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/set_tests.js
@@ -15,7 +15,7 @@ QUnit.test('decrement: should decrease attribute field value', async function (a
     assert.expect(1);
     const { messaging } = await start();
 
-    const task = messaging.models['TestTask'].create({
+    const task = messaging.models['TestTask'].insert({
         id: 10,
         difficulty: 5,
     });
@@ -31,7 +31,7 @@ QUnit.test('increment: should increase attribute field value', async function (a
     assert.expect(1);
     const { messaging } = await start();
 
-    const task = messaging.models['TestTask'].create({
+    const task = messaging.models['TestTask'].insert({
         id: 10,
         difficulty: 5,
     });
@@ -47,7 +47,7 @@ QUnit.test('set: should set a value for attribute field', async function (assert
     assert.expect(1);
     const { messaging } = await start();
 
-    const task = messaging.models['TestTask'].create({
+    const task = messaging.models['TestTask'].insert({
         id: 10,
         difficulty: 5,
     });
@@ -63,7 +63,7 @@ QUnit.test('multiple attribute commands combination', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
 
-    const task = messaging.models['TestTask'].create({
+    const task = messaging.models['TestTask'].insert({
         id: 10,
         difficulty: 5,
     });

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/unlink_all_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/unlink_all_tests.js
@@ -11,7 +11,7 @@ QUnit.test('unlinkAll: should set x2one field undefined', async function (assert
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 20 }),
     });
@@ -33,7 +33,7 @@ QUnit.test('unlinkAll: should set x2many field an empty array', async function (
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace({
             id: 20,

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/unlink_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/unlink_tests.js
@@ -12,7 +12,7 @@ QUnit.test('unlink: should unlink the record for x2one field', async function (a
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         address: insertAndReplace({ id: 10 }),
     });
@@ -34,7 +34,7 @@ QUnit.test('unlink: should unlink the specified record for x2many field', async 
     assert.expect(2);
     const { messaging } = await start();
 
-    const contact = messaging.models['TestContact'].create({
+    const contact = messaging.models['TestContact'].insert({
         id: 10,
         tasks: insertAndReplace([
             { id: 10 },

--- a/addons/mail/static/tests/qunit_suite_tests/models/attachment_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/attachment_tests.js
@@ -12,7 +12,7 @@ QUnit.test('create (txt)', async function (assert) {
     const { messaging } = await start();
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = messaging.models['Attachment'].create({
+    const attachment = messaging.models['Attachment'].insert({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -34,7 +34,7 @@ QUnit.test('displayName', async function (assert) {
     const { messaging } = await start();
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = messaging.models['Attachment'].create({
+    const attachment = messaging.models['Attachment'].insert({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -52,7 +52,7 @@ QUnit.test('extension', async function (assert) {
     const { messaging } = await start();
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = messaging.models['Attachment'].create({
+    const attachment = messaging.models['Attachment'].insert({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -70,7 +70,7 @@ QUnit.test('fileType', async function (assert) {
     const { messaging } = await start();
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = messaging.models['Attachment'].create({
+    const attachment = messaging.models['Attachment'].insert({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -90,7 +90,7 @@ QUnit.test('isTextFile', async function (assert) {
     const { messaging } = await start();
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = messaging.models['Attachment'].create({
+    const attachment = messaging.models['Attachment'].insert({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',
@@ -108,7 +108,7 @@ QUnit.test('isViewable', async function (assert) {
     const { messaging } = await start();
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
 
-    const attachment = messaging.models['Attachment'].create({
+    const attachment = messaging.models['Attachment'].insert({
         filename: "test.txt",
         id: 750,
         mimetype: 'text/plain',

--- a/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
@@ -21,12 +21,12 @@ QUnit.test('create', async function (assert) {
     assert.notOk(messaging.models['Attachment'].findFromIdentifyingData({ id: 750 }));
     assert.notOk(messaging.models['Message'].findFromIdentifyingData({ id: 4000 }));
 
-    const thread = messaging.models['Thread'].create({
+    const thread = messaging.models['Thread'].insert({
         id: 100,
         model: 'mail.channel',
         name: "General",
     });
-    const message = messaging.models['Message'].create({
+    const message = messaging.models['Message'].insert({
         attachments: insertAndReplace({
             filename: "test.txt",
             id: 750,
@@ -97,70 +97,70 @@ QUnit.test('create', async function (assert) {
 QUnit.test('message without body should be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ id: 11 });
+    const message = messaging.models['Message'].insert({ id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "" should be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p></p>" should be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<p></p>", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<p></p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p><br></p>" should be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<p><br></p>", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<p><br></p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p><br/></p>" should be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<p><br/></p>", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<p><br/></p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test(String.raw`message with body "<p>\n</p>" should be considered empty`, async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<p>\n</p>", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<p>\n</p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test(String.raw`message with body "<p>\r\n\r\n</p>" should be considered empty`, async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<p>\r\n\r\n</p>", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<p>\r\n\r\n</p>", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test('message with body "<p>   </p>  " should be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<p>   </p>  ", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<p>   </p>  ", id: 11 });
     assert.ok(message.isEmpty);
 });
 
 QUnit.test(`message with body "<img src=''>" should not be considered empty`, async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "<img src=''>", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "<img src=''>", id: 11 });
     assert.notOk(message.isEmpty);
 });
 
 QUnit.test('message with body "test" should not be considered empty', async function (assert) {
     assert.expect(1);
     const { messaging } = await start();
-    const message = messaging.models['Message'].create({ body: "test", id: 11 });
+    const message = messaging.models['Message'].insert({ body: "test", id: 11 });
     assert.notOk(message.isEmpty);
 });
 

--- a/addons/mail/static/tests/qunit_suite_tests/models/messaging_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/messaging_menu_tests.js
@@ -19,7 +19,7 @@ QUnit.test('messaging menu counter should ignore unread messages in channels tha
         },
     });
     const { messaging } = await start();
-    messaging.models['Thread'].create({
+    messaging.models['Thread'].insert({
         id: 31,
         isServerPinned: false,
         model: 'mail.channel',

--- a/addons/mail/static/tests/qunit_suite_tests/models/thread_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/thread_tests.js
@@ -36,7 +36,7 @@ QUnit.test('create (channel)', async function (assert) {
         model: 'mail.channel',
     }));
 
-    const thread = messaging.models['Thread'].create({
+    const thread = messaging.models['Thread'].insert({
         channel_type: 'channel',
         id: 100,
         members: insert([{
@@ -94,7 +94,7 @@ QUnit.test('create (chat)', async function (assert) {
         model: 'mail.channel',
     }));
 
-    const channel = messaging.models['Thread'].create({
+    const channel = messaging.models['Thread'].insert({
         channel_type: 'chat',
         id: 200,
         members: insert({


### PR DESCRIPTION
The way the code has evolved, `create` is now no more than an unnecessary indirection for `insert`.

This PR removes `create` and replaces its uses with `insert` directly.