### PR TITLE
[FIX] mass_mailing: spurious help overlay

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -340,10 +340,10 @@ class MassMailing(models.Model):
             else:
                 mailing.calendar_date = False
 
-    @api.depends('body_html')
+    @api.depends('body_arch')
     def _compute_is_body_empty(self):
         for mailing in self:
-            mailing.is_body_empty = tools.is_html_empty(mailing.body_html)
+            mailing.is_body_empty = tools.is_html_empty(mailing.body_arch)
 
     def _compute_mail_server_available(self):
         self.mail_server_available = self.env['ir.config_parameter'].sudo().get_param('mass_mailing.outgoing_mail_server')


### PR DESCRIPTION
When duplicating a mailing with a template already set, especially with a slow
connection, hitting the save button as soon as possible was causing the help
overlay to be superposed with the template. This solves the problem.

Task-2937045

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
