### PR TITLE
[FIX] web: ListView invisible column base on context

### DIFF
--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -78,14 +78,13 @@ export class ListArchParser extends XMLParser {
                 }
             } else if (node.tagName === "field") {
                 const fieldInfo = Field.parseFieldNode(node, models, modelName, "list");
-                const invisible = node.getAttribute("invisible");
                 fieldNodes[fieldInfo.name] = fieldInfo;
                 node.setAttribute("field_id", fieldInfo.name);
                 if (fieldInfo.widget === "handle") {
                     handleField = fieldInfo.name;
                 }
                 addFieldDependencies(activeFields, fieldInfo.FieldComponent.fieldDependencies);
-                if (!invisible || !archParseBoolean(invisible)) {
+                if (fieldInfo.modifiers.column_invisible !== true) {
                     const label = fieldInfo.FieldComponent.label;
                     columns.push({
                         ...fieldInfo,

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -287,7 +287,7 @@ export class MockServer {
             modifiersNames.forEach((attr) => {
                 const mod = node.getAttribute(attr);
                 if (mod) {
-                    const v = evaluateExpr(mod, { context }) ? true : false;
+                    const v = evaluateExpr(mod, context) ? true : false;
                     if (inTreeView && !inListHeader && attr === "invisible") {
                         modifiers.column_invisible = v;
                     } else if (v || !(attr in modifiers) || !Array.isArray(modifiers[attr])) {
@@ -1913,10 +1913,11 @@ export class MockServer {
         }
         // return false or the latest range start (related to the shortest
         // granularity (i.e. day, week, ...))
-        return !values.length || values.includes(false) ? false :
-            values.reduce((max, value) => {
-                return value > max ? value : max;
-            });
+        return !values.length || values.includes(false)
+            ? false
+            : values.reduce((max, value) => {
+                  return value > max ? value : max;
+              });
     }
 
     /**

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -962,6 +962,30 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, "th", 2, "should have 2 th");
     });
 
+    QUnit.test(
+        "invisible column based on the context are correctly displayed",
+        async function (assert) {
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: `
+                <tree>
+                    <field name="foo" invisible="context.get('notInvisible')"/>
+                    <field name="bar" invisible="context.get('invisible')"/>
+                </tree>`,
+                context: {
+                    invisible: true,
+                    notInvisible: false,
+                },
+            });
+
+            // 1 th for checkbox, 1 for 1 visible column (foo)
+            assert.containsN(target, "th", 2, "should have 2 th");
+            assert.strictEqual(target.querySelectorAll("th")[1].dataset.name, "foo");
+        }
+    );
+
     QUnit.test("boolean field has no title (data-tooltip)", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
Before this commit, in a ListView, a field containing an invisible
attribute using an expression to be evaluated was never displayed.

Example:
<tree>
    <field name="foo" invisible="context.get('notInvisible')"/>
</tree>
The foo column is never displayed.

The solution is to use the column_invisible modifier to know if the
column should be displayed or not. column_invisible contains the
evaluated expression of the invisible attribute by the server.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
