### PR TITLE
[FIX] sale_timesheet : wrong currency logo on project

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -387,14 +387,14 @@ class Project(models.Model):
                 margin_color = profitability['margin'] > 0 and 'green' or 'red'
             data += [{
                 'name': _("Revenues"),
-                'value': format_amount(self.env, profitability['revenues'], self.env.company.currency_id)
+                'value': format_amount(self.env, profitability['revenues'], self.company_id.currency_id)
             }, {
                 'name': _("Costs"),
-                'value': format_amount(self.env, profitability['costs'], self.env.company.currency_id)
+                'value': format_amount(self.env, profitability['costs'], self.company_id.currency_id)
             }, {
                 'name': _("Margin"),
                 'color': margin_color,
-                'value': format_amount(self.env, profitability['margin'], self.env.company.currency_id)
+                'value': format_amount(self.env, profitability['margin'], self.company_id.currency_id)
             }]
         return {
             'action': self.allow_billable and self.allow_timesheets and "action_view_timesheet",


### PR DESCRIPTION
Steps to reproduce:

  1.Install sale_timesheet
  2.Create a second company with another currency
  3.Switch to second company but keep both selected
  4.Assign an employee to the second company and define its timesheet cost
  5.Create a new project, with a new task and log a new timesheet time for the employee of step 4
  6.Go back to the kanban view and click on "On track"
  7.Switch to the first company while keeping both selected.

Issue:

  Wrong currency logo

Cause:

  The value is computed with the currency of the project but displayed with the currency of the company.

opw-2917438
