### PR TITLE
[FIX] website_sale_autocomplete: fix alignment logo powered

### DIFF
--- a/addons/website_sale_autocomplete/static/src/xml/autocomplete.xml
+++ b/addons/website_sale_autocomplete/static/src/xml/autocomplete.xml
@@ -8,7 +8,7 @@
                t-att-data-google-place-id="result['google_place_id']">
                 <t t-out="result['formatted_address']"/>
             </a>
-            <img class="pull-right pr-1" src="/website_sale_autocomplete/static/src/img/powered_by_google_on_white.png" alt="Powered by Google"/>
+            <img class="float-right pr-1" src="/website_sale_autocomplete/static/src/img/powered_by_google_on_white.png" alt="Powered by Google"/>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
pull-right is not standard Bootstrap 3.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
