### PR TITLE
[FIX] hr_holidays: fix accrual level maximum leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -441,6 +441,8 @@ class HolidaysAllocation(models.Model):
                         nextcall = min(nextcall, current_level_last_date)
                 days_added_per_level[current_level] += allocation._process_accrual_plan_level(
                     current_level, period_start, allocation.lastcall, period_end, allocation.nextcall)
+                if current_level.maximum_leave > 0 and sum(days_added_per_level.values()) > current_level.maximum_leave:
+                    days_added_per_level[current_level] -= sum(days_added_per_level.values()) - current_level.maximum_leave
                 allocation.lastcall = allocation.nextcall
                 allocation.nextcall = nextcall
             if days_added_per_level:

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -639,7 +639,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         allocation.action_validate()
         with freeze_time('2022-7-20'):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10)
+        # The first level gives 3 days
+        # The second level could give 6 days but since the first level was already giving
+        # 3 days, the second level gives 3 days to reach the second level's limit.
+        # The third level gives 1 day since it only counts for one iteration.
+        self.assertEqual(allocation.number_of_days, 7)
 
     def test_accrual_lost(self):
         # Test that when an allocation is made in the past and the second level is technically reached


### PR DESCRIPTION
A test introduced with https://github.com/odoo/odoo/pull/96432
revealed an issue with the level limits for the accrual plans.

The only applied limit was the one of the current level at the end of
the run, however if for whatever reason multiple levels had to be
processed at once (if the database was shut down for a long period of
time for example), the individual levels would not apply any limit logic
to their behaviour which meant that you could have a different behaviour
between running the cron each day and running it after a long period.

This commit aims to fix that issue by applying the said limit.

OPW-2868297
