### PR TITLE
[FIX] mail:  hide sharing screen button on mobile devices

### DIFF
--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -55,6 +55,7 @@
                         <t t-if="messaging.rtc.sendDisplay"><t t-set="displayTitle">Stop screen sharing</t></t>
                         <t t-else=""><t t-set="displayTitle">Share screen</t></t>
                         <button class="o_RtcController_button o_RtcController_videoButton"
+                            t-if="!env.device.isMobileDevice"
                             t-att-class="{
                                 'o-isActive': messaging.rtc.sendDisplay,
                                 'o-isSmall': rtcController.isSmall,


### PR DESCRIPTION
The current implementation of sharing screen uses the
`MediaDevices.getDisplayMedia()` API. Sadly this API is not currently
supported by all major existing mobile browsers[1].
Some users were confused about the browser request permission
notification. As this is a way more complicated than just adding a
permission. We prefer to hide this feature by removing the screen
sharing button on mobile devices.

Links:
[1] https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
[2] https://bugs.chromium.org/p/chromium/issues/detail?id=487935

opw-2915773