### PR TITLE
[IMP] employee: Streamline user creation from employee form.

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -165,10 +165,14 @@ class HrEmployeePrivate(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'res.users',
             'view_mode': 'form',
-            'view_id': self.env.ref('base.view_users_simple_form').id,
+            'view_id': self.env.ref('hr.view_users_simple_form').id,
             'target': 'new',
             'context': {
                 'default_create_employee_id': self.id,
+                'default_name': self.name,
+                'default_phone': self.work_phone,
+                'default_mobile': self.mobile_phone,
+                'default_login': self.work_email,
             }
         }
 

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -205,9 +205,24 @@
             <field name="inherit_id" ref="base.view_users_simple_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='mobile']" position="after">
-                    <field name="create_employee" force_save="1" string="Create Employee" invisible="not context.get('allow_create_employee', True)" attrs="{'invisible': [('id', '>', 0)]}"/>
                     <field name="create_employee_id" force_save="1" invisible="1"/>
+                    <field name="create_employee" force_save="1" string="Create Employee" invisible="not context.get('allow_create_employee', True)" attrs="{'invisible': [('create_employee_id', '>', 0)]}"/>
                 </xpath>
+            </field>
+        </record>
+
+        <record id="view_users_simple_form" model="ir.ui.view">
+            <field name="name">view.users.simple.form.hr</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_simple_form"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <sheet position="after">
+                    <footer>
+                        <button string="Save" special="save" class="btn btn-primary"/>
+                        <button string="Cancel" special="cancel" class="btn btn-secondary"/>
+                    </footer>
+                </sheet>
             </field>
         </record>
 


### PR DESCRIPTION
When selecting the action "Create User" from the employee view, use the available
employee information as default values for this new user. Additionally, make the
"Create Employee" option invisible as this is not relevant when the employee
already exists and save an extra click by closing the user form upon saving.

task-id 2942602

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
