### PR TITLE
[FIX] web: ColorField triggers onchange when is changed

### DIFF
--- a/addons/web/static/src/views/fields/color/color_field.js
+++ b/addons/web/static/src/views/fields/color/color_field.js
@@ -3,12 +3,16 @@
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "../standard_field_props";
 
-const { Component, useState } = owl;
+const { Component, useState, onWillUpdateProps } = owl;
 
 export class ColorField extends Component {
     setup() {
         this.state = useState({
             color: this.props.value || "#000000",
+        });
+
+        onWillUpdateProps((nextProps) => {
+            this.state.color = nextProps.value || "#000000";
         });
     }
 

--- a/addons/web/static/src/views/fields/color/color_field.xml
+++ b/addons/web/static/src/views/fields/color/color_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.ColorField" owl="1">
         <div class="o_field_color d-flex" t-att-class="{ 'o_field_cursor_disabled': readonly }" t-attf-style="background-color: {{state.color}}">
-            <input t-on-click.stop="" class="w-100 h-100 opacity-0" type="color" t-att-value="props.value" t-att-disabled="readonly" t-on-input="(ev) => this.state.color = ev.target.value" t-on-change="(ev) => this.props.update(ev.target.value)" />
+            <input t-on-click.stop="" class="w-100 h-100 opacity-0" type="color" t-att-value="state.color" t-att-disabled="readonly" t-on-input="(ev) => this.state.color = ev.target.value" t-on-change="(ev) => this.props.update(ev.target.value)" />
         </div>
     </t>
 


### PR DESCRIPTION
Have a color field with an onchange on it.
Change the color.

Before this commit, the onchange was not passed to the server. This was
due to the internal of ColorField, which refreshed its value to the old one
even before owl or odoo did anything.

After this commit, the call to onchange is correctly passed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
