### PR TITLE
[IMP] account: harmonize the invoice creation in Documents and Accounting when importing a PDF with embedded Factur-X data

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1205,10 +1205,8 @@ class AccountJournal(models.Model):
         # We simply call the setup bar function.
         return self.env['res.company'].setting_init_bank_account_action()
 
-    def create_invoice_from_attachment(self, attachment_ids=[]):
-        ''' Create the invoices from files.
-         :return: A action redirecting to account.move tree/form view.
-        '''
+    def _generate_invoice_from_attachment(self, attachment_ids=None):
+        """Generate the invoices from attachments."""
         attachments = self.env['ir.attachment'].browse(attachment_ids)
         if not attachments:
             raise UserError(_("No attachment was provided"))
@@ -1219,7 +1217,13 @@ class AccountJournal(models.Model):
             attachment.write({'res_model': 'mail.compose.message'})
             invoice.message_post(attachment_ids=[attachment.id])
             invoices += invoice
+        return invoices
 
+    def create_invoice_from_attachment(self, attachment_ids=None):
+        ''' Create the invoices from files.
+         :return: A action redirecting to account.move tree/form view.
+        '''
+        invoices = self._generate_invoice_from_attachment(attachment_ids=attachment_ids)
         action_vals = {
             'name': _('Generated Documents'),
             'domain': [('id', 'in', invoices.ids)],


### PR DESCRIPTION
Before this PR we had two different behaviour for the same functionnality depending on the App used.
In the Documents App:
- Upload a PDF document with embedded Factur-X in the Documents app
- Click on Create Bill in the actions of the document
- The OCR is triggered.

In the Accounting App:
- Upload a PDF document with embedded Factur-X via the "Upload Bills" button in the Accounting Dashboard
- The invoice is created using the information contained in the Factur-X XML embedded in the PDF without using the OCR.

We should have the same behaviour in both apps. Furthermore, if the invoice information can be retrieved from the XML, it is useless and more error-prone to use the OCR.

This PR fixes this by calling the Accounting importing function instead which also simplifies greatly the code

task-id 2928235

Enterprise PR: https://github.com/odoo/enterprise/pull/30879