### PR TITLE
[IMP] website_slides: create hook to update slides values

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -872,7 +872,7 @@ export class StaticList extends DataPoint {
             if (record) {
                 record.__syncData();
             } else {
-                record = new Record(this.model, {
+                record = new this.model.constructor.Record(this.model, {
                     handle: dp.id,
                     onRecordWillSwitchMode: this.onRecordWillSwitchMode,
                     mode: "readonly",
@@ -1299,6 +1299,7 @@ export class RelationalModel extends Model {
             }
         }
 
+        const Record = this.constructor.Record;
         const newRecord = new Record(this, {
             handle,
             viewType: params.viewMode,
@@ -1370,7 +1371,7 @@ export class RelationalModel extends Model {
             loadParams.context = params.context;
         }
         const state = this.root ? this.root.exportState() : {};
-        const nextRoot = new Record(
+        const nextRoot = new this.constructor.Record(
             this,
             {
                 __bm_load_params__: loadParams,
@@ -1446,7 +1447,8 @@ export class RelationalModel extends Model {
                 context: params.context,
             },
         });
-        return new Record(this, params, state);
+        return new this.constructor.Record(this, params, state);
     }
 }
 RelationalModel.services = ["action", "dialog", "notification"];
+RelationalModel.Record = Record;

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -345,6 +345,20 @@ class WebsiteSlides(WebsiteProfile):
 
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True)
     def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
+        if slug_tags and request.httprequest.method == 'GET':
+            # Redirect `tag-1,tag-2` to `tag-1` to disallow multi tags
+            # in GET request for proper bot indexation;
+            # if the search term is available, do not remove any existing
+            # tags because it is user who provided search term with GET
+            # request and so clearly it's not SEO bot.
+            tag_list = slug_tags.split(',')
+            if len(tag_list) > 1 and not post.get('search'):
+                url = QueryURL('/slides/all', ['tag'], tag=tag_list[0], my=my, slide_category=slide_category)()
+                return request.redirect(url, code=302)
+        render_values = self.slides_channel_all_values(slide_category=slide_category, slug_tags=slug_tags, my=my, **post)
+        return request.render('website_slides.courses_all', render_values)
+
+    def slides_channel_all_values(self, slide_category=None, slug_tags=None, my=False, **post):
         """ Home page displaying a list of courses displayed according to some
         criterion and search terms.
 
@@ -359,22 +373,6 @@ class WebsiteSlides(WebsiteProfile):
 
            * ``search``: filter on course description / name;
         """
-
-        # retro-compatibility for older links, 'slide_category' field was previously named 'slide_type'
-        # can be safely removed after 15.3 (I swear though, don't be afraid, remove it!)
-        slide_category = slide_category or post.get('slide_type')
-
-        if slug_tags and request.httprequest.method == 'GET':
-            # Redirect `tag-1,tag-2` to `tag-1` to disallow multi tags
-            # in GET request for proper bot indexation;
-            # if the search term is available, do not remove any existing
-            # tags because it is user who provided search term with GET
-            # request and so clearly it's not SEO bot.
-            tag_list = slug_tags.split(',')
-            if len(tag_list) > 1 and not post.get('search'):
-                url = QueryURL('/slides/all', ['tag'], tag=tag_list[0], my=my, slide_category=slide_category)()
-                return request.redirect(url, code=302)
-
         options = {
             'displayDescription': True,
             'displayDetail': False,
@@ -416,7 +414,7 @@ class WebsiteSlides(WebsiteProfile):
             'slide_query_url': QueryURL('/slides/all', ['tag']),
         })
 
-        return request.render('website_slides.courses_all', render_values)
+        return render_values
 
     def _prepare_additional_channel_values(self, values, **kwargs):
         return values


### PR DESCRIPTION
With the integration slides-knowledge,
slides can be set on the team, so that the user can be redirected
to them when searching for help.
We want to use the same view as for all slides,
but limit the records presented to the user.

With this commit, we create two distinct methods:
one that prepares the values
one that renders them.
This way, we can hook into the first one to replace the records
before rendering them, when the `/helpdesk/<team_id>/slides`
route is used.

related: https://github.com/odoo/odoo/pull/97739
task-2890043