### PR TITLE
[FIX] mrp: avoid a traceback when using SN in a transfer

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -283,6 +283,7 @@ class StockMove(models.Model):
         if self.raw_material_production_id:
             action['views'] = [(self.env.ref('mrp.view_stock_move_operations_raw').id, 'form')]
             action['context']['show_destination_location'] = False
+            action['context']['active_mo_id'] = self.raw_material_production_id.id
         elif self.production_id:
             action['views'] = [(self.env.ref('mrp.view_stock_move_operations_finished').id, 'form')]
             action['context']['show_source_location'] = False

--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -21,9 +21,6 @@
                 <xpath expr="//label[@for='quantity_done']" position="attributes">
 		    <attribute name="string">Consumed</attribute>
                 </xpath>
-                <xpath expr="//field[@name='quantity_done']" position='after'>
-                    <field name="raw_material_production_id" invisible="1"/>
-                </xpath>
             </field>
         </record>
 
@@ -50,7 +47,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='lot_id']" position="attributes">
 		            <attribute name="context">{
-                        'active_mo_id': parent.raw_material_production_id,
+                        'active_mo_id': context.get('active_mo_id'),
                         'active_picking_id': picking_id,
                         'default_company_id': parent.company_id,
                         'default_product_id': parent.product_id,


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Inventory→ Configuration→ Warehouse Management →Operations Types
- Go inside “Receipts”, and enable the checkbox “Create New Lots/Serial
Numbers for Components” and `Use Existing Lots/Serial Numbers`under the
traceability section
- Create a receipt transfers with a traceable product
- Mark as to do the transfer
- Try to add a SN for the product

Problem:
Traceback is triggered: “key error: raw_material_production_id”
because we use this field to add it in the context from the parent in
the `stock.move.line` view:
https://github.com/odoo/odoo/blob/15.0/addons/mrp/views/stock_move_views.xml#L53

But this field is not present in all views of the `stock.move` model

Solution:
To avoid adding this field in all the `stock.move` views, it is better
to add it in the context from the `python` code




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
