### PR TITLE
[IMP] website_event_track: add location ordering in event agenda

### DIFF
--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -11,6 +11,7 @@ import babel
 import babel.dates
 import base64
 import json
+import operator
 import pytz
 
 from odoo import exceptions, http, fields, tools, _
@@ -203,7 +204,7 @@ class EventTrackController(http.Controller):
         tracks_sudo = request.env['event.track'].sudo().search(base_track_domain)
 
         locations = list(set(track.location_id for track in tracks_sudo))
-        locations.sort(key=lambda x: x.id)
+        locations.sort(key=operator.itemgetter('sequence', 'id'))
 
         # First split day by day (based on start time)
         time_slots_by_tracks = {track: self._split_track_by_days(track, local_tz) for track in tracks_sudo}
@@ -260,7 +261,7 @@ class EventTrackController(http.Controller):
                 locations_by_days[track_day].append(track.location_id)
 
         for used_locations in locations_by_days.values():
-            used_locations.sort(key=lambda location: location.id if location else 0)
+            used_locations.sort(key=operator.itemgetter('sequence', 'id'))
 
         return {
             'days': days,

--- a/addons/website_event_track/models/event_track_location.py
+++ b/addons/website_event_track/models/event_track_location.py
@@ -7,5 +7,7 @@ from odoo import fields, models
 class TrackLocation(models.Model):
     _name = "event.track.location"
     _description = 'Event Track Location'
+    _order = 'sequence, id'
 
     name = fields.Char('Location', required=True)
+    sequence = fields.Integer(default=10, help='Define the order in which the location will appear on "Agenda" page')

--- a/addons/website_event_track/views/event_menus.xml
+++ b/addons/website_event_track/views/event_menus.xml
@@ -21,7 +21,6 @@
         name="Track Locations"
         action="action_event_track_location"
         parent="event.menu_event_configuration"
-        groups="base.group_no_one"
         sequence="32"/>
 
     <menuitem id="event_track_tag_category_menu"

--- a/addons/website_event_track/views/event_track_location_views.xml
+++ b/addons/website_event_track/views/event_track_location_views.xml
@@ -10,6 +10,7 @@
                 <sheet>
                     <group>
                         <field name="name"/>
+                        <field name="sequence"/>
                     </group>
                 </sheet>
             </form>
@@ -21,6 +22,7 @@
         <field name="model">event.track.location</field>
         <field name="arch" type="xml">
             <tree string="Event Location" editable="bottom">
+                <field name="sequence" widget="handle"/>
                 <field name="name"/>
             </tree>
         </field>


### PR DESCRIPTION
This PR adds a `sequence` field in `event.track.location`, allowing event
managers to organize their event location as they want in the "Agenda" page.
To allow re-arrangement of the locations a bit more visible and easy,  this
PR adds handle widget on track locations tree view, and removes the debug
group from the menu "Events > Configuration > Track Locations".

taskID- 2942634