### PR TITLE
[FIX] hr_timesheet: fix error thrown when accessing configuration page

### DIFF
--- a/addons/hr_timesheet/static/src/app_store_widget/app_store_widget.js
+++ b/addons/hr_timesheet/static/src/app_store_widget/app_store_widget.js
@@ -45,6 +45,15 @@ class AppStoreWidget extends Component {
     }
 }
 AppStoreWidget.template = "hr_timesheet.AppStoreWidget";
+AppStoreWidget.props = {
+    ...standardWidgetProps,
+    type: { type: String },
+};
+AppStoreWidget.extractProps = ({ attrs }) => {
+    return {
+        type: attrs.type,
+    };
+};
 
 class AppStoreQRDialog extends Component {
     setup() {
@@ -58,13 +67,5 @@ class AppStoreQRDialog extends Component {
 }
 AppStoreQRDialog.components = { Dialog };
 AppStoreQRDialog.template = "hr_timesheet.AppStoreQRDialog";
-AppStoreQRDialog.props = {
-    ...standardWidgetProps,
-    type: { type: String },
-};
-AppStoreQRDialog.extractProps = ({ attrs }) => {
-    return {
-        type: attrs.type,
-    };
-};
+
 registry.category("view_widgets").add("hr_timesheet.app_store_widget", AppStoreWidget);


### PR DESCRIPTION
This commit fixes an "Uncaught Promise" error that is thrown when the
timesheets configuration page is accessed.
The error stems from the appStoreWidget component and specifically from
how the component props are handled.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
