### PR TITLE
[IMP] mail: improve mail template usability

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -6,11 +6,12 @@
     <data noupdate="1">
         <!--Email template -->
         <record id="email_template_edi_invoice" model="mail.template">
-            <field name="name">Invoice: Send by email</field>
+            <field name="name">Invoice: Sending</field>
             <field name="model_id" ref="account.model_account_move"/>
             <field name="email_from">{{ (object.invoice_user_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
             <field name="subject">{{ object.company_id.name }} Invoice (Ref {{ object.name or 'n/a' }})</field>
+            <field name="description">Sent to customers with their invoices in attachment</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -60,10 +61,11 @@
         </record>
 
         <record id="mail_template_data_payment_receipt" model="mail.template">
-            <field name="name">Payment Receipt: Send by email</field>
+            <field name="name">Payment: Payment Receipt</field>
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="subject">{{ object.company_id.name }} Payment Receipt (Ref {{ object.name or 'n/a' }})</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent manually to customer when clicking on 'Send receipt by email' in payment action</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -89,11 +91,12 @@
         </record>
         <!-- Credit note template -->
         <record id="email_template_edi_credit_note" model="mail.template">
-            <field name="name">Credit note: Send by email</field>
+            <field name="name">Credit Note: Sending</field>
             <field name="model_id" ref="account.model_account_move"/>
             <field name="email_from">{{ (object.invoice_user_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
             <field name="subject">{{ object.company_id.name }} Credit Note (Ref {{ object.name or 'n/a' }})</field>
+            <field name="description">Sent to customers with the credit note in attachment</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">

--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -3,11 +3,12 @@
     <data noupdate="1">
         <!-- Email template for reset password -->
         <record id="reset_password_email" model="mail.template">
-            <field name="name">Auth Signup: Reset Password</field>
+            <field name="name">Settings: User Reset Password</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Password reset</field>
             <field name="email_from">"{{ object.company_id.name }}" &lt;{{ (object.company_id.email or user.email) }}&gt;</field>
             <field name="email_to">{{ object.email_formatted }}</field>
+            <field name="description">Sent to user who requested a password reset</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #FFFFFF; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">
@@ -98,11 +99,12 @@
 
         <!-- Email template for new users -->
         <record id="set_password_email" model="mail.template">
-            <field name="name">Auth Signup: Odoo Connection</field>
+            <field name="name">Settings: New Portal Signup</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">{{ object.create_uid.name }} from {{ object.company_id.name }} invites you to connect to Odoo</field>
             <field name="email_from">"{{ object.company_id.name }}" &lt;{{ (object.company_id.email or user.email) }}&gt;</field>
             <field name="email_to">{{ object.email_formatted }}</field>
+            <field name="description">Sent to new user after you invited them</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #FFFFFF; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">
@@ -193,11 +195,12 @@
 
         <!-- Email template for reminder of unregistered users -->
         <record id="mail_template_data_unregistered_users" model="mail.template">
-            <field name="name">Auth Signup: Unregistered Users</field>
+            <field name="name">Settings: Unregistered User Reminder</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Reminder for unregistered users</field>
             <field name="email_from">{{ object.company_id.partner_id.email_formatted }}</field>
             <field name="email_to">{{ object.email_formatted }}</field>
+            <field name="description">Sent automatically to admin if new user haven't responded to the invitation</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">
@@ -244,11 +247,12 @@
 
         <!-- Email template for new users that used a signup token -->
         <record id="mail_template_user_signup_account_created" model="mail.template">
-            <field name="name">Auth Signup: Odoo Account Created</field>
+            <field name="name">Settings: New User Invite</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Welcome to {{ object.company_id.name }}!</field>
             <field name="email_from">"{{ object.company_id.name }}" &lt;{{ (object.company_id.email or user.email) }}&gt;</field>
             <field name="email_to">{{ object.email_formatted }}</field>
+            <field name="description">Sent to portal user who registered themselves</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #FFFFFF; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">

--- a/addons/auth_totp_mail/data/mail_template_data.xml
+++ b/addons/auth_totp_mail/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
 <data noupdate="1">
     <record id="mail_template_totp_invite" model="mail.template">
-        <field name="name">TOTP for users: Invite by email</field>
+        <field name="name">Settings: 2Fa Invitation</field>
         <field name="model_id" ref="base.model_res_users" />
         <field name="subject">Invitation to activate two-factor authentication on your Odoo account</field>
         <field name="partner_to">{{ object.partner_id.id }}</field>

--- a/addons/auth_totp_mail_enforce/data/mail_template_data.xml
+++ b/addons/auth_totp_mail_enforce/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_totp_mail_code" model="mail.template">
-            <field name="name">TOTP for users: Authentication by email</field>
+            <field name="name">Settings: 2Fa New Login</field>
             <field name="model_id" ref="base.model_res_users" />
             <field name="subject">Your two-factor authentication code</field>
             <field name="email_to">{{ object.email_formatted }}</field>

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -91,21 +91,6 @@
                                                 <button name="%(web.action_report_externalpreview)d" string="Preview Document" type="action" class="oe_link" groups="base.group_no_one"/>
                                             </div>
                                         </div>
-                                    </div> 
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box" id="companies_setting">
-                                    <div class="o_setting_right_pane">
-                                        <field name='company_count' class="w-auto ps-1 fw-bold"/>
-                                        <span class='o_form_label' attrs="{'invisible':[('company_count', '&gt;', '1')]}">
-                                            Company
-                                        </span>
-                                        <span class='o_form_label' attrs="{'invisible':[('company_count', '&lt;=', '1')]}">
-                                            Companies
-                                        </span>
-                                        <br/>
-                                        <div class="mt8">
-                                            <button name="%(base.action_res_company_form)d" icon="fa-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
-                                        </div>
                                     </div>
                                     <br/>
                                     <div id="inter_company" groups="base.group_multi_company" title="Configure company rules to automatically create SO/PO when one of your company sells/buys to another of your company.">
@@ -122,6 +107,21 @@
                                             <div class="content-group" attrs="{'invisible': [('module_account_inter_company_rules','=',False)]}" id="inter_companies_rules">
                                                 <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                             </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-lg-6 o_setting_box" id="companies_setting">
+                                    <div class="o_setting_right_pane">
+                                        <field name='company_count' class="w-auto ps-1 fw-bold"/>
+                                        <span class='o_form_label' attrs="{'invisible':[('company_count', '&gt;', '1')]}">
+                                            Company
+                                        </span>
+                                        <span class='o_form_label' attrs="{'invisible':[('company_count', '&lt;=', '1')]}">
+                                            Companies
+                                        </span>
+                                        <br/>
+                                        <div class="mt8">
+                                            <button name="%(base.action_res_company_form)d" icon="fa-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -9,6 +9,7 @@
             <field name="email_to">{{ ('' if object.partner_id.email and object.partner_id.email == object.email else object.email) }}</field>
             <field name="partner_to">{{ object.partner_id.id if object.partner_id.email and object.partner_id.email == object.email else False }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="description">Invitation email to new attendees</field>
             <field name="body_html" type="html">
 <div>
     <t t-set="colors" t-value="{'needsAction': 'grey', 'accepted': 'green', 'tentative': '#FFFF00', 'declined': 'red'}"/>
@@ -135,13 +136,14 @@
         </record>
 
         <record id="calendar_template_meeting_changedate" model="mail.template">
-            <field name="name">Calendar: Date updated</field>
+            <field name="name">Calendar: Date Updated</field>
             <field name="model_id" ref="calendar.model_calendar_attendee"/>
             <field name="subject">{{ object.event_id.name }}: Date updated</field>
             <field name="email_from">{{ (object.event_id.user_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ ('' if object.partner_id.email and object.partner_id.email == object.email else object.email) }}</field>
             <field name="partner_to">{{ object.partner_id.id if object.partner_id.email and object.partner_id.email == object.email else False }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="description">Sent to all attendees if the schedule change</field>
             <field name="body_html" type="html">
 <div>
 
@@ -272,6 +274,7 @@
             <field name="email_to">{{ ('' if object.partner_id.email and object.partner_id.email == object.email else object.email) }}</field>
             <field name="partner_to">{{ object.partner_id.id if object.partner_id.email and object.partner_id.email == object.email else False }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="description">Sent to all attendees if a reminder is set</field>
             <field name="body_html" type="html">
 <div>
     <t t-set="colors" t-value="{'needsAction': 'grey', 'accepted': 'green', 'tentative': '#FFFF00', 'declined': 'red'}" />
@@ -377,6 +380,7 @@
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ object._get_attendee_emails() }}</field>
             <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="description">Used to manually notifiy attendees</field>
             <field name="body_html" type="html">
 <div>
     <t t-set="colors" t-value="{'needsAction': 'grey', 'accepted': 'green', 'tentative': '#FFFF00', 'declined': 'red'}" />

--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -12,13 +12,16 @@
         <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
 
         <style type="text/css">
+            :root {
+                --color-company: <t t-esc="company.secondary_color or '#875a7b'"/>;
+            }
             body {
                 margin: 0;
                 padding: 0;
                 font-family: Arial, Helvetica, Verdana, sans-serif;
             }
             #header_background {
-                background-color: #875a7b;
+                background-color: var(--color-company);
             }
             .global_layout {
                 max-width: 588px;
@@ -40,7 +43,7 @@
             }
             .button {
                 float: right;
-                background-color: #875a7b;
+                background-color: var(--color-company);
                 color: #ffffff;
                 border-radius: 5px;
             }
@@ -61,7 +64,7 @@
                 text-justify: inter-word;
             }
             .tip_button {
-                background-color: #875a7b;
+                background-color: var(--color-company);
                 border-radius: 5px;
                 margin: 14px 16px 14px 0px;
                 padding: 10px;
@@ -97,7 +100,7 @@
                 padding-top: 2px;
             }
             .kpi_cell_center {
-                border-top: 2px solid #875A7B;
+                border-top: 2px solid var(--color-company);
             }
             .kpi_cell_border {
                 border-top: 2px solid #00A09D;
@@ -108,7 +111,7 @@
                 text-decoration: none;
             }
             .kpi_center_col {
-                color: #875A7B;
+                color: var(--color-company);
             }
             .kpi_border_col {
                 color: #00A09D;
@@ -164,7 +167,7 @@
             }
             .odoo_link_text {
                 font-weight: bold;
-                color: #875a7b;
+                color: var(--color-company);
             }
             .run_business {
                 color: #2d2a26;
@@ -260,8 +263,8 @@
                 }
                 #header {
                     padding: 20px 30px 25px 30px;
-                    border-start: 1px solid #875a7b;
-                    border-end: 1px solid #875a7b;
+                    border-start: 1px solid var(--color-company);
+                    border-end: 1px solid var(--color-company);
                 }
                 .global_layout {
                     padding: 25px 30px 30px 30px;

--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -8,6 +8,7 @@
             <field name="subject">Your badge for {{ object.event_id.name }}</field>
             <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
+            <field name="description">Sent automatically to someone after they registered to an event</field>
             <field name="body_html" type="html">
 <div>
     Dear <t t-out="object.name or ''">Oscar Morgan</t>,<br/>
@@ -28,11 +29,12 @@
         </record>
 
         <record id="event_subscription" model="mail.template">
-            <field name="name">Event: Registration</field>
+            <field name="name">Event: Registration Confirmation</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your registration at {{ object.event_id.name }}</field>
             <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
+            <field name="description">Sent to attendees after registering to an event</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <t t-set="date_begin" t-value="format_datetime(object.event_id.date_begin, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
@@ -262,6 +264,7 @@
             <field name="subject">{{ object.event_id.name }}: {{ object.get_date_range_str() }}</field>
             <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
+            <field name="description">Sent automatically to attendees if there is a reminder defined on the event</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <t t-set="date_begin" t-value="format_datetime(object.event_id.date_begin, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>

--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -2,10 +2,11 @@
 <odoo>
     <data noupdate="1">
         <record id="email_template_badge_received" model="mail.template">
-            <field name="name">Received Badge</field>
+            <field name="name">Gamification: Badge Received</field>
             <field name="subject">New badge {{ object.badge_id.name }} granted</field>
             <field name="model_id" ref="gamification.model_gamification_badge_user"/>
             <field name="partner_to">{{ object.user_id.partner_id.id }}</field>
+            <field name="description">Sent automatically to the user who received a badge</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" style="padding-top: 16px; background-color: #F1F1F1; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" width="590" cellpadding="0" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;" summary="o_mail_notification">
@@ -100,9 +101,10 @@
         </record>
 
         <record id="email_template_goal_reminder" model="mail.template">
-            <field name="name">Goal: Reminder for Goal Update</field>
+            <field name="name">Gamification: Reminder For Goal Update</field>
             <field name="model_id" ref="gamification.model_gamification_goal"/>
             <field name="partner_to">{{ object.user_id.partner_id.id }}</field>
+            <field name="description">Sent automatically to participant who haven't updated their goal</field>
             <field name="body_html" type="html">
 <div>
     <strong>Reminder</strong><br/>
@@ -119,8 +121,9 @@
         </record>
         
         <record id="simple_report_template" model="mail.template">
-            <field name="name">Challenge: Simple Challenge Report Progress</field>
+            <field name="name">Gamification: Challenge Report</field>
             <field name="model_id" ref="gamification.model_gamification_challenge"/>
+            <field name="description">Send a challenge report to all participants</field>
             <field name="body_html" type="html">
 <table cellspacing="0" cellpadding="0" width="100%" style="background-color: #EEE; border-collapse: collapse;">
 <tr>
@@ -317,11 +320,12 @@
         </record>
 
         <record id="mail_template_data_new_rank_reached" model="mail.template">
-            <field name="name">User: New rank reached</field>
+            <field name="name">Gamification: New Rank Reached</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">New rank: {{ object.rank_id.name }}</field>
             <field name="email_to"></field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent automatically when user reaches a new rank</field>
             <field name="body_html" type="html">
 <div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">
 <table style="width:600px;margin:0px auto;background:white;border:1px solid #e1e1e1;">

--- a/addons/hr_presence/data/mail_template_data.xml
+++ b/addons/hr_presence/data/mail_template_data.xml
@@ -2,12 +2,13 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_presence" model="mail.template">
-            <field name="name">Employee: Absence email</field>
+            <field name="name">HR: Employee Absence email</field>
             <field name="model_id" ref="hr.model_hr_employee"/>
             <field name="subject">Unexpected Absence</field>
             <field name="email_from">{{ user.email_formatted }}</field>
             <field name="email_to">{{ (object.user_id.email_formatted or object.work_email) }}</field>
             <field name="auto_delete" eval="False"/>
+            <field name="description">Sent manually in presence module when an employee wasn't working despite not being off</field>
             <field name="body_html" type="html">
                 <div>
                     Dear <t t-out="object.name or ''">Abigail Peterson</t>,<br/><br/>

--- a/addons/hr_recruitment/data/mail_template_data.xml
+++ b/addons/hr_recruitment/data/mail_template_data.xml
@@ -3,11 +3,12 @@
 
     <!-- Templates for interest / refusing applicants -->
     <record id="email_template_data_applicant_refuse" model="mail.template">
-        <field name="name">Applicant: Refuse</field>
+        <field name="name">Recruitment: Refuse</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
         <field name="partner_to">{{ object.partner_id.id or '' }}</field>
+        <field name="description">When you refuse an application, you can choose this template</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
     <tr>
@@ -57,11 +58,12 @@
     </record>
 
     <record id="email_template_data_applicant_interest" model="mail.template">
-        <field name="name">Applicant: Interest</field>
+        <field name="name">Recruitment: Interest</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
         <field name="partner_to">{{ object.partner_id.id or '' }}</field>
+        <field name="description">Set this template to a recruitment stage to send it when applications reach that stage</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="background-color: white; border-collapse: collapse; margin-left: 20px;">
     <tr>
@@ -148,11 +150,12 @@
     </record>
 
     <record id="email_template_data_applicant_congratulations" model="mail.template">
-        <field name="name">Applicant: Acknowledgement</field>
+        <field name="name">Recruitment: Application Acknowledgement</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
         <field name="partner_to">{{ object.partner_id.id or '' }}</field>
+        <field name="description">Confirmation email sent to all new job applications</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="background-color: white; border-collapse: collapse; margin-left: 20px;">
     <tr>
@@ -227,11 +230,12 @@
     </record>
 
     <record id="email_template_data_applicant_not_interested" model="mail.template">
-        <field name="name">Applicant: Not interested anymore</field>
+        <field name="name">Recruitment: Not interested anymore</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
         <field name="partner_to">{{ object.partner_id.id or '' }}</field>
+        <field name="description">When you refuse an application, you can choose this template</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
     <tr>

--- a/addons/loyalty/data/mail_template_data.xml
+++ b/addons/loyalty/data/mail_template_data.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="mail_template_gift_card" model="mail.template">
-        <field name="name">Gift Card: Send by Email</field>
+        <field name="name">Gift Card: Gift Card Information</field>
         <field name="model_id" ref="model_loyalty_card"/>
         <field name="subject">Your Gift Card at {{ object.company_id.name }}</field>
         <field name="partner_to">{{ object._get_mail_partner().id }}</field>
+        <field name="description">Sent to customer who purchased a gift card</field>
         <field name="body_html" type="html">
             <div style="margin:0px; font-size:24px; font-family:arial, 'helvetica neue', helvetica, sans-serif; line-height:36px; color:#333333; text-align: center">
                 Here is your gift card!
@@ -37,12 +38,13 @@
     </record>
 
     <record id="mail_template_loyalty_card" model="mail.template">
-        <field name="name">[Loyalty] Coupon: Send by Email</field>
+        <field name="name">Coupon: Coupon Information</field>
         <field name="model_id" ref="loyalty.model_loyalty_card"/>
         <field name="subject">Your reward coupon from {{ object.program_id.company_id.name }} </field>
         <field name="email_from">{{ object.program_id.company_id.email }}</field>
         <field name="partner_to">{{ object._get_mail_partner().id }}</field>
         <field name="lang">{{ object._get_mail_partner().lang }}</field>
+        <field name="description">Sent to customer with coupon information</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="width:100%; margin:0px auto;"><tbody>
 <tr>

--- a/addons/lunch/data/mail_template_data.xml
+++ b/addons/lunch/data/mail_template_data.xml
@@ -2,12 +2,13 @@
 <odoo>
 <data noupdate="0">
     <record id="lunch_order_mail_supplier" model="mail.template">
-        <field name="name">Lunch: Send by email</field>
+        <field name="name">Lunch: Supplier Order</field>
         <field name="model_id" ref="lunch.model_lunch_supplier"/>
         <field name="email_from">{{ ctx['order']['email_from'] }}</field>
         <field name="partner_to">{{ ctx['order']['supplier_id'] }}</field>
         <field name="subject">Orders for {{ ctx['order']['company_name'] }}</field>
         <field name="lang">{{ ctx.get('default_lang') }}</field>
+        <field name="description">Sent to vendor with the order of the day</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -23,21 +23,11 @@
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 100%; margin-top: 5px;">
         <tbody>
             <tr>
-                <td valign="center">
-                    <img t-att-src="'/logo.png?company=%s' % (company.id or 0)" style="padding: 0px; margin: 0px; height: auto; max-width: 200px; max-height: 36px;" t-att-alt="'%s' % company.name"/>
-                </td>
-            </tr>
-            <tr>
-                <td valign="center">
-                    <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 10px 0px;"/>
-                </td>
-            </tr>
-            <tr>
                 <td valign="center" style="white-space:nowrap;">
                     <table cellspacing="0" cellpadding="0" border="0">
                         <tbody>
                             <tr>
-                                <td t-if="has_button_access" style="border-radius: 3px; background: #875A7B; text-align: center; padding: 8px 12px 11px;">
+                                <td t-if="has_button_access" t-att-style="'border-radius: 3px; text-align: center; padding: 8px 12px 11px; background: ' + (company.secondary_color if company.secondary_color else '#875A7B')">
                                     <a t-att-href="button_access['url']" style="font-size: 12px; color: #FFFFFF; text-decoration: none !important; font-weight: 400;">
                                         <t t-out="button_access['title']"/>
                                     </a>

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3073,8 +3073,10 @@ class MailThread(models.AbstractModel):
 
         for record in self:
             model_description = self.env['ir.model']._get(record._name).display_name
+            company = record.company_id if 'company_id' in record._fields else self.env.company
             values = {
                 'object': record,
+                'company': company,
                 'model_description': model_description,
                 'access_link': record._notify_get_action_link('view'),
             }

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -17,7 +17,7 @@
                         <div class="oe_button_box" name="button_box">
                             <field name="ref_ir_act_window" invisible="1"/>
                             <button class="oe_stat_button"
-                                    groups="base.group_system"
+                                    groups="base.group_no_one"
                                     name="create_action" type="object"
                                     attrs="{'invisible':[('ref_ir_act_window','!=',False)]}" icon="fa-plus"
                                     help="Display an option on related documents to open a composition wizard with this template">
@@ -27,7 +27,7 @@
                                 </div>
                             </button>
                             <button name="unlink_action" type="object"
-                                    groups="base.group_system"
+                                    groups="base.group_no_one"
                                     class="oe_stat_button" icon="fa-minus"
                                     attrs="{'invisible':[('ref_ir_act_window','=',False)]}"
                                     help="Remove the contextual action to use this template on related documents" widget="statinfo">
@@ -41,18 +41,17 @@
                         </div>
                         <div class="oe_title">
                             <label for="name"/>
-                            <h1><field name="name" required="1" placeholder='e.g. "Welcome email"'/></h1>
+                            <h1><field name="name" class="w-100"
+                                required="1" placeholder='e.g. "Welcome email"'/></h1>
                             <group>
                                 <field name="model_id" placeholder="e.g. Contact" required="1" options="{'no_create': True}"/>
+                                <field name="subject" placeholder='e.g. "Welcome to MyCompany" or "Nice to meet you, {{ object.name }}"'/>
                                 <field name="model" invisible="1"/>
+                                <field name="description"/>
                             </group>
                         </div>
                         <notebook>
                             <page string="Content" name="content">
-                                <div class="oe_title"><label for="subject"/></div>
-                                <div class="oe_title">
-                                    <h2 style="display: inline-block;"><field name="subject" placeholder='e.g. "Welcome to MyCompany" or "Nice to meet you, ${object.name}"'/></h2>
-                                </div>
                                 <field name="can_write" invisible="1"/>
                                 <field name="body_html" widget="html" class="oe-bordered-editor"
                                     options="{'style-inline': true, 'codeview': true }"
@@ -75,13 +74,29 @@
                                     <field name="scheduled_date" string="Scheduled Send Date"/>
                                 </group>
                             </page>
-                            <page string="Advanced Settings" name="advanced_settings">
-                                <group>
-                                    <field name="lang" placeholder="{{ object.partner_id.lang }}"/>
-                                    <field name="mail_server_id"/>
-                                    <field name="auto_delete"/>
-                                    <field name="report_template" domain="[('model','=',model)]"/>
-                                    <field name="report_name" attrs="{'invisible':[('report_template','=',False)]}"/>
+                            <page string="Settings" name="email_configuration" class="row">
+                                <group col="2">
+                                    <group>
+                                        <field name="email_from"
+                                                placeholder="Override author's email"/>
+                                        <field name="use_default_to"/>
+                                        <field name="email_to" attrs="{'invisible': [('use_default_to', '=', True)]}"
+                                                placeholder="Comma-separated recipient addresses"/>
+                                        <field name="partner_to" attrs="{'invisible': [('use_default_to', '=', True)]}"
+                                                placeholder="Comma-separated ids of recipient partners"/>
+                                        <field name="email_cc" attrs="{'invisible': [('use_default_to', '=', True)]}"
+                                                placeholder="Comma-separated carbon copy recipients addresses"/>
+                                        <field name="reply_to"
+                                                placeholder="Email address to which replies will be redirected when sending emails in mass"/>
+                                        <field name="scheduled_date" string="Scheduled Send Date"/>
+                                    </group>
+                                    <group>
+                                        <field name="lang" placeholder="{{ object.partner_id.lang }}"/>
+                                        <field name="mail_server_id"/>
+                                        <field name="auto_delete"/>
+                                        <field name="report_template" domain="[('model','=',model)]"/>
+                                        <field name="report_name" attrs="{'invisible':[('report_template','=',False)]}"/>
+                                    </group>
                                 </group>
                             </page>
                         </notebook>
@@ -97,30 +112,33 @@
                 <tree string="Templates">
                     <field name="mail_server_id" invisible="1"/>
                     <field name="name"/>
-                    <field name="model_id"/>
-                    <field name="subject"/>
-                    <field name="email_from"/>
-                    <field name="email_to"/>
-                    <field name="partner_to"/>
-                    <field name="report_name"/>
+                    <field name="model_id" groups="base.group_no_one"/>
+                    <field name="description"/>
+                    <field name="subject" optional="hidden"/>
+                    <field name="email_from" optional="hidden"/>
+                    <field name="email_to" optional="hidden"/>
+                    <field name="partner_to" optional="hidden"/>
+                    <field name="report_name" optional="hidden"/>
                 </tree>
             </field>
         </record>
 
         <record id="view_email_template_search" model="ir.ui.view">
-           <field name="name">email.template.search</field>
-           <field name="model">mail.template</field>
-           <field name="arch" type="xml">
-               <search string="Templates">
+            <field name="name">email.template.search</field>
+            <field name="model">mail.template</field>
+            <field name="arch" type="xml">
+                <search string="Templates">
                     <field name="name" filter_domain="['|', '|', '|',('name','ilike',self), ('report_name','ilike',self), ('subject','ilike',self), ('email_to','ilike',self)]" string="Templates"/>
                     <field name="lang"/>
                     <field name="model_id"/>
+                    <filter name="base_templates" string="Base Templates" domain="[('is_base_template', '=', True)]"/>
+                    <filter name="custom_templates" string="Custom Templates" domain="[('is_base_template', '=', False)]"/>
                     <group expand="0" string="Group by...">
                         <filter string="SMTP Server" name="smtpserver" domain="[]" context="{'group_by':'mail_server_id'}"/>
                         <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
                     </group>
-               </search>
-           </field>
+                </search>
+            </field>
         </record>
 
         <record model="ir.actions.act_window" id="action_email_template_tree_all">
@@ -129,6 +147,7 @@
             <field name="view_mode">form,tree</field>
             <field name="view_id" ref="email_template_tree" />
             <field name="search_view_id" ref="view_email_template_search"/>
+            <field name="context">{'search_default_base_templates': 1}</field>
         </record>
 
     </data>

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -135,6 +135,29 @@
                         </div>
                     </div>
                 </div>
+                <div id="companies_setting" position="inside">
+                    <br/>
+                    <div class="o_setting_right_pane" id="mail_templates_setting"
+                        groups="mail.group_mail_template_editor,base.group_system">
+                        <span class="o_form_label">Email Templates</span>
+                        <div class="text-muted">
+                            Customize the look and feel of automated emails
+                        </div>
+                        <div class="w-50 row">
+                            <span class="d-block w-75 py-2">Header Color</span>
+                            <field name="primary_color" class="d-block w-25 p-0 m-0" widget="color"/>
+                        </div>
+                        <div class="w-50 row mt-1">
+                            <span class="d-block w-75 py-2">Button Color</span>
+                            <field name="secondary_color" class="d-block w-25 p-0 m-0" widget="color"/>
+                        </div>
+                        <button name="open_email_layout" icon="fa-arrow-right"
+                            type="object" string="Update Mail Layout"
+                            groups="base.group_no_one" class="btn-link"/>
+                        <br groups="base.group_no_one"/>
+                        <button name="open_mail_templates" icon="fa-arrow-right" type="object" string="Review All Templates" class="btn-link"/>
+                    </div>
+                </div>
             </field>
         </record>
     </data>

--- a/addons/mail_group/data/mail_template_data.xml
+++ b/addons/mail_group/data/mail_template_data.xml
@@ -5,6 +5,7 @@
         <field name="model_id" ref="mail_group.model_mail_group_member"/>
         <field name="subject">Guidelines of group {{ object.mail_group_id.name }}</field>
         <field name="email_to">{{ object.email }}</field>
+        <field name="description">Sent to people who subscribed to a mailing group with group guidelines</field>
         <field name="body_html" type="html">
             <div>
                 <p>Hello <t t-out="object.partner_id.name or ''"></t>,</p>
@@ -18,9 +19,10 @@
 
     <!-- Confirm subscription email -->
     <record id="mail_template_list_subscribe" model="mail.template">
-        <field name="name">Mail Group: Mailing list subscription</field>
+        <field name="name">Mail Group: Mailing List Subscription</field>
         <field name="model_id" ref="mail_group.model_mail_group"/>
         <field name="subject">Confirm subscription to {{ object.name }}</field>
+        <field name="description">Subscription confirmation to a mailing group</field>
         <field name="body_html" type="html">
             <div style="margin: 0px; padding: 0px;">
                 Hello,<br/><br/>
@@ -36,9 +38,10 @@
 
     <!-- Confirm unsubscription email -->
     <record id="mail_template_list_unsubscribe" model="mail.template">
-        <field name="name">Mail Group: Mailing list unsubscription</field>
+        <field name="name">Mail Group: Mailing List Unsubscription</field>
         <field name="model_id" ref="mail_group.model_mail_group"/>
         <field name="subject">Confirm unsubscription to {{ object.name }}</field>
+        <field name="description">Sent to people who unsubscribed from a mailing group</field>
         <field name="body_html" type="html">
             <div style="margin: 0px; padding: 0px;">
                 Hello,<br/><br/>

--- a/addons/portal/data/mail_template_data.xml
+++ b/addons/portal/data/mail_template_data.xml
@@ -7,6 +7,7 @@
             <field name="model_id" ref="portal.model_portal_wizard_user"/>
             <field name="subject">Your account at {{ object.user_id.company_id.name }}</field>
             <field name="email_to">{{ object.user_id.email_formatted }}</field>
+            <field name="description">Invitation email to contacts to create a user account</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">

--- a/addons/project/data/mail_template_data.xml
+++ b/addons/project/data/mail_template_data.xml
@@ -3,10 +3,11 @@
     <data noupdate="1">
         <!-- Sample stage-related template -->
         <record id="mail_template_data_project_task" model="mail.template">
-            <field name="name">Task: Reception Acknowledgment</field>
+            <field name="name">Project: Request Acknowledgment</field>
             <field name="model_id" ref="project.model_project_task"/>
             <field name="subject">Reception of {{ object.name }}</field>
             <field name="use_default_to" eval="True"/>
+            <field name="description">Set this template on a project's stage to automate email when tasks reach stages</field>
             <field name="body_html" type="html">
 <div>
     Dear <t t-out="object.partner_id.name or 'customer'">Brandon Freeman</t>,<br/>
@@ -26,11 +27,12 @@
 
         <!-- Mail sent to request a rating for a task -->
         <record id="rating_project_request_email_template" model="mail.template">
-            <field name="name">Task: Rating Request</field>
+            <field name="name">Project: Task Rating Request</field>
             <field name="model_id" ref="project.model_project_task"/>
             <field name="subject">{{ object.project_id.company_id.name }}: Satisfaction Survey</field>
             <field name="email_from">{{ (object._rating_get_operator().email_formatted if object._rating_get_operator() else user.email_formatted) }}</field>
             <field name="partner_to" >{{ object._rating_get_partner().id }}</field>
+            <field name="description">Set this template on a project stage to request feedback from your customers. Enable the "customer ratings" feature on the project</field>
             <field name="body_html" type="html">
 <div>
     <t t-set="access_token" t-value="object._rating_get_access_token()"/>

--- a/addons/project/data/mail_template_demo.xml
+++ b/addons/project/data/mail_template_demo.xml
@@ -6,6 +6,7 @@
             <field name="subject">Project status - {{ object.name }}</field>
             <field name="email_from">{{ (object.partner_id.email_formatted if object.partner_id else user.email_formatted) }}</field>
             <field name="partner_to" >{{ object.partner_id.id }}</field>
+            <field name="description">Set on project's stages to inform customers when a project reaches that stage</field>
             <field name="body_html" type="html">
 <div>
     Dear <t t-out="object.partner_id.name or 'customer'">Brandon Freeman</t>,<br/>

--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -2,10 +2,11 @@
 <odoo>
     <data noupdate="1">
         <record id="email_template_edi_purchase" model="mail.template">
-            <field name="name">Purchase Order: Send RFQ</field>
+            <field name="name">Purchase: Request For Quotation</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
             <field name="subject">{{ object.company_id.name }} Order (Ref {{ object.name or 'n/a' }})</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent manually to vendor to request a quotation</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -36,10 +37,11 @@
         </record>
 
         <record id="email_template_edi_purchase_done" model="mail.template">
-            <field name="name">Purchase Order: Send PO</field>
+            <field name="name">Purchase: Purchase Order</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
             <field name="subject">{{ object.company_id.name }} Order (Ref {{ object.name or 'n/a' }})</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent to vendor with the purchase order in attachment</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -74,11 +76,12 @@
         </record>
 
         <record id="email_template_edi_purchase_reminder" model="mail.template">
-            <field name="name">Purchase Order: Vendor Reminder</field>
+            <field name="name">Purchase: Vendor Reminder</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted) }}</field>
             <field name="subject">{{ object.company_id.name }} Order (Ref {{ object.name or 'n/a' }})</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent to vendors before expected arrival, based on the purchase order setting</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">

--- a/addons/repair/data/mail_template_data.xml
+++ b/addons/repair/data/mail_template_data.xml
@@ -2,11 +2,12 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_repair_quotation" model="mail.template">
-            <field name="name">Repair Quotation: Send by email</field>
+            <field name="name">Repair: Quotation</field>
             <field name="model_id" ref="repair.model_repair_order"/>
             <field name="subject">{{ object.partner_id.name }} Repair Orders (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.create_uid.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent manually when clicking on "Send Quotation" on a repair order</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px;font-size: 13px;">

--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -2,11 +2,12 @@
 <odoo>
     <data noupdate="1">
         <record id="email_template_edi_sale" model="mail.template">
-            <field name="name">Sales Order: Send by email</field>
+            <field name="name">Sales: Send Quotation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ object.state in ('draft', 'sent') and (ctx.get('proforma') and 'Proforma' or 'Quotation') or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Used by salespeople when they send quotations or proforma to prospects</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -45,11 +46,12 @@
         </record>
 
         <record id="mail_template_sale_confirmation" model="mail.template">
-            <field name="name">Sales Order: Confirmation Email</field>
+            <field name="name">Sales: Order Confirmation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ (object.get_portal_last_transaction().state == 'pending') and 'Pending Order' or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent to customers on order confirmation</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 12px;">
@@ -239,11 +241,12 @@
         </record>
 
         <record id="sale.mail_template_sale_cancellation" model="mail.template">
-            <field name="name">Sales Order: Cancellation email</field>
+            <field name="name">Sales: Order Cancellation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ object.type_name }} Cancelled (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent automatically to customers when you cancel an order</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -33,13 +33,6 @@ class ResConfigSettings(models.TransientModel):
              "and not after the delivery.",
         config_parameter='sale.automatic_invoice',
     )
-    confirmation_mail_template_id = fields.Many2one(
-        comodel_name='mail.template',
-        string='Confirmation Email Template',
-        domain="[('model', '=', 'sale.order')]",
-        config_parameter='sale.default_confirmation_template',
-        help="Email sent to the customer once the order is paid."
-    )
     deposit_default_product_id = fields.Many2one(
         'product.product',
         'Deposit Product',

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -746,16 +746,7 @@ class SaleOrder(models.Model):
             return self._get_confirmation_template()
 
     def _get_confirmation_template(self):
-        self.ensure_one()
-        default_confirmation_template_id = self.env['ir.config_parameter'].sudo().get_param(
-            'sale.default_confirmation_template'
-        )
-        default_confirmation_template = default_confirmation_template_id \
-            and self.env['mail.template'].browse(int(default_confirmation_template_id)).exists()
-        if default_confirmation_template:
-            return default_confirmation_template
-        else:
-            return self.env.ref('sale.mail_template_sale_confirmation', raise_if_not_found=False)
+        return self.env.ref('sale.mail_template_sale_confirmation', raise_if_not_found=False)
 
     def action_quotation_sent(self):
         if self.filtered(lambda so: so.state != 'draft'):

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -195,18 +195,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="confirmation_email_setting" attrs="{'invisible': [('portal_confirmation_pay', '=', False) , ('portal_confirmation_sign', '=', False)]}" groups="base.group_no_one">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Confirmation Email</span>
-                                <div class="text-muted">
-                                    Automatic email sent after the customer has signed or paid online
-                                </div>
-                                <div class="row mt16">
-                                    <label for="confirmation_mail_template_id" class="col-lg-4 o_light_label"/>
-                                    <field name="confirmation_mail_template_id" class="oe_inline"/>
-                                </div>
-                            </div>
-                        </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="quotation_validity_days">
                             <div class="o_setting_left_pane">
                                 <field name="use_quotation_validity_days"/>

--- a/addons/sale_management/views/res_config_settings_views.xml
+++ b/addons/sale_management/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='confirmation_email_setting']" position="after">
+            <xpath expr="//div[@id='sale_config_online_confirmation_pay']" position="after">
                 <div class="col-12 col-lg-6 o_setting_box" id="standardized_offers_setting">
                     <div class="o_setting_left_pane">
                         <field name="group_sale_order_template"/>

--- a/addons/sms/views/sms_template_views.xml
+++ b/addons/sms/views/sms_template_views.xml
@@ -16,7 +16,7 @@
                     <div class="oe_button_box" name="button_box">
                         <field name="sidebar_action_id" invisible="1"/>
                         <button name="action_create_sidebar_action" type="object"
-                                groups="base.group_system"
+                                groups="base.group_no_one"
                                 class="oe_stat_button"
                                 attrs="{'invisible':[('sidebar_action_id','!=',False)]}" icon="fa-plus"
                                 help="Add a contextual action on the related model to open a sms composer with this template">
@@ -26,7 +26,7 @@
                             </div>
                         </button>
                         <button name="action_unlink_sidebar_action" type="object"
-                                groups="base.group_system"
+                                groups="base.group_no_one"
                                 class="oe_stat_button" icon="fa-minus"
                                 attrs="{'invisible':[('sidebar_action_id','=',False)]}"
                                 help="Remove the contextual action of the related model" widget="statinfo">

--- a/addons/stock/data/mail_template_data.xml
+++ b/addons/stock/data/mail_template_data.xml
@@ -1,10 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo><data noupdate="1">
     <record id="mail_template_data_delivery_confirmation" model="mail.template">
-        <field name="name">Delivery: Send by Email</field>
+        <field name="name">Shipping: Send by Email</field>
         <field name="model_id" ref="model_stock_picking"/>
         <field name="subject">{{ object.company_id.name }} Delivery Order (Ref {{ object.name or 'n/a' }})</field>
         <field name="partner_to">{{ object.partner_id.email and object.partner_id.id or object.partner_id.parent_id.id }}</field>
+        <field name="description">Sent to the customers when orders are delivered, if the setting is enabled</field>
         <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -30,7 +30,6 @@ class ResConfigSettings(models.TransientModel):
         help="Group your move operations in wave transfer to process them together")
     module_stock_barcode = fields.Boolean("Barcode Scanner")
     stock_move_email_validation = fields.Boolean(related='company_id.stock_move_email_validation', readonly=False)
-    stock_mail_confirmation_template_id = fields.Many2one(related='company_id.stock_mail_confirmation_template_id', readonly=False)
     module_stock_sms = fields.Boolean("SMS Confirmation")
     module_delivery = fields.Boolean("Delivery Methods")
     module_delivery_dhl = fields.Boolean("DHL Express Connector")

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -129,10 +129,6 @@
                                     <div class="text-muted">
                                         Send an automatic confirmation email when Delivery Orders are done
                                     </div>
-                                    <div class="row mt16" attrs="{'invisible': [('stock_move_email_validation', '=', False)]}">
-                                        <label for="stock_mail_confirmation_template_id" string="Email Template" class="col-lg-4 o_light_label"/>
-                                        <field name="stock_mail_confirmation_template_id" class="oe_inline" attrs="{'required': [('stock_move_email_validation', '=', True)]}" context="{'default_model': 'stock.picking'}"/>
-                                    </div>
                                 </div>
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="stock_sms">

--- a/addons/survey/data/mail_template_data.xml
+++ b/addons/survey/data/mail_template_data.xml
@@ -6,6 +6,7 @@
             <field name="model_id" ref="model_survey_user_input" />
             <field name="subject">Participate to {{ object.survey_id.display_name }} survey</field>
             <field name="email_to">{{ (object.partner_id.email_formatted or object.email) }}</field>
+            <field name="description">Sent to participant when you share a survey</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px; font-size: 13px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -45,11 +46,12 @@
 
         <!-- Certification Email template -->
         <record id="mail_template_certification" model="mail.template">
-            <field name="name">Survey: Send certification by email</field>
+            <field name="name">Survey: Certification Success</field>
             <field name="model_id" ref="survey.model_survey_user_input"/>
             <field name="subject">Certification: {{ object.survey_id.display_name }}</field>
             <field name="email_from">{{ (object.survey_id.create_uid.email_formatted or user.email_formatted or user.company_id.catchall_formatted) }}</field>
             <field name="email_to">{{ (object.partner_id.email_formatted or object.email) }}</field>
+            <field name="description">Sent to participant if they succeeded the certification</field>
             <field name="body_html" type="html">
 <div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">
     <table style="width:600px;margin:5px auto;">

--- a/addons/web/static/src/legacy/scss/base_document_layout.scss
+++ b/addons/web/static/src/legacy/scss/base_document_layout.scss
@@ -28,11 +28,26 @@
                     cursor: pointer;
                 }
             }
