### PR TITLE
[IMP] point_of_sale: less aggressive offline errors

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -144,7 +144,7 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                 } catch (error) {
                     const iError = identifyError(error);
                     if (iError instanceof ConnectionLostError || iError instanceof ConnectionAbortedError) {
-                        await this.showPopup('ErrorPopup', {
+                        await this.showPopup('OfflineErrorPopup', {
                             title: this.env._t('Network Error'),
                             body: this.env._t('Cannot close the session when offline.'),
                         });

--- a/addons/point_of_sale/static/src/js/Popups/OfflineErrorPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/OfflineErrorPopup.js
@@ -4,19 +4,58 @@ odoo.define('point_of_sale.OfflineErrorPopup', function(require) {
     const ErrorPopup = require('point_of_sale.ErrorPopup');
     const Registries = require('point_of_sale.Registries');
     const { _lt } = require('@web/core/l10n/translation');
+    const { Gui } = require('point_of_sale.Gui');
 
     /**
-     * This is a special kind of error popup as it introduces
-     * an option to not show it again.
+     * This is a special kind of error popup: we want to display it only once, because otherwise it creates
+     * a negative UX. Instead of throwing errors at the user, we remind them that some actions are unavailable
+     * during the offline mode by keeping the sync status icon (top right corner of the UI) always up to date
+     * and by displaying a toast notification.
      */
     class OfflineErrorPopup extends ErrorPopup {
-        dontShowAgain() {
-            this.constructor.dontShow = true;
-            this.cancel();
+        setup() {
+            super.setup();
+            if (!this.constructor.shouldShow) {
+                Gui.showNotification(this.props.body, 3000);
+                this.cancel();
+            } else {
+                this.constructor.shouldShow = false;
+                this.startPolling();
+            }
+            owl.onWillUnmount(() => this.env.pos.set_synch('disconnected'));
+        }
+        startPolling() {
+            this.constructor.pollingIntervalId = setInterval(async () => {
+                const isConnectionOk = await this.pingServer();
+                const newStatus = isConnectionOk ? 'connected' : 'disconnected';
+                this.updateSyncStatus(newStatus);
+                if (isConnectionOk) this.stopPolling();
+            }, 30000);
+        }
+        stopPolling() {
+            clearInterval(this.constructor.pollingIntervalId);
+            this.constructor.pollingIntervalId = false;
+            this.constructor.shouldShow = true;
+        }
+        updateSyncStatus(newStatus) {
+            this.env.pos.set_synch('connecting');
+            // delay 2 sec so that the 'connecting' phase is visible to the user
+            setTimeout(() => this.env.pos.set_synch(newStatus), 2000);
+        }
+        async pingServer() {
+            try {
+                await this.env.services.rpc({
+                    route: '/web/webclient/version_info'
+                });
+                return true;
+            } catch {
+                return false;
+            }
         }
     }
     OfflineErrorPopup.template = 'OfflineErrorPopup';
-    OfflineErrorPopup.dontShow = false;
+    OfflineErrorPopup.shouldShow = true;
+    OfflineErrorPopup.pollingIntervalId = false;
     OfflineErrorPopup.defaultProps = {
         confirmText: _lt('Ok'),
         cancelText: _lt('Cancel'),

--- a/addons/point_of_sale/static/src/js/Popups/PosPopupController.js
+++ b/addons/point_of_sale/static/src/js/Popups/PosPopupController.js
@@ -41,10 +41,6 @@ odoo.define('point_of_sale.PosPopupController', function(require) {
             if (!component) {
                 throw new Error(`'${name}' is not found. Make sure the file is loaded and the component is properly registered using 'Registries.Component.add'.`);
             }
-            if (component.dontShow) {
-                resolve();
-                return;
-            }
             this.popups.push({
                 name,
                 component,

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -204,7 +204,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                         syncOrderResult.map((res) => res.id)
                     );
                     if (!postPushResult) {
-                        this.showPopup('ErrorPopup', {
+                        this.showPopup('OfflineErrorPopup', {
                             title: this.env._t('Error: no internet connection.'),
                             body: this.env._t('Some, if not all, post-processing after syncing order failed.'),
                         });

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
@@ -44,7 +44,7 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
                     throw error;
                 } else {
                     // NOTE: error here is most probably undefined
-                    this.showPopup('ErrorPopup', {
+                    this.showPopup('OfflineErrorPopup', {
                         title: this.env._t('Network Error'),
                         body: this.env._t('Unable to download invoice.'),
                     });
@@ -109,7 +109,7 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
                 await this._invoiceOrder();
             } catch (error) {
                 if (isConnectionError(error)) {
-                    this.showPopup('ErrorPopup', {
+                    this.showPopup('OfflineErrorPopup', {
                         title: this.env._t('Network Error'),
                         body: this.env._t('Unable to invoice order.'),
                     });

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -2607,7 +2607,6 @@ td {
 }
 
 .pos .popup .body.traceback {
-    height: 238px;
     overflow: auto;
     font-size: 14px;
     white-space: pre-wrap;
@@ -2723,6 +2722,9 @@ td {
 .pos .popup.popup-error .title {
     color: white;
     background: rgba(255, 76, 76, 0.5);
+}
+.pos .popup.popup-error .body {
+    min-height: 1.5rem;
 }
 .pos .popup.popup-selection .selection {
     overflow-y: auto;

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -2646,10 +2646,6 @@ td {
 .pos .popup-textarea .popup-textarea-wrap {
     padding: map-get($spacers, 2);
 }
-.pos .popup .button.dont-show-again {
-    width: 130px;
-}
-
 .pos .popup .button.icon {
     width: 40px;
     font-size: 20px;

--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -3,3 +3,10 @@
         width: 500px;
 	}
 }
+
+/* PoS Settings View */
+.settings .o_setting_right_pane .o_field_widget[name="pos_default_bill_ids"],
+.settings .o_setting_right_pane .o_field_widget[name="pos_default_bill_ids"] .o_field_many2many_selection {
+    width: 100%;
+    max-width: 380px;
+}

--- a/addons/point_of_sale/static/src/xml/Popups/OfflineErrorPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/OfflineErrorPopup.xml
@@ -12,9 +12,6 @@
                         <div class="button confirm" t-on-click="confirm">
                             Ok
                         </div>
-                        <div class="button dont-show-again" t-on-click="dontShowAgain">
-                            Don't show again
-                        </div>
                     </footer>
                 </div>
             </Draggable>

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -94,7 +94,7 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
                 return newTable;
             } catch (error) {
                 if (isConnectionError(error)) {
-                    await this.showPopup('ErrorPopup', {
+                    await this.showPopup('OfflineErrorPopup', {
                         title: this.env._t('Offline'),
                         body: this.env._t('Unable to create table because you are offline.'),
                     });

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
@@ -53,7 +53,7 @@ odoo.define('pos_sale.SaleOrderFetcher', function (require) {
                 this.trigger('update');
             } catch (error) {
                 if (isConnectionError(error)) {
-                    Gui.showPopup('ErrorPopup', {
+                    Gui.showPopup('OfflineErrorPopup', {
                         title: this.comp.env._t('Network Error'),
                         body: this.comp.env._t('Unable to fetch orders if offline.'),
                     });

--- a/addons/pos_sale/static/src/js/SetSaleOrderButton.js
+++ b/addons/pos_sale/static/src/js/SetSaleOrderButton.js
@@ -34,7 +34,7 @@ odoo.define('pos_sale.SetSaleOrderButton', function(require) {
               Gui.showScreen(screen);
           } catch (error) {
               if (isConnectionError(error)) {
-                  this.showPopup('ErrorPopup', {
+                  this.showPopup('OfflineErrorPopup', {
                       title: this.env._t('Network Error'),
                       body: this.env._t('Cannot access order management screen if offline.'),
                   });


### PR DESCRIPTION
In this PR, we make the UI more usable in 2 ways:

1) Showing errors when connection is lost is now handled less aggressively: we display less error messages and prefer toast notifications instead. We also make sure to keep the status of the sync icon always up to date.

2) Increase the width of the coins/bills widget in the PoS settings menu.

task-2895447
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
