### PR TITLE
[FIX] web: apply correctly the css to the boolean fields in the settings

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -746,6 +746,8 @@ $o-form-label-margin-right: 0px;
     // Boolean
     .o_field_boolean {
         margin-right: $o-form-spacing-unit;
+        max-width: 40px !important;
+        padding-right: 0 !important;
     }
 
     // Timezone widget warning


### PR DESCRIPTION
Since 4f984568e139d8da448018af12ef79005e317cf6, the css theme is not
correctly applied to the boolean fields in the settings, allows them to
take a big width.

Now, the max width is fixed. Note that, this was already the case on the
legacy views
