### PR TITLE
[FIX] calendar: select and inserting text add many spaces

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1968,10 +1968,10 @@ export function enforceWhitespace(el, offset, direction, rule) {
     let expr;
     if (direction === DIRECTIONS.LEFT) {
         domPath = leftLeafOnlyNotBlockPath(el, offset);
-        expr = /[^\S\u00A0]+$/;
+        expr = /\s+/g;
     } else {
         domPath = rightLeafOnlyNotBlockPath(el, offset);
-        expr = /^[^\S\u00A0]+/;
+        expr = /\s+/g;
     }
 
     const invisibleSpaceTextNodes = [];


### PR DESCRIPTION
**Current behavior before PR:**

When we try to select and insert a text then it will add many spaces before
the text.

**Desired behavior after PR is merged:**

Now when we try to select and insert a text it will not add extra spaces
between text.

Task-2581275

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
