### PR TITLE
[IMP] base: add the reason of skipped test in log

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1033,7 +1033,6 @@ class ChromeBrowser:
                 if os.path.exists(bin_):
                     return bin_
 
-        self._logger.warning("Chrome executable not found")
         raise unittest.SkipTest("Chrome executable not found")
 
     def _chrome_without_limit(self, cmd):

--- a/odoo/tests/runner.py
+++ b/odoo/tests/runner.py
@@ -198,7 +198,7 @@ class OdooTestResult(unittest.result.TestResult):
 
     def addSkip(self, test, reason):
         super().addSkip(test, reason)
-        self.log(logging.INFO, 'skipped %s', self.getDescription(test), test=test)
+        self.log(logging.INFO, 'skipped %s : %s', self.getDescription(test), reason, test=test)
 
     def addUnexpectedSuccess(self, test):
         super().addUnexpectedSuccess(test)


### PR DESCRIPTION
When test are skipped, we don't have any information of why.
It seems important to log also the reason, it can help
developers to find the source of issues (example: when your chrome
doesn't the devtools active: you just know that test is skipped, but
don't know why).
