### PR TITLE
[FIX] web_editor: properly convert link-wrapped card-images

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -266,15 +266,7 @@ function cardToTable($editable) {
         for (const child of [...card.childNodes]) {
             const row = document.createElement('tr');
             const col = document.createElement('td');
-            if (child.nodeName === 'IMG') {
-                col.append(child);
-            } else if (child.nodeType === Node.TEXT_NODE) {
-                if (child.textContent.replace(RE_WHITESPACE, '').length) {
-                    col.append(child);
-                } else {
-                    continue;
-                }
-            } else {
+            if (isBlock(child)) {
                 for (const attr of child.attributes) {
                     col.setAttribute(attr.name, attr.value);
                 }
@@ -282,6 +274,14 @@ function cardToTable($editable) {
                     col.append(descendant);
                 }
                 child.remove();
+            } else if (child.nodeType === Node.TEXT_NODE) {
+                if (child.textContent.replace(RE_WHITESPACE, '').length) {
+                    col.append(child);
+                } else {
+                    continue;
+                }
+            } else {
+                col.append(child);
             }
             const subTable = _createTable();
             const superRow = document.createElement('tr');


### PR DESCRIPTION
The e-mail conversion process for Bootstrap cards stripped card-images from their link when they had one. This corrects the process to preserve the link.

task-2937123

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
