### PR TITLE
[FIX] web: form: click on create always opens an form in edit

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -247,7 +247,12 @@ export class Record extends DataPoint {
             }
         }
 
-        this.mode = params.mode || (this.resId ? state.mode || "readonly" : "edit");
+        if (!this.resId && this.__viewType === "form") {
+            this.mode = "edit"; // always edit a new record in form view.
+        } else {
+            this.mode = params.mode || state.mode || "readonly";
+        }
+
         this._onWillSwitchMode = params.onRecordWillSwitchMode || (() => {});
 
         if (this.__bm_handle__) {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -11471,4 +11471,44 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(target, ".o_form_view .test");
         assert.verifySteps(["error"]);
     });
+
+    QUnit.test(
+        "form with an initial mode (readonly) -- create new record from an existing one",
+        async (assert) => {
+            await makeView({
+                type: "form",
+                resId: 1, // important
+                resModel: "partner",
+                serverData,
+                arch: `<form><field name="display_name" /></form>`,
+                mode: "readonly", // important
+            });
+
+            assert.containsOnce(target, ".o_form_readonly");
+            assert.containsOnce(target, ".o_form_button_edit");
+            assert.containsOnce(target, ".o_form_button_create");
+
+            await click(target, ".o_form_button_create");
+            assert.containsOnce(target, ".o_form_editable");
+            assert.containsOnce(target, ".o_form_button_save");
+            assert.containsOnce(target, ".o_form_button_cancel");
+        }
+    );
+
+    QUnit.test(
+        "form with an initial mode (readonly) -- new record from scratch",
+        async (assert) => {
+            await makeView({
+                type: "form",
+                resModel: "partner", // no resId: important
+                serverData,
+                arch: `<form><field name="display_name" /></form>`,
+                mode: "readonly", // important
+            });
+
+            assert.containsOnce(target, ".o_form_editable");
+            assert.containsOnce(target, ".o_form_button_save");
+            assert.containsOnce(target, ".o_form_button_cancel");
+        }
+    );
 });

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -1426,10 +1426,11 @@ QUnit.module("ActionManager", (hooks) => {
         serverData.actions[44] = {
             id: 33,
             name: "Partners",
+            res_id: 1,
             res_model: "partner",
             type: "ir.actions.act_window",
             flags: {
-                mode: "readonly",
+                mode: "edit",
             },
             views: [[false, "form"]],
         };
@@ -1440,16 +1441,11 @@ QUnit.module("ActionManager", (hooks) => {
         await doAction(webClient, 44);
         assert.containsOnce(
             target,
-            ".o_form_view .o_form_readonly",
-            "should display the form view in readonly mode"
-        ); // provided that the default mode is edit
+            ".o_form_view .o_form_editable",
+            "should display the form view in edit mode"
+        ); // provided that the default mode is readonly
 
-        assert.verifySteps([
-            "/web/webclient/load_menus",
-            "/web/action/load",
-            "get_views",
-            "onchange",
-        ]);
+        assert.verifySteps(["/web/webclient/load_menus", "/web/action/load", "get_views", "read"]);
     });
 
     QUnit.test("save current search", async function (assert) {


### PR DESCRIPTION
Spawn a form view with a record and set its props "mode" to readonly.
Click on "Create".

Before this commit, the new record was in readonly mode.
This is never what we want, we always want a new record to open
in edit mode.

After this commit, the new record is in edit mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
