### PR TITLE
[14.0][FIX] website_hr_recruitment: fix website job description

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -116,7 +116,11 @@
                 </div>
             </section>
 
-            <div t-field="job.website_description"/>
+            <section class="pb32">
+                <div class="container">
+                    <div t-field="job.description"/>
+                </div>
+            </section>
 
             <div class="oe_structure">
                 <section class="o_job_bottom_bar mt32 mb32">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
job description not displayed on website job detail page.

Current behavior before PR:
job description not displayed on website job detail page

Desired behavior after PR is merged:
job description is displayed on website job detail page.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
