### PR TITLE
[FIX] web_editor: restore "custom" image filters option for bg images

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5233,6 +5233,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     _isImageProcessingWidget(widgetName, params) {
         return params.optionsPossibleValues.glFilter
+            || 'customFilter' in params.optionsPossibleValues
             || params.optionsPossibleValues.setQuality
             || widgetName === 'width_select_opt';
     },


### PR DESCRIPTION
The widgets related to "custom" image filters in the case of background
images were never shown anymore since [1]. [1] is actually a
forward-ported version of [2] but the bug only appeared since [1] as
the forward-port adaptation created the error: the widgets of this
option were not shown or hidden before... but simply not rendered at
all, kinda by mistake. The adaptation in [1] used the conventional way
of doing things by using the `_computeWidgetVisibility` method to
indicate if widgets should be shown or not. The problem is that an
error was done when writing that visibility condition.

[1]: https://github.com/odoo/odoo/commit/89ce9f9ab5b8db148c273f70be0a06c768892566
[2]: https://github.com/odoo/odoo/commit/7c17d78fbdbb64b1aa5b55f78d3202a64a85ed2f
