### PR TITLE
[FIX] mrp: do not compute unit_factor for done moves

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -11,12 +11,16 @@ from odoo import api, SUPERUSER_ID
 
 def _pre_init_mrp(cr):
     """ Allow installing MRP in databases with large stock.move table (>1M records)
-        - Creating the computed+stored field stock_move.is_done is terribly slow with the ORM and
-          leads to "Out of Memory" crashes
+        - Creating the computed+stored field stock_move.is_done and
+          stock_move.unit_factor is terribly slow with the ORM and leads to "Out of
+          Memory" crashes
     """
     cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool;""")
     cr.execute("""UPDATE stock_move
                      SET is_done=COALESCE(state in ('done', 'cancel'), FALSE);""")
+    cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision;""")
+    cr.execute("""UPDATE stock_move
+                     SET unit_factor=1;""")
 
 def _create_warehouse_data(cr, registry):
     """ This hook is used to add a default manufacture_pull_id, manufacture


### PR DESCRIPTION
Installing mrp on a large database will take lots of time computing the
unit_factor of stock_moves created in stock. As this value is only
needed in mrp, this commit bypass the computation for done moves

Task: 2918852

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
