### PR TITLE
[IMP] base: add index on `key` of ir_ui_view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -224,7 +224,7 @@ class View(models.Model):
 
     name = fields.Char(string='View Name', required=True)
     model = fields.Char(index=True)
-    key = fields.Char()
+    key = fields.Char(index='btree_not_null')
     priority = fields.Integer(string='Sequence', default=16, required=True)
     type = fields.Selection([('tree', 'Tree'),
                              ('form', 'Form'),


### PR DESCRIPTION
The `key` field is often (`_get_view_id`/`_get_specific_views`) used to
find an ir_ui_view. Because `key` doesn't have index, PostgreSQL will
always do a SeqScan. Because the table is small, it doesn't create a
huge performance bottleneck, but it still not very efficient.