### PR TITLE
[IMP] hr(_fleet): add private car plate

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -120,6 +120,7 @@ class HrEmployeePrivate(models.Model):
     message_main_attachment_id = fields.Many2one(groups="hr.group_hr_user")
     id_card = fields.Binary(string="ID Card Copy", groups="hr.group_hr_user")
     driving_license = fields.Binary(string="Driving License", groups="hr.group_hr_user")
+    private_car_plate = fields.Char(groups="hr.group_hr_user", help="If you have more than one car, just separate the plates by a space.")
 
     _sql_constraints = [
         ('barcode_uniq', 'unique (barcode)', "The Badge ID must be unique, this one is already assigned to another employee."),

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -8,10 +8,12 @@
             <field name="arch" type="xml">
                 <search string="Employees">
                     <field name="name" string="Employees" filter_domain="['|',('work_email','ilike',self),('name','ilike',self)]"/>
-                    <field name="job_title" string="Job Title"/>
-                    <field name="department_id" string="Department"/>
+                    <searchpanel>
+                        <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
+                        <field name="department_id" icon="fa-users" enable_counters="1"/>
+                    </searchpanel>
                     <field name="parent_id" string="Manager"/>
-                    <field name="company_id" string="Company"/>
+                    <field name="job_title"/>
                     <separator/>
                     <filter name="my_team" string="My Team" domain="[('parent_id.user_id', '=', uid)]"/>
                     <filter name="my_department" string="My Department" domain="[('member_of_department', '=', True)]"/>
@@ -22,10 +24,6 @@
                         <filter name="group_department" string="Department" domain="[]" context="{'group_by':'department_id'}"/>
                         <filter name="group_company" string="Company" domain="[]" context="{'group_by':'company_id'}"/>
                     </group>
-                    <searchpanel>
-                        <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
-                        <field name="department_id" icon="fa-users" enable_counters="1"/>
-                    </searchpanel>
                 </search>
              </field>
         </record>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -8,9 +8,14 @@
             <field name="arch" type="xml">
                 <search string="Employees">
                     <field name="name" string="Employee" filter_domain="['|', ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
-                    <field name="category_ids" groups="hr.group_hr_user"/>
-                    <field name="job_id"/>
+                    <searchpanel>
+                        <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
+                        <field name="department_id" icon="fa-users" enable_counters="1"/>
+                    </searchpanel>
                     <field name="parent_id" string="Manager"/>
+                    <field name="job_id"/>
+                    <field name="category_ids" groups="hr.group_hr_user"/>
+                    <field name="private_car_plate" />
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]"/>
                     <separator/>
@@ -31,10 +36,6 @@
                         <filter name="group_job" string="Job" domain="[]" context="{'group_by': 'job_id'}"/>
                         <filter name="group_category_ids" string="Tags" domain="[]" context="{'group_by': 'category_ids'}"/>
                     </group>
-                    <searchpanel>
-                        <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
-                        <field name="department_id" icon="fa-users" enable_counters="1"/>
-                    </searchpanel>
                 </search>
              </field>
         </record>
@@ -146,6 +147,9 @@
                                             <field name="km_home_work" groups="hr.group_hr_user"/>
                                             <span>Km</span>
                                         </div>
+                                        </group>
+                                        <group colspan="2">
+                                            <field name="private_car_plate" />
                                         </group>
                                     </group>
                                     <group>

--- a/addons/hr_fleet/views/employee_views.xml
+++ b/addons/hr_fleet/views/employee_views.xml
@@ -28,9 +28,8 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_filter"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='job_id']" position="after">
-                <field name="car_ids" string="License Plate"
-                    filter_domain="[('car_ids.license_plate', 'ilike', self)]"/>
+            <xpath expr="//field[@name='private_car_plate']" position="replace">
+                <field name="license_plate"/>
             </xpath>
         </field>
     </record>

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -21,7 +21,7 @@
         <field name="model">hr.employee.public</field>
         <field name="inherit_id" ref="hr.hr_employee_public_view_search"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='company_id']" position="after">
+            <xpath expr="//field[@name='job_title']" position="after">
                 <field name="employee_skill_ids"/>
                 <field name="resume_line_ids" string="Resumé" filter_domain="['|', ('resume_line_ids.name', 'ilike', self), ('resume_line_ids.description', 'ilike', self)]"/>
             </xpath>


### PR DESCRIPTION
Not all employees have a company car. This commit adds a private license plate field on hr.employee.
The field allows the HR Officer and HR Administrator to search for emloyees based on their license plates.
If fleet and hr apps are installed, the search is based on both the company car and private car license plates.

task-2936873

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
