### PR TITLE
[FIX] web: actionService: consider "dialog_size" in context

### DIFF
--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -55,8 +55,7 @@ class LegacyAdaptedActionDialog extends ActionDialog {
     setup() {
         super.setup();
         const actionProps = this.props && this.props.actionProps;
-        const action = actionProps && actionProps.action;
-        const actionContext = action && action.context;
+        const actionContext = actionProps && actionProps.context;
         const actionDialogSize = actionContext && actionContext.dialog_size;
         this.props.size = LEGACY_SIZE_CLASSES[actionDialogSize] || Dialog.defaultProps.size;
         const ControllerComponent = this.props && this.props.ActionComponent;

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -845,7 +845,8 @@ function makeActionManager(env) {
         const { views: viewDescriptions } = await keepLast.add(prom);
         const domParser = new DOMParser();
         const views = [];
-        for (const [, type] of action.views) {
+        for (let [, type] of action.views) {
+            type = type === "tree" ? "list" : type;
             if (type !== "search") {
                 const arch = viewDescriptions[type].arch;
                 const archDoc = domParser.parseFromString(arch, "text/xml").documentElement;

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -443,6 +443,32 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_kanban_view");
     });
 
+    QUnit.test("action with 'dialog_size' key in context", async function (assert) {
+        const action = {
+            name: "Some Action",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            target: "new",
+            views: [[false, "form"]],
+        };
+        const webClient = await createWebClient({ serverData });
+
+        await doAction(webClient, action);
+        assert.hasClass(target.querySelector(".o_dialog .modal-dialog"), "modal-lg");
+
+        await doAction(webClient, { ...action, context: { dialog_size: "small" } });
+        assert.hasClass(target.querySelector(".o_dialog .modal-dialog"), "modal-sm");
+
+        await doAction(webClient, { ...action, context: { dialog_size: "medium" } });
+        assert.hasClass(target.querySelector(".o_dialog .modal-dialog"), "modal-md");
+
+        await doAction(webClient, { ...action, context: { dialog_size: "large" } });
+        assert.hasClass(target.querySelector(".o_dialog .modal-dialog"), "modal-lg");
+
+        await doAction(webClient, { ...action, context: { dialog_size: "extra-large" } });
+        assert.hasClass(target.querySelector(".o_dialog .modal-dialog"), "modal-xl");
+    });
+
     QUnit.module('Actions in target="fullscreen"');
 
     QUnit.test(


### PR DESCRIPTION
In the context of an action, one can specify the "dialog_size" key
(only useful for actions in target="new"), which impacts the size
of the dialog. Before this commit, the corresponding bootstrap
classname wasn't applied. As a result, the dialog size was always
"large". This commit fixes that issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
