### PR TITLE
[FIX] account: allow change account on tax line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1013,7 +1013,12 @@ class AccountMove(models.Model):
                     else:
                         tax_type = line.tax_ids[0].type_tax_use
                         is_refund = (tax_type == 'sale' and line.debit) or (tax_type == 'purchase' and line.credit)
-                    taxes = line.tax_ids.flatten_taxes_hierarchy()
+                    taxes = line.tax_ids._origin.flatten_taxes_hierarchy().filtered(
+                        lambda tax: (
+                                tax.amount_type == 'fixed' and not invoice.company_id.currency_id.is_zero(tax.amount)
+                                or not float_is_zero(tax.amount, precision_digits=4)
+                        )
+                    )
                     if is_refund:
                         tax_rep_lines = taxes.refund_repartition_line_ids._origin.filtered(lambda x: x.repartition_type == "tax")
                     else:


### PR DESCRIPTION
Before this commit, in invoice/bill, when changing
the account of a tax line while having one of the invoice
lines with tax 0%, the tax line was not displayed anymore.

The cause of the issue is that in _recompute_dynamic_lines
method, when setting the tax repartition lines to
recompute, we did not filter the 0 tax. The consequence was
that we had a delta between expected and current taxes,
although the line of tax 0% was not displayed anyway.
By filtering the 0 tax, we have expected taxes == current taxes,
so we do not have delta anymore, therefore no tax line to recompute.

opw-2901833