+            .o_custom_colors {
+                position: relative;
+                input {
+                    opacity: 0;
+                    width: 2rem;
+                    height: 2rem;
+                }
+                input:hover {
+                    cursor: pointer;
+                }
+                span {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                }
+            }
         }
         select.o_input {
             height: 25px;
         }
-
     }
 }
 

--- a/addons/web/views/base_document_layout_views.xml
+++ b/addons/web/views/base_document_layout_views.xml
@@ -19,10 +19,11 @@
                             <div class="o_document_layout_colors">
                                 <field name="primary_color" widget="color"/>
                                 <field name="secondary_color" widget="color"/>
-                                <field name="custom_colors" class="d-none" />
-                                <button class="btn btn-link" title="Reset to logo colors" attrs="{'invisible': [('custom_colors', '=', False)]}">
-                                    <label for="custom_colors" class="fa fa-refresh" string="" />
-                                </button>
+                                <div class="o_custom_colors" title="Reset to logo colors"
+                                    attrs="{'invisible': [('custom_colors', '=', False)]}">
+                                    <span class="fa fa-refresh fa-2x"></span>
+                                    <field name="custom_colors" nolabel="1"/>
+                                </div>
                             </div>
                             <field name="layout_background" widget="selection" required="1"/>
                             <field name="layout_background_image" options="{'accepted_file_extensions': 'image/*'}" attrs="{'invisible': [('layout_background', '!=', 'Custom')], 'required': [('layout_background', '=', 'Custom')]}">Upload your file</field>

