### PR TITLE
[IMP] point_of_sale: Send Context Closing POS Session

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -130,6 +130,7 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                         model: 'pos.session',
                         method: 'close_session_from_ui',
                         args: [this.env.pos.pos_session.id, bankPaymentMethodDiffPairs],
+                        context: this.env.session.user_context,
                     });
                     if (!response.successful) {
                         return this.handleClosingError(response);


### PR DESCRIPTION
Sending a context when you are closing a `pos.session` will allow you to make some validations/actions only when the closing is being done from the UI.
For example, sending values for new fields or a message that includes something from the pos, like the Cashier ID, name, etc.


Also, it will help more when it is necessary to inherit the function in a simpler way, to avoid having to overwrite it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
