### PR TITLE
[FIX] website_sale: Some translation bugs

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1327,6 +1327,12 @@ msgid "Extra Variant Media"
 msgstr ""
 
 #. module: website_sale
+#: code:addons/website_sale/models/website.py:0
+#, python-format
+msgid "Featured"
+msgstr ""
+
+#. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
 msgid "FedEx"
 msgstr ""
@@ -1692,6 +1698,12 @@ msgid "Name"
 msgstr ""
 
 #. module: website_sale
+#: code:addons/website_sale/models/website.py:0
+#, python-format
+msgid "Name (A-Z)"
+msgstr ""
+
+#. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_sale_order_line__name_short
 msgid "Name Short"
 msgstr ""
@@ -1707,6 +1719,12 @@ msgstr ""
 #. module: website_sale
 #: model:product.ribbon,html:website_sale.new_ribbon
 msgid "New!"
+msgstr ""
+
+#. module: website_sale
+#: code:addons/website_sale/models/website.py:0
+#, python-format
+msgid "Newest Arrivals"
 msgstr ""
 
 #. module: website_sale
@@ -2097,6 +2115,18 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_sale.cart_summary
 #: model_terms:ir.ui.view,arch_db:website_sale.product_searchbar_input_snippet_options
 msgid "Price"
+msgstr ""
+
+#. module: website_sale
+#: code:addons/website_sale/models/website.py:0
+#, python-format
+msgid "Price - High to Low"
+msgstr ""
+
+#. module: website_sale
+#: code:addons/website_sale/models/website.py:0
+#, python-format
+msgid "Price - Low to High"
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -51,11 +51,11 @@ class Website(models.Model):
     @staticmethod
     def _get_product_sort_mapping():
         return [
-            ('website_sequence asc', 'Featured'),
-            ('create_date desc', 'Newest Arrivals'),
-            ('name asc', 'Name (A-Z)'),
-            ('list_price asc', 'Price - Low to High'),
-            ('list_price desc', 'Price - High to Low'),
+            ('website_sequence asc', _('Featured')),
+            ('create_date desc', _('Newest Arrivals')),
+            ('name asc', _('Name (A-Z)')),
+            ('list_price asc', _('Price - Low to High')),
+            ('list_price desc', _('Price - High to Low')),
         ]
     shop_default_sort = fields.Selection(selection='_get_product_sort_mapping', default='website_sequence asc', required=True)
 


### PR DESCRIPTION
Issue: When using other languages, some expressions aren't translated.

Solution: Add the untranslated words in the .pot file of the module website_sale, which will
be translated later in [transifex](https://www.transifex.com) or directly in the customer database.

opw-2938969

Signed-off-by: Eteil Djoumatchoua (etdj) <etdj@odoo.com>
