### PR TITLE
[FIX] website: prevent to have two modals for Images Wall

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -26,6 +26,9 @@ const GalleryWidget = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onClickImg: function (ev) {
+        if (this.$modal) {
+            return;
+        }
         var self = this;
         var $cur = $(ev.currentTarget);
 
@@ -43,29 +46,30 @@ const GalleryWidget = publicWidget.Widget.extend({
         var $img = ($cur.is('img') === true) ? $cur : $cur.closest('img');
 
         const milliseconds = $cur.closest('.s_image_gallery').data('interval') || false;
-        var $modal = $(qweb.render('website.gallery.slideshow.lightbox', {
+        this.$modal = $(qweb.render('website.gallery.slideshow.lightbox', {
             images: $images.get(),
             index: $images.index($img),
             dim: dimensions,
             interval: milliseconds || 0,
             id: _.uniqueId('slideshow_'),
         }));
-        $modal.modal({
+        this.$modal.modal({
             keyboard: true,
             backdrop: true,
         });
-        $modal.on('hidden.bs.modal', function () {
+        this.$modal.on('hidden.bs.modal', function () {
             $(this).hide();
             $(this).siblings().filter('.modal-backdrop').remove(); // bootstrap leaves a modal-backdrop
             $(this).remove();
+            self.$modal = undefined;
         });
-        $modal.find('.modal-content, .modal-body.o_slideshow').css('height', '100%');
-        $modal.appendTo(document.body);
+        this.$modal.find('.modal-content, .modal-body.o_slideshow').css('height', '100%');
+        this.$modal.appendTo(document.body);
 
-        $modal.one('shown.bs.modal', function () {
+        this.$modal.one('shown.bs.modal', function () {
             self.trigger_up('widgets_start_request', {
                 editableMode: false,
-                $target: $modal.find('.modal-body.o_slideshow'),
+                $target: self.$modal.find('.modal-body.o_slideshow'),
             });
         });
     },


### PR DESCRIPTION
Before this PR, when you double-clicked on an image in the Images
Wall block, the modal appeared twice. This PR ensures that for the
block Images Wall, only one modal can be present at a time.

Steps to reproduce the problem:
- Drop the block Images Wall on a page
- Save
- Click twice quickly on the same image

-> Two modals are open (one on top of the other)

task-2937538
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
