### PR TITLE
[IMP] bus: remove longpolling polls in tests

### DIFF
--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -48,3 +48,9 @@ class BusController(Controller):
         headers = [('Content-Type', 'application/json'),
                    ('Cache-Control', 'no-store')]
         return request.make_response(data, headers)
+
+    @route('/bus/get_model_definitions', methods=['POST'], type='http', auth='user')
+    def get_model_definitions(self, model_names_to_fetch, **kwargs):
+        return request.make_response(json.dumps(
+            request.env['ir.model']._get_model_definitions(json.loads(model_names_to_fetch)),
+        ))

--- a/addons/bus/models/__init__.py
+++ b/addons/bus/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import bus
 from . import bus_presence
+from . import ir_model
 from . import res_users
 from . import res_partner

--- a/addons/bus/models/ir_model.py
+++ b/addons/bus/models/ir_model.py
@@ -1,0 +1,32 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrModel(models.Model):
+    _inherit = 'ir.model'
+
+    def _get_model_definitions(self, model_names_to_fetch):
+        fields_by_model_names = {}
+        for model_name in model_names_to_fetch:
+            model = self.env[model_name]
+            # get fields, relational fields are kept only if the related model is in model_names_to_fetch
+            fields_data_by_fname = {
+                fname: field_data
+                for fname, field_data in model.fields_get(
+                    attributes=['name', 'type', 'relation', 'required', 'readonly', 'selection', 'string']
+                ).items()
+                if not field_data.get('relation') or field_data['relation'] in model_names_to_fetch
+            }
+            for fname, field_data in fields_data_by_fname.items():
+                if fname in model._fields:
+                    inverse_fields = [
+                        field for field in model.pool.field_inverses[model._fields[fname]]
+                        if field.model_name in model_names_to_fetch
+                    ]
+                    if inverse_fields:
+                        field_data['inverse_fname_by_model_name'] = {field.model_name: field.name for field in inverse_fields}
+                    if field_data['type'] == 'many2one_reference':
+                        field_data['model_name_ref_fname'] = model._fields[fname].model_field
+            fields_by_model_names[model_name] = fields_data_by_fname
+        return fields_by_model_names

--- a/addons/bus/static/tests/assets_watchdog_tests.js
+++ b/addons/bus/static/tests/assets_watchdog_tests.js
@@ -3,6 +3,7 @@
 import { busService } from "@bus/services/bus_service";
 import { presenceService } from "@bus/services/presence_service";
 import { multiTabService } from "@bus/multi_tab_service";
