### PR TITLE
[FIX] web_editor: properly define the signature command

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
@@ -89,6 +89,18 @@ export class Powerbox {
      * @param {Array<{name: string, priority: number}} [categories=this.categories]
      */
     open(commands=this.commands, categories=this.categories) {
+        commands = (commands || []).map(command => ({
+            ...command,
+            category: command.category || '',
+            name: command.name || '',
+            priority: command.priority || 0,
+            description: command.description || '',
+            callback: command.callback || (() => {}),
+        }));
+        categories = (categories || []).map(category => ({
+            name: category.name || '',
+            priority: category.priority || 0,
+        }));
         const order = (a, b) => b.priority - a.priority || a.name.localeCompare(b.name);
         if (this.onOpen) {
             this.onOpen();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1871,8 +1871,8 @@ const Wysiwyg = Widget.extend({
                 },
             },
             {
-                groupName: _t('Basic blocks'),
-                title: _t('Signature'),
+                category: _t('Basic blocks'),
+                name: _t('Signature'),
                 description: _t('Insert your signature.'),
                 fontawesome: 'fa-pencil-square-o',
                 callback: async () => {


### PR DESCRIPTION
The signature command was using the wrong property names, leading to the Powerbox crashing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
