### PR TITLE
disable werkzeug pincode

### DIFF
--- a/doc/cla/individual/gertcuykens.md
+++ b/doc/cla/individual/gertcuykens.md
@@ -1,0 +1,11 @@
+Belgium, 2022-07-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gert Cuykens gert.cuykens@gmail.com https://github.com/gertcuykens

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1338,7 +1338,7 @@ def start(preload=None, stop=False):
                 module = 'watchdog'
             _logger.warning("'%s' module not installed. Code autoreload feature is disabled", module)
     if 'werkzeug' in config['dev_mode']:
-        server.app = DebuggedApplication(server.app, evalex=True)
+        server.app = DebuggedApplication(server.app, evalex=True, pin_security=False)
 
     rc = server.run(preload, stop)
 


### PR DESCRIPTION
First of all the werkzeug pin code is never able to print anyway in stdout the way the server is designed, second its annoying to have to enter it, and last the werkzeug dev tag is ment to be used in local development

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
