### PR TITLE
[FIX] web: tests: clearInterval and remove listener after test

### DIFF
--- a/addons/barcodes/static/tests/barcode_tests.js
+++ b/addons/barcodes/static/tests/barcode_tests.js
@@ -36,18 +36,14 @@ function simulateBarCode(chars, target = document.body) {
 }
 
 QUnit.module('Barcodes', {
-    before() {
+    beforeEach: function () {
         barcodeService.maxTimeBetweenKeysInMs = 0;
         registry.category("services").add("barcode", barcodeService, { force: true});
         registry.category("services").add("barcode_autoclick", barcodeGenericHandlers, { force: true});
         // remove this one later
         registry.category("services").add("barcode_remapper", barcodeRemapperService);
         this.env = makeTestEnv();
-    },
-    after() {
-        barcodeService.maxTimeBetweenKeysInMs = maxTimeBetweenKeysInMs;
-    },
-    beforeEach: function () {
+
         this.data = {
             order: {
                 fields: {
@@ -82,7 +78,10 @@ QUnit.module('Barcodes', {
                 ],
             },
         };
-    }
+    },
+    afterEach: function () {
+        barcodeService.maxTimeBetweenKeysInMs = maxTimeBetweenKeysInMs;
+    },
 });
 
 QUnit.test('Button with barcode_trigger', async function (assert) {


### PR DESCRIPTION
In the QUnit test suite, we have cleanup code that runs after each
test to ensure that event listeners, setTimeouts... registered
during a test are removed. This is particularly useful for services,
as they do not have a "destroy" function to cleanup those handlers
they would have registered at startup. Side note: they don't
because it would only be useful for tests, as a service lives
forever in the prod environment.

Before this commit, that cleanup code didn't remove callbacks
registered with a setInterval. Moreover, we didn't remove event
handlers bound on document.body either. As a consequence, there
were memory leaks in the test suite (e.g. callbacks of the tooltip
service), and some crashes could occur if the user interacted with
the window after test completion.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
