### PR TITLE
[FIX] hr_expense : mobile display quantity uom

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -148,7 +148,7 @@
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="quantity" attrs="{'invisible': [('product_has_cost', '=', False)]}"/>
                             <div class="o_row" attrs="{'invisible': [('product_has_cost', '=', False)]}">
-                                <field name="quantity" class="oe_inline" attrs="{'readonly': [('sheet_is_editable', '=', False)]}"/>
+                                <field name="quantity" class="oe_inline" attrs="{'readonly': [('sheet_is_editable', '=', False)]}" style="width: auto !important;"/>
                                 <field name="product_uom_id" required="1" options="{'no_open': True, 'no_create': True}" class="oe_inline" groups="uom.group_uom"/>
                             </div>
                             <label for="total_amount" string="Total" attrs="{'invisible': [('product_has_cost', '=', True)]}"/>


### PR DESCRIPTION
Steps to reproduce:

	1. Install hr_expense,inventory
	2. Enable unit of measure in the invetory setting
	3. Create an expense product with a uom
	4. Switch to mobile display and refresh
	5. Try to create a new expense, the quantity field is not visible

Cause:

	In 15.0 it was decided in PR #68387 to switch from the selection widget to options. This changed the css of the element.

Solution:

	Checking the entire codebase with the following regex "<div.*class="o_row".*\n.*class="oe_inline".*\n.*class="oe_inline".*\n.*<\/div>"
	in order to find an other usage of o_row with two inline element yielded no result other than hr_expense. In order to minimise the amount of changes,
	a local fix of the styling is probably more appropriate.

opw-2924276