### PR TITLE
[FIX] website_event_track: avoid showing an empty agenda

### DIFF
--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -259,14 +259,15 @@ class EventTrackController(http.Controller):
             if track.location_id not in locations_by_days[track_day]:
                 locations_by_days[track_day].append(track.location_id)
 
-        for locations in locations_by_days.values():
-            locations.sort(key=lambda location: location.id if location else 0)
+        for used_locations in locations_by_days.values():
+            used_locations.sort(key=lambda location: location.id if location else 0)
 
         return {
             'days': days,
             'tracks_by_days': tracks_by_days,
             'locations_by_days': locations_by_days,
             'time_slots': global_time_slots_by_day,
+            'locations': locations  # TODO: clean me in master, kept for retro-compatibility
         }
 
     def _get_locale_time(self, dt_time, lang_code):


### PR DESCRIPTION
Oversight of: 129b91027700313066db0305876adcf9b2a3817d

If the view is not up to date, it will not display any agenda locations.
We need to keep the 'locations' key into the returned values for code
retro-compatibility.

Task-2942630

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
