### PR TITLE
[FIX] hr(_attendance): display the presence bubble

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -62,10 +62,12 @@
                                 <field name="name" placeholder="Employee's Name" required="True" style="font-size: min(4vw, 2.6rem);" />
                                 <field name="last_activity_time" invisible="1"/>
                                 <field name="last_activity" invisible="1"/>
-                                <div id="hr_presence_status" attrs="{'invisible': ['|', ('last_activity', '=', False), ('user_id', '=', False)]}">
-                                    <div role="img" class="fa fa-fw fa-circle text-success o_button_icon hr_presence" attrs="{'invisible': [('hr_presence_state', '!=', 'present')]}" aria-label="Available" title="Available"/>
-                                    <div role="img" class="fa fa-2xs fa-fw fa-circle text-warning o_button_icon hr_presence" attrs="{'invisible': [('hr_presence_state', '!=', 'to_define')]}" aria-label="Away" title="Away"/>
-                                    <div role="img" class="fa fa-2xs fa-fw fa-circle text-danger o_button_icon hr_presence" attrs="{'invisible': [('hr_presence_state', '!=', 'absent')]}" aria-label="Not available" title="Not available"/>
+                                <field name="hr_icon_display" invisible="1"/>
+                                <div id="hr_presence_status" attrs="{'invisible': [('user_id', '=', False)]}">
+                                    <div role="img" class="fa fa-fw fa-circle text-success o_button_icon hr_presence" attrs="{'invisible': [('hr_icon_display', '!=', 'presence_present')]}" aria-label="Available" title="Available"/>
+                                    <div role="img" class="fa fa-fw fa-circle-o text-muted o_button_icon hr_presence" attrs="{'invisible': [('hr_icon_display', '!=', 'presence_absent')]}" aria-label="Away" title="Away"/>
+                                    <div role="img" class="fa fa-fw fa-circle-o text-success o_button_icon hr_presence" attrs="{'invisible': [('hr_icon_display', '!=', 'presence_absent_active')]}" aria-label="Away" title="Away"/>
+                                    <div role="img" class="fa fa-fw fa-circle text-warning o_button_icon hr_presence" attrs="{'invisible': [('hr_icon_display', '!=', 'presence_to_define')]}" aria-label="Not available" title="Not available"/>
                                 </div>
                                 <a title="Chat" icon="fa-comments" href="#" class="ml8 o_employee_chat_btn" invisible="not context.get('chat_icon')" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
                             </h1>

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='hr_presence_status']" position="attributes">
                 <attribute name="attrs">
-                    {'invisible': ['|', '|', ('user_id', '=', False), ('hr_presence_state', '=', 'absent'), ('attendance_state', '=', 'checked_in')]}
+                    {'invisible': False}
                 </attribute>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">

--- a/addons/hr_holidays_attendance/views/hr_employee_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_employee_views.xml
@@ -58,12 +58,7 @@
             <!-- Merge invisible attr of both module -->
             <xpath expr="//div[@id='hr_presence_status']" position="attributes">
                 <attribute name="attrs">
-                    {'invisible': ['|', '|', '|',
-                        ('is_absent', '=', True),
-                        ('hr_presence_state', '=', 'absent'),
-                        ('attendance_state', '=', 'checked_in'),
-                        ('id', '=', False),
-                    ]}
+                    {'invisible': False}
                 </attribute>
             </xpath>
         </field>


### PR DESCRIPTION
The presence bubble on the employee form is hidden while it is shown on the kanban view of the employees.
This commit fixes the presence bubble to have a consistent behaviour between the employees kanban view and the employee form.

task-2945615

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
