### PR TITLE
[FIX] web: fix css issue with rtl in calendar view

### DIFF
--- a/addons/web/static/src/legacy/scss/web_calendar.scss
+++ b/addons/web/static/src/legacy/scss/web_calendar.scss
@@ -341,6 +341,7 @@ $o-cw-filter-avatar-size: 20px;
                 }
 
                 .fc-time:not(:empty) {
+                    /*rtl:ignore*/
                     padding-right: 0.5em;
                 }
 


### PR DESCRIPTION
This commit fixes following html block [1]

``` xml
<div class="fc-content">
            <span class="fc-time">08:00</span>
            <div class="o_event_title">Mitchel Admin - Administrator</div>
</div>
```

`rtlcss` lib changes `padding-right` to `padding-left`, which doesn't work if we
use `span` block next to `div` block, because position of the blocks are not
changed (time is still on the left side and title is on the right). Adding the
`ignore` directive solves the issue.

[1]: https://github.com/odoo/odoo/blob/4a996060e6b922fecb299eca32d6763dbb12b831/addons/web/static/src/legacy/xml/web_calendar.xml#L16-L17

opw-2925491

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
