### PR TITLE
[IMP] l10n_nl: account data improvements

### DIFF
--- a/addons/l10n_nl/data/account_chart_template_post_data.xml
+++ b/addons/l10n_nl/data/account_chart_template_post_data.xml
@@ -6,9 +6,9 @@
         <field name="property_account_payable_id" ref="pay"/>
         <field name="property_account_expense_categ_id" ref="7001"/>
         <field name="property_account_income_categ_id" ref="8001"/>
-        <field name="property_stock_account_input_categ_id" ref="0120"/>
-        <field name="property_stock_account_output_categ_id" ref="0129"/>
-        <field name="property_stock_valuation_account_id" ref="4830"/>
+        <field name="property_stock_account_input_categ_id" ref="1450"/>
+        <field name="property_stock_account_output_categ_id" ref="1250"/>
+        <field name="property_stock_valuation_account_id" ref="3200"/>
         <field name="expense_currency_exchange_account_id" ref="4920"/>
         <field name="income_currency_exchange_account_id" ref="8920"/>
         <field name="default_pos_receivable_account_id" ref="recv_pos"/>

--- a/addons/l10n_nl/data/account_fiscal_position_tax_template.xml
+++ b/addons/l10n_nl/data/account_fiscal_position_tax_template.xml
@@ -11,11 +11,6 @@
             <field name="tax_src_id" ref="btw_0"/>
             <field name="tax_dest_id" ref="btw_X1"/>
         </record>
-        <record id="position_tax_extracom_6" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_6"/>
-            <field name="tax_dest_id" ref="btw_X1"/>
-        </record>
         <record id="position_tax_extracom_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_non_eu"/>
             <field name="tax_src_id" ref="btw_9"/>
@@ -26,20 +21,10 @@
             <field name="tax_src_id" ref="btw_21"/>
             <field name="tax_dest_id" ref="btw_X1"/>
         </record>
-        <record id="position_tax_extracom_overig" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_overig"/>
-            <field name="tax_dest_id" ref="btw_X1"/>
-        </record>
         <record id="position_tax_extracom_d_0" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_non_eu"/>
             <field name="tax_src_id" ref="btw_0_d"/>
             <field name="tax_dest_id" ref="btw_X1"/>
-        </record>
-        <record id="position_tax_extracom_d_6" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_6_d"/>
-            <field name="tax_dest_id" ref="btw_X3"/>
         </record>
         <record id="position_tax_extracom_d_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_non_eu"/>
@@ -51,17 +36,6 @@
             <field name="tax_src_id" ref="btw_21_d"/>
             <field name="tax_dest_id" ref="btw_X1"/>
         </record>
-        <record id="position_tax_extracom_d_overig" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_overig_d"/>
-            <field name="tax_dest_id" ref="btw_X1"/>
-        </record>
-        <!-- VAT on buying from outside the EU -->
-        <record id="position_tax_extracom_6" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_6_buy"/>
-            <field name="tax_dest_id" ref="btw_E1"/>
-        </record>
         <record id="position_tax_extracom_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_non_eu"/>
             <field name="tax_src_id" ref="btw_9_buy"/>
@@ -71,16 +45,6 @@
             <field name="position_id" ref="fiscal_position_template_non_eu"/>
             <field name="tax_src_id" ref="btw_21_buy"/>
             <field name="tax_dest_id" ref="btw_E2"/>
-        </record>
-        <record id="position_tax_extracom_8" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_overig_buy"/>
-            <field name="tax_dest_id" ref="btw_E_overig"/>
-        </record>
-        <record id="position_tax_extracom_d_6" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_6_buy_d"/>
-            <field name="tax_dest_id" ref="btw_E1"/>
         </record>
         <record id="position_tax_extracom_d_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_non_eu"/>
@@ -92,21 +56,11 @@
             <field name="tax_src_id" ref="btw_21_buy_d"/>
             <field name="tax_dest_id" ref="btw_E2"/>
         </record>
-        <record id="position_tax_extracom_d_8" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_non_eu"/>
-            <field name="tax_src_id" ref="btw_overig_buy_d"/>
-            <field name="tax_dest_id" ref="btw_E_overig_d"/>
-        </record>
 
         <!-- EU Countries -->
         <record id="position_tax_intracom_1" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_eu"/>
             <field name="tax_src_id" ref="btw_0"/>
