### PR TITLE
[IMP] base: add index and unaccent to store_fname field on ir_attachm…

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -400,7 +400,7 @@ class IrAttachment(models.Model):
     raw = fields.Binary(string="File Content (raw)", compute='_compute_raw', inverse='_inverse_raw')
     datas = fields.Binary(string='File Content (base64)', compute='_compute_datas', inverse='_inverse_datas')
     db_datas = fields.Binary('Database Data', attachment=False)
-    store_fname = fields.Char('Stored Filename')
+    store_fname = fields.Char('Stored Filename', index=True, unaccent=False)
     file_size = fields.Integer('File Size', readonly=True)
     checksum = fields.Char("Checksum/SHA1", size=40, index=True, readonly=True)
     mimetype = fields.Char('Mime Type', readonly=True)


### PR DESCRIPTION
…ent model

**NOTE**
There was already a PR to merge this: https://github.com/odoo/odoo/pull/96571. However, my commit in the original PR had no author and therefore it did not pass the CLA. When I fixed the author in my commit, I accidentally recreated my branch instead of just reset the author and now it seems I am unable to reopen the original PR, this is why we decided to create a new PR. I already waited a couple of days to check if it would allow me to re-open the original PR, but I am still unable.

**Description of the issue/feature this PR addresses:**
Improves the odoo garbage collector for large amounts of attachments.

**Current behavior before PR:**
The odoo garbage collector takes around 20 sec to process 1000 records. In one of our deployed projects with production data, there are 790,000 records. Each batch of 1000 records takes 20 seconds, as threw by a pg **ANALYZE**. Hence the whole process is currently taking around 4 hours to complete, as shown below:

 (790,000 records / 1000) * 20 sec *(1 min / 60 sec) * (1 hour / 60 min)  = 4.38 hours. 

Since the Odoo garbage collector routine runs periodically and currently takes more than 4 hours, this behavior **is not acceptable in this application**, because if there is any other app that tries to use attachments at the same time (for instance invoicing), it will not be able to do it since the Odoo garbage collector will lock the table, leading to a deadlock.

**Desired behavior after PR is merged:**
A pg **ANALYZE** after adding the index parameter to the store_fname field in our local patch, throws that the total time decreases drastically from 4 hours to 10 seconds since now each batch of 1000 k records takes only 13 ms. Adding unaccent=True was suggested in the original PR.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
