### PR TITLE
[IMP] point_of_sale: display warning when closing session if orders

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -66,6 +66,15 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
         }
         //@override
         async confirm() {
+            if(Object.values(this.env.pos.get_order_list()).filter(order => order.orderlines.length || order.paymentlines.length).length) {
+                let confirmedPopup = await this.showPopup('ConfirmPopup', {
+                    title: this.env._t('Order still in ongoing state'),
+                    body: this.env._t('Do you really want to close the pos with ongoing orders?'),
+                });
+                if (!confirmedPopup.confirmed) {
+                    this.cancel();
+                }
+            }
             if (!this.cashControl || !this.hasDifference()) {
                 this.closeSession();
             } else if (this.hasUserAuthority()) {


### PR DESCRIPTION
When the user will close the session, a warning will ask if he really wants to close the session if there are still ongoing orders.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
