### PR TITLE
[FIX] web: fix image field preview not updating when uploading an image

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -51,7 +51,7 @@ export class ImageField extends Component {
 
     getUrl(previewFieldName) {
         if (this.state.isValid && this.props.value) {
-            if (previewFieldName !== this.props.name || isBinarySize(this.props.value)) {
+            if (isBinarySize(this.props.value)) {
                 return url("/web/image", {
                     model: this.props.record.resModel,
                     id: this.props.record.resId,


### PR DESCRIPTION
Previously, when editing an image field and choosing a new image, the
image preview would update itself to show the selected image. With the
conversion of the image field, this behaviour was lost. This commit
restores that behaviour.