### PR TITLE
[IMP] repair: Reserve and Repair

### DIFF
--- a/addons/repair/__init__.py
+++ b/addons/repair/__init__.py
@@ -3,3 +3,13 @@
 
 from . import models
 from . import wizard
+
+from odoo import api, SUPERUSER_ID
+
+
+def _create_repair_picking_type(cr, registry):
+    """ This hook is used to add a default repair picking_type on every warehouses.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    for wh in env['stock.warehouse'].search([]):
+        wh._create_or_update_sequences_and_picking_types()

--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -39,5 +39,15 @@ The following topics are covered by this module:
     'demo': ['data/repair_demo.xml'],
     'installable': True,
     'application': True,
+    'post_init_hook': '_create_repair_picking_type',
+    'assets': {
+        'web.assets_qweb': [
+            'repair/static/src/xml/forecast_widget.xml',
+        ],
+        'web.assets_backend': [
+            'repair/static/src/js/forecast_widget.js',
+            'repair/static/src/scss/forecast_widget.scss',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/repair/models/__init__.py
+++ b/addons/repair/models/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import repair
 from . import stock_picking
+from .import stock_warehouse
 from . import stock_traceability
 from . import stock_lot
 from . import account_move

--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -13,6 +13,10 @@ class PickingType(models.Model):
         help="If ticked, you will be able to directly create repair orders from a return.")
     return_type_of_ids = fields.One2many('stock.picking.type', 'return_picking_type_id')
 
+    code = fields.Selection(selection_add=[
+        ('repair', 'Repair')
+    ], ondelete={'repair': 'cascade'})
+
     @api.depends('return_type_of_ids', 'code')
     def _compute_is_repairable(self):
         for picking_type in self:

--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class StockWarehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    repair_type_id = fields.Many2one(
+        'stock.picking.type', 'Repair Operation Type',
+        domain="[('code', '=', 'repair'), ('company_id', '=', company_id)]", check_company=True)
+
+    def _get_picking_type_update_values(self):
+        data = super(StockWarehouse, self)._get_picking_type_update_values()
+        data.update({
+            'repair_type_id': {
+                'active': self.active,
+            },
+        })
+        return data
+
+    def _get_picking_type_create_values(self, max_sequence):
+        data, next_sequence = super(StockWarehouse, self)._get_picking_type_create_values(max_sequence)
+        data.update({
+            'repair_type_id': {
+                'name': _('Repair'),
+                'code': 'repair',
+                'use_create_lots': True,
+                'use_existing_lots': True,
+                'sequence': next_sequence + 1,
+                'sequence_code': 'RO',
+                'company_id': self.company_id.id,
+            },
+        })
+        return data, next_sequence + 2
+
+    def _get_sequence_values(self):
+        values = super(StockWarehouse, self)._get_sequence_values()
+        values.update({
+            'repair_type_id': {'name': self.name + ' ' + _('Sequence repair'), 'prefix': self.code + '/RO/', 'padding': 5, 'company_id': self.company_id.id},
+        })
+        return values

--- a/addons/repair/report/report_stock_forecasted.xml
+++ b/addons/repair/report/report_stock_forecasted.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="repair_report_product_product_replenishment" inherit_id="stock.report_product_product_replenishment">
+        <xpath expr="//button[@name='unreserve_link']" position="replace">
+            <button t-if="line['move_out'] and line['move_out'].repair_id and line['move_out'].repair_id.unreserve_visible"
+                class="btn btn-sm btn-primary o_report_replenish_unreserve"
+                t-attf-model="repair.order"
+                t-att-model-id="line['move_out'].repair_id.id">
+                Unreserve
+            </button>
+        </xpath>
+        <xpath expr="//button[@name='reserve_link']" position="replace">
+            <button t-if="line['move_out'] and line['move_out'].repair_id and line['move_out'].repair_id.reserve_visible"
+                class="btn btn-sm btn-primary o_report_replenish_reserve"
+                t-attf-model="repair.order"
+                t-att-model-id="line['move_out'].repair_id.id">
+                Reserve
+            </button>
+        </xpath>
+        <xpath expr="//button[@name='change_priority_link']" position="replace">
+            <button t-if="line['move_out'] and line['move_out'].repair_id"
+                t-attf-class="o_priority o_priority_star o_report_replenish_change_priority fa fa-star#{' one' if line['move_out'].repair_id.priority=='1' else '-o zero'}"
+                t-attf-model="repair.order"
+                t-att-model-id="line['move_out'].repair_id.id"
+            />
+        </xpath>
+   </template>
+</odoo>

--- a/addons/repair/static/src/js/forecast_widget.js
+++ b/addons/repair/static/src/js/forecast_widget.js
@@ -1,0 +1,81 @@
+odoo.define('repair.forecast_widget', function (require) {
+'use strict';
+
+const AbstractField = require('web.AbstractField');
+const fieldRegistry = require('web.field_registry');
+const field_utils = require('web.field_utils');
+const utils = require('web.utils');
+const core = require('web.core');
+const QWeb = core.qweb;
+
+const RepairForecastWidgetField = AbstractField.extend({
+    supportedFieldTypes: ['float'],
+
+    _render: function () {
+        var data = Object.assign({}, this.record.data, {
+            forecast_availability_str: field_utils.format.float(
+                this.record.data.forecast_availability,
+                this.record.fields.forecast_availability,
+                this.nodeOptions
+            ),
+            reserved_availability_str: field_utils.format.float(
+                this.record.data.reserved_availability,
+                this.record.fields.reserved_availability,
+                this.nodeOptions
+            ),
+            forecast_expected_date_str: field_utils.format.date(
+                this.record.data.forecast_expected_date,
+                this.record.fields.forecast_expected_date
+            ),
+        });
+        console.log('render')
+        console.log(data.forecast_expected_date)
+        console.log(data.schedule_date)
+
+        if (data.forecast_expected_date && data.schedule_date) {
+            console.log(data.schedule_date)
+            data.forecast_is_late = data.forecast_expected_date > data.schedule_date;
+        }
+        data.will_be_fulfilled = utils.round_decimals(data.forecast_availability, this.record.fields.forecast_availability.digits[1]) >= utils.round_decimals(data.product_qty, this.record.fields.forecast_availability.digits[1]);
+
+        this.$el.html(QWeb.render('repair.forecastWidget', data));
+        this.$('.o_forecast_report_button').on('click', this._onOpenReport.bind(this));
+    },
+
+    isSet: function () {
+        return true;
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Opens the Forecast Report for the `stock.move` product.
+     *
+     * @param {MouseEvent} ev
+     */
+    _onOpenReport: function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        if (!this.recordData.id) {
+            return;
+        }
+        this._rpc({
+            model: 'stock.move',
+            method: 'action_product_forecast_report',
+            args: [this.recordData.id],
+        }).then(action => {
+            action.context = Object.assign(action.context || {}, {
+                active_model: 'product.product',
+                active_id: this.recordData.product_id.res_id,
+            });
+            this.do_action(action);
+        });
+    },
+});
+
+fieldRegistry.add('repair_forecast_widget', RepairForecastWidgetField);
+
+return RepairForecastWidgetField;
+});

--- a/addons/repair/static/src/scss/forecast_widget.scss
+++ b/addons/repair/static/src/scss/forecast_widget.scss
@@ -1,0 +1,8 @@
+.o_forecast_widget_cell {
+    text-align: right;
+    padding-right: 24px!important;
+
+    button {
+        position: absolute;
+    }
+}

--- a/addons/repair/static/src/xml/forecast_widget.xml
+++ b/addons/repair/static/src/xml/forecast_widget.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<templates id="template" xml:space="preserve">
-    <t t-name="repair.forecastWidget">
-        <span t-if="['draft', 'partially_available', 'assigned', 'cancel', 'done'].includes(move_state)" t-esc="reserved_availability_str"/>
-        <span t-elif="!forecast_expected_date_str and will_be_fulfilled" class="text-success">Available</span>
-        <span t-elif="forecast_expected_date_str and will_be_fulfilled" t-att-class="forecast_is_late ? 'text-danger' : 'text-warning'">Exp <t t-esc="forecast_expected_date_str"/></span>
-        <span t-else="" class="text-danger">Not Available</span>
-        <button t-if="product_type == 'product'" t-att="id ? {} : {'disabled': ''}" class="o_forecast_report_button btn btn-link o_icon_button ms-2" title="Forecasted Report">
-            <i t-attf-class="fa fa-fw fa-area-chart {{ move_state != 'draft' and (!will_be_fulfilled or forecast_is_late) ? 'text-danger' : '' }}"/>
-        </button>
-    </t>
-</templates>
+ <templates id="template" xml:space="preserve">
+
+     <t t-name="repair.ForecastWidget" owl="1">
+         <span t-if="['draft', 'partially_available', 'assigned', 'cancel', 'done'].includes(moveState)"
+               t-esc="reservedAvailability"/>
+         <span t-elif="!forecastExpectedDate and willBeFulfilled" class="text-success">
+             Available
+         </span>
+         <span t-elif="forecastExpectedDate and willBeFulfilled"
+               t-att-class="forecastIsLate ? 'text-danger' : 'text-warning'">
+             Exp <t t-esc="forecastExpectedDate"/>
+         </span>
+         <span t-else="" class="text-danger">Not Available</span>
+         <button t-if="product_type == 'product'" title="Forecasted Report"
+                 t-on-click="_openReport" t-att="resId ? {} : {'disabled': ''}"
+                 class="o_forecast_report_button btn btn-link o_icon_button ms-2">
+             <i class="fa fa-fw fa-area-chart"
+                t-att-class="moveState != 'draft' and (!willBeFulfilled or forecastIsLate) ? 'text-danger' : ''"/>
+         </button>
+     </t>
+
+ </templates>

--- a/addons/repair/static/src/xml/forecast_widget.xml
+++ b/addons/repair/static/src/xml/forecast_widget.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="repair.forecastWidget">
+        <span t-if="['draft', 'partially_available', 'assigned', 'cancel', 'done'].includes(move_state)" t-esc="reserved_availability_str"/>
+        <span t-elif="!forecast_expected_date_str and will_be_fulfilled" class="text-success">Available</span>
+        <span t-elif="forecast_expected_date_str and will_be_fulfilled" t-att-class="forecast_is_late ? 'text-danger' : 'text-warning'">Exp <t t-esc="forecast_expected_date_str"/></span>
+        <span t-else="" class="text-danger">Not Available</span>
+        <button t-if="product_type == 'product'" t-att="id ? {} : {'disabled': ''}" class="o_forecast_report_button btn btn-link o_icon_button ms-2" title="Forecasted Report">
+            <i t-attf-class="fa fa-fw fa-area-chart {{ move_state != 'draft' and (!will_be_fulfilled or forecast_is_late) ? 'text-danger' : '' }}"/>
+        </button>
+    </t>
+</templates>

--- a/addons/repair/tests/__init__.py
+++ b/addons/repair/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_repair
+from . import test_repair_w_reserve

--- a/addons/repair/tests/test_repair_w_reserve.py
+++ b/addons/repair/tests/test_repair_w_reserve.py
@@ -1,0 +1,434 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.fields import Datetime
+from odoo.tests import tagged
+from datetime import timedelta
+from odoo.tests.common import TransactionCase
+
+
+@tagged('post_install', '-at_install')
+class TestRepairWithReserve(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRepairWithReserve, cls).setUpClass()
+        # Partners
+        cls.res_partner_1 = cls.env['res.partner'].create({'name': 'Wood Corner'})
+        cls.res_partner_address_1 = cls.env['res.partner'].create({'name': 'Willie Burke', 'parent_id': cls.res_partner_1.id})
+        cls.res_partner_12 = cls.env['res.partner'].create({'name': 'Partner 12'})
+
+        # Locations
+        cls.stock_warehouse = cls.env['stock.warehouse'].search([('company_id', '=', cls.env.company.id)], limit=1)
+        cls.stock_location_14 = cls.env['stock.location'].create({
+            'name': 'Shelf 2',
+            'location_id': cls.stock_warehouse.lot_stock_id.id,
+        })
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
+
+        # Products
+        cls.repair_product = cls.env['product.product'].create({
+            'name': "Repair Product",
+            'type': 'product',
+            'categ_id': cls.env.ref('product.product_category_all').id,
+        })
+
+        cls.avail_product = cls.env['product.product'].create({
+            'name': "Available Product",
+            'type': 'product',
+            'categ_id': cls.env.ref('product.product_category_all').id,
+        })
+        cls.partial_product = cls.env['product.product'].create({
+            'name': "Parital_Available Product",
+            'type': 'product',
+            'categ_id': cls.env.ref('product.product_category_all').id,
+        })
+        cls.not_avail_product = cls.env['product.product'].create({
+            'name': "Not Available Product",
+            'type': 'product',
+            'categ_id': cls.env.ref('product.product_category_all').id,
+        })
+
+        cls.picking = cls.env.ref('stock.picking_type_in')
+
+    def _create_product(self, tracking='none', name=False):
+        return self.env['product.product'].create({
+            'name': name or f'Product {tracking}',
+            'type': 'product',
+            'tracking': tracking,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+    def _create_repair_order_with_product(self, product_to_repair):
+        partner = self.res_partner_address_1
+        return self.env['repair.order'].create({
+            'product_id': product_to_repair.id,
+            'product_uom': product_to_repair.uom_id.id,
+            'address_id': partner.id,
+            'guarantee_limit': '2019-01-01',
+            'invoice_method': 'none',
+            'partner_invoice_id': partner.id,
+            'location_id': self.stock_warehouse.lot_stock_id.id,
+            'partner_id': self.res_partner_12.id
+        })
+
+    def _create_operation(self, product_to_add, repair_id=False, qty=0.0, price_unit=0.0):
+        return self.env['repair.line'].create({
+            'name': 'Add The product',
+            'type': 'add',
+            'product_id': product_to_add.id,
+            'product_uom_qty': qty,
+            'product_uom': product_to_add.uom_id.id,
+            'price_unit': price_unit,
+            'repair_id': repair_id,
+            'location_id': self.stock_warehouse.lot_stock_id.id,
+            'location_dest_id': product_to_add.property_stock_production.id,
+            'company_id': self.env.company.id,
+        })
+
+    def test_repair_reserve_flow(self):
+        '''This test create a flow of repair using 3 Parts:
+        a fully-stocked product, a partially-stocked product,
+        and a zero-stock product. We will later refill the stock
+        and complete the flow'''
+
+        repair = self._create_repair_order_with_product(self.repair_product)
+
+        op1 = self._create_operation(
+            self.avail_product,
+            repair_id=repair.id,
+            qty=2.0,
+            price_unit=25.0)
+        op2 = self._create_operation(
+            self.partial_product,
+            repair_id=repair.id,
+            qty=10.0,
+            price_unit=25.0)
+        op3 = self._create_operation(
+            self.not_avail_product,
+            repair_id=repair.id,
+            qty=3.0,
+            price_unit=25.0)
+
+        self.assertEqual(repair.state, 'draft')
+
+        # Assign stock quantities
+        quants = self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.avail_product.id,
+            'inventory_quantity': 5
+        })
+
+        quants |= self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.partial_product.id,
+            'inventory_quantity': 5
+        })
+
+        quants |= self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.not_avail_product.id,
+            'inventory_quantity': 0
+        })
+        quants.action_apply_inventory()
+
+        self.assertEqual(op1.state, 'draft')
+        self.assertEqual(op2.state, 'draft')
+        self.assertEqual(op3.state, 'draft')
+
+        repair.action_repair_confirm()
+
+        self.assertEqual(op1.state, 'confirmed')
+        self.assertEqual(op2.state, 'confirmed')
+        self.assertEqual(op3.state, 'confirmed')
+
+        self.assertEqual(op1.move_id.state, 'assigned')
+        self.assertEqual(op2.move_id.state, 'partially_available')
+        self.assertEqual(op3.move_id.state, 'confirmed')
+
+        # Updating stock for the partially available product
+        self.assertEqual(repair.operations_availability_state, 'late')
+        self.assertEqual(op2.forecast_availability, 5.0)
+
+        self.env['stock.quant']._update_available_quantity(
+            self.partial_product,
+            self.stock_location_14,
+            10.0
+        )
+        op2.move_id._compute_forecast_information()
+
+        self.assertEqual(op2.forecast_availability, 10.0)
+        self.assertEqual(repair.operations_availability_state, 'late')
+
+        # Create a move to re-stock the unavailable product
+        move1 = self.env['stock.move'].create({
+            'name': 'test_in_1',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location_14.id,
+            'product_id': self.not_avail_product.id,
+            'product_uom': self.not_avail_product.uom_id.id,
+            'product_uom_qty': 10.0,
+            'date': Datetime.now() + timedelta(days=3),
+            'picking_type_id': self.picking.id,
+        })
+        move1._action_confirm()
+        move1._compute_forecast_information()
+        op3.move_id._compute_forecast_information()
+        repair._compute_operations_availability()
+
+        self.assertEqual(op3.forecast_availability, 3)
+
+        # The state is still late since the date of the repair order is now()
+        self.assertEqual(repair.operations_availability_state, 'late')
+
+        # Set the schedule date of the repair order > than the expected date of the parts
+        repair.write({'schedule_date': Datetime.now() + timedelta(days=10)})
+        self.assertEqual(repair.operations_availability_state, 'expected')
+
+        # Finish the move
+        move_line = move1.move_line_ids[0]
+        self.assertEqual(move_line.reserved_qty, 10.0)
+        self.assertEqual(move_line.qty_done, 0.0)
+        move_line.qty_done = 10.0
+        move1._action_done()
+        self.assertEqual(move1.state, 'done')
+
+        # Check the reservations
+        self.assertEqual(op1.reserved_availability, 2.0)
+        self.assertEqual(op2.reserved_availability, 5.0)
+        self.assertEqual(op3.reserved_availability, 0.0)
+
+        # Check availability button
+        repair.action_assign()
+        self.assertEqual(op1.reserved_availability, 2.0)
+        self.assertEqual(op2.reserved_availability, 10.0)
+        self.assertEqual(op3.reserved_availability, 3.0)
+
+        # I check the state is in "Confirmed".
+        self.assertEqual(repair.state, "confirmed")
+        repair.action_repair_start()
+
+        # I check the state is in "Under Repair".
+        self.assertEqual(repair.state, "under_repair")
+
+        # Repairing process for product is in Done state and I end Repair process by clicking on "End Repair" button.
+        repair.action_repair_end()
+        self.assertEqual(repair.state, "done")
+
+        # Check if there is move lines
+        self.assertEqual(len(repair.move_id.move_line_ids[0].consume_line_ids), 3)
+        self.assertEqual(len(repair.move_id.move_line_ids[0]), 1)
+
+        # Check if the move lines contain the parts
+        self.assertEqual(repair.move_id.move_line_ids[0].product_id.name, self.repair_product.name)
+        self.assertTrue(self.avail_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+        self.assertTrue(self.partial_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+        self.assertTrue(self.not_avail_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+
+        # Check if the quantities of the move lines equal the ops product qty
+        self.assertEqual(repair.move_id.move_line_ids[0].qty_done, 1.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.avail_product.name)[0].qty_done, 2.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.partial_product.name)[0].qty_done, 10.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.not_avail_product.name)[0].qty_done, 3.0)
+
+
+    def test_add_product_after_confirm(self):
+        repair = self._create_repair_order_with_product(self.repair_product)
+
+        op1 = self._create_operation(
+            self.avail_product,
+            repair_id=repair.id,
+            qty=5.0,
+            price_unit=25.0)
+        op2 = self._create_operation(
+            self.partial_product,
+            repair_id=repair.id,
+            qty=6.0,
+            price_unit=25.0)
+
+        self.assertEqual(repair.state, 'draft')
+
+        # Assign stock quantities
+        quants = self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.avail_product.id,
+            'inventory_quantity': 5
+        })
+
+        quants |= self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.partial_product.id,
+            'inventory_quantity': 6
+        })
+
+        quants |= self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.not_avail_product.id,
+            'inventory_quantity': 7
+        })
+        quants.action_apply_inventory()
+
+        self.assertEqual(op1.state, 'draft')
+        self.assertEqual(op2.state, 'draft')
+
+        repair.action_repair_confirm()
+
+        self.assertEqual(op1.state, 'confirmed')
+        self.assertEqual(op2.state, 'confirmed')
+
+        self.assertEqual(op1.move_id.state, 'assigned')
+        self.assertEqual(op2.move_id.state, 'assigned')
+
+        self.assertEqual(repair.operations_availability_state, 'available')
+
+        op3 = self._create_operation(
+            self.not_avail_product,
+            repair_id=repair.id,
+            qty=7.0,
+            price_unit=25.0)
+        self.assertEqual(op3.move_id.state, 'assigned')
+
+        # I check the state is in "Confirmed".
+        self.assertEqual(repair.state, "confirmed")
+        repair.action_repair_start()
+
+        # I check the state is in "Under Repair".
+        self.assertEqual(repair.state, "under_repair")
+
+        # Repairing process for product is in Done state and I end Repair process by clicking on "End Repair" button.
+        repair.action_repair_end()
+        self.assertEqual(repair.state, "done")
+
+        # Check if there is move lines
+        self.assertEqual(len(repair.move_id.move_line_ids[0].consume_line_ids), 3)
+        self.assertEqual(len(repair.move_id.move_line_ids[0]), 1)
+
+        # Check if the move lines contain the parts
+        self.assertEqual(repair.move_id.move_line_ids[0].product_id.name, self.repair_product.name)
+        self.assertTrue(self.avail_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+        self.assertTrue(self.partial_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+        self.assertTrue(self.not_avail_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+
+        # Check if the quantities of the move lines equal the ops product qty
+        self.assertEqual(repair.move_id.move_line_ids[0].qty_done, 1.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.avail_product.name)[0].qty_done, 5.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.partial_product.name)[0].qty_done, 6.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.not_avail_product.name)[0].qty_done, 7.0)
+
+
+    def test_reserve_unreserve_flow(self):
+        repair = self._create_repair_order_with_product(self.repair_product)
+
+        op1 = self._create_operation(
+            self.avail_product,
+            repair_id=repair.id,
+            qty=5.0,
+            price_unit=25.0)
+        op2 = self._create_operation(
+            self.partial_product,
+            repair_id=repair.id,
+            qty=6.0,
+            price_unit=25.0)
+        op3 = self._create_operation(
+            self.not_avail_product,
+            repair_id=repair.id,
+            qty=7.0,
+            price_unit=25.0)
+
+        self.assertEqual(repair.state, 'draft')
+
+        # Assign stock quantities
+        quants = self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.avail_product.id,
+            'inventory_quantity': 5
+        })
+
+        quants |= self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.partial_product.id,
+            'inventory_quantity': 6
+        })
+
+        quants |= self.env['stock.quant'].create({
+            'location_id': self.stock_location_14.id,
+            'product_id': self.not_avail_product.id,
+            'inventory_quantity': 7
+        })
+        quants.action_apply_inventory()
+
+        self.assertEqual(op1.state, 'draft')
+        self.assertEqual(op2.state, 'draft')
+        self.assertEqual(op3.state, 'draft')
+
+        repair.action_repair_confirm()
+
+        self.assertEqual(op1.state, 'confirmed')
+        self.assertEqual(op2.state, 'confirmed')
+        self.assertEqual(op3.state, 'confirmed')
+
+        self.assertEqual(op1.move_id.state, 'assigned')
+        self.assertEqual(op2.move_id.state, 'assigned')
+        self.assertEqual(op3.move_id.state, 'assigned')
+
+        self.assertEqual(repair.operations_availability_state, 'available')
+
+        # Check the reservations
+        self.assertEqual(op1.reserved_availability, 5.0)
+        self.assertEqual(op2.reserved_availability, 6.0)
+        self.assertEqual(op3.reserved_availability, 7.0)
+
+        # Check unreserve button
+        repair.do_unreserve()
+        self.assertEqual(op1.reserved_availability, 0.0)
+        self.assertEqual(op2.reserved_availability, 0.0)
+        self.assertEqual(op3.reserved_availability, 0.0)
+
+        # Check availability button
+        repair.action_assign()
+        self.assertEqual(op1.reserved_availability, 5.0)
+        self.assertEqual(op2.reserved_availability, 6.0)
+        self.assertEqual(op3.reserved_availability, 7.0)
+
+        # I check the state is in "Confirmed".
+        self.assertEqual(repair.state, "confirmed")
+        repair.action_repair_start()
+
+        # I check the state is in "Under Repair".
+        self.assertEqual(repair.state, "under_repair")
+
+        # Repairing process for product is in Done state and I end Repair process by clicking on "End Repair" button.
+        repair.action_repair_end()
+        self.assertEqual(repair.state, "done")
+
+        # Check if there is move lines
+        self.assertEqual(len(repair.move_id.move_line_ids[0].consume_line_ids), 3)
+        self.assertEqual(len(repair.move_id.move_line_ids[0]), 1)
+
+        # Check if the move lines contain the parts
+        self.assertEqual(repair.move_id.move_line_ids[0].product_id.name, self.repair_product.name)
+        self.assertTrue(self.avail_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+        self.assertTrue(self.partial_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+        self.assertTrue(self.not_avail_product.name in repair.move_id.move_line_ids[0].consume_line_ids.product_id.mapped('name'))
+
+        # Check if the quantities of the move lines equal the ops product qty
+        self.assertEqual(repair.move_id.move_line_ids[0].qty_done, 1.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.avail_product.name)[0].qty_done, 5.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.partial_product.name)[0].qty_done, 6.0)
+        self.assertEqual(
+            repair.move_id.move_line_ids[0].consume_line_ids
+                .filtered(lambda line: line.product_id.name == self.not_avail_product.name)[0].qty_done, 7.0)

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -10,6 +10,14 @@
                 <field name="priority" optional="show" widget="priority" nolabel="1"/>
                 <field name="name"/>
                 <field name="schedule_date" optional="show" widget="remaining_days"/>
+                <field name="operations_availability_state" invisible="1" options='{"lazy": true}'/>
+                <field name="reservation_state" optional="hide" decoration-danger="reservation_state == 'confirmed'" decoration-success="reservation_state == 'assigned'"/>
+                <field name="operations_availability" options='{"lazy": true}'
+                    attrs="{'invisible': [('state', 'in', ['draft', 'done', 'cancel', '2binvoiced'])]}"
+                    optional="show"
+                    decoration-success="reservation_state == 'assigned' or operations_availability_state == 'available'"
+                    decoration-warning="reservation_state != 'assigned' and operations_availability_state in ('expected', 'available')"
+                    decoration-danger="reservation_state != 'assigned' and operations_availability_state == 'late'"/>
                 <field name="description" optional="hide"/>
                 <field name="product_id" readonly="1" optional="show"/>
                 <field name="product_qty" optional="hide" string="Quantity"/>
@@ -42,6 +50,10 @@
                    <button name="action_repair_invoice_create" type="object" string="Create Invoice" class="oe_highlight" groups="account.group_account_invoice" attrs="{'invisible': ['|', ('state', '!=', '2binvoiced'), ('invoice_id', '!=', False)]}" data-hotkey="w"/>
                    <button name="action_send_mail" states="draft" string="Send Quotation" type="object" data-hotkey="g"/>
                    <button name="print_repair_order" states="draft" string="Print Quotation" type="object" data-hotkey="y"/>
+                   <button name="action_assign" type="object" string="Check Availability" attrs="{'invisible': [('reserve_visible', '=', False)]}"/>
+                   <button name="do_unreserve" type="object" string="Unreserve" attrs="{'invisible': [('unreserve_visible', '=', False)]}"/>
+                   <field name="unreserve_visible" invisible="1"/>
+                   <field name="reserve_visible" invisible="1"/>
                    <button name="action_repair_cancel_draft" states="cancel" string="Set to Draft" type="object" data-hotkey="z"/>
                    <button name="action_repair_cancel" string="Cancel Repair" type="object" confirm="Draft invoices for this order will be cancelled. Do you confirm the action?" attrs="{'invisible':['|', ('state', '=', 'cancel'), ('invoice_state', '!=', 'draft')]}" data-hotkey="l"/>
                    <button name="action_repair_cancel" string="Cancel Repair" type="object" attrs="{'invisible': ['|', ('state','=', 'cancel',), ('invoice_state', '=', 'draft')]}" data-hotkey="l"/>
@@ -90,10 +102,21 @@
                             <field name="picking_id" domain="[('picking_type_id','in', allowed_picking_type_ids)]" options="{'no_create': True}"/>
                         </group>
                         <group>
-                            <field name="schedule_date"/>
+                            <field name="schedule_date"
+                                attrs="{'readonly': [('state', 'in', ['close', 'cancel'])]}"
+                                    decoration-warning="state not in ('done', 'cancel') and schedule_date &lt; now"
+                                    decoration-danger="state not in ('done', 'cancel') and schedule_date &lt; current_date"
+                                    decoration-bf="state not in ('done', 'cancel') and (schedule_date &lt; current_date or schedule_date &lt; now)"/>
+                            />
+                            <field name="operations_availability_state" invisible="1"/>
+                            <field name="reservation_state" invisible="1"/>
+                            <field name="operations_availability"
+                                attrs="{'invisible': [('state', 'in', ['draft', 'done', 'cancel', '2binvoiced'])]}"
+                                optional="show"
+                                decoration-success="reservation_state == 'assigned' or operations_availability_state == 'available'"
+                                decoration-warning="reservation_state != 'assigned' and operations_availability_state in ('expected', 'available')"
+                                decoration-danger="reservation_state != 'assigned' and operations_availability_state == 'late'"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
-                            <field name="location_id" options="{'no_create': True}"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                             <field name="guarantee_limit"/>
                             <field name="invoice_method"/>
                             <field name="partner_invoice_id" attrs="{'invisible':[('invoice_method','=', 'none')],'required':[('invoice_method','!=','none')]}" groups="account.group_delivery_invoice_address"/>
@@ -142,16 +165,27 @@
                                 <field name='name' optional="show"/>
                                 <field name="product_uom_category_id" invisible="1"/>
                                 <field name="tracking" invisible="1"/>
+                                <field name="product_qty" invisible="1" readonly="1"/>
+                                <field name="product_type" invisible="1"/>
+                                <field name="state" invisible="1" force_save="1"/>
+                                <field name="move_state" string="Stock state" invisible="1"/>
+                                <field name="reserved_availability" invisible="1"/>
+                                <field name="forecast_expected_date" invisible="1"/>
+                                <field name="type" invisible="1"/>
                                 <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'readonly':[('tracking', 'not in', ['serial', 'lot'])]}"/>
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" optional="show"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" optional="show"/>
-                                <field name="product_uom_qty" string="Quantity"/>
+                                <field name="product_uom_qty" string="Quantity" attrs="{'readonly':[('tracking', '==', 'serial')]}"/>
                                 <field name="product_uom" string="UoM" groups="uom.group_uom" optional="show"/>
+                                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'column_invisible': [('parent.state', '!=', 'draft')], 'invisible': ['|', ('type', '=', 'remove'), ('forecast_availability', '&lt;', 0)]}"/>
+                                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger" attrs="{'column_invisible': [('parent.state', '!=', 'draft')], 'invisible': ['|', ('type', '=', 'remove'), ('forecast_availability', '&gt;=', 0)]}"/>
+                                <field name="forecast_availability" attrs="{'invisible':[('type', '=', 'remove')], 'column_invisible': [('parent.state', 'in', ('draft', 'done', 'cancel'))]}" string="Reserved" widget="repair_forecast_widget"/>
                                 <field name="price_unit"/>
                                 <field name="tax_id" widget="many2many_tags" optional="show"/>
                                 <field name="price_subtotal" widget="monetary" groups="account.group_show_line_subtotals_tax_excluded"/>
                                 <field name="price_total" widget="monetary" groups="account.group_show_line_subtotals_tax_included"/>
                                 <field name="currency_id" invisible="1"/>
+                                <field name="schedule_date" invisible="1"/>
                             </tree>
                         </field>
                         <group class="oe_subtotal_footer oe_right">
@@ -216,6 +250,12 @@
                     </page>
                     <page string="Quotation Notes">
                         <field name="quotation_notes" placeholder="Add quotation notes."/>
+                    </page>
+                    <page string="Miscellaneous" name="miscellaneous">
+                        <group>
+                            <field name="location_id" string="Repair Location" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                        </group>
                     </page>
                 </notebook>
                 </sheet>


### PR DESCRIPTION
task-2851415

Add reservation to repair model - this will allow users to reserve and replenish components in time for their planned repair orders. 

Just like Manufacturing order, compute Product Availability based on Repair Order scheduled date and components reservation status. 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
