### PR TITLE
[FIX] l10n_in_edi: submission of e-invoice to the portal

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -408,15 +408,23 @@ class AccountEdiFormat(models.Model):
         if is_overseas:
             json_payload.update({
                 "ExpDtls": {
-                    "ShipBNo": invoice.l10n_in_shipping_bill_number or "",
-                    "ShipBDt": invoice.l10n_in_shipping_bill_date
-                       and invoice.l10n_in_shipping_bill_date.strftime("%d/%m/%Y") or "",
-                    "Port": invoice.l10n_in_shipping_port_code_id.code or "",
                     "RefClm": tax_details_by_code.get("igst") and "Y" or "N",
                     "ForCur": invoice.currency_id.name,
                     "CntCode": saler_buyer.get("buyer_details").country_id.code or "",
                 }
             })
+            if invoice.l10n_in_shipping_bill_number:
+                json_payload["ExpDtls"].update({
+                    "ShipBNo": invoice.l10n_in_shipping_bill_number,
+                })
+            if invoice.l10n_in_shipping_bill_date:
+                json_payload["ExpDtls"].update({
+                    "ShipBDt": invoice.l10n_in_shipping_bill_date.strftime("%d/%m/%Y"),
+                })
+            if invoice.l10n_in_shipping_port_code_id:
+                json_payload["ExpDtls"].update({
+                    "Port": invoice.l10n_in_shipping_port_code_id.code
+                })
         return json_payload
 
     @api.model

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -403,7 +403,7 @@ class AccountEdiFormat(models.Model):
             })
         if saler_buyer.get("buyer_details") != saler_buyer.get("ship_to_details"):
             json_payload.update({
-                "ShipDtls": self._get_l10n_in_edi_partner_details(saler_buyer.get("ship_to_details"))
+                "ShipDtls": self._get_l10n_in_edi_partner_details(saler_buyer.get("ship_to_details"), is_overseas=is_overseas)
             })
         if is_overseas:
             json_payload.update({


### PR DESCRIPTION
Before this commit, not able to submit overseas invoices to the portal if the
delivery and billing address are different, the same overseas invoice can be
submitted to the portal if the delivery and billing address are the same.
Also, when we create an export Invoice ( foreign customer )
without shipping details and processing the invoice, the system asks for
mandatory to provide details of shipping, which are not compulsory to
generate an E-Invoice in India.

After this commit, we can able to submit an e-invoice even if the delivery and
billing addresses are different. Also, the system will proceed with E-Invoicing 
in case of export without shipping details on the invoice form.

task-id: 2871478, 2948375

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
