### PR TITLE
[FIX] website, web_editor: remove the SnippetsMenu after reloading, block clicks when the iframe is blocked, prompt 'discard your changes' dialog when switch lang

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1514,6 +1514,7 @@ var SnippetsMenu = Widget.extend({
         }
         core.bus.off('deactivate_snippet', this, this._onDeactivateSnippet);
         $(document.body).off('click', this._checkEditorToolbarVisibilityCallback);
+        this.el.ownerDocument.body.classList.remove('editor_has_snippets');
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -561,7 +561,7 @@ class Website(Home):
     # ------------------------------------------------------
 
     @http.route(['/website/add', '/website/add/<path:path>'], type='http', auth="user", website=True, methods=['POST'])
-    def pagenew(self, path="", add_menu=False, template=False, **kwargs):
+    def pagenew(self, path="", add_menu=False, template=False, redirect=False, **kwargs):
         # for supported mimetype, get correct default template
         _, ext = os.path.splitext(path)
         ext_special_case = ext and ext in _guess_mimetype() and ext != '.html'
@@ -575,9 +575,14 @@ class Website(Home):
         page = request.env['website'].new_page(path, add_menu=add_menu, **template)
         url = page['url']
 
-        if ext_special_case:  # redirect non html pages to backend to edit
-            return request.redirect('/web#id=' + str(page.get('view_id')) + '&view_type=form&model=ir.ui.view')
-        return request.redirect(request.env['website'].get_client_action_url(url, True))
+        if redirect:
+            if ext_special_case:  # redirect non html pages to backend to edit
+                return request.redirect('/web#id=' + str(page.get('view_id')) + '&view_type=form&model=ir.ui.view')
+            return request.redirect(request.env['website'].get_client_action_url(url, True))
+
+        if ext_special_case:
+            return json.dumps({'view_id': page.get('view_id')})
+        return json.dumps({'url': url})
 
     @http.route("/website/get_switchable_related_views", type="json", auth="user", website=True)
     def get_switchable_related_views(self, key):

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -9,7 +9,7 @@ import {svgToPNG} from 'website.utils';
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 
-const { Component, onMounted, reactive, useEnv, useRef, useState, useSubEnv, onWillStart } = owl;
+const { Component, onMounted, reactive, useEnv, useRef, useState, useSubEnv, onWillStart, useExternalListener } = owl;
 
 const ROUTES = {
     descriptionScreen: 2,
@@ -608,13 +608,13 @@ class Configurator extends Component {
         this.router = useService('router');
 
         // Using the back button must update the router state.
-        window.addEventListener("popstate", () => {
+        useExternalListener(window, "popstate", () => {
             const match = window.location.pathname.match(/\/website\/configurator\/(.*)$/);
             const step = parseInt(match && match[1], 10) || 1;
             // Do not use navigate because URL is already updated.
             this.state.currentStep = step;
         });
-        
+
         const initialStep = this.props.action.context.params && this.props.action.context.params.step;
         const store = reactive(new Store(), () => this.updateStorage(store));
 

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -268,9 +268,19 @@ export class WebsitePreview extends Component {
                 });
             } else if (classList.contains('js_change_lang') && isEditing) {
                 ev.preventDefault();
-                // The switch to the right language is handled by the
-                // Website Root, inside the iframe.
-                this.websiteService.leaveEditMode();
+                const lang = linkEl.dataset['url_code'];
+                // The "edit_translations" search param coming from keep_query
+                // is removed, and the hash is added.
+                const destinationUrl = new URL(href, window.location);
+                destinationUrl.searchParams.delete('edit_translations');
+                destinationUrl.hash = this.websiteService.contentWindow.location.hash;
+                const forceLangUrl = `/website/lang/${lang}?r=${destinationUrl.toString()}`;
+                this.websiteService.bus.trigger('LEAVE-EDIT-MODE', {
+                    onLeave: () => {
+                        this.websiteService.goToWebsite({ path: forceLangUrl });
+                    },
+                    reloadIframe: false,
+                });
             } else if (href && target !== '_blank' && !isEditing && this._isTopWindowURL(linkEl)) {
                 ev.preventDefault();
                 this.router.redirect(href);

--- a/addons/website/static/src/client_actions/website_preview/website_preview.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.scss
@@ -18,6 +18,10 @@
         margin-right: $o-we-sidebar-width !important;
     }
 
+    &.o_is_blocked {
+        pointer-events: none;
+    }
+
     .o_iframe_container {
         position: relative;
         height: 100%;
@@ -43,7 +47,7 @@
                     box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
                 }
 
-                .o_block_iframe {
+                .o_block_preview {
                     border-radius: 25px;
                 }
             }
@@ -65,6 +69,10 @@
             border-bottom: 0px;
         }
     }
+
+    .o_block_preview {
+        z-index: $zindex-modal-backdrop + 1 !important;
+    }
 }
 
 header {
@@ -73,6 +81,6 @@ header {
     }
 }
 
