### PR TITLE
[FIX] web: legacy field retrieve noLabel from the legacy widget

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -347,6 +347,7 @@ function registerField(name, LegacyFieldWidget) {
     LegacyField.fieldsToFetch = LegacyFieldWidget.prototype.fieldsToFetch || {};
     LegacyField.fieldDependencies = LegacyFieldWidget.prototype.fieldDependencies || {};
     LegacyField.useSubView = LegacyFieldWidget.prototype.useSubview;
+    LegacyField.noLabel = LegacyFieldWidget.prototype.noLabel || false;
     if (!fieldRegistry.contains(name)) {
         if (odoo.debug) {
             console.log(`Fields: using legacy ${name} FieldWidget`);


### PR DESCRIPTION
Have a legacy field with the noLabel attribute to true (in the actual widget definition).
Put that field in a list view (new OWL framework).

Before this commit, the noLabel attribute was not taken into account.

After this commit, it is.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
