### PR TITLE
[FIX] web: ask to save new record before translating

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -171,6 +171,13 @@ class FieldAdapter extends ComponentAdapter {
             }
         } else if (evType === "history_back") {
             return this.wowlEnv.config.historyBack();
+        } else if (evType === "translate") {
+            const { fieldParams, record, update } = this.props;
+            return this.translationDialog({
+                fieldName: fieldParams.name,
+                record,
+                updateField: update,
+            });
         }
         super._trigger_up(...arguments);
     }


### PR DESCRIPTION
Have a translatable field in a form view.
Create a new record with that form view.
Click on the button to open translations for that field.

Before this commit, the record was not before opening the translation dialog, hence
changing the translations could not work properly.

After this commit, this feature is back, and we ask to save a new record before
opening the translation dialog.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
