### PR TITLE
[FIX] website_sale_delivery: no carrier change if there is a valid transaction

### DIFF
--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -27,6 +27,8 @@ class WebsiteSaleDelivery(WebsiteSale):
         order = request.website.sale_get_order()
         carrier_id = int(post['carrier_id'])
         if order:
+            if any(tx.state not in ("canceled", "error") for tx in order.transaction_ids):
+                raise UserError(_('It seems that there is already a transaction for your order, you can not change the delivery method anymore'))
             order._check_carrier_quotation(force_carrier_id=carrier_id)
         return self._update_website_sale_delivery_return(order, **post)
 

--- a/addons/website_sale_delivery/i18n/website_sale_delivery.pot
+++ b/addons/website_sale_delivery/i18n/website_sale_delivery.pot
@@ -113,6 +113,14 @@ msgstr ""
 #: code:addons/website_sale_delivery/controllers/main.py:0
 #, python-format
 msgid ""
+"It seems that there is already a transaction for your order, you can not "
+"change the delivery method anymore"
+msgstr ""
+
+#. module: website_sale_delivery
+#: code:addons/website_sale_delivery/controllers/main.py:0
+#, python-format
+msgid ""
 "No shipping method is available for your current order and shipping address."
 " Please contact us for more information."
 msgstr ""

--- a/addons/website_sale_delivery/tests/__init__.py
+++ b/addons/website_sale_delivery/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_ui
+from . import test_controller

--- a/addons/website_sale_delivery/tests/test_controller.py
+++ b/addons/website_sale_delivery/tests/test_controller.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.exceptions import UserError
+from odoo.addons.payment.tests.common import PaymentCommon
+from odoo.addons.website_sale_delivery.controllers.main import WebsiteSaleDelivery
+from odoo.addons.website.tools import MockRequest
+from odoo.tests import tagged
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleDeliveryController(PaymentCommon):
+    def setUp(self):
+        super().setUp()
+        self.website = self.env.ref('website.default_website')
+        self.Controller = WebsiteSaleDelivery()
+
+    # test that changing the carrier while there is a pending transaction raises an error
+    def test_controller_change_carrier_when_transaction(self):
+        with MockRequest(self.env, website=self.website):
+            order = self.website.sale_get_order(force_create=True)
+            order.transaction_ids = self.create_transaction(flow='redirect', state='pending')
+            with self.assertRaises(UserError):
+                self.Controller.update_eshop_carrier(carrier_id=1)


### PR DESCRIPTION
Issue:
Customers can use Mollie and lower the price on a quotation through changing the
delivery method, if they have two pages "/shop/payment" and proceed with payment
on one they can still change the carrier on the second. Although the quotation is
not confirmed because of mismatching amount, a confirmation email is still sent
and a bank payment is still created. Please see the following test video.

Solution:
We add a check so that changing a carrier can only be done when a no active/done
transaction is linked to the sale order.

opw-2925673