### PR TITLE
[FIX] web: parseMonetary with NBSP as a thousands separator and no currency

### DIFF
--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -566,6 +566,9 @@ function parseMonetary(value, field, options) {
         }
         currency = session.get_currency(currency_id);
     }
+    if (!currency) {
+        return parseFloat(value);
+    }
     if (!value.includes(currency.symbol)) {
         throw new Error(_.str.sprintf(core._t("'%s' is not a correct monetary field"), value));
     }

--- a/addons/web/static/tests/fields/field_utils_tests.js
+++ b/addons/web/static/tests/fields/field_utils_tests.js
@@ -243,7 +243,7 @@ QUnit.test('parse integer', function(assert) {
 });
 
 QUnit.test('parse monetary', function(assert) {
-    assert.expect(13);
+    assert.expect(15);
     var originalCurrencies = session.currencies;
     const originalParameters = _.clone(core._t.database.parameters);
     session.currencies = {
@@ -275,11 +275,13 @@ QUnit.test('parse monetary', function(assert) {
     const nbsp = '\u00a0';
     _.extend(core._t.database.parameters, {
         grouping: [3, 0],
-        decimal_point: ',',
+        decimal_point: '.',
         thousands_sep: nbsp,
     });
     assert.strictEqual(fieldUtils.parse.monetary(`1${nbsp}000.00${nbsp}€`, {}, {currency_id: 1}), 1000);
     assert.strictEqual(fieldUtils.parse.monetary(`$${nbsp}1${nbsp}000.00`, {}, {currency_id: 3}), 1000);
+    assert.strictEqual(fieldUtils.parse.monetary(`1${nbsp}000.00`), 1000);
+    assert.strictEqual(fieldUtils.parse.monetary(`1${nbsp}000${nbsp}000.00`), 1000000);
 
     session.currencies = originalCurrencies;
     core._t.database.parameters = originalParameters;


### PR DESCRIPTION
Steps to reproduce:

  - Switch language to french
  - Refresh the page
  - Create a new payment
  - Select a partner
  - Enter an amount of 100000,00
  - Save the record
  → The following field is incorrect: amount

Cause of the issue:

 `parseMonetary` wrongly assumed that a currency was always passed in
 the parameters

opw-2937403
