### PR TITLE
[FIX] website: restore help message in edit menu dialog

### DIFF
--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -16,6 +16,7 @@
             </label>
             <div class="col-md-9">
                 <input id="url_input" t-ref="url-input" type="text" t-model="url.input.value" class="form-control" t-att-class="{ 'is-invalid': url.input.hasError }"/>
+                <small class="form-text">Hint: Type '/' to search an existing page and '#' to link to an anchor.</small>
             </div>
         </div>
     </WebsiteDialog>


### PR DESCRIPTION
This commit restores the hint that [1] lost when adapting the "Edit
menu" dialog to owl.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506
