### PR TITLE
[FIX] web: FormView: correctly eval domain involving "id"

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -3959,6 +3959,9 @@ var BasicModel = AbstractModel.extend({
                 if (fieldValue === null) {
                     return false;
                 }
+                if (fieldName === "id" && !fieldValue) {
+                    return false;
+                }
 
                 if (field.type === 'date' || field.type === 'datetime') {
                     if (fieldValue) {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -1940,6 +1940,38 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
+    QUnit.test("field with readonly modifier depending on id", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="int_field" attrs="{'readonly': [('id', '!=', False)]}"/>
+                </form>`,
+        });
+
+        assert.containsOnce(target, ".o_form_editable");
+        assert.containsOnce(target, ".o_field_widget[name=int_field] input");
+        assert.doesNotHaveClass(
+            target.querySelector(".o_field_widget[name=int_field]"),
+            "o_readonly_modifier"
+        );
+
+        await editInput(target, ".o_field_widget[name=int_field] input", "34");
+        await click(target.querySelector(".o_form_button_save"));
+        assert.containsOnce(target, ".o_form_readonly");
+        assert.strictEqual(target.querySelector(".o_field_widget[name=int_field]").innerText, "34");
+
+        await click(target.querySelector(".o_form_button_edit"));
+        assert.containsOnce(target, ".o_form_editable");
+        assert.containsNone(target, ".o_field_widget[name=int_field] input");
+        assert.hasClass(
+            target.querySelector(".o_field_widget[name=int_field]"),
+            "o_readonly_modifier"
+        );
+    });
+
     QUnit.test(
         "readonly attrs on lines are re-evaluated on field change 2",
         async function (assert) {


### PR DESCRIPTION
Before this commit, modifiers containing conditions on the "id"
fields weren't always correctly evaluated in form views. This
happened when the "id" field wasn't present in the view. In this
case, its value in the evalContext was "undefined", so a domain
like ("id", "!=", "False") was always evaluated to true. The "id"
field is handled a bit differently than the other ones, as we do
not require for the field to be present to use it in modifiers
(mostly because we don't need it to be present to know its value).

This commit fixes the issue by forcing a `false` value for "id"
when the record has no id yet.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
