### PR TITLE
[FIX] google_gmail, *: Changed client secret field type to password

### DIFF
--- a/addons/google_gmail/views/res_config_settings_views.xml
+++ b/addons/google_gmail/views/res_config_settings_views.xml
@@ -21,7 +21,7 @@
                                 </div>
                                 <div class="row mt16" id="gmail_client_secret">
                                     <label string="Client Secret" for="google_gmail_client_secret" class="col-lg-3 o_light_label"/>
-                                    <field name="google_gmail_client_secret" class="ml-2"/>
+                                    <field name="google_gmail_client_secret" password="True" class="ml-2"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/microsoft_outlook/views/res_config_settings_views.xml
+++ b/addons/microsoft_outlook/views/res_config_settings_views.xml
@@ -23,7 +23,7 @@
                                 <div class="row mt16" id="outlook_client_secret">
                                     <label string="Client Secret" for="microsoft_outlook_client_secret"
                                         class="col-lg-3 o_light_label"/>
-                                    <field name="microsoft_outlook_client_secret" class="ml-2"/>
+                                    <field name="microsoft_outlook_client_secret" password="True" class="ml-2"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/website_twitter/views/res_config_settings_views.xml
+++ b/addons/website_twitter/views/res_config_settings_views.xml
@@ -20,7 +20,7 @@
                             </div>
                             <div class="row">
                                 <label class="col-lg-3 o_light_label" string="API secret" for="twitter_api_secret"/>
-                                <field name="twitter_api_secret" class="oe_inline"/>
+                                <field name="twitter_api_secret" password="True" class="oe_inline"/>
                             </div>
                             <a data-toggle="collapse" href="#" data-target="#twitter_tutorial" aria-label="Twitter tutorial">
                                 <i class="fa fa-arrow-right"/>


### PR DESCRIPTION
*: microsoft_outlook, website_twitter

Steps to reproduce:
- install the google_gmail, microsoft_outlook and website_twitter
modules
- go to Settings > General settings > Discuss > External email servers
- for the twitter module go to Settings > Website > Features > Twitter
roller
- the client secret fields are visible

This commit changes the fields types into 'password'.

opw-2936506