### PR TITLE
[FIX] sms: correctly render body in mass sms

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -180,9 +180,12 @@ class SendSMS(models.TransientModel):
         subtype_id = self.env['ir.model.data'].xmlid_to_res_id('mail.mt_note')
 
         messages = self.env['mail.message']
+        all_bodies = self._prepare_body_values(records)
+
         for record in records:
-            messages |= record._message_sms(
-                self.body, subtype_id=subtype_id,
+            messages += record._message_sms(
+                all_bodies[record.id],
+                subtype_id=subtype_id,
                 partner_ids=self.partner_ids.ids or False,
                 number_field=self.number_field_name,
                 sms_numbers=self.sanitized_numbers.split(',') if self.sanitized_numbers else None)

--- a/addons/test_mail_full/tests/test_sms_composer.py
+++ b/addons/test_mail_full/tests/test_sms_composer.py
@@ -134,10 +134,11 @@ class TestSMSComposerComment(test_mail_full_common.BaseFunctionalTest, sms_commo
 
 
 class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.MockSMS):
+
     @classmethod
     def setUpClass(cls):
         super(TestSMSComposerBatch, cls).setUpClass()
-        cls._test_body = 'Zizisse an SMS.'
+        cls._test_body = 'Hello ${object.name} zizisse an SMS.'
 
         cls._create_records_for_batch('mail.test.sms', 3)
         cls.sms_template = cls._create_sms_template('mail.test.sms')
@@ -157,7 +158,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
                 messages = composer._action_send_sms()
 
         for record in self.records:
-            self.assertSMSNotification([{'partner': r.customer_id} for r in self.records], 'Zizisse an SMS.', messages)
+            self.assertSMSNotification(
+                [{'partner': record.customer_id}],
+                'Hello ${object.name} zizisse an SMS.',
+                messages
+            )
 
     def test_composer_batch_active_ids(self):
         with self.sudo('employee'):
@@ -173,7 +178,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
                 messages = composer._action_send_sms()
 
         for record in self.records:
-            self.assertSMSNotification([{'partner': r.customer_id} for r in self.records], 'Zizisse an SMS.', messages)
+            self.assertSMSNotification(
+                [{'partner': record.customer_id}],
+                'Hello ${object.name} zizisse an SMS.',
+                messages
+            )
 
     def test_composer_batch_domain(self):
         with self.sudo('employee'):
@@ -190,7 +199,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
                 messages = composer._action_send_sms()
 
         for record in self.records:
-            self.assertSMSNotification([{'partner': r.customer_id} for r in self.records], 'Zizisse an SMS.', messages)
+            self.assertSMSNotification(
+                [{'partner': record.customer_id}],
+                'Hello ${object.name} zizisse an SMS.',
+                messages
+            )
 
     def test_composer_batch_res_ids(self):
         with self.sudo('employee'):
@@ -206,7 +219,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
                 messages = composer._action_send_sms()
 
         for record in self.records:
-            self.assertSMSNotification([{'partner': r.customer_id} for r in self.records], 'Zizisse an SMS.', messages)
+            self.assertSMSNotification(
+                [{'partner': record.customer_id}],
+                'Hello ${object.name} zizisse an SMS.',
+                messages
+            )
 
 
 class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.MockSMS):
@@ -214,9 +231,9 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
     @classmethod
     def setUpClass(cls):
         super(TestSMSComposerMass, cls).setUpClass()
-        cls._test_body = 'Zizisse an SMS.'
+        cls._test_body = 'Hello ${object.name} zizisse an SMS.'
 
-        cls._create_records_for_batch('mail.test.sms', 3)
+        cls._create_records_for_batch('mail.test.sms', 10)
         cls.sms_template = cls._create_sms_template('mail.test.sms')
 
     def test_composer_mass_active_domain(self):
@@ -235,7 +252,10 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
                 composer.action_send_sms()
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, self._test_body)
+            self.assertSMSOutgoing(
+                record.customer_id, None,
+                content='Hello %s zizisse an SMS.' % record.name
+            )
 
     def test_composer_mass_active_domain_w_template(self):
         with self.sudo('employee'):
@@ -253,7 +273,10 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
                 composer.action_send_sms()
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, 'Dear %s this is an SMS.' % record.display_name)
+            self.assertSMSOutgoing(
+                record.customer_id, None,
+                content='Dear %s this is an SMS.' % record.display_name
+            )
 
     def test_composer_mass_active_ids(self):
         with self.sudo('employee'):
@@ -269,8 +292,11 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
             with self.mockSMSGateway():
                 composer.action_send_sms()
 
