### PR TITLE
[FIX] project: fix not displayed default user in gantt view

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1810,7 +1810,7 @@ class Task(models.Model):
             if project.analytic_tag_ids:
                 vals['analytic_tag_ids'] = [Command.set(project.analytic_tag_ids.ids)]
         else:
-            vals['user_ids'] = [Command.link(self.env.user.id)]
+            vals['user_ids'] = self._context.get('default_user_ids', False) or [Command.link(self.env.user.id)]
 
         return vals
 


### PR DESCRIPTION
Before This Commit:when  we create a new task in project gantt view should not
assigned to the active user.

After This Commit: when we create a new task in project gantt view assign a
 default user.

Task-ID :  2920824
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
