### PR TITLE
Saas 15.3 hr timesheet,project fix jech

### DIFF
--- a/addons/project/static/src/project_sharing/views/list/renderer.js
+++ b/addons/project/static/src/project_sharing/views/list/renderer.js
@@ -1,0 +1,35 @@
+/** @odoo-module */
+
+import ListRenderer from 'web.ListRenderer';
+
+export default ListRenderer.extend({
+    updateState(state, params) {
+        // populate the columnInvisibleFields in params to compute the domain in column_invisible
+        const columnInvisibleFields = params.columnInvisibleFields || {};
+        const model = this.getParent().model;
+        const record = state.data[0];
+        const data = Object.entries(record.data).reduce((acc, entry) => {
+            const [fieldName, value] = entry;
+            const field = record.fields[fieldName];
+            if (['one2many', 'many2many'].includes(field.type)) {
+                if (value instanceof Object && value.type === 'list') {
+                    acc[fieldName] = value.id;
+                }
+            }
+            return acc;
+        }, record.data);
+        if (Object.keys(data).length) {
+            for (const node of this.arch.children) {
+                if (node.tag === 'field' && node.attrs.modifiers.column_invisible instanceof Array) {
+                    columnInvisibleFields[node.attrs.name] = model._evalModifiers({ ...record, data }, { column_invisible: node.attrs.modifiers.column_invisible }).column_invisible;
+                }
+            }
+        }
+        return this._super(
+            state,
+            Object.assign({}, params, {
+                columnInvisibleFields,
+            }),
+        );
+    }
+});

--- a/addons/project/static/src/project_sharing/views/list/view.js
+++ b/addons/project/static/src/project_sharing/views/list/view.js
@@ -2,10 +2,12 @@
 
 import ListView from 'web.ListView';
 import Controller from './controller';
+import Renderer from './renderer';
 
 export default ListView.extend({
     config: Object.assign({}, ListView.prototype.config, {
         Controller,
+        Renderer,
     }),
 
     init: function (viewInfo, params) {

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -686,7 +686,7 @@
                     <field name="last_update_color"/>
                     <field name="last_update_status"/>
                     <field name="tag_ids"/>
-                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info"}'/>
+                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "to_define": "muted"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
                         <t t-name="kanban-box">


### PR DESCRIPTION
Before this commit, when filtering on projects with no status, the kanban cards of the matching projects are muted.

so in this commit, apply the filter to display the progressbar filtering with proper UI.

Before this commit, when we open a project sharing portal and open a list view then back to kanban view and again back to list view than fields are not longer displayed due to the invalid use of the column_invisible without parent view.

so in this commit, replace the column_invisible with invisible attrs to display the fields.

task-2920824