### PR TITLE
[FIX] sale_stock: propagate SO line sequence to stock moves

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -247,6 +247,7 @@ class SaleOrderLine(models.Model):
             'product_description_variants': self.with_context(lang=self.order_id.partner_id.lang)._get_sale_order_line_multiline_description_variants(),
             'company_id': self.order_id.company_id,
             'product_packaging_id': self.product_packaging_id,
+            'sequence': self.sequence,
         })
         return values
 

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -59,7 +59,7 @@ class StockRule(models.Model):
 
     def _get_custom_move_fields(self):
         fields = super(StockRule, self)._get_custom_move_fields()
-        fields += ['sale_line_id', 'partner_id']
+        fields += ['sale_line_id', 'partner_id', 'sequence']
         return fields
 
 


### PR DESCRIPTION
Correct forward port of https://github.com/odoo/odoo/pull/95549.

The default order of the picking moves generated from a sale order should be the same order as the sale order lines.

Steps to reproduce:
- Create a sale order with several sale lines.
- Change the order of the sale lines.
- Confirm the sale order.
  => The moves of the picking don't maintain same order as set before.

X-original-commit: b5c2cd01e16c2c6091cb967b688718c0b81abda5


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr