### PR TITLE
[IMP] hr_timesheet: Modify session info

### DIFF
--- a/addons/hr_timesheet/models/ir_http.py
+++ b/addons/hr_timesheet/models/ir_http.py
@@ -19,6 +19,7 @@ class Http(models.AbstractModel):
             for company in company_ids:
                 result["user_companies"]["allowed_companies"][company.id].update({
                     "timesheet_uom_id": company.timesheet_encode_uom_id.id,
+                    "is_timesheet_day_uom": not company._is_timesheet_hour_uom(),
                     "timesheet_uom_factor": company.project_time_mode_id._compute_quantity(
                         1.0,
                         company.timesheet_encode_uom_id,


### PR DESCRIPTION
After this commit, the session information related to each company in [user_companies][allowed_companies] contains a new bool field called is_timesheet_day_uom. it's True when Encoding uom is Days.

Task-2892346

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
