### PR TITLE
14.0 account _is_downpayment, l10n_it_edi TD02

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3705,6 +3705,12 @@ class AccountMoveLine(models.Model):
                 qties[aml.product_id] -= qty
         return qties
 
+    def _is_downpayment(self):
+        ''' Return true if the invoice is a downpayment.
+        Down-payments can be created from a sale order. This method is overridden in the sale order module.
+        '''
+        return False
+
     # -------------------------------------------------------------------------
     # ONCHANGE METHODS
     # -------------------------------------------------------------------------
@@ -5226,3 +5232,9 @@ class AccountMoveLine(models.Model):
                 rslt += tag
 
         return rslt
+
+    def _get_downpayment_lines(self):
+        ''' Return the downpayment move lines associated with the move line.
+        This method is overridden in the sale order module.
+        '''
+        return self.env['account.move.line']

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -20,12 +20,12 @@
                         <CodiceValore t-esc="format_alphanumeric(line.product_id.default_code)"/>
                     </CodiceArticolo>
                     <Descrizione>
-                        <t t-esc="format_alphanumeric(line.name[:1000])"/>
+                        <t t-esc="format_alphanumeric(line.name[:1000] if not downpayment_dict.get(line.id) else (line.name + ' / documento: ' + downpayment_dict.get(line.id))[:1000])"/>
                         <t t-if="not line.name" t-esc="'NO NAME'"/>
                     </Descrizione>
-                    <Quantita t-esc="format_numbers(line.quantity)"/>
+                    <Quantita t-esc="format_numbers(abs(line.quantity))"/>
                     <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')"  t-esc="format_alphanumeric(line.product_uom_id.name)"/>
-                    <PrezzoUnitario t-esc="'%.06f' % (price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.quantity and line.discount != 100.0 else line.price_unit)"/>
+                    <PrezzoUnitario t-esc="'%.06f' % (price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * abs(line.quantity)) if line.quantity and line.discount != 100.0 else line.price_unit)"/>
                     <ScontoMaggiorazione t-if="line.discount != 0">
                         <Tipo t-esc="discount_type(line.discount)"/>
                         <Percentuale t-esc="format_numbers(abs(line.discount))"/>

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -213,6 +213,7 @@ class AccountEdiFormat(models.Model):
     def _l10n_it_document_type_mapping(self):
         return {
             'TD01': dict(move_types=['out_invoice'], import_type='in_invoice'),
+            'TD02': dict(move_types=['out_invoice'], import_type='in_invoice', downpayment=True),
             'TD04': dict(move_types=['out_refund'], import_type='in_refund'),
             'TD07': dict(move_types=['out_invoice'], import_type='in_invoice', simplified=True),
             'TD08': dict(move_types=['out_refund'], import_type='in_refund', simplified=True),
@@ -233,6 +234,7 @@ class AccountEdiFormat(models.Model):
             info_partner_in_eu = infos.get('partner_in_eu', False)
             if all([
                 invoice.move_type in infos.get('move_types', False),
+                invoice._is_downpayment() == infos.get('downpayment', False),
                 is_self_invoice == infos.get('self_invoice', False),
                 is_simplified == infos.get('simplified', False),
                 info_services_or_goods in ("both", services_or_goods),

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -194,6 +194,16 @@ class AccountMove(models.Model):
             if rc_refund:
                 document_total = -abs(document_total)
 
+        # For each line, if it follows a downpayment / downpayments, an entry is added
+        # to the dictionary containing the names of the downpayment invoices
+        downpayment_dict = {}
+        if not document_type == 'TD02':
+            for line in self.invoice_line_ids.filtered(lambda line: not line.display_type):
+                if line.price_subtotal < 0:
+                    moves = line._get_downpayment_lines().move_id
+                    if moves:
+                        downpayment_dict.update({line.id: ', '.join([move.name for move in moves])})
+
         # Create file content.
         template_values = {
             'record': self,
@@ -219,6 +229,7 @@ class AccountMove(models.Model):
             'format_numbers_two': format_numbers_two,
             'format_phone': format_phone,
             'format_alphanumeric': format_alphanumeric,
+            'downpayment_dict': downpayment_dict,
             'discount_type': discount_type,
             'formato_trasmissione': formato_trasmissione,
             'document_type': document_type,

--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -97,3 +97,8 @@ class AccountMove(models.Model):
         # OVERRIDE
         self.ensure_one()
         return self.partner_shipping_id.id or super(AccountMove, self)._get_invoice_delivery_partner_id()
+
+    def _is_downpayment(self):
+        # OVERRIDE
+        self.ensure_one()
+        return self.line_ids.sale_line_ids and all(sale_line.is_downpayment for sale_line in self.line_ids.sale_line_ids) or False

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -232,3 +232,7 @@ class AccountMoveLine(models.Model):
         if currency_id and currency_id != order.currency_id:
             price_unit = currency_id._convert(price_unit, order.currency_id, order.company_id, order.date_order or fields.Date.today())
         return price_unit
+
+    def _get_downpayment_lines(self):
+        # OVERRIDE
+        return self.sale_line_ids.filtered('is_downpayment').invoice_lines.filtered(lambda line: line.move_id._is_downpayment())


### PR DESCRIPTION
### `_is_downpayment` method on account move
Currently there is no simple way of finding if an invoice is a downpayment.

Downpayments can be created from a sale order. An invoice is generated representing the downpayment. When the sale order is used to generate the complete invoice, the downpayment is deducted.

There is no fast way to distinguish a downpayment invoice. The only way of knowing is that the lines of the invoice will have sale_line_ids for which 'is_downpayment' (a boolean field on the sale order line) is true. 
_(although another way of telling that an invoice line is a downpayment is that, by default, the product 'Downpayment' is used for the invoice line representing the downpayment)_

This commit adds a helper method '_is_downpayment' to the account.move model, which will return False if sale is not installed, and True if sale is installed, and _is_downpayment is true of all the sale lines associated with all the lines of the invoice.

### TipoDocumento TD02 type (downpayment) in l10n_it_edi
The edi system does not properly represent the type when exporting downpayment invoices. The type (TipoDocumento) should be TD02, and instead it is TD04.

To fix this, a new key is added to the _l10n_it_document_type_mapping function that maps invoices for which _is_downpayment is true to the document type 'TD02'.

opw-2924728








