### PR TITLE
[FIX] purchase_stock: avoid updating kit components price_unit

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -335,7 +335,8 @@ class PurchaseOrderLine(models.Model):
         result = super(PurchaseOrderLine, self).write(values)
         if 'price_unit' in values:
             for line in lines:
-                moves = line.move_ids.filtered(lambda s: s.state not in ('cancel', 'done'))
+                # Avoid updating kit components' stock.move
+                moves = line.move_ids.filtered(lambda s: s.state not in ('cancel', 'done') and s.product_id == line.product_id)
                 moves.write({'price_unit': line._get_stock_move_price_unit()})
         if 'product_qty' in values:
             lines.with_context(previous_product_qty=previous_product_qty)._create_or_update_picking()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
Necessary fix on purchase_stock for kit products after changes made by https://github.com/odoo/odoo/commit/87ffe5983be7f0f4a926b458c4bd1f13001048ec

cf : https://github.com/odoo/odoo/pull/96611#discussion_r934184718


## Current behavior before PR:
When you update the price_unit of a PO line of a kit product, the price_unit of each components' stock.move is updated with the kit's price.


## Desired behavior after PR is merged:
When you update the price_unit of a PO line of a kit product, the price_unit of each components' stock.move is **not** updated.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
