### PR TITLE
[FIX] web: stacked bar is properly displayed

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -439,7 +439,7 @@ export class GraphRenderer extends Component {
                 suggestedMax: 0,
                 suggestedMin: 0,
             },
-            stacked: mode === "line" && stacked,
+            stacked: mode === "line" && stacked ? stacked : undefined,
         };
         return { xAxes: [xAxe], yAxes: [yAxe] };
     }

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -916,9 +916,9 @@ QUnit.module("Views", (hooks) => {
             "graph should be a classic line chart."
         );
         assert.strictEqual(
-            getScaleY(graph).every((y) => y.stacked),
-            false,
-            "The y axes should have stacked property set to false"
+            getScaleY(graph).every((y) => y.stacked == undefined),
+            true,
+            "The y axes should have stacked property set to undefined"
         );
     });
 


### PR DESCRIPTION
In stacked bar some records of the 2nd level `group bar` were [not displayed](https://watch.screencastify.com/v/yDiPDXAiDJCZgzGCNBjW ), this commit solves it. 

Stacked bar does not support the `stacked` option in the y axes.
This option was introduced in the stacked line generalization and was
set to False if the user is in the bar mode.

