### PR TITLE
[FIX] web : background layout cropped on download

### DIFF
--- a/addons/web/static/src/legacy/scss/layout_background.scss
+++ b/addons/web/static/src/legacy/scss/layout_background.scss
@@ -32,7 +32,7 @@
     }
 }
 .o_layout_background {
-    background-size: cover;
+    background-size: contain;
     background-position: bottom center;
     background-repeat: no-repeat;
     min-height: 620px


### PR DESCRIPTION
Steps to reproduce:

	1. Install sale_management
	2. Go into settings and click 'configure document layout'
	3. add a square custom background, for example, the odoo logo
	4. Download the preview pdf, the background is cropped on the top

Issue:

	The preview and the downloaded pdf are not the same in terms of background

Cause:

	CSS styling

Solution:

	Using the background-size: contain rather than cover prevent the cropping.

Before:
preview: 
![odoo-preview](https://user-images.githubusercontent.com/105292262/181759098-eaded84b-7a12-43d5-bebc-2a4eb47b708d.png)
pdf:
![odoo-result](https://user-images.githubusercontent.com/105292262/181759185-bbf77462-254c-4f80-a3fa-ad27e8b46d26.png)

After: 
Preview: 
![odoo-preview-corrected](https://user-images.githubusercontent.com/105292262/181759732-9f61b79c-1ea6-4c5c-b5f2-771512805852.png)
pdf: 
![odoo-corrected](https://user-images.githubusercontent.com/105292262/181759794-6d5b0041-a17f-49a1-95e4-31d8abc12d65.png)

opw-2901598