### PR TITLE
[IMP] hr_holidays: make stress days department-specific

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -131,3 +131,6 @@ class Department(models.Model):
         action = self.env['ir.actions.actions']._for_xml_id('hr.hr_plan_action')
         action['context'] = {'default_department_id': self.id, 'search_default_department_id': self.id}
         return action
+
+    def get_children_department_ids(self):
+        return self.env['hr.department'].search([('id', 'child_of', self.ids)])

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -473,13 +473,9 @@ class HolidaysRequest(models.Model):
         date_from, date_to = min(self.mapped('date_from')), max(self.mapped('date_to'))
         resource_calendar_id = self.employee_id.resource_calendar_id or self.env.company.resource_calendar_id
         if date_from and date_to:
-            stress_days = self.env['hr.leave.stress.day'].search([
-                ('start_date', '<=', date_to.date()),
-                ('end_date', '>=', date_from.date()),
-                '|',
-                    ('resource_calendar_id', '=', False),
-                    ('resource_calendar_id', 'in', resource_calendar_id.ids),
-            ])
+            stress_days = self.employee_id._get_stress_days(
+                date_from.date(),
+                date_to.date())
 
             for leave in self:
                 domain = [

--- a/addons/hr_holidays/models/hr_leave_stress_day.py
+++ b/addons/hr_holidays/models/hr_leave_stress_day.py
@@ -17,26 +17,8 @@ class StressDay(models.Model):
     color = fields.Integer(default=lambda dummy: randint(1, 11))
     resource_calendar_id = fields.Many2one('resource.calendar', 'Working Hours',
         default=lambda self: self.env.company.resource_calendar_id.id, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    department_ids = fields.Many2many('hr.department', string="Departments")
 
     _sql_constraints = [
         ('date_from_after_day_to', 'CHECK(start_date <= end_date)', 'The start date must be anterior than the end date.')
     ]
-
-    @api.model
-    def get_stress_days(self, start_date, end_date, resource_calendar_id=None):
-        resource_calendar_id = resource_calendar_id or self.env.user.employee_id.resource_calendar_id or self.env.company.resource_calendar_id
-        all_days = {}
-        stress_days = self.env['hr.leave.stress.day'].search([
-            ('start_date', '>=', start_date),
-            ('end_date', '<=', end_date),
-            '|',
-                ('resource_calendar_id', '=', False),
-                ('resource_calendar_id', '=', resource_calendar_id.id),
-        ])
-
-        for stress_day in stress_days:
-            num_days = (stress_day.end_date - stress_day.start_date).days
-            for d in range(num_days + 1):
-                all_days[str(stress_day.start_date + relativedelta(days=d))] = stress_day.color
-
-        return all_days

--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
@@ -106,10 +106,17 @@ export const TimeOffCalendarController = CalendarController.extend({
 
     _update() {
         return this._super(...arguments).then(() => {
+            const request_args = [
+                this.res_id,
+                this.model.data.start_date,
+                this.model.data.end_date,
+            ]
+            if (this.context.employee_id)
+                request_args[0] = this.context.employee_id;
             this._rpc({
-                model: 'hr.leave.stress.day',
+                model: 'hr.employee',
                 method: 'get_stress_days',
-                args: [this.model.data.start_date, this.model.data.end_date],
+                args: request_args,
                 context: this.context,
             }).then((stressDays) => {
                 this.$el.find('td.fc-day').toArray().forEach((td) => {

--- a/addons/hr_holidays/tests/test_stress_days.py
+++ b/addons/hr_holidays/tests/test_stress_days.py
@@ -99,7 +99,7 @@ class TestHrLeaveStressDays(TransactionCase):
 
     @freeze_time('2021-10-15')
     def test_get_stress_days(self):
-        stress_days = self.env['hr.leave.stress.day'].with_user(self.employee_user.id).get_stress_days('2021-11-01', '2021-11-30')
+        stress_days = self.employee_emp.get_stress_days('2021-11-01', '2021-11-30')
 
         # Stress Days spanning multiple days should be split in single days
         expected_data = {'2021-11-02': 1, '2021-11-08': 2, '2021-11-09': 2, '2021-11-10': 2, '2021-11-11': 2, '2021-11-12': 2}
@@ -117,3 +117,82 @@ class TestHrLeaveStressDays(TransactionCase):
 
             leave_form.request_date_to = datetime(2021, 11, 5)
             self.assertTrue(leave_form.has_stress_day)
+
+    @freeze_time('2021-10-15')
+    def test_department_stress_days(self):
+        production_department = self.env['hr.department'].create({
+            'name': 'Production Department',
+            'company_id': self.company.id,
+        })
+        post_production_department = self.env['hr.department'].create({
+            'name': 'Post-Production Department',
+            'company_id': self.company.id,
+            'parent_id': production_department.id,
+        })
+        deployment_department = self.env['hr.department'].create({
+            'name': 'Deployment Department',
+            'company_id': self.company.id,
+            'parent_id': production_department.id,
+        })
+
+        self.employee_emp.write({
+            'department_id': post_production_department.id
+        })
+
+        # Create one stress day for each department
+        self.env['hr.leave.stress.day'].create({
+            'name': 'Last Rush Before Launch (production)',
+            'company_id': self.company.id,
+            'start_date': datetime(2021, 11, 3),
+            'end_date': datetime(2021, 11, 3),
+            'color': 1,
+            'resource_calendar_id': self.default_calendar.id,
+            'department_ids': [production_department.id],
+        })
+        self.env['hr.leave.stress.day'].create({
+            'name': 'Last Rush Before Launch (post-production)',
+            'company_id': self.company.id,
+            'start_date': datetime(2021, 11, 4),
+            'end_date': datetime(2021, 11, 4),
+            'color': 1,
+            'resource_calendar_id': self.default_calendar.id,
+            'department_ids': [post_production_department.id],
+        })
+        self.env['hr.leave.stress.day'].create({
+            'name': 'Last Rush Before Launch (deployment)',
+            'company_id': self.company.id,
+            'start_date': datetime(2021, 11, 5),
+            'end_date': datetime(2021, 11, 5),
+            'color': 1,
+            'resource_calendar_id': self.default_calendar.id,
+            'department_ids': [deployment_department.id],
+        })
+
+        # The employee should only be able to create a time off on stress days
+        # that do not include his department
+        with self.assertRaises(ValidationError):
+            self.env['hr.leave'].with_user(self.employee_user.id).create({
+                'name': 'have been given the black spot',
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': self.employee_emp.id,
+                'date_from': datetime(2021, 11, 3),
+                'date_to': datetime(2021, 11, 3),
+                'number_of_days': 1,
+            })
+        with self.assertRaises(ValidationError):
+            self.env['hr.leave'].with_user(self.employee_user.id).create({
+                'name': 'have been given the black spot',
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': self.employee_emp.id,
+                'date_from': datetime(2021, 11, 4),
+                'date_to': datetime(2021, 11, 4),
+                'number_of_days': 1,
+            })
+        self.env['hr.leave'].with_user(self.employee_user.id).create({
+            'name': 'have been given the black spot',
+            'holiday_status_id': self.leave_type.id,
+            'employee_id': self.employee_emp.id,
+            'date_from': datetime(2021, 11, 5),
+            'date_to': datetime(2021, 11, 5),
+            'number_of_days': 1,
+        })

--- a/addons/hr_holidays/views/hr_leave_stress_day_views.xml
+++ b/addons/hr_holidays/views/hr_leave_stress_day_views.xml
@@ -35,6 +35,7 @@
                 <field name="start_date"/>
                 <field name="end_date"/>
                 <field name="color" widget="color_picker" width="1"/>
+                <field name="department_ids" widget="many2many_tags"/>
                 <field name="resource_calendar_id" optional="hide"/>
             </tree>
         </field>


### PR DESCRIPTION
This commit adds the possibility to link a stress day
to specific departments. If the employee is in a
sub-department of the department subject to a stress
day, the stress day will also apply for that employee.

taskID 2946420
