### PR TITLE
[FIX] l10n_{latam_invoice_document,ar,cl}: Unable to edit reports with studio

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -445,4 +445,18 @@
 
     </template>
 
+    <template id="report_invoice" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document_with_payments"]' position="replace">
+            <t t-if="o._get_name_invoice_report('account.report_invoice_document') == 'l10n_ar.report_invoice_document'"
+               t-call="l10n_ar.report_invoice_document" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document_with_payments"]' position="after">
+            <t t-if="o._get_name_invoice_report('account.report_invoice_document_with_payments') == 'l10n_ar.report_invoice_document_with_payments'"
+               t-call="l10n_ar.report_invoice_document" t-lang="lang"/>
+        </xpath>
+    </template>
+
 </odoo>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -274,5 +274,18 @@
         </xpath>
     </template>
 
+     <template id="report_invoice" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document_with_payments"]' position="replace">
+            <t t-if="o._get_name_invoice_report('account.report_invoice_document') == 'l10n_cl.report_invoice_document'"
+               t-call="l10n_cl.report_invoice_document" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document_with_payments"]' position="after">
+            <t t-if="o._get_name_invoice_report('account.report_invoice_document_with_payments') == 'l10n_cl.report_invoice_document_with_payments'"
+               t-call="l10n_cl.report_invoice_document" t-lang="lang"/>
+        </xpath>
+    </template>
 
 </odoo>

--- a/addons/l10n_latam_invoice_document/views/report_invoice.xml
+++ b/addons/l10n_latam_invoice_document/views/report_invoice.xml
@@ -5,16 +5,18 @@
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
     </template>
 
-    <template id="report_invoice" inherit_id="account.report_invoice">
-        <t t-call="account.report_invoice_document" position="attributes">
-            <attribute name="t-call">#{ o._get_name_invoice_report('account.report_invoice_document') }</attribute>
-        </t>
+     <template id="report_invoice" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document_with_payments"]' position="replace">
+            <t t-if="o._get_name_invoice_report('account.report_invoice_document') == 'account.report_invoice_document'"
+               t-call="account.report_invoice_document" t-lang="lang"/>
+        </xpath>
     </template>
 
-    <template id="report_invoice_with_payments" inherit_id="account.report_invoice_with_payments">
-        <t t-call="account.report_invoice_document_with_payments" position="attributes">
-            <attribute name="t-call">#{ o._get_name_invoice_report('account.report_invoice_document_with_payments') }</attribute>
-        </t>
+     <template id="report_invoice_with_payments" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document_with_payments"]' position="replace">
+            <t t-if="o._get_name_invoice_report('account.report_invoice_document_with_payments') == 'account.report_invoice_document_with_payments'"
+               t-call="account.report_invoice_document" t-lang="lang"/>
+        </xpath>
     </template>
 
 </odoo>


### PR DESCRIPTION
Steps to reproduce:

  - Install web_studio,l10n_latam_invoice_document
  - Go to a vendor bill, open studio and try to edit the report
  → It is not possible to edit the report

Cause of the issue:

When a `t-call` is dynamic, studio can't edit the report.
See: https://github.com/odoo/enterprise/blob/2708f9131c397a6c976101579b714a4e5b8d7137/web_studio/controllers/report.py#L175-L180

Solution:

Replace dynamic t-calls by inheritance specs
Also see https://github.com/odoo/odoo/pull/60609

opw-2860354