### PR TITLE
Fix behaviors of ProgressBarField 

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -27,11 +27,14 @@ const { status, useComponent, useEffect, useRef, onWillUnmount } = owl;
  * Focus an element referenced by a t-ref="autofocus" in the current component
  * as soon as it appears in the DOM and if it was not displayed before.
  * If it is an input/textarea, set the selection at the end.
+ * @param {Object} [params]
+ * @param {string} [params.refName] override the ref name "autofocus"
+ * @param {boolean} [params.selectAll] if true, will select the entire text value.
  * @returns {Object} the element reference
  */
-export function useAutofocus() {
+export function useAutofocus({ refName, selectAll } = {}) {
     const comp = useComponent();
-    const ref = useRef("autofocus");
+    const ref = useRef(refName || "autofocus");
     // Prevent autofocus in mobile
     if (comp.env.isSmall) {
         return ref;
@@ -45,8 +48,9 @@ export function useAutofocus() {
         (el) => {
             if (el) {
                 el.focus();
-                if (["INPUT", "TEXTAREA"].includes(el.tagName) && el.type !== 'number') {
-                    el.selectionStart = el.selectionEnd = el.value.length;
+                if (["INPUT", "TEXTAREA"].includes(el.tagName) && el.type !== "number") {
+                    el.selectionEnd = el.value.length;
+                    el.selectionStart = selectAll ? 0 : el.value.length;
                 }
             }
         },

--- a/addons/web/static/src/views/fields/progress_bar/kanban_progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/kanban_progress_bar_field.js
@@ -5,7 +5,7 @@ import { ProgressBarField } from "./progress_bar_field";
 
 export class KanbanProgressBarField extends ProgressBarField {
     onClick() {
-        if (this.props.isEditable && !this.props.record.isReadonly(this.props.name)) {
+        if (this.props.isEditable) {
             this.state.isEditing = true;
         }
     }

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -1,10 +1,11 @@
 /** @odoo-module **/
 
-import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useAutofocus } from "@web/core/utils/hooks";
+import { useNumpadDecimal } from "../numpad_decimal_hook";
 import { parseFloat } from "../parsers";
 import { standardFieldProps } from "../standard_field_props";
-import { useNumpadDecimal } from "../numpad_decimal_hook";
 
 const { Component, onWillUpdateProps, useState } = owl;
 const formatters = registry.category("formatters");
@@ -13,6 +14,8 @@ const parsers = registry.category("parsers");
 export class ProgressBarField extends Component {
     setup() {
         useNumpadDecimal();
+        useAutofocus({ refName: "max-value", selectAll: true });
+        useAutofocus({ refName: "current-value", selectAll: true });
         this.state = useState({
             currentValue: this.getCurrentValue(this.props),
             maxValue: this.getMaxValue(this.props),
@@ -62,10 +65,10 @@ export class ProgressBarField extends Component {
         return formatter(this.state.maxValue, { humanReadable });
     }
 
-    onCurrentValueChange(value) {
+    onCurrentValueChange(ev) {
         let parsedValue;
         try {
-            parsedValue = parseFloat(value);
+            parsedValue = parseFloat(ev.target.value);
         } catch {
             this.props.record.setInvalidField(this.props.name);
             return;
@@ -81,10 +84,10 @@ export class ProgressBarField extends Component {
             this.props.record.save();
         }
     }
-    onMaxValueChange(value) {
+    onMaxValueChange(ev) {
         let parsedValue;
         try {
-            parsedValue = parseFloat(value);
+            parsedValue = parseFloat(ev.target.value);
         } catch {
             this.props.record.setInvalidField(this.props.name);
             return;
@@ -151,7 +154,7 @@ ProgressBarField.extractProps = ({ attrs }) => {
         maxValueField: attrs.options.max_value,
         currentValueField: attrs.options.current_value,
         isPercentage: !attrs.options.max_value,
-        isEditable: attrs.options.editable,
+        isEditable: !attrs.options.readonly && attrs.options.editable,
         isEditableInReadonly: attrs.options.editable_readonly,
         isCurrentValueEditable:
             attrs.options.editable &&

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
@@ -30,8 +30,8 @@
                             inputmode="numeric"
                             t-att-value="formatCurrentValue() or ''"
                             t-att-required="props.required"
-                            t-on-change="(ev) => this.onCurrentValueChange(ev.target.value)"
-                            t-on-input="(ev) => this.onCurrentValueInput(ev)"
+                            t-on-change="onCurrentValueChange"
+                            t-on-input="onCurrentValueInput"
                             t-on-blur="onBlur"
                         />
                         <span>%</span>
@@ -40,23 +40,25 @@
                 <t t-else="">
                     <input
                         t-if="props.isCurrentValueEditable"
+                        t-ref="current-value"
                         class="o_progressbar_value o_input"
                         type="text"
                         inputmode="numeric"
                         t-att-value="formatCurrentValue()"
-                        t-on-change="(ev) => this.onCurrentValueChange(ev.target.value)"
-                        t-on-input="(ev) => this.onCurrentValueInput(ev)"
+                        t-on-change="onCurrentValueChange"
+                        t-on-input="onCurrentValueInput"
                         t-on-blur="onBlur"
                     />
                     <span t-if="props.isCurrentValueEditable and props.isMaxValueEditable" t-esc="'/'" />
                     <input
                         t-if="props.isMaxValueEditable"
+                        t-ref="max-value"
                         class="o_progressbar_value o_input"
                         type="text"
                         inputmode="numeric"
                         t-att-value="formatMaxValue()"
-                        t-on-change="(ev) => this.onMaxValueChange(ev.target.value)"
-                        t-on-input="(ev) => this.onMaxValueInput(ev)"
+                        t-on-change="onMaxValueChange"
+                        t-on-input="onMaxValueInput"
                         t-on-blur="onBlur"
                     />
                 </t>
@@ -65,4 +67,3 @@
     </t>
 
 </templates>
-

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -72,6 +72,11 @@ export class KanbanArchParser extends XMLParser {
                     node.setAttribute("widget", "many2many_tags");
                 }
                 const fieldInfo = Field.parseFieldNode(node, models, modelName, "kanban", jsClass);
+                if (!node.hasAttribute("force_save")) {
+                    // Force save is true by default on kanban views:
+                    // this allows to write on any field regardless of its modifiers.
+                    fieldInfo.forceSave = true;
+                }
                 const name = fieldInfo.name;
                 fieldNodes[name] = fieldInfo;
                 node.setAttribute("field_id", name);


### PR DESCRIPTION
This PR extends the API of the `useAutofocus` hook and fixes behavior issues in the `ProgressBarField`.

- the `useAutofocus` hook can now take an arbitrary ref name and select
the entire input text value if needed;

- the progressbar would not write on a field if it was declared as
'readonly' on the server (it sounds counter-intuitive but this widget
was supposed to write on records unless given the 'readonly' flag in the
field options);

- the "isEditable" prop was incorrectly computed, resulting in the field
not being editable in kanban views when it should be;

- when editing a value in the field, the focus should be automatically
given to the first input (using the newly added params of `useAutofocus`).

These issues have been fixed in this PR.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
