### PR TITLE
[FIX] website_blog: see blog post even if tag doesn't exist anymore

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -71,8 +71,9 @@ class WebsiteBlog(http.Controller):
         if active_tag_ids:
             fixed_tag_slug = ",".join(slug(t) for t in request.env['blog.tag'].browse(active_tag_ids).exists())
             if fixed_tag_slug != tags:
-                new_url = request.httprequest.full_path.replace("/tag/%s" % tags, "/tag/%s" % fixed_tag_slug, 1)
-                if new_url != request.httprequest.full_path:  # check that really replaced and avoid loop
+                path = request.httprequest.full_path
+                new_url = path.replace("/tag/%s" % tags, fixed_tag_slug and "/tag/%s" % fixed_tag_slug or "", 1)
+                if new_url != path:  # check that really replaced and avoid loop
                     return request.redirect(new_url, 301)
             domain += [('tag_ids', 'in', active_tag_ids)]
 


### PR DESCRIPTION
If you delete a tag, but still have some link to this one, you arrive on
a 404 /blog/tag/.
We decide to redirect to the blog post without tag instead.
What is probably the expected behaviour for most customers.
