### PR TITLE
[FIX] mail: `Message`, temp. message padding

### DIFF
--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -148,7 +148,7 @@
                                     'w-100': !(messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms') and !messageView.isInChatWindow,
                                     'me-5': messageView.isInChatWindowAndIsAlignedLeft and !messageView.composerViewInEditing,
                                     'ms-5': messageView.isInChatWindowAndIsAlignedRight and !messageView.composerViewInEditing,
-                                    'p-3': messageView.message.prettyBody !== '' and !messageView.composerViewInEditing, 
+                                    'p-3': messageView.message.prettyBody !== '' and !messageView.composerViewInEditing and !messageView.message.isTemporary, 
                                     'p-2': messageView.composerViewInEditing, 
                                     'text-muted': messageView.message.is_note and messageView.message.message_type !== 'sms',
                                 }"


### PR DESCRIPTION
Prior to this commit, temporary messages (e.g. "Creating a new
record...") had the bubble padding but no background color. To keep
consistency with the notification layout, this commit removes this
padding.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
