### PR TITLE
[FIX] core: make name_search and filtered_domain consistent again

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -779,14 +779,14 @@ class AccountGroup(models.Model):
         return result
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name, args=None, operator='ilike'):
         args = args or []
         if operator == 'ilike' and not (name or '').strip():
             domain = []
         else:
             criteria_operator = ['|'] if operator not in expression.NEGATIVE_TERM_OPERATORS else ['&', '!']
             domain = criteria_operator + [('code_prefix_start', '=ilike', name + '%'), ('name', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
+        return expression.AND([domain, args])
 
     @api.constrains('code_prefix_start', 'code_prefix_end')
     def _constraint_prefix_overlap(self):

--- a/addons/event/models/mail_template.py
+++ b/addons/event/models/mail_template.py
@@ -9,7 +9,7 @@ class MailTemplate(models.Model):
     _inherit = 'mail.template'
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name, args=None, operator='ilike'):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
@@ -19,4 +19,4 @@ class MailTemplate(models.Model):
         """
         if self.env.context.get('filter_template_on_event'):
             args = expression.AND([[('model', '=', 'event.registration')], args])
-        return super(MailTemplate, self)._name_search(name, args, operator, limit, name_get_uid)
+        return super()._name_search_domain(name, args, operator)

--- a/addons/event_sms/models/sms_template.py
+++ b/addons/event_sms/models/sms_template.py
@@ -9,7 +9,7 @@ class SmsTemplate(models.Model):
     _inherit = 'sms.template'
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name, args=None, operator='ilike'):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
@@ -19,4 +19,4 @@ class SmsTemplate(models.Model):
         """
         if self.env.context.get('filter_template_on_event'):
             args = expression.AND([[('model', '=', 'event.registration')], args])
-        return super(SmsTemplate, self)._name_search(name, args, operator, limit, name_get_uid)
+        return super()._name_search_domain(name, args, operator)

--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -38,7 +38,7 @@ class ChatbotScriptAnswer(models.Model):
         return result
 
     @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name='', args=None, operator='ilike'):
         """
         Search the records whose name or step message are matching the ``name`` pattern.
         The chatbot_script_id is also passed to the context through the custom widget
@@ -62,4 +62,4 @@ class ChatbotScriptAnswer(models.Model):
         if force_domain_chatbot_script_id:
             domain = expression.AND([domain, [('chatbot_script_id', '=', force_domain_chatbot_script_id)]])
 
-        return self._search(domain, limit=limit, access_rights_uid=name_get_uid)
+        return domain

--- a/addons/l10n_eg_edi_eta/models/eta_activity_type.py
+++ b/addons/l10n_eg_edi_eta/models/eta_activity_type.py
@@ -14,10 +14,10 @@ class EtaActivityType(models.Model):
     code = fields.Char(required=True)
 
     @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name='', args=None, operator='ilike'):
         args = args or []
         if operator == 'ilike' and not(name or '').strip():
             domain = []
         else:
             domain = ['|', ('name', operator, name), ('code', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
+        return expression.AND([domain, args])

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -39,6 +39,11 @@ class TestVariantsSearch(ProductVariantsCommon):
         self.assertIn(self.product_template_shirt, search_value,
                       'Shirt should be found searching L')
 
+        filtered_search_value = search_value.filtered_domain(
+            [('attribute_line_ids', '=', 'L')]
+        )
+        self.assertEqual(filtered_search_value, search_value, 'filtered_domain should work with Attributes')
+
     def test_name_search(self):
         self.product_slip_template = self.env['product.template'].create({
             'name': 'Slip',

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2628,11 +2628,11 @@ class ProjectTags(models.Model):
         return super().search_read(domain=domain, fields=fields, offset=offset, limit=limit, order=order)
 
     @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name='', args=None, operator='ilike'):
         domain = args
         if 'project_id' in self.env.context:
             domain = self._get_project_tags_domain(domain, self.env.context.get('project_id'))
-        return super()._name_search(name, domain, operator, limit, name_get_uid)
+        return super()._name_search_domain(name, domain, operator)
 
     @api.model
     def name_create(self, name):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -173,13 +173,13 @@ class PickingType(models.Model):
         return res
 
     @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name='', args=None, operator='ilike'):
         # Try to reverse the `name_get` structure
         parts = name.split(': ')
         if len(parts) == 2:
             domain = [('warehouse_id.name', operator, parts[0]), ('name', operator, parts[1])]
-            return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        return super()._name_search(name=name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
+            return expression.AND([domain, args])
+        return super()._name_search_domain(name, args, operator)
 
     @api.onchange('code')
     def _onchange_picking_code(self):

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -38,14 +38,14 @@ class Bank(models.Model):
         return result
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name, args=None, operator='ilike'):
         args = args or []
         domain = []
         if name:
             domain = ['|', ('bic', '=ilike', name + '%'), ('name', operator, name)]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = ['&'] + domain
-        return self._search(domain + args, limit=limit, access_rights_uid=name_get_uid)
+        return domain + args
 
     @api.onchange('country')
     def _onchange_country_id(self):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -107,13 +107,13 @@ class PartnerCategory(models.Model):
         return res
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+    def _name_search_domain(self, name, args=None, operator='ilike'):
         args = args or []
         if name:
             # Be sure name_search is symetric to name_get
             name = name.split(' / ')[-1]
             args = [('name', operator, name)] + args
-        return self._search(args, limit=limit, access_rights_uid=name_get_uid)
+        return args
 
 
 class PartnerTitle(models.Model):


### PR DESCRIPTION
Method `filtered_domain` is supposed to process domain in the same way as method
`search`. In previous implementation `filtered_domain` used `display_name` and
ignored method `_name_search`.

The commit introduces new intermediate method `_name_search_domain` to allow
using it in `filtered_domain`.

opw-2867315
task-2941674

