### PR TITLE
[FIX] google_calendar: sync events without an attendee's state

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -193,7 +193,10 @@ class Meeting(models.Model):
             'location': self.location or '',
             'guestsCanModify': True,
             'organizer': {'email': self.user_id.email, 'self': self.user_id == self.env.user},
-            'attendees': [{'email': attendee.email, 'responseStatus': attendee.state} for attendee in self.attendee_ids],
+            'attendees': [{
+                'email': attendee.email,
+                'responseStatus': attendee.state or 'needsAction',
+            } for attendee in self.attendee_ids if attendee.email],
             'extendedProperties': {
                 'shared': {
                     '%s_odoo_id' % self.env.cr.dbname: self.id,

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -67,6 +67,40 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         self.assertFalse('%s_owner_id' % self.env.cr.dbname in values.get('extendedProperties', {}).get('shared', {}))
 
     @patch_api
+    def test_event_without_attendee_state(self):
+        partner_1 = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
+        partner_2 = self.env['res.partner'].create({'name': 'Phineas', 'email': 'phineas@opoo.com'})
+        partner_3 = self.env['res.partner'].create({'name': 'Ferb'})
+        event = self.env['calendar.event'].create({
+            'name': "Event",
+            'start': datetime(2020, 1, 15, 8, 0),
+            'stop': datetime(2020, 1, 15, 18, 0),
+            'partner_ids': [(4, partner_1.id), (4, partner_2.id), (4, partner_3.id)],
+            'privacy': 'private',
+            'need_sync': False,
+        })
+        attendee_2 = event.attendee_ids.filtered(lambda a: a.partner_id.id == partner_2.id)
+        attendee_2.write({
+            'state': False,
+        })
+        event._sync_odoo2google(self.google_service)
+        self.assertGoogleEventInserted({
+            'id': False,
+            'start': {'dateTime': '2020-01-15T08:00:00+00:00'},
+            'end': {'dateTime': '2020-01-15T18:00:00+00:00'},
+            'summary': 'Event',
+            'description': '',
+            'location': '',
+            'visibility': 'private',
+            'guestsCanModify': True,
+            'reminders': {'useDefault': False, 'overrides': []},
+            'organizer': {'email': 'odoobot@example.com', 'self': True},
+            'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'needsAction'},
+                          {'email': 'phineas@opoo.com', 'responseStatus': 'needsAction'}],
+            'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}}
+        })
+
+    @patch_api
     def test_event_allday_creation(self):
         event = self.env['calendar.event'].create({
             'name': "Event",


### PR DESCRIPTION
Before this commit: if an event's attendee didn't have a state, it couldn't
get synced with Google.

The solution is first to set a default value for it.

opw-2915661

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
