### PR TITLE
[FIX] website: add longer timeout to long website form test

### DIFF
--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -7,7 +7,7 @@ import odoo.tests
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteFormEditor(odoo.tests.HttpCase):
     def test_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin', timeout=120)
         self.start_tour('/', 'website_form_editor_tour_submit')
         self.start_tour('/', 'website_form_editor_tour_results', login="admin")
 


### PR DESCRIPTION
This test is quite long as it is testing all the website form behaviors
in edit mode.
It is sometime failing due to the tour taking longer than 60 seconds.

runbot-4257
