### PR TITLE
[FIX] web: press a key when focusing column header

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1131,7 +1131,7 @@ export class ListRenderer extends Component {
     onCellKeydownEditMode(hotkey, cell, group, record) {
         const { activeActions, cycleOnTab, list } = this.props;
         const row = cell.parentElement;
-        const applyMultiEditBehavior = record.selected && list.model.multiEdit;
+        const applyMultiEditBehavior = record && record.selected && list.model.multiEdit;
 
         if (
             applyMultiEditBehavior &&

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -12118,6 +12118,33 @@ QUnit.module("Fields", (hooks) => {
         }
     );
 
+    QUnit.test(
+        "be able to press a key on the keyboard when focusing a column header without crashing",
+        async function (assert) {
+            assert.expect(0);
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <form>
+                        <field name="turtles">
+                            <tree editable="bottom">
+                                <field name="turtle_int" />
+                            </tree>
+                        </field>
+                    </form>`,
+                resId: 1,
+            });
+            await clickEdit(target);
+            await click(target.querySelector(".o_data_row .o_data_cell"));
+            target.querySelector(".o_list_renderer .o_column_sortable").focus();
+            triggerHotkey("a");
+            await nextTick();
+        }
+    );
+
     QUnit.test("Check onchange with two consecutive one2one", async function (assert) {
         serverData.models.product.fields.product_partner_ids = {
             string: "User",


### PR DESCRIPTION
Before this commit, if the header of a column (X2many/ListView) has the
focus, a record is being edited and a key is pressed, then a crash is
displayed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
