### PR TITLE
[FIX] web: restore specialData when discarding

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -432,6 +432,7 @@ var BasicModel = AbstractModel.extend({
                 elem.limit -= elem.tempLimitIncrement;
                 delete elem.tempLimitIncrement;
             }
+            elem.specialData = Object.assign({}, elem._specialDataSavepoint);
         });
         element.offset = initialOffset;
     },
@@ -4574,6 +4575,7 @@ var BasicModel = AbstractModel.extend({
         defs.push(this._fetchSpecialData(record, options));
 
         return Promise.all(defs).then(function () {
+            record._specialDataSavepoint = Object.assign({}, record.specialData);
             return record;
         });
     },

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -99,6 +99,7 @@ QUnit.module("Views", (hooks) => {
                         {
                             id: 1,
                             display_name: "first record",
+                            product_id: 37,
                             bar: true,
                             foo: "yop",
                             int_field: 10,
@@ -3975,6 +3976,47 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".o_form_button_cancel"));
 
         assert.containsNone(document.body, ".modal", "there should not be a confirm modal");
+    });
+
+    QUnit.test("discard form with specialdata", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <header>
+                        <field name="product_id" domain="[('display_name', '=', name)]" widget="statusbar"></field>
+                    </header>
+                    <sheet>
+                        <group>
+                            <field name="name"></field>
+                        </group>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+        await click(target.querySelector(".o_form_button_edit"));
+        assert.containsOnce(
+            target,
+            ".o_statusbar_status button",
+            "Must have only one statusbar button"
+        );
+        await editInput(target, "input#name.o_input", "xpad");
+        assert.containsN(
+            target,
+            ".o_statusbar_status button",
+            2,
+            "Must have only two statusbar buttons"
+        );
+        await click(target.querySelector(".o_form_button_cancel"));
+        assert.containsOnce(
+            target,
+            ".o_statusbar_status button",
+            "Must have only one statusbar button"
+        );
+        const buttonText = target.querySelectorAll(".o_statusbar_status button")[0].textContent;
+        assert.strictEqual(buttonText, "xphone", "The statusbar button should be xphone");
     });
 
     QUnit.test("switching to another record from a dirty one", async function (assert) {


### PR DESCRIPTION
Changed specialData (as in statusbar) were not discarded when clicking "Discard".
Now, when a form is Discarded, the specialData is restored.