### PR TITLE
[FIX] mass_mailing: preset active mailing and fix email import

### DIFF
--- a/addons/mass_mailing/static/src/js/mailing_contact_view_kanban.js
+++ b/addons/mass_mailing/static/src/js/mailing_contact_view_kanban.js
@@ -12,9 +12,12 @@ var MailingContactController = KanbanController.extend({
     }),
 
     _onImport() {
-        this.do_action('mass_mailing.mailing_contact_import_action', {
-            additional_context: this.renderer.state.context,
-        });
+        const context = this.renderer.state.context || {};
+        const actionParams = { additional_context: context };
+        if (!context.default_mailing_list_ids && context.active_model === 'mailing.list' && context.active_ids) {
+            actionParams.additional_context.default_mailing_list_ids = context.active_ids;
+        }
+        this.do_action('mass_mailing.mailing_contact_import_action', actionParams);
     }
 });
 

--- a/addons/mass_mailing/static/src/js/mailing_contact_view_list.js
+++ b/addons/mass_mailing/static/src/js/mailing_contact_view_list.js
@@ -19,9 +19,12 @@ const MailingContactController = ListController.extend({
     }),
 
     _onImport() {
-        this.do_action('mass_mailing.mailing_contact_import_action', {
-            additional_context: this.renderer.state.context,
-        });
+        const context = this.renderer.state.context || {};
+        const actionParams = { additional_context: context };
+        if (!context.default_mailing_list_ids && context.active_model === 'mailing.list' && context.active_ids) {
+            actionParams.additional_context.default_mailing_list_ids = context.active_ids;
+        }
+        this.do_action('mass_mailing.mailing_contact_import_action', actionParams);
     }
 });
 

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -193,14 +193,18 @@ class TestMailingContactImport(MassMailCommon):
         ))
 
         contact_import.contact_list = '''
+            invalid line1
             alice@example.com
             bob@example.com
+            invalid line2
             "Bob" <bob@EXAMPLE.com>
             "Test" <bob@example.com>
+
+            invalid line3, with a comma
             already_exists_list_1@example.com
             already_exists_list_2@example.com
             "Test" <already_exists_list_1_and_2@example.com>
-            invalid line
+            invalid line4
         '''
         contact_import = contact_import.save()
 

--- a/addons/mass_mailing/wizard/mailing_contact_import.py
+++ b/addons/mass_mailing/wizard/mailing_contact_import.py
@@ -16,7 +16,7 @@ class MailingContactImport(models.TransientModel):
         """Import each lines of "contact_list" as a new contact."""
         self.ensure_one()
 
-        contacts = tools.email_split_tuples(self.contact_list)
+        contacts = tools.email_split_tuples(', '.join(self.contact_list.splitlines()))
         if not contacts:
             return {
                 'type': 'ir.actions.client',


### PR DESCRIPTION
[FIX] mass_mailing: preset active mailing list in import wizard

When starting the import contact wizard from an active mailing list, the
mailing list to which the contact will be imported was not set. This solves the
problem.

[FIX] mass_mailing: fix email import by skipping invalid lines

When importing email in mass mailing through the form (not with an excel file),
incorrect email lines were concatenated with the following next valid email
line, resulting to an incorrect import.
This solves the problem by ignoring incorrect email lines.

Task-2924241