--- a/addons/website_crm_partner_assign/data/mail_template_data.xml
+++ b/addons/website_crm_partner_assign/data/mail_template_data.xml
@@ -8,6 +8,7 @@
             <field name="subject">Fwd: Lead: {{ ctx['partner_id'].name }}</field>
             <field name="email_from">{{ user.email_formatted }}</field>
             <field name="email_to">{{ ctx['partner_id'].email_formatted }}</field>
+            <field name="description">Sent to partner when a lead has been assigned to him</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data noupdate="1">
     <record id="mail_template_data_track_confirmation" model="mail.template">
-        <field name="name">Track: Confirmation</field>
+        <field name="name">Event: Track Confirmation</field>
         <field name="model_id" ref="website_event_track.model_event_track"/>
         <field name="subject">Confirmation of {{ object.name }}</field>
         <field name="use_default_to" eval="True"/>
+        <field name="description">Sent to speakers whose track proposal is accepted (set the template on the right stage)</field>
         <field name="body_html" type="html">
 <div>
     Dear <t t-out="object.partner_id.name or object.partner_name or ''">Brandon Freeman</t><br/>

--- a/addons/website_payment/data/mail_template_data.xml
+++ b/addons/website_payment/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_donation" model="mail.template">
-            <field name="name">Donation</field>
+            <field name="name">Website: Donation</field>
             <field name="model_id" ref="payment.model_payment_transaction" />
             <field name="lang">{{ object.partner_id.lang }}</field>
         </record>

