### PR TITLE
[FIX] stock_picking_batch: add picks to batch

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -168,7 +168,7 @@ class StockPickingBatch(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if not self.picking_ids and self.state == 'in_progress':
+        if not self.picking_ids and 'in_progress' in self.mapped('state'):
             self.action_cancel()
         if vals.get('picking_type_id'):
             self._sanity_check()


### PR DESCRIPTION
When adding list of transfers to batch from transfer tree view,
if transfers belong to two or more batches an error traceback pops.

To reproduce:

1-Create Transfer 1, go to Transfer list view and add it to batch under Action, choose
add to a new batch transfer and confirm.
2-Create Transfer 2 and do the same.
3-Now that we have two transfer belonging to two different batches,
Under Inventory->Operations->Transfers, select the two transfers
in the tree view and choose add to batch under Action, choose add to new batch
and confirm, error popsup

TaskId:2871679


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
