### PR TITLE
[FIX] l10n_it_edi: empty payment reference error

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -176,7 +176,7 @@
                     <IstitutoFinanziario t-if="partner_bank.bank_id" t-esc="format_alphanumeric(partner_bank.bank_id.name[:80])"/>
                     <IBAN t-if="partner_bank.acc_type == 'iban'" t-esc="partner_bank.sanitized_acc_number"/>
                     <BIC t-elif="partner_bank.acc_type == 'bank' and partner_bank.bank_id.bic" t-esc="partner_bank.bank_id.bic"/>
-                    <CodicePagamento t-esc="format_alphanumeric(record.payment_reference[:60])"/>
+                    <CodicePagamento t-if="record.payment_reference" t-esc="format_alphanumeric(record.payment_reference[:60])"/>
                 </DettaglioPagamento>
             </t>
         </DatiPagamento>


### PR DESCRIPTION
When the payment reference on an invoice is empty an error occurs when
trying to post. The error comes from trying to retrieve a slice on a
bool.

To solve this, a t-if has been added in this commit, such that the
function is not called when the field is empty.