### PR TITLE
[FIX] l10n_it_edi: attachments from xml missing res_model/res_id

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -723,6 +723,8 @@ class AccountEdiFormat(models.Model):
                         'name': name_attachment,
                         'datas': attachment_64,
                         'type': 'binary',
+                        'res_model': 'account.move',
+                        'res_id': new_invoice.id,
                     })
 
                     # default_res_id is had to context to avoid facturx to import his content


### PR DESCRIPTION
Install Documents
Open Settings > Documents, enable 'Accounting' files centralization
Configure 'Journals' with a single line
- Journal -> Vendor Bills
- Workspace -> Finance / Supplier Invoices
Now in go to Accounting>Vendor>Bills
Upload an xml representing a vendor bill, including an attachment
encoded in the <Allegati> tag
Open created bill

Traceback. The error is caused by the attachment included in the xml
registered without res_id/res_model.
In the document flow the attachment will receive a res_id, but not the
res_model, causing the traceback when retrieving the attachment

opw-2919610


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
