### PR TITLE
[REM] : remove useless variable in_date

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -319,7 +319,6 @@ class StockMoveLine(models.Model):
                 if ml.product_id.type == 'product':
                     Quant = self.env['stock.quant']
                     quantity = ml.product_uom_id._compute_quantity(ml.qty_done, ml.move_id.product_id.uom_id,rounding_method='HALF-UP')
-                    in_date = None
                     available_qty, in_date = Quant._update_available_quantity(ml.product_id, ml.location_id, -quantity, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id)
                     if available_qty < 0 and ml.lot_id:
                         # see if we can compensate the negative quants with some untracked quants


### PR DESCRIPTION
in create method we have to specify default in_date to use it in creation/update of stock.quant,we have removed the useless in_date variable

Description of the issue/feature this PR addresses:
The variable in_date in the methode create of stock.move.line is useless as it will be erased in the next lines in all cases 

Current behavior before PR:
existing of useless variable in_date 
Desired behavior after PR is merged:
remove this variable for more elegant code



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
