### PR TITLE
[FIX] web: fix autofocus when input type is 'number'

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -46,7 +46,7 @@ export function useAutofocus(params = {}) {
             const target = comp.el.querySelector(selector);
             if (target) {
                 target.focus();
-                if (["INPUT", "TEXTAREA"].includes(target.tagName)) {
+                if (["INPUT", "TEXTAREA"].includes(target.tagName) && target.type !== 'number') {
                     const inputEl = target;
                     inputEl.selectionStart = inputEl.selectionEnd = inputEl.value.length;
                 }

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -42,6 +42,33 @@ QUnit.module("utils", () => {
             comp.destroy();
         });
 
+        QUnit.test("useAutofocus: simple usecase when input type is number", async function (assert) {
+            class MyComponent extends Component {
+                setup() {
+                    useAutofocus();
+                }
+            }
+            MyComponent.template = tags.xml`
+                <span>
+                    <input type="number" autofocus="" />
+                </span>
+            `;
+
+            registry.category("services").add("ui", uiService);
+
+            const env = await makeTestEnv();
+            const target = getFixture();
+            const comp = await mount(MyComponent, { env, target });
+
+            assert.strictEqual(document.activeElement, comp.el.querySelector("input"));
+
+            comp.render();
+            await nextTick();
+            assert.strictEqual(document.activeElement, comp.el.querySelector("input"));
+
+            comp.destroy();
+        });
+
         QUnit.test("useAutofocus: conditional autofocus", async function (assert) {
             class MyComponent extends Component {
                 setup() {


### PR DESCRIPTION
Before this commit, when the autofocus is used on an input with
`type="number"`, the `selectionEnd` is not available because the input
element's type ('number') does not support selection.

This commit checks the input type is not a number:
- if it is the case then the selection is used to place the cursor at
  the end of the input content,
- otherwise the selection properties are not used and the input is
  simply focused.
