### PR TITLE
[FIX] mail: text emojis field should remove its dropdown on destroy

### DIFF
--- a/addons/mail/static/src/js/field_emojis_common.js
+++ b/addons/mail/static/src/js/field_emojis_common.js
@@ -131,6 +131,13 @@ var FieldEmojiCommon = {
         } else {
             this.$emojisIcon.hide();
         }
+    },
+
+    destroy() {
+        this._super(...arguments);
+        if (this.$emojisIcon) {
+            this.$emojisIcon.remove();
+        }
     }
 };
 

--- a/addons/mail/static/tests/qunit_suite_tests/components/field_text_emojis_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/field_text_emojis_tests.js
@@ -1,0 +1,46 @@
+/**@odoo-module **/
+
+import { clickEdit, clickSave, getFixture } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+QUnit.module("Field text emojis", (hooks) => {
+    let target = undefined;
+    let serverData = undefined;
+    hooks.beforeEach(() => {
+        target = getFixture();
+
+        serverData = {
+            models: {
+                partner: {
+                    fields: {
+                        foo: { type: "char" }
+                    },
+                    records: [{ id: 1 }]
+                }
+            }
+        };
+
+        setupViewRegistries();
+    });
+
+    QUnit.test("emojis button is not shown in readonly", async (assert) => {
+        await makeView({
+            type: "form",
+            resId: 1,
+            resModel: "partner",
+            arch: `<form><field name="foo" widget="text_emojis" /></form>`,
+            serverData
+        });
+
+        assert.containsOnce(target, ".o_field_text_emojis");
+        assert.containsOnce(target, ".o_field_text_emojis button");
+        assert.isNotVisible(target.querySelector(".o_field_text_emojis button"));
+
+        await clickEdit(target);
+        assert.isVisible(target, ".o_field_text_emojis button .fa-smile");
+
+        await clickSave(target);
+        assert.containsOnce(target, ".o_field_text_emojis button");
+        assert.isNotVisible(target.querySelector(".o_field_text_emojis button"));
+    });
+});


### PR DESCRIPTION
Have a field with widget text_emojis.
Click Edit on the form view.
Click Save.

Before this commit, the button that opens the dropdown was still present in the dom in readonly mode.

After this commit, it is correctly removed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
