### PR TITLE
[FIX] mondialrelay: brand is not a secret, it is public in url

### DIFF
--- a/addons/delivery_mondialrelay/models/delivery_carrier.py
+++ b/addons/delivery_mondialrelay/models/delivery_carrier.py
@@ -8,7 +8,7 @@ class DeliveryCarrierMondialRelay(models.Model):
     _inherit = 'delivery.carrier'
 
     is_mondialrelay = fields.Boolean(compute='_compute_is_mondialrelay')
-    mondialrelay_brand = fields.Char(string='Brand Code', default='BDTEST  ', groups="base.group_system")
+    mondialrelay_brand = fields.Char(string='Brand Code', default='BDTEST  ')
     mondialrelay_packagetype = fields.Char(default="24R", groups="base.group_system")  # Advanced
 
     @api.depends('product_id.default_code')


### PR DESCRIPTION
Allow non system user to get the mondial relay url for tracking parcel.                                                                                                                                   
