### PR TITLE
[IMP] web: add kanban option to prevent dragging columns

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -36,6 +36,7 @@ export class KanbanArchParser extends XMLParser {
         const defaultGroupBy = xmlDoc.getAttribute("default_group_by");
         const limit = xmlDoc.getAttribute("limit");
         const recordsDraggable = archParseBoolean(xmlDoc.getAttribute("records_draggable"), true);
+        const groupsDraggable = archParseBoolean(xmlDoc.getAttribute("groups_draggable"), true);
         const activeActions = {
             ...getActiveActions(xmlDoc),
             groupArchive: archParseBoolean(xmlDoc.getAttribute("archivable"), true),
@@ -144,6 +145,7 @@ export class KanbanArchParser extends XMLParser {
             openAction,
             quickCreateView,
             recordsDraggable,
+            groupsDraggable,
             limit: limit && parseInt(limit, 10),
             progressAttributes,
             cardColorField,

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -186,7 +186,12 @@ export class KanbanRenderer extends Component {
             return false;
         }
         const { modifiers, type } = this.props.list.groupByField;
-        return !(modifiers && modifiers.readonly) && DRAGGABLE_GROUP_TYPES.includes(type);
+        const { groupsDraggable } = this.props.archInfo;
+        return (
+            groupsDraggable &&
+            !(modifiers && modifiers.readonly) &&
+            DRAGGABLE_GROUP_TYPES.includes(type)
+        );
     }
 
     get canResequenceRecords() {


### PR DESCRIPTION
Before this commit, when the kanban view is grouped by m2o field, the
columns can be resequence by doing a drag and drop on one of them. In
some cases, this resequence should be disabled to keep the order of the
columns in the kanban view. For instance, in the project sharing
feature, the views are accessible by the portal users to easily follow
the tasks in the project shared but the actions allowed to the portal
user are restricted to only one model (that is `project.task` model).
So, in that case, the order of the columns should always be the same.

To avoid doing a customization code to be able to prevent the
resequence of columns in the kanban view, this commit adds a new option
in the kanban view called `groups_draggable`. By default, this option
will be true to allow the user to resequence the kanban columns
(if the field used for the group by is a m2o and not readonly).
If the option is false then the resequence of the kanban columns will
be disabled.

task-2941335
