### PR TITLE
[FIX] account_edi: "process now" throws when already processing

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -617,6 +617,9 @@ class AccountMove(models.Model):
     # Business operations
     ####################################################
 
+    def button_process_edi_web_services(self):
+        self.action_process_edi_web_services(with_commit=False)
+
     def action_process_edi_web_services(self, with_commit=True):
         docs = self.edi_document_ids.filtered(lambda d: d.state in ('to_send', 'to_cancel') and d.blocking_level != 'error')
         docs._process_documents_web_services(with_commit=with_commit)

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -69,7 +69,7 @@
                          <div>The invoice will be processed asynchronously by the following E-invoicing service :
                             <field name="edi_web_services_to_process" class="oe_inline"/>
                          </div>
-                         <button name="action_process_edi_web_services" type="object" class="oe_link" string="Process now" /> 
+                         <button name="button_process_edi_web_services" type="object" class="oe_link" string="Process now" /> 
                     </div>
                     <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'error')]}">


### PR DESCRIPTION
The "Process now" button throws a UserError if doc is already processing
- only thrown if  parameter with_commit=False

PR odoo/odoo#87266 changed with_commit default for test purposes
- accidentally prevented this pop-up

This PR restores with_commit default value for button action
- User now gets the expected UserError pop up

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
