### PR TITLE
[FIX][15.0] hr_holidays: fix the error of displaying wrong timezone

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2005-2006 Axelor SARL. (http://www.axelor.com)
 
 import logging
+import pytz
 
 from collections import namedtuple, defaultdict
 
@@ -1104,11 +1105,13 @@ class HolidaysRequest(models.Model):
 
         # Post a second message, more verbose than the tracking message
         for holiday in self.filtered(lambda holiday: holiday.employee_id.user_id):
+            user_tz = timezone(holiday.tz)
+            utc_tz = pytz.utc.localize(holiday.date_from).astimezone(user_tz)
             holiday.message_post(
                 body=_(
                     'Your %(leave_type)s planned on %(date)s has been accepted',
                     leave_type=holiday.holiday_status_id.display_name,
-                    date=holiday.date_from
+                    date=utc_tz.replace(tzinfo=None)
                 ),
                 partner_ids=holiday.employee_id.user_id.partner_id.ids)
 


### PR DESCRIPTION
While testing the application, I get the following error:
when i approve someone else's leave request, system shows log note with wrong local time, i do this PR to correct that error, help show correct local time zone.

[steps]:
-  Access the Time Off module
-  Create a custom hour break
- Go to My Time Off
- Approve My Time Off
- In the log note shows the approved time off information

[Actual] :
- In log notes: showing wrong timezone (showing UTC+0)

[Expected]:
- Log notes show the correct local time zone





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
