### PR TITLE
[IMP] web: improve tooling

### DIFF
--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -19,7 +19,9 @@
     "no-unsafe-negation": ["error"],
     "no-duplicate-imports": ["error"],
     "valid-typeof": ["error"],
-    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all", "caughtErrorsIgnorePattern": "^_" }]
+    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all", "caughtErrorsIgnorePattern": "^_" }],
+    "curly": ["error", "all"],
+    "prefer-const": ["error"]
   },
   "globals": {
     "owl": "readonly",

--- a/addons/web/tooling/hooks/pre-commit
+++ b/addons/web/tooling/hooks/pre-commit
@@ -1,5 +1,18 @@
 #!/bin/bash
 # run tooling only on branches that start with master to avoid linting noise in stable
 if [[ $(git branch --show-current) == master* ]]; then
+    if ! cmp -s -- addons/web/tooling/_package.json package.json; then
+        echo "Your package.json is out of date, reload the tooling using the reload script"
+        exit 1
+    fi
+    if
+        ! cmp -s -- addons/web/tooling/_eslintignore .eslintignore ||
+        ! cmp -s -- addons/web/tooling/_prettierignore .prettierignore ||
+        ! cmp -s -- addons/web/tooling/_eslintrc.json .eslintrc.json ||
+        ! cmp -s -- addons/web/tooling/_prettierrc.json .prettierrc.json
+    then
+        echo "Some of your eslint/prettier config files are out of date, refresh them using the refresh script"
+        exit 1
+    fi
     npm run format-staged
 fi

--- a/addons/web/tooling/refresh.sh
+++ b/addons/web/tooling/refresh.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+community=$(cd -- "$(dirname "$0")" &> /dev/null && cd ../../.. && pwd)
+tooling="$community/addons/web/tooling"
+testRealPath="$(realpath --relative-to=. "$tooling/hooks")"
+if [[ $testRealPath == "" ]]; then
+    echo "Please install realpath"
+    exit 1
+fi
+
+refreshInDir () {
+    cd $1
+    cp "$tooling/_eslintignore" .eslintignore
+    cp "$tooling/_prettierignore" .prettierignore
+    cp "$tooling/_eslintrc.json" .eslintrc.json
+    cp "$tooling/_prettierrc.json" .prettierrc.json
+    cp "$tooling/_package.json" package.json
+    cd - &> /dev/null
+}
+
+read -p "Refresh tooling in enterprise ? [y, n]" doEnterprise
+if [[ $doEnterprise != "n" ]]; then
+    read -p "What is the relative path from community to enterprise ? (../enterprise)" pathToEnterprise
+    pathToEnterprise=${pathToEnterprise:-../enterprise}
+    pathToEnterprise=$(realpath $community/$pathToEnterprise)
+fi
+
+refreshInDir "$community"
+
+if [[ $doEnterprise != "n" ]]
+then
+    refreshInDir "$pathToEnterprise" copy
+fi
+
+echo ""
+echo "The JS tooling config files have been refreshed"
+echo "Make sure to refresh the eslint service and configure your IDE so it uses the config files"
+echo 'For VSCode, look inside your .vscode/settings.json file ("editor.defaultFormatter": "dbaeumer.vscode-eslint")'
+echo "If you still have issues, try doing a full reload instead which will reinstall the node modules"
+echo ""


### PR DESCRIPTION
This PR enables some eslint rules, adds a refresh script that allows refreshing the eslint and prettier config files without reinstalling the node modules, and adds a check in the pre-commit hook that aborts commits when the tooling is out of date.