-        for partner in self.partners:
-            self.assertSMSOutgoing(partner, None, self._test_body)
+        for partner, record in zip(self.partners, self.records):
+            self.assertSMSOutgoing(
+                partner, None,
+                content='Hello %s zizisse an SMS.' % record.name
+            )
 
     def test_composer_mass_active_ids_w_blacklist(self):
         self.env['phone.blacklist'].create([{
@@ -292,10 +318,16 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
             with self.mockSMSGateway():
                 composer.action_send_sms()
 
-        for partner in self.partners[5:]:
-            self.assertSMSOutgoing(partner, partner.phone_sanitized, content=self._test_body)
-        for partner in self.partners[:5]:
-            self.assertSMSCanceled(partner, partner.phone_sanitized, 'sms_blacklist', content=self._test_body)
+        for partner, record in zip(self.partners[5:], self.records[5:]):
+            self.assertSMSOutgoing(
+                partner, partner.phone_sanitized,
+                content='Hello %s zizisse an SMS.' % record.name
+            )
+        for partner, record in zip(self.partners[:5], self.records[:5]):
+            self.assertSMSCanceled(
+                partner, partner.phone_sanitized, 'sms_blacklist',
+                content='Hello %s zizisse an SMS.' % record.name
+            )
 
     def test_composer_mass_active_ids_wo_blacklist(self):
         self.env['phone.blacklist'].create([{
@@ -317,17 +349,22 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
             with self.mockSMSGateway():
                 composer.action_send_sms()
 
-        for partner in self.partners:
-            self.assertSMSOutgoing(partner, partner.phone_sanitized, content=self._test_body)
+        for partner, record in zip(self.partners, self.records):
+            self.assertSMSOutgoing(
+                partner, partner.phone_sanitized,
+                content='Hello %s zizisse an SMS.' % record.name
+            )
 
     def test_composer_mass_active_ids_w_blacklist_and_done(self):
+        """ Create some duplicates + blacklist. record[5] will have duplicated
+        number on 6 and 7. """
         self.env['phone.blacklist'].create([{
             'number': p.phone_sanitized,
             'active': True,
         } for p in self.partners[:5]])
-        for p in self.partners[8:]:
-            p.mobile = self.partners[8].mobile
-            self.assertEqual(p.phone_sanitized, self.partners[8].phone_sanitized)
+        for p in self.partners[5:8]:
+            p.mobile = self.partners[5].mobile
+            self.assertEqual(p.phone_sanitized, self.partners[5].phone_sanitized)
 
         with self.sudo('employee'):
             composer = self.env['sms.composer'].with_context(
@@ -343,12 +380,27 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
             with self.mockSMSGateway():
                 composer.action_send_sms()
 
-        for partner in self.partners[8:]:
-            self.assertSMSOutgoing(partner, partner.phone_sanitized, content=self._test_body)
-        for partner in self.partners[5:8]:
-            self.assertSMSCanceled(partner, partner.phone_sanitized, 'sms_duplicate', content=self._test_body)
-        for partner in self.partners[:5]:
-            self.assertSMSCanceled(partner, partner.phone_sanitized, 'sms_blacklist', content=self._test_body)
+        self.assertSMSOutgoing(
+            self.partners[5], self.partners[5].phone_sanitized,
+            content='Hello %s zizisse an SMS.' % self.records[5].name
+        )
+        for partner, record in zip(self.partners[8:], self.records[8:]):
+            self.assertSMSOutgoing(
+                partner, partner.phone_sanitized,
+                content='Hello %s zizisse an SMS.' % record.name
+            )
+        # duplicates
+        for partner, record in zip(self.partners[6:8], self.records[6:8]):
+            self.assertSMSCanceled(
+                partner, partner.phone_sanitized, 'sms_duplicate',
+                content='Hello %s zizisse an SMS.' % record.name
+            )
+        # blacklist
+        for partner, record in zip(self.partners[:5], self.records[:5]):
+            self.assertSMSCanceled(
+                partner, partner.phone_sanitized, 'sms_blacklist',
+                content='Hello %s zizisse an SMS.' % record.name
+            )
 
     def test_composer_mass_active_ids_w_template(self):
         with self.sudo('employee'):
@@ -365,7 +417,10 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
                 composer.action_send_sms()
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, 'Dear %s this is an SMS.' % record.display_name)
+            self.assertSMSOutgoing(
+                record.customer_id, None,
+                content='Dear %s this is an SMS.' % record.display_name
+            )
 
     def test_composer_mass_active_ids_w_template_and_lang(self):
         self.env.ref('base.lang_fr').write({'active': True})
@@ -399,9 +454,15 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
 
         for record in self.records:
             if record.customer_id == self.partners[2]:
-                self.assertSMSOutgoing(record.customer_id, None, 'Cher·e· %s ceci est un SMS.' % record.display_name)
+                self.assertSMSOutgoing(
+                    record.customer_id, None,
+                    content='Cher·e· %s ceci est un SMS.' % record.display_name
+                )
             else:
-                self.assertSMSOutgoing(record.customer_id, None, 'Dear %s this is an SMS.' % record.display_name)
+                self.assertSMSOutgoing(
+                    record.customer_id, None,
+                    content='Dear %s this is an SMS.' % record.display_name
+                )
 
     def test_composer_mass_active_ids_w_template_and_log(self):
         with self.sudo('employee'):
@@ -418,7 +479,10 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
                 composer.action_send_sms()
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, 'Dear %s this is an SMS.' % record.display_name)
+            self.assertSMSOutgoing(
+                record.customer_id, None,
+                content='Dear %s this is an SMS.' % record.display_name
+            )
             self.assertSMSLogged(record, 'Dear %s this is an SMS.' % record.display_name)
 
     def test_composer_template_context_action(self):
@@ -470,7 +534,10 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
                 messages = composer._action_send_sms()
 
         number = self.partners[2].phone_get_sanitized_number()
-        self.assertSMSNotification([{'partner': test_record_2.customer_id, 'number': number}], "Hello %s ceci est en français." % test_record_2.display_name, messages)
+        self.assertSMSNotification(
+            [{'partner': test_record_2.customer_id, 'number': number}],
+            "Hello %s ceci est en français." % test_record_2.display_name, messages
+        )
 
         # Composer creation with context from a template context action (simulate) - mass (multiple recipient)
         with self.sudo('employee'):
@@ -494,5 +561,11 @@ class TestSMSComposerMass(test_mail_full_common.BaseFunctionalTest, sms_common.M
             with self.mockSMSGateway():
                 composer.action_send_sms()
 
-        self.assertSMSOutgoing(test_record_1.customer_id, None, 'Dear %s this is an SMS.' % test_record_1.display_name)
-        self.assertSMSOutgoing(test_record_2.customer_id, None, "Hello %s ceci est en français." % test_record_2.display_name)
+        self.assertSMSOutgoing(
+            test_record_1.customer_id, None,
+            content='Dear %s this is an SMS.' % test_record_1.display_name
+        )
+        self.assertSMSOutgoing(
+            test_record_2.customer_id, None,
+            content="Hello %s ceci est en français." % test_record_2.display_name
+        )

--- a/addons/test_mail_full/tests/test_sms_composer.py
+++ b/addons/test_mail_full/tests/test_sms_composer.py
@@ -157,11 +157,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
             with self.mockSMSGateway():
                 messages = composer._action_send_sms()
 
-        for record in self.records:
+        for record, message in zip(self.records, messages):
             self.assertSMSNotification(
                 [{'partner': record.customer_id}],
-                'Hello ${object.name} zizisse an SMS.',
-                messages
+                'Hello %s zizisse an SMS.' % record.name,
+                message
             )
 
     def test_composer_batch_active_ids(self):
@@ -177,11 +177,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
             with self.mockSMSGateway():
                 messages = composer._action_send_sms()
 
-        for record in self.records:
+        for record, message in zip(self.records, messages):
             self.assertSMSNotification(
                 [{'partner': record.customer_id}],
-                'Hello ${object.name} zizisse an SMS.',
-                messages
+                'Hello %s zizisse an SMS.' % record.name,
+                message
             )
 
     def test_composer_batch_domain(self):
@@ -198,11 +198,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
             with self.mockSMSGateway():
                 messages = composer._action_send_sms()
 
-        for record in self.records:
+        for record, message in zip(self.records, messages):
             self.assertSMSNotification(
                 [{'partner': record.customer_id}],
-                'Hello ${object.name} zizisse an SMS.',
-                messages
+                'Hello %s zizisse an SMS.' % record.name,
+                message
             )
 
     def test_composer_batch_res_ids(self):
@@ -218,11 +218,11 @@ class TestSMSComposerBatch(test_mail_full_common.BaseFunctionalTest, sms_common.
             with self.mockSMSGateway():
                 messages = composer._action_send_sms()
 
-        for record in self.records:
+        for record, message in zip(self.records, messages):
             self.assertSMSNotification(
                 [{'partner': record.customer_id}],
-                'Hello ${object.name} zizisse an SMS.',
-                messages
+                'Hello %s zizisse an SMS.' % record.name,
+                message
             )
 
 


### PR DESCRIPTION
When sending SMS on several records in comment mode (aka: post sms message
in batch) the body is sent as it is. This does not happen frequently as
default usage is either

  * comment on a single record -> body is rendered by onchange / compute;
  * mass SMS on several records -> body is rendered for all records then
    sent to all recipients;

Using comment mode in mass is not common, and is mainly achieved through
handcrafted actions. However this can be fixed by correctly rendering the
body before posting on all records.

Task-2613245 (Server actions mail update / cleaning
