### PR TITLE
[FIX] rating: ensure `rating_last_value` computation is deterministic

### DIFF
--- a/addons/project/tests/test_project_report.py
+++ b/addons/project/tests/test_project_report.py
@@ -19,7 +19,7 @@ class TestProjectReport(TestProjectCommon):
             {**rating_vals, 'rating': 4.25, 'res_id': self.task_2.id},
         ])
         self.assertEqual(self.task_1.rating_avg, 4.5)
-        self.assertEqual(self.task_1.rating_last_value, 5.0)
+        self.assertEqual(self.task_1.rating_last_value, 4.0)
 
         self.assertEqual(self.task_2.rating_avg, 4.25)
         self.assertEqual(self.task_2.rating_last_value, 4.25)

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -11,7 +11,7 @@ from odoo.modules.module import get_resource_path
 class Rating(models.Model):
     _name = "rating.rating"
     _description = "Rating"
-    _order = 'write_date desc'
+    _order = 'write_date desc, id desc'
     _rec_name = 'res_name'
 
     @api.model

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -35,7 +35,7 @@ class RatingMixin(models.AbstractModel):
             return
         self.env.cr.execute("""
             SELECT
-                array_agg(rating ORDER BY write_date DESC) AS "ratings",
+                array_agg(rating ORDER BY write_date DESC, id DESC) AS "ratings",
                 res_id as res_id
             FROM "rating_rating"
             WHERE


### PR DESCRIPTION
Running tests for `project` module only fails with the following error:

```
2022-08-02 08:19:41,777 5669 ERROR testdb odoo.addons.project.tests.test_project_report: FAIL: TestProjectReport.test_avg_rating_measure
Traceback (most recent call last):
  File "/build/odoo/saas-15.3/addons/project/tests/test_project_report.py", line 22, in test_avg_rating_measure
    self.assertEqual(self.task_1.rating_last_value, 5.0)
AssertionError: 4.0 != 5.0
```

With the ORM flush mechanisms when multiple ratings are created at once
they all have the same `create_date` and/or `write_date`, this commit
ensure the order is deterministic.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
