### PR TITLE
 [FIX] web: fix tooling not working in enterprise and autorefresh config

### DIFF
--- a/addons/web/tooling/hooks/pre-commit
+++ b/addons/web/tooling/hooks/pre-commit
@@ -1,18 +1,18 @@
 #!/bin/bash
 # run tooling only on branches that start with master to avoid linting noise in stable
 if [[ $(git branch --show-current) == master* ]]; then
-    if ! cmp -s -- addons/web/tooling/_package.json package.json; then
-        echo "Your package.json is out of date, reload the tooling using the reload script"
-        exit 1
-    fi
-    if
-        ! cmp -s -- addons/web/tooling/_eslintignore .eslintignore ||
-        ! cmp -s -- addons/web/tooling/_prettierignore .prettierignore ||
-        ! cmp -s -- addons/web/tooling/_eslintrc.json .eslintrc.json ||
-        ! cmp -s -- addons/web/tooling/_prettierrc.json .prettierrc.json
+    tooling_dir=$(cd -- "$(dirname "$0")" &> /dev/null && cd .. && pwd)
+    if ! cmp -s -- "$tooling_dir/_package.json" package.json; then
+        echo "Your package.json is out of date, reloading the tooling using the reload script"
+        "$tooling_dir/reload.sh"
+    elif
+        ! cmp -s -- "$tooling_dir/_eslintignore" .eslintignore ||
+        ! cmp -s -- "$tooling_dir/_prettierignore" .prettierignore ||
+        ! cmp -s -- "$tooling_dir/_eslintrc.json" .eslintrc.json ||
+        ! cmp -s -- "$tooling_dir/_prettierrc.json" .prettierrc.json
     then
-        echo "Some of your eslint/prettier config files are out of date, refresh them using the refresh script"
-        exit 1
+        echo "Some of your eslint/prettier config files are out of date, refreshing them using the refresh script"
+        "$tooling_dir/refresh.sh"
     fi
     npm run format-staged
 fi


### PR DESCRIPTION
Previously, the pre-commit hook was modified to disallow commiting when
the config files were not up to date, the paths that were checked for
changes assumed that the hook was executed in the community repo which
breaks in enterprise and disallows commiting completely instead.

This commit fixes that, and also reloads or refreshes the tooling
automatically when it is not up to date before running prettier and
eslint instead of aborting the commit and asking the user to do it by
hand.
