### PR TITLE
[IMP] core: support more than 255 http workers

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -201,21 +201,7 @@ class ThreadedWSGIServerReloadable(LoggingBaseWSGIServerMixIn, werkzeug.serving.
         t.start_time = time.time()
         t.start()
 
-    # TODO: Remove this method as soon as either of the revision
-    # - python/cpython@8b1f52b5a93403acd7d112cd1c1bc716b31a418a for Python 3.6,
-    # - python/cpython@908082451382b8b3ba09ebba638db660edbf5d8e for Python 3.7,
-    # is included in all Python 3 releases installed on all operating systems supported by Odoo.
-    # These revisions are included in Python from releases 3.6.8 and Python 3.7.2 respectively.
     def _handle_request_noblock(self):
-        """
-        In the python module `socketserver` `process_request` loop,
-        the __shutdown_request flag is not checked between select and accept.
-        Thus when we set it to `True` thanks to the call `httpd.shutdown`,
-        a last request is accepted before exiting the loop.
-        We override this function to add an additional check before the accept().
-        """
-        if self._BaseServer__shutdown_request:
-            return
         if self.max_http_threads and not self.http_threads_sem.acquire(timeout=0.1):
             # If the semaphore is full we will return immediately to the upstream (most probably
             # socketserver.BaseServer's serve_forever loop  which will retry immediately as the


### PR DESCRIPTION
Use the most efficient Selector implementation available on the current platform

Odoo supports only SelectSelector but it is a little obsolete

python >= 3.4 supports a new high-level library Selectors:
 - https://docs.python.org/es/3/library/selectors.html

It could to auto-choose the following ones:
 - SelectSelector
 - PollSelector
 - EpollSelector
 - DevpollSelector
 - KqueueSelector

Using the DefaultSelector class the most efficient implementation available on the current platform will be use:
 - https://docs.python.org/3/library/selectors.html#selectors.DefaultSelector

It helps to support better the resources of the system

Using SelectSelector you are not able to run workers >=255

If you set `ulimit -n 10240` and run `odoo-bin --workers=255`
the following error is raised:

    Traceback (most recent call last):
    File "odoo/service/server.py", line 926, in run
        self.sleep()
    File "odoo/service/server.py", line 852, in sleep
        sel.select(self.beat)
    File "python3.8/lib/python3.8/selectors.py", line 323, in select
        r, w, _ = self._select(self._readers, self._writers, [], timeout)
    ValueError: filedescriptor out of range in select()

But using PollSelector it is not reproduced even using more workers

Most of platform supports PollSelector but using DefaultSelector we can be sure
that even too old system are supported too

And using this High-level library will allow to use the future new improvements

e.g. Epoll has better performance improvements

More info about:
 - https://devarea.com/linux-io-multiplexing-select-vs-poll-vs-epoll
 - https://github.com/redis/redis-py/issues/486

Co-Authored-By: Julien Castiaux <juc@odoo.com>