### PR TITLE
[FIX] calendar_sms: fix bad default value

### DIFF
--- a/addons/calendar_sms/models/calendar_event.py
+++ b/addons/calendar_sms/models/calendar_event.py
@@ -36,7 +36,7 @@ class CalendarEvent(models.Model):
                 'default_composition_mode': 'mass',
                 'default_res_model': 'res.partner',
                 'default_res_ids': self.partner_ids.ids,
-                'default_sms_mass_keep_log': True,
+                'default_mass_keep_log': True,
             },
         }
 


### PR DESCRIPTION
Fix a typo in a default / field name for SMS composer.

Task-2613245 (Server actions mail update / cleaning
