### PR TITLE
[FIX] web: load the correct fields in the /web/dataset/load

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -23,7 +23,7 @@ class DataSet(http.Controller):
     def load(self, model, id, fields):
         warnings.warn("the route /web/dataset/load is deprecated and will be removed in Odoo 17. Use /web/dataset/call_kw with method 'read' and a list containing the id as args instead", DeprecationWarning)
         value = {}
-        r = request.env[model].browse([id]).read()
+        r = request.env[model].browse([id]).read(fields)
         if r:
             value = r[0]
         return {'value': value}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Load the correct fields in then /web/dataset/load.

Current behavior before PR:
The argument fields is not used.

Desired behavior after PR is merged:
The argument fields is used.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
