### PR TITLE
[FIX] l10n_ch: fix typo in PDF export

### DIFF
--- a/addons/l10n_ch/models/ir_actions_report.py
+++ b/addons/l10n_ch/models/ir_actions_report.py
@@ -49,7 +49,7 @@ class IrActionsReport(models.Model):
                 for invoice_id, stream in qr_res.items():
                     streams_to_append[invoice_id] = stream
             if isr_inv_ids:
-                isr_res = self.env.ref('l10n_ch.l10n_ch_isr_report')._render_qweb_pdf_prepare_streams(data, res_ids=qr_inv_ids)
+                isr_res = self.env.ref('l10n_ch.l10n_ch_isr_report')._render_qweb_pdf_prepare_streams(data, res_ids=isr_inv_ids)
                 for invoice_id, stream in isr_res.items():
                     streams_to_append[invoice_id] = stream
             # Add to results


### PR DESCRIPTION
Just fixing a typo in `_render_qweb_pdf_prepare_streams()`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
