### PR TITLE
[FIX] survey: wrong redirect when answer token doesn't match user

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -218,14 +218,12 @@ class Survey(http.Controller):
          * a token linked to an answer or generate a new token if access is allowed;
         """
         # Get the current answer token from cookie
-        answer_from_cookie = False
         if not answer_token:
             answer_token = request.httprequest.cookies.get('survey_%s' % survey_token)
-            answer_from_cookie = bool(answer_token)
 
         access_data = self._get_access_data(survey_token, answer_token, ensure_token=False)
 
-        if answer_from_cookie and access_data['validity_code'] in ('answer_wrong_user', 'token_wrong'):
+        if access_data['validity_code'] in ('answer_wrong_user', 'token_wrong'):
             # If the cookie had been generated for another user or does not correspond to any existing answer object
             # (probably because it has been deleted), ignore it and redo the check.
             # The cookie will be replaced by a legit value when resolving the URL, so we don't clean it further here.


### PR DESCRIPTION
Steps to reproduce:

1. Create a survey and invite any user
2. Open the url in the email with another user logged it
3. instead of creating a new answer token, the user is redirected to
homepage

Bug:

this specific use case is not considered (when there is an answer
token with wrong user)

Fix:
to make the checking more general and include this case, we can just
remove `answer_from_cookie` from the condition. the following 2
scenarios should be treated the same anyways:

1- answer token exists, wrong user (now is a bug)
2- answer token doesn't exist (works fine and will keep working fine
after the fix)

so since the existence of answer token doesn't change anything. it
should be removed from the condition and this will make the erroneous
scenario work fine

OPW-2947325