### PR TITLE
[FIX] stock: use active_test=False when creating warehouse

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -110,7 +110,8 @@ class Warehouse(models.Model):
             vals[field_name] = self.env['stock.location'].with_context(active_test=False).create(values).id
 
         # actually create WH
-        warehouse = super(Warehouse, self).create(vals)
+        wh = super(Warehouse, self).create(vals)
+        warehouse = wh.with_context(active_test=False)
         # create sequences and operation types
         new_vals = warehouse._create_or_update_sequences_and_picking_types()
         warehouse.write(new_vals)  # TDE FIXME: use super ?
@@ -127,7 +128,7 @@ class Warehouse(models.Model):
         # update partner data if partner assigned
         if vals.get('partner_id'):
             self._update_partner_data(vals['partner_id'], vals.get('company_id'))
-        return warehouse
+        return wh
 
     def write(self, vals):
         if 'company_id' in vals:


### PR DESCRIPTION
When doing write on a warehouse, we use active_test=False in context in order to let all searches in the method use this context, i.e, like finding things in inactive picking types. Then, this commit assures the create method also use this context.

**Description of the issue/feature this PR addresses:** Basically, it's a fine-tuning of https://github.com/odoo/odoo/commit/b6ba6038ad8f419fb5ba805c10c987eb3ff93530.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
