### PR TITLE
[IMP] survey: allow live session participant identification

### DIFF
--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -119,8 +119,9 @@
             <tree string="Survey User inputs" decoration-muted="test_entry == True" create="false">
                 <field name="create_date"/>
                 <field name="survey_id"/>
-                <field name="partner_id"/>
-                <field name="email"/>
+                <field name="nickname" optional="hide"/>
+                <field name="partner_id" optional="show"/>
+                <field name="email" optional="show"/>
                 <field name="attempts_number"/>
                 <field name="deadline"/>
                 <field name="test_entry" invisible="True"/>


### PR DESCRIPTION
In the participation screen (user_input tree view), the users can
see the email and contact name of the participants. However, this
is fixed. Those will be empty for live session participants.

Therefore, make those optional but show them as default. Also add
the nickname field in the view before them, not shown by default
but optional, in order to be able to see nicknames for live session
and identify the participants.

Task-2928143
