### PR TITLE
[IMP] web: configure prefer-const eslint rule to be more lax

### DIFF
--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -21,7 +21,10 @@
     "valid-typeof": ["error"],
     "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all", "caughtErrorsIgnorePattern": "^_" }],
     "curly": ["error", "all"],
-    "prefer-const": ["error"]
+    "prefer-const": ["error", {
+      "destructuring": "all",
+      "ignoreReadBeforeAssign": true
+    }]
   },
   "globals": {
     "owl": "readonly",


### PR DESCRIPTION
We recently added the prefer-const eslint rule, but the default
configuration of this rule disallows some things that we often do and
which we do not think are bad practice such as declaring a variable with
let so that it's available to a function defined below, but assign it
only once later, we also sometimes destructure variables with let where
some of the variables could be const but not all, in those cases we
accept that some variables will be mutable even though it's not strictly
necessary in favour of conciseness.