### PR TITLE
[FIX] core: special casing of `sequence` in read_group

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2357,6 +2357,8 @@ class BaseModel(metaclass=MetaModel):
                 orderby_terms.append(' '.join(order_split))
             elif order_field not in self._fields:
                 raise ValueError("Invalid field %r on model %r" % (order_field, self._name))
+            elif order_field == 'sequence':
+                pass
             else:
                 # Cannot order by a field that will not appear in the results (needs to be grouped or aggregated)
                 _logger.warning('%s: read_group order by `%s` ignored, cannot sort on empty columns (not grouped/aggregated)',


### PR DESCRIPTION
The sequence field is special-cased early on in read_group (_raw): if
the caller requests the aggregation of ``sequence`` that request is
ignored:

    if fspec == 'sequence':
        continue

This was added a long time ago, probably due to the special-ish status
of `sequence` (summing sequence number doesn't really make much
sense).

The issue is that it's also possible to request ordering by
`sequence`, which requires `sequence` to be one of the aggregated
fields. This is checked in `_read_group_prepare` and triggers a
warning.

This leads to an inconsistent behavior, where the user requests
aggregating & ordering by `sequence`, we remove it from the aggregated
fields, then warn that they didn't aggregate on the field.

Make the behavior consistent by also ignoring requests to order by
`sequence`.
