### PR TITLE
Make restart support virtualenv

### DIFF
--- a/doc/cla/individual/sjamaan.md
+++ b/doc/cla/individual/sjamaan.md
@@ -1,0 +1,11 @@
+Netherlands, 2022-08-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Peter Bex peter@more-magic.net https://github.com/sjamaan

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1220,12 +1220,11 @@ def _reexec(updated_modules=None):
     """reexecute openerp-server process with (nearly) the same arguments"""
     if odoo.tools.osutil.is_running_as_nt_service():
         subprocess.call('net stop {0} && net start {0}'.format(nt_service_name), shell=True)
-    exe = os.path.basename(sys.executable)
     args = stripped_sys_argv()
     if updated_modules:
         args += ["-u", ','.join(updated_modules)]
-    if not args or args[0] != exe:
-        args.insert(0, exe)
+    if not args or args[0] != sys.executable:
+        args.insert(0, sys.executable)
     # We should keep the LISTEN_* environment variabled in order to support socket activation on reexec
     os.execve(sys.executable, args, os.environ)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  Odoo in a virtual environment does not restart with correct Python executable (#33479)

Current behavior before PR: When starting Odoo from a virtualenv, and restarts for whatever reason it can no longer import libraries (in my case, bailing out with an import error for `PyPDF2`).

Desired behavior after PR is merged: A restarted server works exactly like one started cleanly from the CLI.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
