### PR TITLE
[FIX] account_qr_code_sepa: fix test_out_invoice_create_refund_qr_code

### DIFF
--- a/addons/account_qr_code_sepa/tests/test_sepa_qr.py
+++ b/addons/account_qr_code_sepa/tests/test_sepa_qr.py
@@ -24,11 +24,13 @@ class TestSEPAQRCode(AccountTestInvoicingCommon):
             'acc_number': 'SA4420000001234567891234',
             'partner_id': cls.company_data['company'].partner_id.id,
         })
-
+        # Make sure EUR is activated
+        currency_eur = cls.env.ref('base.EUR')
+        currency_eur.active = True
         cls.sepa_qr_invoice = cls.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': cls.partner_a.id,
-            'currency_id': cls.env.ref('base.EUR').id,
+            'currency_id': currency_eur.id,
             'partner_bank_id': cls.acc_sepa_iban.id,
             'company_id': cls.company_data['company'].id,
             'invoice_line_ids': [


### PR DESCRIPTION
- test_out_invoice_create_refund_qr_code is using EUR, but this module does not guarantee EUR is activated.
- This commit activates EUR




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
