### PR TITLE
[FIX] web: settings form view: save on click on an action button

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
@@ -20,26 +20,30 @@ export class SettingsFormController extends formView.Controller {
             ) {
                 const message = this.env._t("Would you like to save your changes?");
                 await new Promise((resolve) => {
-                    this.dialogService.add(
-                        SettingsConfirmationDialog,
-                        {
-                            body: message,
-                            confirm: async () => {
-                                await this.model.root.save({ stayInEdition: true });
-                                await this.save();
-                            },
-                            cancel: () => {},
-                            stayHere: () => {
-                                _continue = false;
-                            },
+                    this.dialogService.add(SettingsConfirmationDialog, {
+                        body: message,
+                        confirm: async () => {
+                            await this.model.root.save({ stayInEdition: true });
+                            await this.save();
+                            // It doesn't make sense to do the action of the button
+                            // as the res.config.settings `execute` method will trigger a reload.
+                            _continue = false;
+                            resolve();
                         },
-                        { onClose: resolve }
-                    );
+                        cancel: async () => {
+                            await this.model.root.discard();
+                            await this.model.root.save({ stayInEdition: true });
+                            _continue = true;
+                            resolve();
+                        },
+                        stayHere: () => {
+                            _continue = false;
+                            resolve();
+                        },
+                    });
                 });
             } else {
-                if (clickParams.name === "execute") {
-                    _continue = await this.model.root.save({ stayInEdition: true });
-                }
+                _continue = await this.model.root.save({ stayInEdition: true });
             }
             return _continue;
         };


### PR DESCRIPTION
On the res.config.settings form view, click on button that will do an action
e.g. defined as some flavor of `<button type="object" name="myMethod" />`

Before this commit, this did not work as we never fully created the res.config.settings record in python
hence, when executing myMethod on the model res.config.settings, the ID was unset, pointing to no record.

After this commit, we "create" in python the transient res.config.settings record before doing anything.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
