### PR TITLE
[IMP] stock: unreserved linked moves

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -841,7 +841,7 @@ class Picking(models.Model):
         """
         self.filtered(lambda picking: picking.state == 'draft').action_confirm()
         moves = self.move_ids.filtered(lambda move: move.state not in ('draft', 'cancel', 'done')).sorted(
-            key=lambda move: (-int(move.priority), not bool(move.date_deadline), move.date_deadline, move.date, move.id)
+            key=lambda move: (-int(move.priority), not bool(move.date_deadline), bool(move.move_orig_ids), move.date_deadline, move.date, move.id)
         )
         if not moves:
             raise UserError(_('Nothing to check the availability for.'))


### PR DESCRIPTION
Before this commit, not possible to perform a transfer while waiting for another
operation, even if products are available at that location.

After this commit, If a transfer is unreserved and products are available on the
next transfer, then we can operate on the next transfer.

task-id: 2799814
PR: #97541

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
