### PR TITLE
[IMP] core: allow some users to bypass the sanitize of HTML field

### DIFF
--- a/addons/sale_quotation_builder/models/sale_order.py
+++ b/addons/sale_quotation_builder/models/sale_order.py
@@ -12,6 +12,7 @@ class SaleOrder(models.Model):
         string="Website Description",
         compute='_compute_website_description',
         store=True, readonly=False, precompute=True,
+        sanitize_overridable=True,
         sanitize_attributes=False, translate=html_translate, sanitize_form=False)
 
     @api.depends('partner_id', 'sale_order_template_id')

--- a/addons/sale_quotation_builder/models/sale_order_option.py
+++ b/addons/sale_quotation_builder/models/sale_order_option.py
@@ -12,6 +12,7 @@ class SaleOrderOption(models.Model):
         string="Website Description",
         compute='_compute_website_description',
         store=True, readonly=False, precompute=True,
+        sanitize_overridable=True,
         sanitize_attributes=False, translate=html_translate)
 
     @api.depends('product_id')

--- a/addons/sale_quotation_builder/models/sale_order_template.py
+++ b/addons/sale_quotation_builder/models/sale_order_template.py
@@ -11,6 +11,7 @@ class SaleOrderTemplate(models.Model):
     website_description = fields.Html(
         string="Website Description",
         translate=html_translate,
+        sanitize_overridable=True,
         sanitize_attributes=False,
         sanitize_form=False)
 

--- a/addons/sale_quotation_builder/models/sale_order_template_line.py
+++ b/addons/sale_quotation_builder/models/sale_order_template_line.py
@@ -15,6 +15,7 @@ class SaleOrderTemplateLine(models.Model):
         compute='_compute_website_description',
         store=True, readonly=False,
         translate=html_translate,
+        sanitize_overridable=True,
         sanitize_form=False)
 
     @api.depends('product_id')

--- a/addons/sale_quotation_builder/models/sale_order_template_option.py
+++ b/addons/sale_quotation_builder/models/sale_order_template_option.py
@@ -13,6 +13,7 @@ class SaleOrderTemplateOption(models.Model):
         compute='_compute_website_description',
         store=True, readonly=False,
         translate=html_translate,
+        sanitize_overridable=True,
         sanitize_attributes=False)
 
     @api.depends('product_id')

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -380,7 +380,7 @@ class HTML(models.AbstractModel):
         attrs = super().attributes(record, field_name, options, values)
         if options.get('inherit_branding'):
             field = record._fields[field_name]
-            if field.sanitize:
+            if field.sanitize and not (field.sanitize_overridable and record.user_has_groups('base.group_sanitize_override')):
                 attrs['data-oe-sanitize'] = 1 if field.sanitize_form else 'allow_form'
         return attrs
 

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -29,6 +29,7 @@ from werkzeug import urls
 import odoo.modules
 
 from odoo import _, api, models, fields
+from odoo.exceptions import UserError
 from odoo.tools import ustr, posix_to_ldml, pycompat
 from odoo.tools import html_escape as escape
 from odoo.tools.misc import get_lang, babel_locale_parse
@@ -380,8 +381,21 @@ class HTML(models.AbstractModel):
         attrs = super().attributes(record, field_name, options, values)
         if options.get('inherit_branding'):
             field = record._fields[field_name]
