### PR TITLE
[FIX] web: fix debug mode in domain selector

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector.js
@@ -193,6 +193,7 @@ Object.assign(DomainSelector, {
         className: { type: String, optional: true },
         resModel: String,
         value: String,
+        debugValue: { type: String, optional: true },
         readonly: { type: Boolean, optional: true },
         update: { type: Function, optional: true },
         isDebugMode: { type: Boolean, optional: true },

--- a/addons/web/static/src/core/domain_selector/domain_selector.xml
+++ b/addons/web/static/src/core/domain_selector/domain_selector.xml
@@ -10,6 +10,7 @@
                 readonly="props.readonly"
                 resModel="props.resModel"
                 isDebugMode="props.isDebugMode"
+                debugValue="props.debugValue or props.value"
                 className="props.className"
             />
         </t>

--- a/addons/web/static/src/core/domain_selector/domain_selector_leaf_node.xml
+++ b/addons/web/static/src/core/domain_selector/domain_selector_leaf_node.xml
@@ -5,7 +5,7 @@
         <div class="o_domain_node o_domain_leaf o_domain_selector_row" t-ref="root">
             <t t-if="props.readonly">
                 <div class="o_domain_leaf_info">
-                    <ModelFieldSelector fieldName="props.node.operands[0]" resModel="props.resModel" readonly="props.readonly" isDebugMode="props.isDebugMode" />
+                    <ModelFieldSelector fieldName="props.node.operands[0].toString()" resModel="props.resModel" readonly="props.readonly" isDebugMode="props.isDebugMode" />
                     <t t-if="typeof props.node.operands[1] === 'string'">
                         <span class="o_domain_leaf_operator"> <t t-esc="displayedOperator" /></span>
                         <span class="o_domain_leaf_value text-primary"> "<t t-esc="props.node.operands[1]" />"</span>
@@ -38,7 +38,7 @@
                     onHoverInsertBranchNodeBtn.bind="onHoverInsertBranchNodeBtn"
                 />
                 <div class="o_domain_leaf_edition">
-                    <ModelFieldSelector fieldName="props.node.operands[0]" resModel="props.resModel" readonly="props.readonly" update="(name) => this.onFieldChange(name)" isDebugMode="props.isDebugMode" />
+                    <ModelFieldSelector fieldName="props.node.operands[0].toString()" resModel="props.resModel" readonly="props.readonly" update="(name) => this.onFieldChange(name)" isDebugMode="props.isDebugMode" />
                     <t t-set="field" t-value="getFieldComponent(fieldInfo.type)" />
                     <t t-if="field">
                         <div>

--- a/addons/web/static/src/core/domain_selector/domain_selector_root_node.xml
+++ b/addons/web/static/src/core/domain_selector/domain_selector_root_node.xml
@@ -44,7 +44,7 @@
             <t t-if="props.isDebugMode and !props.readonly">
                 <label class="o_domain_debug_container">
                     <span class="small"># Code editor</span>
-                    <textarea type="text" class="o_domain_debug_input" t-att-value="props.value" t-on-change="onChange" />
+                    <textarea type="text" class="o_domain_debug_input" t-att-value="props.debugValue" t-on-change="onChange" />
                 </label>
             </t>
         </div>

--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -21,22 +21,21 @@ export class DomainField extends Component {
         this.addDialog = useOwnedDialogs();
 
         this.displayedDomain = null;
-        this.isDebugEdited = false;
+        this.debugValue = undefined;
 
         onWillStart(() => {
             this.displayedDomain = this.props.value;
             this.loadCount(this.props);
         });
         onWillUpdateProps((nextProps) => {
-            this.isDebugEdited = this.isDebugEdited && this.props.readonly === nextProps.readonly;
-            if (!this.isDebugEdited) {
+            if (this.debugValue === undefined || this.props.readonly !== nextProps.readonly) {
                 this.displayedDomain = nextProps.value;
                 this.loadCount(nextProps);
             }
         });
 
         useBus(this.env.bus, "RELATIONAL_MODEL:NEED_LOCAL_CHANGES", async (ev) => {
-            if (this.isDebugEdited) {
+            if (this.debugValue !== undefined) {
                 const prom = this.loadCount(this.props);
                 ev.detail.proms.push(prom);
                 await prom;
@@ -104,7 +103,7 @@ export class DomainField extends Component {
     }
 
     update(domain, isDebugEdited) {
-        this.isDebugEdited = isDebugEdited;
+        this.debugValue = isDebugEdited ? domain : undefined;
         return this.props.update(domain);
     }
 

--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -10,6 +10,7 @@
                     readonly="props.readonly or props.editInDialog"
                     update.bind="update"
                     isDebugMode="!!env.debug"
+                    debugValue="debugValue"
                     className="props.readonly ? 'o_read_mode' : 'o_edit_mode'"
                 />
                 <div class="o_field_domain_panel">

--- a/addons/web/static/tests/views/fields/domain_field_tests.js
+++ b/addons/web/static/tests/views/fields/domain_field_tests.js
@@ -666,7 +666,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("domain field: edit domain with dynamic content", async function (assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         patchWithCleanup(odoo, { debug: true });
 
@@ -709,9 +709,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         await doAction(webClient, 1);
-
         await click(target, ".o_form_button_edit");
-
         assert.strictEqual(target.querySelector(".o_domain_debug_input").value, rawDomain);
 
         rawDomain = `
@@ -720,6 +718,8 @@ QUnit.module("Fields", (hooks) => {
             ]
         `;
         await editInput(target, ".o_domain_debug_input", rawDomain);
+        assert.strictEqual(target.querySelector(".o_domain_debug_input").value, rawDomain);
+
         await click(target, ".o_form_button_save");
     });
 


### PR DESCRIPTION
Before this commit, focusing out the debug textarea of the
domain selector was reseting the value.
Now, the value is kept and can be modified.