### PR TITLE
[FIX] web: update and keep view props after switching/restoring

### DIFF
--- a/addons/web/static/src/legacy/backend_utils.js
+++ b/addons/web/static/src/legacy/backend_utils.js
@@ -220,6 +220,10 @@ export function getGlobalState(legacyControllerState) {
 
 export function getLocalState(legacyControllerState) {
     const state = Object.assign({}, legacyControllerState);
+    if ("currentId" in state) {
+        state.resId = state.currentId;
+        delete state.currentId;
+    }
     delete state.searchModel;
     delete state.searchPanel;
     delete state.resIds;

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -5,17 +5,17 @@ import { makeContext } from "@web/core/context";
 import { useDebugCategory } from "@web/core/debug/debug_context";
 import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
-import { useService, useBus } from "@web/core/utils/hooks";
+import { SIZES } from "@web/core/ui/ui_service";
+import { useBus, useService } from "@web/core/utils/hooks";
 import { createElement } from "@web/core/utils/xml";
 import { ActionMenus } from "@web/search/action_menus/action_menus";
 import { Layout } from "@web/search/layout";
 import { usePager } from "@web/search/pager_hook";
 import { useModel } from "@web/views/model";
 import { standardViewProps } from "@web/views/standard_view_props";
-import { useSetupView } from "@web/views/view_hook";
 import { isX2Many } from "@web/views/utils";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
-import { SIZES } from "@web/core/ui/ui_service";
+import { useSetupView } from "@web/views/view_hook";
 
 const { Component, onWillStart, useEffect, useRef, onRendered, useState, toRaw } = owl;
 
@@ -99,19 +99,14 @@ export class FormController extends Component {
 
         this.archInfo = this.props.archInfo;
         const activeFields = this.archInfo.activeFields;
-        let resId;
-        if ("resId" in this.props) {
-            resId = this.props.resId; // could be false, for "create" mode
-        } else {
-            resId = this.props.state ? this.props.state.resId : false;
-        }
+
         this.beforeLoadResolver = null;
         const beforeLoadProm = new Promise((r) => {
             this.beforeLoadResolver = r;
         });
         this.model = useModel(this.props.Model, {
             resModel: this.props.resModel,
-            resId,
+            resId: this.props.resId || false,
             resIds: this.props.resIds,
             fields: this.props.fields,
             activeFields,

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1383,10 +1383,13 @@ function makeActionManager(env) {
         }
         const controller = controllerStack[index];
         if (controller.action.type === "ir.actions.act_window") {
-            Object.assign(
-                controller,
-                _getViewInfo(controller.view, controller.action, controller.views)
-            );
+            const { action, exportedState, view, views } = controller;
+            const props = { ...controller.props };
+            if (exportedState && "resId" in exportedState) {
+                // When restoring, we want to use the last exported ID of the controller
+                props.resId = exportedState.resId;
+            }
+            Object.assign(controller, _getViewInfo(view, action, views, props));
         }
         await clearUncommittedChanges(env);
         return _updateUI(controller, { index });


### PR DESCRIPTION
There were 2 problems before this PR:

1. When switching view and coming back from the breadcrumbs: the
previous view props (such as the pager props) were lost;

2. When paging to the next record, switching view and coming back from
the breadcrumb, the view was reverted to the first selected record,
effectively ignoring the paging step.

This PR fixes both of these issues by keeping the controller's
props during a "restore" action, and by also updating the current
controller's props when using the pager.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
