### PR TITLE
[FIX] pos_coupon: respect promotions program max amount

### DIFF
--- a/addons/pos_coupon/static/src/js/tours/PosCoupon3tour.js
+++ b/addons/pos_coupon/static/src/js/tours/PosCoupon3tour.js
@@ -1,0 +1,30 @@
+odoo.define('pos_coupon.tour.pos_coupon3', function (require) {
+    'use strict';
+
+    // --- PoS Coupon Tour Basic Part 3 ---
+
+    const { PosCoupon } = require('pos_coupon.tour.PosCouponTourMethods');
+    const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
+    const { getSteps, startSteps } = require('point_of_sale.tour.utils');
+    var Tour = require('web_tour.tour');
+
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickHomeCategory();
+
+    ProductScreen.exec.addOrderline('Promo Product', '1');
+    PosCoupon.check.orderTotalIs('34.50');
+    ProductScreen.exec.addOrderline('Product B', '1');
+    PosCoupon.check.hasRewardLine('100.0% discount on products', '25.00');
+    ProductScreen.exec.addOrderline('Product A', '1');
+    PosCoupon.check.hasRewardLine('100.0% discount on products', '15.00');
+    PosCoupon.check.orderTotalIs('34.50');
+    ProductScreen.exec.addOrderline('Product A', '2');
+    PosCoupon.check.hasRewardLine('100.0% discount on products', '21.82');
+    PosCoupon.check.hasRewardLine('100.0% discount on products', '18.18');
+    PosCoupon.check.orderTotalIs('49.50');
+
+
+    Tour.register('PosCouponTour3', { test: true, url: '/pos/web' }, getSteps());
+});


### PR DESCRIPTION
Current behavior:
If you create a promotion program that applies on specific products that
have different taxes, the maximum amount of the promotion was not
respected. For example, if you had 2 products with 2 different taxes you
could have 2 discounts with the maximum amount of the promotion program.

Steps to reproduce:
-Create 2 products A (15$) and B (25$) with different taxes T1 and T2
-Create product C (30$) that we will use to activate the promotion
-Create a promotion program, based on product C, that applies
 on products A and B. It should have a max amount of 40$ and
 a discount of 100%.
-Go in the PoS application and apply the new promotion program on a PoS
 and start a new session.
-Add 2 products A and 2 products B to the order, then add product C. The promotion
 is applied but it creates 2 discount lines of 30$ and 40$ which is more than the
 maximum amount of 40$ set in the promotion program

opw-2927711
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
