### PR TITLE
[FIX] account : unlink paired internal transfer payment

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3166,6 +3166,7 @@ class AccountMove(models.Model):
             move.mapped('line_ids.analytic_line_ids').unlink()
 
         self.mapped('line_ids').remove_move_reconcile()
+        self.payment_id.paired_internal_transfer_payment_id.unlink()
         self.write({'state': 'draft', 'is_move_sent': False})
 
     def button_cancel(self):


### PR DESCRIPTION
To reproduce
============

* Create two bank journals
* Send the money from Bank1 - Bank2
* This will create statements in both bank
* Reset the bank1 internal transfer to draft and edit the amount
* Repost the internal transfer
* Bank2 internal transfer amount doesn't get impacted.

Purpose
=======

we have this issue because we don't have sync betwee internal transfers

Specification
=============

to solve the issue wehen resetting to draft we unlink the `paired_internal_transfer_payment_id`
because it will be recreated with the new values

opw-2926472