### PR TITLE
[FIX] website: make dynamic snippet compatible with visible on mobile

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -165,11 +165,17 @@ const DynamicSnippet = publicWidget.Widget.extend({
      */
     _render: function () {
         if (this.data.length > 0 || this.editableMode) {
-            this.$el.removeClass('d-none');
+            this.$el.removeClass('o_dynamic_empty');
             this._prepareContent();
         } else {
-            this.$el.addClass('d-none');
+            this.$el.addClass('o_dynamic_empty');
             this.renderedContent = '';
+        }
+        // TODO Remove in master: adapt already existing snippet from former version.
+        if (this.$el[0].classList.contains('d-none') && !this.$el[0].classList.contains('d-md-block')) {
+            // Remove the 'd-none' of the old template if it is not related to
+            // the visible on mobile option.
+            this.$el[0].classList.remove('d-none');
         }
         this._renderContent();
     },
@@ -208,7 +214,7 @@ const DynamicSnippet = publicWidget.Widget.extend({
      * @private
      */
     _toggleVisibility: function (visible) {
-        this.$el.toggleClass('d-none', !visible);
+        this.$el.toggleClass('o_dynamic_empty', !visible);
     },
 
     //------------------------------------- -------------------------------------

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
@@ -1,4 +1,7 @@
 .s_dynamic {
+    &.o_dynamic_empty {
+        display: none !important;
+    }
     [data-url] {
         cursor: pointer;
     }

--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -27,6 +27,12 @@ const dynamicSnippetOptions = options.Class.extend({
      */
     onBuilt: function () {
         this._setOptionsDefaultValues();
+        // TODO Remove in master: adapt dropped snippet template.
+        if (this.$target[0].classList.contains('d-none') && !this.$target[0].classList.contains('d-md-block')) {
+            // Remove the 'd-none' of the old template if it is not related to
+            // the visible on mobile option.
+            this.$target[0].classList.remove('d-none');
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="website.s_dynamic_snippet_template">
+        <!-- TODO In master, replace `d-none` by `o_dynamic_empty` -->
         <section t-attf-class="#{snippet_name} #{snippet_classes} s_dynamic d-none pt32 pb32">
             <div class="container o_not_editable">
                 <div class="css_non_editable_mode_hidden">


### PR DESCRIPTION
Both dynamic snippets and visible on mobile use the `d-none` class:
- dynamic snippets activate it by default and only remove it when the
content is ready to be displayed
- visible on mobile makes the section `d-none` when it must be hidden on
mobile and the class is contradicted by another class which is only
taken into account non-mobile

This commit introduces a dedicated class to temporarily hide the dynamic
snippets.

task-2930503
