### PR TITLE
[IMP] bus: move sendNotification to mail module

### DIFF
--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -3,109 +3,11 @@
 import { CrossTab } from '@bus/crosstab_bus';
 
 import { registry } from '@web/core/registry';
-import session from 'web.session';
-
-export class BusService extends CrossTab {
-    constructor(env, services) {
-        super(env, services);
-
-        // properties
-        this._audio = null;
-    }
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
-    /**
-     * Send a notification, and notify once per browser's tab
-     *
-     * @param {function} [callback] if given callback will be called when user clicks on notification
-     * @param {Object} options
-     * @param {string} options.message
-     * @param {string} options.title
-     * @param {string} [options.type] 'info', 'success', 'warning', 'danger' or ''
-     */
-    sendNotification(options, callback) {
-        if (window.Notification && Notification.permission === "granted") {
-            if (this.env.services['multi_tab'].isOnMainTab()) {
-                try {
-                    this._sendNativeNotification(options.title, options.message, callback);
-                } catch (error) {
-                    // Notification without Serviceworker in Chrome Android doesn't works anymore
-                    // So we fallback to the notification service in this case
-                    // https://bugs.chromium.org/p/chromium/issues/detail?id=481856
-                    if (error.message.indexOf('ServiceWorkerRegistration') > -1) {
-                        this.env.services['notification'].add(options.message, options);
-                        this._beep();
-                    } else {
-                        throw error;
-                    }
-                }
-            }
-        } else {
-            this.env.services['notification'].add(options.message, options);
-            if (this.env.services['multi_tab'].isOnMainTab()) {
-                this._beep();
-            }
-        }
-    }
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * Lazily play the 'beep' audio on sent notification
-     *
-     * @private
-     */
-    _beep() {
-        if (typeof(Audio) !== "undefined") {
-            if (!this._audio) {
-                this._audio = new Audio();
-                var ext = this._audio.canPlayType("audio/ogg; codecs=vorbis") ? ".ogg" : ".mp3";
-                this._audio.src = session.url("/mail/static/src/audio/ting" + ext);
-            }
-            Promise.resolve(this._audio.play()).catch(_.noop);
-        }
-    }
-
-    /**
-     * Show a browser notification
-     *
-     * @private
-     * @param {string} title
-     * @param {string} content
-     * @param {function} [callback] if given callback will be called when user clicks on notification
-     */
-    _sendNativeNotification(title, content, callback) {
-        var notification = new Notification(
-            // The native Notification API works with plain text and not HTML
-            // unescaping is safe because done only at the **last** step
-            _.unescape(title),
-            {
-                body: _.unescape(content),
-                icon: "/mail/static/src/img/odoobot_transparent.png"
-            });
-        notification.onclick = function () {
-            window.focus();
-            if (this.cancel) {
-                this.cancel();
-            } else if (this.close) {
-                this.close();
-            }
-            if (callback) {
-                callback();
-            }
-        };
-    }
-}
 
 export const busService = {
     dependencies: ['notification', 'presence', 'rpc', 'multi_tab'],
     start(env, services) {
-        return new BusService(env, services);
+        return new CrossTab(env, services);
     },
 };
 registry.category('services').add('bus_service', busService);

