### PR TITLE
[FIX] account: fix bug when opening a misc journal entry

### DIFF
--- a/addons/account/static/src/js/legacy_tax_totals.js
+++ b/addons/account/static/src/js/legacy_tax_totals.js
@@ -159,6 +159,8 @@ class LegacyTaxTotalsComponent extends AbstractFieldOwl {
     }
 
     _computeTotalsFormat() {
+        if (!this.totals.value) // Misc journal entry
+            return;
         let amount_untaxed = this.totals.value.amount_untaxed;
         let amount_tax = 0;
         let subtotals = [];


### PR DESCRIPTION
Before this PR, opening a misc journal entry resulted in an error because we tried
to compute the tax totals as if it was an invoice.

This PR ignores the computation of these tax totals in case we have a misc journaly entry.

opw-2946634