+import { getPyEnv } from '@bus/../tests/helpers/mock_python_environment';
 
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
@@ -34,24 +35,10 @@ QUnit.module("Bus Assets WatchDog", (hooks) => {
     QUnit.test("can listen on bus and displays notifications in DOM", async (assert) => {
         assert.expect(4);
 
-        let pollNumber = 0;
-        const mockRPC = async (route, args) => {
-            if (route === "/longpolling/poll") {
-                if (pollNumber > 0) {
-                    return new Promise(() => {}); // let it hang to avoid further calls
-                }
-                pollNumber++;
-                return [{
-                    message: {
-                        type: 'bundle_changed',
-                        payload: { server_version: "NEW_MAJOR_VERSION" },
-                    },
-                }];
-            }
-        };
-
-        await createWebClient({
-            mockRPC,
+        await createWebClient({});
+        const pyEnv = await getPyEnv();
+        pyEnv['bus.bus']._sendone("broadcast", "bundle_changed", {
+            server_version: "NEW_MAJOR_VERSION"
         });
 
         await nextTick();

--- a/addons/bus/static/tests/helpers/mock_python_environment.js
+++ b/addons/bus/static/tests/helpers/mock_python_environment.js
@@ -1,0 +1,209 @@
+/** @odoo-module **/
+
+import { TEST_USER_IDS } from '@bus/../tests/helpers/test_constants';
+
+import { registry } from '@web/core/registry';
+import { registerCleanup } from "@web/../tests/helpers/cleanup";
+import { MockServer } from "@web/../tests/helpers/mock_server";
+import core from 'web.core';
+
+const modelDefinitionsPromise = new Promise(resolve => {
+    QUnit.begin(() => resolve(getModelDefinitions()));
+});
+
+/**
+ * Fetch model definitions from the server then insert fields present in the
+ * `bus.model.definitions` registry. Use `addModelNamesToFetch`/`insertModelFields`
+ * helpers in order to add models to be fetched, default values to the fields,
+ * fields to a model definition.
+ *
+ * @return {Map<string, Object>} A map from model names to model fields definitions.
+ * @see model_definitions_setup.js
+ */
+async function getModelDefinitions() {
+    const modelDefinitionsRegistry = registry.category('bus.model.definitions');
+    const modelNamesToFetch = modelDefinitionsRegistry.get('modelNamesToFetch');
+    const fieldsToInsertRegistry = modelDefinitionsRegistry.category('fieldsToInsert');
+
+    // fetch the model definitions.
+    const formData = new FormData();
+    formData.append('csrf_token', core.csrf_token);
+    formData.append('model_names_to_fetch', JSON.stringify(modelNamesToFetch));
+    const response = await window.fetch('/bus/get_model_definitions', { body: formData, method: 'POST' });
+    if (response.status !== 200) {
+        throw new Error('Error while fetching required models');
+    }
+    const modelDefinitions = new Map(Object.entries(await response.json()));
+
+    for (const [modelName, fields] of modelDefinitions) {
+         // insert fields present in the fieldsToInsert registry : if the field
+         // exists, update its default value according to the one in the
+         // registry; If it does not exist, add it to the model definition.
+        const fieldNamesToFieldToInsert = fieldsToInsertRegistry.category(modelName).getEntries();
+        for (const [fname, fieldToInsert] of fieldNamesToFieldToInsert) {
+            if (fname in fields) {
+                fields[fname].default = fieldToInsert.default;
+            } else {
+                fields[fname] = fieldToInsert;
+            }
+        }
+        // apply default values for date like fields if none was passed.
+        for (const fname in fields) {
+            const field = fields[fname];
+            if (['date', 'datetime'].includes(field.type) && !field.default) {
+                const defaultFieldValue = field.type === 'date'
+                    ? () => moment.utc().format('YYYY-MM-DD')
+                    : () => moment.utc().format("YYYY-MM-DD HH:mm:ss");
+                field.default = defaultFieldValue;
+            } else if (fname === 'active' && !('default' in field)) {
+                // records are active by default.
+                field.default = true;
+            }
+        }
+    }
+    // add models present in the fake models registry to the model definitions.
+    const fakeModels = modelDefinitionsRegistry.category('fakeModels').getEntries();
+    for (const [modelName, fields] of fakeModels) {
+        modelDefinitions.set(modelName, fields);
+    }
+    return modelDefinitions;
+}
+
+let pyEnv;
+/**
+ * Creates an environment that can be used to setup test data as well as
+ * creating data after test start.
+ *
+ * @returns {Object} An environment that can be used to interact with the mock
+ * server (creation, deletion, update of records...)
+ */
+ export async function startServer() {
+    const models = {};
+    const views = {};
+    const modelDefinitions = await modelDefinitionsPromise;
+    const recordsToInsertRegistry = registry.category('bus.model.definitions').category('recordsToInsert');
+    for (const [modelName, fields] of modelDefinitions) {
+        const records = [];
+        if (recordsToInsertRegistry.contains(modelName)) {
+            // prevent tests from mutating the records.
+            records.push(...JSON.parse(JSON.stringify(recordsToInsertRegistry.get(modelName))));
+        }
+        models[modelName] = { fields: { ...fields }, records };
+
+        // generate default views for this model.
+        const viewArchsSubRegistries = registry.category('bus.view.archs').subRegistries;
+        for (const [viewType, archsRegistry] of Object.entries(viewArchsSubRegistries)) {
+            views[`${modelName},false,${viewType}`] =
+                archsRegistry.get(modelName, archsRegistry.get('default'));
+        }
+    }
+    pyEnv = new Proxy(
+        {
+            getData() {
+                return this.mockServer.models;
+            },
+            getViews() {
+                return views;
+            },
+            ...TEST_USER_IDS,
+            get currentPartner() {
+                return this.mockServer.currentPartner;
+            },
+        },
+        {
+            get(target, name) {
+                if (target[name]) {
+                    return target[name];
+                }
+                const modelAPI = {
+                    /**
+                     * Simulate a 'create' operation on a model.
+                     *
+                     * @param {Object[]|Object} values records to be created.
+                     * @returns {integer[]|integer} array of ids if more than one value was passed,
+                     * id of created record otherwise.
+                     */
+                    create(values) {
+                        if (!values) {
+                            return;
+                        }
+                        if (!Array.isArray(values)) {
+                            values = [values];
+                        }
+                        const recordIds = values.map(value => target.mockServer.mockCreate(name, value));
+                        return recordIds.length === 1 ? recordIds[0] : recordIds;
+                    },
+                    /**
+                     * Simulate a 'search' operation on a model.
+                     *
+                     * @param {Array} domain
+                     * @param {Object} context
+                     * @returns {integer[]} array of ids corresponding to the given domain.
+                     */
+                    search(domain, context = {}) {
+                        return target.mockServer.mockSearch(name, [domain], context);
+                    },
+                    /**
+                     * Simulate a `search_count` operation on a model.
+                     *
+                     * @param {Array} domain
+                     * @return {number} count of records matching the given domain.
+                     */
+                    searchCount(domain) {
+                        return this.search(domain).length;
+                    },
+                    /**
+                     * Simulate a 'search_read' operation on a model.
+                     *
+                     * @param {Array} domain
+                     * @param {Object} kwargs
+                     * @returns {Object[]} array of records corresponding to the given domain.
+                     */
+                    searchRead(domain, kwargs = {}) {
+                        return target.mockServer.mockSearchRead(name, [domain], kwargs);
+                    },
+                    /**
+                     * Simulate an 'unlink' operation on a model.
+                     *
+                     * @param {integer[]} ids
+                     * @returns {boolean} mockServer 'unlink' method always returns true.
+                     */
+                    unlink(ids) {
+                        return target.mockServer.mockUnlink(name, [ids]);
+                    },
+                    /**
+                     * Simulate a 'write' operation on a model.
+                     *
+                     * @param {integer[]} ids ids of records to write on.
+                     * @param {Object} values values to write on the records matching given ids.
+                     * @returns {boolean} mockServer 'write' method always returns true.
+                     */
+                    write(ids, values) {
+                        return target.mockServer.mockWrite(name, [ids, values]);
+                    },
+                };
+                if (name === 'bus.bus') {
+                    modelAPI['_sendone'] = target.mockServer._mockBusBus__sendone.bind(target.mockServer);
+                    modelAPI['_sendmany'] = target.mockServer._mockBusBus__sendmany.bind(target.mockServer);
+                }
+                return modelAPI;
+            },
+            set(target, name, value) {
+                return target[name] = value;
+            },
+         },
+    );
+    pyEnv['mockServer'] = new MockServer({ models }, {});
+    await pyEnv['mockServer'].setup();
+    registerCleanup(() => pyEnv = undefined);
+    return pyEnv;
+}
+
+/**
+ *
+ * @returns {Object} An environment that can be used to interact with the mock
+ * server (creation, deletion, update of records...)
+ */
+export function getPyEnv() {
+    return pyEnv || startServer();
+}

--- a/addons/bus/static/tests/helpers/mock_server.js
+++ b/addons/bus/static/tests/helpers/mock_server.js
@@ -1,5 +1,8 @@
 /** @odoo-module **/
 
+import { TEST_USER_IDS } from "@bus/../tests/helpers/test_constants";
+import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
+
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 import { makeDeferred } from "@web/../tests/helpers/utils";
@@ -7,8 +10,19 @@ import { makeDeferred } from "@web/../tests/helpers/utils";
 patch(MockServer.prototype, 'bus', {
     init() {
         this._super(...arguments);
+        Object.assign(this, TEST_USER_IDS);
         this.pendingLongpollingPromise = null;
         this.notificationsToBeResolved = [];
+    },
+
+    /**
+     * @override
+     */
+    async setup() {
+        this.pyEnv = await getPyEnv();
+        // link the pyEnv to the actual mockServer after execution of
+        // createWebClient.
+        this.pyEnv.mockServer = this;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/bus/static/tests/helpers/model_definitions_helpers.js
+++ b/addons/bus/static/tests/helpers/model_definitions_helpers.js
@@ -2,7 +2,7 @@
 
 import { registry } from '@web/core/registry';
 
-const modelDefinitionsRegistry = registry.category('mail.model.definitions');
+const modelDefinitionsRegistry = registry.category('bus.model.definitions');
 const customModelFieldsRegistry = modelDefinitionsRegistry.category('fieldsToInsert');
 const recordsToInsertRegistry = modelDefinitionsRegistry.category('recordsToInsert');
 const fakeModelsRegistry = modelDefinitionsRegistry.category('fakeModels');

--- a/addons/bus/static/tests/helpers/model_definitions_setup.js
+++ b/addons/bus/static/tests/helpers/model_definitions_setup.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import { TEST_USER_IDS } from '@mail/../tests/helpers/test_utils';
+import { TEST_USER_IDS } from '@bus/../tests/helpers/test_constants';
 import {
     addFakeModel,
     addModelNamesToFetch,
     insertModelFields,
     insertRecords
-} from '@mail/../tests/helpers/model_definitions_helpers';
+} from '@bus/../tests/helpers/model_definitions_helpers';
 
 //--------------------------------------------------------------------------
 // Models

--- a/addons/bus/static/tests/helpers/test_constants.js
+++ b/addons/bus/static/tests/helpers/test_constants.js
@@ -1,0 +1,9 @@
+/** @odoo-module **/
+
+export const TEST_USER_IDS = {
+    partnerRootId: 2,
+    currentPartnerId: 3,
+    currentUserId: 2,
+    publicPartnerId: 4,
+    publicUserId: 3,
+};

--- a/addons/bus/static/tests/helpers/view_definitions_setup.js
+++ b/addons/bus/static/tests/helpers/view_definitions_setup.js
@@ -2,7 +2,7 @@
 
 import { registry } from '@web/core/registry';
 
-const viewArchsRegistry = registry.category('mail.view.archs');
+const viewArchsRegistry = registry.category('bus.view.archs');
 const activityArchsRegistry = viewArchsRegistry.category('activity');
 const formArchsRegistry = viewArchsRegistry.category('form');
 const kanbanArchsRegistry = viewArchsRegistry.category('kanban');

--- a/addons/calendar/static/tests/calendar_notification_tests.js
+++ b/addons/calendar/static/tests/calendar_notification_tests.js
@@ -3,6 +3,7 @@
 import { busService } from "@bus/services/bus_service";
 import { presenceService } from "@bus/services/presence_service";
 import { multiTabService } from "@bus/multi_tab_service";
+import { getPyEnv } from '@bus/../tests/helpers/mock_python_environment';
 
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { calendarNotificationService } from "@calendar/js/services/calendar_notification_service";
@@ -13,7 +14,6 @@ import { registry } from "@web/core/registry";
 const serviceRegistry = registry.category("services");
 
 QUnit.module("Calendar Notification", (hooks) => {
-    let legacyServicesRegistry;
     let target;
     hooks.beforeEach(() => {
         target = getFixture();
@@ -34,30 +34,7 @@ QUnit.module("Calendar Notification", (hooks) => {
         async (assert) => {
             assert.expect(5);
 
-            let pollNumber = 0;
             const mockRPC = (route, args) => {
-                if (route === "/longpolling/poll") {
-                    if (pollNumber > 0) {
-                        return new Promise(() => {}); // let it hang to avoid further calls
-                    }
-                    pollNumber++;
-                    return Promise.resolve([
-                        {
-                            id: "prout",
-                            message: {
-                                type: "calendar.alarm",
-                                payload: [{
-                                    alarm_id: 1,
-                                    event_id: 2,
-                                    title: "Meeting",
-                                    message: "Very old meeting message",
-                                    timer: 20 * 60,
-                                    notify_at: "1978-04-14 12:45:00",
-                                }],
-                            },
-                        },
-                    ]);
-                }
                 if (route === "/calendar/notify") {
                     return Promise.resolve([]);
                 }
@@ -66,12 +43,16 @@ QUnit.module("Calendar Notification", (hooks) => {
                     return Promise.resolve(true);
                 }
             };
-
-            await createWebClient({
-                legacyParams: { serviceRegistry: legacyServicesRegistry },
-                mockRPC,
-            });
-
+            await createWebClient({ mockRPC });
+            const pyEnv = await getPyEnv();
+            pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "calendar.alarm", [{
+                "alarm_id": 1,
+                "event_id": 2,
+                "title": "Meeting",
+                "message": "Very old meeting message",
+                "timer": 20 * 60,
+                "notify_at": "1978-04-14 12:45:00",
+            }]);
             await nextTick();
 
             assert.containsOnce(target, ".o_notification_body");
@@ -92,30 +73,7 @@ QUnit.module("Calendar Notification", (hooks) => {
         async (assert) => {
             assert.expect(5);
 
-            let pollNumber = 0;
             const mockRPC = (route, args) => {
-                if (route === "/longpolling/poll") {
-                    if (pollNumber > 0) {
-                        return new Promise(() => {}); // let it hang to avoid further calls
-                    }
-                    pollNumber++;
-                    return Promise.resolve([
-                        {
-                            id: "prout",
-                            message: {
-                                type: "calendar.alarm",
-                                payload: [{
-                                    alarm_id: 1,
-                                    event_id: 2,
-                                    title: "Meeting",
-                                    message: "Very old meeting message",
-                                    timer: 20 * 60,
-                                    notify_at: "1978-04-14 12:45:00",
-                                }],
-                            },
-                        },
-                    ]);
-                }
                 if (route === "/calendar/notify") {
                     return Promise.resolve([]);
                 }
@@ -137,11 +95,16 @@ QUnit.module("Calendar Notification", (hooks) => {
             };
             serviceRegistry.add("action", fakeActionService, { force: true });
 
-            await createWebClient({
-                legacyParams: { serviceRegistry: legacyServicesRegistry },
-                mockRPC,
-            });
-
+            await createWebClient({ mockRPC });
+            const pyEnv = await getPyEnv();
+            pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "calendar.alarm", [{
+                "alarm_id": 1,
+                "event_id": 2,
+                "title": "Meeting",
+                "message": "Very old meeting message",
+                "timer": 20 * 60,
+                "notify_at": "1978-04-14 12:45:00",
+            }]);
             await nextTick();
 
             assert.containsOnce(target, ".o_notification_body");
@@ -162,30 +125,7 @@ QUnit.module("Calendar Notification", (hooks) => {
         async (assert) => {
             assert.expect(4);
 
-            let pollNumber = 0;
             const mockRPC = (route, args) => {
-                if (route === "/longpolling/poll") {
-                    if (pollNumber > 0) {
-                        return new Promise(() => {}); // let it hang to avoid further calls
-                    }
-                    pollNumber++;
-                    return Promise.resolve([
-                        {
-                            message: {
-                                id: "prout",
-                                type: "calendar.alarm",
-                                payload: [{
-                                    alarm_id: 1,
-                                    event_id: 2,
-                                    title: "Meeting",
-                                    message: "Very old meeting message",
-                                    timer: 20 * 60,
-                                    notify_at: "1978-04-14 12:45:00",
-                                }],
-                            },
-                        },
-                    ]);
-                }
                 if (route === "/calendar/notify") {
                     return Promise.resolve([]);
                 }
@@ -195,11 +135,16 @@ QUnit.module("Calendar Notification", (hooks) => {
                 }
             };
 
-            await createWebClient({
-                legacyParams: { serviceRegistry: legacyServicesRegistry },
-                mockRPC,
-            });
-
+            await createWebClient({ mockRPC });
+            const pyEnv = await getPyEnv();
+            pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "calendar.alarm", [{
+                "alarm_id": 1,
+                "event_id": 2,
+                "title": "Meeting",
+                "message": "Very old meeting message",
+                "timer": 20 * 60,
+                "notify_at": "1978-04-14 12:45:00",
+            }]);
             await nextTick();
 
             assert.containsOnce(target, ".o_notification_body");

--- a/addons/calendar/static/tests/helpers/model_definitions_setup.js
+++ b/addons/calendar/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['calendar.event', 'calendar.attendee']);

--- a/addons/calendar/static/tests/helpers/view_definitions_setup.js
+++ b/addons/calendar/static/tests/helpers/view_definitions_setup.js
@@ -2,7 +2,7 @@
 
 import { registry } from '@web/core/registry';
 
-const viewArchsRegistry = registry.category('mail.view.archs');
+const viewArchsRegistry = registry.category('bus.view.archs');
 const calendarArchsRegistry = viewArchsRegistry.category('calendar');
 
 calendarArchsRegistry.add('default', '<calendar date_start="start"/>');

--- a/addons/hr/static/tests/helpers/model_definitions_setup.js
+++ b/addons/hr/static/tests/helpers/model_definitions_setup.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { addFakeModel, addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addFakeModel, addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['hr.employee.public']);
 

--- a/addons/hr_holidays/static/tests/helpers/model_definitions_setup.js
+++ b/addons/hr_holidays/static/tests/helpers/model_definitions_setup.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insertModelFields } from '@mail/../tests/helpers/model_definitions_helpers';
+import { insertModelFields } from '@bus/../tests/helpers/model_definitions_helpers';
 
 insertModelFields('res.partner', {
     out_of_office_date_end: { type: 'date' },

--- a/addons/im_livechat/static/tests/helpers/model_definitions_setup.js
+++ b/addons/im_livechat/static/tests/helpers/model_definitions_setup.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch, insertModelFields } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch, insertModelFields } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['im_livechat.channel']);
 insertModelFields('res.users.settings', {

--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -203,12 +203,6 @@ class DiscussController(http.Controller):
     def mail_load_message_failures(self, **kwargs):
         return request.env.user.partner_id._message_fetch_failed()
 
-    @http.route('/mail/get_model_definitions', methods=['POST'], type='http', auth='user')
-    def get_model_definitions(self, model_names_to_fetch, **kwargs):
-        return request.make_response(json.dumps(
-            request.env['ir.model']._get_model_definitions(json.loads(model_names_to_fetch)),
-        ))
-
     # --------------------------------------------------------------------------
     # Mailbox
     # --------------------------------------------------------------------------

--- a/addons/mail/models/ir_model.py
+++ b/addons/mail/models/ir_model.py
@@ -99,29 +99,11 @@ class IrModel(models.Model):
         return model_class
 
     def _get_model_definitions(self, model_names_to_fetch):
-        fields_by_model_names = {}
-        for model_name in model_names_to_fetch:
+        fields_by_model_names = super()._get_model_definitions(model_names_to_fetch)
+        for model_name, field_by_fname in fields_by_model_names.items():
             model = self.env[model_name]
-            # get fields, relational fields are kept only if the related model is in model_names_to_fetch
-            fields_data_by_fname = {
-                fname: field_data
-                for fname, field_data in model.fields_get(
-                    attributes=['name', 'type', 'relation', 'required', 'readonly', 'selection', 'string']
-                ).items()
-                if not field_data.get('relation') or field_data['relation'] in model_names_to_fetch
-            }
             tracked_field_names = model._track_get_fields() if 'mail.thread' in model._inherit else []
-            for fname, field_data in fields_data_by_fname.items():
+            for fname, field in field_by_fname.items():
                 if fname in tracked_field_names:
-                    field_data['tracking'] = True
-                if fname in model._fields:
-                    inverse_fields = [
-                        field for field in model.pool.field_inverses[model._fields[fname]]
-                        if field.model_name in model_names_to_fetch
-                    ]
-                    if inverse_fields:
-                        field_data['inverse_fname_by_model_name'] = {field.model_name: field.name for field in inverse_fields}
-                    if field_data['type'] == 'many2one_reference':
-                        field_data['model_name_ref_fname'] = model._fields[fname].model_field
-            fields_by_model_names[model_name] = fields_data_by_fname
+                    field['tracking'] = True
         return fields_by_model_names

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { getPyEnv, TEST_USER_IDS } from '@mail/../tests/helpers/test_utils';
+// ensure bus mock server is loaded first.
+import '@bus/../tests/helpers/mock_server';
 
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
@@ -11,12 +12,10 @@ import { date_to_str, datetime_to_str } from 'web.time';
 patch(MockServer.prototype, 'mail', {
     init({ models }) {
         this._super(...arguments);
-        Object.assign(this, TEST_USER_IDS);
 
         if (this.currentPartnerId && models && 'res.partner' in models) {
             this.currentPartner = this.getRecords('res.partner', [['id', '=', this.currentPartnerId]])[0];
         }
-        MockServer.currentMockServer = this;
         // creation of the ir.model.fields records, required for tracked fields
         for (const modelName in models) {
             const fieldNamesToFields = models[modelName].fields;
@@ -26,12 +25,6 @@ patch(MockServer.prototype, 'mail', {
                 }
             }
         }
-    },
-    /**
-     * @override
-     */
-    async setup() {
-        this.pyEnv = await getPyEnv();
     },
     /**
      * @override

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -1,23 +1,18 @@
 /** @odoo-module **/
 
+import { getPyEnv, startServer } from '@bus/../tests/helpers/mock_python_environment';
+
 import { nextTick } from '@mail/utils/utils';
 import { getAdvanceTime } from '@mail/../tests/helpers/time_control';
 import { getWebClientReady } from '@mail/../tests/helpers/webclient_setup';
 
-import { registry } from '@web/core/registry';
 import { wowlServicesSymbol } from "@web/legacy/utils";
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
-import { MockServer } from "@web/../tests/helpers/mock_server";
 import { getFixture, makeDeferred, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { doAction, getActionManagerServerData } from "@web/../tests/webclient/helpers";
 
-import core from 'web.core';
-
 const { App, EventBus } = owl;
 const { afterNextRender } = App;
-const modelDefinitionsPromise = new Promise(resolve => {
-    QUnit.begin(() => resolve(getModelDefinitions()));
-});
 
 //------------------------------------------------------------------------------
 // Private
@@ -53,215 +48,6 @@ function nextAnimationFrame() {
     return new Promise(function (resolve) {
         setTimeout(() => requestAnimationFrame(() => resolve()));
     });
-}
-
-//------------------------------------------------------------------------------
-// Model definitions setup
-//------------------------------------------------------------------------------
-
-export const TEST_USER_IDS = {
-    partnerRootId: 2,
-    currentPartnerId: 3,
-    currentUserId: 2,
-    publicPartnerId: 4,
-    publicUserId: 3,
-};
-
-/**
- * Fetch model definitions from the server then insert fields present in the
- * `mail.model.definitions` registry. Use `addModelNamesToFetch`/`insertModelFields`
- * helpers in order to add models to be fetched, default values to the fields,
- * fields to a model definition.
- *
- * @return {Map<string, Object>} A map from model names to model fields definitions.
- * @see model_definitions_setup.js
- */
-async function getModelDefinitions() {
-    const modelDefinitionsRegistry = registry.category('mail.model.definitions');
-    const modelNamesToFetch = modelDefinitionsRegistry.get('modelNamesToFetch');
-    const fieldsToInsertRegistry = modelDefinitionsRegistry.category('fieldsToInsert');
-
-    // fetch the model definitions.
-    const formData = new FormData();
-    formData.append('csrf_token', core.csrf_token);
-    formData.append('model_names_to_fetch', JSON.stringify(modelNamesToFetch));
-    const response = await window.fetch('/mail/get_model_definitions', { body: formData, method: 'POST' });
-    if (response.status !== 200) {
-        throw new Error('Error while fetching required models');
-    }
-    const modelDefinitions = new Map(Object.entries(await response.json()));
-
-    for (const [modelName, fields] of modelDefinitions) {
-         // insert fields present in the fieldsToInsert registry : if the field
-         // exists, update its default value according to the one in the
-         // registry; If it does not exist, add it to the model definition.
-        const fieldNamesToFieldToInsert = fieldsToInsertRegistry.category(modelName).getEntries();
-        for (const [fname, fieldToInsert] of fieldNamesToFieldToInsert) {
-            if (fname in fields) {
-                fields[fname].default = fieldToInsert.default;
-            } else {
-                fields[fname] = fieldToInsert;
-            }
-        }
-        // apply default values for date like fields if none was passed.
-        for (const fname in fields) {
-            const field = fields[fname];
-            if (['date', 'datetime'].includes(field.type) && !field.default) {
-                const defaultFieldValue = field.type === 'date'
-                    ? () => moment.utc().format('YYYY-MM-DD')
-                    : () => moment.utc().format("YYYY-MM-DD HH:mm:ss");
-                field.default = defaultFieldValue;
-            } else if (fname === 'active' && !('default' in field)) {
-                // records are active by default.
-                field.default = true;
-            }
-        }
-    }
-    // add models present in the fake models registry to the model definitions.
-    const fakeModels = modelDefinitionsRegistry.category('fakeModels').getEntries();
-    for (const [modelName, fields] of fakeModels) {
-        modelDefinitions.set(modelName, fields);
-    }
-    return modelDefinitions;
-}
-
-let pyEnv;
-/**
- * Creates an environment that can be used to setup test data as well as
- * creating data after test start.
- *
- * @returns {Object} An environment that can be used to interact with the mock
- * server (creation, deletion, update of records...)
- */
- export async function startServer() {
-    const models = {};
-    const views = {};
-    const modelDefinitions = await modelDefinitionsPromise;
-    const recordsToInsertRegistry = registry.category('mail.model.definitions').category('recordsToInsert');
-    for (const [modelName, fields] of modelDefinitions) {
-        const records = [];
-        if (recordsToInsertRegistry.contains(modelName)) {
-            // prevent tests from mutating the records.
-            records.push(...JSON.parse(JSON.stringify(recordsToInsertRegistry.get(modelName))));
-        }
-        models[modelName] = { fields: { ...fields }, records };
-
-        // generate default views for this model.
-        const viewArchsSubRegistries = registry.category('mail.view.archs').subRegistries;
-        for (const [viewType, archsRegistry] of Object.entries(viewArchsSubRegistries)) {
-            views[`${modelName},false,${viewType}`] =
-                archsRegistry.get(modelName, archsRegistry.get('default'));
-        }
-    }
-    pyEnv = new Proxy(
-        {
-            getData() {
-                return this.mockServer.models;
-            },
-            getViews() {
-                return views;
-            },
-            ...TEST_USER_IDS,
-            get currentPartner() {
-                return this.mockServer.currentPartner;
-            },
-        },
-        {
-            get(target, name) {
-                if (target[name]) {
-                    return target[name];
-                }
-                const modelAPI = {
-                    /**
-                     * Simulate a 'create' operation on a model.
-                     *
-                     * @param {Object[]|Object} values records to be created.
-                     * @returns {integer[]|integer} array of ids if more than one value was passed,
-                     * id of created record otherwise.
-                     */
-                    create(values) {
-                        if (!values) {
-                            return;
-                        }
-                        if (!Array.isArray(values)) {
-                            values = [values];
-                        }
-                        const recordIds = values.map(value => target.mockServer.mockCreate(name, value));
-                        return recordIds.length === 1 ? recordIds[0] : recordIds;
-                    },
-                    /**
-                     * Simulate a 'search' operation on a model.
-                     *
-                     * @param {Array} domain
-                     * @param {Object} context
-                     * @returns {integer[]} array of ids corresponding to the given domain.
-                     */
-                    search(domain, context = {}) {
-                        return target.mockServer.mockSearch(name, [domain], context);
-                    },
-                    /**
-                     * Simulate a `search_count` operation on a model.
-                     *
-                     * @param {Array} domain
-                     * @return {number} count of records matching the given domain.
-                     */
-                    searchCount(domain) {
-                        return this.search(domain).length;
-                    },
-                    /**
-                     * Simulate a 'search_read' operation on a model.
-                     *
-                     * @param {Array} domain
-                     * @param {Object} kwargs
-                     * @returns {Object[]} array of records corresponding to the given domain.
-                     */
-                    searchRead(domain, kwargs = {}) {
-                        return target.mockServer.mockSearchRead(name, [domain], kwargs);
-                    },
-                    /**
-                     * Simulate an 'unlink' operation on a model.
-                     *
-                     * @param {integer[]} ids
-                     * @returns {boolean} mockServer 'unlink' method always returns true.
-                     */
-                    unlink(ids) {
-                        return target.mockServer.mockUnlink(name, [ids]);
-                    },
-                    /**
-                     * Simulate a 'write' operation on a model.
-                     *
-                     * @param {integer[]} ids ids of records to write on.
-                     * @param {Object} values values to write on the records matching given ids.
-                     * @returns {boolean} mockServer 'write' method always returns true.
-                     */
-                    write(ids, values) {
-                        return target.mockServer.mockWrite(name, [ids, values]);
-                    },
-                };
-                if (name === 'bus.bus') {
-                    modelAPI['_sendone'] = target.mockServer._mockBusBus__sendone.bind(target.mockServer);
-                    modelAPI['_sendmany'] = target.mockServer._mockBusBus__sendmany.bind(target.mockServer);
-                }
-                return modelAPI;
-            },
-            set(target, name, value) {
-                return target[name] = value;
-            },
-         },
-    );
-    pyEnv['mockServer'] = new MockServer({ models }, {});
-    await pyEnv['mockServer'].setup();
-    registerCleanup(() => pyEnv = undefined);
-    return pyEnv;
-}
-
-/**
- *
- * @returns {Object} An environment that can be used to interact with the mock
- * server (creation, deletion, update of records...)
- */
-export function getPyEnv() {
-    return pyEnv || startServer();
 }
 
 //------------------------------------------------------------------------------
@@ -460,7 +246,7 @@ async function start(param0 = {}) {
         waitUntilEventPromise = Promise.resolve();
     }
 
-    pyEnv = await getPyEnv();
+    const pyEnv = await getPyEnv();
     param0.serverData = param0.serverData || getActionManagerServerData();
     param0.serverData.models = { ...pyEnv.getData(), ...param0.serverData.models };
     param0.serverData.views = { ...pyEnv.getViews(), ...param0.serverData.views };
@@ -482,8 +268,6 @@ async function start(param0 = {}) {
         await webClient.env.services.messaging.modelManager.messagingCreatedPromise;
         await webClient.env.services.messaging.modelManager.messagingInitializedPromise;
     }
-    // link the pyEnv to the actual mockServer after execution of createWebClient.
-    pyEnv.mockServer = MockServer.currentMockServer;
     const openView = async (action, options) => {
         action['type'] = action['type'] || 'ir.actions.act_window';
         await afterNextRender(() => doAction(webClient, action, { props: options }));
@@ -603,4 +387,5 @@ export {
     nextTick,
     pasteFiles,
     start,
+    startServer,
 };

--- a/addons/note/static/tests/helpers/model_definitions_setup.js
+++ b/addons/note/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['note.note']);

--- a/addons/rating/static/tests/helpers/model_definitions_setup.js
+++ b/addons/rating/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['rating.rating']);

--- a/addons/snailmail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/snailmail/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['snailmail.letter']);

--- a/addons/test_mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/test_mail/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['mail.test.track.all', 'mail.test.activity']);

--- a/addons/test_mail_full/static/tests/helpers/model_definitions_setup.js
+++ b/addons/test_mail_full/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['mail.test.rating']);

--- a/addons/website_livechat/static/tests/helpers/model_definitions_setup.js
+++ b/addons/website_livechat/static/tests/helpers/model_definitions_setup.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch, insertModelFields } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch, insertModelFields } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['website.visitor']);
 insertModelFields('mail.channel', {

--- a/addons/website_slides/static/tests/helpers/model_definitions_setup.js
+++ b/addons/website_slides/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['slide.channel']);

--- a/addons/website_slides/static/tests/helpers/view_definitions_setup.js
+++ b/addons/website_slides/static/tests/helpers/view_definitions_setup.js
@@ -2,7 +2,7 @@
 
 import { registry } from '@web/core/registry';
 
-const viewArchsRegistry = registry.category('mail.view.archs');
+const viewArchsRegistry = registry.category('bus.view.archs');
 
 viewArchsRegistry.category('form').add(
     'slide.channel',


### PR DESCRIPTION
[IMP] bus: remove longpolling polls in tests

In order to prepare the ground/reduce the noise in the PR
introducing the websockets in Odoo, the mocks of the longpolling
route in tests is replaced by calls to sendone/sendmany.
This will allow to keep the same code while changing the underlying
technology.

task-2053917

enterprise: https://github.com/odoo/enterprise/pull/30244