### PR TITLE
[FIX] website: fix configurator/edit menu ui

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -8,7 +8,7 @@ import {svgToPNG} from 'website.utils';
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 
-const { Component, onMounted, reactive, useEnv, useRef, useState, useSubEnv, onWillStart } = owl;
+const { Component, onMounted, reactive, useEnv, useRef, useState, useSubEnv, onWillStart, useEffect } = owl;
 
 const ROUTES = {
     descriptionScreen: 2,
@@ -598,7 +598,7 @@ class Configurator extends Component {
             // Do not use navigate because URL is already updated.
             this.state.currentStep = step;
         });
-        
+
         const initialStep = this.props.action.context.params && this.props.action.context.params.step;
         const store = reactive(new Store(), () => this.updateStorage(store));
 
@@ -627,6 +627,18 @@ class Configurator extends Component {
                 this.updateBrowserUrl();
             });
         });
+
+        useEffect(() => {
+            const rootEl = document.querySelector(':root');
+            const initalFontSize = rootEl.style.fontSize;
+            rootEl.style.fontSize = '16px';
+            return () => {
+                rootEl.style.fontSize = initalFontSize;
+                if (!rootEl.getAttribute('style')) {
+                    rootEl.removeAttribute('style');
+                }
+            };
+        }, () => []);
     }
 
     get pathname() {

--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -1,6 +1,37 @@
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,700,700i&display=swap");
+
 .o_configurator_container {
     @include o-position-absolute(0, 0, 0, 0);
     background-color: $white;
+    font-family: "Source Sans Pro", "Roboto", $font-family-sans-serif;
+
+    .container {
+        max-width: map-get($container-max-widths, xl);
+    }
+
+    .small {
+        font-size: 80%;
+    }
+
+    .h4 {
+        font-size: 1.5rem !important;
+    }
+
+    .text-info {
+        color: $o-info !important;
+    }
+
+    .text-warning {
+        color: $o-warning !important;
+    }
+
+    .card {
+        background-color: $white !important;
+
+        .card-body {
+            background-color: rgba($white, 0.9) !important;
+        }
+    }
 
     .o_configurator_screen {
 

--- a/addons/website/static/src/components/dialog/dialog.scss
+++ b/addons/website/static/src/components/dialog/dialog.scss
@@ -2,4 +2,8 @@
     label {
         font-weight: $font-weight-bold;
     }
+
+    .form-group {
+        margin-bottom: 1rem;
+    }
 }

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -16,6 +16,7 @@
             </label>
             <div class="col-md-9">
                 <input id="url_input" t-ref="url-input" type="text" t-model="url.input.value" class="form-control" t-att-class="{ 'is-invalid': url.input.hasError }"/>
+                <small class="form-text text-muted">Hint: Type '/' to search an existing page and '#' to link to an anchor.</small>
             </div>
         </div>
     </WebsiteDialog>

--- a/addons/website/static/src/components/website_loader/website_loader.scss
+++ b/addons/website/static/src/components/website_loader/website_loader.scss
@@ -2,7 +2,7 @@
     font-family: "Montserrat", $font-family-sans-serif;
     background-color: rgba($o-shadow-color, .9);
     pointer-events: all;
-    font-size: 3.5rem;
+    font-size: 42px;
     justify-content: space-evenly;
     z-index: $zindex-modal - 1;
     padding: 7%;


### PR DESCRIPTION
[FIX] website: fix edit menu dialog ui

This commit adds the hint that [1] missed when adapting the "Edit menu"
dialog to owl, and adds a margin removed by the bootsrap update.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: fix configurator style

When [1] moved the configurator frontend to a backend client action, it
did not correctly adapt the style: the backend's root element has a
font-size of 12px when the frontend has the default one (16px). As a
result, every css property using rem units was inaccurate.
This commit temporarily sets the root element font size to 16px when the
configurator client action is displayed to restore the style it had on
versions 15.X.
It also adapts the style to bootsrap 5.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
