### PR TITLE
[FIX] website: not record header animation in editor history

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -81,6 +81,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
      * @private
      */
     _adaptToHeaderChange: function () {
+        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerUnactive();
         this._updateMainPaddingTop();
         // Take menu into account when `dom.scrollTo()` is used whenever it is
         // visible - be it floating, fully displayed or partially hidden.
@@ -89,6 +90,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
         for (const callback of extraMenuUpdateCallbacks) {
             callback();
         }
+        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerActive();
     },
     /**
      * @private


### PR DESCRIPTION
Before this commit when the header scroll effect was happening, the
related DOM updates were recorded in the editor's history.

This commit deactivates the history during the updates of the header.

Steps to reproduce:
- Drop a "Text" block in the page.
- Drop 4 "Banner" blocks below the "Text" block to make the page
scrollable.
- Save.
- Edit page.
- DO NOT SCROLL until the last step.
- Select the Text block.
- Delete the Text block.
- Click undo => Text block reappears as expected.
- Click redo => Text block disappears as expected.
- Click undo.
- Scroll down until header vanishes and reappears.
=> Redo step is lost, undo tries to undo the header animation.

task-2930568

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