-            <field name="tax_dest_id" ref="btw_X0_producten"/>
-        </record>
-        <record id="position_tax_intracom_2" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_6"/>
             <field name="tax_dest_id" ref="btw_X0_producten"/>
         </record>
         <record id="position_tax_intracom_2_9" model="account.fiscal.position.tax.template">
@@ -129,11 +83,6 @@
             <field name="tax_src_id" ref="btw_0_d"/>
             <field name="tax_dest_id" ref="btw_X0_diensten"/>
         </record>
-        <record id="position_tax_intracom_d_2" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_6_d"/>
-            <field name="tax_dest_id" ref="btw_X0_diensten"/>
-        </record>
         <record id="position_tax_intracom_d_2_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_eu"/>
             <field name="tax_src_id" ref="btw_9_d"/>
@@ -143,16 +92,6 @@
             <field name="position_id" ref="fiscal_position_template_eu"/>
             <field name="tax_src_id" ref="btw_21_d"/>
             <field name="tax_dest_id" ref="btw_X0_diensten"/>
-        </record>
-        <record id="position_tax_intracom_d_4" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_overig_d"/>
-            <field name="tax_dest_id" ref="btw_X0_diensten"/>
-        </record>
-        <record id="position_tax_intracom_6" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_6_buy"/>
-            <field name="tax_dest_id" ref="btw_I_6"/>
         </record>
         <record id="position_tax_intracom_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_eu"/>
@@ -164,16 +103,6 @@
             <field name="tax_src_id" ref="btw_21_buy"/>
             <field name="tax_dest_id" ref="btw_I_21"/>
         </record>
-        <record id="position_tax_intracom_8" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_overig_buy"/>
-            <field name="tax_dest_id" ref="btw_I_overig"/>
-        </record>
-        <record id="position_tax_intracom_d_6" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_6_buy_d"/>
-            <field name="tax_dest_id" ref="btw_I_6_d"/>
-        </record>
         <record id="position_tax_intracom_d_9" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_eu"/>
             <field name="tax_src_id" ref="btw_9_buy_d"/>
@@ -183,11 +112,6 @@
             <field name="position_id" ref="fiscal_position_template_eu"/>
             <field name="tax_src_id" ref="btw_21_buy_d"/>
             <field name="tax_dest_id" ref="btw_I_21_d"/>
-        </record>
-        <record id="position_tax_intracom_d_8" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu"/>
-            <field name="tax_src_id" ref="btw_overig_buy_d"/>
-            <field name="tax_dest_id" ref="btw_I_overig_d"/>
         </record>
 
         <!-- BTW verlegd -->

--- a/addons/l10n_nl/data/account_fiscal_position_template.xml
+++ b/addons/l10n_nl/data/account_fiscal_position_template.xml
@@ -17,18 +17,19 @@
         </record>
         <record id="fiscal_position_template_eu_private" model="account.fiscal.position.template">
             <field name="sequence">2</field>
-            <field name="name">EU landen privaat</field>
+            <field name="name">EU landen B2C</field>
             <field name="chart_template_id" ref="l10nnl_chart_template" />
             <field name="auto_apply" eval="True"/>
             <field name="country_group_id" ref="base.europe"/>
         </record>
         <record id="fiscal_position_template_eu" model="account.fiscal.position.template">
             <field name="sequence">3</field>
-            <field name="name">EU landen</field>
+            <field name="name">EU landen B2B</field>
             <field name="chart_template_id" ref="l10nnl_chart_template" />
             <field name="auto_apply" eval="True"/>
             <field name="vat_required" eval="True"/>
             <field name="country_group_id" ref="base.europe"/>
+            <field name="note">Intracommunautaire levering, artikel 138, lid 1, Richtlijn 2006/112</field>
         </record>
         <record id="fiscal_position_template_non_eu" model="account.fiscal.position.template">
             <field name="sequence">4</field>
@@ -52,11 +53,6 @@
             <field name="tax_src_id" ref="btw_verk_0"/>
             <field name="tax_dest_id" ref="btw_X2"/>
         </record>
