### PR TITLE
[FIX] calendar: clean action before sending it to webclient

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -3,6 +3,8 @@
 
 from odoo import api, models, fields, tools, _
 from odoo.tools import is_html_empty
+from odoo.addons.web.controllers.main import clean_action
+
 
 class MailActivityType(models.Model):
     _inherit = "mail.activity.type"
@@ -18,6 +20,7 @@ class MailActivity(models.Model):
     def action_create_calendar_event(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("calendar.action_calendar_event")
+        action = clean_action(action, env=self.env)
         action['context'] = {
             'default_activity_type_id': self.activity_type_id.id,
             'default_res_id': self.env.context.get('default_res_id'),


### PR DESCRIPTION
In a contact form view, schedule an activity (from the chatter),
select type Meeting, and click on the "Open Calendar" button.
In the calendar view, create a new event. Then, go back to the
contact form view. The activity should be there, and it should
display a "Reschedule" button. Before this commit, it crashed when
we clicked on that button.

The reason is that the click handler calls a python method that
returns an action description (action from xmlid, with modified
context). However, this action was sent back to the client without
being "cleaned", which is what the client expects. In particular,
the 'tree' view type is unknown client side, it must be renamed
into 'list'.

This commit fixes the issue by cleaning the action before sending
it back.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
