### PR TITLE
[FIX] website_event_track: remove unused locations in agenda

### DIFF
--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
+from collections import defaultdict
 from datetime import timedelta
 from pytz import timezone, utc
 from werkzeug.exceptions import Forbidden, NotFound
@@ -251,15 +252,21 @@ class EventTrackController(http.Controller):
 
         # count the number of tracks by days
         tracks_by_days = dict.fromkeys(days, 0)
+        locations_by_days = defaultdict(list)
         for track in tracks_sudo:
             track_day = fields.Datetime.from_string(track.date).replace(tzinfo=pytz.utc).astimezone(local_tz).date()
             tracks_by_days[track_day] += 1
+            if track.location_id not in locations_by_days[track_day]:
+                locations_by_days[track_day].append(track.location_id)
+
+        for locations in locations_by_days.values():
+            locations.sort(key=lambda location: location.id if location else 0)
 
         return {
             'days': days,
             'tracks_by_days': tracks_by_days,
+            'locations_by_days': locations_by_days,
             'time_slots': global_time_slots_by_day,
-            'locations': locations
         }
 
     def _get_locale_time(self, dt_time, lang_code):

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -89,6 +89,7 @@
         </div>
         <hr class="mt-2 pb-1 mb-1"/>
 
+        <t t-set="locations" t-value="locations_by_days[day]"/>
         <!-- Day Agenda -->
         <div class="o_we_online_agenda">
         <table id="table_search" class="table table-sm border-0 h-100">


### PR DESCRIPTION
This commit adapts the agenda template to avoid displaying a complete column
for a location if that location is unused for this specific day.

This allows having multiple different locations for your different event days
without cluttering the display by showing empty columns for unused locations.

Task-2942630
