### PR TITLE
[FIX] gift_card,pos_gift_card: Card with no expiration date can't be used

### DIFF
--- a/addons/gift_card/models/gift_card.py
+++ b/addons/gift_card/models/gift_card.py
@@ -50,7 +50,7 @@ class GiftCard(models.Model):
 
     def can_be_used(self):
         # expired state are computed once a day, so can be not synchro
-        return self.state == 'valid' and self.balance > 0 and self.expired_date >= fields.Date.today()
+        return self.state == 'valid' and self.balance > 0 and (not self.expired_date or self.expired_date >= fields.Date.today())
 
     @api.depends("initial_amount")
     def _compute_balance(self):

--- a/addons/pos_gift_card/models/gift_card.py
+++ b/addons/pos_gift_card/models/gift_card.py
@@ -41,4 +41,4 @@ class GiftCard(models.Model):
 
     def can_be_used_in_pos(self):
         # expired state are computed once a day, so can be not synchro
-        return self.state == 'valid' and self.balance > 0 and self.expired_date >= fields.Date.today()
+        return self.state == 'valid' and self.balance > 0 and (not self.expired_date or self.expired_date >= fields.Date.today())


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a gift card without expiration date
- Create an order an use the gift card code

Issue:
Empty expiration dates have a boolean type(don't really know why), so when the validity of the card is checked,
we try to compare a boolean to the current date

Solution:
On check, use the tomorrow date when there is no expiration date so it will always be valid.

opw-2947267

Signed-off by: Eteil Djoumatchoua <etdj@odoo.com>