--- a/addons/mail/static/src/components/notification_request/notification_request.js
+++ b/addons/mail/static/src/components/notification_request/notification_request.js
@@ -31,7 +31,7 @@ export class NotificationRequest extends Component {
     _handleResponseNotificationPermission(value) {
         this.messaging.refreshIsNotificationPermissionDefault();
         if (value !== 'granted') {
-            this.env.services['bus_service'].sendNotification({
+            this.messaging.userNotificationManager.sendNotification({
                 message: this.env._t("Odoo will not have the permission to send native notifications on this device."),
                 title: this.env._t("Permission denied"),
             });

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -483,6 +483,11 @@ registerModel({
          * Mailbox Starred.
          */
         starred: one('Thread'),
+        userNotificationManager: one('UserNotificationManager', {
+            default: insertAndReplace(),
+            isCausal: true,
+            readonly: true,
+        }),
         userSetting: one('UserSetting', {
             default: insertAndReplace(),
             isCausal: true,

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -629,7 +629,7 @@ registerModel({
             // then open a chat for the current user with the new user.
             const message = sprintf(this.env._t('%s connected'), username);
             const title = this.env._t("This is their first connection. Wish them luck.");
-            this.env.services['bus_service'].sendNotification({ message, title, type: 'info' });
+            this.messaging.userNotificationManager.sendNotification({ message, title, type: 'info' });
             const chat = await this.messaging.getChat({ partnerId });
             if (!this.exists() || !chat || this.messaging.device.isSmall) {
                 return;
@@ -671,7 +671,7 @@ registerModel({
             const notificationContent = escape(
                 htmlToTextContentInline(message.body).substr(0, PREVIEW_MSG_MAX_SIZE)
             );
-            this.env.services['bus_service'].sendNotification({
+            this.messaging.userNotificationManager.sendNotification({
                 message: notificationContent,
                 title: notificationTitle,
                 type: 'info',

--- a/addons/mail/static/src/models/user_notification_manager.js
+++ b/addons/mail/static/src/models/user_notification_manager.js
@@ -1,0 +1,139 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { attr } from '@mail/model/model_field';
+
+import { url } from '@web/core/utils/urls';
+
+registerModel({
+    name: 'UserNotificationManager',
+    identifyingFields: [],
+    recordMethods: {
+        /**
+         * Send a notification, preferably a native one. If native
+         * notifications are disable or unavailable on the current
+         * platform, fallback on the notification service.
+         *
+         * @param {Object} param0
+         * @param {string} [param0.message] The body of the
+         * notification.
+         * @param {string} [param0.title] The title of the notification.
+         * @param {string} [param0.type] The type to be passed to the no
+         * service when native notifications can't be sent.
+         * @returns
+         */
+        sendNotification({ message, title, type }) {
+            if (!this.canSendNativeNotification) {
+                this._sendOdooNotification(message, { title, type });
+                return;
+            }
+            if (!this.messaging.env.services['multi_tab'].isOnMainTab()) {
+                return;
+            }
+            try {
+                this._sendNativeNotification(title, message);
+            } catch (error) {
+                // Notification without Serviceworker in Chrome Android doesn't works anymore
+                // So we fallback to the notification service in this case
+                // https://bugs.chromium.org/p/chromium/issues/detail?id=481856
+                if (error.message.includes('ServiceWorkerRegistration')) {
+                    this._sendOdooNotification(message, { title, type });
+                } else {
+                    throw error;
+                }
+            }
+        },
+        /**
+         * @private
+         * @returns {HTMLAudioElement}
+         */
+        _computeAudio() {
+            const audioElement = new Audio();
+            audioElement.src = audioElement.canPlayType("audio/ogg; codecs=vorbis")
+                ? url('/mail/static/src/audio/ting.ogg')
+                : url('mail/static/src/audio/ting.mp3');
+            return audioElement;
+        },
+        /**
+         * Determines whether or not sending native notification is
+         * allowed.
+         *
+         * @private
+         * @returns {boolean}
+         */
+        _computeCanSendNativeNotification() {
+            return Boolean(
+                this.messaging.browser.Notification &&
+                this.messaging.browser.Notification.permission === 'granted'
+            );
+        },
+        /**
+         * Method to be called when the users click on a notification.
+         *
+         * @param {Event} ev
+         * @param {Notification} [ev.target] The notification that have
+         * been clicked.
+         * @private
+         */
+        _onClickNotification({ target: notification }) {
+            window.focus();
+            notification.close();
+        },
+        /**
+         * Send a native notification.
+         *
+         * @param {string} title
+         * @param {string} message
+         */
+        _sendNativeNotification(title, message) {
+            const notification = new Notification(
+                // The native Notification API works with plain text and not HTML
+                // unescaping is safe because done only at the **last** step
+                _.unescape(title),
+                {
+                    body: _.unescape(message),
+                    icon: this.icon,
+                }
+            );
+            notification.addEventListener('click', this._onClickNotification);
+        },
+        /**
+         * Send a notification through the notification service.
+         *
+         * @param {string} message
+         * @param {Object} options
+         */
+        async _sendOdooNotification(message, options) {
+            this.messaging.env.services['notification'].add(message, options);
+            if (this.canPlayAudio && this.messaging.env.services['multi_tab'].isOnMainTab()) {
+                try {
+                    await this.audio.play();
+                } catch {
+                    // Ignore errors due to the user not having interracted
+                    // with the page before playing the sound.
+                }
+            }
+        },
+    },
+    fields: {
+        /**
+         * HTMLAudioElement used to play sound when a notification is
+         * sent.
+         */
+        audio: attr({
+            compute: '_computeAudio',
+        }),
+        canPlayAudio: attr({
+            default: typeof(Audio) !== 'undefined',
+        }),
+        canSendNativeNotification: attr({
+            compute: '_computeCanSendNativeNotification',
+        }),
+        /**
+         * Icon to be displayed by the notification.
+         */
+        icon: attr({
+            default: '/mail/static/src/img/odoobot_transparent.png',
+        }),
+    },
+});

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -6,6 +6,7 @@ import { makeBusServiceToLegacyEnv } from '@bus/services/legacy/make_bus_service
 import { makeMultiTabToLegacyEnv } from '@bus/services/legacy/make_multi_tab_to_legacy_env';
 import { makeFakePresenceService } from '@bus/../tests/helpers/mock_services';
 
+import { insertAndReplace } from '@mail/model/model_field_command';
 import { ChatWindowManagerContainer } from '@mail/components/chat_window_manager_container/chat_window_manager_container';
 import { DialogManagerContainer } from '@mail/components/dialog_manager_container/dialog_manager_container';
 import { DiscussContainer } from '@mail/components/discuss_container/discuss_container';
@@ -81,6 +82,7 @@ function setupMessagingServiceRegistries({
                 disableAnimation: true,
                 loadingBaseDelayDuration,
                 messagingBus,
+                userNotificationManager: insertAndReplace({ canPlayAudio: false }),
             };
         }
     };
@@ -90,7 +92,6 @@ function setupMessagingServiceRegistries({
         start() {
             const originalService = busService.start(...arguments);
             Object.assign(originalService, {
-                _beep() {}, // Do nothing
                 _registerWindowUnload() {}, // Do nothing
                 updateOption() {},
             });


### PR DESCRIPTION
The BusService class only adds the possibilty to send notifications.
This is only used in the mail module. Let's remove this unnecessary
override and move this functionnality into mail models.
