### PR TITLE
[FIX] point_of_sale: Set use pricelist when session opened

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -225,7 +225,7 @@
                         <div class="row mt16 o_settings_container" id="pos_pricing_section">
                             <div class="col-12 col-lg-6 o_setting_box" id="multiple_prices_setting">
                                 <div class="o_setting_left_pane">
-                                    <field name="pos_use_pricelist"/>
+                                    <field name="pos_use_pricelist" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
                                 </div>
                                 <div class="o_setting_right_pane">
                                     <label for="pos_use_pricelist" string="Flexible Pricelists" />


### PR DESCRIPTION
When a session is opened, the setting that allow using pricelist cannot
be modified, as it can change the prices that should be used, but
existing opened POS will still use the old one.

As the pos settings are now in the res config settings, each time a
setting is changed, all settings are re-written. As the use pricelist
setting is not readonly when a session is open, its value is sent, and
we try two write it (even if value not changed) and it trigger a
constraint saying it cannot be modified.

To avoid such a wrong behavior, we make it readonly when it cannot be
modified.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
