### PR TITLE
[FIX] core: missing _auto_init when tb is missing

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -555,6 +555,7 @@ class Registry(Mapping):
             # recreate missing tables
             for name in missing:
                 _logger.info("Recreate table of model %s.", name)
+                env[name]._auto_init()
                 env[name].init()
             env.flush_all()
             # check again, and log errors if tables are still missing


### PR DESCRIPTION
`_auto_init` and `init` should be called along-wise when creating the
table for a model in postgres.

opw-2936917