### PR TITLE
[FIX] Project: Unrestricted access on projects no matter the user company

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -376,7 +376,7 @@
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
-                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" attrs="{'readonly':[('active','=',False)]}" domain="[('share', '=', False)]"/>
+                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" attrs="{'readonly':[('active','=',False)]}" domain="[('share', '=', False), ('company_ids', '=', company_id)]"/>
                             <label for="date_start" string="Dates"/>
                             <div name="dates" class="o_row">
                                 <field name="date_start" widget="daterange" options='{"related_end_date": "date"}'/>
@@ -866,7 +866,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2many_avatar_user"
-                                domain="[('share', '=', False), ('active', '=', True)]"/>
+                                domain="[('share', '=', False), ('active', '=', True), ('company_ids', '=', company_id)]"/>
                             <field name="parent_id"
                                 attrs="{'invisible' : [('allow_subtasks', '=', False)]}"
                                 groups="base.group_no_one"


### PR DESCRIPTION
Steps to reproduce issue:
Add users and restrict some to certain companies and create a project in one company.

Current behaviour:
The restricted users can still be added as eg: project managers on a project in a company they cannot access.

Expected behaviour:
A domain on the user fields to restrict the selection of the users to the company they are assigned to.

Solution:
Add condition on domain attribut in  "user_ids" in project.task.form  and "user_id" in project.project.form

opw-2937019

Signed-off by: Eteil Djoumatchoua <etdj@odoo.com>
