### PR TITLE
[FIX] mrp: set default `Operation Type` in picking

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -531,7 +531,7 @@
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_mrp_production_filter"/>
             <field name="domain">[('picking_type_id', '=', active_id)]</field>
-            <field name="context">{}</field>
+            <field name="context">{'default_picking_type_id': active_id}</field>
         </record>
 
         <record id="mrp_production_action_unreserve_tree" model="ir.actions.server">


### PR DESCRIPTION
Purpose
======
When creating a specific Operation Type of type 'Manufacture' the default
operation type is not the correct one on object creation.

So in this commit, we set default `Operation Type` in picking when Type of
Operation is `Manufacture`.

taskID - 2939078