### PR TITLE
[IMP] stock_picking_batch: added `Draft` checkbox in batch wizard

### DIFF
--- a/addons/stock_picking_batch/wizard/stock_picking_to_batch.py
+++ b/addons/stock_picking_batch/wizard/stock_picking_to_batch.py
@@ -12,6 +12,7 @@ class StockPickingToBatch(models.TransientModel):
     batch_id = fields.Many2one('stock.picking.batch', string='Batch Transfer', domain="[('state', '=', 'draft')]")
     mode = fields.Selection([('existing', 'an existing batch transfer'), ('new', 'a new batch transfer')], default='new')
     user_id = fields.Many2one('res.users', string='Responsible')
+    is_create_draft = fields.Boolean(string="Draft", help='When checked, create the batch in draft status')
 
     def attach_pickings(self):
         self.ensure_one()
@@ -29,3 +30,6 @@ class StockPickingToBatch(models.TransientModel):
             batch = self.batch_id
 
         pickings.write({'batch_id': batch.id})
+        # you have to set some pickings to batch before confirm it.
+        if self.mode == 'new' and not self.is_create_draft:
+            batch.action_confirm()

--- a/addons/stock_picking_batch/wizard/stock_picking_to_batch_views.xml
+++ b/addons/stock_picking_batch/wizard/stock_picking_to_batch_views.xml
@@ -13,6 +13,7 @@
                         <field name="mode" widget="radio" nolabel="1"/>
                         <field name="batch_id" options="{'no_create_edit': True, 'no_open': True}" attrs="{'invisible': [('mode', '=', 'new')], 'required': [('mode', '=', 'existing')]}"/>
                         <field name="user_id" options="{'no_create_edit': True}" attrs="{'invisible': [('mode', '=', 'existing')]}"/>
+                        <field name="is_create_draft"  attrs="{'invisible': [('mode', '!=', 'new')]}"/>
                     </group>
                 </group>
 


### PR DESCRIPTION
Purpose
=======
Confirm batch when `Draft` checkbox is unchecked.

So in this commit, we have added one `Draft` checkbox in the batch wizard.
While creating a new batch, if this `Draft` checkbox is checked then batch will be
create in draft state and if it's not then the batch will be create in confirm state.

TaskID - 2925593