### PR TITLE
[IMP] point_of_sale: deletion of order for support

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -402,8 +402,11 @@ class PosOrder(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_draft_or_cancel(self):
-        for pos_order in self.filtered(lambda pos_order: pos_order.state not in ['draft', 'cancel']):
-            raise UserError(_('In order to delete a sale, it must be new or cancelled.'))
+        for pos_order in self:
+            if (pos_order.state not in ['draft', 'cancel'] and not self.env.user.has_group('base.group_system')) or \
+                pos_order.session_id.state == 'closed' or \
+                pos_order.is_invoiced:
+                raise UserError(_('In order to delete a sale, it must be new or cancelled.'))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -16,7 +16,7 @@ class PosPayment(models.Model):
     _order = "id desc"
 
     name = fields.Char(string='Label', readonly=True)
-    pos_order_id = fields.Many2one('pos.order', string='Order', required=True)
+    pos_order_id = fields.Many2one('pos.order', string='Order', required=True, ondelete='cascade')
     amount = fields.Monetary(string='Amount', required=True, currency_field='currency_id', readonly=True, help="Total amount of the payment.")
     payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True)
     payment_date = fields.Datetime(string='Date', required=True, readonly=True, default=lambda self: fields.Datetime.now())


### PR DESCRIPTION
When we want to delete an order from the POS that is validated, we get
an error saying that we can only delete draft ones. For some support
tickets, we sometimes need to delete an order that has corrurpted data
that prevent session closure and it needs to do a script to avoid the
deletion constraint.

To ease the support of those issues, we are allowing deletion of orders
for the database administrator when the session is not closed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
