### PR TITLE
[FIX] survey: avoid horizontal scroll

### DIFF
--- a/addons/survey/static/src/xml/survey_breadcrumb_templates.xml
+++ b/addons/survey/static/src/xml/survey_breadcrumb_templates.xml
@@ -15,12 +15,12 @@
                     <t t-set="canGoBack" t-value="false" />
                 </t>
                 <t t-if="canGoBack">
-                    <a class="text-primary" href="#">
+                    <a class="text-primary text-break" href="#">
                         <span t-esc="page.title" />
                     </a>
                 </t>
                 <t t-else="">
-                    <span t-att-class="(isActivePage ? 'text-black' : 'text-muted')"
+                    <span t-att-class="'text-break ' + (isActivePage ? 'text-black' : 'text-muted')"
                           t-esc="page.title" />
                 </t>
             </li>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -128,7 +128,7 @@
     <template id="survey_fill_form_start" name="Survey: start form content">
         <div class="wrap o_survey_start">
             <div class='mb32'>
-                <div t-field='survey.description' class="oe_no_empty pb-5"/>
+                <div t-field='survey.description' class="oe_no_empty pb-5 text-break"/>
                 <t t-if="answer.is_session_answer">
                     <div class="font-weight-bold">
                         The session will begin automatically when the host starts.
@@ -165,8 +165,8 @@
             t-att-data-time-limit-minutes="time_limit_minutes"/>
         <t t-if="survey.questions_layout == 'one_page'">
             <t t-foreach='survey.question_and_page_ids' t-as='question'>
-                <h2 t-if="question.is_page" t-field='question.title' class="o_survey_title pb16" />
-                <div t-if="question.is_page" t-field='question.description'/>
+                <h2 t-if="question.is_page" t-field='question.title' class="o_survey_title pb16 text-break" />
+                <div t-if="question.is_page" t-field='question.description' class="text-break"/>
                 <t t-if="not question.is_page and question in answer.predefined_question_ids" t-call="survey.question_container"/>
             </t>
 
@@ -177,8 +177,8 @@
         </t>
 
         <t t-if="survey.questions_layout == 'page_per_section'">
-            <h2 t-field='page.title' class="o_survey_title pb16" />
-            <div t-field='page.description' class="oe_no_empty"/>
+            <h2 t-field='page.title' class="o_survey_title pb16 text-break" />
+            <div t-field='page.description' class="oe_no_empty text-break"/>
 
             <input type="hidden" name="page_id" t-att-value="page.id" />
             <t t-foreach='page.question_ids' t-as='question'>
@@ -307,10 +307,10 @@
              t-att-data-validation-error-msg="question.validation_error_msg">
             <div class="mb-4">
                 <h3 t-if="not hide_question_title">
-                    <span t-field='question.title' />
+                    <span t-field='question.title' class="text-break" />
                     <span t-if="question.constr_mandatory" class="text-danger">*</span>
                 </h3>
-                <div t-if="not is_html_empty(question.description)" t-field='question.description' class="text-muted oe_no_empty mt-1"/>
+                <div t-if="not is_html_empty(question.description)" t-field='question.description' class="text-muted oe_no_empty mt-1 text-break"/>
             </div>
             <t t-if="question.question_type == 'text_box'"><t t-call="survey.question_text_box"/></t>
             <t t-if="question.question_type == 'char_box'"><t t-call="survey.question_char_box"/></t>
@@ -415,7 +415,7 @@
                         <t t-call="survey.survey_selection_key">
                             <t t-set="selection_key_class" t-value="'position-relative o_survey_radio_btn float-left d-flex'"/>
                         </t>
-                        <span class="ml-2" t-field='label.value'/>
+                        <span class="ml-2 text-break" t-field='label.value'/>
                         <input t-att-id="str(question.id) + '_' + str(label.id)" type="radio" t-att-value='label.id' class="o_survey_form_choice_item invisible position-absolute"
                                t-att-name='question.id'
                                t-att-checked="answer_line and answer_line.suggested_answer_id.id == label.id and 'checked' or None"
@@ -481,7 +481,7 @@
                                t-att-name="question.id"
                                t-att-checked="'checked' if answer_line else None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
-                        <span class="ml-2" t-field='label.value'/>
+                        <span class="ml-2 text-break" t-field='label.value'/>
                         <i class="fa fa-check-square float-right mt-1 position-relative"></i>
                         <i class="fa fa-square-o float-right mt-1 position-relative"></i>
                         <t t-call="survey.question_suggested_value_image"/>

--- a/addons/survey/views/survey_templates_print.xml
+++ b/addons/survey/views/survey_templates_print.xml
@@ -9,8 +9,8 @@
             <div class="wrap">
                 <div class="o_survey_print container">
                     <div class='py-5 mt32'>
-                        <h1><span t-field='survey.title'/></h1>
-                        <t t-if="survey.description"><div t-field='survey.description' class="oe_no_empty"/></t>
+                        <h1><span t-field='survey.title' class="text-break"/></h1>
+                        <t t-if="survey.description"><div t-field='survey.description' class="oe_no_empty text-break"/></t>
                         <t t-if="review" t-call="survey.survey_button_retake"/>
                     </div>
                     <div role="form">
@@ -22,19 +22,19 @@
                                             or not is_html_empty(question.description))">
                                     <hr t-if="question != survey.page_ids[0]" />
                                     <div class="o_page_header">
-                                        <h1 t-field='question.title' />
-                                        <div t-if="question.description" t-field='question.description' class="oe_no_empty"/>
+                                        <h1 t-field='question.title' class="text-break" />
+                                        <div t-if="question.description" t-field='question.description' class="oe_no_empty text-break"/>
                                     </div>
                                 </t>
                                 <t t-if="not question.is_page and not answer or (question in answer.predefined_question_ids &amp; questions_to_display)" >
                                     <t t-set="answer_lines" t-value="answer.user_input_line_ids.filtered(lambda line: line.question_id == question)"/>
                                     <div class="js_question-wrapper" t-att-id="question.id">
                                         <h2>
-                                            <span t-field='question.title'/>
+                                            <span t-field='question.title' class="text-break"/>
                                             <span t-if="question.constr_mandatory" class="text-danger">*</span>
                                             <span t-if="scoring_display_correction" class="badge badge-pill" t-att-data-score-question="question.id"></span>
                                         </h2>
-                                        <t t-if="question.description"><div class="text-muted oe_no_empty" t-field='question.description'/></t>
+                                        <t t-if="question.description"><div class="text-muted oe_no_empty text-break" t-field='question.description'/></t>
                                         <t t-if="question.question_type == 'text_box'"><t t-call="survey.question_text_box"/></t>
                                         <t t-if="question.question_type == 'char_box'"><t t-call="survey.question_char_box"/></t>
                                         <t t-if="question.question_type == 'numerical_box'"><t t-call="survey.question_numerical_box"/></t>


### PR DESCRIPTION
Currently, in the survey, if the survey/section/question title, description,
survey breadcrumb and multiple choice question options have a very long
link in the label, then on mobile the card is too long, which makes browsers
display a horizontal scroll.

This commit solves the above problem by adding the `text-break` class to the
label.

task-2925648

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
