### PR TITLE
[FIX] website_event: fix flag size in country events snippet

### DIFF
--- a/addons/website_event/static/src/scss/website_event.scss
+++ b/addons/website_event/static/src/scss/website_event.scss
@@ -277,3 +277,10 @@ $o-wevent-event-title-sizes-variants: (
         }
     }
 }
+
+// Country snippet
+.country_events_list .o_wevent_sidebar_title > img {
+    max-height: 1em;
+    vertical-align: top;
+    margin: 0 0.2em;
+}


### PR DESCRIPTION
When the country events snippet displayed events specific to a country
(geoip properly installed + upcoming confirmed events in that country),
a flag of the country was displayed but it was way too big.

Difficult to say when the bug was created, at least from 12.0. In 15.1,
that snippet has been refactored anyway and is now entirely different to
make it more attractive.

opw-2904427

Before:
![image](https://user-images.githubusercontent.com/10338094/183907541-6fa3cbac-a46c-454d-bbe3-0c3f7c263d3f.png)

After:
![image](https://user-images.githubusercontent.com/10338094/183907587-ee1232a4-7f3f-4e65-b8dd-f43fa4516a2c.png)