-        <record id="position_tax_eu_no_taxes_report_3" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu_no_taxes_report"/>
-            <field name="tax_src_id" ref="btw_6"/>
-            <field name="tax_dest_id" ref="btw_X2"/>
-        </record>
         <record id="position_tax_eu_no_taxes_report_4" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_eu_no_taxes_report"/>
             <field name="tax_src_id" ref="btw_9"/>
@@ -75,11 +71,6 @@
         <record id="position_tax_eu_no_taxes_report_7" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fiscal_position_template_eu_no_taxes_report"/>
             <field name="tax_src_id" ref="btw_0_d"/>
-            <field name="tax_dest_id" ref="btw_X2"/>
-        </record>
-        <record id="position_tax_eu_no_taxes_report_8" model="account.fiscal.position.tax.template">
-            <field name="position_id" ref="fiscal_position_template_eu_no_taxes_report"/>
-            <field name="tax_src_id" ref="btw_6_d"/>
             <field name="tax_dest_id" ref="btw_X2"/>
         </record>
         <record id="position_tax_eu_no_taxes_report_9" model="account.fiscal.position.tax.template">

--- a/addons/l10n_nl/data/account_tax_group_data.xml
+++ b/addons/l10n_nl/data/account_tax_group_data.xml
@@ -5,10 +5,6 @@
             <field name="name">BTW 0%</field>
             <field name="country_id" ref="base.nl"/>
         </record>
-        <record id="tax_group_6" model="account.tax.group">
-            <field name="name">BTW 6%</field>
-            <field name="country_id" ref="base.nl"/>
-        </record>
         <record id="tax_group_9" model="account.tax.group">
             <field name="name">BTW 9%</field>
             <field name="country_id" ref="base.nl"/>

--- a/addons/l10n_nl/data/account_tax_template.xml
+++ b/addons/l10n_nl/data/account_tax_template.xml
@@ -26,38 +26,6 @@
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
     </record>
-    <record id="btw_6" model="account.tax.template">
-        <field name="sequence">10</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Verkopen/omzet laag 6%</field>
-        <field name="description">6% BTW</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">sale</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_1b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_1b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_1b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_1b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_9" model="account.tax.template">
         <field name="sequence">10</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
@@ -159,7 +127,7 @@
         <field name="sequence">10</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Verkopen/omzet onbelast (nul-tarief) diensten</field>
-        <field name="description">0% BTW diensten</field>
+        <field name="description">0% BTW</field>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -179,43 +147,11 @@
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
     </record>
-    <record id="btw_6_d" model="account.tax.template">
-        <field name="sequence">10</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Verkopen/omzet laag diensten 6%</field>
-        <field name="description">6% BTW diensten</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">sale</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_1b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_d'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_1b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_1b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_d'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_1b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_9_d" model="account.tax.template">
         <field name="sequence">10</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Verkopen/omzet laag diensten 9%</field>
-        <field name="description">9% BTW diensten</field>
+        <field name="description">9% BTW</field>
         <field eval="9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -247,7 +183,7 @@
         <field name="sequence">6</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Verkopen/omzet hoog diensten</field>
-        <field name="description">21% BTW diensten</field>
+        <field name="description">21% BTW</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -308,32 +244,6 @@
             ]"/>
     </record>
     <!--Inkoop BTW -->
-    <record id="btw_6_buy" model="account.tax.template">
-        <field name="sequence">10</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">BTW te vorderen laag (inkopen) 6%</field>
-        <field name="description">6% BTW</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {'repartition_type': 'base'}),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {'repartition_type': 'base'}),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_9_buy" model="account.tax.template">
         <field name="sequence">10</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
@@ -343,33 +253,6 @@
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="tax_group_id" ref="tax_group_9"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {'repartition_type': 'base'}),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {'repartition_type': 'base'}),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
-    <record id="btw_6_buy_incl" model="account.tax.template">
-        <field name="sequence">10</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">BTW te vorderen laag (inkopen incl. BTW) 6%</field>
-        <field name="description">6% BTW Incl.</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="price_include">True</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
         <field name="invoice_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {'repartition_type': 'base'}),
                 (0,0, {
@@ -494,37 +377,11 @@
             ]"/>
     </record>
     <!--Inkoop BTW diensten -->
-    <record id="btw_6_buy_d" model="account.tax.template">
-        <field name="sequence">10</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">BTW te vorderen laag (inkopen) diensten 6%</field>
-        <field name="description">6% BTW diensten</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {'repartition_type': 'base'}),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_d'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {'repartition_type': 'base'}),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_d'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_9_buy_d" model="account.tax.template">
         <field name="sequence">10</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">BTW te vorderen laag (inkopen) diensten 9%</field>
