### PR TITLE
[FIX] pos_restaurant: Check products (variants of type Instantly)  exist while searching for old lines.

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -201,7 +201,7 @@ models.Order = models.Order.extend({
         for (p_key in old_res) {
             for (note in old_res[p_key]['qties']) {
                 var found = p_key in current_res && note in current_res[p_key]['qties'];
-                if (!found) {
+                if (!found && this.pos.db.get_product_by_id(pid)) {
                     var old = old_res[p_key];
                     var pid = old.pid;
                     rem.push({

--- a/doc/cla/individual/RachidAlassir.md
+++ b/doc/cla/individual/RachidAlassir.md
@@ -1,0 +1,9 @@
+Tunisia, 2020-11-05
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Rachid Al Assir rachidalassir@gmail.com https://github.com/RachidAlassir


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Error happened once product variants are set to Instantly and available to a kitchen printer

![image](https://user-images.githubusercontent.com/48803268/182741896-436dc9dc-836a-48b9-aef0-e4ad707e6058.png)

Desired behavior after PR is merged:

Check products (variants of type Instantly)  exist

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
