### PR TITLE
[FIX] website_hr_recruitment: disable caching on thank you page

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -461,6 +461,7 @@
     <field name="name">Thank you (Recruitment)</field>
     <field name="type">qweb</field>
     <field name="key">website_hr_recruitment.thankyou</field>
+    <field name="cache_time">0</field>
     <field name="arch" type="xml">
         <t name="Thank you (Recruitment)" t-name="website_hr_recruitment.thankyou">
             <t t-call="website.layout">


### PR DESCRIPTION
The Thank You page was cached and could potentially show the same
recruiter for different job applications.