### PR TITLE
[FIX] mail, tools: decode_message_header and email_split_tuples format modification

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1391,8 +1391,8 @@ class MailThread(models.AbstractModel):
         if message.get('Subject'):
             msg_dict['subject'] = tools.decode_message_header(message, 'Subject')
 
-        email_from = tools.decode_message_header(message, 'From')
-        email_cc = tools.decode_message_header(message, 'cc')
+        email_from = tools.decode_message_header(message, 'From', separator=',')
+        email_cc = tools.decode_message_header(message, 'cc', separator=',')
         email_from_list = tools.email_split_and_format(email_from)
         email_cc_list = tools.email_split_and_format(email_cc)
         msg_dict['email_from'] = email_from_list[0] if email_from_list else email_from
@@ -1402,18 +1402,18 @@ class MailThread(models.AbstractModel):
         # for all the odd MTAs out there, as there is no standard header for the envelope's `rcpt_to` value.
         msg_dict['recipients'] = ','.join(set(formatted_email
             for address in [
-                tools.decode_message_header(message, 'Delivered-To'),
-                tools.decode_message_header(message, 'To'),
-                tools.decode_message_header(message, 'Cc'),
-                tools.decode_message_header(message, 'Resent-To'),
-                tools.decode_message_header(message, 'Resent-Cc')
+                tools.decode_message_header(message, 'Delivered-To', separator=','),
+                tools.decode_message_header(message, 'To', separator=','),
+                tools.decode_message_header(message, 'Cc', separator=','),
+                tools.decode_message_header(message, 'Resent-To', separator=','),
+                tools.decode_message_header(message, 'Resent-Cc', separator=',')
             ] if address
             for formatted_email in tools.email_split_and_format(address))
         )
         msg_dict['to'] = ','.join(set(formatted_email
             for address in [
-                tools.decode_message_header(message, 'Delivered-To'),
-                tools.decode_message_header(message, 'To')
+                tools.decode_message_header(message, 'Delivered-To', separator=','),
+                tools.decode_message_header(message, 'To', separator=',')
             ] if address
             for formatted_email in tools.email_split_and_format(address))
         )

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -1013,3 +1013,11 @@ Remote-MTA: 10.245.192.40
 
 
 --_av-UfLe6y6qxNo54-urtAxbJQ--"""
+
+MAIL_FORWARDED = """X-Original-To: lucie@petitebedaine.fr
+Delivered-To: raoul@grosbedon.fr
+Delivered-To: lucie@petitebedaine.fr
+To: lucie@petitebedaine.fr
+From: "Bruce Wayne" <bruce@wayneenterprises.com>
+
+SSBhbSB0aGUgQmF0TWFuCg=="""

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -52,6 +52,9 @@ class TestEmailParsing(TestMailCommon):
         self.assertEqual(res['body'], '')
         self.assertEqual(res['attachments'][0][0], 'thetruth.pdf')
 
+        res = self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_FORWARDED))
+        self.assertIn(res['recipients'], ['lucie@petitebedaine.fr,raoul@grosbedon.fr', 'raoul@grosbedon.fr,lucie@petitebedaine.fr'])
+
         res = self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_MULTIPART_WEIRD_FILENAME))
         self.assertEqual(res['attachments'][0][0], '62_@;,][)=.(ÇÀÉ.txt')
 


### PR DESCRIPTION
Steps to reproduce:
1.) Create a custom email domain and incoming email server on a database, set the
Actions to Perform on Incoming Mails to Create a new record: Helpdesk Ticket.
2.) Set an email alias for a Helpdesk team, set the assignment method to
balanced/random, assign some users to the team.
3.) Set another email address to forward emails to the alias for the Helpdesk team.
4.) Emails received directly by the email alias will create tickets and assign
properly, emails that are forwarded to the email alias will fall back on assignment
defaults.

Explanation:
When we get the "Delivered-To" field for the message dictionnary we use
decode_message_header and the message.get_all() function, this function
returns a list with two addresses but it is transformed back into a string
in decode_message_header  with a white space as separator. 
https://github.com/odoo/odoo/blob/ef4756fd1b7640fae7cbc57c8e46203e8f12d925/odoo/tools/mail.py#L555
This create an issue when we use email_split_and_format
https://github.com/odoo/odoo/blob/ef4756fd1b7640fae7cbc57c8e46203e8f12d925/odoo/tools/mail.py#L485
on this string as it uses email.utils.getaddresses that expects a list of headers field or a text
where addresses are separated with a comma instead of a string with the
header fields separated by " ". Because of that getaddresses fails to get
the right addresses and the recipients field of the message dictionnary is
missing the right address. Hence when we check if the alias is in this
values it does not find it and use the default fall back.

Example of getaddresses behavior:
```
>>> from email.utils import getaddresses
>>> emails_w_comma =["test@test.com ,  test2@test2.com"]
>>> emails_w_space = ["test@test.com   test@test.com"]
>>> getaddresses(emails_w_comma)
[('', 'test@test.com'), ('', 'test2@test2.com')]
>>> getaddresses(emails_w_space)
[('', ''), ('', '@test.com')]
```
Solution:
To solve the issue we set the separator as a comma in decode_message_header.

opw-2917543