### PR TITLE
[14.0][FIX] stock_account: stock move valuation must be taken from the incoming stock move…

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -310,11 +310,21 @@ class ProductProduct(models.Model):
 
         # Find back incoming stock valuation layers (called candidates here) to value `quantity`.
         qty_to_take_on_candidates = quantity
-        candidates = self.env['stock.valuation.layer'].sudo().search([
-            ('product_id', '=', self.id),
-            ('remaining_qty', '>', 0),
-            ('company_id', '=', company.id),
-        ])
+        location = self.env.context.get('location')
+        candidates = self.env['stock.valuation.layer']
+        if location:
+            candidates = self.env['stock.valuation.layer'].sudo().search([
+                ('product_id', '=', self.id),
+                ('remaining_qty', '>', 0),
+                ('company_id', '=', company.id),
+                ('stock_move_id.location_dest_id', '=', location.id),
+            ])
+        if len(candidates) == 0 or location is None:
+            candidates = self.env['stock.valuation.layer'].sudo().search([
+                ('product_id', '=', self.id),
+                ('remaining_qty', '>', 0),
+                ('company_id', '=', company.id),
+            ])
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in candidates:


### PR DESCRIPTION
…s corresponding to the source location

Description of the issue/feature this PR addresses:
- setup a product in fifo and automatic valuation
- setup 2 locations in the warehouse
- purchase and receipt the product (qty=10) purchase price 5 $ in location A
- return qty = 2 from location A to the vendor
- receive back the qty = 2 in location B
- apply a landed cost on the second receipt (cost price becomes more than 5$ for those 2 products)
- make a sale order from location B qty=1
- deliver the product to the customer

Current behavior before PR:
- the journal entry for the delivery is 5$ 
Desired behavior after PR is merged:
- the journal entry for the delivery should be 5$ + landed costs




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
