### PR TITLE
[FIX] sale_stock: duplicate SN/LN for rental products

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -42,7 +42,7 @@ class AccountMove(models.Model):
         previous_qties_delivered = defaultdict(float)
         stock_move_lines = current_invoice_amls.sale_line_ids.move_ids.move_line_ids.filtered(lambda sml: sml.state == 'done' and sml.lot_id).sorted(lambda sml: (sml.date, sml.id))
         for sml in stock_move_lines:
-            if sml.product_id not in invoiced_products:
+            if sml.product_id not in invoiced_products or 'customer' not in {sml.location_id.usage, sml.location_dest_id.usage}:
                 continue
             product = sml.product_id
             product_uom = product.uom_id


### PR DESCRIPTION
Steps to reproduce:

1. Go to Inventory-->Settings-->Check option to "Display Lots & Serial
Numbers on Invoices"
2. Go to Rental App
3. Create a new Rental Order for a product that is tracked by Serial
Number. Pop up shows up. Also something to note here, though not
necessarily related to this ticket, but you cannot select available
serial number from this pop-up. It doesn't let you choose anything
even when there are multiple serial number available/in stock.
4. Confirm the order.
5. Validate the Pickup and set the Serial Number in the popup.
6. Create the invoice.
7. Confirm the invoice.
8. Print "Invoices without payment"

Bug:

in https://github.com/odoo/odoo/commit/7a030f616f7e04b3994fc718840d265b1dd21068

the filter functions were removed. They had the effect
of making sure that the sml is either a delivery or a return
by filtering on `sml.location_id.usage` and
`sml.location_dest_id.usage`

Fix:
check if the product is a delivery or a return by
making sure that either of `sml.location_id.usage` and
`sml.location_dest_id.usage` is `customer`

OPW-2936505
