### PR TITLE
[MERGE] website: use new OWL components for page properties

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -4,7 +4,6 @@ import { registry } from '@web/core/registry';
 import { useService } from '@web/core/utils/hooks';
 import core from 'web.core';
 import { AceEditorAdapterComponent } from '../../components/ace_editor/ace_editor';
-import { PagePropertiesDialogWrapper } from '../../components/dialog/page_properties';
 import { WebsiteEditorComponent } from '../../components/editor/editor';
 import { WebsiteTranslator } from '../../components/translator/translator';
 import {OptimizeSEODialog} from '@website/components/dialog/seo';
@@ -307,7 +306,6 @@ WebsitePreview.components = {
     BlockIframe,
     WebsiteTranslator,
     AceEditorAdapterComponent,
-    PagePropertiesDialogWrapper,
 };
 
 registry.category('actions').add('website_preview', WebsitePreview);

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -34,7 +34,6 @@
             reloadIframe.bind="this.reloadIframe"
             removeWelcomeMessage.bind="this.removeWelcomeMessage"/>
         <AceEditorAdapterComponent t-if="websiteContext.showAceEditor"/>
-        <PagePropertiesDialogWrapper t-if="websiteContext.showPageProperties"/>
     </div>
 </t>
 

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -60,7 +60,7 @@
         <p>Are you sure you want to delete this page ?</p>
         <p class="text-warning">Don't forget to update all links referring to this page.</p>
         <PageDependencies pageId="props.pageId" mode="'collapse'"/>
-        <CheckBox onChange.bind="onConfirmCheckboxChange">
+        <CheckBox value="state.confirm" onChange.bind="onConfirmCheckboxChange">
             <p class="text-warning">I am sure about this.</p>
         </CheckBox>
 
@@ -73,6 +73,13 @@
             </button>
         </t>
     </WebsiteDialog>
+</t>
+
+<t t-name="website.PagePropertiesDialog" t-inherit="web.FormViewDialog" owl="1">
+    <xpath expr="//t[@t-set-slot='footer']" position="inside">
+        <button class="btn btn-link order-last ms-auto" t-on-click="clonePage"><i class="fa fa-fw fa-clone"/>Duplicate Page</button>
+        <button class="btn btn-link order-last" t-on-click="deletePage"><i class="fa fa-fw fa-trash"/>Delete Page</button>
+    </xpath>
 </t>
 
 </templates>

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -1,35 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
 
-<t t-name="website.FieldPageUrl" owl="1">
-    <div>
+<t t-name="website.PageUrlField" owl="1">
+    <t t-if="props.readonly">
+        <a class="o_form_uri o_text_overflow" t-att-href="props.value" t-esc="props.value || ''"/>
+    </t>
+    <t t-else="">
         <div class="d-flex">
-            <div class="input-group-text rounded-start text-lowercase border-0" t-esc="serverUrl.length > 30 ? serverUrl.slice(0,14) + '..' + serverUrl.slice(-14) : serverUrl"/>
-            <input t-model="state.url" type="text" class="o_input"/>
+            <div
+                class="input-group-text rounded-start text-lowercase border-0"
+                t-esc="serverUrl.length > 30 ? serverUrl.slice(0,14) + '..' + serverUrl.slice(-14) : serverUrl"
+            />
+            <input
+                class="o_input"
+                type="text"
+                t-att-placeholder="props.placeholder"
+                t-att-required="props.required"
+                t-att-id="props.id"
+                t-model="state.url"
+                t-ref="input"
+            />
         </div>
         <div t-if="enableRedirect">
             <div class="d-flex mt-4">
-                <Switch extraClasses="'me-auto'" label="'Redirect Old URL'" value="state.redirect_old_url" onChange="(value) => this.onChangeRedirectOldUrl(value)"/>
-                <PageDependencies pageId="resId" mode="'popover'"/>
+                <Switch
+                    extraClasses="'me-auto'"
+                    label="'Redirect Old URL'"
+                    value="state.redirect_old_url"
+                    onChange="(value) => this.onChangeRedirectOldUrl(value)"
+                />
+                <PageDependencies pageId="props.record.resId" mode="'popover'"/>
             </div>
             <div t-if="state.redirect_old_url" class="d-flex mt-4">
                 <label class="my-0 me-4 fw-bold" for="redirect_type">Type</label>
-                <select class="o_input w-50" id="redirect_type" t-model="state.redirect_type">
+                <select class="o_input w-50" id="redirect_type" t-model="state.redirect_type" t-on-change="updateValues">
                     <option value="301">301 Moved permanently</option>
                     <option value="302">302 Moved temporarily</option>
                 </select>
             </div>
         </div>
