### PR TITLE
[FIX] stock_dropshipping: lack of picking type

### DIFF
--- a/addons/stock_dropshipping/models/res_company.py
+++ b/addons/stock_dropshipping/models/res_company.py
@@ -90,6 +90,8 @@ class ResCompany(models.Model):
                 ('default_location_src_id.usage', '=', 'supplier'),
                 ('default_location_dest_id.usage', '=', 'customer'),
             ], limit=1, order='sequence')
+            if not dropship_picking_type:
+                continue
             dropship_vals.append({
                 'name': '%s → %s' % (supplier_location.name, customer_location.name),
                 'action': 'buy',


### PR DESCRIPTION
Sometimes, no picking type match the domain, but picking_type_id is a required field.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
