### PR TITLE
[REM] : remove useless variable in_date

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -319,7 +319,6 @@ class StockMoveLine(models.Model):
                 if ml.product_id.type == 'product':
                     Quant = self.env['stock.quant']
                     quantity = ml.product_uom_id._compute_quantity(ml.qty_done, ml.move_id.product_id.uom_id,rounding_method='HALF-UP')
-                    in_date = None
                     available_qty, in_date = Quant._update_available_quantity(ml.product_id, ml.location_id, -quantity, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id)
                     if available_qty < 0 and ml.lot_id:
                         # see if we can compensate the negative quants with some untracked quants


### PR DESCRIPTION
Remove useless variable in_date for more readable and elegant code

Description of the issue/feature this PR addresses:
We have to remove the variable in_date in the method create in model stock.move.live ,this variable is useless as it will be erased in all cases in the next few lines of code

Current behavior before PR:
existence of useless variable in_date
Desired behavior after PR is merged:
remove of this useless variable for more readable and elegant code



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
