### PR TITLE
[IMP] survey: add tooltip for presenter on live survey

### DIFF
--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -315,6 +315,12 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
 
         &.o_survey_session_navigation_next {
             right: 1rem;
+            border: 2px solid #35979c;
+            border-radius: 5px;
+
+            &:hover {
+                border-color: #2a797c;
+            }
         }
 
         &.o_survey_session_navigation_previous {

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -46,7 +46,10 @@
                         </h2>
                     </div>
                     <a role="button"
-                        class="fw-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
+                        class="o_survey_session_navigation o_survey_session_navigation_next p-2">
+                        <span class="o_survey_session_navigation_next_label me-2 fw-bold">Start</span>
+                        <i class="fw-bold fa fa-chevron-right"/>
+                    </a>
                 </div>
             </div>
         </t>
@@ -67,6 +70,7 @@
             t-att-style="'display: none;' if is_rpc_call else ''"
             t-att-data-is-rpc-call="is_rpc_call"
             t-att-data-survey-id="survey.id"
+            t-att-data-survey-has-conditional-questions="survey.has_conditional_questions"
             t-att-data-attendees-count="survey.session_answer_count"
             t-att-data-survey-access-token="survey.access_token"
             t-att-data-timer="survey.session_question_start_time.isoformat()"
@@ -109,7 +113,10 @@
                     <div t-field="survey.description_done"/>
                 </div>
                 <a role="button"
-                    class="fw-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
+                    class="o_survey_session_navigation o_survey_session_navigation_next p-2">
+                    <span class="o_survey_session_navigation_next_label me-2 fw-bold"/>
+                    <i class="fw-bold fa fa-chevron-right"/>
+                </a>
                 <a role="button"
                     class="fw-bold fa fa-chevron-left o_survey_session_navigation o_survey_session_navigation_previous p-3" />
                 <div class="o_survey_session_results flex-column flex-grow-1 mx-5">


### PR DESCRIPTION
Current behavior before PR:

While presenting a survey, sometimes it is good to know what content
will be next. However, this is not possible currently.

Desired behavior after PR is merged:

Ease the job of the live speaker by letting them know in advance
what the next slide will be about?
Added a label next to the arrow icon based on what the next slide will be.

Task: https://www.odoo.com/web#id=2791000&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
