### PR TITLE
[FIX] stock: Customer Delivery email incorrectly sent to suppliers

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -845,7 +845,12 @@ class Picking(models.Model):
         return True
 
     def _send_confirmation_email(self):
-        for stock_pick in self.filtered(lambda p: p.company_id.stock_move_email_validation and p.picking_type_id.code == 'outgoing'):
+        to_email = self.filtered(
+            lambda p: p.company_id.stock_move_email_validation
+            and p.picking_type_id.code == 'outgoing'
+            and p.location_dest_id.usage == 'customer'
+        )
+        for stock_pick in to_email:
             delivery_template_id = stock_pick.company_id.stock_mail_confirmation_template_id.id
             stock_pick.with_context(force_send=True).message_post_with_template(delivery_template_id, email_layout_xmlid='mail.mail_notification_light')
 


### PR DESCRIPTION
Impacted versions:

- 15.0

Steps to reproduce:

1. On Settings / Inventory / Shipping section: enable "Email Confirmation" option
2. On Purchase app: create a PO and Receive it
3. On the PT Receipt Order, create a return and Validate it

Current behavior:

- The Delivery Order shipped email is sent to the supplier.

Expected behavior:

- No Delivery Order shipped email sent to the supplier. It should be sent to customers only.

Support ticket number submitted via odoo.com/help:

- Ticket #2948705 submitted

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
