### PR TITLE
[FIX] web: ColorPickerField behavior/style

### DIFF
--- a/addons/web/static/src/core/colorlist/colorlist.js
+++ b/addons/web/static/src/core/colorlist/colorlist.js
@@ -7,7 +7,7 @@ const { Component, useRef, useState, useExternalListener } = owl;
 export class ColorList extends Component {
     setup() {
         this.colorlistRef = useRef("colorlist");
-        this.state = useState({ isExpanded: false });
+        this.state = useState({ isExpanded: this.props.isExpanded });
         useExternalListener(window, "click", this.onOutsideClick);
     }
     get colors() {
@@ -15,17 +15,21 @@ export class ColorList extends Component {
     }
     onColorSelected(id) {
         this.props.onColorSelected(id);
-        this.state.isExpanded = false;
+        if (!this.props.forceExpanded) {
+            this.state.isExpanded = false;
+        }
     }
     onOutsideClick(ev) {
-        if (this.colorlistRef.el.contains(ev.target)) {
+        if (this.colorlistRef.el.contains(ev.target) || this.props.forceExpanded) {
             return;
         }
         this.state.isExpanded = false;
     }
-    onToggle(focus = true) {
-        this.state.isExpanded = !this.state.isExpanded;
-        if (focus) {
+    onToggle(ev) {
+        if (this.props.canToggle) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            this.state.isExpanded = !this.state.isExpanded;
             this.colorlistRef.el.firstElementChild.focus();
         }
     }
@@ -46,9 +50,15 @@ ColorList.COLORS = [
     _lt("Purple"),
 ];
 ColorList.template = "web.ColorList";
+ColorList.defaultProps = {
+    forceExpanded: false,
+    isExpanded: false,
+}
 ColorList.props = {
+    canToggle: { type: Boolean, optional: true },
     colors: Array,
+    forceExpanded: { type: Boolean, optional: true },
     isExpanded: { type: Boolean, optional: true },
     onColorSelected: Function,
-    togglerColor: { type: Number, optional: true },
+    selectedColor: { type: Number, optional: true },
 };

--- a/addons/web/static/src/core/colorlist/colorlist.scss
+++ b/addons/web/static/src/core/colorlist/colorlist.scss
@@ -1,16 +1,12 @@
 .o_colorlist {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    max-width: 100%;
-    gap: 10px;
-
     button {
-        padding: 0;
         border: 1px solid white;
         box-shadow: 0 0 0 1px #c9ccd2;
         width: 22px;
         height: 17px;
+    }
+    .o_colorlist_selected {
+        box-shadow: 0 0 0 2px $o-brand-odoo !important;
     }
 }
 

--- a/addons/web/static/src/core/colorlist/colorlist.xml
+++ b/addons/web/static/src/core/colorlist/colorlist.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ColorList" owl="1">
-        <div class="o_colorlist" aria-atomic="true" t-ref="colorlist">
-            <t t-if="props.togglerColor !== undefined and !state.isExpanded">
-                <button t-on-click.prevent.stop="onToggle" role="menuitem" t-att-title="colors[props.togglerColor]" t-att-data-color="props.togglerColor" t-att-aria-label="colors[props.togglerColor]" t-attf-class="{{'btn o_colorlist_toggler o_colorlist_item_color_' + props.togglerColor }}"/>
+        <div class="o_colorlist d-flex flex-wrap align-items-center mw-100 gap-2" aria-atomic="true" t-ref="colorlist">
+            <t t-if="!props.forceExpanded and !state.isExpanded">
+                <button t-on-click="onToggle" role="menuitem" t-att-title="colors[props.selectedColor]" t-att-data-color="props.selectedColor" t-att-aria-label="colors[props.selectedColor]" t-attf-class="btn p-0 o_colorlist_toggler o_colorlist_item_color_{{ props.selectedColor }}"/>
             </t>
             <t t-else="" t-foreach="props.colors" t-as="colorId" t-key="colorId">
-                <button t-on-click.prevent.stop="() => this.onColorSelected(colorId)" role="menuitem" t-att-title="colors[colorId]" t-att-data-color="colorId" t-att-aria-label="colors[colorId]" t-attf-class="{{'btn o_colorlist_item_color_' + colorId }}"/>
+                <button t-on-click.prevent.stop="() => this.onColorSelected(colorId)" role="menuitem" t-att-title="colors[colorId]" t-att-data-color="colorId" t-att-aria-label="colors[colorId]" t-attf-class="btn p-0 o_colorlist_item_color_{{ colorId }} {{ colorId === props.selectedColor ? 'o_colorlist_selected' : '' }}"/>
             </t>
         </div>
     </t>

--- a/addons/web/static/src/legacy/scss/color_picker.scss
+++ b/addons/web/static/src/legacy/scss/color_picker.scss
@@ -1,4 +1,4 @@
-.o_field_color_picker {
+.o_legacy_field_widget .o_field_color_picker {
     display: flex;
     float: right;
     margin-right: 7px;

--- a/addons/web/static/src/views/fields/color_picker/color_picker_field.js
+++ b/addons/web/static/src/views/fields/color_picker/color_picker_field.js
@@ -7,6 +7,14 @@ import { standardFieldProps } from "../standard_field_props";
 const { Component } = owl;
 
 export class ColorPickerField extends Component {
+    get canToggle() {
+        return this.props.record.activeFields[this.props.name].viewType !== "list";
+    }
+
+    get isExpanded() {
+        return !this.canToggle && !this.props.readonly;
+    }
+
     switchColor(colorIndex) {
         this.props.update(colorIndex);
     }

--- a/addons/web/static/src/views/fields/color_picker/color_picker_field.scss
+++ b/addons/web/static/src/views/fields/color_picker/color_picker_field.scss
@@ -1,9 +1,4 @@
 .o_field_widget.o_field_color_picker > div {
-
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-
     // to compensate on the 2px margin used to space the elements relative to each other
     // we keep the top one cause the widget is a bit to high anyway
     margin-left: -2px;
@@ -15,16 +10,5 @@
         border: 1px solid white;
         box-shadow: 0 0 0 1px map-get($grays, '300');
         margin: 2px;
-
-        > a {
-            display: block;
-
-            &::after {
-                content: "";
-                display: block;
-                width: 20px;
-                height: 15px;
-            }
-        }
     }
 }

--- a/addons/web/static/src/views/fields/color_picker/color_picker_field.xml
+++ b/addons/web/static/src/views/fields/color_picker/color_picker_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ColorPickerField" owl="1">
-        <ColorList colors="constructor.RECORD_COLORS" onColorSelected.bind="switchColor" togglerColor="props.value || 0"/>
+        <ColorList canToggle="canToggle" colors="constructor.RECORD_COLORS" forceExpanded="isExpanded" onColorSelected.bind="switchColor" selectedColor="props.value || 0"/>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -23,7 +23,7 @@
 
     <t t-name="web.Many2ManyTagsFieldColorListPopover" owl="1">
         <div class="o_tag_popover m-2">
-            <ColorList colors="props.colors" onColorSelected="(id) => props.switchTagColor(id, props.tag)"/>
+            <ColorList colors="props.colors" forceExpanded="true" onColorSelected="(id) => props.switchTagColor(id, props.tag)"/>
             <CheckBox className="'pt-2'" value="props.tag.colorIndex === 0" onChange.bind="(isChecked) => props.onTagVisibilityChange(isChecked, props.tag)">Hide in kanban</CheckBox>
         </div>
     </t>

--- a/addons/web/static/src/views/list/list_controller.scss
+++ b/addons/web/static/src/views/list/list_controller.scss
@@ -45,6 +45,9 @@
                 width: 17px;
                 height: 17px;
             }
+            &.o_color_picker_cell .o_field_color_picker .o_colorlist {
+                justify-content: flex-end;
+            }
             &.o_list_button {
                 white-space: nowrap;
                 > button {

--- a/addons/web/static/tests/core/colorlist_tests.js
+++ b/addons/web/static/tests/core/colorlist_tests.js
@@ -37,13 +37,14 @@ async function mountComponent(Picker, props) {
 QUnit.module("Components", () => {
     QUnit.module("ColorList");
 
-    QUnit.test("basic rendering", async function (assert) {
+    QUnit.test("basic rendering with forceExpanded props", async function (assert) {
         await mountComponent(ColorList, {
             colors: [0, 9],
+            forceExpanded: true,
         });
 
         assert.containsOnce(target, ".o_colorlist");
-        assert.containsN(target, "button", 2, "two buttons are available");
+        assert.containsN(target, ".o_colorlist button", 2, "two buttons are available");
         const secondBtn = target.querySelectorAll(".o_colorlist button")[1];
         assert.strictEqual(
             secondBtn.attributes.title.value,
@@ -57,11 +58,11 @@ QUnit.module("Components", () => {
         );
     });
 
-    QUnit.test("toggler is available if togglerColor props is given", async function (assert) {
-        const togglerColorId = 0;
+    QUnit.test("color click does not open the list if canToggle props is not given", async function (assert) {
+        const selectedColorId = 0;
         await mountComponent(ColorList, {
             colors: [4, 5, 6],
-            togglerColor: togglerColorId,
+            selectedColor: selectedColorId,
             onColorSelected: (colorId) => assert.step("color #" + colorId + " is selected"),
         });
 
@@ -71,9 +72,29 @@ QUnit.module("Components", () => {
             "button.o_colorlist_toggler",
             "only the toggler button is available"
         );
+
+        await click(target.querySelector(".o_colorlist button"));
+
+        assert.containsOnce(
+            target,
+            "button.o_colorlist_toggler",
+            "button is still visible"
+        );
+    });
+
+    QUnit.test("open the list of colors if canToggle props is given", async function (assert) {
+        const selectedColorId = 0;
+        await mountComponent(ColorList, {
+            canToggle: true,
+            colors: [4, 5, 6],
+            selectedColor: selectedColorId,
+            onColorSelected: (colorId) => assert.step("color #" + colorId + " is selected"),
+        });
+
+        assert.containsOnce(target, ".o_colorlist");
         assert.hasClass(
             target.querySelector(".o_colorlist button"),
-            "o_colorlist_item_color_" + togglerColorId,
+            "o_colorlist_item_color_" + selectedColorId,
             "toggler has the right class"
         );
 


### PR DESCRIPTION
This commit fixes the recently converted color_picker field
widget. It is now always opened in a list as in legacy,
no longer togglable and some style issues have been fixed.

In form views, we still toggle the opened state because
always edit is coming and it would bloat the UI to
keep it always open.

Tests has been added/modified to assert those desired
behaviors.
