### PR TITLE
[FIX] web: ask to save new record before translating

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -8,6 +8,7 @@ import { ComponentAdapter } from "web.OwlCompatibility";
 import viewUtils from "web.viewUtils";
 import { useWowlService } from "@web/legacy/utils";
 import { RPCError } from "@web/core/network/rpc_service";
+import { useTranslationDialog } from "@web/views/fields/translation_button";
 
 const { Component, useEffect, xml } = owl;
 const fieldRegistry = registry.category("fields");
@@ -22,6 +23,7 @@ const legacyFieldTemplate = xml`
 class FieldAdapter extends ComponentAdapter {
     setup() {
         super.setup();
+        this.translationDialog = useTranslationDialog();
         this.wowlEnv = this.env;
         this.env = Component.env;
         this.orm = useWowlService("orm");

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -19,11 +19,8 @@
             <t t-if="props.isTranslatable">
                 <TranslationButton
                     fieldName="props.name"
-                    resId="props.record.resId"
-                    resModel="props.record.resModel"
-                    value="props.value"
+                    record="props.record"
                     updateField="props.update"
-                    context="props.record.context"
                 />
             </t>
         </t>

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -18,11 +18,8 @@
             <t t-if="props.isTranslatable">
                 <TranslationButton
                     fieldName="props.name"
-                    resId="props.record.resId"
-                    resModel="props.record.resModel"
-                    value="props.value"
+                    record="props.record"
                     updateField="props.update"
-                    context="props.record.context"
                 />
             </t>
         </t>

--- a/addons/web/static/src/views/fields/translation_button.js
+++ b/addons/web/static/src/views/fields/translation_button.js
@@ -3,14 +3,75 @@
 import { localization } from "@web/core/l10n/localization";
 import { useService } from "@web/core/utils/hooks";
 import { TranslationDialog } from "./translation_dialog";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-const { Component } = owl;
+const { Component, useEnv } = owl;
+
+/**
+ * Prepares a function that will open the dialog that allows to edit translation
+ * values for a given field.
+ *
+ * It is mainly a factorization of the feature that is also used
+ * in legacy_fields. We expect it to be fully implemented in TranslationButton
+ * when legacy code is removed.
+ */
+export function useTranslationDialog() {
+    const dialog = useService("dialog");
+    const rpc = useService("rpc");
+    const env = useEnv();
+
+    async function openTranslationDialog({ record, fieldName, updateField }) {
+        if (!record.resId) {
+            let _continue = true;
+            await new Promise((resolve) => {
+                dialog.add(ConfirmationDialog, {
+                    async confirm() {
+                        _continue = await record.save({ stayInEdition: true });
+                        resolve();
+                    },
+                    cancel() {
+                        _continue = false;
+                        resolve();
+                    },
+                    body: env._t(
+                        "You need to save this new record before editing the translation. Do you want to proceed?"
+                    ),
+                    title: env._t("Warning"),
+                });
+            });
+            if (!_continue) {
+                return;
+            }
+        }
+        const { resModel, resId, context } = record;
+        const result = await rpc("/web/dataset/call_button", {
+            model: "ir.translation",
+            method: "translate_fields",
+            args: [resModel, resId, fieldName],
+            kwargs: { context },
+        });
+
+        dialog.add(TranslationDialog, {
+            domain: result.domain,
+            searchName: result.context.search_default_name,
+            fieldName: fieldName,
+            userLanguageValue: record.data[fieldName] || "",
+            isComingFromTranslationAlert: false,
+            isText: result.context.translation_type === "text",
+            showSource: result.context.translation_show_src,
+            updateField,
+        });
+    }
+
+    return openTranslationDialog;
+}
 
 export class TranslationButton extends Component {
     setup() {
         this.user = useService("user");
         this.rpc = useService("rpc");
         this.dialog = useService("dialog");
+        this.translationDialog = useTranslationDialog();
     }
 
     get isMultiLang() {
@@ -20,24 +81,9 @@ export class TranslationButton extends Component {
         return this.user.lang.split("_")[0].toUpperCase();
     }
 
-    async onClick() {
-        const result = await this.rpc("/web/dataset/call_button", {
-            model: "ir.translation",
-            method: "translate_fields",
-            args: [this.props.resModel, this.props.resId, this.props.fieldName],
-            kwargs: { context: this.props.context },
-        });
-
-        this.dialog.add(TranslationDialog, {
-            domain: result.domain,
-            searchName: result.context.search_default_name,
-            fieldName: this.props.fieldName,
-            userLanguageValue: this.props.value || "",
-            isComingFromTranslationAlert: false,
-            isText: result.context.translation_type === "text",
-            showSource: result.context.translation_show_src,
-            updateField: this.props.updateField,
-        });
+    onClick() {
+        const { fieldName, record, updateField } = this.props;
+        this.translationDialog({ fieldName, record, updateField });
     }
 }
 TranslationButton.template = "web.TranslationButton";


### PR DESCRIPTION
Fixup for 4caa9596bcc6bfe3494de451f8c988c23ea6efcf, where a rebase went bad.

Have a translatable field in a form view.
Create a new record with that form view.
Click on the button to open translations for that field.

Before this commit, the record was not before opening the translation dialog, hence
changing the translations could not work properly.

After this commit, this feature is back, and we ask to save a new record before
opening the translation dialog.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
