### PR TITLE
[FIX] hr_expense: add default_partner_bank_id in context

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1196,6 +1196,7 @@ class HrExpenseSheet(models.Model):
             'context': {
                 'active_model': 'account.move',
                 'active_ids': self.account_move_id.ids,
+                'default_partner_bank_id': self.employee_id.bank_account_id.id,
             },
             'target': 'new',
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
The mistake was made in odoo#81904

Instead of 'default_partner_bank_id' we have 'partner_bank_id' in the
context of action_register_payment.

In this commit, we undo that mistake and also backport the change to v15.

task - 2774594





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
