### PR TITLE
[FIX] l10n_it_edi: fix codice fiscale validation regex

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -45,7 +45,7 @@ class ResPartner(models.Model):
 
     @api.constrains('l10n_it_codice_fiscale')
     def validate_codice_fiscale(self):
-        p = re.compile(r'^([A-Za-z]{6}[0-9]{2}[A-Za-z]{1}[0-9]{2}[A-Za-z]{1}[0-9]{3}[A-Za-z]{1}$)|([0-9]{11})|(IT[0-9]{11})$')
+        p = re.compile(r'^([A-Za-z]{6}[0-9]{2}[A-Za-z][0-9]{2}[A-Za-z]\w{4}$)|((IT)?[0-9]{11})$')
         for record in self:
             if record.l10n_it_codice_fiscale and not p.match(record.l10n_it_codice_fiscale):
                 raise UserError(_("Invalid Codice Fiscale '%s': should be like 'MRTMTT91D08F205J' for physical person and '12345678901' or 'IT12345678901' for businesses.", record.l10n_it_codice_fiscale))


### PR DESCRIPTION
According to this doc : https://housinganywhere.com/Italy/codice-fiscale-italy the "Country of birth" part of the codice fiscale is not always 3 digits and one letter as the current validation is expecting. This part is 4 times any alphanumeric characters.
This commit implement this and also refactor the regex a little bit (useless {1} removed and condensing of the enterprise validation part).

Task: opw-2927179