--- a/addons/website_profile/data/mail_template_data.xml
+++ b/addons/website_profile/data/mail_template_data.xml
@@ -4,11 +4,12 @@
 
         <!-- Email template for email validation (for karma purpose) -->
         <record id="validation_email" model="mail.template">
-            <field name="name">Profile: Email Verification</field>
+            <field name="name">Forum: Email Verification</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">{{ object.company_id.name }} Profile validation</field>
             <field name="email_from">{{ object.company_id.email_formatted or object.email_formatted }}</field>
             <field name="email_to">{{ object.email_formatted }}</field>
+            <field name="description">Sent to forum visitors to confirm their mail address</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -2,11 +2,12 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_sale_cart_recovery" model="mail.template">
-            <field name="name">Sales Order: Cart Recovery Email</field>
+            <field name="name">Ecommerce: Cart Recovery</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">You left items in your cart!</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">If the setting is set, sent to authenticated visitors who abandoned their cart</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 0px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -413,17 +413,6 @@
             </xpath>
 
             <div id="website_marketing_automation" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="confirmation_email_setting">
-                    <div class="o_setting_right_pane">
-                        <span class="o_form_label">Automated Emails</span>
-                        <div class="text-muted">
-                            Configure mails at order confirmation, abandoned carts, etc
-                        </div>
-                        <div class="mt8">
-                            <button type="object" name="action_open_sale_mail_templates" string="Customize Email Templates" class="btn-link" icon="fa-arrow-right"/>
-                        </div>
-                    </div>
-                </div>
                 <div class="col-xs-12 col-lg-6 o_setting_box" id="abandoned_carts_setting" title="Customer needs to be signed in otherwise the mail address is not known.
     &#10;&#10;- If a potential customer creates one or more abandoned checkouts and then completes a sale before the recovery email gets sent, then the email won't be sent.
     &#10;&#10;- If user has manually sent a recovery email, the mail will not be sent a second time

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -2,9 +2,10 @@
 <odoo>
     <data noupdate="1">
          <record id="slide_template_published" model="mail.template">
