### PR TITLE
[master] account: remove 2 duplicate ir.rule

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -218,7 +218,9 @@
         <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
-    <!-- Billing record rules for account.move -->
+    <!-- Billing record rules for account.move
+         Some modules (i.e. sale) restrict the access for some users
+         We want the invoice group to still have all access on all moves. -->
 
     <record id="account_move_see_all" model="ir.rule">
         <field name="name">All Journal Entries</field>
@@ -230,6 +232,13 @@
     <record id="account_move_line_see_all" model="ir.rule">
         <field name="name">All Journal Items</field>
         <field ref="model_account_move_line" name="model_id"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
+
+    <record id="account_invoice_send_rule_group_invoice" model="ir.rule">
+        <field name="name">Readonly Invoice Send and Print</field>
+        <field name="model_id" ref="model_account_invoice_send"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
@@ -269,29 +278,6 @@
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
-    </record>
-
-    <!-- Some modules (i.e. sale) restrict the access for some users
-    We want the invoice group to still have all access on all moves.-->
-    <record id="account_move_rule_group_invoice" model="ir.rule">
-        <field name="name">Readonly Move</field>
-        <field name="model_id" ref="model_account_move"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
-    </record>
-
-    <record id="account_move_line_rule_group_invoice" model="ir.rule">
-        <field name="name">Readonly Move Line</field>
-        <field name="model_id" ref="model_account_move_line"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
-    </record>
-
-    <record id="account_invoice_send_rule_group_invoice" model="ir.rule">
-        <field name="name">Readonly Invoice Send and Print</field>
-        <field name="model_id" ref="model_account_invoice_send"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
     <!-- account analytic default-->


### PR DESCRIPTION
There was 2 identical ir.rule on account.move: account.account_move_see_all https://github.com/odoo/odoo/blob/master/addons/account/security/account_security.xml#L223 and account.account_move_rule_group_invoice https://github.com/odoo/odoo/blob/master/addons/account/security/account_security.xml#L276
There was also 2 identical ir.rule on account.move.line: account.account_move_line_see_all https://github.com/odoo/odoo/blob/master/addons/account/security/account_security.xml#L230 and account.account_move_line_rule_group_invoice https://github.com/odoo/odoo/blob/master/addons/account/security/account_security.xml#L283

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
