### PR TITLE
[FIX] website_slides_survey: prevent crash on survey deletion

### DIFF
--- a/addons/website_slides_survey/i18n/website_slides_survey.pot
+++ b/addons/website_slides_survey/i18n/website_slides_survey.pot
@@ -16,6 +16,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: website_slides_survey
+#: code:addons/website_slides_survey/models/survey_survey.py:0
+#, python-format
+msgid "- %s (Courses - %s)"
+msgstr ""
+
+#. module: website_slides_survey
 #: model_terms:ir.ui.view,arch_db:website_slides_survey.survey_survey_view_kanban
 msgid ""
 "<br/>\n"
@@ -383,8 +389,8 @@ msgstr ""
 #: code:addons/website_slides_survey/models/survey_survey.py:0
 #, python-format
 msgid ""
-"The Certification '%(certification_name)s' cannot be deleted because it is "
-"still being used by the Course(s) '%(courses_names)s'"
+"Any Survey listed below is currently used as a Course Certification and cannot be deleted:\n"
+"%s"
 msgstr ""
 
 #. module: website_slides_survey

--- a/addons/website_slides_survey/tests/test_course_certification_unlink.py
+++ b/addons/website_slides_survey/tests/test_course_certification_unlink.py
@@ -16,17 +16,26 @@ class TestSurvey(SlidesCase):
 
     @users('user_manager')
     def test_unlink(self):
-        self.certification = self.env['slide.slide'].create({
+        [certification, _dummy] = self.env['slide.slide'].create([{
             'name': 'Certification',
             'slide_type': 'certification',
             'channel_id': self.channel.id,
             'survey_id': self.survey.id,
-        })
+        }, {
+            'name': 'Second Certification',
+            'slide_type': 'certification',
+            'channel_id': self.channel.id,
+            'survey_id': self.survey2.id,
+        }])
 
-        with self.assertRaises(ValidationError, msg="The error is unexpected"):
-            self.survey.unlink()
+        with self.assertRaises(
+            ValidationError,
+            msg="Should raise when trying to unlink a survey linked to courses"
+        ):
+            (self.survey | self.survey2).unlink()
 
         self.assertTrue(self.survey.exists())
-        self.certification.survey_id = self.survey2
+        self.assertTrue(self.survey2.exists())
+        certification.survey_id = self.survey2
         self.survey.unlink()
         self.assertFalse(self.survey.exists())


### PR DESCRIPTION
Currently, when we delete a single certification that is linked to a course,
it gives a validation error, which is good. But when we try to delete multiple
certifications that are linked with courses, it throws an error.

This commit fixes the issue by properly handling multiple records in the
deletion check, and updates the ValidationError message accordingly.

taskID-2901629

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
