### PR TITLE
[FIX] web: record's images correctly cached by the browser.

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -10,7 +10,7 @@ import { useService } from "@web/core/utils/hooks";
 import { sprintf } from "@web/core/utils/strings";
 import { url } from "@web/core/utils/urls";
 import { Field } from "@web/views/fields/field";
-import { fileTypeMagicWordMap } from "@web/views/fields/image/image_field";
+import { fileTypeMagicWordMap, imageCacheKey } from "@web/views/fields/image/image_field";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useViewCompiler } from "@web/views/view_compiler";
 import { Widget } from "@web/views/widgets/widget";
@@ -82,7 +82,12 @@ function getImageSrcFromRecordInfo(record, model, field, idOrIds, placeholder) {
         return placeholder;
     } else {
         // Else: fetches the image related to the given id.
-        return url("/web/image", { model, field, id });
+        return url("/web/image", {
+            model,
+            field,
+            id,
+            unique: imageCacheKey(record.data.__last_update),
+        });
     }
 }
 

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -8403,7 +8403,10 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("test displaying image (__last_update field)", async (assert) => {
         // the presence of __last_update field ensures that the image is reloaded when necessary
-        assert.expect(1);
+        assert.expect(2);
+
+        const rec = serverData.models.partner.records.find((r) => r.id === 1);
+        rec.__last_update = "2022-08-05 08:37:00";
 
         await makeView({
             type: "kanban",
@@ -8421,7 +8424,17 @@ QUnit.module("Views", (hooks) => {
                     assert.deepEqual(kwargs.fields, ["id", "__last_update"]);
                 }
             },
+            domain: [["id", "in", [1]]],
         });
+
+        assert.ok(
+            target
+                .querySelector(".o_kanban_record:not(.o_kanban_ghost) img")
+                .dataset.src.endsWith(
+                    "/web/image?model=partner&field=image&id=1&unique=1659688620000"
+                ),
+            "image src is the preview image given in option"
+        );
     });
 
     QUnit.test("test displaying image (binary & placeholder)", async (assert) => {
@@ -8521,12 +8534,12 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(
             target,
-            'img[data-src*="/web/image"][data-src$="&id=1"]',
+            'img[data-src*="/web/image"][data-src$="&id=1&unique="]',
             "image url should contain id of set partner_id"
         );
         assert.containsOnce(
             target,
-            'img[data-src*="/web/image"][data-src$="&id="]',
+            'img[data-src*="/web/image"][data-src$="&id=&unique="]',
             "image url should contain an empty id if partner_id is not set"
         );
     });
@@ -10897,14 +10910,16 @@ QUnit.module("Views", (hooks) => {
             type: "kanban",
             resModel: "partner",
             serverData,
-            arch:
-                "<kanban>" +
-                '<templates><t t-name="kanban-box">' +
-                "<div>" +
-                '<field name="int_field"/>' +
-                "</div>" +
-                "</t></templates>" +
-                "</kanban>",
+            arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="int_field"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
             groupBy: ["product_id"],
         });
 


### PR DESCRIPTION
Before this commit, images' url where just built upon the record's id and model.
Since the browser caches GET requests by url, the same record would always have the same image url.
Hence it appeared that when changing a record's image in form view, and going back
to the kanban, the image displayed was the old one.

A good enough approximation to solve this (and was actually solved in legacy code), is to use
the record's __last_update field, which basically tells the browser to re-fetch
a record's image when then record go through any modification.

After this commit, images are correctly updated in kanban and form views.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
