### PR TITLE
[FIX] hr_timesheet: calculate effective_hours on all users' hours

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -128,8 +128,14 @@ class Task(models.Model):
 
     @api.depends('timesheet_ids.unit_amount')
     def _compute_effective_hours(self):
+        if not any(self._ids):
+            for task in self:
+                task.effective_hours = round(sum(task.timesheet_ids.mapped('unit_amount')), 2)
+            return
+        timesheet_read_group = self.env['account.analytic.line'].read_group([('task_id', 'in', self.ids)], ['unit_amount', 'task_id'], ['task_id'])
+        timesheets_per_task = {res['task_id'][0]: res['unit_amount'] for res in timesheet_read_group}
         for task in self:
-            task.effective_hours = round(sum(task.timesheet_ids.mapped('unit_amount')), 2)
+            task.effective_hours = round(timesheets_per_task.get(task.id, 0.0), 2)
 
     @api.depends('effective_hours', 'subtask_effective_hours', 'planned_hours')
     def _compute_progress_hours(self):


### PR DESCRIPTION
Reproduction:
1. Install Timesheet, and Project, check the timesheet box in the
setting of Project
2. Go to Setting->manage users, set access right for Marc Demo, Project
as “User”, Timesheets as “See own timesheets”, and Helpdesk	as “User”
3. Go to Project, create a task and assign it to Marc Demo, go to the
timesheet tab, set Initially Planned Hours as 20 hours, click save
4. Open an incognito page and log in as Marc Demo, go to this new task->
timesheet, edit, log 5 hours, save. Hour spent is now 5
5. Switch back to Mitchell Admin, refresh the task page, edit, log 3
hours, save. Hour spent is now 8.
6. Switch to the incognito page of Marc Demo, edit, log 2 hours and save
Hour spent is now 7, which doesn’t consider the hours logged by Mitchell
The right result should be 10 hours.
7. Switch back as Mitchell Demo, the spent hours are also wrong

Reason: The cause is that effective_hours is a stored computed field.
When Marc Demo logs hours after Mithcell Admin, the hours from Mitchell
do not show for Marc Demo. Marc Demo cannot get the hours from other
users because he can only see his own timesheet. Thus the computation is
wrong and because it’s a stored computed field, it won’t change even
after switching back to Mitchell Admin

Fix: Use read_group to get the grouped by value of the amount spent on
the task. This makes sure that the value of Hours spent is correctly
computed after saving. It also allows the onchange to take the change
made by the user into account before saving.

Opw-2909444

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