-            <field name="name">Slide Published</field>
+            <field name="name">Elearning: New Course Content Notification</field>
             <field name="model_id" ref="model_slide_slide"/>
             <field name="subject">New {{ object.slide_category }} published on {{ object.channel_id.name }}</field>
+            <field name="description">Sent to attendees when new course is published</field>
             <field name="body_html" type="html">
                 <div style="margin: 0px; padding: 0px;">
                     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -34,11 +35,12 @@
         </record>
 
         <record id="slide_template_shared" model="mail.template">
-            <field name="name">Slide Shared</field>
+            <field name="name">Elearning: Course Share</field>
             <field name="model_id" ref="model_slide_slide"/>
             <field name="subject">{{ user.name }} shared a {{ object.slide_category }} with you!</field>
             <field name="email_from">{{ user.email_formatted }}</field>
             <field name="email_to">{{ ctx.get('email', '') }}</field>
+            <field name="description">Sent when attendees share the course by email</field>
             <field name="body_html" type="html">
                 <div style="margin: 0px; padding: 0px;">
                     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -65,11 +67,12 @@
 
         <!-- Completed Channel Message -->
         <record id="mail_template_channel_completed" model="mail.template">
-            <field name="name">Completed Course</field>
+            <field name="name">Elearning: Completed Course</field>
             <field name="model_id" ref="model_slide_channel_partner"/>
             <field name="subject">Congratulation! You completed {{ object.channel_id.name }}</field>
             <field name="email_from">{{ (object.channel_id.user_id.email_formatted or object.channel_id.user_id.company_id.catchall_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent to attendees once they've completed the course</field>
             <field name="body_html" type="html">
                 <div style="margin: 0px; padding: 0px;">
                     <div style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -130,10 +133,11 @@
 
         <!-- Slide channel invite feature -->
         <record id="mail_template_slide_channel_invite" model="mail.template">
-            <field name="name">Channel: Invite by email</field>
+            <field name="name">Elearning: Course Invite</field>
             <field name="model_id" ref="model_slide_channel_partner" />
             <field name="subject">You have been invited to join {{ object.channel_id.name }}</field>
             <field name="use_default_to" eval="True"/>
+            <field name="description">Sent to attendees when they are added to a course</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px; font-size: 13px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">

--- a/addons/website_slides_survey/data/mail_template_data.xml
+++ b/addons/website_slides_survey/data/mail_template_data.xml
@@ -2,10 +2,11 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_user_input_certification_failed" model="mail.template">
-            <field name="name">Certification failed email</field>
+            <field name="name">Survey: Certification Failure</field>
             <field name="model_id" ref="model_survey_user_input" />
             <field name="subject">You have failed the course: {{ object.slide_partner_id.channel_id.name }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
+            <field name="description">Sent to participant if they failed the certification</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px; font-size: 13px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">


### PR DESCRIPTION
Allow our users to modify mail template more easily;
* make the list accessible from the settings
* give them a link to update relevant views to update header/footer
* make the list and form of templates more readable

taskID 2944770