### PR TITLE
[FIX] web: allow empty domains on arch

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -100,7 +100,7 @@ function mapActiveFieldsToFieldsInfo(activeFields, fields, viewType, env) {
         }
         Widget = Widget || fieldRegistry.get("abstract");
         let domain;
-        if (fieldDescr.domain && fieldDescr.domain.toString() !== "[]") {
+        if (fieldDescr.domain) {
             domain = fieldDescr.domain.toString();
         }
         let mode = fieldDescr.viewMode;

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -201,7 +201,6 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         name,
         viewType,
         context: node.getAttribute("context") || "{}",
-        domain: node.getAttribute("domain") || "[]",
         string: node.getAttribute("string") || field.string,
         widget,
         modifiers,
@@ -215,6 +214,9 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         options: evaluateExpr(node.getAttribute("options") || "{}"),
         alwaysInvisible: modifiers.invisible === true || modifiers.column_invisible === true,
     };
+    if (node.getAttribute("domain")) {
+        fieldInfo.domain = node.getAttribute("domain");
+    }
     for (const attribute of node.attributes) {
         if (attribute.name in Field.forbiddenAttributeNames) {
             throw new Error(Field.forbiddenAttributeNames[attribute.name]);

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -4039,6 +4039,33 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(document.body, ".modal", "there should not be a confirm modal");
     });
 
+    QUnit.test("Domain: allow empty domain on fieldInfo", async function (assert) {
+        assert.expect(1);
+        serverData.models.partner.fields.product_id.domain = "[('display_name', '=', name)]";
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <header>
+                        <field name="product_id" widget="statusbar" domain="[]"></field>
+                    </header>
+                    <sheet>
+                        <group>
+                            <field name="name"></field>
+                        </group>
+                    </sheet>
+                </form>`,
+            resId: 1,
+            mockRPC(route, args) {
+                if (args.method === "search_read") {
+                    assert.strictEqual(JSON.stringify(args.kwargs.domain), "[]");
+                }
+            },
+        });
+    });
+
     QUnit.test("discard form with specialdata", async function (assert) {
         await makeView({
             type: "form",
@@ -11543,7 +11570,8 @@ QUnit.module("Views", (hooks) => {
             assert.containsOnce(target, ".o_form_editable");
             assert.containsOnce(target, ".o_form_button_save");
             assert.containsOnce(target, ".o_form_button_cancel");
-        });
+        }
+    );
 
     QUnit.test("save a form view with an invisible required field", async function (assert) {
         serverData.models.partner.fields.text = { string: "Text", type: "char", required: 1 };


### PR DESCRIPTION
Since the new views, the empty domains on the archs were not be taking
into account.

Now, the empty domains are taken into account, this was the legacy
behaviour
