### PR TITLE
[IMP] mrp: back to basics 7 ngtr

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -409,9 +409,9 @@ class MrpBomLine(models.Model):
             'You should install the mrp_byproduct module if you want to manage extra products on BoMs !'),
     ]
 
-    @api.depends('product_id', 'tracking')
+    @api.depends('product_id', 'tracking', 'operation_id')
     def _compute_manual_consumption(self):
-        self.filtered(lambda m: m.tracking != 'none').manual_consumption = True
+        self.filtered(lambda m: m.tracking != 'none' or m.operation_id).manual_consumption = True
 
     @api.depends('product_id', 'bom_id')
     def _compute_child_bom_id(self):

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -616,7 +616,7 @@ class MrpProduction(models.Model):
     @api.depends('state', 'move_raw_ids')
     def _compute_show_lot_ids(self):
         for order in self:
-            order.show_lot_ids = order.state != 'draft' and any(m.product_id.tracking == 'serial' for m in order.move_raw_ids)
+            order.show_lot_ids = order.state != 'draft' and any(m.product_id.tracking != 'none' for m in order.move_raw_ids)
 
     @api.depends('state', 'move_raw_ids')
     def _compute_show_serial_mass_produce(self):

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -745,7 +745,7 @@ class MrpWorkorder(models.Model):
             duration_expected_working = (self.duration_expected - self.workcenter_id.time_start - self.workcenter_id.time_stop) * self.workcenter_id.time_efficiency / 100.0
             if duration_expected_working < 0:
                 duration_expected_working = 0
-            return self.workcenter_id.time_start + self.workcenter_id.time_stop + duration_expected_working * ratio * 100.0 / self.workcenter_id.time_efficiency
+            return self.workcenter_id._get_expected_duration(self.product_id) + duration_expected_working * ratio * 100.0 / self.workcenter_id.time_efficiency
         qty_production = self.production_id.product_uom_id._compute_quantity(self.qty_production, self.production_id.product_id.uom_id)
         capacity = self.workcenter_id._get_capacity(self.product_id)
         cycle_number = float_round(qty_production / capacity, precision_digits=0, rounding_method='UP')
@@ -756,9 +756,9 @@ class MrpWorkorder(models.Model):
                 duration_expected_working = 0
             capacity = alternative_workcenter._get_capacity(self.product_id)
             alternative_wc_cycle_nb = float_round(qty_production / capacity, precision_digits=0, rounding_method='UP')
-            return alternative_workcenter.time_start + alternative_workcenter.time_stop + alternative_wc_cycle_nb * duration_expected_working * 100.0 / alternative_workcenter.time_efficiency
+            return alternative_workcenter._get_expected_duration(self.product_id) + alternative_wc_cycle_nb * duration_expected_working * 100.0 / alternative_workcenter.time_efficiency
         time_cycle = self.operation_id.time_cycle
