### PR TITLE
[FIX] website_sale: prevent changing name when invoiced are issued

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -539,6 +539,13 @@ class WebsiteSale(http.Controller):
         error = dict()
         error_message = []
 
+        # prevent name change if invoices exist
+        if data.get('partner_id'):
+            partner = request.env['res.partner'].browse(int(data['partner_id']))
+            if partner.exists() and not partner.sudo().can_edit_vat() and 'name' in data and (data['name'] or False) != (partner.name or False):
+                error['name'] = 'error'
+                error_message.append(_('Changing your name is not allowed once invoices have been issued for your account. Please contact us directly for this operation.'))
+
         # Required fields from form
         required_fields = [f for f in (all_form_values.get('field_required') or '').split(',') if f]
         # Required fields from mandatory field function

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -768,6 +768,14 @@ msgid "Chairs"
 msgstr ""
 
 #. module: website_sale
+#: code:addons/website_sale/controllers/main.py:0
+#, python-format
+msgid ""
+"Changing your name is not allowed once invoices have been issued for your "
+"account. Please contact us directly for this operation."
+msgstr ""
+
+#. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__child_id
 msgid "Children Categories"
 msgstr ""

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -134,6 +134,8 @@ class TestWebsiteSaleCheckoutAddress(odoo.tests.TransactionCase):
 
             # 2. Logged in user, edit billing
             self.default_address_values['partner_id'] = self.demo_partner.id
+            # Name cannot be changed if there are issued invoices
+            self.default_address_values['name'] = self.demo_partner.name
             self.WebsiteSaleController.address(**self.default_address_values)
             self.assertEqual(self.demo_partner.company_id, self.company_c, "Logged in user edited billing (the partner itself) should not get its company modified.")
 


### PR DESCRIPTION
/my/account controller blocks name/vat/company_name updating if there are issued invoices.

However Before this commit, user can change name via /shop/address page

STEPS

1/ install sales, eCommerce,inventory,Accounting
2/ create a sales order from the portal page, validate and create an invoice from SO and post it
3/ Try to change the name from the Portal > Account
Result - not possible = correct
4/ Place a new SO by the same portal user and edit the name on the address before proceeding to checkout

[1]: https://github.com/odoo/odoo/blob/1f49528a4b198e8912beb33be921d2855c694e2e/addons/account/controllers/portal.py#L111-L113

opw-2848251

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
