### PR TITLE
[FIX] product_expiry: fix expiration date on stock move line

### DIFF
--- a/addons/product_expiry/tests/test_stock_production_lot.py
+++ b/addons/product_expiry/tests/test_stock_production_lot.py
@@ -525,3 +525,43 @@ class TestStockProductionLot(TestStockCommon):
         })
 
         self.assertEqual(sml.expiration_date, exp_date)
+
+        exp_date = exp_date + relativedelta(days=10)
+        lot.expiration_date = exp_date
+        self.assertEqual(sml.expiration_date, exp_date)
+
+    def test_apply_lot_without_date_on_sml(self):
+        """
+        When assigning a lot to a SML, if the lot has no expiration date,
+        dates on lot and SML should be correctly set
+        """
+        #create lot without expiration date
+        lot = self.env['stock.production.lot'].create({
+            'name': 'Lot 1',
+            'product_id': self.apple_product.id,
+            'company_id': self.env.company.id,
+        })
+
+        sml = self.env['stock.move.line'].create({
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+            'product_id': self.apple_product.id,
+            'qty_done': 3,
+            'product_uom_id': self.apple_product.uom_id.id,
+            'lot_id': lot.id,
+            'company_id': self.env.company.id,
+        })
+        today_date = datetime.today()
+        time_gap = timedelta(seconds=10)
+        exp_date = today_date + timedelta(days=self.apple_product.expiration_time)
+
+        self.assertAlmostEqual(sml.expiration_date, exp_date, delta=time_gap)
+
+        self.assertAlmostEqual(
+            lot.expiration_date, exp_date, delta=time_gap)
+        self.assertAlmostEqual(
+            lot.use_date, today_date + timedelta(days=self.apple_product.use_time), delta=time_gap)
+        self.assertAlmostEqual(
+            lot.removal_date, today_date + timedelta(days=self.apple_product.removal_time), delta=time_gap)
+        self.assertAlmostEqual(
+            lot.alert_date, today_date + timedelta(days=self.apple_product.alert_time), delta=time_gap)

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -520,6 +520,14 @@ class StockMoveLine(models.Model):
             lines |= picking_id.move_line_ids.filtered(lambda ml: ml.product_id == self.product_id and (ml.lot_id or ml.lot_name))
         return lines
 
+    def _get_value_production_lot(self):
+        self.ensure_one()
+        return {
+            'company_id': self.company_id.id,
+            'name': self.lot_name,
+            'product_id': self.product_id.id
+        }
+
     def _create_and_assign_production_lot(self):
         """ Creates and assign new production lots for move lines."""
         lot_vals = []
@@ -532,11 +540,7 @@ class StockMoveLine(models.Model):
             key_to_mls[key] |= ml
             if ml.tracking != 'lot' or key not in key_to_index:
                 key_to_index[key] = len(lot_vals)
-                lot_vals.append({
-                    'company_id': ml.company_id.id,
-                    'name': ml.lot_name,
-                    'product_id': ml.product_id.id
-                })
+                lot_vals.append(ml._get_value_production_lot())
 
         lots = self.env['stock.production.lot'].create(lot_vals)
         for key, mls in key_to_mls.items():


### PR DESCRIPTION
To Reporduce
=============
- Install inventory, purchase and product_expiry
- Create a new storable product that is tracked by lots or serial numbers and expiration date and set expiration days to a value
- Go to inventory > configuration > Warehouse Management > Operations Types
- In “San Francisco: Receipts” > Enable "Create New Lots/Serial Numbers"
- Create a new RFQ > select the created product > Confirm the order
- Click on “Receipt”
- Click on the icon with 3 bars (last thing on line) to open Detailed Operations view
- add a line and set a `lot/serial Number`
- from the same view open the `lot/serial number` wizard and edit the expiration the date
- save/confirm

Problem
=======
The expiration date on Detailed Operations doesn't change

Solution
=========
to solve the issue a condition in compute method was corrected

opw-2937438
