### PR TITLE
[FIX] account_edi_ubl_cii: fix Bis 3 support for Australia and Singapore

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -76,6 +76,8 @@ COUNTRY_EAS = {
     'SE': 9955,
     'FR': 9957,
     'NO': '0192',
+    'SG': '0195',
+    'AU': '0151',
 }
 
 
@@ -173,7 +175,11 @@ class AccountEdiCommon(models.AbstractModel):
                     tax_exemption_reason_code='VATEX-EU-IC',
                     tax_exemption_reason=_('Intra-Community supply'),
                 )
-        return create_dict()
+
+        if tax.amount != 0:
+            return create_dict(tax_category_code='S')
+        else:
+            return create_dict(tax_category_code='E', tax_exemption_reason=_('Articles 226 items 11 to 15 Directive 2006/112/EN'))
 
     def _get_tax_category_list(self, invoice, taxes):
         """ Full list: https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -54,6 +54,11 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             vals.pop('registration_name', None)
             vals.pop('registration_address_vals', None)
 
+            # /!\ For Australian companies, the ABN is encoded on the VAT field, but doesn't have the 2 digits prefix,
+            # causing a validation error
+            if partner.country_id.code == "AU" and partner.vat and not partner.vat.upper().startswith("AU"):
+                vals['company_id'] = "AU" + partner.vat
+
         # sources:
         #  https://anskaffelser.dev/postaward/g3/spec/current/billing-3.0/norway/#_applying_foretaksregisteret
         #  https://docs.peppol.eu/poacc/billing/3.0/bis/#national_rules (NO-R-002 (warning))
@@ -117,6 +122,11 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     'endpoint_id': partner.l10n_nl_kvk,
                     'endpoint_id_attrs': {'schemeID': '0106'},
                 })
+        if partner.country_id.code == 'SG' and 'l10n_sg_unique_entity_number' in partner._fields:
+            vals.update({
+                'endpoint_id': partner.l10n_sg_unique_entity_number,
+                'endpoint_id_attrs': {'schemeID': '0195'},
+            })
 
         return vals
 


### PR DESCRIPTION
Add Australia and Singapore codes in the EAS list, enabling
the UBL Bis 3 format on the journals of these companies.

Also map the EAS codes to the correct Odoo fields:
* Australia uses the ABN, corresponding to the Odoo vat field
* Singapore uses the UEN, which has a custom Odoo field 'l10n_sg_unique_entity_number'

Fix the missing tax category codes for suppliers not in the european
economic area (e.g. Australian company invoicing a Singaporian one)
