### PR TITLE
[FIX] l10n_eu_service: add spain to oss tag

### DIFF
--- a/addons/l10n_eu_service/models/eu_tag_map.py
+++ b/addons/l10n_eu_service/models/eu_tag_map.py
@@ -199,7 +199,7 @@ EU_TAG_MAP = {
     },
     # Spain
     'l10n_es.account_chart_template_common': {
-        'invoice_base_tag': None,
+        'invoice_base_tag': "l10n_es.mod_303_124",
         'invoice_tax_tag': None,
         'refund_base_tag': None,
         'refund_tax_tag': None,

--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-from .eu_tax_map import EU_TAX_MAP
+from odoo import api, models
+from odoo.addons.account.models.account_tax_report import AccountTaxReportLine
 from .eu_tag_map import EU_TAG_MAP
+from .eu_tax_map import EU_TAX_MAP
 
 
 class Company(models.Model):
@@ -125,11 +126,11 @@ class Company(models.Model):
             'refund_tax_tag': None,
         })
 
-        return {
-            repartition_line_key: (
-                self.env.ref(tag_xml_id).tag_ids.filtered(lambda t: not t.tax_negate)
-                if tag_xml_id
-                else None
-            )
-            for repartition_line_key, tag_xml_id in tag_for_country.items()
-        }
+        mapping = {}
+        for repartition_line_key, tag_xml_id in tag_for_country.items():
+            tag = self.env.ref(tag_xml_id) if tag_xml_id else None
+            if isinstance(tag, AccountTaxReportLine):
+                tag = tag.tag_ids.filtered(lambda t: not t.tax_negate)
+            mapping[repartition_line_key] = tag
+
+        return mapping

--- a/addons/l10n_eu_service/tests/test_oss.py
+++ b/addons/l10n_eu_service/tests/test_oss.py
@@ -42,6 +42,39 @@ class TestOSSBelgium(AccountTestInvoicingCommon):
 
 
 @tagged('post_install', 'post_install_l10n', '-at_install')
+class TestOSSSpain(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='l10n_es.account_chart_template_common'):
+        try:
+            super().setUpClass(chart_template_ref=chart_template_ref)
+        except ValueError as e:
+            if e.args[0] == "External ID not found in the system: l10n_be.l10nbe_chart_template":
+                cls.skipTest(cls, reason="Belgian CoA is required for this testSuite but l10n_be isn't installed")
+            else:
+                raise e
+        cls.company_data['company'].country_id = cls.env.ref('base.be')
+        cls.company_data['company']._map_eu_taxes()
+
+    def test_country_tag_from_spain(self):
+        # get an eu country which isn't the current one:
+        another_eu_country_code = (self.env.ref('base.europe').country_ids - self.company_data['company'].country_id)[0].code
+        tax_oss = self.env['account.tax'].search([('name', 'ilike', f'%{another_eu_country_code}%')], limit=1)
+
+        for doc_type, tag_xml_id in (
+                ("invoice", "l10n_es.mod_303_124"),
+        ):
+            with self.subTest(doc_type=doc_type, report_line_xml_id=tag_xml_id):
+                oss_tag_id = tax_oss[f"{doc_type}_repartition_line_ids"]\
+                    .filtered(lambda x: x.repartition_type == 'base')\
+                    .tag_ids
+
+                expected_tag_id = self.env.ref(tag_xml_id)
+
+                self.assertIn(expected_tag_id, oss_tag_id, f"{doc_type} tag from Belgian CoA not correctly linked")
+
+
+@tagged('post_install', 'post_install_l10n', '-at_install')
 class TestOSSUSA(AccountTestInvoicingCommon):
 
     @classmethod
@@ -56,7 +89,6 @@ class TestOSSUSA(AccountTestInvoicingCommon):
         tax_oss = self.env['account.tax'].search([('name', 'ilike', f'%{another_eu_country_code}%')], limit=1)
 
         self.assertFalse(len(tax_oss), "OSS tax shouldn't be instanced on a US company")
-
 
 
 @tagged('post_install', 'post_install_l10n', '-at_install')


### PR DESCRIPTION
## The aim of this commit is to:
- allow OSS to use tax that aren't declare by TaxReportLine
- have the oss tax automatically populated with the correct tags for spanish
  tax report

## Previous to this commit:
Spanish OSS tax were created without the official modulo 124 tag

## After this commit:
Spanish OSS tax are created with the official modulo 124 tag

community-PR: https://github.com/odoo/odoo/pull/97174

task: 2930758