### PR TITLE
[IMP] web: grouped kanban asynchronous tooltips 

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -508,7 +508,7 @@ export class KanbanRenderer extends Component {
     }
 
     tooltipAttributes(group) {
-        if (!group.tooltip) {
+        if (!group.tooltip.length) {
             return {};
         }
         return {


### PR DESCRIPTION
Purpose:
The purpose of this PR is to increase the responsiveness of the kanban
by rendering the view as soon as possible:

Current behavior before PR:
The kanban view when grouped do orm call to fetch the tooltips.
The rendering of the kanban view is waiting for this orm call.

Desired behavior after PR is merged:
Now the tooltips orm call is done asynchronously and the kanban view
is re-rendered once the call returns.
