### PR TITLE
[FIX] web: field: relational: search more: _view_ref passed in context

### DIFF
--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.js
@@ -25,8 +25,7 @@ export class SelectCreateDialog extends Component {
     }
 
     get viewProps() {
-        let id;
-        const viewProps = {
+        return {
             ...this.baseViewProps,
             context: this.props.context,
             domain: this.props.domain,
@@ -36,14 +35,6 @@ export class SelectCreateDialog extends Component {
             searchViewId: this.props.searchViewId,
             type: this.env.isSmall ? "kanban" : "list",
         };
-        const context = this.props.context || {};
-        if (viewProps.type === "kanban") {
-            viewProps.forceGlobalClick = true;
-            id = context["kanban_view_ref"];
-        } else {
-            id = context["list_view_ref"] || context["tree_view_ref"];
-        }
-        return { ...viewProps, viewId: id || false };
     }
 
     async select(resIds) {


### PR DESCRIPTION
Have a x2many field with a _view_ref (ie tree_view_ref) in its context
Open the select create dialog (Search More) of that field

Before this commit, there was a crash because the _view_ref string was passed to the get_views
as if it were an Integer ID.

After this commit, there is no crash, and the select create dialog opens correctly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
