### PR TITLE
[FIX] purchase_stock: subcontracting with dropship to other sub

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -326,6 +326,8 @@ class PurchaseOrderLine(models.Model):
                         ):
                             if move.to_refund:
                                 total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                            elif move.location_id.usage == 'internal':
+                                total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         else:
                             total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                 line._track_qty_received(total)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
#92505 was fixing a use case where move.to_refund is not set and adding
quantities although it was not intended, but also is now missing the
adding of quantities of a po with subcontracting with dropship
to another subcontractor (internal -> internal)

In order to overcome those missed quantities we add those quantities accordingly


**Current behavior before PR:**
Received quantities are not counted for this use case

**Desired behavior after PR is merged:**
Received quantities are counted for this use case

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
