### PR TITLE
[FIX] account_edi: documents of draft invoice no longer sent

### DIFF
--- a/addons/account_edi/data/cron.xml
+++ b/addons/account_edi/data/cron.xml
@@ -3,7 +3,7 @@
         <field name="name">EDI : Perform web services operations</field>
         <field name="model_id" ref="model_account_edi_document"/>
         <field name="state">code</field>
-        <field name="code">model.search([('state', 'in', ('to_send', 'to_cancel'))])._process_documents_web_services(job_count=20)</field>
+        <field name="code">model.search([('state', 'in', ('to_send', 'to_cancel')), ('move_id.state', '=', 'posted')])._process_documents_web_services(job_count=20)</field>
         <field name="interval_number">1</field>
         <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>


### PR DESCRIPTION
How to reproduce the bug ?

- install point_of_sale,l10n_mx_edi
- In Point of Sale > Settings, add at least one Payment Methods
- Still in Point of Sale > Settings, create one Point of Sale
- In Point of Sale > Products > Products, select one product.
- In the Accounting tab of the product, set the UNSPSC Category.
- Go back on the dashboard of Point of Sale and start a new session.
- Add the product you have selected before and go to calidate the
invoice.
- Pick a payment methode and a costumer and check the invoice option.
- Validate the invoice.
- Close the session and go to Point of Sale > Orders > Orders.
- Click on the order you have just created and click on Invoice (in the
top right corner).
- Reset the invoice in draft.
- Wait for the cron task to be executed or execute it manually.

What is the bug ?

The cron task that send all the edi documents doesn't consider the state
of the account_move linked to it. Because of that if an invoice poster
is reset to draft, it will have a document and this document will be
sent.

opw-2925137

closes odoo/odoo#97009

Signed-off-by: Adrien Minet <admi@odoo.com>
Signed-off-by: Josse Colpaert <jco@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
