### PR TITLE
[FIX] web_editor: try to paste html before files

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -3023,10 +3023,10 @@ export class OdooEditor extends EventTarget {
         const sel = this.document.getSelection();
         const files = getImageFiles(ev.clipboardData);
         const clipboardHtml = ev.clipboardData.getData('text/html');
-        if (files.length) {
-            this.addImagesFiles(files);
-        } else if (clipboardHtml) {
+        if (clipboardHtml) {
             this.execCommand('insertHTML', this._prepareClipboardData(clipboardHtml));
+        } else if (files.length) {
+            this.addImagesFiles(files);
         } else {
             const text = ev.clipboardData.getData('text/plain');
             const splitAroundUrl = text.split(URL_REGEX);


### PR DESCRIPTION
Before this commit, when trying to paste into the Odoo editor, if file
and html was in the clipboard, the file got precedence and were added
instead of html.

task-2941679




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
