### PR TITLE
Master project improve burndown chart ltu

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -14,7 +14,7 @@
                 <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
                 <field name="stage_id" />
                 <separator/>
-                <filter name="filter_date" date="date" string="Date" />
+                <filter name="filter_date" date="date" string="Date" default_period="this_year,last_year" />
                 <filter name="filter_date_deadline" date="date_deadline"/>
                 <filter name="filter_date_assign" date="date_assign"/>
                 <filter string="Last Month" invisible="1" name="last_month" domain="[('date','&gt;=', (context_today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]"/>
@@ -22,7 +22,7 @@
                 <filter string="Late Milestones" name="late_milestone" domain="[('is_closed', '=', False), ('has_late_and_unreached_milestone', '=', True)]" groups="project.group_project_milestone"/>
                 <group expand="0" string="Group By">
                     <filter string="Date" name="date" context="{'group_by': 'date'}" />
-                    <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}" />
+                    <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}" invisible="1"/>
                 </group>
             </search>
         </field>
@@ -44,7 +44,7 @@
         <field name="res_model">project.task.burndown.chart.report</field>
         <field name="view_mode">graph</field>
         <field name="search_view_id" ref="project_task_burndown_chart_report_view_search"/>
-        <field name="context">{'search_default_project_id': active_id, 'search_default_date': 1, 'search_default_stage': 1}</field>
+        <field name="context">{'search_default_project_id': active_id, 'search_default_date': 1, 'search_default_stage': 1, 'search_default_filter_date': 1, 'search_default_open_tasks': 1}</field>
         <field name="domain">[('display_project_id', '!=', False)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -38,14 +38,8 @@ tour.register('burndown_chart_tour', {
     content: 'Open the group by menu',
     trigger: '.o_group_by_menu button',
 }, {
-    content: 'Click on the Stage group menu item',
-    trigger: '.o_group_by_menu .o_menu_item:contains("Stage")',
-}, {
-    content: 'A "The Burndown Chart must be grouped by Stage" notification is shown when trying to remove the group by "Date: Month > Stage"',
-    trigger: '.o_notification_manager .o_notification:contains("The Burndown Chart must be grouped by Stage") button.o_notification_close',
-}, {
-    content: 'Open the group by menu',
-    trigger: '.o_group_by_menu button',
+    content: 'The Stage group menu item is invisible',
+    trigger: '.o_group_by_menu:not(:has(.o_menu_item:contains("Stage")))',
 }, {
     content: 'Open the Date group by sub menu',
     trigger: '.o_group_by_menu button.o_menu_item:contains("Date")',

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -208,9 +208,9 @@ export class SearchArchParser extends XMLParser {
                 preSearchItem.type = "dateFilter";
                 preSearchItem.fieldName = fieldName;
                 preSearchItem.fieldType = this.fields[fieldName].type;
-                preSearchItem.defaultGeneratorId = DEFAULT_PERIOD;
+                preSearchItem.defaultGeneratorIds = [DEFAULT_PERIOD];
                 if (node.hasAttribute("default_period")) {
-                    preSearchItem.defaultGeneratorId = node.getAttribute("default_period");
+                    preSearchItem.defaultGeneratorIds = node.getAttribute("default_period").split(',');
                 }
             } else {
                 let stringRepr = "[]";

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -884,31 +884,33 @@ export class SearchModel extends EventBus {
         if (searchItem.type !== "dateFilter") {
             return;
         }
-        generatorId = generatorId || searchItem.defaultGeneratorId;
-        const index = this.query.findIndex(
-            (queryElem) =>
-                queryElem.searchItemId === searchItemId &&
-                "generatorId" in queryElem &&
-                queryElem.generatorId === generatorId
-        );
-        if (index >= 0) {
-            this.query.splice(index, 1);
-            if (!yearSelected(this._getSelectedGeneratorIds(searchItemId))) {
-                // This is the case where generatorId was the last option
-                // of type 'year' to be there before being removed above.
-                // Since other options of type 'month' or 'quarter' do
-                // not make sense without a year we deactivate all options.
-                this.query = this.query.filter(
-                    (queryElem) => queryElem.searchItemId !== searchItemId
-                );
-            }
-        } else {
-            this.query.push({ searchItemId, generatorId });
-            if (!yearSelected(this._getSelectedGeneratorIds(searchItemId))) {
-                // Here we add 'this_year' as options if no option of type
-                // year is already selected.
-                const { defaultYearId } = this.optionGenerators.find((o) => o.id === generatorId);
-                this.query.push({ searchItemId, generatorId: defaultYearId });
+        const generatorIds = generatorId ? [generatorId] : searchItem.defaultGeneratorIds;
+        for (const generatorId of generatorIds) {
+            const index = this.query.findIndex(
+                (queryElem) =>
+                    queryElem.searchItemId === searchItemId &&
+                    "generatorId" in queryElem &&
+                    queryElem.generatorId === generatorId
+            );
+            if (index >= 0) {
+                this.query.splice(index, 1);
+                if (!yearSelected(this._getSelectedGeneratorIds(searchItemId))) {
+                    // This is the case where generatorId was the last option
+                    // of type 'year' to be there before being removed above.
+                    // Since other options of type 'month' or 'quarter' do
+                    // not make sense without a year we deactivate all options.
+                    this.query = this.query.filter(
+                        (queryElem) => queryElem.searchItemId !== searchItemId
+                    );
+                }
+            } else {
+                this.query.push({ searchItemId, generatorId });
+                if (!yearSelected(this._getSelectedGeneratorIds(searchItemId))) {
+                    // Here we add 'this_year' as options if no option of type
+                    // year is already selected.
+                    const { defaultYearId } = this.optionGenerators.find((o) => o.id === generatorId);
+                    this.query.push({ searchItemId, generatorId: defaultYearId });
+                }
             }
         }
         this._checkComparisonStatus();

--- a/addons/web/static/tests/search/filter_menu_tests.js
+++ b/addons/web/static/tests/search/filter_menu_tests.js
@@ -471,6 +471,34 @@ QUnit.module("Search", (hooks) => {
         assert.deepEqual(getFacetTexts(target), ["Date: June 2019"]);
     });
 
+    QUnit.test("filter with multiple values in default_period date attribute set as search_default", async function (assert) {
+        assert.expect(3);
+
+        patchDate(2019, 6, 31, 13, 43, 0);
+
+        await makeWithSearch({
+            serverData,
+            resModel: "foo",
+            Component: ControlPanel,
+            searchViewId: false,
+            searchMenuTypes: ["filter"],
+            searchViewArch: `
+                    <search>
+                        <filter string="Date" name="date_field" date="date_field" default_period="this_year,last_year"/>
+                    </search>
+                `,
+            context: { search_default_date_field: true },
+        });
+
+        await toggleFilterMenu(target);
+        await toggleMenuItem(target, "Date");
+
+        assert.ok(isItemSelected(target, "Date"));
+        assert.ok(isOptionSelected(target, "Date", "2019"));
+        assert.ok(isOptionSelected(target, "Date", "2018"));
+
+    });
+
     QUnit.test("filter domains are correcly combined by OR and AND", async function (assert) {
         assert.expect(2);
 

--- a/addons/web/static/tests/search/search_model_tests.js
+++ b/addons/web/static/tests/search/search_model_tests.js
@@ -232,7 +232,42 @@ QUnit.module("Search", (hooks) => {
         ]);
     });
 
-    QUnit.test("parsing one filter tag with date attribute", async function (assert) {
+    QUnit.test("parsing one filter tag with default_period date attribute", async function (assert) {
+        assert.expect(1);
+        const model = await makeSearchModel({
+            serverData,
+            searchViewArch: `
+                    <search>
+                        <filter name="date_filter" string="Date" date="date_field" default_period="this_year,last_year"/>
+                    </search>
+                `,
+        });
+        const dateFilterId = model.getSearchItems((f) => f.type === "dateFilter")[0].id;
+        assert.deepEqual(sanitizeSearchItems(model), [
+            {
+                defaultGeneratorIds: ["this_year", "last_year"],
+                description: "Date",
+                fieldName: "date_field",
+                fieldType: "date",
+                type: "dateFilter",
+                name: "date_filter",
+            },
+            {
+                comparisonOptionId: "previous_period",
+                dateFilterId,
+                description: "Date: Previous Period",
+                type: "comparison",
+            },
+            {
+                comparisonOptionId: "previous_year",
+                dateFilterId,
+                description: "Date: Previous Year",
+                type: "comparison",
+            },
+        ]);
+    });
+
+    QUnit.test("parsing one filter tag with date attribute ", async function (assert) {
         assert.expect(1);
         const model = await makeSearchModel({
             serverData,
@@ -245,7 +280,7 @@ QUnit.module("Search", (hooks) => {
         const dateFilterId = model.getSearchItems((f) => f.type === "dateFilter")[0].id;
         assert.deepEqual(sanitizeSearchItems(model), [
             {
-                defaultGeneratorId: "this_month",
+                defaultGeneratorIds: ["this_month"],
                 description: "Date",
                 fieldName: "date_field",
                 fieldType: "date",


### PR DESCRIPTION
This PR's purpose is to improve the user experience when using the
burdown chart as well as preventing fetching all the data in order to
prevent long loading time on big databases.

This PR adds `Allocated Hours` (`planned_hours` field) in the chart
measures as well as default filters in order to restrict the data to
the tasks which stage have been modified this year or the previous
one, or which current stage is not `closed`.

task-2941625

Related To:
* Documentation: odoo/documentation#2551

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
