### PR TITLE
[FIX] delivery: avoid invisible product_uom_id

### DIFF
--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -49,6 +49,7 @@ class TestDeliveryCost(common.TransactionCase):
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
             [self.env.ref('base.USD').id, self.env.company.id])
         self.pricelist.currency_id = self.env.ref('base.USD').id
+        self.env.user.groups_id |= self.env.ref('uom.group_uom')
 
     def test_00_delivery_cost(self):
         # In order to test Carrier Cost


### PR DESCRIPTION
Since commit 5ccc32fcf72cbfb6bb077d99a7657416c502aac1, it's no longer
possible to write on invisible fields.

Make sure the field product_uom_id is visible to avoid a traceback.

