### PR TITLE
[FIX] many2many_tags_avatar_field:fix the select customer and try to …

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -11,7 +11,7 @@ export class Many2ManyTagsAvatarField extends Many2ManyTagsField {
             id: record.id, // datapoint_X
             text: record.data.display_name,
             img: `/web/image/${this.props.relation}/${record.resId}/avatar_128`,
-            onDelete: !this.props.readonly ? () => this.onDelete(record.resId) : undefined,
+            onDelete: !this.props.readonly ? () => this.deleteTag(record.id) : undefined,
         }));
     }
 }


### PR DESCRIPTION
…remove it

Before this commit, in sale(coupons & loyalty ) when we generate coupon and
'selected customers' option are select and try to remove select customer
at that time trackback error occupied.

After this commit, using deleteTag() fix this bug and when we try to remove
select customer and we have easily remove it.

task-2927335

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
