### PR TITLE
[FIX] web_editor: multiple issues with Bootstrap grid conversion

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -187,13 +187,13 @@ function bootstrapToTable($editable) {
                 if (gridIndex + columnSize < 12) {
                     currentCol = grid[gridIndex];
                     _applyColspan(currentCol, columnSize);
+                    gridIndex += columnSize;
                     if (columnIndex === bootstrapColumns.length - 1) {
                         // We handled all the columns but there is still space
                         // in the row. Insert the columns and fill the row.
-                        grid[gridIndex].setAttribute('colspan', 12 - gridIndex);
+                        _applyColspan(grid[gridIndex], 12 - gridIndex);
                         currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
                     }
-                    gridIndex += columnSize;
                 } else if (gridIndex + columnSize === 12) {
                     // Finish the row.
                     currentCol = grid[gridIndex];
@@ -224,10 +224,8 @@ function bootstrapToTable($editable) {
                     if (columnIndex === bootstrapColumns.length - 1 && gridIndex < 12) {
                         // We handled all the columns but there is still space
                         // in the row. Insert the columns and fill the row.
-                        grid[gridIndex].setAttribute('colspan', 12 - gridIndex);
-                        currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
-                        // Adapt width to colspan.
                         _applyColspan(grid[gridIndex], 12 - gridIndex);
+                        currentRow.append(...grid.filter(td => td.getAttribute('colspan')));
                     }
                 }
                 if (currentCol) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -113,6 +113,9 @@ function bootstrapToTable($editable) {
     // These containers from the mass mailing masonry snippet require full
     // height contents, which is only possible if the table itself has a set
     // height. We also need to restyle it because of the change in structure.
+    for(const masonryTopInnerContainer of editable.querySelectorAll('.s_masonry_block > .container')) {
+        masonryTopInnerContainer.style.setProperty('height', '100%');
+    }
     for (const masonryGrid of editable.querySelectorAll('.o_masonry_grid_container')) {
         masonryGrid.style.setProperty('padding', 0);
         for (const fakeTable of [...masonryGrid.children].filter(c => c.classList.contains('o_fake_table'))) {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -886,6 +886,20 @@ section, .oe_img_bg, [data-oe-shape-data] {
     }
 }
 
+// Background Images
+.oe_img_bg {
+    background-size: cover;
+    background-repeat: no-repeat;
+
+    &.o_bg_img_opt_repeat {
+        background-size: auto;
+        background-repeat: repeat;
+    }
+    &.o_bg_img_center {
+        background-position: center;
+    }
+}
+
 // Gradient
 // TODO should be in the editor lib since it is handled there... but could not
 // find the right place for it.

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -305,6 +305,24 @@ QUnit.module('convert_inline', {}, function () {
                 .replace(/<tr><td[^>]*>(\(2, 0\))<\/td>/, '<img><tr><td><strong class="b">$1</strong></td>'),
             "should have converted a list group structure into a table");
     });
+    QUnit.test('convert a grid with offsets to a table', async function (assert) {
+        assert.expect(2);
+
+        let $editable = $('<div><div class="container"><div class="row"><div class="col-6 offset-4">(0, 0)</div></div></div>');
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getTableHtml([[[4, 33.33, ''], [6, 50, '(0, 0)'], [2, 16.67, '']]]),
+            "should have converted a column with an offset to two columns, then completed the column");
+
+        $editable = $('<div><div class="container"><div class="row"><div class="col-6 offset-4">(0, 0)</div><div class="col-6 offset-1">(0, 1)</div></div></div>');
+        convertInline.bootstrapToTable($editable);
+        assert.strictEqual($editable.html(),
+            getTableHtml([
+                [[4, 33.33, ''], [6, 50, '(0, 0)'], [1, 8.33, ''], [1, 8.33, '']],
+                [[6, 50, '(0, 1)'], [6, 50, '']],
+            ]),
+            "should have converted a column with an offset to two columns, then completed the column (overflowing)");
+    });
 
     QUnit.module('Normalize styles');
     // Test normalizeColors, normalizeRem and formatTables

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -42,7 +42,8 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr></table>`,
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;"></td></tr></table>`,
             "should have converted a 1x13 grid to an equivalent table (overflowing)");
 
         // 1x14
@@ -51,7 +52,8 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
                 `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
-                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 13)</td></tr></table>`,
+                `<td colspan="1" width="8.33%" style="width: 8.33%;">(0, 13)</td>` +
+                `<td colspan="10" width="83.33%" style="width: 83.33%;"></td></tr></table>`,
             "should have converted a 1x14 grid to an equivalent table (overflowing)");
 
         // 1x25
@@ -61,7 +63,8 @@ QUnit.module('convert_inline', {}, function () {
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 24)</td></tr></table>`,
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 24)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;"></td></tr></table>`,
             "should have converted a 1x25 grid to an equivalent table (overflowing)");
 
         // 1x26
@@ -72,7 +75,8 @@ QUnit.module('convert_inline', {}, function () {
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
                 `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 24)</td>` +
-                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 25)</td></tr></table>`,
+                `<td colspan="1" width="8.33%" style="width: 8.33%;">(0, 25)</td>` +
+                `<td colspan="10" width="83.33%" style="width: 83.33%;"></td></tr></table>`,
             "should have converted a 1x26 grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a multi-row regular grid', async function (assert) {
@@ -110,8 +114,9 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr>` +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 0)</td></tr></table>`,
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;"></td></tr>` + // 13 overflowed the row by 1 -> fill up
+                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 0)</td></tr></table>`, // 1 col with no size == col-12
             "should have converted a 2x[13,1] grid to an equivalent table (overflowing)");
 
         // 2x[1,13]
@@ -119,7 +124,8 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr></table>`,
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(1, 12)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;"></td></tr></table>`, // 13 overflowed the row by 1 -> fill up
             "should have converted a 2x[1,13] grid to an equivalent table (overflowing)");
 
         // 3x[1,13,6]
@@ -127,7 +133,8 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr>` +
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(1, 12)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;"></td></tr>` + // 13 overflowed the row by 1 -> fill up
                 getRegularTableHtml(1, 6, 2, 16.67).replace(/\(0,/g, `(2,`).replace(/^<table[^<]*>/, ''),
             "should have converted a 3x[1,13,6] grid to an equivalent table (overflowing)");
 
@@ -136,7 +143,9 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.bootstrapToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(2, 12)</td></tr></table>`,
+                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(2, 12)</td>` +
+                `<td colspan="11" width="91.67%" style="width: 91.67%;"></td></tr>` + // 13 overflowed the row by 1 -> fill up
+                `</table>`,
             "should have converted a 3x[1,6,13] grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a single-row irregular grid', async function (assert) {assert.expect(4);


### PR DESCRIPTION
When we convert Bootstrap grids to tables for e-mail compatibility, we need to complete rows whose column sizes don't add up to 12. The way it was, the last column was stretched to fill up the row, which is wrong as it can affect the width of its contents.
With this commit, a new, empty column is appended to the row to fill it up without affecting the existing rows. This is a more accurate way to emulate the behavior of Flexbox.

The option to switch background types depends on CSS which was in the website builder but absent from mass_mailing.

Masonry's top inner container needs to have a 100% height to properly size its contents.

When converting Bootstrap grids to tables for e-mail compatibility, we need to take into account Bootstrap offsets on columns. We were doing this by adding that offset to the column but we actually need to create an extra column instead.

task-2936705

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
