### PR TITLE
[FIX] web: t-ifs in settings compiler correctly combined

### DIFF
--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -254,12 +254,12 @@ export class ViewCompiler {
             return;
         }
         if (!params.enableInvisible) {
-            combineAttributes(
-                compiled,
-                "t-if",
-                `!evalDomainFromRecord(props.record,${JSON.stringify(invisible)})`,
-                " and "
-            );
+            let isVisileExpr = `!evalDomainFromRecord(props.record,${JSON.stringify(invisible)})`;
+            if (compiled.hasAttribute("t-if")) {
+                const formerTif = compiled.getAttribute("t-if");
+                isVisileExpr = `( ${formerTif} ) and ${isVisileExpr}`;
+            }
+            compiled.setAttribute("t-if", isVisileExpr);
         } else {
             appendAttr(compiled, "class", `o_invisible_modifier:${invisible}`);
         }


### PR DESCRIPTION
Have a section of a settings view that can be search in.
Have a dynamic invisble modifier (governed by a domain) on it.

Before this commit, the condition were just juxtaposed, which will cause problem
if one of them contains a "OR" operator. So, sections that should have been invisible were visible
because the if looked like: `search() or search_other() and isVisible()`.

After this commit, the t-ifs are correctly written so that they look like:
`(search() or search_other()) and isVisible()`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
