### PR TITLE
[FIX] web: list view optional columns button top border

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -48,7 +48,7 @@
                         <td t-if="props.activeActions and props.activeActions.onDelete"/>
                     </tr>
                 </tfoot>
-                <Dropdown t-if="displayOptionalFields" class="'o_optional_columns_dropdown'" position="'bottom-end'">
+                <Dropdown t-if="displayOptionalFields" class="'o_optional_columns_dropdown border-top-0'" position="'bottom-end'">
                     <t t-set-slot="toggler">
                         <i class="oi oi-settings-adjust o_optional_columns_dropdown_toggle"/>
                     </t>


### PR DESCRIPTION
Steps to reproduce:
- Open Online Appointment in list view
=> a "double-border" is visible above the optional columns button