### PR TITLE
[FIX] web: one2many in kanban can remove a new record

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -13,6 +13,9 @@
                     <button class="btn btn-primary o_form_button_save" t-on-click="save" data-hotkey="c">Save &amp; Close</button>
                     <button class="btn btn-primary o_form_button_save_new" t-on-click="saveAndNew" data-hotkey="n">Save &amp; New</button>
                     <button class="btn btn-secondary o_form_button_cancel" t-on-click="discard" data-hotkey="j">Discard</button>
+                    <t t-if="props.delete">
+                        <button class="btn btn-secondary o_btn_remove" t-on-click="remove" data-hotkey="k">Remove</button>
+                    </t>
                 </t>
                 <t t-elif="record.isInEdition">
                     <button class="btn btn-primary o_form_button_save" t-on-click="save" data-hotkey="c">Save</button>


### PR DESCRIPTION
Have a one2many in a form view. It displays its records with a kanban.
Add a record, now click on that new record.

Before this commit, there was not "Remove" button, preventing to effectively
remove a new (virtual at this point) record from the one2many.

Aftet this commit, there is a remove button that effectively removes the
record from the one2many.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
