### PR TITLE
[IMP] sale_subscription: order dependent closability and payment mode

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -600,7 +600,7 @@
                                 <field name="client_order_ref"/>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             </group>
-                            <group name="sale_info" string="Invoicing and Payments">
+                            <group name="sale_info" string="Invoicing">
                                 <field name="show_update_fpos" invisible="1"/>
                                 <label for="fiscal_position_id"/>
                                 <div class="o_row">


### PR DESCRIPTION
This commit aims allow `user_closable` and `payment_mode` to be
directly linked to a sale_order.
This allow modification of behaviour after the confirmation of
SO.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
