### PR TITLE
[FIX] mrp: assign lots on by-products

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -15,6 +15,9 @@
             <field name="mode">primary</field>
             <field name="inherit_id" ref="stock.view_stock_move_operations" />
             <field name="arch" type="xml">
+                <field name="move_line_ids" position="attributes">
+                    <attribute name="context">{'tree_view_ref': 'stock.view_stock_move_line_operation_tree_finished', 'default_product_uom_id': product_uom, 'default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_company_id': company_id}</attribute>
+                </field>
                 <xpath expr="//label[@for='product_uom_qty']" position="attributes">
 		    <attribute name="string">Total To Consume</attribute>
                 </xpath>
@@ -43,9 +46,11 @@
             </field>
         </record>
 
+        <!-- TODO MASTER: rename into view_stock_move_line_operation_tree_raw -->
         <record id="view_stock_move_line_operation_tree_finished" model="ir.ui.view">
             <field name="name">stock.move.line.operation.tree.finished</field>
             <field name="model">stock.move.line</field>
+            <field name="mode">primary</field>
             <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='lot_id']" position="attributes">


### PR DESCRIPTION
When trying to assign a lot on a "by-product", an error is raised.

To reproduce the issue:
1. In Settings, enable "By-Products"
2. Create three products P_compo, P_finish01, P_finish02
    - P_finish02 is tracked
3. Create a bill of materials:
    - Product: P_finish01
    - Type: Manufacture
    - Components: 1 x P_compo
    - By-products: 1 x P_finish02
4. Create and confirm a MO with 1 x P_finish01
5. Open the detailed operations of P_finish02 and try to add a lot on
the line

Error: An Odoo Client Error is raised "Error: KeyError:
'raw_material_production_id'"

When clicking on the detailed operations, we open the form view of the
related stock move. This view is based on
`stock.view_stock_move_operations` and there are actually three
primary-type inheritances of it:
- V1: `mrp.view_stock_move_operations_raw`
    - It gets the field `raw_material_production_id`
    - It is used on a MO, when opening the detailed operations of a
component
- V2: `mrp.view_stock_move_operations_finished`
    - It does not get the field `raw_material_production_id`
    - It is used on a MO, when opening the detailed operations of a
finished move (for instance step 5 in above use case)
- V3: `stock.view_stock_move_nosuggest_operations`
    - It does not get the field `raw_material_production_id`
    - It is used on a picking, when opening the detailed operations of a
transferred product

As said, all these three views are based on
`stock.view_stock_move_operations`. This view lists all related stock
move lines thanks to another view:
`stock.view_stock_move_line_operation_tree`
https://github.com/odoo/odoo/blob/289d0d845df092eeae6ce0598ffef9158978ad30/addons/stock/views/stock_move_views.xml#L177
And in MRP, this tree view is extended by
`mrp.view_stock_move_line_operation_tree_finished`. This extension adds
the value of `raw_material_production_id` in the context of the field
`lot_id`:
https://github.com/odoo/odoo/blob/6d0ddc388d1c389e1911a6bb1c59c252870da1a7/addons/mrp/views/stock_move_views.xml#L46-L53
(this is used later to check if, on a component, the new lot can be
created. See [1] for more details).

In conclusion, this structure can not work: we have three views based on
the form `stock.view_stock_move_operations`. This form view lists all
SML thanks to a tree view which is overridden and uses the field
`raw_material_production_id`. However, only V1 will get and provide a
value for that field. So, when using V2 or V3 (basic use case: deliver a
tracked product), it will raise an error.

[1] 6d0ddc388d1c389e1911a6bb1c59c252870da1a7

OPW-2942049