### PR TITLE
[FIX] l10n_es_edi_sii: use a certificate on SSL connection

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
 from urllib3.util.ssl_ import create_urllib3_context, DEFAULT_CIPHERS
+from urllib3.contrib.pyopenssl import inject_into_urllib3
 from OpenSSL.crypto import load_certificate, load_privatekey, FILETYPE_PEM
 from zeep.transports import Transport
 
@@ -27,6 +28,7 @@ class PatchedHTTPAdapter(requests.adapters.HTTPAdapter):
 
     def init_poolmanager(self, *args, **kwargs):
         # OVERRIDE
+        inject_into_urllib3()
         kwargs['ssl_context'] = create_urllib3_context(ciphers=EUSKADI_CIPHERS)
         return super().init_poolmanager(*args, **kwargs)
 


### PR DESCRIPTION
It is not possible to process an invoice and send it to the SII

Steps to reproduce:
1. Install l10n_es_edi_sii module
2. Switch to company 'ES Company'
3. Go to Settings > Invoicing > Spain Localization > Registro de Libros
   connection SII and select 'Hacienda Foral de Gipuzkoa'
4. Go to Invoicing > Configuration > Accounting > Journals and open
   'Customer Invoices'. In the 'Advanced Settings' tab, enable EDI
   functionality 'SII IVA Llevanza de libros registro (ES)'
5. Go to Invoicing > Configuration > Spain > Certificate (ES) and import
   the certificate (file named sello_entidad_act.p12 in
   l10n_es_edi_sii/demo/certificates/) with password "IZDesa2021"
6. Create an invoice with any customer and product and confirm it
7. Click on 'Process now', an error is raised

Solution:
Use PyOpenSSL to be able to use certificate checking

Problem:
With the version of requests specified in the requirements, SSLContext
object doesn't have a `_ctx` attribute anymore. That's because PyOpenSSL
is not used by default (https://pyup.io/changelogs/requests/#2.24.0) and
ssl is used instead. However we need PyOpenSSL to be able to use
certificate checking (https://urllib3.readthedocs.io/en/latest/reference/contrib/pyopenssl.html)

opw-2925510