### PR TITLE
[FIX] web: restore "auto more menu" feature ("+" button) post-BS5

### DIFF
--- a/addons/web/static/src/legacy/js/core/menu.js
+++ b/addons/web/static/src/legacy/js/core/menu.js
@@ -30,8 +30,8 @@ export async function initAutoMoreMenu(el, options) {
     const isUserNavbar = el.parentElement.classList.contains('o_main_navbar');
     const dropdownSubMenuClasses = ['show', 'border-0', 'position-static'];
     const dropdownToggleClasses = ['h-auto', 'py-2', 'text-secondary'];
-    var autoMarginLeftRegex = /\bm[lx]?(?:-(?:sm|md|lg|xl))?-auto\b/;
-    var autoMarginRightRegex = /\bm[rx]?(?:-(?:sm|md|lg|xl))?-auto\b/;
+    const autoMarginLeftRegex = /\bm[sx]?(?:-(?:sm|md|lg|xl|xxl))?-auto\b/; // grep: ms-auto mx-auto
+    const autoMarginRightRegex = /\bm[ex]?(?:-(?:sm|md|lg|xl|xxl))?-auto\b/; // grep: me-auto mx-auto
     var extraItemsToggle = null;
     let debounce;
     const afterFontsloading = new Promise((resolve) => {


### PR DESCRIPTION
Since the migration to BS5 at [1], the feature that makes a "+" button
appear at the end of the website menu was not properly working anymore
(the "+" button appeared while there were still enough spaces for more
menus).

This is because the logic uses regexes to match ml-auto and mr-auto
classes which do not exist in BS5 anymore, as they have been replaced by
ms-auto and me-auto classes (for "start" instead of "left" and "end"
instead of "right"). This also adds the new XXL breakpoint to the regex
(to match ms-xxl-auto and me-xxl-auto classes). This also adds a comment
so that if we were to grep searching for ms-auto or me-auto classes in
the future, we will find this code.

[1]: https://github.com/odoo/odoo/commit/971e5a91aab96d36129a823e03f1f9f1b1293968
