### PR TITLE
[FIX] web: fix daterangepicker default value

### DIFF
--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -34,8 +34,8 @@ export class DateRangeField extends Component {
                                 ? localization.dateTimeFormat
                                 : localization.dateFormat,
                         },
-                        startDate: window.moment(this.formattedStartDate),
-                        endDate: window.moment(this.formattedEndDate),
+                        startDate: this.formattedStartDate ? window.moment(this.formattedStartDate) : window.moment(),
+                        endDate: this.formattedEndDate ? window.moment(this.formattedEndDate) : window.moment(),
                     });
                     this.pickerContainer = window.$(el).data("daterangepicker").container[0];
 


### PR DESCRIPTION
The new OWL DateRange field added in [1] and used in views since [2]
sets a wrong value on its 'daterangepicker' when the related record has
no value (e.g. like when creating a new event).

The goal of this commit is to fix this behavior by using default values
on daterangepicker's startDate / endDate config.

[1]: https://github.com/odoo/odoo/commit/48ef812a635f70571b395f82ffdb2969ce99da9e
[2]: https://github.com/odoo/odoo/commit/bc0a0cead62edd1e0b299fb9a90cd21792814618

Discovered while fixing task-2687506
