### PR TITLE
[FIX] mail: fix compute audio triggered on each qunit test

### DIFF
--- a/addons/mail/static/src/models/user_notification_manager.js
+++ b/addons/mail/static/src/models/user_notification_manager.js
@@ -2,6 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
+import { clear } from "@mail/model/model_field_command";
 
 import { url } from '@web/core/utils/urls';
 
@@ -48,6 +49,9 @@ registerModel({
          * @returns {HTMLAudioElement}
          */
         _computeAudio() {
+            if (!this.canPlayAudio) {
+                return clear();
+            }
             const audioElement = new Audio();
             audioElement.src = audioElement.canPlayType("audio/ogg; codecs=vorbis")
                 ? url('/mail/static/src/audio/ting.ogg')


### PR DESCRIPTION
During qunit test, the audio notification is never used but the audio
element is still computed. This leads to unnecessary get requests
being triggered on the server. This PR fixes this issue.

