### PR TITLE
[FIX] project: use correct lang when creating personal stages

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1216,7 +1216,7 @@ class Task(models.Model):
                 # In the case no stages have been found, we create the default stages for the user
                 if not stage:
                     stages = self.env['project.task.type'].sudo().with_context(lang=user_id.partner_id.lang, default_project_id=False).create(
-                        self._get_default_personal_stage_create_vals(user_id.id)
+                        self.with_context(lang=user_id.partner_id.lang)._get_default_personal_stage_create_vals(user_id.id)
                     )
                     stage = stages[0]
                 personal_stage_by_user[user_id].sudo().write({'stage_id': stage.id})


### PR DESCRIPTION
It's expected that the personal stage is in the lang of the `user_id`. This commit assures it happens.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr