### PR TITLE
[FIX] base: make user login constrain case insensitive

### DIFF
--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -61,9 +61,9 @@ class TestImportModule(odoo.tests.TransactionCase):
 
     def test_import_and_update_module(self):
         self.test_user = new_test_user(
-            self.env, login='Admin',
+            self.env, login='Admin2',
             groups='base.group_user,base.group_system',
-            name='Admin',
+            name='Admin2',
         )
         bundle = 'web.assets_backend'
         path = 'test_module/static/src/js/test.js'

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -337,9 +337,10 @@ class Users(models.Model):
     groups_count = fields.Integer('# Groups', help='Number of groups that apply to the current user',
                                   compute='_compute_accesses_count', compute_sudo=True)
 
-    _sql_constraints = [
-        ('login_key', 'UNIQUE (login)',  'You can not have two users with the same login !')
-    ]
+    def _auto_init(self):
+        super(Users, self)._auto_init()
+        if not tools.index_exists(self._cr, 'res_users_login_unique'):
+            self._cr.execute("CREATE UNIQUE INDEX res_users_login_unique ON res_users (UPPER(login)) WHERE active = TRUE")
 
     def init(self):
         cr = self.env.cr


### PR DESCRIPTION
login field is usually used for email. The email addresses are case insensitive,
so xxx@example.com and XXX@example.com should be considered as the same.

Previous implimentation was case sensitive, which may lead to a confusion on the
following scenario:

* create two users with the same email typed in a different cases
* merge related partners
* ping the user in a chatter
* RESULT: notification settings (email/inbox) are used from the first user,
which might be different from what user sees in their Profile settings

opw-2908939