### PR TITLE
[FIX] stock: Check move_id exist before using it.

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -467,7 +467,7 @@ class StockMoveLine(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for ml in self:
             # Unlinking a move line should unreserve.
-            if ml.product_id.type == 'product' and not ml.move_id._should_bypass_reservation(ml.location_id) and not float_is_zero(ml.product_qty, precision_digits=precision):
+            if ml.product_id.type == 'product' and ml.move_id and not ml.move_id._should_bypass_reservation(ml.location_id) and not float_is_zero(ml.product_qty, precision_digits=precision):
                 self.env['stock.quant']._update_reserved_quantity(ml.product_id, ml.location_id, -ml.product_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
         moves = self.mapped('move_id')
         res = super(StockMoveLine, self).unlink()


### PR DESCRIPTION
Reproduce steps:
https://watch.screencastify.com/v/k5w8DL3sLtwJc0BYX5ui

- Create P1: storable, tracked by SN, manufacture
- Create C1: storable, tracked by lot
- Add 100 unit of C1 in Stock location
- Add 2 unit of P1 in Production location
- Create BoM for P1 with C1 as component
- Create MO for 2 unit of P1 > Confirm > Mass Produce > Generate Serials > Apply
=> Traceback on ensure_one()

In mrp_production.py in _split_productions(), the 'move_id' field is removed before unlink() is called in order to avoid calling recompute_state().
As move_id is not guaranteed to exist, we need to check before using it.

OPW-2878461

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
