### PR TITLE
[FIX] sale_stock: invoice report lot_values

### DIFF
--- a/addons/sale_stock/views/report_invoice.xml
+++ b/addons/sale_stock/views/report_invoice.xml
@@ -2,10 +2,11 @@
 <odoo>
     <template id="sale_stock_report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//div[@id='total']" position="after">
+          <t groups="sale_stock.group_lot_on_invoice">
             <t t-set="lot_values" t-value="o._get_invoiced_lot_values()"/>
             <t t-if="lot_values">
                 <br/>
-                <table groups="sale_stock.group_lot_on_invoice" class="table table-sm" style="width: 50%;" name="invoice_snln_table">
+                <table class="table table-sm" style="width: 50%;" name="invoice_snln_table">
                     <thead>
                         <tr>
                             <th><span>Product</span></th>
@@ -27,6 +28,7 @@
                     </tbody>
                 </table>
             </t>
+          </t>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Before this change, the lots info of the products that are shown in the invoice report were always computed, no matter if they were printed or not.

### Current behavior before PR:

It is always computing the lots information, no matter if it will be printed or not

### Desired behavior after PR is merged:

The lot info only is computed when is actually used and will be printed: that is when the user has the sale_stock.group_lot_on_invoice group.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
