### PR TITLE
[FIX] sale_coupon: missing translation term 

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -188,14 +188,12 @@ class SaleOrder(models.Model):
 
             discount_amount -= discount_line_amount_price * lines_total / lines_price
 
-            tax_name = ""
-            if len(tax_ids) == 1:
-                tax_name = " - " + _("On product with following tax: ") + ', '.join(tax_ids.mapped('name'))
-            elif len(tax_ids) > 1:
-                tax_name = " - " + _("On product with following taxes: ") + ', '.join(tax_ids.mapped('name'))
-
             reward_lines[tax_ids] = {
-                'name': _("Discount: ") + program.name + tax_name,
+                'name': _(
+                    "Discount: %(program)s - On product with following taxes: %(taxes)s",
+                    program=program.name,
+                    taxes=", ".join(tax_ids.mapped('name')),
+                ),
                 'product_id': program.discount_line_product_id.id,
                 'price_unit': -discount_line_amount_price,
                 'product_uom_qty': 1.0,


### PR DESCRIPTION
Steps to reproduce:
    1- activate developer mode
    2- add an extra language
    3- generate missing terms
    4- filter by text: 'On product with following tax'

Bug:
'On product with following tax:' and 'On product with following taxes:'
are missing on transifex

Fix:
added the missing strings to the .pot

opw-2945810