### PR TITLE
[FIX] {purchase_,}stock: decrease qty of PO line with multi-steps

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -688,3 +688,58 @@ class TestReorderingRule(TransactionCase):
         self.assertRecordValues(orderpoint, [
             {'qty_forecast': 0, 'qty_to_order': 0},
         ])
+
+    def test_decrease_qty_multi_step_receipt(self):
+        """
+        Two-steps receipt. An orderpoint generates a move from Input to Stock
+        with 5 x Product01 and a purchase order to fulfill the need of that SM.
+        Then, the user decreases the qty on the PO and confirms it. The existing
+        SM should be updated and another one should be created (from Vendors to
+        Input, for the PO)
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.reception_steps = 'two_steps'
+        input_location_id = warehouse.wh_input_stock_loc_id.id
+        stock_location_id = warehouse.lot_stock_id.id
+        customer_location_id = self.ref('stock.stock_location_customers')
+        supplier_location_id = self.ref('stock.stock_location_suppliers')
+
+        self.product_01.description = 'Super Note'
+
+        op = self.env['stock.warehouse.orderpoint'].create({
+            'name': self.product_01.name,
+            'location_id': stock_location_id,
+            'product_id': self.product_01.id,
+            'product_min_qty': 0,
+            'product_max_qty': 0,
+            'trigger': 'manual',
+        })
+
+        out_move = self.env['stock.move'].create({
+            'name': self.product_01.name,
+            'product_id': self.product_01.id,
+            'product_uom': self.product_01.uom_id.id,
+            'product_uom_qty': 5,
+            'location_id': stock_location_id,
+            'location_dest_id': customer_location_id,
+        })
+        out_move._action_confirm()
+
+        op.action_replenish()
+
+        moves = self.env['stock.move'].search([('id', '!=', out_move.id), ('product_id', '=', self.product_01.id)])
+        self.assertRecordValues(moves, [
+            {'location_id': input_location_id, 'location_dest_id': stock_location_id, 'product_uom_qty': 5}
+        ])
+
+        purchase = self.env['purchase.order'].search([('partner_id', '=', self.partner.id)], order="id desc", limit=1)
+        with Form(purchase) as form:
+            with form.order_line.edit(0) as line:
+                line.product_qty = 4
+        purchase.button_confirm()
+
+        moves = self.env['stock.move'].search([('id', '!=', out_move.id), ('product_id', '=', self.product_01.id)], order='id desc')
+        self.assertRecordValues(moves, [
+            {'location_id': supplier_location_id, 'location_dest_id': input_location_id, 'product_qty': 4},
+            {'location_id': input_location_id, 'location_dest_id': stock_location_id, 'product_qty': 4},
+        ])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -817,7 +817,7 @@ class StockMove(models.Model):
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
-        return []
+        return ['description_picking']
 
     def _clean_merged(self):
         """Cleanup hook used when merging moves"""
@@ -1266,7 +1266,10 @@ class StockMove(models.Model):
                             or (move.reservation_date and move.reservation_date <= fields.Date.today())))\
              ._action_assign()
         if new_push_moves:
-            new_push_moves._action_confirm()
+            neg_push_moves = new_push_moves.filtered(lambda sm: float_compare(sm.product_uom_qty, 0, precision_rounding=sm.product_uom.rounding) < 0)
+            (new_push_moves - neg_push_moves)._action_confirm()
+            # Negative moves do not have any picking, so we should try to merge it with their siblings
+            neg_push_moves._action_confirm(merge_into=neg_push_moves.move_orig_ids.move_dest_ids)
 
         return moves
 


### PR DESCRIPTION
2-steps receipt. A reordering rule created a picking from Input to Stock
and a purchase order to fulfill the need from Input. The user now
decreases the quantity of the purchase order and then confirms it: an
unexpected picking is created.

To reproduce the issue:
1. In Settings, enable "Multi-Step Routes"
2. Edit the warehouse:
    - Incoming Shipments: 2 steps
3. Create a product P:
    - Type: Storable
    - With a vendor
    - Routes: Buy
4. Add a reordering rule to P:
    - Min = Max = 0
5. Create and confirm a planned delivery order with 3 x P
6. Run the scheduler, it should create:
    - An internal transfer IT (Input -> Stock) with one stock move SM
    - A purchase order PO
7. Edit PO:
    - 2 x P (instead of 3)
8. Confirm PO
9. List all transfers related to P

Error: There is a transfer from Stock to Input with 1 x P. It should not
exist and its stock move should be merged with SM

As explained, when running the scheduler, a stock move from Input to
Stock is created. Let SM01 be that stock move.
When confirming the PO, two stock moves SM02 and SM03 are created, both
from Vendors to Input. The first one has a quantity equal to 5 and the
second one to -1. When confirming these stock moves, we apply the 'push
rules'
https://github.com/odoo/odoo/blob/0183298293192538a801f52262c047ea34a1b76a/addons/stock/models/stock_move.py#L1233
Since SM02 already has one `move_dest_ids` (i.e., SM01), we skip it.
However, we can apply a push rule on SM03. It creates an new stock move
SM04 with -1 x P from Input to Stock:
https://github.com/odoo/odoo/blob/7e8a038e3a08e32a9a32ac66ef0dc67800af95cb/addons/stock/models/stock_rule.py#L192-L196
And, as shown in the above code, we then define this new SM04 as a
`move_dest_ids` of SM03. So, at that point, here is the situation:
| Name | Qty | From    | To    | Dest |
|------|-----|---------|-------|------|
| SM01 | 5   | Input   | Stock | /    |
| SM02 | 5   | Vendors | Input | SM01 |
| SM03 | -1  | Vendors | Input | SM04 |
| SM04 | -1  | Input   | Stock | /    |

Back to the confirmation of SM2 and SM3, we eventually try to confirm
the moves created from push rules (i.e., SM04):
https://github.com/odoo/odoo/blob/0183298293192538a801f52262c047ea34a1b76a/addons/stock/models/stock_move.py#L1268-L1269
As shown, we don't define any `merge_into`. During the confirmation of
SM04, we try to assign it to a picking. However, because of its negative
qty, we skip it:
https://github.com/odoo/odoo/blob/0183298293192538a801f52262c047ea34a1b76a/addons/stock/models/stock_move.py#L1077-L1081
Then, still in the confirmation of SM04, we try to merge it with some
other SMs. Because there isn't any `merge_into`, we try to find some
candidates:
https://github.com/odoo/odoo/blob/0183298293192538a801f52262c047ea34a1b76a/addons/stock/models/stock_move.py#L839-L840
And because SM04 does not have any picking, we don't find any candidate:
https://github.com/odoo/odoo/blob/0183298293192538a801f52262c047ea34a1b76a/addons/stock/models/stock_move.py#L826-L828
As a result, we don't merge it and we will create the unexpected
picking.
=> In such situation (when confirming a negative push move), we should
suggest some candidates.

Last but not least: suppose the above issue as fixed and reproduce the
same steps, but this time the product P has a description. Again, when
confirming the PO, the same unexpected picking will be created.

When running the scheduler, SM01 is created and its field
`description_picking` is defined thanks to the description of P:
https://github.com/odoo/odoo/blob/f11d9c3ea08fc98e62459602d9bce004e83898db/addons/stock/models/product.py#L237-L243
However, when creating SM03, we use the name of the purchase line (i.e.,
the product's name) as description because, in our case, the product
does not have any `description_pickingin`:
https://github.com/odoo/odoo/blob/c18b2ce767dd5a5b4dbe766b849b56243dffb723/addons/purchase_stock/models/purchase.py#L523
And, as shown before, SM04 is partially a copy of SM03: it has the same
`description_picking`. As a result, SM01 and SM04 doesn't have the same
value for that field and we can not merge them.

OPW-2861605