### PR TITLE
[FIX] website_sale_comparison : error when entering number of item in product

### DIFF
--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -261,7 +261,7 @@ publicWidget.registry.ProductComparison = publicWidget.Widget.extend(cartHandler
     events: {
         'click .o_add_compare, .o_add_compare_dyn': '_onClickAddCompare',
         'click #o_comparelist_table tr': '_onClickComparelistTr',
-        'submit form[action="/shop/cart/update"]': '_onFormSubmit',
+        'submit .o_add_cart_form_compare': '_onFormSubmit',
     },
 
     /**

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -134,7 +134,7 @@
                                                 </small>
                                             </span>
 
-                                            <form action="/shop/cart/update" method="post" class="text-center">
+                                            <form action="/shop/cart/update" method="post" class="text-center o_add_cart_form_compare">
                                             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                                                 <input name="product_id" t-att-value="product.id" type="hidden"
                                                        t-att-data-product-tracking-info="json.dumps(request.env['product.template'].get_google_analytics_data(combination_info))"/>


### PR DESCRIPTION
Steps to reproduce:
- Install eCommerce with product comparator
- Open the product in </shop>
- Change the product quantity
- Click on the <Enter> key

Current behavior:
En error message appears.

Expected behavior:
No error message appears.

Explanation:
The productComparison widget overrided the submit with a selector
that was not specific to the comparison so its _onFormSubmit function
could be called from other pages creating errors. To solve the issue
we add a specific class to the form and to the selector.

opw-2936994