-.o_block_iframe {
-    z-index: $zindex-dropdown - 1;
+.o_block_preview {
+    z-index: $zindex-dropdown - 1 !important;
 }

--- a/addons/website/static/src/client_actions/website_preview/website_preview.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.scss
@@ -57,7 +57,7 @@
     }
 }
 
-.o_website_fullscreen, .editor_has_snippets {
+.o_website_fullscreen, .editor_has_snippets, .editor_has_dummy_snippets {
     header {
         .o_main_navbar {
             height: 0px;

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-<t t-name="website.BlockIframe" owl="1">
-    <t t-if="this.state.blockIframe">
-        <div class="o_block_iframe position-absolute d-flex justify-content-center align-items-center flex-column h-100 w-100" t-att-class="{ 'bg-black-50': this.state.showLoader }">
-            <t t-if="this.state.showLoader">
-                <div class="o_spinner mb-4">
-                    <img src="/web/static/img/spin.svg" alt="Loading..."/>
-                </div>
-            </t>
+<t t-name="website.BlockPreview" owl="1">
+    <div class="o_blockUI o_block_preview position-fixed d-flex justify-content-center align-items-center flex-column h-100 w-100 bg-black-50">
+        <div class="o_spinner mb-4">
+            <img src="/web/static/img/spin.svg" alt="Loading..."/>
         </div>
-    </t>
+    </div>
 </t>
+
 <t t-name="website.WebsitePreview" owl="1">
-    <div class="o_website_preview" t-att-class="{ 'editor_enable editor_has_snippets': this.websiteContext.snippetsLoaded }" t-ref="container">
+    <div class="o_website_preview" t-att-class="{ 'editor_enable editor_has_snippets': this.websiteContext.snippetsLoaded, 'o_is_blocked': this.blockedState.isBlocked }" t-ref="container">
+        <BlockPreview t-if="this.blockedState.showLoader"/>
         <div class="o_iframe_container" t-att-class="{ 'o_is_mobile': this.websiteContext.isMobile }">
-            <BlockIframe/>
             <iframe t-if="!testMode"
                 t-att-src="iframeFallbackUrl"
                 class="o_ignore_in_tour"

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -5,7 +5,7 @@ import { useService } from '@web/core/utils/hooks';
 import { WysiwygAdapterComponent } from '../wysiwyg_adapter/wysiwyg_adapter';
 import { useActiveElement } from '@web/core/ui/ui_service';
 
-const { markup, Component, useState, useChildSubEnv, useEffect, onWillStart, onMounted } = owl;
+const { markup, Component, useState, useChildSubEnv, useEffect, onWillStart, onMounted, onWillUnmount } = owl;
 
 export class WebsiteEditorComponent extends Component {
     /**
@@ -41,6 +41,12 @@ export class WebsiteEditorComponent extends Component {
             }
         });
 
+        onWillUnmount(() => {
+            if (this.onWillUnmount) {
+                this.onWillUnmount();
+            }
+        });
+
         useActiveElement('wysiwyg-adapter');
     }
     /**
@@ -61,7 +67,10 @@ export class WebsiteEditorComponent extends Component {
      */
     wysiwygReady() {
         this.websiteContext.snippetsLoaded = true;
-        this.state.reloading = false;
+        if (this.state.reloading) {
+            document.body.classList.remove('editor_has_dummy_snippets');
+            this.state.reloading = false;
+        }
         this.wysiwygOptions.invalidateSnippetCache = false;
         this.websiteService.unblockIframe();
         this.websiteService.hideLoader();
@@ -76,13 +85,10 @@ export class WebsiteEditorComponent extends Component {
     willReload(widgetEl) {
         this.websiteService.blockIframe();
         if (widgetEl) {
-            widgetEl.querySelectorAll('#oe_manipulators').forEach(el => el.remove());
-            widgetEl.querySelectorAll('we-input input').forEach(input => {
-                input.setAttribute('value', input.closest('we-input').dataset.selectStyle || '');
-            });
             this.loadingDummy = markup(widgetEl.innerHTML);
         }
         this.state.reloading = true;
+        document.body.classList.add('editor_has_dummy_snippets');
     }
     /**
      * Dismount the editor and reload the iframe.
@@ -106,12 +112,18 @@ export class WebsiteEditorComponent extends Component {
     }
     /**
      * Blocks the iframe and start the hiding transition.
-     *
+     * @param {Boolean} [reloadIframe=true]
+     * @param {Function} onLeave A callback that will be played after the
+     * transition, when the component is unmounted.
      * @returns {Promise<void>}
      */
-    async quit() {
-        this.websiteService.blockIframe(true, 400);
-        document.body.classList.remove('editor_has_snippets');
+    async quit({ reloadIframe = true, onLeave } = {}) {
+        this.onWillUnmount = onLeave;
+        if (reloadIframe) {
+            this.websiteService.blockIframe(true);
+            await this.props.reloadIframe();
+            this.websiteService.unblockIframe();
+        }
         this.websiteContext.snippetsLoaded = false;
         setTimeout(this.destroyAfterTransition.bind(this), 400);
     }
@@ -120,11 +132,9 @@ export class WebsiteEditorComponent extends Component {
      *
      * @returns {Promise<void>}
      */
-    async destroyAfterTransition() {
+    destroyAfterTransition() {
         this.state.showWysiwyg = false;
-        await this.props.reloadIframe();
         this.websiteContext.edition = false;
-        this.websiteService.unblockIframe();
     }
 }
 WebsiteEditorComponent.components = { WysiwygAdapterComponent };

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -25,7 +25,6 @@ export class WebsiteEditorComponent extends Component {
         useChildSubEnv(legacyEnv);
 
         onWillStart(async () => {
-            this.websiteService.blockIframe(false);
             this.Wysiwyg = await this.websiteService.loadWysiwyg();
         });
 
@@ -36,6 +35,7 @@ export class WebsiteEditorComponent extends Component {
         }, () => [this.websiteContext.isPublicRootReady]);
 
         onMounted(() => {
+            this.websiteService.blockPreview(false);
             if (this.websiteContext.isPublicRootReady) {
                 this.publicRootReady();
             }
@@ -56,7 +56,7 @@ export class WebsiteEditorComponent extends Component {
     publicRootReady() {
         if (this.websiteService.currentWebsite.metadata.translatable) {
             this.websiteContext.edition = false;
-            this.websiteService.unblockIframe();
+            this.websiteService.unblockPreview();
         } else {
             this.state.showWysiwyg = true;
         }
@@ -72,7 +72,7 @@ export class WebsiteEditorComponent extends Component {
             this.state.reloading = false;
         }
         this.wysiwygOptions.invalidateSnippetCache = false;
-        this.websiteService.unblockIframe();
+        this.websiteService.unblockPreview();
         this.websiteService.hideLoader();
     }
     /**
@@ -83,7 +83,7 @@ export class WebsiteEditorComponent extends Component {
      * @param widgetEl {HTMLElement} Widget element of the editor to copy.
      */
     willReload(widgetEl) {
-        this.websiteService.blockIframe();
+        this.websiteService.blockPreview();
         if (widgetEl) {
             this.loadingDummy = markup(widgetEl.innerHTML);
         }
@@ -120,9 +120,9 @@ export class WebsiteEditorComponent extends Component {
     async quit({ reloadIframe = true, onLeave } = {}) {
         this.onWillUnmount = onLeave;
         if (reloadIframe) {
-            this.websiteService.blockIframe(true);
+            this.websiteService.blockPreview();
             await this.props.reloadIframe();
-            this.websiteService.unblockIframe();
+            this.websiteService.unblockPreview();
         }
         this.websiteContext.snippetsLoaded = false;
         setTimeout(this.destroyAfterTransition.bind(this), 400);

--- a/addons/website/static/src/components/editor/editor.scss
+++ b/addons/website/static/src/components/editor/editor.scss
@@ -92,7 +92,7 @@
 
 .o_loading_dummy {
     position: absolute;
-    z-index: 100000;
+    z-index: $zindex-modal-backdrop;
 }
 
 .o_website_fullscreen {

--- a/addons/website/static/src/components/editor/editor.scss
+++ b/addons/website/static/src/components/editor/editor.scss
@@ -1,4 +1,4 @@
-.editor_has_snippets {
+.editor_has_snippets, .editor_has_dummy_snippets {
     .o_notification_manager {
         @include o-position-absolute($top: map-get($spacers, 2), $right: calc(#{$o-we-sidebar-width} + 0.5rem));
     }

--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -91,11 +91,9 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
     /**
      * @override
      */
-    async destroyAfterTransition() {
+    destroyAfterTransition() {
         this.state.showWysiwyg = false;
-        await this.props.reloadIframe();
         this.websiteContext.translation = false;
-        this.websiteService.unblockIframe();
     }
 
     get savableSelector() {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -1,17 +1,17 @@
 /** @odoo-module */
 
 import { ComponentAdapter } from 'web.OwlCompatibility';
-import { _t } from '@web/core/l10n/translation';
 
 import { useWowlService } from '@web/legacy/utils';
 import { useHotkey } from '@web/core/hotkeys/hotkey_hook';
 import { setEditableWindow } from 'web_editor.utils';
+import { useBus } from "@web/core/utils/hooks";
 
 import { EditMenuDialog, MenuDialog } from "../dialog/edit_menu";
 import { WebsiteDialog } from '../dialog/dialog';
 import { PageOption } from "./page_options";
 
-const { onWillStart, useEffect } = owl;
+const { onWillStart, useEffect, onWillUnmount } = owl;
 
 /**
  * This component adapts the Wysiwyg widget from @web_editor/wysiwyg.js.
@@ -31,6 +31,8 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
         this.orm = useWowlService('orm');
         this.dialogs = useWowlService('dialog');
         this.action = useWowlService('action');
+
+        useBus(this.websiteService.bus, 'LEAVE-EDIT-MODE', (ev) => this.leaveEditMode(ev.detail));
 
         this.oeStructureSelector = '#wrapwrap .oe_structure[data-oe-xpath][data-oe-id]';
         this.oeFieldSelector = '#wrapwrap [data-oe-field]:not([data-oe-sanitize-prevent-edition])';
@@ -98,6 +100,12 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             };
         }, () => []);
 
+        onWillUnmount(() => {
+            if (this.dummyWidgetEl) {
+                this.dummyWidgetEl.remove();
+                document.body.classList.remove('editor_has_dummy_snippets');
+            }
+        });
     }
     /**
      * @override
@@ -177,6 +185,38 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 lang: (this.websiteService.pageDocument.documentElement.getAttribute('lang') || 'en_US').replace('-', '_'),
             },
         );
+    }
+    leaveEditMode({ onLeave, forceLeave, onStay, reloadIframe = true } = {}) {
+        const leave = () => {
+            this.dummyWidgetEl = this._getDummmySnippetsEl();
+            this.widget.el.parentElement.appendChild(this.dummyWidgetEl);
+            document.body.classList.add('editor_has_dummy_snippets');
+            // The wysiwyg is destroyed to avoid listeners from the OdooEditor
+            // and the SnippetsMenu to be triggered when reloading the iframe.
+            this.widget.destroy();
+            this.props.quitCallback({ onLeave, reloadIframe });
+        };
+
+        if (!forceLeave && this._isDirty()) {
+            let leaving = false;
+            // The onStay/leave callbacks are not passed directly as
+            // primaryClick/secondaryClick props, so that closing the dialog
+            // with "esc" or the top right cross icon also executes onStay.
+            this.dialogs.add(WebsiteDialog, {
+                body: this.env._t("If you discard the current edits, all unsaved changes will be lost. You can cancel to return to edit mode."),
+                primaryClick: () => leaving = true,
+            }, {
+                onClose: () => {
+                    if (leaving) {
+                        leave();
+                    } else if (onStay) {
+                        onStay();
+                    }
+                }
+            });
+        } else {
+            leave();
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -277,7 +317,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
     _addEditorMessages() {
         const $wrap = this.$editable.find('.oe_structure.oe_empty, [data-oe-type="html"]');
         this.$editorMessageElement = $wrap.not('[data-editor-message]')
-                .attr('data-editor-message', _t('DRAG BUILDING BLOCKS HERE'));
+                .attr('data-editor-message', this.env._t('DRAG BUILDING BLOCKS HERE'));
         $wrap.filter(':empty').attr('contenteditable', false);
     }
     /**
@@ -559,10 +599,10 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
      * @private
      */
     async _onSaveRequest(event) {
-        let callback = () => this.props.quitCallback();
+        let callback = () => this.leaveEditMode({ forceLeave: true });
         if (event.data.reload || event.data.reloadEditor) {
             this.widget.trigger_up('disable_loading_effects');
-            this.props.willReload(this.widget.el);
+            this.props.willReload(this._getDummmySnippetsEl());
             callback = async () => {
                 if (event.data.onSuccess) {
                     await event.data.onSuccess();
@@ -581,8 +621,11 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             callback = () => window.location = `/web#action=website.website_preview&website_id=${websiteId}&path=${currentPath}&enable_editor=1`;
         } else if (event.data.action) {
             callback = () => {
-                this.websiteService.leaveEditMode();
-                this.action.doAction(event.data.action);
+                this.leaveEditMode({
+                    onLeave: () => this.action.doAction(event.data.action),
+                    forceLeave: true,
+                    reloadIframe: false,
+                });
             };
         }
         if (this._isDirty()) {
@@ -610,24 +653,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
      * @private
      */
     _onCancelRequest(event) {
-        if (this._isDirty()) {
-            let discarding = false;
-            this.dialogs.add(WebsiteDialog, {
-                body: _t("If you discard the current edits, all unsaved changes will be lost. You can cancel to return to edit mode."),
-                primaryClick: () => {
-                    discarding = true;
-                },
-            }, {
-                onClose: () => {
-                    if (discarding) {
-                        return this.props.quitCallback();
-                    }
-                    return event.data.onReject();
-                }
-            });
-        } else {
-            return this.props.quitCallback();
-        }
+        this.leaveEditMode({ onStay: event.data.onReject });
     }
     /**
      * Called when a snippet is about to be cloned in the page. Notifies the
@@ -760,6 +786,21 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
     async _onGetSwitchableRelatedViews(event) {
         const views = await this.switchableRelatedViews;
         event.data.onSuccess(views);
+    }
+    /**
+     * This method returns a visual skeleton of the snippets menu, by making a
+     * copy of the Wysiwyg element. This is used when reloading the iframe or
+     * leaving the edit mode, so that the widget can be destroyed under the
+     * hood (ideally, the Wysiwyg would remove its listeners on the document,
+     * so that they are not triggered during a reload).
+     */
+    _getDummmySnippetsEl() {
+        const dummySnippetsEl = this.widget.el.cloneNode(true);
+        dummySnippetsEl.querySelectorAll('#oe_manipulators, .d-none, .oe_snippet_body').forEach(el => el.remove());
+        dummySnippetsEl.querySelectorAll('we-input input').forEach(input => {
+            input.setAttribute('value', input.closest('we-input').dataset.selectStyle || '');
+        });
+        return dummySnippetsEl;
     }
 }
 WysiwygAdapterComponent.prototype.events = {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -100,6 +100,31 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             };
         }, () => []);
 
+        useEffect(() => {
+            // Back navigation is handled with an additional state in the
+            // history, used to capture the popstate event.
+            history.pushState(null, '');
+            let hasFakeState = true;
+            const leaveOnBackNavigation = () => {
+                hasFakeState = false;
+                this.leaveEditMode({
+                    onStay: () => {
+                        history.pushState(null, '');
+                        hasFakeState = true;
+                    },
+                    onLeave: () => history.back(),
+                    reloadIframe: false
+                });
+            };
+            window.addEventListener('popstate', leaveOnBackNavigation);
+            return () => {
+                window.removeEventListener('popstate', leaveOnBackNavigation);
+                if (hasFakeState) {
+                    history.back();
+                }
+            };
+        }, () => []);
+
         onWillUnmount(() => {
             if (this.dummyWidgetEl) {
                 this.dummyWidgetEl.remove();

--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -39,19 +39,6 @@ export const WebsiteRoot = publicRootData.PublicRoot.extend(KeyboardNavigationMi
      */
     start: function () {
         KeyboardNavigationMixin.start.call(this);
-        // Compatibility lang change ?
-        if (!this.$('.js_change_lang').length) {
-            var $links = this.$('.js_language_selector a:not([data-oe-id])');
-            var m = $(_.min($links, function (l) {
-                return $(l).attr('href').length;
-            })).attr('href');
-            $links.each(function () {
-                var $link = $(this);
-                var t = $link.attr('href');
-                var l = (t === m) ? "default" : t.split('/')[1];
-                $link.data('lang', l).addClass('js_change_lang');
-            });
-        }
 
         // Enable magnify on zommable img
         this.$('.zoomable img[data-zoom]').zoomOdoo();
@@ -178,7 +165,11 @@ export const WebsiteRoot = publicRootData.PublicRoot.extend(KeyboardNavigationMi
      */
     _onLangChangeClick: function (ev) {
         ev.preventDefault();
-
+        // In edit mode, the client action redirects the iframe to the correct
+        // location with the chosen language.
+        if (document.body.classList.contains('editor_enable')) {
+            return;
+        }
         var $target = $(ev.currentTarget);
         // retrieve the hash before the redirect
         var redirect = {

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -43,14 +43,14 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         this.__onSelectionChange = ev => {
             this._toggleAnimatedTextButton();
         };
-        this.ownerDocument.addEventListener('selectionchange', this.__onSelectionChange);
+        this.$body[0].addEventListener('selectionchange', this.__onSelectionChange);
     },
     /**
      * @override
      */
     destroy() {
         this._super(...arguments);
-        this.ownerDocument.removeEventListener('selectionchange', this.__onSelectionChange);
+        this.$body[0].removeEventListener('selectionchange', this.__onSelectionChange);
         this.$body[0].classList.remove('o_animated_text_highlighted');
     },
 

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -204,16 +204,6 @@ export const websiteService = {
             unblockIframe(processId) {
                 bus.trigger('UNBLOCK', { processId });
             },
-            leaveEditMode() {
-                // FIXME this does not care about if the page is dirty or not.
-
-                // TODO this should not be needed here, the one who was in
-                // charge of adding this class should be the one in charge of
-                // removing it.
-                document.body.classList.remove('editor_has_snippets');
-                context.snippetsLoaded = false;
-                context.edition = false;
-            },
             showLoader(props) {
                 bus.trigger('SHOW-WEBSITE-LOADER', props);
             },

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2187,7 +2187,7 @@
             <div class="container">
                 <div class="alert alert-info text-center d-lg-flex justify-content-between align-items-center">
                     <p class="m-lg-0 text-info">This page does not exist, but you can create it as you are editor of this site.</p>
-                    <a role="button" class="btn btn-info js_disable_on_click post_link" t-attf-href="/website/add/#{ path }#{ from_template and '?template=%s' % from_template }">Create Page</a>
+                    <a role="button" class="btn btn-info js_disable_on_click post_link" t-attf-href="/website/add/#{path}?redirect=1#{from_template and '&amp;template=%s' % from_template}">Create Page</a>
                 </div>
                 <div class="text-center text-muted p-3"><i class="fa fa-info-circle"></i> Edit the content below this line to adapt the default <strong>Page not found</strong> page.</div>
             </div>


### PR DESCRIPTION
[IMP] website: do not reload webclient when creating new pages

Before this commit, the /website/add was always redirecting the requests
to the newly created pages. This way, the controller could be called
from a frontend 404 page (when clicking on the "Create page" button),
and from the WebsitePreview client action's "new content" modal,
introduced in [1].

This commit adds a "redirect" parameter to the controller that will be
used by the 404 page, to keep the same behaviour for this use case. But
when called from the webclient, it will return either the id of the
created view (for *.js, *.xml, ... urls), or the new page url, so that
the webclient is not fully reloaded when it is not necessary.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: fix back/forth navigation from iframe to other routes

Before this commit, following this flow on enterprise:
- Go to the webclient, on the homepage: '/web'
- Click on the website
- Click on the "contact us" menu
- Click on the browser's back button
=> The back navigation happens in the iframe, it's normal
- Click on the back button again
=> The url has changed for the webclient "homepage" one but the
WebsitePreview is still displayed.

This happens because the router service listens to the hashchange events
to communicate the webclient which component to display.
But with [1] it was decided to replace the regular webclient's router url from the
WebsitePreview client action with the frontend's url. As a result, the
'hashchange' is never fired when navigating back from the client action
to another webclient route.

To fix that, the 'popstate' event is listened at the client action
level. If the new url is a regular webclient's router one, an
'hashchange' event is triggered to continue the flow as if the browser's
url was never changed.

The same hook is used to revert back the original webclient route
/web#action=website.website_preview... when leaving it, so that the
router can replay it correctly when navigating back from another route.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: remove global event listener from the configurator

[1] refactored the Configurator from its own frontend app to a component
of the web client.

[2] forward-ported a fix, targeting the Configurator standalone app,
which did not need to remove the window "popstate" event listener. But
after [1], that global listener was never removed.

This commit changes adding this event listener by using the
useExternalListener hook, which will remove it when the Configurator is
unmounted.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b
[2]: https://github.com/odoo/odoo/commit/3d3f9ffaa7caf5280602553459062fc6c9e35856

task-2687506

-----

[FIX] website: handle back navigation in edit mode

Before this commit, clicking on the back button in edit mode would
reload the page, but keep the editor open and lead to bugs.

Now, the WysiwygAdapter handles back navigation with an empty history
state. On the popstate event, triggered by a back navigation request,
the WysiwygAdapter will leave the edit mode with the leaveEditMode
method introduced in [1].

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

[1]: 37faf4c5b507

task-2687506

-----

[IMP] website: block the client action clicks when blocking the iframe

Before this commit, the BlockIframe component was managing its
visibility based on the 'BLOCK'/'UNBLOCK' events. Also, it was possible
to continue to interact with the SnippetsMenu when the iframe was
blocked.

With the previous commit modifications, it is needed to block the clicks
and prevent interactions with the SnippetsMenu when reloading the
iframe. For that, the BlockIframe component is reworked: a specific
state for this component is added at the WebsitePreview level. This
allows to add a o_is_blocked class on the container which prevents the
clicks on the client action when it is blocked. Therefore, it is not
blocking only the iframe anymore, but the whole preview. It is renamed
accordingly.
The 'loaderDelay' parameter is dropped, as it was used only to show the
loader after the snippets menu transition. As now the snippets menu is
removed after the reload, it is not useful anymore.

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] web_editor, website: leave edit mode from any website component

This commit reworks the way the edit mode is left, from the client
action. It does 2 things:
1/ It keeps the SnippetsMenu as long as the iframe is reloading. Once
everything is ready, the SnippetsMenu is removed with a transition.
2/ It prompts the "Discard your changes" modal when switching language in
edit mode.

1/ Before this commit, the WysiwygAdapter was dismounted before
reloading the iframe. It was simpler this way, because the OdooEditor
has set some listeners on the editable document, which will crash during
a reload of the iframe.
Now, in a leaveEditMode method, the WysiwygAdapter will make a copy of
the snippet's menu html element, and display that skeleton while the
editor is destroyed.
It will also check if the editable is dirty and prompt a
modal to the user if needed, as it was before.
Some of the code to display that "fake" snippets menu is shared with the
Editor component which uses it to unmount and remount the WysiwygAdapter
while reloading the iframe (in a _getDummySnippetsEl method).

2/ With that, the quit method, passed as a prop to the WysiwygAdapter,
and played in the new leaveEditMode method, is updated with two
parameters: an onLeave function that will be played when the component
is unmounted, and a reloadIframe boolean.
As the WysiwygAdapter listens to a new 'LEAVE-EDIT-MODE' event using
these parameters, it allows for any website component to request leaving
the edit mode, with a reload or not, and execute an action after that.
This fixes [1], which was leaving the edit mode without going through
the WysiwygAdapter, and so, without checking if the editable was dirty
or not (i.e. without prompting the "Discard your changes" modal).

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

[1]: https://github.com/odoo/odoo/commit/11429329b8dea2dd0b2496dc8c1c8627751cccff

task-2687506


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
