### PR TITLE
[FIX] web: duplicate translation alert

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -371,7 +371,9 @@ export class FormController extends Component {
     computeTranslateAlert() {
         if (this.shouldShowTranslateAlert) {
             this.translateAlertData[this.model.root.resId] = new Set([
-                ...(this.translateAlertData[this.model.root.resId] || []),
+                ...(this.translateAlertData[this.model.root.resId]
+                    ? toRaw(this.translateAlertData[this.model.root.resId])
+                    : []),
                 ...this.model.root.dirtyTranslatableFields,
             ]);
         }

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -7833,7 +7833,8 @@ QUnit.module("Views", (hooks) => {
         );
 
         await clickEdit(target);
-        await editInput(target, '[name="display_name"] input', "test2");
+        await editInput(target, '[name="foo"] input', "test2");
+        await editInput(target, '[name="display_name"] input', "test3");
         await clickSave(target);
         assert.containsN(
             target,


### PR DESCRIPTION
Before this commit, it is possible to have duplicate field names in an
alert translation.

How:
- enable multi-language
- go to a form view with at least one translatable field
- edit the value of that field
- click on save (the translate alert displays the field name once)
- edit the same field a second time
- click on save

Result Before:
The translate alert displays the field name twice.

Result After:
The translate alert displays the field name once.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
