### PR TITLE
[FIX] web: field help attribute in xml has precedence

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -202,6 +202,7 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         context: node.getAttribute("context") || "{}",
         domain: node.getAttribute("domain") || "[]",
         string: node.getAttribute("string") || field.string,
+        help: node.getAttribute("help"),
         widget,
         modifiers: JSON.parse(node.getAttribute("modifiers") || "{}"),
         onChange: archParseBoolean(node.getAttribute("on_change")),

--- a/addons/web/static/src/views/fields/field_tooltip.js
+++ b/addons/web/static/src/views/fields/field_tooltip.js
@@ -20,7 +20,7 @@ export function getTooltipInfo(params) {
         field: {
             label: params.field.string,
             name: params.field.name,
-            help: params.help || params.field.help,
+            help: params.fieldInfo.help !== null ? params.fieldInfo.help : params.field.help,
             type: params.field.type,
             widget: params.fieldInfo.widget,
             widgetDescription,

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -11544,4 +11544,21 @@ QUnit.module("Views", (hooks) => {
             assert.containsOnce(target, ".o_form_button_cancel");
         }
     );
+
+    QUnit.test("help on field as precedence over field's declaration -- form", async (assert) => {
+        serverData.models.partner.fields.foo.help = "pythonHelp";
+        patchWithCleanup(odoo, { debug: "1" });
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            arch: `<form><sheet><field name="foo" help="xmlHelp" /></sheet></form>`,
+            serverData,
+        });
+
+        assert.strictEqual(
+            JSON.parse(target.querySelector(".o_field_widget").dataset.tooltipInfo).field.help,
+            "xmlHelp"
+        );
+    });
 });


### PR DESCRIPTION
Have a field declared in python with a "help" property.
Put that field in a view with a "help" attribute.

Before this commit, the xml declaration was not taken into account.

After this commit, xml declaration has precedence over the python one.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
