### PR TITLE
[IMP] web, base: WIP example sign to the left (hebrew, arabic)


### DIFF
--- a/addons/web/static/src/legacy/js/fields/field_utils.js
+++ b/addons/web/static/src/legacy/js/fields/field_utils.js
@@ -178,7 +178,7 @@ function formatFloat(value, field, options) {
     }
     var formatted = _.str.sprintf('%.' + precision + 'f', value || 0).split('.');
     formatted[0] = utils.insert_thousand_seps(formatted[0]);
-    return formatted.join(l10n.decimal_point);
+    return '\u202A' + formatted.join(l10n.decimal_point) + '\u202C';
 }
 
 
@@ -250,9 +250,9 @@ function formatInteger(value, field, options) {
         return "";
     }
     if (options.humanReadable && options.humanReadable(value)) {
-        return utils.human_number(value, options.decimals, options.minDigits, options.formatterCallback);
+        return '\u202A' + utils.human_number(value, options.decimals, options.minDigits, options.formatterCallback) + '\u202C';
     }
-    return utils.insert_thousand_seps(_.str.sprintf('%d', value));
+    return '\u202A' + utils.insert_thousand_seps(_.str.sprintf('%d', value)) + '\u202C';
 }
 
 /**

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -138,7 +138,7 @@ class IntegerConverter(models.AbstractModel):
 
     @api.model
     def value_to_html(self, value, options):
-        return pycompat.to_text(self.user_lang().format('%d', value, grouping=True).replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}'))
+        return pycompat.to_text('\u202A' + self.user_lang().format('%d', value, grouping=True).replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}')+ '\u202C')
 
 
 class FloatConverter(models.AbstractModel):
@@ -176,7 +176,7 @@ class FloatConverter(models.AbstractModel):
         if precision is None:
             formatted = re.sub(r'(?:(0|\d+?)0+)$', r'\1', formatted)
 
-        return pycompat.to_text(formatted)
+        return pycompat.to_text('\u202A' + formatted + '\u202C')
 
     @api.model
     def record_to_html(self, record, field_name, options):
@@ -455,9 +455,9 @@ class MonetaryConverter(models.AbstractModel):
             sep = lang.decimal_point
             integer_part, decimal_part = formatted_amount.split(sep)
             integer_part += sep
-            return M('{pre}<span class="oe_currency_value">{0}</span><span class="oe_currency_value" style="font-size:0.5em">{1}</span>{post}').format(integer_part, decimal_part, pre=pre, post=post)
+            return M('{pre}<span class="oe_currency_value" dir=ltr">{0}</span><span class="oe_currency_value" style="font-size:0.5em">{1}</span>{post}').format(integer_part, decimal_part, pre=pre, post=post)
 
-        return M('{pre}<span class="oe_currency_value">{0}</span>{post}').format(formatted_amount, pre=pre, post=post)
+        return M('{pre}<span class="oe_currency_value" dir="ltr">{0}</span>{post}').format(formatted_amount, pre=pre, post=post)
 
     @api.model
     def record_to_html(self, record, field_name, options):


### PR DESCRIPTION
WIP example of code that would be necessary for having the negative sign
to the left of float, integer and monetary fields for RTL language,
where it currently can be wrongly on the right (which may be correct in
some case, but not in pure arabic/hebrew with arabic numerals.

opw-2941412

note: this doesn't take into account parsing that should take sign into account, so it's only working for formatting not parsing