### PR TITLE
[FIX] base: allow to put a class on calendar view

### DIFF
--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -24,6 +24,7 @@
             <rng:optional><rng:attribute name="hide_time"/></rng:optional>
             <rng:optional><rng:attribute name="hide_date"/></rng:optional>
             <rng:optional><rng:attribute name="create"/></rng:optional>
+            <rng:optional><rng:attribute name="class"/></rng:optional>
             <rng:optional><rng:attribute name="delete"/></rng:optional>
             <rng:optional><rng:attribute name="scales"/></rng:optional>
             <rng:optional>


### PR DESCRIPTION
Allow the RNG to accept a class attribute on <calendar>, as it's supported by the client.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
