### PR TITLE
[FIX] l10n_be: change tab to space

### DIFF
--- a/addons/l10n_be/data/account_data.xml
+++ b/addons/l10n_be/data/account_data.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <odoo>
-	<data noupdate="1">
-		
-		<!-- Account Tax Group -->
-		<record id="tax_group_tva_21" model="account.tax.group">
-			<field name="name">TVA 21%</field>
-		</record>
+    <data noupdate="1">
 
-		<record id="tax_group_tva_12" model="account.tax.group">
-			<field name="name">TVA 12%</field>
-		</record>
+        <!-- Account Tax Group -->
+        <record id="tax_group_tva_21" model="account.tax.group">
+            <field name="name">TVA 21%</field>
+        </record>
 
-		<record id="tax_group_tva_6" model="account.tax.group">
-			<field name="name">TVA 6%</field>
-		</record>
+        <record id="tax_group_tva_12" model="account.tax.group">
+            <field name="name">TVA 12%</field>
+        </record>
 
-		<record id="tax_group_tva_0" model="account.tax.group">
-			<field name="name">TVA 0%</field>
-		</record>
+        <record id="tax_group_tva_6" model="account.tax.group">
+            <field name="name">TVA 6%</field>
+        </record>
 
-	</data>
+        <record id="tax_group_tva_0" model="account.tax.group">
+            <field name="name">TVA 0%</field>
+        </record>
+
+    </data>
 </odoo>


### PR DESCRIPTION
This old file is indented with tabs instead of spaces.
This is a problem because the file is using as template to write new localization.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
