### PR TITLE
[IMP] POS: allows to create invoices for a pos order at a later time

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3629,3 +3629,15 @@ class AccountMove(models.Model):
         Down-payments can be created from a sale order. This method is overridden in the sale order module.
         '''
         return False
+
+    @api.model
+    def get_invoice_localisation_fields_required_to_invoice(self, country_id):
+        """ Returns the list of fields that needs to be filled when creating an invoice for the selected country.
+        This is required for some flows that would allow a user to request an invoice from the portal.
+        Using these, we can get their information and dynamically create form inputs based for the fields required legally for the company country_id.
+        The returned fields must be of type ir.model.fields in order to handle translations
+
+        :param country_id: The country for which we want the fields.
+        :return: an array of ir.model.fields for which the user should provide values.
+        """
+        return []

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -655,3 +655,15 @@ class ResPartner(models.Model):
                     _logger.debug('Another transaction already locked partner rows. Cannot update partner ranks.')
                 else:
                     raise e
+
+    @api.model
+    def get_partner_localisation_fields_required_to_invoice(self, country_id):
+        """ Returns the list of fields that needs to be filled when creating an invoice for the selected country.
+        This is required for some flows that would allow a user to request an invoice from the portal.
+        Using these, we can get their information and dynamically create form inputs based for the fields required legally for the company country_id.
+        The returned fields must be of type ir.model.fields in order to handle translations
+
+        :param country_id: The country for which we want the fields.
+        :return: an array of ir.model.fields for which the user should provide values.
+        """
+        return []

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -169,4 +169,24 @@
             </div>
         </div>
     </template>
+
+    <!-- Get the fields set in required_fields and display them as form elements. Doesn't create the form itself. -->
+    <template id="portal_invoice_required_fields_form">
+        <t t-foreach="required_fields" t-as="required_field">
+            <div t-attf-class="mb-3 #{error.get(required_field.name) and 'o_has_error' or ''} col-xl-6">
+                <!-- select by default the value passed in the data or corresponding to the "default" attribute on the field -->
+                <t t-set="field_info" t-value="env[required_field.model]._fields[required_field.name]"/>
+                <t t-set="default_value" t-value="extra_field_values.get(field_prefix + required_field.name) or field_info.default and field_info.default(required_field.model)"/>
+                <t t-if="required_field.ttype == 'selection'">
+                    <label class="col-form-label" t-att-for="field_prefix + required_field.name"><t t-out="required_field.field_description"/></label>
+                    <select class="form-select" t-att-name="field_prefix + required_field.name" required="required">
+                        <option t-att-selected="not default_value" disabled="disabled" value=""><t t-out="'Select the %s ...' % required_field.field_description.lower()"/></option>
+                        <t t-foreach="required_field.selection_ids" t-as="selection">
+                            <option t-att-selected="default_value and default_value == selection.value" t-att-value="selection.value"><t t-out="selection.name"/></option>
+                        </t>
+                    </select>
+                </t>
+            </div>
+        </t>
+    </template>
 </odoo>

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -222,19 +222,34 @@ class ResPartner(models.Model):
         expected_format = _ref_vat.get(country_code, "'CC##' (CC=Country Code, ##=VAT Number)")
 
         if company.vat_check_vies:
+            if 'False' not in record_label:
+                return '\n' + _(
+                    "The VAT number [%(wrong_vat)s] for %(record_label)s either failed the VIES VAT validation check or did not respect the expected format %(expected_format)s.",
+                    wrong_vat=wrong_vat,
+                    record_label=record_label,
+                    expected_format=expected_format,
+                )
+            else:
+                return '\n' + _(
+                    "The VAT number [%(wrong_vat)s] either failed the VIES VAT validation check or did not respect the expected format %(expected_format)s.",
+                    wrong_vat=wrong_vat,
+                    expected_format=expected_format,
+                )
+
+        # Catch use case where the record label is about the public user (name: False)
+        if 'False' not in record_label:
             return '\n' + _(
-                "The VAT number [%(wrong_vat)s] for %(record_label)s either failed the VIES VAT validation check or did not respect the expected format %(expected_format)s.",
+                'The VAT number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \nNote: the expected format is %(expected_format)s',
                 wrong_vat=wrong_vat,
                 record_label=record_label,
                 expected_format=expected_format,
             )
-
-        return '\n' + _(
-            'The VAT number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \nNote: the expected format is %(expected_format)s',
-            wrong_vat=wrong_vat,
-            record_label=record_label,
-            expected_format=expected_format,
-        )
+        else:
+            return '\n' + _(
+                'The VAT number [%(wrong_vat)s] does not seem to be valid. \nNote: the expected format is %(expected_format)s',
+                wrong_vat=wrong_vat,
+                expected_format=expected_format,
+            )
 
     __check_vat_ch_re = re.compile(r'E([0-9]{9}|-[0-9]{3}\.[0-9]{3}\.[0-9]{3})(MWST|TVA|IVA)$')
 

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -43,6 +43,7 @@
         'views/point_of_sale_dashboard.xml',
         'views/report_invoice.xml',
         'views/res_config_settings_views.xml',
+        'views/pos_ticket_view.xml',
     ],
     'demo': [
         'data/point_of_sale_demo.xml',
@@ -121,6 +122,7 @@
             'point_of_sale/static/lib/**/*.js',
             'web_editor/static/lib/html2canvas.js',
             'point_of_sale/static/src/js/**/*.js',
+            'web/static/lib/zxing-library/zxing-library.js',
         ],
         # This bundle contains the code responsible for starting the POS UI.
         # It is practically the entry point.

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
-import json
 import logging
 
-from odoo import http
+from odoo import http, _
 from odoo.http import request
 from odoo.osv.expression import AND
+from odoo.tools import format_amount
+from odoo.addons.account.controllers.portal import PortalAccount
 
 _logger = logging.getLogger(__name__)
 
 
-class PosController(http.Controller):
+class PosController(PortalAccount):
 
     @http.route(['/pos/web', '/pos/ui'], type='http', auth='user')
     def pos_web(self, config_id=False, **k):
@@ -84,3 +85,128 @@ class PosController(http.Controller):
         pdf, _ = request.env['ir.actions.report'].with_context(date_start=date_start, date_stop=date_stop)._render_qweb_pdf('point_of_sale.sale_details_report', r)
         pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', len(pdf))]
         return request.make_response(pdf, headers=pdfhttpheaders)
+
+    @http.route(['/pos/ticket/validate'], type='http', auth="public", website=True, sitemap=False)
+    def show_ticket_validation_screen(self, access_token='', **kwargs):
+        def _parse_additional_values(fields, prefix, kwargs):
+            """ Parse the values in the kwargs by extracting the ones matching the given fields name.
+            :return a dict with the parsed value and the field name as key, and another on with the prefix to
+            re-render the form with previous values if needed.
+            """
+            res, res_prefixed = {}, {}
+            for field in fields:
+                key = prefix + field.name
+                if key in kwargs:
+                    val = kwargs.pop(key)
+                    res[field.name] = val
+                    res_prefixed[key] = val
+            return res, res_prefixed
+
+        # If the route is called directly, return a 404
+        if not access_token:
+            return request.not_found()
+        # Get the order using the access token. We can't use the id in the route because we may not have it yet when the QR code is generated.
+        pos_order = request.env['pos.order'].sudo().search([('access_token', '=', access_token)])
+        if not pos_order:
+            return request.not_found()
+
+        # If the order was already invoiced, return the invoice directly by forcing the access token so that the non-connected user can see it.
+        if pos_order.account_move and pos_order.account_move.is_sale_document():
+            return request.redirect('/my/invoices/%s?access_token=%s' % (pos_order.account_move.id, pos_order.account_move._portal_ensure_token()))
+
+        # Get the optional extra fields that could be required for a localisation.
+        pos_order_country = pos_order.company_id.account_fiscal_country_id
+        additional_partner_fields = request.env['res.partner'].get_partner_localisation_fields_required_to_invoice(pos_order_country)
+        additional_invoice_fields = request.env['account.move'].get_invoice_localisation_fields_required_to_invoice(pos_order_country)
+
+        user_is_connected = not request.env.user._is_public()
+
+        # Validate the form by ensuring required fields are filled and the VAT is correct.
+        form_values = {'error': {}, 'error_message': {}, 'extra_field_values': {}}
+        if kwargs and request.httprequest.method == 'POST':
+            form_values.update(kwargs)
+            # Extract the additional fields values from the kwargs now as they can't be there when validating the 'regular' partner form.
+            partner_values, prefixed_partner_values = _parse_additional_values(additional_partner_fields, 'partner_', kwargs)
+            form_values['extra_field_values'].update(prefixed_partner_values)
+            # Do the same for invoice values, separately as they are only needed for the invoice creation.
+            invoice_values, prefixed_invoice_values = _parse_additional_values(additional_invoice_fields, 'invoice_', kwargs)
+            form_values['extra_field_values'].update(prefixed_invoice_values)
+            # Check the basic form fields if the user is not connected as we will need these information to create the new user.
+            if not user_is_connected:
+                error, error_message = self.details_form_validate(kwargs, partner_creation=True)
+            else:
+                # Check that the billing information of the user are filled.
+                error, error_message = {}, []
+                partner = request.env.user.partner_id
+                for field in self.MANDATORY_BILLING_FIELDS:
+                    if not partner[field]:
+                        error[field] = 'error'
+                        error_message.append(_('The %s must be filled in your details.', request.env['ir.model.fields']._get('res.partner', field).field_description))
+            # Check that the "optional" additional fields are filled.
+            error, error_message = self.extra_details_form_validate(partner_values, additional_partner_fields, error, error_message)
+            error, error_message = self.extra_details_form_validate(invoice_values, additional_invoice_fields, error, error_message)
+            if not error:
+                return self._get_invoice(partner_values, invoice_values, pos_order, additional_invoice_fields, kwargs)
+            else:
+                form_values.update({'error': error, 'error_message': error_message})
+
+        # Most of the time, the country of the customer will be the same as the order. We can prefill it by default with the country of the company.
+        if 'country_id' not in form_values:
+            form_values['country_id'] = pos_order_country.id
+
+        partner = request.env['res.partner']
+        # Prefill the customer extra values if there is any and an user is connected
+        if user_is_connected:
+            partner = request.env.user.partner_id
+            if additional_partner_fields:
+                form_values['extra_field_values'] = {'partner_' + field.name: partner[field.name] for field in additional_partner_fields if field.name not in form_values['extra_field_values']}
+
+            # This is just to ensure that the user went and filled its information at least once.
+            # Another more thorough check is done upon posting the form.
+            if not partner.country_id or not partner.street:
+                form_values['partner_address'] = False
+            else:
+                form_values['partner_address'] = partner._display_address()
+
+        return request.render("point_of_sale.ticket_validation_screen", {
+            'partner': partner,
+            'address_url': f'/my/account?redirect=/pos/ticket/validate?access_token={access_token}',
+            'user_is_connected': user_is_connected,
+            'format_amount': format_amount,
+            'env': request.env,
+            'countries': request.env['res.country'].sudo().search([]),
+            'states': request.env['res.country.state'].sudo().search([]),
+            'partner_can_edit_vat': True,
+            'pos_order': pos_order,
+            'invoice_required_fields': additional_invoice_fields,
+            'partner_required_fields': additional_partner_fields,
+            'access_token': access_token,
+            **form_values,
+        })
+
+    def _get_invoice(self, partner_values, invoice_values, pos_order, additional_invoice_fields, kwargs):
+        # If the user is not connected, then we will simply create a new partner with the form values.
+        # Matching with existing partner was tried, but we then can't update the values, and it would force the user to use the ones from the first invoicing.
+        if request.env.user._is_public():
+            partner_values.update({key: kwargs[key] for key in self.MANDATORY_BILLING_FIELDS})
+            partner_values.update({key: kwargs[key] for key in self.OPTIONAL_BILLING_FIELDS if key in kwargs})
+            for field in {'country_id', 'state_id'} & set(partner_values.keys()):
+                try:
+                    partner_values[field] = int(partner_values[field])
+                except Exception:
+                    partner_values[field] = False
+            partner_values.update({'zip': partner_values.pop('zipcode', '')})
+            partner = request.env['res.partner'].sudo().create(partner_values)  # In this case, partner_values contains the whole partner info form.
+        # If the user is connected, then we can update if needed its fields with the additional localized fields if any, then proceed.
+        else:
+            partner = request.env.user.partner_id
+            partner.write(partner_values)  # In this case, partner_values only contains the additional fields that can be updated.
+
+        pos_order.partner_id = partner
+        # Get the required fields for the invoice and add them to the context as default values.
+        with_context = {}
+        for field in additional_invoice_fields:
+            with_context.update({f'default_{field.name}': invoice_values.get(field.name)})
+        # Allowing default values for moves is important for some localizations that would need specific fields to be set on the invoice, such as Mexico.
+        pos_order.with_context(with_context).action_pos_order_invoice()
+        return request.redirect('/my/invoices/%s?access_token=%s' % (pos_order.account_move.id, pos_order.account_move._portal_ensure_token()))

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -4,6 +4,7 @@ import logging
 from datetime import timedelta
 from functools import partial
 from itertools import groupby
+from collections import defaultdict
 
 import psycopg2
 import pytz
@@ -12,7 +13,6 @@ import re
 from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare
 from odoo.exceptions import ValidationError, UserError
-from odoo.http import request
 from odoo.osv.expression import AND
 import base64
 
@@ -21,6 +21,7 @@ _logger = logging.getLogger(__name__)
 
 class PosOrder(models.Model):
     _name = "pos.order"
+    _inherit = ["portal.mixin"]
     _description = "Point of Sale Orders"
     _order = "date_order desc, name desc, id desc"
 
@@ -54,6 +55,7 @@ class PosOrder(models.Model):
             'to_ship': ui_order['to_ship'] if "to_ship" in ui_order else False,
             'is_tipped': ui_order.get('is_tipped', False),
             'tip_amount': ui_order.get('tip_amount', 0),
+            'access_token': ui_order.get('access_token', '')
         }
 
     @api.model
@@ -591,6 +593,7 @@ class PosOrder(models.Model):
     def _prepare_invoice_vals(self):
         self.ensure_one()
         timezone = pytz.timezone(self._context.get('tz') or self.env.user.tz or 'UTC')
+        invoice_date = fields.Datetime.now() if self.session_id.state == 'closed' else self.date_order
         vals = {
             'invoice_origin': self.name,
             'journal_id': self.session_id.config_id.invoice_journal_id.id,
@@ -601,7 +604,7 @@ class PosOrder(models.Model):
             # considering partner's sale pricelist's currency
             'currency_id': self.pricelist_id.currency_id.id,
             'invoice_user_id': self.user_id.id,
-            'invoice_date': self.date_order.astimezone(timezone).date(),
+            'invoice_date': invoice_date.astimezone(timezone).date(),
             'fiscal_position_id': self.fiscal_position_id.id,
             'invoice_line_ids': self._prepare_invoice_lines(),
             'invoice_cash_rounding_id': self.config_id.rounding_method.id
@@ -611,6 +614,186 @@ class PosOrder(models.Model):
         if self.note:
             vals.update({'narration': self.note})
         return vals
+
+    def _prepare_aml_values_list_per_nature(self):
+        self.ensure_one()
+        sign = 1 if self.amount_total < 0 else -1
+        commercial_partner = self.partner_id.commercial_partner_id
+        company_currency = self.company_id.currency_id
+        rate = self.currency_id._get_conversion_rate(self.currency_id, company_currency, self.company_id, self.date_order)
+
+        # Concert each order line to a dictionary containing business values. Also, prepare for taxes computation.
+        base_line_vals_list = []
+        for line in self.lines.with_company(self.company_id):
+            account = line.product_id._get_product_accounts()['income']
+            if not account:
+                raise UserError(_(
+                    "Please define income account for this product: '%s' (id:%d).",
+                    line.product_id.name, line.product_id.id,
+                ))
+
+            if self.fiscal_position_id:
+                account = self.fiscal_position_id.map_account(account)
+
+            is_refund = line.qty * line.price_unit < 0
+
+            base_line_vals_list.append(self.env['account.tax']._convert_to_tax_base_line_dict(
+                line,
+                partner=commercial_partner,
+                currency=self.currency_id,
+                product=line.product_id,
+                taxes=line.tax_ids_after_fiscal_position,
+                price_unit=line.price_unit,
+                quantity=sign * line.qty,
+                discount=line.discount,
+                account=account,
+                is_refund=is_refund,
+            ))
+
+        tax_results = self.env['account.tax']._compute_taxes(base_line_vals_list)
+
+        total_balance = 0.0
+        total_amount_currency = 0.0
+        aml_vals_list_per_nature = defaultdict(list)
+
+        # Create the tax lines
+        for tax_line_vals in tax_results['tax_lines_to_add']:
+            tax_rep = self.env['account.tax.repartition.line'].browse(tax_line_vals['tax_repartition_line_id'])
+            amount_currency = tax_line_vals['tax_amount']
+            balance = company_currency.round(amount_currency * rate)
+            aml_vals_list_per_nature['tax'].append({
+                'name': tax_rep.tax_id.name,
+                'account_id': tax_line_vals['account_id'],
+                'partner_id': tax_line_vals['partner_id'],
+                'currency_id': tax_line_vals['currency_id'],
+                'tax_repartition_line_id': tax_line_vals['tax_repartition_line_id'],
+                'tax_ids': tax_line_vals['tax_ids'],
+                'tax_tag_ids': tax_line_vals['tax_tag_ids'],
+                'group_tax_id': None if tax_rep.tax_id.id == tax_line_vals['tax_id'] else tax_line_vals['tax_id'],
+                'amount_currency': amount_currency,
+                'balance': balance,
+            })
+            total_amount_currency += amount_currency
+            total_balance += balance
+
+        # Create the aml values for order lines.
+        for base_line_vals, update_base_line_vals in tax_results['base_lines_to_update']:
+            order_line = base_line_vals['record']
+            amount_currency = update_base_line_vals['price_subtotal']
+            balance = company_currency.round(amount_currency * rate)
+            aml_vals_list_per_nature['product'].append({
+                'name': order_line.full_product_name,
+                'account_id': base_line_vals['account'].id,
+                'partner_id': base_line_vals['partner'].id,
+                'currency_id': base_line_vals['currency'].id,
+                'tax_ids': [(6, 0, base_line_vals['taxes'].ids)],
+                'tax_tag_ids': update_base_line_vals['tax_tag_ids'],
+                'amount_currency': amount_currency,
+                'balance': balance,
+            })
+            total_amount_currency += amount_currency
+            total_balance += balance
+
+        # Cash rounding.
+        cash_rounding = self.config_id.rounding_method
+        if self.config_id.cash_rounding and cash_rounding and not self.config_id.only_round_cash_method:
+            amount_currency = cash_rounding.compute_difference(self.currency_id, total_amount_currency)
+            if not self.currency_id.is_zero(amount_currency):
+                balance = company_currency.round(amount_currency * rate)
+
+                if cash_rounding.strategy == 'biggest_tax':
+                    biggest_tax_aml_vals = None
+                    for aml_vals in aml_vals_list_per_nature['tax']:
+                        if not biggest_tax_aml_vals or float_compare(-sign * aml_vals['amount_currency'], -sign * biggest_tax_aml_vals['amount_currency'], precision_rounding=self.currency_id.rounding) > 0:
+                            biggest_tax_aml_vals = aml_vals
+                    if biggest_tax_aml_vals:
+                        biggest_tax_aml_vals['amount_currency'] += amount_currency
+                        biggest_tax_aml_vals['balance'] += balance
+                elif cash_rounding.strategy == 'add_invoice_line':
+                    if -sign * amount_currency > 0.0 and cash_rounding.loss_account_id:
+                        account_id = cash_rounding.loss_account_id.id
+                    else:
+                        account_id = cash_rounding.profit_account_id.id
+                    aml_vals_list_per_nature['cash_rounding'].append({
+                        'name': cash_rounding.name,
+                        'account_id': account_id,
+                        'partner_id': commercial_partner.id,
+                        'currency_id': self.currency_id.id,
+                        'amount_currency': amount_currency,
+                        'balance': balance,
+                        'display_type': 'rounding',
+                    })
+
+                total_amount_currency += amount_currency
+                total_balance += balance
+
+        # Stock.
+        if self.company_id.anglo_saxon_accounting and self.picking_ids.ids:
+            stock_moves = self.env['stock.move'].sudo().search([
+                ('picking_id', 'in', self.picking_ids.ids),
+                ('product_id.categ_id.property_valuation', '=', 'real_time')
+            ])
+            for stock_move in stock_moves:
+                expense_account = stock_move.product_id._get_product_accounts()['expense']
+                stock_output_account = stock_move.product_id.categ_id.property_stock_account_output_categ_id
+                balance = -sum(stock_move.stock_valuation_layer_ids.mapped('value'))
+                aml_vals_list_per_nature['stock'].append({
+                    'name': _("Stock input for %s", stock_move.product_id.name),
+                    'account_id': expense_account.id,
+                    'partner_id': commercial_partner.id,
+                    'currency_id': self.company_id.currency_id.id,
+                    'amount_currency': balance,
+                    'balance': balance,
+                })
+                aml_vals_list_per_nature['stock'].append({
+                    'name': _("Stock output for %s", stock_move.product_id.name),
+                    'account_id': stock_output_account.id,
+                    'partner_id': commercial_partner.id,
+                    'currency_id': self.company_id.currency_id.id,
+                    'amount_currency': -balance,
+                    'balance': -balance,
+                })
+
+        # Payment terms.
+        pos_receivable_account = self.company_id.account_default_pos_receivable_account_id
+        aml_vals_list_per_nature['payment_terms'].append({
+            'name': f"{pos_receivable_account.code} {pos_receivable_account.code}",
+            'account_id': pos_receivable_account.id,
+            'currency_id': self.currency_id.id,
+            'amount_currency': -total_amount_currency,
+            'balance': -total_balance,
+        })
+
+        return aml_vals_list_per_nature
+
+    def _create_misc_reversal_move(self, payment_moves):
+        """ Create a misc move to reverse this POS order and "remove" it from the POS closing entry.
+        This is done by taking data from the order and using it to somewhat replicate the resulting entry in order to
+        reverse partially the movements done ine the POS closing entry.
+        """
+        aml_values_list_per_nature = self._prepare_aml_values_list_per_nature()
+        move_lines = []
+        for aml_values_list in aml_values_list_per_nature.values():
+            for aml_values in aml_values_list:
+                aml_values['balance'] = -aml_values['balance']
+                aml_values['amount_currency'] = -aml_values['amount_currency']
+                move_lines.append(aml_values)
+
+        # Make a move with all the lines.
+        reversal_entry = self.env['account.move'].with_context(default_journal_id=self.config_id.journal_id.id).create({
+            'journal_id': self.config_id.journal_id.id,
+            'date': fields.Date.context_today(self),
+            'ref': _('Reversal of POS closing entry %s for order %s from session %s', self.session_move_id.name, self.name, self.session_id.name),
+            'invoice_line_ids': [(0, 0, aml_value) for aml_value in move_lines],
+        })
+        reversal_entry.action_post()
+
+        # Reconcile the new receivable line with the lines from the payment move.
+        pos_account_receivable = self.company_id.account_default_pos_receivable_account_id
+        reversal_entry_receivable = reversal_entry.line_ids.filtered(lambda l: l.account_id == pos_account_receivable)
+        payment_receivable = payment_moves.line_ids.filtered(lambda l: l.account_id == pos_account_receivable)
+        (reversal_entry_receivable | payment_receivable).reconcile()
+
     def action_pos_order_invoice(self):
         self.write({'to_invoice': True})
         res = self._generate_pos_order_invoice()
@@ -636,7 +819,11 @@ class PosOrder(models.Model):
             order.write({'account_move': new_move.id, 'state': 'invoiced'})
             new_move.sudo().with_company(order.company_id)._post()
             moves += new_move
-            order._apply_invoice_payments()
+            payment_moves = order._apply_invoice_payments()
+
+            if order.session_id.state == 'closed':  # If the session isn't closed this isn't needed.
+                # If a client requires the invoice later, we need to revers the amount from the closing entry, by making a new entry for that.
+                order._create_misc_reversal_move(payment_moves)
 
         if not moves:
             return {}
@@ -658,7 +845,7 @@ class PosOrder(models.Model):
         return self.write({'state': 'cancel'})
 
     def _apply_invoice_payments(self):
-        receivable_account = self.env["res.partner"]._find_accounting_partner(self.partner_id).property_account_receivable_id
+        receivable_account = self.env["res.partner"]._find_accounting_partner(self.partner_id).with_company(self.company_id).property_account_receivable_id
         payment_moves = self.payment_ids._create_payment_moves()
         invoice_receivable = self.account_move.line_ids.filtered(lambda line: line.account_id == receivable_account)
         # Reconcile the invoice to the created payment moves.
@@ -666,6 +853,7 @@ class PosOrder(models.Model):
         if not invoice_receivable.reconciled and receivable_account.reconcile:
             payment_receivables = payment_moves.mapped('line_ids').filtered(lambda line: line.account_id == receivable_account)
             (invoice_receivable | payment_receivables).reconcile()
+        return payment_moves
 
     @api.model
     def create_from_ui(self, orders, draft=False):
@@ -830,7 +1018,6 @@ class PosOrder(models.Model):
             'amount_tax': order.amount_tax,
             'amount_return': order.amount_return,
             'pos_session_id': order.session_id.id,
-            'is_session_closed': order.session_id.state == 'closed',
             'pricelist_id': order.pricelist_id.id,
             'partner_id': order.partner_id.id,
             'user_id': order.user_id.id,
@@ -844,6 +1031,7 @@ class PosOrder(models.Model):
             'id': order.id,
             'is_tipped': order.is_tipped,
             'tip_amount': order.tip_amount,
+            'access_token': order.access_token,
         }
 
     def _get_fields_for_order_line(self):
@@ -976,6 +1164,7 @@ class PosOrderLine(models.Model):
         return {
             'price_subtotal_incl': taxes['total_included'],
             'price_subtotal': taxes['total_excluded'],
+            'taxes': taxes['taxes']
         }
 
     @api.onchange('product_id')

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -84,7 +84,7 @@ class PosPayment(models.Model):
             payment.write({'account_move_id': payment_move.id})
             amounts = pos_session._update_amounts({'amount': 0, 'amount_converted': 0}, {'amount': payment.amount}, payment.payment_date)
             credit_line_vals = pos_session._credit_amounts({
-                'account_id': accounting_partner.property_account_receivable_id.id,
+                'account_id': accounting_partner.with_company(order.company_id).property_account_receivable_id.id,  # The field being company dependant, we need to make sure the right value is received.
                 'partner_id': accounting_partner.id,
                 'move_id': payment_move.id,
             }, amounts['amount'], amounts['amount_converted'])

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1609,6 +1609,7 @@ class PosSession(models.Model):
             fiscal_position['fiscal_position_taxes_by_id'] = {tax_id: fiscal_position_by_id[tax_id] for tax_id in fiscal_position['tax_ids']}
 
         loaded_data['attributes_by_ptal_id'] = self._get_attributes_by_ptal_id()
+        loaded_data['base_url'] = self.get_base_url()
 
     @api.model
     def _pos_ui_models_to_load(self):
@@ -1646,7 +1647,7 @@ class PosSession(models.Model):
                 'domain': [('id', '=', self.company_id.id)],
                 'fields': [
                     'currency_id', 'email', 'website', 'company_registry', 'vat', 'name', 'phone', 'partner_id',
-                    'country_id', 'state_id', 'tax_calculation_rounding_method', 'nomenclature_id'
+                    'country_id', 'state_id', 'tax_calculation_rounding_method', 'nomenclature_id', 'point_of_sale_use_ticket_qr_code',
                 ],
             }
         }

--- a/addons/point_of_sale/models/res_company.py
+++ b/addons/point_of_sale/models/res_company.py
@@ -11,6 +11,9 @@ class ResCompany(models.Model):
             ('real', 'In real time (recommended)'),
             ], default='real', string="Update quantities in stock",
             help="At the session closing: A picking is created for the entire session when it's closed\n In real time: Each order sent to the server create its own picking")
+    point_of_sale_use_ticket_qr_code = fields.Boolean(
+        string='Use QR code on ticket',
+        help="Add a QR code on the ticket, which the user can scan to request the invoice linked to its order.")
 
     @api.constrains('period_lock_date', 'fiscalyear_lock_date')
     def validate_period_lock_date(self):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -100,6 +100,7 @@ class ResConfigSettings(models.TransientModel):
     pos_tip_product_id = fields.Many2one('product.product', string='Tip Product', compute='_compute_pos_tip_product_id', readonly=False, store=True)
     pos_use_pricelist = fields.Boolean(related='pos_config_id.use_pricelist', readonly=False)
     pos_warehouse_id = fields.Many2one(related='pos_config_id.warehouse_id', readonly=False, string="Warehouse (PoS)")
+    point_of_sale_use_ticket_qr_code = fields.Boolean(related='company_id.point_of_sale_use_ticket_qr_code', readonly=False)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
@@ -21,8 +21,6 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
             } else {
                 return this.isAlreadyInvoiced
                     ? this.env._t('Reprint Invoice')
-                    : this.props.order.isFromClosedSession
-                    ? this.env._t('Cannot Invoice')
                     : this.env._t('Invoice');
             }
         }
@@ -59,19 +57,9 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
 
             const orderId = order.backendId;
 
-            // Part 0.1. If already invoiced, print the invoice.
+            // Part 0. If already invoiced, print the invoice.
             if (this.isAlreadyInvoiced) {
                 await this._downloadInvoice(orderId);
-                return;
-            }
-
-            // Part 0.2. Check if order belongs to an active session.
-            // If not, do not allow invoicing.
-            if (order.isFromClosedSession) {
-                this.showPopup('ErrorPopup', {
-                    title: this.env._t('Session is closed'),
-                    body: this.env._t('Cannot invoice order from closed session.'),
-                });
                 return;
             }
 

--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -122,6 +122,14 @@
 
             <div class="before-footer" />
 
+            <div t-if="receipt.pos_qr_code">
+                <br /><br />
+                <div class="pos-receipt-order-data">
+                    Scan me to request an invoice for your purchase.
+                </div>
+                <img id="posqrcode" t-att-src="receipt.pos_qr_code" class="pos-receipt-logo"/>
+            </div>
+
             <!-- Footer -->
             <div t-if="receipt.footer_html"  class="pos-receipt-center-align">
                 <t t-out="receipt.footer_html" />

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import time
+from freezegun import freeze_time
 
 import odoo
 from odoo import fields, tools
@@ -1213,3 +1214,96 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         pos_order = self.PosOrder.search([('id', '=', pos_order_id)])
         #assert account_move amount_residual is 300
         self.assertEqual(pos_order.account_move.amount_residual, 300)
+
+    def test_sale_order_postponed_invoicing(self):
+        """ Test the flow of creating an invoice later, after the POS session has been closed and everything has been processed.
+        The process should:
+           - Create a new misc entry, that will revert part of the POS closing entry.
+           - Create the move and associating payment(s) entry, as it would do when closing with invoice.
+           - Reconcile the receivable lines from the created misc entry with the ones from the created payment(s)
+        """
+        # Create the order on the first of january.
+        with freeze_time('2020-01-01'):
+            product = self.env['product.product'].create({
+                'name': 'Dummy product',
+                'type': 'product',
+                'categ_id': self.env.ref('product.product_category_all').id,
+                'taxes_id': self.tax_sale_a.ids,
+            })
+            self.pos_config.open_ui()
+            pos_session = self.pos_config.current_session_id
+            untax, atax = self.compute_tax(product, 500, 1)
+            pos_order_data = {
+                'data': {
+                    'amount_paid': untax + atax,
+                    'amount_return': 0,
+                    'amount_tax': atax,
+                    'amount_total': untax + atax,
+                    'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+                    'fiscal_position_id': False,
+                    'pricelist_id': self.pos_config.available_pricelist_ids[0].id,
+                    'lines': [(0, 0, {
+                        'discount': 0,
+                        'id': 42,
+                        'pack_lot_ids': [],
+                        'price_unit': 500.0,
+                        'product_id': product.id,
+                        'price_subtotal': 500.0,
+                        'price_subtotal_incl': 575.0,
+                        'qty': 1,
+                        'tax_ids': [(6, 0, product.taxes_id.ids)]
+                    })],
+                    'name': 'Order 12345-123-1234',
+                    'partner_id': False,
+                    'pos_session_id': pos_session.id,
+                    'sequence_number': 2,
+                    'statement_ids': [(0, 0, {
+                        'amount': untax + atax,
+                        'name': fields.Datetime.now(),
+                        'payment_method_id': self.cash_payment_method.id
+                    })],
+                    'uid': '12345-123-1234',
+                    'user_id': self.env.uid
+                },
+                'id': '12345-123-1234',
+                'to_invoice': False
+            }
+            pos_order_id = self.PosOrder.create_from_ui([pos_order_data])[0]['id']
+            pos_order = self.env['pos.order'].browse(pos_order_id)
+            # End the session. The order has been created without any invoice.
+            self.pos_config.current_session_id.action_pos_session_closing_control()
+            self.assertFalse(pos_order.account_move.exists())
+        # Client is back on the 3rd, asks for an invoice.
+        with freeze_time('2020-01-03'):
+            # We set the partner on the order
+            pos_order.partner_id = self.partner1.id
+            pos_order.action_pos_order_invoice()
+            # We should now have: an invoice, a payment, and a misc entry reconciled with the payment that reverse the original POS closing entry.
+            invoice = pos_order.account_move
+            closing_entry = pos_order.session_move_id
+            # This search isn't the best, but we don't have any references to this move stored on other models.
+            misc_reversal_entry = self.env['account.move'].search([('ref', '=', f'Reversal of POS closing entry {closing_entry.name} for order {pos_order.name} from session {pos_order.session_id.name}')])
+            # In this case we will have only one, for cash payment
+            payment = self.env['account.move'].search([('ref', '=like', f'Invoice payment for {pos_order.name} ({pos_order.account_move.name}) using {self.cash_payment_method.name}')])
+            # And thus only one bank statement for it
+            statement = self.env['account.move'].search([('journal_id', '=', self.company_data['default_journal_cash'].id)])
+            self.assertTrue(invoice.exists() and closing_entry.exists() and misc_reversal_entry.exists() and payment.exists())
+            # Check 1: Check that we have reversed every credit line on the closing entry.
+            for closing_entry_line, misc_reversal_entry_line in zip(closing_entry.line_ids, misc_reversal_entry.line_ids):
+                if closing_entry_line.balance < 0:
+                    self.assertEqual(closing_entry_line.balance, -misc_reversal_entry_line.balance)
+                    self.assertEqual(closing_entry_line.account_id, misc_reversal_entry_line.account_id)
+
+            # Check 2: Reconciliation
+            # The invoice receivable should be reconciled with the payment receivable of the same account.
+            invoice_receivable_line = invoice.line_ids.filtered(lambda line: line.account_id == self.company_data['default_account_receivable'])
+            payment_receivable_line = payment.line_ids.filtered(lambda line: line.account_id == self.company_data['default_account_receivable'])
+            self.assertEqual(invoice_receivable_line.matching_number, payment_receivable_line.matching_number)
+            # The payment receivable (POS) is reconciled with the closing entry receivable (POS)
+            payment_receivable_pos_line = payment.line_ids.filtered(lambda line: line.account_id == self.company_data['company'].account_default_pos_receivable_account_id)
+            misc_receivable_pos_line = misc_reversal_entry.line_ids.filtered(lambda line: line.account_id == self.company_data['company'].account_default_pos_receivable_account_id)
+            self.assertEqual(misc_receivable_pos_line.matching_number, payment_receivable_pos_line.matching_number)
+            # The closing entry receivable is reconciled with the bank statement
+            closing_entry_receivable_line = closing_entry.line_ids.filtered(lambda line: line.account_id == self.company_data['default_account_receivable'])  # Because the payment method use the default receivable
+            statement_receivable_line = statement.line_ids.filtered(lambda line: line.account_id == self.company_data['default_account_receivable'] and line.name == pos_order.session_id.name)  # Because the payment method use the default receivable
+            self.assertEqual(closing_entry_receivable_line.matching_number, statement_receivable_line.matching_number)

--- a/addons/point_of_sale/views/pos_ticket_view.xml
+++ b/addons/point_of_sale/views/pos_ticket_view.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- This is the "validation" screen. Recap the ticket info, warn the user to check/set his address and eventually set localization fields if needed. -->
+    <template id="ticket_validation_screen">
+        <t t-call="portal.portal_layout">
+            <t t-set="no_breadcrumbs" t-value="True"/>
+            <div class="row justify-content-md-center">
+                <form method="post" target="_self" t-att-action="'/pos/ticket/validate'">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="access_token" t-att-value="access_token"/>
+                    <div class="col-12 col-md-6 mt-4 offset-md-3">
+                        <div class="row">
+                            <h2>Invoicing confirmation</h2>
+                            <hr class="mt-1 mb-0"/>
+                        </div>
+                        <div class="row">
+                            <h4 class="mt-2"><t t-out="pos_order.pos_reference"/></h4>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 fw-bold">
+                                Products:
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12">
+                                <ul>
+                                    <t t-foreach="pos_order.lines" t-as="order_line">
+                                        <li><t t-out="int(order_line.qty)"/> <t t-out="order_line.full_product_name"/> for <t t-out="format_amount(env, order_line.price_subtotal_incl, order_line.currency_id)"/></li>
+                                    </t>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12">
+                                <strong>Amounting to:</strong> <t t-out="format_amount(env, pos_order.amount_total, pos_order.currency_id)"/>
+                            </div>
+                        </div>
+                        <t t-if="user_is_connected">
+                            <div class="row mt-4">
+                                <div class="col-12">
+                                    <h4>Billing address:</h4>
+                                </div>
+                            </div>
+                            <div t-if="error_message" class="alert alert-danger" role="alert">
+                                <div class="col-lg-12">
+                                    <t t-foreach="error_message" t-as="err"><t t-esc="err"/><br /></t>
+                                </div>
+                            </div>
+                            <t t-if="not partner_address">
+                                Your address is missing or incomplete. <br/>
+                                Please make sure to <a t-att-href="address_url">fill all relevant information</a> before continuing.
+                            </t>
+                            <t t-else="">
+                                <div class="row">
+                                    <div class="col-12">
+                                        <t t-out="partner.name"/>
+                                        <t t-if="partner.company_name">
+                                            , <t t-out="partner.company_name"/>
+                                        </t><br />
+                                        <t t-if="partner.vat">
+                                            <t t-out="partner.vat" /><br />
+                                        </t>
+                                        <t t-out="partner_address"/> <a role="button" t-att-href="address_url" class="btn btn-sm btn-link"><i class="fa fa-pencil"/> Edit</a>
+                                    </div>
+                                </div>
+                            </t>
+                            <t t-if="partner_required_fields">
+                                <div class="row mt-4">
+                                    <div class="col-12">
+                                        <h4>Additional required user information:</h4>
+                                        <t t-set="required_fields" t-value="partner_required_fields"/>
+                                        <t t-set="field_prefix" t-value="'partner_'"/>
+                                        <t t-call="account.portal_invoice_required_fields_form"/>
+                                    </div>
+                                </div>
+                            </t>
+                            <t t-if="invoice_required_fields">
+                                <div class="row mt-4">
+                                    <div class="col-12">
+                                        <h4>Additional required invoicing information:</h4>
+                                        <t t-set="required_fields" t-value="invoice_required_fields"/>
+                                        <t t-set="field_prefix" t-value="'invoice_'"/>
+                                        <t t-call="account.portal_invoice_required_fields_form"/>
+                                    </div>
+                                </div>
+                            </t>
+                        </t>
+                        <t t-else="">
+                            <div class="row mt-4">
+                                <div class="col-12">
+                                    <h4>Please enter your billing information <small class="text-muted">or</small> <a role="button" t-att-href="'/web/login?redirect=/pos/ticket/validate?access_token=%s' % access_token" style="margin-top: -11px"> Sign in</a>:</h4>
+                                </div>
+                            </div>
+                            <div class="row o_portal_details">
+                                <div class="col-lg-12">
+                                    <div class="row">
+                                        <t t-call="portal.portal_my_details_fields" />
+                                        <t t-if="partner_required_fields">
+                                            <t t-set="required_fields" t-value="partner_required_fields"/>
+                                            <t t-set="field_prefix" t-value="'partner_'"/>
+                                            <t t-call="account.portal_invoice_required_fields_form"/>
+                                        </t>
+                                    </div>
+                                </div>
+                            </div>
+                            <t t-if="invoice_required_fields">
+                                <div class="row mt-4">
+                                    <div class="col-12">
+                                        <div class="row">
+                                            <h4>Additional required information:</h4>
+                                            <t t-set="required_fields" t-value="invoice_required_fields"/>
+                                            <t t-set="field_prefix" t-value="'invoice_'"/>
+                                            <t t-call="account.portal_invoice_required_fields_form"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </t>
+                        </t>
+                        <div class="row mt-4">
+                            <div class="col-12 col-md-4">
+                                <t t-if="user_is_connected and not partner_address">
+                                    <button class="btn btn-primary w-100" disabled="True">Get my invoice</button>
+                                </t>
+                                <t t-else="">
+                                    <button class="btn btn-primary w-100">Get my invoice</button>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -362,6 +362,15 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="o_setting_left_pane mt-4">
+                                    <field name="point_of_sale_use_ticket_qr_code"/>
+                                </div>
+                                <div class="o_setting_right_pane mt-4">
+                                    <label for="point_of_sale_use_ticket_qr_code"/>
+                                    <div class="text-muted">
+                                        Print a QR code on the receipt to allow the user to easily request the invoice for an order.
+                                    </div>
+                                </div>
                             </div>
                             <div id="order_reference" class="col-12 col-lg-6 o_setting_box" groups="base.group_no_one">
                                 <div class="o_setting_right_pane">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -371,91 +371,94 @@
         </div>
     </template>
 
+    <template id="portal_my_details_fields">
+        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+        <div t-if="error_message" class="alert alert-danger" role="alert">
+            <div class="col-lg-12">
+                <t t-foreach="error_message" t-as="err"><t t-esc="err"/><br /></t>
+            </div>
+        </div>
+        <div t-attf-class="mb-3 #{error.get('name') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="name">Name</label>
+            <input type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="name or partner.name" />
+        </div>
+        <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="email">Email</label>
+            <input type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="email or partner.email" />
+        </div>
+
+        <div class="clearfix" />
+        <div t-attf-class="mb-1 #{error.get('company_name') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label label-optional" for="company_name">Company Name</label>
+            <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
+                 The user might not have rights to change company_name but should still be able to see it.
+            -->
+            <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner.commercial_company_name" t-att-disabled="None if partner_can_edit_vat else '1'" />
+            <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">
+                Changing company name is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
+            </small>
+        </div>
+        <div t-attf-class="mb-1 #{error.get('vat') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label label-optional" for="vat">VAT Number</label>
+            <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
+                 The user might not have rights to change company_name but should still be able to see it.
+            -->
+            <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner.vat" t-att-disabled="None if partner_can_edit_vat else '1'" />
+            <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">Changing VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</small>
+        </div>
+        <div t-if="not partner_can_edit_vat" class="col-12 d-none d-xl-block">
+            <small class="form-text text-muted">Changing company name or VAT number is not allowed once document(s) have been issued for your account. <br/>Please contact us directly for this operation.</small>
+        </div>
+        <div t-attf-class="mb-3 #{error.get('phone') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="phone">Phone</label>
+            <input type="tel" name="phone" t-attf-class="form-control #{error.get('phone') and 'is-invalid' or ''}" t-att-value="phone or partner.phone" />
+        </div>
+
+        <div class="clearfix" />
+        <div t-attf-class="mb-3 #{error.get('street') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="street">Street</label>
+            <input type="text" name="street" t-attf-class="form-control #{error.get('street') and 'is-invalid' or ''}" t-att-value="street or partner.street"/>
+        </div>
+        <div t-attf-class="mb-3 #{error.get('city') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="city">City</label>
+            <input type="text" name="city" t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}" t-att-value="city or partner.city" />
+        </div>
+        <div t-attf-class="mb-3 #{error.get('zip') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label label-optional" for="zipcode">Zip / Postal Code</label>
+            <input type="text" name="zipcode" t-attf-class="form-control #{error.get('zip') and 'is-invalid' or ''}" t-att-value="zipcode or partner.zip" />
+        </div>
+        <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="country_id">Country</label>
+            <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}">
+                <option value="">Country...</option>
+                <t t-foreach="countries or []" t-as="country">
+                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
+                        <t t-esc="country.name" />
+                    </option>
+                </t>
+            </select>
+        </div>
+        <div t-attf-class="mb-3 #{error.get('state_id') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label label-optional" for="state_id">State / Province</label>
+            <select name="state_id" t-attf-class="form-select #{error.get('state_id') and 'is-invalid' or ''}">
+                <option value="">select...</option>
+                <t t-foreach="states or []" t-as="state">
+                    <option t-att-value="state.id" style="display:none;" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == int(state_id) if state_id else state.id == partner.state_id.id">
+                        <t t-esc="state.name" />
+                    </option>
+                </t>
+            </select>
+        </div>
+    </template>
+
     <template id="portal_my_details">
         <t t-call="portal.portal_layout">
             <t t-set="additional_title">Contact Details</t>
             <form action="/my/account" method="post">
-                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                 <div class="row o_portal_details">
                     <div class="col-lg-8">
                         <div class="row">
-                            <t t-set="partner_can_edit_vat" t-value="partner.can_edit_vat()"/>
-                            <div class="col-lg-12">
-                              <div t-if="error_message" class="alert alert-danger" role="alert">
-                                  <t t-foreach="error_message" t-as="err"><t t-esc="err"/><br /></t>
-                              </div>
-                            </div>
-                            <div t-attf-class="form-group #{error.get('name') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label" for="name">Name</label>
-                                <input type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="name or partner.name" />
-                            </div>
-                            <div t-attf-class="form-group #{error.get('email') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label" for="email">Email</label>
-                                <input type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="email or partner.email" />
-                            </div>
-
-                            <div class="clearfix" />
-                            <div t-attf-class="form-group mb-1 #{error.get('company_name') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label label-optional" for="company_name">Company Name</label>
-                                <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
-                                     The user might not have rights to change company_name but should still be able to see it.
-                                -->
-                                <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner.commercial_company_name" t-att-disabled="None if partner_can_edit_vat else '1'" />
-                                <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">
-                                    Changing company name is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
-                                </small>
-                            </div>
-                            <div t-attf-class="form-group mb-1 #{error.get('vat') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label label-optional" for="vat">VAT Number</label>
-                                <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
-                                     The user might not have rights to change company_name but should still be able to see it.
-                                -->
-                                <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner.vat" t-att-disabled="None if partner_can_edit_vat else '1'" />
-                                <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">Changing VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</small>
-                            </div>
-                            <div t-if="not partner_can_edit_vat" class="col-12 d-none d-xl-block">
-                                <small class="form-text text-muted">Changing company name or VAT number is not allowed once document(s) have been issued for your account. <br/>Please contact us directly for this operation.</small>
-                            </div>
-                            <div t-attf-class="form-group #{error.get('phone') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label" for="phone">Phone</label>
-                                <input type="tel" name="phone" t-attf-class="form-control #{error.get('phone') and 'is-invalid' or ''}" t-att-value="phone or partner.phone" />
-                            </div>
-
-                            <div class="clearfix" />
-                            <div t-attf-class="form-group #{error.get('street') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label" for="street">Street</label>
-                                <input type="text" name="street" t-attf-class="form-control #{error.get('street') and 'is-invalid' or ''}" t-att-value="street or partner.street"/>
-                            </div>
-                            <div t-attf-class="form-group #{error.get('city') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label" for="city">City</label>
-                                <input type="text" name="city" t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}" t-att-value="city or partner.city" />
-                            </div>
-                            <div t-attf-class="form-group #{error.get('zip') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label label-optional" for="zipcode">Zip / Postal Code</label>
-                                <input type="text" name="zipcode" t-attf-class="form-control #{error.get('zip') and 'is-invalid' or ''}" t-att-value="zipcode or partner.zip" />
-                            </div>
-                            <div t-attf-class="form-group #{error.get('country_id') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label" for="country_id">Country</label>
-                                <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}">
-                                    <option value="">Country...</option>
-                                    <t t-foreach="countries or []" t-as="country">
-                                        <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
-                                            <t t-esc="country.name" />
-                                        </option>
-                                    </t>
-                                </select>
-                            </div>
-                            <div t-attf-class="form-group #{error.get('state_id') and 'o_has_error' or ''} col-xl-6">
-                                <label class="col-form-label label-optional" for="state_id">State / Province</label>
-                                <select name="state_id" t-attf-class="form-select #{error.get('state_id') and 'is-invalid' or ''}">
-                                    <option value="">select...</option>
-                                    <t t-foreach="states or []" t-as="state">
-                                        <option t-att-value="state.id" style="display:none;" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == partner.state_id.id">
-                                            <t t-esc="state.name" />
-                                        </option>
-                                    </t>
-                                </select>
-                            </div>
+                            <t t-call="portal.portal_my_details_fields"/>
                             <input type="hidden" name="redirect" t-att-value="redirect"/>
                         </div>
                         <div class="clearfix">


### PR DESCRIPTION
Some countries, such as mexico, require a seller to be able to
generate an invoices from a ticket from a sale done in a shop,
even after a few days.
This change aims to allow this, by allowing to create an invoice at
a later date after the POS has been closed.
This is done by partially reversing the POS closing entry, and then
generating an invoice the same way it would be done at the POS closing.

The customer can scan a QR code if enabled in order to request the
invoice by himself, requiring him to fill a for to give the customer
information required for the invoicing.

Allows to fill additional fields depending on the localization that are
required to be set on the partner or the invoice.

Some small changes in portal have been done to allow to reuse the user form without a partner.

Task id #2946604

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
