### PR TITLE
[IMP] *: optimize redundant calls to `exists()`

### DIFF
--- a/addons/mail/models/update.py
+++ b/addons/mail/models/update.py
@@ -98,10 +98,6 @@ class PublisherWarrantyContract(AbstractModel):
             # old behavior based on res.log; now on mail.message, that is not necessarily installed
             user = self.env['res.users'].sudo().browse(SUPERUSER_ID)
             poster = self.sudo().env.ref('mail.channel_all_employees')
-            if not (poster and poster.exists()):
-                if not user.exists():
-                    return True
-                poster = user
             for message in result["messages"]:
                 try:
                     poster.message_post(body=message, subtype_xmlid='mail.mt_comment', partner_ids=[user.partner_id.id])

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -36,7 +36,7 @@ class PortalProjectAccount(PortalAccount, ProjectCustomerPortal):
         type='http', auth="user", website=True)
     def portal_my_tasks_invoices(self, task_id=None, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
         task = request.env['project.task'].search([('id', '=', task_id)])
-        if not task.exists():
+        if not task:
             return NotFound()
 
         domain = [('id', 'in', task.sale_order_id.invoice_ids.ids)]

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1300,7 +1300,7 @@ class GroupsView(models.Model):
         # We have to try-catch this, because at first init the view does not
         # exist but we are already creating some basic groups.
         view = self.env.ref('base.user_groups_view', raise_if_not_found=False)
-        if not (view and view.exists() and view._name == 'ir.ui.view'):
+        if not (view and view._name == 'ir.ui.view'):
             return
 
         if self._context.get('install_filename') or self._context.get(MODULE_UNINSTALL_FLAG):


### PR DESCRIPTION
Making a `exists()` on a record got by a `search()` is useless and
lead to a extra useless query. Remove them.
