### PR TITLE
[FIX] website_sale: wrong css selector for visitor in product description

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -235,7 +235,7 @@ $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale
         padding: var(--o-wsale-card-info-padding, #{map-get($spacers, 2)} 0);
     }
 
-    [data-oe-field="description_sale"][data-oe-type] {
+    .oe_subdescription div {
         min-height: calc(#{$font-size-sm * 1.1} * 2);
         overflow: hidden;
         display: -webkit-box;


### PR DESCRIPTION
Issue:
The product descriptions on the /shop page (always shown if the product
description option is checked) are shortened... but only if the user is
logged in. It should also be the case for visitors.

Explanation:
Using css selector for data-oe stuff is a problem for visitors as they
don't apply to them. To fix the issue we change the selector to a classic
css class.

opw-2926847
