### PR TITLE
[FIX] base: fix qweb t-field with default value

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -1187,7 +1187,8 @@ class QWeb(object):
         code_options = self._compile_directive(el, options, 'options', indent) or [self._indent("t_field_t_options = {}", indent)]
         code.extend(code_options)
         code.append(self._indent(f"attrs, content, force_display = self._get_field({self._compile_expr(record, raise_on_missing=True)}, {repr(field_name)}, {repr(expression)}, {repr(tagName)}, t_field_t_options, compile_options, values)", indent))
-        code.append(self._indent("content = self._compile_to_str(content)", indent))
+        code.append(self._indent("if content is not None and content is not False:", indent))
+        code.append(self._indent("content = self._compile_to_str(content)", indent + 1))
         code.extend(self._compile_widget_value(el, options, indent))
         return code
 


### PR DESCRIPTION
Since 5913b7265ef5bd8a01a882fa0977bbd64321054d it was not possible
anymore to use default value with `t-field`, this commit restore the
previous behavior.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
