### PR TITLE
[FIX] web: sort on grouped list

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -2208,8 +2208,11 @@ export class DynamicGroupList extends DynamicList {
     // ------------------------------------------------------------------------
 
     async _loadGroups() {
-        const orderby = orderByToString(this.orderBy);
         const firstGroupByName = this.firstGroupBy.split(":")[0];
+        const _orderBy = this.orderBy.filter(
+            (o) => o.name === firstGroupByName || this.fields[o.name].group_operator !== undefined
+        );
+        const orderby = orderByToString(_orderBy);
         const { groups, length } = await this.model.orm.webReadGroup(
             this.resModel,
             this.domain,

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -2758,6 +2758,72 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test(
+        "groups can not be sorted on a different field than the first field of the groupBy - 1",
+        async function (assert) {
+            assert.expect(1);
+
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: '<tree default_order="foo"><field name="foo"/><field name="bar"/></tree>',
+                mockRPC(route, args) {
+                    if (args.method === "web_read_group") {
+                        assert.strictEqual(args.kwargs.orderby, "", "should not have an orderBy");
+                    }
+                },
+                groupBy: ["bar"],
+            });
+        }
+    );
+
+    QUnit.test(
+        "groups can not be sorted on a different field than the first field of the groupBy - 2",
+        async function (assert) {
+            assert.expect(1);
+
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: '<tree default_order="foo"><field name="foo"/><field name="bar"/></tree>',
+                mockRPC(route, args) {
+                    if (args.method === "web_read_group") {
+                        assert.strictEqual(args.kwargs.orderby, "", "should not have an orderBy");
+                    }
+                },
+                groupBy: ["bar", "foo"],
+            });
+        }
+    );
+
+    QUnit.test("groups can be sorted on the first field of the groupBy", async function (assert) {
+        assert.expect(3);
+
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree default_order="bar desc"><field name="foo"/><field name="bar"/></tree>',
+            mockRPC(route, args) {
+                if (args.method === "web_read_group") {
+                    assert.strictEqual(args.kwargs.orderby, "bar DESC", "should have an orderBy");
+                }
+            },
+            groupBy: ["bar"],
+        });
+
+        assert.strictEqual(
+            document.querySelector(".o_group_header:first-child").textContent.trim(),
+            "Yes (3)"
+        );
+        assert.strictEqual(
+            document.querySelector(".o_group_header:last-child").textContent.trim(),
+            "No (1)"
+        );
+    });
+
     QUnit.test("groups can be sorted on aggregates", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
Since 48ef812a635f70571b395f82ffdb2969ce99da9e, a warning was raised
(python side) when a grouped list is sorted by anything different from
an aggregate or the first field of the group.

Now, only the first field of the group or an aggregate fields can be
used to sort a grouped list.