### PR TITLE
[FIX] website: prevent to have two modals for Images Wall

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -26,6 +26,9 @@ const GalleryWidget = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onClickImg: function (ev) {
+        if (document.querySelector('.modal[aria-labbelledby="Image Gallery Dialog"]')) {
+            return;
+        }
         var self = this;
         var $cur = $(ev.currentTarget);
 


### PR DESCRIPTION
Before this commit, when you double-clicked on an image in the Images
Wall block, the modal appeared twice. This commit ensures that for the
block Images Wall, only one modal can be at a time.

Steps to reproduce the problem:
Drop the block Images Wall on a page
Save
Click twice quickly on the same image

->Two modals are open (one on top of the other)

task-2937538
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
