### PR TITLE
[FIX] account: fix drag and drop feature

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -719,8 +719,8 @@ class AccountJournal(models.Model):
             })
         else:
             action_vals.update({
-                'views': [[False, "tree"], [False, "kanban"], [False, "form"]],
-                'view_mode': 'tree, kanban, form',
+                'views': [[False, "list"], [False, "kanban"], [False, "form"]],
+                'view_mode': 'list, kanban, form',
             })
         return action_vals
 


### PR DESCRIPTION
Task 2888341

After the OWL update, the drag and drop feature doesn't work anymore.
This slight change does both things mentioned in the task: it fixes the upload + shows the list view when the documents are uploaded


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
