### PR TITLE
[FIX] mail: creating a channel with 'channel_partner_ids' should not raise an error

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -190,7 +190,7 @@ class Channel(models.Model):
             if any(cmd[0] not in (4, 6) for cmd in partner_ids_cmd):
                 raise ValidationError(_('Invalid value when creating a channel with members, only 4 or 6 are allowed.'))
             partner_ids = [cmd[1] for cmd in partner_ids_cmd if cmd[0] == 4]
-            partner_ids += [cmd[2] for cmd in partner_ids_cmd if cmd[0] == 6]
+            partner_ids += [p_id for cmd in partner_ids_cmd if cmd[0] == 6 for p_id in cmd[2]]
 
             # find partners to add from channel_last_seen_partner_ids
             membership_ids_cmd = vals.get('channel_last_seen_partner_ids') or []


### PR DESCRIPTION
Before this fix, the code 'self.env['mail.channel'].create({'channel_partner_ids': [(6, 0, self.env.user.partner_id.ids)]})' raises the following error:

Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "<decorator-gen-137>", line 2, in create
  File "/opt/odoo/odoo/odoo/api.py", line 412, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/odoo/addons/mail/models/mail_channel.py", line 203, in create
    partner_ids_to_add = list(set(partner_ids + [self.env.user.partner_id.id]))
TypeError: unhashable type: 'list'

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
