### PR TITLE
[FIX] product: fix test test_variant_images

### DIFF
--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -667,7 +667,7 @@ class TestVariantsImages(common.TestProductCommon):
         """
         # Pretend setup happened in an older transaction by updating on the SQL layer and making sure it gets reloaded
         # Using _write() instead of write() because write() only allows updating log access fields at boot time
-        before = datetime.now() - timedelta(seconds=1)
+        before = self.env.cr.now() - timedelta(seconds=1)
         self.template._write({
             'create_date': before,
             'write_date': before,


### PR DESCRIPTION
- In setUp, self.template._get_variant_for_combination(color_value).write, sytem will set self.env.cr.now(). self.env.cr.now() is constant after each call.
- When assigning variable before is using datetime.now(). datetime.now() always changes each call. Sometimes, before will be greater than self.env.cr.now(). So causing test error.
- After this commit, before will use self.env.cr.now()




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
