### PR TITLE
[IMP] web: add spreadsheet modules to web tooling

### DIFF
--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -74,3 +74,22 @@ web_map/static/tests/legacy/**/*
 # whitelist purchase setup
 !addons/purchase
 !addons/purchase/**/*
+
+# Whitelist documents_spreadsheet
+!documents_spreadsheet
+!documents_spreadsheet/**/*
+
+# Whitelist spreadsheet
+!spreadsheet
+!spreadsheet/**/*
+
+# blacklist o-spreadsheet lib
+spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
+
+# Whitelist spreadsheet_edition
+!spreadsheet_edition
+!spreadsheet_edition/**/*
+
+# Whitelist spreadsheet_account
+!spreadsheet_account
+!spreadsheet_account/**/*

--- a/addons/web/tooling/_prettierignore
+++ b/addons/web/tooling/_prettierignore
@@ -74,3 +74,22 @@ web_map/static/tests/legacy/**/*
 # whitelist purchase
 !addons/purchase
 !addons/purchase/**/*
+
+# Whitelist documents_spreadsheet
+!documents_spreadsheet
+!documents_spreadsheet/**/*
+
+# Whitelist spreadsheet
+!spreadsheet
+!spreadsheet/**/*
+
+# blacklist o-spreadsheet lib
+spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
+
+# Whitelist spreadsheet_edition
+!spreadsheet_edition
+!spreadsheet_edition/**/*
+
+# Whitelist spreadsheet_account
+!spreadsheet_account
+!spreadsheet_account/**/*


### PR DESCRIPTION
Enable automatic linting and formatting for spreadsheet modules.

`o_spreadsheet.js` lib file should not be checked since the file comes from
an external library (`o-spreadsheet`)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
