### PR TITLE
[FIX] l10n_it_edi: IT Company pa index demo data

### DIFF
--- a/addons/l10n_it_edi/data/account_invoice_demo.xml
+++ b/addons/l10n_it_edi/data/account_invoice_demo.xml
@@ -12,6 +12,10 @@
             <field name="zip">12345</field>
         </record>
 
+        <record id="l10n_it.partner_demo_company_it" model="res.partner">
+            <field name="l10n_it_pa_index">0803HR0</field>
+        </record>
+
         <record id="partner_demo_it" model="res.partner">
             <field name="name">Palazzo dell'Arte</field>
             <field name="vat">IT00000010215</field>


### PR DESCRIPTION
In order to perform reverse charge self-invoicing, a company must have
its codice destinario (pa index) defined. This commit adds a valid
pa_index (from the sdicoop test channel) to the demo company.