### PR TITLE
[FIX] hr_recruitment_survey: start the survey linked to an application

### DIFF
--- a/addons/hr_recruitment_survey/__init__.py
+++ b/addons/hr_recruitment_survey/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import controllers
 from . import models

--- a/addons/hr_recruitment_survey/controllers/__init__.py
+++ b/addons/hr_recruitment_survey/controllers/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main

--- a/addons/hr_recruitment_survey/controllers/main.py
+++ b/addons/hr_recruitment_survey/controllers/main.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request
+from odoo.addons.survey.controllers.main import Survey
+
+
+class RecruitmentSurvey(Survey):
+
+    def _check_validity(self, survey_token, answer_token, ensure_token=True, check_partner=True):
+        check_partner = check_partner and not request.env.user.has_group('hr_recruitment.group_hr_recruitment_user')
+        return super(RecruitmentSurvey, self)._check_validity(survey_token, answer_token, ensure_token, check_partner)


### PR DESCRIPTION
The survey of a job application cannot be started

Steps to reproduce:
1. Install 'Hr Recruitment Interview Forms' module
2. Go to Recruitment and open the applications for the 'Experienced
   Developer' job position
3. Open any application and click on 'Start Interview'
4. You are redirected to the website (you should be redirected to the
   survey)

Solution:
Override the `_check_validity` function in hr_recruitment_survey to
allow hr officers to open the survey

Problem:
When trying to open the url of the survey, we check that the user
opening the survey is the same user of the survey answer
https://github.com/odoo/odoo/blob/5599995d80d1cefaa7ddcb91a201756acc8cbf02/addons/survey/controllers/main.py#L90-L92
This check will not pass when we try to open a survey through a job
application

opw-2936795