### PR TITLE
[FIX] mrp: correct barcodes on production order report

### DIFF
--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -100,7 +100,7 @@
                                     </td>
                                     <td t-if="has_product_barcode" width="15%" class="text-center">
                                         <t t-if="raw_line.product_id.barcode">
-                                            <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px'}"/>
+                                            <div t-field="raw_line.product_id.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px'}"/>
                                         </t>
                                     </td>
                                 </tr>


### PR DESCRIPTION
Steps to reproduce:

- Inventory app > Settings > enable barcode scanner
- Manufacturing app > Create a new manufacturing order
- Under components, add a product that has a barcode
- Save > Print > Production order

The barcodes of the products on the report all encode the
same (incorrect) value, which is the manufacturing order name.

This commit changes the barcodes on the report to encode the
corresponding barcode string of the products.

opw-2930848