### PR TITLE
[FIX] account,base,web: fix "Send & Print" on invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3241,8 +3241,10 @@ class AccountMove(models.Model):
             custom_layout="mail.mail_notification_paynow",
             model_description=self.with_context(lang=lang).type_name,
             force_email=True,
+            active_ids=self.ids,
         )
-        return {
+
+        report_action = {
             'name': _('Send Invoice'),
             'type': 'ir.actions.act_window',
             'view_type': 'form',
@@ -3253,6 +3255,11 @@ class AccountMove(models.Model):
             'target': 'new',
             'context': ctx,
         }
+
+        if self.env.is_admin() and not self.env.company.external_report_layout_id and not self.env.context.get('discard_logo_check'):
+            return self.env['ir.actions.report']._action_configure_external_report_layout(report_action)
+
+        return report_action
 
     def _get_new_hash(self, secure_seq_number):
         """ Returns the hash to write on journal entries when they get posted"""

--- a/addons/web/tests/test_base_document_layout.py
+++ b/addons/web/tests/test_base_document_layout.py
@@ -223,3 +223,16 @@ class TestBaseDocumentLayout(TestBaseDocumentLayoutHelpers):
     #         self.assertColors(doc_layout, default_colors)
     #         doc_layout.report_layout_id = self.report_layout2
     #         self.assertColors(doc_layout, self.report_layout2)
+
+    def test_company_details_blank_lines(self):
+        """Test that the company address is generated dynamically using only the fields that are defined,
+        without leaving any blank lines."""
+        # Make sure there is no blank line in the company details.
+        doc_layout_1 = self.env['base.document.layout'].create({'company_id': self.company.id})
+        self.assertFalse('\n<br>\n' in doc_layout_1.company_details)
+
+        # Make sure that 'street2' (an optional field, initially blank),
+        # appears in the company details when it is defined.
+        self.company.write({'street2': 'street_2_detail'})
+        doc_layout_2 = self.env['base.document.layout'].create({'company_id': self.company.id})
+        self.assertTrue('street_2_detail' in doc_layout_2.company_details)

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -1002,12 +1002,14 @@ class IrActionsReport(models.Model):
 
         discard_logo_check = self.env.context.get('discard_logo_check')
         if self.env.is_admin() and not self.env.company.external_report_layout_id and config and not discard_logo_check:
-            action = self.env["ir.actions.actions"]._for_xml_id("web.action_base_document_layout_configurator")
-            ctx = action.get('context')
-            py_ctx = json.loads(ctx) if ctx else {}
-            report_action['close_on_report_download'] = True
-            py_ctx['report_action'] = report_action
-            action['context'] = py_ctx
-            return action
+            return self._action_configure_external_report_layout(report_action)
 
         return report_action
+
+    def _action_configure_external_report_layout(self, report_action):
+        action = self.env["ir.actions.actions"]._for_xml_id("web.action_base_document_layout_configurator")
+        py_ctx = json.loads(action.get('context', {}))
+        report_action['close_on_report_download'] = True
+        py_ctx['report_action'] = report_action
+        action['context'] = py_ctx
+        return action


### PR DESCRIPTION
The purpose of the task is twofold:

1. Remove empty lines in the company address.

Until now, the address format was fixed, which could
lead to empty lines if one or more field(s) were missing.
We are now removing empty fields to avoid that.

2. Make sure the external report layout is configured
before generating the PDF.

This will ensure that the company data will appear
in the file. If no layout is defined,
it would not be shown.

task-2834517

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
