### PR TITLE
[FIX] account: fix bank statement import from BNP

### DIFF
--- a/addons/account_bank_statement_import/account_bank_statement_import.py
+++ b/addons/account_bank_statement_import/account_bank_statement_import.py
@@ -136,7 +136,8 @@ class AccountBankStatementImport(models.TransientModel):
         sanitized_acc_number = journal.bank_account_id.sanitized_acc_number
         if " " in sanitized_acc_number:
             sanitized_acc_number = sanitized_acc_number.split(" ")[0]
-        if len(sanitized_acc_number) == 27 and sanitized_acc_number[:2].upper() == "FR":
+        # Needed for BNP France
+        if len(sanitized_acc_number) == 27 and len(account_number) == 11 and sanitized_acc_number[:2].upper() == "FR":
             return sanitized_acc_number[14:-2] == account_number
         return sanitized_acc_number == account_number
 


### PR DESCRIPTION
Before this PR, importing an .OFX file from BNP failed because the account number format is not the same.

This is a problem on BNP's side but it is blocking for our clients and needs to be fixed.

This PR fixes this by checking that the account number corresponds to a specific part of the IBAN (for France only).

Task id 2860720

Same fix for version 14+: https://github.com/odoo/enterprise/pull/30085