### PR TITLE
[FIX] l10n_it_edi: negative quantity downpayment lines

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -17,9 +17,9 @@
                         <t t-esc="format_alphanumeric(line.name[:1000])"/>
                         <t t-if="not line.name" t-esc="'NO NAME'"/>
                     </Descrizione>
-                    <Quantita t-esc="format_numbers(line.quantity)"/>
+                    <Quantita t-esc="format_numbers(abs(line.quantity))"/>
                     <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')"  t-esc="format_alphanumeric(line.product_uom_id.name)"/>
-                    <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.quantity and line.discount != 100.0 else line.price_unit)"/>
+                    <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * abs(line.quantity)) if line.quantity and line.discount != 100.0 else line.price_unit)"/>
                     <ScontoMaggiorazione t-if="line.discount != 0">
                         <Tipo t-esc="discount_type(line.discount)"/>
                         <Percentuale t-esc="format_numbers(abs(line.discount))"/>


### PR DESCRIPTION
When a downpayment has been generated in odoo, upon generating the
complete invoice, a negative line (representing the downpayment) is
included. This line has a positive unit price, and a negative quantity.
Since the edi system in Italy does not accept negative quantities, we
must handle this by providing a positive quantity, and a negative
unit-price (and a negative line subtotal).

This commit changes the quantity element of the xml to utilise the
absolute value of the quantity. The calculation of the PrezzoUnitario
element is also changed to use the absolute value of the quantity, so
that the value of PrezzoUnitario can be negative when the subtotal is.

ticket-id: 2924728
