### PR TITLE
[FIX] account: search's `filter_domain` in the currencies list view 

### DIFF
--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -66,13 +66,13 @@
             <field name="model">res.currency</field>
             <field name="arch" type="xml">
                 <search string="Currencies">
-                    <field name="name" string="Currency" filter_domain="('|','|','|','|',
+                    <field name="name" string="Currency" filter_domain="['|','|','|','|',
                                                                         ('name', 'ilike', self),
                                                                         ('full_name', 'ilike', self),
                                                                         ('symbol', 'ilike', self),
                                                                         ('currency_unit_label', 'ilike', self),
                                                                         ('currency_subunit_label', 'ilike', self),
-                                                                        )"/>
+                                                                        ]"/>
                     <filter name="active" string="Active" domain="[('active','=',True)]" help="Show active currencies"/>
                     <filter name="inactive" string="Inactive" domain="[('active','=',False)]" help="Show inactive currencies"/>
                 </search>


### PR DESCRIPTION
To reproduce the bug:
- Install the Invoicing/Accounting app
- Go to the Settings
- Go to the Currencies
- Search for a currency (e.g. Euro)
- An exception is raised (InvalidDomainError: Invalid domain AST)

This error is thrown because the expected type of the `filter_domain` is a list, and not a tuple.

This PR fixes this problem by converting the `filter_domain` into a list.

task-id 2948653