-        <field name="description">9% BTW diensten</field>
+        <field name="description">9% BTW</field>
         <field eval="9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -550,7 +407,7 @@
         <field name="sequence">6</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">BTW te vorderen hoog (inkopen) diensten</field>
-        <field name="description">21% BTW diensten</field>
+        <field name="description">21% BTW</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -669,55 +526,11 @@
     </record>
     <!-- Binnen de EU -->
     <!-- BTW inkoop -->
-    <record id="btw_I_6" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import binnen EU laag 6%</field>
-        <field name="description">6% BTW import binnen EU</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_4b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_4b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_I_9" model="account.tax.template">
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Inkopen import binnen EU laag 9%</field>
-        <field name="description">9% BTW import binnen EU</field>
+        <field name="description">0% EU</field>
         <field eval="9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -761,7 +574,7 @@
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="sequence">20</field>
         <field name="name">Inkopen import binnen EU hoog</field>
-        <field name="description">21% BTW import binnen EU</field>
+        <field name="description">0% EU</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -801,36 +614,12 @@
                 }),
             ]"/>
     </record>
-    <record id="btw_I_overig" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import binnen EU overig</field>
-        <field name="description">0% BTW import binnen EU</field>
-        <field eval="0" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {'repartition_type': 'tax'}),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {'repartition_type': 'tax'}),
-            ]"/>
-    </record>
     <!-- BTW verkoop -->
     <record id="btw_X0_producten" model="account.tax.template">
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Verkopen export binnen EU (producten)</field>
-        <field name="description">BTW export binnen EU (producten)</field>
+        <field name="description">0% EU</field>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -854,7 +643,7 @@
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Verkopen export binnen EU (diensten)</field>
-        <field name="description">BTW export binnen EU (diensten)</field>
+        <field name="description">0% EU</field>
         <field eval="0" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -899,55 +688,11 @@
             ]"/>
     </record>
     <!-- BTW inkoop diensten -->
-    <record id="btw_I_6_d" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import binnen EU laag diensten 6%</field>
-        <field name="description">6% BTW import binnen EU diensten</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_d_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_4b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_d_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_d_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_4b_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_d_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_I_9_d" model="account.tax.template">
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Inkopen import binnen EU laag diensten 9%</field>
-        <field name="description">9% BTW import binnen EU diensten</field>
+        <field name="description">0% EU</field>
         <field eval="9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -991,7 +736,7 @@
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="sequence">20</field>
         <field name="name">Inkopen import binnen EU hoog diensten</field>
-        <field name="description">21% BTW import binnen EU diensten</field>
+        <field name="description">0% EU</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1031,81 +776,13 @@
                 }),
             ]"/>
     </record>
-    <record id="btw_I_overig_d" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import binnen EU overig diensten</field>
-        <field name="description">0% BTW import binnen EU diensten</field>
-        <field eval="0" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_0"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {'repartition_type': 'tax'}),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4b_tag')],
-                }),
-                (0,0, {'repartition_type': 'tax'}),
-            ]"/>
-    </record>
     <!-- Buiten de EU -->
     <!-- BTW inkoop -->
-    <record id="btw_E1" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import buiten EU laag 6%</field>
-        <field name="description">BTW import buiten EU laag inkopen</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_E1_9" model="account.tax.template">
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Inkopen import buiten EU laag 9%</field>
-        <field name="description">BTW import buiten EU laag inkopen</field>
+        <field name="description">0% Non-EU</field>
         <field eval="9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1149,45 +826,45 @@
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Inkopen import buiten EU hoog</field>
-        <field name="description">BTW import buiten EU hoog inkopen</field>
+        <field name="description">0% Non-EU</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="tax_group_id" ref="tax_group_21"/>
         <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_h_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_h_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_line_ids': [ref('tax_report_rub_4a')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('vat_payable_h_non_eu'),
