### PR TITLE
[FIX] stock: fix undefined key in aggregated move lines

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -798,6 +798,7 @@ class StockMoveLine(models.Model):
                     'qty_done': False,
                     'qty_ordered': qty_ordered,
                     'product_uom': uom.name,
+                    'product_uom_rec': uom,
                     'product': empty_move.product_id,
                 }
             else:


### PR DESCRIPTION
- Steps to reproduce:

=> Install stock
=> Install l10n_mx_edi_stock
=> Make necessary configuration for mx_edi
=> Create a picking with 4 products
=> Check availability of the products so stock move lines are created
=> Keep 1 stock move line
=> Validate the transfer and sign it

- Current behavior before PR:

Printing the delivery slip returns a key error

```
File /home/odoo/src/enterprise/15.0/l10n_mx_edi_stock/models/stock_move_line.py, line 25, in _get_aggregated_product_quantities
    v['weight'] = v['product_uom_rec']._compute_quantity(v['qty_done'], v['product'].uom_id) * v['product'].weight
KeyError: 'product_uom_rec'
```

Because product_uom_rec is not defined for the stock move lines that were deleted.

- Desired behavior after PR is merged:

The user should be able to print the delivery slip with no problem.

opw-2893008