-    </div>
+    </t>
 </t>
 
-<t t-name="website.FieldPageName" owl="1">
-    <div>
-        <input t-model="state.name" type="text" class="o_input"/>
+<t t-name="website.PageNameField" owl="1">
+    <t t-if="props.readonly">
+        <span t-esc="formattedPageName"/>
+    </t>
+    <t t-else="">
+        <input
+            class="o_input"
+            type="text"
+            t-att-placeholder="props.placeholder"
+            t-att-required="props.required"
+            t-att-id="props.id"
+            t-model="state.name"
+            t-ref="input"
+        />
         <div t-if="warnAboutCall" class="mt-4">
-            <PageDependencies pageId="resId" mode="'popover'" type="'key'"/>
+            <PageDependencies pageId="props.record.resId" mode="'popover'" type="'key'"/>
         </div>
-    </div>
+    </t>
 </t>
 
 <t t-name="website.FieldFaPrefix" owl="1">

--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -6,6 +6,7 @@ import { registry } from "@web/core/registry";
 import { patch } from 'web.utils';
 import { EditMenuDialog } from '@website/components/dialog/edit_menu';
 import { OptimizeSEODialog } from '@website/components/dialog/seo';
+import {PagePropertiesDialog} from '@website/components/dialog/page_properties';
 
 const websiteSystrayRegistry = registry.category('website_systray');
 const { useState } = owl;
@@ -13,6 +14,7 @@ const { useState } = owl;
 patch(NavBar.prototype, 'website_navbar', {
     setup() {
         this._super();
+        this.orm = useService('orm');
         this.websiteService = useService('website');
         this.websiteContext = useState(this.websiteService.context);
 
@@ -41,8 +43,15 @@ patch(NavBar.prototype, 'website_navbar', {
                 isDisplayed: () => this.canShowAceEditor(),
             },
             'website.menu_page_properties': {
-                openWidget: () => this.websiteContext.showPageProperties = true,
+                Component: PagePropertiesDialog,
                 isDisplayed: () => this.canShowPageProperties(),
+                getProps: () => ({
+                    onRecordSaved: (record) => {
+                        return this.orm.read('website.page', [record.resId], ['url']).then(res => {
+                            this.websiteService.goToWebsite({websiteId: record.data.website_id[0], path: res[0]['url']});
+                        });
+                    },
+                })
             },
         };
     },

--- a/addons/website/static/src/js/website_page_list.js
+++ b/addons/website/static/src/js/website_page_list.js
@@ -4,7 +4,7 @@ import ListController from 'web.ListController';
 import viewRegistry from 'web.view_registry';
 import ListView from 'web.ListView';
 import {ComponentWrapper} from 'web.OwlCompatibility';
-import {PagePropertiesDialogWrapper} from '@website/components/dialog/page_properties';
+import {PagePropertiesDialogManager} from '@website/components/dialog/page_properties';
 import {qweb} from 'web.core';
 
 const WebsitePageListController = ListController.extend({
@@ -86,9 +86,10 @@ const WebsitePageListController = ListController.extend({
      * @private
      */
     async _addDialog(record, mode = '') {
-        this._pagePropertiesDialog = new ComponentWrapper(this, PagePropertiesDialogWrapper, {
-            currentPage: record.data.id,
+        this._pagePropertiesDialog = new ComponentWrapper(this, PagePropertiesDialogManager, {
+            resId: record.data.id,
             onClose: this._onCloseDialog.bind(this),
+            onRecordSaved: this.reload.bind(this),
             mode: mode,
         });
         await this._pagePropertiesDialog.mount(this.el);

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -46,7 +46,6 @@ export const websiteService = {
             isPublicRootReady: false,
             snippetsLoaded: false,
             isMobile: false,
-            showPageProperties: false,
         });
         const bus = new EventBus();
 

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -136,7 +136,7 @@
                     <notebook>
                         <page string="Name">
                             <group class="mt-4">
-                                <field name="name" string="Page Name" widget="page_name"/>
+                                <field name="name" string="Page Name" widget="page_name" placeholder="e.g. Home Page"/>
                             </group>
                             <group>
                                 <field name="website_id" invisible="1"/>


### PR DESCRIPTION
Follows the merge of the 'website in backend' task at [1] and the new
OWL views structure at [2].

See sub-commits for details.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b
[2]: https://github.com/odoo/odoo/commit/48ef812a635f70571b395f82ffdb2969ce99da9e

task-2687506