### PR TITLE
[FIX] web: legacy form view dialog opened with res_id and view_id

### DIFF
--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -77,7 +77,9 @@ export class FormViewDialog extends Component {
                 this.state.error = e.cause;
                 const adapterParent = standaloneAdapter({ Component });
                 const dialog = new LegacyFormViewDialog(adapterParent, {
+                    res_id: this.props.resId,
                     res_model: this.props.resModel,
+                    view_id: this.props.viewId,
                     context: this.props.context || {},
                     title: this.props.title,
                     disable_multiple_selection: true,


### PR DESCRIPTION
Open a record in a many2one.
Make the form view to take a js_class that is an extend of the legacy form view

Before this commit, the resId of the record and the view id were not transmitted to the legacy form view dialog.

After this commit, they are.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
