### PR TITLE
[IMP] web: add props for `FormController` and `ConfirmationDialog`

### DIFF
--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -34,9 +34,13 @@ ConfirmationDialog.props = {
     },
     body: String,
     confirm: { type: Function, optional: true },
+    confirmLabel: { type: String, optional: true },
     cancel: { type: Function, optional: true },
+    cancelLabel: { type: String, optional: true },
 };
 ConfirmationDialog.defaultProps = {
+    confirmLabel: _lt("Ok"),
+    cancelLabel: _lt("Cancel"),
     title: _lt("Confirmation"),
 };
 

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -5,12 +5,8 @@
     <Dialog size="'md'" title="props.title">
       <t t-esc="props.body" />
       <t t-set-slot="footer" owl="1">
-        <button class="btn btn-primary" t-on-click="_confirm">
-          Ok
-        </button>
-        <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel">
-          Cancel
-        </button>
+        <button class="btn btn-primary" t-on-click="_confirm" t-esc="props.confirmLabel"/>
+        <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel"/>
       </t>
     </Dialog>
   </t>
@@ -19,12 +15,8 @@
     <Dialog size="'sm'" title="props.title" contentClass="props.contentClass">
       <t t-esc="props.body" />
       <t t-set-slot="footer" owl="1">
-        <button class="btn btn-primary" t-on-click="_confirm">
-          Ok
-        </button>
-        <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel">
-          Cancel
-        </button>
+        <button class="btn btn-primary" t-on-click="_confirm" t-esc="props.confirmLabel"/>
+        <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel"/>
       </t>
     </Dialog>
   </t>

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -11986,4 +11986,22 @@ QUnit.module("Views", (hooks) => {
             "xmlHelp"
         );
     });
+
+    QUnit.test("onSave/onDiscard props", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><field name="foo"/></form>`,
+            resId: 1,
+            onSave: () => assert.step("save"),
+            onDiscard: () => assert.step("discard"),
+        });
+
+        await click(target, ".o_form_button_edit");
+        await click(target, ".o_form_button_save");
+        await click(target, ".o_form_button_edit");
+        await click(target, ".o_form_button_cancel");
+        assert.verifySteps(["save", "discard"]);
+    });
 });


### PR DESCRIPTION
**[IMP] web: add onSave/onDiscard on form_controller]**
> Adds two new props in `form_controller` in order to call a function from
the parent `Component` when the form view is saved/discarded.

**[IMP] web: ConfirmationDialog buttons' name**
> This commit adds two props for the `ConfirmationDialog`:
`cancelLabel` and `confirmLabel`.
Both are `String` and optional and the buttons will remain named "Ok"
and "Cancel" by default.

Enterprise PR: odoo/enterprise/pull/30045