### PR TITLE
[FIX] web: toggle a bool in a x2m with the view in edition

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -121,7 +121,10 @@ export class Field extends Component {
         const modifiers = fieldInfo.modifiers || {};
         const required = evalDomain(modifiers.required, evalContext);
         const readonlyFromModifiers = evalDomain(modifiers.readonly, evalContext);
-        const readonlyFromViewMode = !this.props.record.isInEdition;
+        const readonlyFromRecord = !record.isInEdition;
+        const readonlyFromViewMode = record.model.root
+            ? !record.model.root.isInEdition
+            : readonlyFromRecord;
         const emptyRequiredValue = required && !this.props.value;
 
         // Decoration props
@@ -166,7 +169,7 @@ export class Field extends Component {
             },
             value: this.props.record.data[this.props.name],
             decorations: decorationMap,
-            readonly: readonlyFromViewMode || readonlyFromModifiers || false,
+            readonly: readonlyFromRecord || readonlyFromModifiers || false,
             ...propsFromAttrs,
             ...props,
             type: field.type,

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1393,6 +1393,10 @@ class DynamicList extends DataPoint {
     // Getters
     // -------------------------------------------------------------------------
 
+    get isInEdition() {
+        return !!this.editedRecord;
+    }
+
     get currentParams() {
         return JSON.stringify([this.domain, this.groupBy]);
     }

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -12369,4 +12369,36 @@ QUnit.module("Fields", (hooks) => {
 
         await clickSave(target);
     });
+
+    QUnit.test("toggle boolean in o2m with the formView in edition", async function (assert) {
+        serverData.models.partner.onchanges = {
+            turtles: () => {},
+        };
+        serverData.models.turtle.onchanges = {
+            turtle_bar: () => {},
+        };
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="turtles">
+                        <tree>
+                            <field name="turtle_bar" widget="boolean_toggle"/>
+                        </tree>
+                    </field>
+                </form>`,
+            resId: 1,
+            mockRPC(route, args) {
+                assert.step(args.method + " " + args.model);
+            },
+        });
+        await clickEdit(target);
+        assert.verifySteps(["get_views partner", "read partner", "read turtle"]);
+
+        await click(target, ".o_boolean_toggle");
+        assert.verifySteps(["onchange turtle", "onchange partner"]);
+    });
 });


### PR DESCRIPTION
Before this commit, in a form view in edition, if you clicked a toggle
boolean in an X2many, the view was saved. A toggle boolean should not do
a save if the main view is in edit mode.

The solution is to save the record only if the view's root datapoint
is in edition.

How to reproduce:
- Go to a form view in edit mode with an X2many that contains a toggle
   boolean field.
- Click on the toggle boolean in the x2many

Result before:
    The view is saved.

Result after:
    The view is not saved and is still in edit mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
