### PR TITLE
[FIX] web: don't hide datepicker on scroll for iOS

### DIFF
--- a/addons/web/static/src/js/components/datepicker.js
+++ b/addons/web/static/src/js/components/datepicker.js
@@ -1,6 +1,7 @@
 odoo.define('web.DatePickerOwl', function (require) {
     "use strict";
 
+    const config = require('web.config');
     const field_utils = require('web.field_utils');
     const time = require('web.time');
     const { useAutofocus } = require('web.custom_hooks');
@@ -167,7 +168,7 @@ odoo.define('web.DatePickerOwl', function (require) {
          * @private
          */
         _onWindowScroll(ev) {
-            if (ev.target !== this.inputRef.el) {
+            if (!config.device.isIOS && ev.target !== this.inputRef.el) {
                 this._datetimepicker('hide');
             }
         }


### PR DESCRIPTION
This commit fixes a glitch on iOS (both iPhone & iPad landscape) where,
when the user attempts to open the datepicker of a custom filter's
field, it pops up and immediately close.

This is due to the desktop behavior which hides datepickers on scroll to
avoid hidding fields behind it.

In our case, a scroll is triggered once the focus is set in the date's
input and the virtual keyboard opens up... which then hides the
datepicker!

Sadly, this behavior's purpose being still useful in desktop, we don't
have much other solution than "just" disabling it on affected platforms
(ie. iOS) as it affects both small screens (ie. iPhones) and
dekstop-like ones (ie. iPad).

Hopefully, a better solution will be found at some point in a future
version, avoiding this kind of "trick"...

Note: replacing the "scroll" event with the "wheel" event seems to fix
the issue at first glance... but actually has side-effects for devices
using both touchscreens and a mouse (ie. 2-in-1 laptops).

Steps to reproduce:
- Open any collection view (list, kanban...)
- Open "Filter" dropdown and add a custom filter
- Choose a date/datetime field (ie. created_on)
- Tap the input
=> datepicker opens up and close immediately

opw-2671618
opw-2819299

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