-            if field.sanitize and not (field.sanitize_overridable and record.user_has_groups('base.group_sanitize_override')):
-                attrs['data-oe-sanitize'] = 1 if field.sanitize_form else 'allow_form'
+            if field.sanitize:
+                if field.sanitize_overridable and not record.user_has_groups('base.group_sanitize_override'):
+                    try:
+                        field.convert_to_column(record[field_name], record)
+                    except UserError:
+                        # The field contains element(s) that would be removed if
+                        # sanitized. It means that someone who was part of a
+                        # group allowing to bypass the sanitation saved that
+                        # field previously. Mark the field as not editable.
+                        attrs['data-oe-sanitize-prevent-edition'] = 1
+                if not (field.sanitize_overridable and record.user_has_groups('base.group_sanitize_override')):
+                    # Don't mark the field as 'sanitize' if the sanitize is
+                    # defined as overridable and the user has the right to do so
+                    attrs['data-oe-sanitize'] = 1 if field.sanitize_form else 'allow_form'
+
         return attrs
 
     @api.model

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -215,6 +215,10 @@ const Wysiwyg = Widget.extend({
             this._peerToPeerLoading.then(() => this.ptp.notifyAllClients('ptp_join'));
         }
 
+        this.$editable.on('click', '[data-oe-field][data-oe-sanitize-prevent-edition]', () => {
+            Dialog.alert(this, _t("Someone with escalated rights previously modified this area, you are therefore not able to modify it yourself."));
+        });
+
         this._observeOdooFieldChanges();
         this.$editable.on(
             'mousedown touchstart',

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -11,7 +11,7 @@
     <record id="group_website_designer" model="res.groups">
         <field name="name">Editor and Designer</field>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
-        <field name="implied_ids" eval="[(4, ref('group_website_publisher'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_website_publisher')), (4, ref('base.group_sanitize_override'))]"/>
         <field name="category_id" ref="base.module_category_website_website"/>
     </record>
 

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -33,7 +33,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
         this.action = useWowlService('action');
 
         this.oeStructureSelector = '#wrapwrap .oe_structure[data-oe-xpath][data-oe-id]';
-        this.oeFieldSelector = '#wrapwrap [data-oe-field]';
+        this.oeFieldSelector = '#wrapwrap [data-oe-field]:not([data-oe-sanitize-prevent-edition])';
         this.oeCoverSelector = '#wrapwrap .s_cover[data-res-model], #wrapwrap .o_record_cover_container[data-res-model]';
         if (this.props.savableSelector) {
             this.savableSelector = this.props.savableSelector;
@@ -144,6 +144,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             .not('img[data-oe-field="arch"], br[data-oe-field="arch"], input[data-oe-field="arch"]')
             .not('.oe_snippet_editor')
             .not('hr, br, input, textarea')
+            .not('[data-oe-sanitize-prevent-edition]')
             .add('.o_editable');
     }
     /**

--- a/addons/website_event_booth_sale_exhibitor/models/event_booth_registration.py
+++ b/addons/website_event_booth_sale_exhibitor/models/event_booth_registration.py
@@ -12,7 +12,7 @@ class EventBoothRegistration(models.Model):
     sponsor_mobile = fields.Char(string='Sponsor Mobile')
     sponsor_phone = fields.Char(string='Sponsor Phone')
     sponsor_subtitle = fields.Char(string='Sponsor Slogan')
-    sponsor_website_description = fields.Html(string='Sponsor Description')
+    sponsor_website_description = fields.Html(string='Sponsor Description', sanitize_overridable=True,)
     sponsor_image_512 = fields.Image(string='Sponsor Logo')
 
     def _get_fields_for_booth_confirmation(self):

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -42,6 +42,7 @@ class Sponsor(models.Model):
         string="Sponsor Type", default="sponsor")
     website_description = fields.Html(
         'Description', compute='_compute_website_description',
+        sanitize_overridable=True,
         sanitize_attributes=False, sanitize_form=True, translate=html_translate,
         readonly=False, store=True)
     # contact information

--- a/addons/website_hr_recruitment/models/hr_recruitment.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment.py
@@ -55,7 +55,11 @@ class Job(models.Model):
         return self.env['ir.qweb']._render("website_hr_recruitment.default_website_description", raise_if_not_found=False)
 
     website_published = fields.Boolean(help='Set if the application is published on the website of the company.')
-    website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, default=_get_default_website_description, prefetch=False, sanitize_form=False)
+    website_description = fields.Html(
+        'Website description', translate=html_translate,
+        default=_get_default_website_description, prefetch=False,
+        sanitize_overridable=True,
+        sanitize_attributes=False, sanitize_form=False)
 
     def _compute_website_url(self):
         super(Job, self)._compute_website_url()

--- a/addons/website_livechat/models/im_livechat.py
+++ b/addons/website_livechat/models/im_livechat.py
@@ -16,4 +16,8 @@ class ImLivechatChannel(models.Model):
         for channel in self:
             channel.website_url = "/livechat/channel/%s" % (slug(channel),)
 
-    website_description = fields.Html("Website description", default=False, help="Description of the channel displayed on the website page", sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html(
+        "Website description", default=False, translate=html_translate,
+        sanitize_overridable=True,
+        sanitize_attributes=False, sanitize_form=False,
+        help="Description of the channel displayed on the website page")

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -29,7 +29,7 @@ class ProductPublicCategory(models.Model):
     child_id = fields.One2many('product.public.category', 'parent_id', string='Children Categories')
     parents_and_self = fields.Many2many('product.public.category', compute='_compute_parents_and_self')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.", index=True, default=_default_sequence)
-    website_description = fields.Html('Category Description', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Category Description', sanitize_overridable=True, sanitize_attributes=False, translate=html_translate, sanitize_form=False)
     product_tmpl_ids = fields.Many2many('product.template', relation='product_public_category_product_template_rel')
 
     @api.constrains('parent_id')

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -20,7 +20,10 @@ class ProductTemplate(models.Model):
     _mail_post_access = 'read'
     _check_company_auto = True
 
-    website_description = fields.Html('Description for the website', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html(
+        'Description for the website', translate=html_translate,
+        sanitize_overridable=True,
+        sanitize_attributes=False, sanitize_form=False)
     alternative_product_ids = fields.Many2many(
         'product.template', 'product_alternative_rel', 'src_id', 'dest_id', check_company=True,
         string='Alternative Products', help='Suggest alternatives to your customer (upsell strategy). '

--- a/odoo/addons/base/security/base_groups.xml
+++ b/odoo/addons/base/security/base_groups.xml
@@ -12,9 +12,13 @@
             <field name="implied_ids" eval="[Command.link(ref('group_user'))]"/>
         </record>
 
+        <record id="group_sanitize_override" model="res.groups">
+            <field name="name">Bypass HTML Field Sanitize</field>
+        </record>
+
         <record model="res.groups" id="group_system">
             <field name="name">Settings</field>
-            <field name="implied_ids" eval="[Command.link(ref('group_erp_manager'))]"/>
+            <field name="implied_ids" eval="[Command.link(ref('group_erp_manager')), Command.link(ref('group_sanitize_override'))]"/>
             <field name="users" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"/>
         </record>
 

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -315,6 +315,7 @@ class MixedModel(models.Model):
     comment2 = fields.Html(sanitize_attributes=True, strip_classes=False)
     comment3 = fields.Html(sanitize_attributes=True, strip_classes=True)
     comment4 = fields.Html(sanitize_attributes=True, strip_style=True)
+    comment5 = fields.Html(sanitize_overridable=True, sanitize_attributes=False)
 
     currency_id = fields.Many2one('res.currency', default=lambda self: self.env.ref('base.EUR'))
     amount = fields.Monetary()


### PR DESCRIPTION
[IMP] core: allow some users to bypass the sanitize of HTML field
Add the possibility to flag a HTML field as `sanitize_overridable`.
The sanitizer will then be bypassed if the user doing the operation is
part of the new group `base.group_sanitize_override`.
The "Settings" users are part of that new group.

If such a user wrote some HTML that would have normally been removed by
the sanitizer, then users without the right to bypass the sanitizer
won't be able to write on that field anymore.
Otherwise, it would sanitize the previously written data.
Such cases are detected, and the modification prevented by the system,
which will warn the user about it.

For instance, with a `field.html(sanitize_overridable=True)`: one being
part of `group_sanitize_override` could write `<script></script>`.
Then, someone not part of the group trying to add an element inside that
field like appending a `<p/>` -> `<script></script><p>New Content</p>`
would not be able to because it would go through the sanitizer and
ultimately, removing part of the original value:
`<p>New Content</p>` (`<script></script>` would be removed).

== Real use case ==
In the website builder, there is 2 editor rights:
- group_website_publisher: restricted editor
- group_website_designer: editor & designer

The designer editor can edit pages and views, while the restricted
editor can't do anything unless he is part of other groups.
In edit mode, the restricted editor will only be able to edit fields of
record he has access to.
For instance, being a sales manager allows you to edit a product
description on the website.
Being an event manager -> edit event. Slide manager -> Slides etc.
As those restricted editor are able to edit those fields, they are
(almost) always sanitized to prevent them to introduce malicious code.

Since those fields are sanitized, even admins / designer editor are not
able to fully use the website builder in such fields.

Some clients don't really care about that sanitation, they'd prefer to
avoid it as they trust their manager and would prefer to have the full
builder capability instead.
This is typically the case in small project (butcher, hairdresser,
reseller etc) and in SMEs.

With the new `sanitize_overridable` feature, they will be able to do
that, as the "Designer & Editor" group now also receive the group
`base.group_sanitize_override` (done in next commit).