### PR TITLE
[IMP] hr(_holidays): improve department filters

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -10,7 +10,6 @@
                     <field name="name" string="Employee" filter_domain="['|', ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
                     <field name="category_ids" groups="hr.group_hr_user"/>
                     <field name="job_id"/>
-                    <field name="department_id" string="Department"/>
                     <field name="parent_id" string="Manager"/>
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]"/>

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -941,7 +941,7 @@ class HrExpenseSheet(models.Model):
         for sheet in self:
             sheet.expense_number = result.get(sheet.id, 0)
 
-    @api.depends('employee_id')
+    @api.depends('employee_id', 'employee_id.department_id')
     def _compute_from_employee_id(self):
         for sheet in self:
             sheet.address_id = sheet.employee_id.sudo().address_home_id

--- a/addons/hr_holidays/models/hr_department.py
+++ b/addons/hr_holidays/models/hr_department.py
@@ -46,3 +46,27 @@ class Department(models.Model):
             department.leave_to_approve_count = res_leave.get(department.id, 0)
             department.allocation_to_approve_count = res_allocation.get(department.id, 0)
             department.absence_of_today = res_absence.get(department.id, 0)
+
+    def _get_action_context(self):
+        return {
+            'search_default_approve': 1,
+            'search_default_active_employee': 2,
+            'search_default_department_id': self.id,
+            'default_department_id': self.id,
+        }
+
+    def action_open_leave_department(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("hr_holidays.hr_leave_action_action_approve_department")
+        action['context'] = {
+            **self._get_action_context(),
+            'search_default_active_time_off': 3,
+            'hide_employee_name': 1,
+            'holiday_status_name_get': False
+        }
+        return action
+
+    def action_open_allocation_department(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("hr_holidays.hr_leave_allocation_action_approve_department")
+        action['context'] = self._get_action_context()
+        action['context']['search_default_second_approval'] = 3
+        return action

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -31,7 +31,6 @@
                 <separator/>
                 <filter string="My Allocations" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <separator/>
-                <field name="department_id" operator="child_of"/>
                 <field name="holiday_status_id"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                     domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -41,7 +41,6 @@
         <field name="arch" type="xml">
             <search string="Search Time Off">
                 <field name="employee_id"/>
-                <field name="department_id" operator="child_of"/>
                 <field name="holiday_status_id"/>
                 <field name="name"/>
                 <filter domain="[('state','in',('confirm','validate1'))]" string="To Approve" name="approve"/>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -7,7 +7,7 @@
        <field name="view_mode">kanban,tree,form</field>
        <field name="context">{
            'search_default_is_absent': 1,
-           'searchpanel_default_department_id': active_id,
+           'search_default_department_id': active_id,
            'default_department_id': active_id}
        </field>
        <field name="search_view_id" ref="hr.view_employee_filter"/>
@@ -33,14 +33,14 @@
                     <t groups="hr_holidays.group_hr_holidays_user">
                         <div t-if="record.leave_to_approve_count.raw_value > 0" class="row ml16">
                             <div class="col">
-                                <a name="%(hr_leave_action_action_approve_department)d" type="action">
+                                <a name="action_open_leave_department" type="object">
                                     <field name="leave_to_approve_count"/> Time Off Requests
                                 </a>
                             </div>
                         </div>
                         <div t-if="record.allocation_to_approve_count.raw_value > 0" class="row ml16">
                             <div class="col">
-                                <a name="%(hr_leave_allocation_action_approve_department)d" type="action">
+                                <a name="action_open_allocation_department" type="object">
                                     <field name="allocation_to_approve_count"/> Allocation Requests
                                 </a>
                             </div>


### PR DESCRIPTION
In the Employees app, when using the department kanban view and clicking on the
Time Off Requests or Allocation Requests, it leads to a tree view but the department
from which the user comes from is not part of the filters.

This commit adds the department in the filters of the tree view.

Due to the search panel being present in the tree view, the department filter is removed from the list of
filters to avoid a duplication of the filters in the search panel.

task-2939207

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
