### PR TITLE
[IMP] Make anglo saxon accounting true for nl

### DIFF
--- a/addons/l10n_nl/data/account_chart_template.xml
+++ b/addons/l10n_nl/data/account_chart_template.xml
@@ -11,6 +11,7 @@
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.EUR"/>
             <field name="country_id" ref="base.nl"/>
+            <field name="use_anglo_saxon" eval="True"/>
         </record>
 
     </data>

--- a/doc/cla/corporate/bizzappdev.md
+++ b/doc/cla/corporate/bizzappdev.md
@@ -14,3 +14,4 @@ List of contributors:
 
 Ruchir Shukla ruchir@bizzappdev.com https://github.com/bizzappdev
 
+VIJ VIJ@bizzappdev.com https://github.com/bizzappdev


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Improvement of the Dutch localization. In the Netherlands, we use Anglo Saxon accounting!

Current behavior before PR: Setting Anglo-Saxon accounting is default False

Desired behavior after PR is merged: Setting Anglo-Saxon accounting is default True

Also saves Odoo SA a lot of issues on implementing Dutch companies :) It is now by default correct.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
