### PR TITLE
[FIX] website: fix link editor dropdown

### DIFF
--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -33,12 +33,12 @@ weWidgets.LinkTools.include({
         var def = await this._super.apply(this, arguments);
         const options = {
             position: {
-                collision: 'flip fit',
+                collision: 'flip flipfit',
             },
             classes: {
                 "ui-autocomplete": 'o_website_ui_autocomplete'
             },
-        }
+        };
         wUtils.autocompleteWithPages(this, this.$('input[name="url"]'), options);
         this._adaptPageAnchor();
         return def;


### PR DESCRIPTION
Fix the position of the dropdown with the suggested links in the snippet
options. (e.g. url input of the link editor, redirect url input of the
countdown snippet)

Before this commit the dropdown went over the input while editing the
url.

task-2900529

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
