### PR TITLE
[FIX] survey: fix broken questions in form view

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -5,7 +5,7 @@
         <field name="name">survey.survey.view.form</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
-            <form string="Survey" class="o_survey_form">
+            <form string="Survey" class="o_survey_form" js_class="legacy_form">
                 <field name="id" invisible="1"/>
                 <field name="session_state" invisible="1"/>
                 <field name="question_ids" invisible="1"/>


### PR DESCRIPTION
With the conversion to the new views, legacy x2many fields go through a
thin and incomplete compatibility layer to talk to the new model. This
compatibility layer is not very robust and as such most custom x2many
fields are broken in this configuration, in this case the field
"question_page_one2many".

The proper fix is to convert this field widget, but in the mean time,
the simple fix is to force this view to keep using the legacy view
instead of the new view.