### PR TITLE
[FIX] web: actionService: do not crash on unknown view type

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -851,8 +851,10 @@ function makeActionManager(env) {
                 const arch = viewDescriptions[type].arch;
                 const archDoc = domParser.parseFromString(arch, "text/xml").documentElement;
                 const jsClass = archDoc.getAttribute("js_class");
-                const key = viewRegistry.contains(jsClass) ? jsClass : type;
-                views.push(viewRegistry.get(key));
+                const view = viewRegistry.get(jsClass, false) || viewRegistry.get(type, false);
+                if (view) {
+                    views.push(view);
+                }
             }
         }
         // END LEGACY CODE COMPATIBILITY

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -938,7 +938,7 @@ QUnit.module("ActionManager", (hooks) => {
         "requests for execute_action of type object: disable buttons",
         async function (assert) {
             assert.expect(2);
-            let def;
+            let def = undefined;
             const mockRPC = async (route, args) => {
                 if (route === "/web/dataset/call_button") {
                     return Promise.resolve(false);
@@ -1398,6 +1398,26 @@ QUnit.module("ActionManager", (hooks) => {
             "get_views",
             "web_search_read",
         ]);
+    });
+
+    QUnit.test("execute action with unknown view type", async function (assert) {
+        serverData.views["partner,false,unknown"] = "<unknown/>";
+        serverData.actions[33] = {
+            id: 33,
+            name: "Partners",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [
+                [false, "list"],
+                [false, "unknown"], // typically, an enterprise-only view on a community db
+                [false, "kanban"],
+                [false, "form"],
+            ],
+        };
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 33);
+        assert.containsOnce(target, ".o_list_view");
+        assert.containsN(target, ".o_cp_switch_buttons button", 2);
     });
 
     QUnit.test("flags field of ir.actions.act_window is used", async function (assert) {


### PR DESCRIPTION
In community, some actions contain view types that only exist in
enterprise (e.g. in MRP, Work Orders, there's a gantt view). Before
this commit, it crashed because the view doesn't exist. This commit
simply ignores those unknown views.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