-        return self.workcenter_id.time_start + self.workcenter_id.time_stop + cycle_number * time_cycle * 100.0 / self.workcenter_id.time_efficiency
+        return self.workcenter_id._get_expected_duration(self.product_id) + cycle_number * time_cycle * 100.0 / self.workcenter_id.time_efficiency
 
     def _get_conflicted_workorder_ids(self):
         """Get conlicted workorder(s) with self.

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -99,7 +99,7 @@
                                     <field name="allowed_operation_ids" invisible="1"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" optional="hidden" attrs="{'column_invisible': [('parent.type','not in', ('normal', 'phantom'))]}" options="{'no_quick_create':True,'no_create_edit':True}"/>
                                     <field name="tracking" invisible="1"/>
-                                    <field name="manual_consumption" optional="hide" width="1.0" attrs="{'readonly': [('tracking', '!=', 'none')]}"/>
+                                    <field name="manual_consumption" groups="mrp.group_mrp_routings" optional="hide" width="1.0" attrs="{'readonly': ['|', ('tracking', '!=', 'none'), ('operation_id', '!=', False)]}"/>
                                 </tree>
                             </field>
                         </page>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -346,9 +346,12 @@
                                     <field name="manual_consumption" invisible="1" force_save="1"/>
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
-                                        groups="stock.group_production_lot" optional="hide"
-                                        attrs="{'invisible': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')],
-                                                'readonly': ['|', '|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial'), ('parent.state', '=', 'draft')],
+                                        optional="hide" 
+                                        readonly="1"
+                                        string="Lot/Serial Numbers"
+                                        help="Displays the consumed Lot/Serial Numbers."
+                                        groups="stock.group_production_lot" 
+                                        attrs="{'invisible': ['|', ('show_details_visible', '=', False), ('parent.state', '=', 'draft')],
                                                 'column_invisible': [('parent.show_lot_ids', '=',  False)]}"
                                         options="{'create': [('parent.use_create_components_lots', '!=', False)]}"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id}"

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -393,6 +393,8 @@
                                         <field name="product_id"/>
                                         <field name="product_uom_id" groups="uom.group_uom"/>
                                         <field name="capacity"/>
+                                        <field name="time_start" optional="hide"/>
+                                        <field name="time_stop" optional="hide"/>
                                     </tree>
                                 </field>
                             </page>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -62,7 +62,7 @@
         <field name="model">mrp.workorder</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <tree editable="bottom">
+            <tree editable="bottom" multi_edit="1">
                 <field name="consumption" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="is_produced" invisible="1"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -341,9 +341,9 @@
                         <div class="row g-0">
                             <div class="col">
                                 <ul class="ps-1 mb-0 list-unstyled">
-                                    <li><strong>Start Date: </strong> <t t-esc="userTimezoneStartDate.format('L LTS')"/></li>
-                                    <li><strong>Stop Date: </strong> <t t-esc="userTimezoneStopDate.format('L LTS')"/></li>
-                                    <li><strong>Workcenter: </strong> <t t-esc="workcenter_id[1]"/></li>
+                                    <li><strong>Start Date: </strong> <t t-out="userTimezoneStartDate.format('L LTS')"/></li>
+                                    <li><strong>Stop Date: </strong> <t t-out="userTimezoneStopDate.format('L LTS')"/></li>
+                                    <li><strong>Workcenter: </strong> <t t-out="workcenter_id[1]"/></li>
                                 </ul>
                             </div>
                         </div>
@@ -378,9 +378,9 @@
                         <div class="row g-0">
                             <div class="col">
                                 <ul class="ps-1 mb-0 list-unstyled">
-                                    <li><strong>Start Date: </strong> <t t-esc="userTimezoneStartDate.format('L LTS')"/></li>
-                                    <li><strong>Stop Date: </strong> <t t-esc="userTimezoneStopDate.format('L LTS')"/></li>
-                                    <li><strong>Workcenter: </strong> <t t-esc="workcenter_id[1]"/></li>
+                                    <li><strong>Start Date: </strong> <t t-out="userTimezoneStartDate.format('L LTS')"/></li>
+                                    <li><strong>Stop Date: </strong> <t t-out="userTimezoneStopDate.format('L LTS')"/></li>
+                                    <li><strong>Workcenter: </strong> <t t-out="workcenter_id[1]"/></li>
                                 </ul>
                             </div>
                         </div>
@@ -404,7 +404,7 @@
                 <field name="working_state"/>
                 <field name="workcenter_id"/>
                 <field name="product_id"/>
-                <field name="qty_production"/>
+                <field name="qty_remaining"/>
                 <field name="product_uom_id" force_save="1"/>
                 <templates>
                     <t t-name="kanban-box">
@@ -412,20 +412,20 @@
                             <div class="o_kanban_card_header o_kanban_record_top">
                                 <div class="o_kanban_record_headings o_kanban_card_header_title">
                                     <strong class="o_primary">
-                                        <span><t t-esc="record.production_id.value"/></span> - <span><t t-esc="record.name.value"/></span>
+                                        <span t-out="record.production_id.value"/> - <span t-out="record.name.value"/>
                                     </strong>
                                 </div>
                                 <div class="o_kanban_manage_button_section">
                                     <h2 class="ml8">
                                         <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'waiting', 'pending'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
-                                            <t t-esc="record.state.value"/>
+                                            <t t-out="record.state.value"/>
                                         </span>
                                     </h2>
                                 </div>
                             </div>
                             <div class="o_kanban_record_bottom">
                                 <h5 class="oe_kanban_bottom_left">
-                                    <span><t t-esc="record.product_id.value"/>, </span> <span><t t-esc="record.qty_production.value"/> <t t-esc="record.product_uom_id.value"/></span>
+                                    <span t-out="record.product_id.value"/>, <span t-out="record.qty_remaining.value"/> <span t-out="record.product_uom_id.value"/>
                                 </h5>
                                 <div class="oe_kanban_bottom_right" t-if="record.state.raw_value == 'progress'">
                                     <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0"><i class="fa fa-play" role="img" aria-label="Run" title="Run"/></span>

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -55,9 +55,9 @@
                     </group>
                     <field name="production_detailed_vals_ids" attrs="{'invisible': [('counter', '=', 0)]}">
                         <tree editable="top">
-                            <field name="quantity"/>
-                            <field name="user_id"/>
                             <field name="date"/>
+                            <field name="user_id"/>
+                            <field name="quantity"/>
                         </tree>
                     </field>
                     <field name="production_split_multi_id" invisible="1"/>

--- a/addons/mrp/wizard/stock_assign_serial_numbers.xml
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.xml
@@ -27,7 +27,7 @@
                 </group>
                 <field name="multiple_lot_components_names" invisible="1"/>
                 <group col="1">
-                    <p class="o_form_label oe_inline" attrs="{'invisible': [('multiple_lot_components_names', '=', False)]}">
+                    <p class="o_form_label oe_inline text-danger" attrs="{'invisible': [('multiple_lot_components_names', '=', False)]}">
                         Note that components <field name="multiple_lot_components_names" readonly="True"/> have multiple lot reservations.<br/>
                         Do you want to confirm anyway ?
                     </p>


### PR DESCRIPTION
A series of 7 UI improvement or small implementations:
- Match qty field in Work Order kanban view
- UI Fix for Lot/serial column in MO form view
- Improve UI of Manual Consumption field on BOM
- UI Improvement of review split window field rearrangement
- Add setup/cleanup time to Work Center Specific Capacities
- Allow multi-edit Work Order

task-2925474

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
