### PR TITLE
[FIX] web: ListView navigation from header

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1499,10 +1499,7 @@ export class ListRenderer extends Component {
         this.tableRef.el.querySelector("tbody").classList.remove("o_keyboard_navigation");
 
         const target = ev.target;
-        if (
-            this.tableRef.el.contains(target) &&
-            (target.closest(".o_data_row") || target.closest(".o_column_sortable"))
-        ) {
+        if (this.tableRef.el.contains(target) && target.closest(".o_data_row")) {
             // ignore clicks inside the table that are originating from a record row
             // as they are handled directly by the renderer.
             return;

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -2058,7 +2058,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.test(
         "editable list view: save data when list sorting in edit mode",
         async function (assert) {
-            assert.expect(3);
+            assert.expect(2);
 
             serverData.models.foo.fields.foo.sortable = true;
 
@@ -2081,15 +2081,7 @@ QUnit.module("Views", (hooks) => {
             await click(target.querySelector(".o_data_cell"));
             await editInput(target, '.o_field_widget[name="foo"] input', "xyz");
             await click(target.querySelector(".o_column_sortable"));
-
-            assert.hasClass(
-                target.querySelector(".o_data_row"),
-                "o_selected_row",
-                "first row should still be in edition"
-            );
-
-            await click(target.querySelector(".o_list_button_save"));
-            assert.containsNone(target, ".o_list_button_save");
+            assert.containsNone(target, ".o_selected_row");
         }
     );
 


### PR DESCRIPTION
Before this commit, in a list view with a record being edited, if the
focus is placed on the header of a column and a key is pressed then a
crash is displayed.

How to reproduce:
- Go to a list view
- Switch a record to edit mode
- Click on the header of an sotable column
- Press a key (for example "a")

Before:
    Crash is displayed

After:
    Nothing happens

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