+                'minus_report_expression_ids': [ref('tax_report_rub_btw_4a')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('vat_refund_h_non_eu'),
+                'plus_report_expression_ids': [ref('tax_report_rub_btw_5b')],
+            }),
+        ]"/>
         <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_h_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_h_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_rub_4a')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('vat_payable_h_non_eu'),
+                'plus_report_expression_ids': [ref('tax_report_rub_btw_4a')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('vat_refund_h_non_eu'),
+                'minus_report_expression_ids': [ref('tax_report_rub_btw_5b')],
+            }),
+        ]"/>
     </record>
     <record id="btw_E_overig" model="account.tax.template">
         <field name="sequence">20</field>
@@ -1283,55 +960,11 @@
             ]"/>
     </record>
     <!-- BTW inkoop diensten -->
-    <record id="btw_E1_d" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import buiten EU laag diensten 6%</field>
-        <field name="description">BTW import buiten EU laag inkopen diensten</field>
-        <field eval="6" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_6"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_d_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_d_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_l_d_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_l_d_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
     <record id="btw_E1_d_9" model="account.tax.template">
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Inkopen import buiten EU laag diensten 9%</field>
-        <field name="description">BTW import buiten EU laag inkopen diensten</field>
+        <field name="description">0% Non-EU</field>
         <field eval="9" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1375,51 +1008,7 @@
         <field name="sequence">20</field>
         <field name="chart_template_id" ref="l10nnl_chart_template"/>
         <field name="name">Inkopen import buiten EU hoog diensten</field>
-        <field name="description">BTW import buiten EU hoog inkopen diensten</field>
-        <field eval="21" name="amount"/>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_21"/>
-        <field name="invoice_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'plus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_h_d_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_h_d_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5,0,0),
-                (0,0, {
-                    'repartition_type': 'base',
-                    'minus_report_expression_ids': [ref('tax_report_rub_4a_tag')],
-                }),
-                (0,0, {
-                    'factor_percent': -100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_payable_h_d_non_eu'),
-                    'plus_report_expression_ids': [ref('tax_report_rub_btw_4a_tag')],
-                }),
-                (0,0, {
-                    'repartition_type': 'tax',
-                    'account_id': ref('vat_refund_h_d_non_eu'),
-                    'minus_report_expression_ids': [ref('tax_report_rub_btw_5b_tag')],
-                }),
-            ]"/>
-    </record>
-    <record id="btw_E_overig_d" model="account.tax.template">
-        <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10nnl_chart_template"/>
-        <field name="name">Inkopen import buiten EU overig diensten</field>
-        <field name="description">BTW import buiten EU overig inkopen diensten</field>
+        <field name="description">0% Non-EU</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_nl/demo/demo_company.xml
+++ b/addons/l10n_nl/demo/demo_company.xml
@@ -2,11 +2,11 @@
 <odoo>
     <record id="partner_demo_company_nl" model="res.partner">
         <field name="name">NL Company</field>
-        <field name="vat">NL43603B11</field>
+        <field name="vat">NL219987701B73</field>
         <field name="street">Bloemstraat 42</field>
         <field name="city">Groningen</field>
         <field name="country_id" ref="base.nl"/>
-        <field name="state_id" ref="base.state_nl_bq3"/>
+        <field name="state_id" ref="base.state_nl_gr"/>
         <field name="zip">9700</field>
         <field name="phone">+31 6 12345678</field>
         <field name="email">info@company.nlexample.com</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Improvement Dutch Lokalisation

Current behavior before PR:

Desired behavior after PR is merged:
1. The stock valuation, input and output account were wrong. Now correct accounts are set
2. Removed the 6% VAT. Is not used for years now in the Netherlands. It is now 9%
3. Removed the "BTW overige" for sales/purchases within EU and outside. These taxes do not exist. "BTW overige" is only domestic
4. Renamed 'EU landen privaat' for better name B2C (that is what it is used for)
5. Added valid TAX Identification number on company
6. Changed the state to a state within the Netherlands and not in the Dutch Caribbean

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
