### PR TITLE
[FIX] project: fix Cannot access the form view of projects

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1857,7 +1857,9 @@ class Task(models.Model):
             if project.analytic_account_id:
                 vals['analytic_account_id'] = project.analytic_account_id.id
         else:
-            vals['user_ids'] = [Command.link(self.env.user.id)]
+            user_ids = vals.get('user_ids', [])
+            user_ids.append(Command.link(self.env.user.id))
+            vals['user_ids'] = user_ids
 
         return vals
 


### PR DESCRIPTION
Before this commit, when we create a new task in the project Gantt view, the default current user is assigned to the task instead of the corresponding user.

So in this commit, assign the default user from context then if not found then assign the current user to the task.

task-2920824