### PR TITLE
[IMP] project,sale_project,sale_timesheet: generic improvements for project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -942,18 +942,6 @@ class Project(models.Model):
                 'show': True,
                 'sequence': 60,
             })
-            buttons.append({
-                'icon': 'users',
-                'text': _lt('Collaborators'),
-                'number': self.collaborator_count,
-                'action_type': 'action',
-                'action': 'project.project_collaborator_action',
-                'additional_context': json.dumps({
-                    'active_id': self.id,
-                }),
-                'show': self.privacy_visibility == "portal",
-                'sequence': 66,
-            })
         return buttons
 
     # ---------------------------------------------------

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -182,7 +182,7 @@
                                     <span class="badge rounded-pill text-bg-info mw-100 text-truncate" title="Current project of the task" t-esc="task.project_id.name" />
                                 </td>
                                 <td t-if="groupby != 'stage'" class="text-end">
-                                    <span t-attf-class="badge #{'text-bg-primary' if task.stage_id.fold else 'text-bg-light'}" title="Current stage of the task" t-esc="task.stage_id.name"/>
+                                    <span t-attf-class="badge #{'text-bg-primary' if task.stage_id.fold else 'text-bg-light'} o_text_overflow" t-attf-title="#{task.stage_id.name}" t-esc="task.stage_id.name"/>
                                 </td>
                             </tr>
                         </t>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -701,6 +701,8 @@
                     <field name="analytic_account_id" optional="hide" groups="analytic.group_analytic_accounting"/>
                     <field name="date_start" string="Start Date" widget="daterange" options="{'related_end_date': 'date'}"/>
                     <field name="date" string="End Date" widget="daterange" options="{'related_start_date': 'date_start'}"/>
+                    <field name="activity_ids" string="Next Activity" widget="list_activity" optional="hide"/>
+                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" optional="hide"/>
                     <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True, 'no_create_edit': True}"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
@@ -1518,7 +1520,10 @@
                     <field name="user_ids" optional="show" widget="many2many_avatar_user" domain="[('share', '=', False), ('active', '=', True)]" options='{"no_quick_create": True}'/>
                     <field name="company_id" groups="base.group_multi_company" optional="show" readonly="True"/>
                     <field name="company_id" invisible="1"/>
+                    <field name="create_date" optional="hide"/>
+                    <field name="date_last_stage_update" optional="hide"/>
                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show"/>
+                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" optional="hide"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible': [('is_closed', '=', True)]}"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="rating_active" invisible="1"/>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -83,6 +83,17 @@
         </field>
     </record>
 
+    <record id="view_task_tree2_inherit_sale_project" model="ir.ui.view">
+        <field name="name">project.task.form.inherit.sale.project</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_tree2"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="sale_line_id" optional="hide" options="{'no_create': True}" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="project_task_view_search" model="ir.ui.view">
         <field name="name">project.task.search.inherit</field>
         <field name="model">project.task</field>

--- a/addons/sale_timesheet/models/project_update.py
+++ b/addons/sale_timesheet/models/project_update.py
@@ -32,10 +32,8 @@ class ProjectUpdate(models.Model):
             return {}
 
         services = []
-        total_sold, total_effective, total_remaining = 0, 0, 0
         sols = self.env['sale.order.line'].search(
             project._get_sale_items_domain([
-                ('is_service', '=', True),
                 ('is_downpayment', '=', False),
             ]),
         )
@@ -60,16 +58,9 @@ class ProjectUpdate(models.Model):
                     'is_hour': unit == product_uom_hour,
                     'sol': sol,
                 })
-                if sol.product_uom.category_id == company_uom.category_id:
-                    total_sold += product_uom_qty
-                    total_effective += qty_delivered
-        total_remaining = total_sold - total_effective
 
         return {
             'data': services,
-            'total_sold': total_sold,
-            'total_effective': total_effective,
-            'total_remaining': total_remaining,
             'company_unit_name': company_uom.name,
             'is_hour': company_uom == product_uom_hour,
         }

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -268,8 +268,8 @@ tour.register('sale_timesheet_tour', {
     content: "Give a name to Project Update",
     run: 'text New update',
 }, {
-    trigger: ".o_field_widget[name=description] h3:contains('Sold')",
-    content: "Sold title must be in description in description",
+    trigger: ".o_field_widget[name=description] h3:contains('Sales')",
+    content: "Sales title must be in description in description",
     run: function () {},
     }, {
     trigger: ".o_field_widget[name=description] td:contains('Prepaid Hours')",

--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -5,13 +5,13 @@
         <xpath expr="//div[@name='milestone']" position="before">
 <br/>
 <div t-if="show_sold">
-<h3 style="font-weight: bolder"><u>Sold</u></h3>
+<h3 style="font-weight: bolder"><u>Sales</u></h3>
 <table class="table table-bordered table-striped">
 <tbody>
 <thead>
-<td style="font-weight: bolder">Service</td>
+<td class="w-50" style="font-weight: bolder">Sales Order Items</td>
 <td style="font-weight: bolder">Sold</td>
-<td style="font-weight: bolder">Effective</td>
+<td style="font-weight: bolder">Delivered</td>
 <td style="font-weight: bolder">Remaining</td>
 </thead>
 <tr t-foreach="services['data']" t-as="service">
@@ -21,12 +21,6 @@
 <td t-attf-class="#{ 'fst-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-esc="format_value(service['effective_value'], service['is_hour'])"/> <t t-esc="service['unit']"/></td>
 <td t-attf-class="#{ 'fst-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-esc="format_value(service['remaining_value'], service['is_hour'])"/> <t t-esc="service['unit']"/></td>
 </tr>
-<tfoot>
-<td style="font-weight: bolder; text-align: right">Total</td>
-<td style="font-weight: bolder; text-align: right; vertical-align: middle;"><t t-esc="format_value(services['total_sold'], services['is_hour'])"/> <t t-esc="services['company_unit_name']"/></td>
-<td style="font-weight: bolder; text-align: right; vertical-align: middle;"><t t-esc="format_value(services['total_effective'], services['is_hour'])"/> <t t-esc="services['company_unit_name']"/></td>
-<td style="font-weight: bolder; text-align: right; vertical-align: middle;"><t t-esc="format_value(services['total_remaining'], services['is_hour'])"/> <t t-esc="services['company_unit_name']"/></td>
-</tfoot>
 </tbody>
 </table>
 <br/>


### PR DESCRIPTION
Purpose of the PR is to do the generic improvements for project.

So in this PR did the following changes:
- add the 'creation date', 'last stage update', 'SOL', 'my deadline' fields in
  project task list view.
- add the 'my deadline', 'next activity' fields in project list view.
- crop the label of the stage after x characters in task portal form view.
- remove the 'collaborators' stat button from project update right-side panel.
- renamed sold->sales, services->sales order items, effective->delivered,
  remove the totals, include non-service SOLs, increase the size of the SOL
  column

task-2928100
