### PR TITLE
[FIX] hr_contract: remove create button for contract history

### DIFF
--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -168,7 +168,7 @@
         <field name="name">hr.contract.history.view.kanban</field>
         <field name="model">hr.contract.history</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_small_column" default_order="date_end" sample="1">
+            <kanban class="o_kanban_small_column" default_order="date_end" sample="1" create="false">
                 <field name="employee_id"/>
                 <field name="activity_state"/>
                 <field name="state"/>


### PR DESCRIPTION
Steps to reproduce:
- install hr and hr_contract apps
- go to Employees app > Employees > Contracts
- switch to Kanban view

There you can see a 'Create' button. If you click it, it creates a
contract history form view for the default employee, which is 'False'.

This view is not needed, since it doesn't make sense to create a contract
history by itself, as opposed to creating a contract history when a new
employee is added to the database.

This commit removes the contract history 'Create' button.

opw-2929424
