### PR TITLE
[FIX] l10n_it_edi: Use invoice currency except when reverse charge, Use TD02 for downpayments

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3158,6 +3158,13 @@ class AccountMove(models.Model):
 
         return groups
 
+    def _is_downpayment(self):
+        ''' Return true if the invoice is a downpayment.
+        Down-payments can be created from a sale order. This method is overridden in the sale order module.
+        '''
+        return False
+
+
 class AccountMoveLine(models.Model):
     _name = "account.move.line"
     _description = "Journal Item"
@@ -5226,3 +5233,9 @@ class AccountMoveLine(models.Model):
                 rslt += tag
 
         return rslt
+
+    def _get_downpayment_lines(self):
+        ''' Return the downpayment move lines associated with the move line.
+        This method is overridden in the sale order module.
+        '''
+        return self.env['account.move.line']

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -25,6 +25,16 @@
                     <AliquotaIVA t-if="line.tax_ids.amount_type == 'percent'" t-esc="format_numbers(line.tax_ids.amount)"/>
                     <AliquotaIVA t-elif="line.tax_ids.amount_type != 'percent'" t-esc="'0.00'"/>
                     <Natura t-if="line.tax_ids.l10n_it_has_exoneration" t-esc="line.tax_ids.l10n_it_kind_exoneration"/>
+                    <AltriDatiGestionali t-if="conversion_rate">
+                        <TipoDato>Currency</TipoDato>
+                        <RiferimentoTesto t-esc="format_alphanumeric(record.currency_id.name)"/>
+                        <RiferimentoNumero t-esc="'%.06f' % line.price_subtotal"/>
+                    </AltriDatiGestionali>
+                    <AltriDatiGestionali t-if="conversion_rate">
+                        <TipoDato>Exch.Rate</TipoDato>
+                        <RiferimentoNumero t-esc="conversion_rate"/>
+                        <RiferimentoData t-esc="format_date(record.invoice_date)"/>
+                    </AltriDatiGestionali>
                 </DettaglioLinee>
 </template>
 
@@ -152,9 +162,9 @@
                 <DatiRiepilogo>
                     <AliquotaIVA t-esc="format_numbers(tax.amount)"/>
                     <Natura t-if="has_exoneration" t-esc="kind_exoneration"/>
-                    <Arrotondamento t-if="tax_line['rounding']" t-esc="format_numbers(tax_line['rounding'])"/>
-                    <ImponibileImporto t-esc="format_monetary(tax_dict['base_amount_currency'], currency)"/>
-                    <Imposta t-esc="format_monetary(tax_dict['tax_amount_currency'], currency)"/>
+                    <Arrotondamento t-if="(tax_dict.get('rounding') and currency.name != 'EUR') or (tax_dict.get('rounding_euros') and currency.name == 'EUR')" t-esc="format_numbers(tax_dict['rounding'] if currency.name != 'EUR' else tax_dict['rounding_euros'])"/>
+                    <ImponibileImporto t-esc="format_monetary(tax_dict['base_amount'] if currency.name == 'EUR' else tax_dict['base_amount_currency'], currency)"/>
+                    <Imposta t-esc="format_monetary(tax_dict['tax_amount'] if currency.name == 'EUR' else tax_dict['base_amount_currency'], currency)"/>
                     <EsigibilitaIVA t-if="not has_exoneration or kind_exoneration == 'N6'" t-esc="tax.l10n_it_vat_due_date"/>
                     <RiferimentoNormativo t-if="has_exoneration" t-esc="format_alphanumeric(tax.l10n_it_law_reference[:100])"/>
                 </DatiRiepilogo>

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -3,14 +3,8 @@
     <data>
 
 <template id="account_invoice_line_it_FatturaPA">
-                <t t-if="rc_refund">
-                    <t t-set="price_subtotal" t-value="-line.price_subtotal"/>
-                </t>
-                <t t-else="">
-                    <t t-set="price_subtotal" t-value="line.price_subtotal"/>
-                </t>
                 <DettaglioLinee>
-                    <NumeroLinea t-esc="line_counter"/>
+                    <NumeroLinea t-esc="line_dict['line_number']"/>
                     <CodiceArticolo t-if="line.product_id.barcode">
                         <CodiceTipo>EAN</CodiceTipo>
                         <CodiceValore t-esc="format_alphanumeric(line.product_id.barcode)"/>
@@ -19,18 +13,15 @@
                         <CodiceTipo>INTERNAL</CodiceTipo>
                         <CodiceValore t-esc="format_alphanumeric(line.product_id.default_code)"/>
                     </CodiceArticolo>
-                    <Descrizione>
-                        <t t-esc="format_alphanumeric(line.name[:1000])"/>
-                        <t t-if="not line.name" t-esc="'NO NAME'"/>
-                    </Descrizione>
-                    <Quantita t-esc="format_numbers(line.quantity)"/>
+                    <Descrizione t-esc="format_alphanumeric(line_dict['description'])"/>
+                    <Quantita t-esc="format_numbers(abs(line.quantity))"/>
                     <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')"  t-esc="format_alphanumeric(line.product_uom_id.name)"/>
-                    <PrezzoUnitario t-esc="'%.06f' % (price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.quantity and line.discount != 100.0 else line.price_unit)"/>
+                    <PrezzoUnitario t-esc="'%.06f' % (line_dict['unit_price'])"/>
                     <ScontoMaggiorazione t-if="line.discount != 0">
                         <Tipo t-esc="discount_type(line.discount)"/>
                         <Percentuale t-esc="format_numbers(abs(line.discount))"/>
                     </ScontoMaggiorazione>
-                    <PrezzoTotale t-esc="format_monetary(price_subtotal, currency)"/>
+                    <PrezzoTotale t-esc="format_monetary(line_dict['subtotal_price'], currency)"/>
                     <AliquotaIVA t-if="line.tax_ids.amount_type == 'percent'" t-esc="format_numbers(line.tax_ids.amount)"/>
                     <AliquotaIVA t-elif="line.tax_ids.amount_type != 'percent'" t-esc="'0.00'"/>
                     <Natura t-if="line.tax_ids.l10n_it_has_exoneration" t-esc="line.tax_ids.l10n_it_kind_exoneration"/>
@@ -149,10 +140,8 @@
             </DatiDDT>
         </DatiGenerali>
         <DatiBeniServizi>
-            <t t-set="line_counter" t-value="0"/>
-            <t t-foreach="record.invoice_line_ids.filtered(lambda l: not l.display_type)" t-as="line">
-                <t t-set="line_counter" t-value="line_counter + 1"/>
-                <t t-set="taxes" t-value="line.tax_ids.compute_all(line.price_unit)"/>
+            <t t-foreach="invoice_lines" t-as="line_dict">
+                <t t-set="line" t-value="line_dict['line']"/>
                 <t t-call="l10n_it_edi.account_invoice_line_it_FatturaPA"/>
             </t>
             <t t-foreach="tax_details['tax_details']" t-as="tax_name">
@@ -163,15 +152,9 @@
                 <DatiRiepilogo>
                     <AliquotaIVA t-esc="format_numbers(tax.amount)"/>
                     <Natura t-if="has_exoneration" t-esc="kind_exoneration"/>
-                    <Arrotondamento t-if="tax_dict.get('rounding')" t-esc="format_numbers(tax_dict['rounding'])"/>
-                    <t t-if="rc_refund">
-                        <ImponibileImporto t-esc="format_monetary(tax_dict['base_amount_currency'], currency)"/>
-                        <Imposta t-esc="format_monetary(tax_dict['tax_amount_currency'], currency)"/>
-                    </t>
-                    <t t-else="">
-                        <ImponibileImporto t-esc="format_monetary(abs(tax_dict['base_amount_currency']), currency)"/>
-                        <Imposta t-esc="format_monetary(abs(tax_dict['tax_amount_currency']), currency)"/>
-                    </t>
+                    <Arrotondamento t-if="tax_line['rounding']" t-esc="format_numbers(tax_line['rounding'])"/>
+                    <ImponibileImporto t-esc="format_monetary(tax_dict['base_amount_currency'], currency)"/>
+                    <Imposta t-esc="format_monetary(tax_dict['tax_amount_currency'], currency)"/>
                     <EsigibilitaIVA t-if="not has_exoneration or kind_exoneration == 'N6'" t-esc="tax.l10n_it_vat_due_date"/>
                     <RiferimentoNormativo t-if="has_exoneration" t-esc="format_alphanumeric(tax.l10n_it_law_reference[:100])"/>
                 </DatiRiepilogo>

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -213,6 +213,7 @@ class AccountEdiFormat(models.Model):
     def _l10n_it_document_type_mapping(self):
         return {
             'TD01': dict(move_types=['out_invoice'], import_type='in_invoice'),
+            'TD02': dict(move_types=['out_invoice'], import_type='in_invoice', downpayment=True),
             'TD04': dict(move_types=['out_refund'], import_type='in_refund'),
             'TD07': dict(move_types=['out_invoice'], import_type='in_invoice', simplified=True),
             'TD08': dict(move_types=['out_refund'], import_type='in_refund', simplified=True),
@@ -233,6 +234,7 @@ class AccountEdiFormat(models.Model):
             info_partner_in_eu = infos.get('partner_in_eu', False)
             if all([
                 invoice.move_type in infos.get('move_types', False),
+                invoice._is_downpayment() == infos.get('downpayment', False),
                 is_self_invoice == infos.get('self_invoice', False),
                 is_simplified == infos.get('simplified', False),
                 info_services_or_goods in ("both", services_or_goods),

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -87,6 +87,54 @@ class AccountMove(models.Model):
         """
         return len(self.commercial_partner_id.l10n_it_pa_index or '')  == 6
 
+    def _l10n_it_edi_prepare_fatturapa_line_details(self, rc_refund=False):
+        """ Returns a list of dictionaries passed to the template for the invoice lines (DettaglioLinee)
+        """
+        invoice_lines = []
+        lines = self.invoice_line_ids.filtered(lambda l: not l.display_type)
+        for num, line in enumerate(lines):
+            # In the case of reverse charge refund, the values for the unit price and total price should be negative
+            price_subtotal = line.price_subtotal if not rc_refund else -line.price_subtotal
+
+            # Unit price
+            unit_price = 0
+            if line.quantity and line.discount != 100.0:
+                unit_price = price_subtotal / ((1 - (line.discount or 0.0) / 100.0) * line.quantity)
+            else:
+                unit_price = line.price_unit
+
+            line_dict = {
+                'line': line,
+                'line_number': num + 1,
+                'description': line.name or 'NO NAME',
+                'unit_price': unit_price,
+                'subtotal_price': price_subtotal,
+            }
+            invoice_lines.append(line_dict)
+        return invoice_lines
+
+    def _l10n_it_edi_prepare_fatturapa_tax_details(self, tax_details, rc_refund=False):
+        """ Returns an adapted dictionary passed to the template for the tax lines (DatiRiepilogo)
+        """
+        for _tax_name, tax_dict in tax_details['tax_details'].items():
+            # The assumption is that the company currency is EUR.
+            base_amount_currency = tax_dict['base_amount_currency']
+            tax_amount_currency = tax_dict['tax_amount_currency']
+            tax_rate = tax_dict['tax'].amount
+            expected_base_amount_currency = tax_amount_currency * 100 / tax_rate if tax_rate else False
+            # Constraints within the edi make local rounding on price included taxes a problem.
+            # To solve this there is a <Arrotondamento> or 'rounding' field, such that:
+            #   taxable base = sum(taxable base for each unit) + Arrotondamento
+            if tax_dict['tax'].price_include and tax_dict['tax'].amount_type == 'percent':
+                if expected_base_amount_currency and float_compare(base_amount_currency, expected_base_amount_currency, 2):
+                    tax_dict['rounding'] = base_amount_currency - (tax_amount_currency * 100 / tax_rate)
+                    tax_dict['base_amount_currency'] = base_amount_currency - tax_dict['rounding']
+
+            if not reverse_charge_refund:
+                tax_dict['base_amount_currency'] = abs(tax_dict['base_amount_currency'])
+                tax_dict['tax_amount_currency'] = abs(tax_dict['tax_amount_currency'])
+        return tax_details
+
     def _prepare_fatturapa_export_values(self):
         self.ensure_one()
 
@@ -157,21 +205,9 @@ class AccountMove(models.Model):
                 if tax.amount == 0.0:
                     tax_map[tax] = tax_map.get(tax, 0.0) + line.price_subtotal
 
-        # Constraints within the edi make local rounding on price included taxes a problem.
-        # To solve this there is a <Arrotondamento> or 'rounding' field, such that:
-        #   taxable base = sum(taxable base for each unit) + Arrotondamento
         tax_details = self._prepare_edi_tax_details(
             filter_to_apply=lambda l: l['tax_repartition_line_id'].factor_percent >= 0
         )
-        for _tax_name, tax_dict in tax_details['tax_details'].items():
-            base_amount = tax_dict['base_amount_currency']
-            tax_amount = tax_dict['tax_amount_currency']
-            tax_rate = tax_dict['tax'].amount
-            if tax_dict['tax'].price_include and tax_dict['tax'].amount_type == 'percent':
-                expected_base_amount = tax_amount * 100 / tax_rate if tax_rate else False
-                if expected_base_amount and float_compare(base_amount, expected_base_amount, 2):
-                    tax_dict['rounding'] = base_amount - (tax_amount * 100 / tax_rate)
-                    tax_dict['base_amount_currency'] = base_amount - tax_dict['rounding']
 
         company = self.company_id
         partner = self.commercial_partner_id
@@ -193,6 +229,9 @@ class AccountMove(models.Model):
             document_total += sum([abs(v['tax_amount_currency']) for k, v in tax_details['tax_details'].items()])
             if rc_refund:
                 document_total = -abs(document_total)
+
+        invoice_lines = self._l10n_it_edi_prepare_fatturapa_line_details(rc_refund)
+        tax_details = self._l10n_it_edi_prepare_fatturapa_tax_details(tax_details, rc_refund)
 
         # Create file content.
         template_values = {
@@ -232,6 +271,7 @@ class AccountMove(models.Model):
             'get_vat_country': get_vat_country,
             'in_eu': in_eu,
             'rc_refund': rc_refund,
+            'invoice_lines': invoice_lines,
         }
         return template_values
 

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -87,41 +87,58 @@ class AccountMove(models.Model):
         """
         return len(self.commercial_partner_id.l10n_it_pa_index or '')  == 6
 
-    def _l10n_it_edi_prepare_fatturapa_line_details(self, rc_refund=False):
+    def _l10n_it_edi_prepare_fatturapa_line_details(self, reverse_charge_refund=False, is_downpayment=False, convert_to_euros=True):
         """ Returns a list of dictionaries passed to the template for the invoice lines (DettaglioLinee)
         """
         invoice_lines = []
         lines = self.invoice_line_ids.filtered(lambda l: not l.display_type)
+
         for num, line in enumerate(lines):
-            # In the case of reverse charge refund, the values for the unit price and total price should be negative
-            price_subtotal = line.price_subtotal if not rc_refund else -line.price_subtotal
+            price_subtotal = line.balance if convert_to_euros else line.price_subtotal
+            # The price_subtotal should be negative when:
+            # The line has downpayment lines, but is not a downpayment (i.e. the final invoice, from which downpayment lines are subtracted) or,
+            # the line is a reverse charge refund.
+            if (line._get_downpayment_lines() and not is_downpayment) or reverse_charge_refund:
+                price_subtotal = -abs(price_subtotal)
+            else:
+                price_subtotal = abs(price_subtotal)
 
             # Unit price
-            unit_price = 0
+            price_unit = 0
             if line.quantity and line.discount != 100.0:
-                unit_price = price_subtotal / ((1 - (line.discount or 0.0) / 100.0) * line.quantity)
+                price_unit = price_subtotal / ((1 - (line.discount or 0.0) / 100.0) * abs(line.quantity))
             else:
-                unit_price = line.price_unit
+                price_unit = line.price_unit
+
+            description = line.name
+            if not is_downpayment:
+                if line.price_subtotal < 0:
+                    moves = line._get_downpayment_lines().move_id
+                    if moves:
+                        description += ', '.join([move.name for move in moves])
 
             line_dict = {
                 'line': line,
                 'line_number': num + 1,
-                'description': line.name or 'NO NAME',
-                'unit_price': unit_price,
+                'description': description or 'NO NAME',
+                'unit_price': price_unit,
                 'subtotal_price': price_subtotal,
             }
             invoice_lines.append(line_dict)
         return invoice_lines
 
-    def _l10n_it_edi_prepare_fatturapa_tax_details(self, tax_details, rc_refund=False):
+    def _l10n_it_edi_prepare_fatturapa_tax_details(self, tax_details, reverse_charge_refund=False):
         """ Returns an adapted dictionary passed to the template for the tax lines (DatiRiepilogo)
         """
         for _tax_name, tax_dict in tax_details['tax_details'].items():
             # The assumption is that the company currency is EUR.
+            base_amount = tax_dict['base_amount']
             base_amount_currency = tax_dict['base_amount_currency']
+            tax_amount = tax_dict['tax_amount']
             tax_amount_currency = tax_dict['tax_amount_currency']
             tax_rate = tax_dict['tax'].amount
             expected_base_amount_currency = tax_amount_currency * 100 / tax_rate if tax_rate else False
+            expected_base_amount = tax_amount * 100 / tax_rate if tax_rate else False
             # Constraints within the edi make local rounding on price included taxes a problem.
             # To solve this there is a <Arrotondamento> or 'rounding' field, such that:
             #   taxable base = sum(taxable base for each unit) + Arrotondamento
@@ -129,9 +146,14 @@ class AccountMove(models.Model):
                 if expected_base_amount_currency and float_compare(base_amount_currency, expected_base_amount_currency, 2):
                     tax_dict['rounding'] = base_amount_currency - (tax_amount_currency * 100 / tax_rate)
                     tax_dict['base_amount_currency'] = base_amount_currency - tax_dict['rounding']
+                if expected_base_amount and float_compare(base_amount, expected_base_amount, 2):
+                    tax_dict['rounding_euros'] = base_amount - (tax_amount * 100 / tax_rate)
+                    tax_dict['base_amount'] = base_amount - tax_dict['rounding_euros']
 
             if not reverse_charge_refund:
+                tax_dict['base_amount'] = abs(tax_dict['base_amount'])
                 tax_dict['base_amount_currency'] = abs(tax_dict['base_amount_currency'])
+                tax_dict['tax_amount'] = abs(tax_dict['tax_amount'])
                 tax_dict['tax_amount_currency'] = abs(tax_dict['tax_amount_currency'])
         return tax_details
 
@@ -188,11 +210,19 @@ class AccountMove(models.Model):
 
         formato_trasmissione = "FPA12" if self._is_commercial_partner_pa() else "FPR12"
 
+        # Flags
         in_eu = self.env['account.edi.format']._l10n_it_edi_partner_in_eu
         is_self_invoice = self.env['account.edi.format']._l10n_it_edi_is_self_invoice(self)
         document_type = self.env['account.edi.format']._l10n_it_get_document_type(self)
         if self.env['account.edi.format']._l10n_it_is_simplified_document_type(document_type):
             formato_trasmissione = "FSM10"
+
+        document_type = self.env['account.edi.format']._l10n_it_get_document_type(self)
+        # Represent if the document is a reverse charge refund in a single variable
+        reverse_charge = document_type in ['TD17', 'TD18', 'TD19']
+        is_downpayment = document_type in ['TD02']
+        reverse_charge_refund = self.move_type == 'in_refund' and reverse_charge
+        convert_to_euros = self.currency_id.name != 'EUR'
 
         pdf = self.env.ref('account.account_invoices')._render_qweb_pdf(self.id)[0]
         pdf = base64.b64encode(pdf)
@@ -219,19 +249,22 @@ class AccountMove(models.Model):
             or (partner.country_id.code == 'IT' and '0000000')
             or 'XXXXXXX')
 
-        # Represent if the document is a reverse charge refund in a single variable
-        rc_refund = self.move_type == 'in_refund' and document_type in ['TD16', 'TD17', 'TD18']
-
         # Self-invoices are technically -100%/+100% repartitioned
         # but functionally need to be exported as 100%
         document_total = self.amount_total
         if is_self_invoice:
             document_total += sum([abs(v['tax_amount_currency']) for k, v in tax_details['tax_details'].items()])
-            if rc_refund:
+            if reverse_charge_refund:
                 document_total = -abs(document_total)
 
-        invoice_lines = self._l10n_it_edi_prepare_fatturapa_line_details(rc_refund)
-        tax_details = self._l10n_it_edi_prepare_fatturapa_tax_details(tax_details, rc_refund)
+        # Reference line for finding the conversion rate used in the document
+        conversion_line = self.invoice_line_ids.sorted(lambda l: abs(l.balance), reverse=True)[0] if self.invoice_line_ids else None
+        conversion_rate = float_repr(
+            abs(conversion_line.balance / conversion_line.amount_currency), precision_digits=5,
+        ) if convert_to_euros and conversion_line else None
+
+        invoice_lines = self._l10n_it_edi_prepare_fatturapa_line_details(reverse_charge_refund, is_downpayment, convert_to_euros)
+        tax_details = self._l10n_it_edi_prepare_fatturapa_tax_details(tax_details, reverse_charge_refund)
 
         # Create file content.
         template_values = {
@@ -245,7 +278,7 @@ class AccountMove(models.Model):
             'buyer_is_company': is_self_invoice or partner.is_company,
             'seller': seller,
             'seller_partner': company.partner_id if not is_self_invoice else partner,
-            'currency': self.currency_id or self.company_currency_id,
+            'currency': self.currency_id or self.company_currency_id if not convert_to_euros else self.env.ref('base.EUR'),
             'document_total': document_total,
             'representative': company.l10n_it_tax_representative_partner_id,
             'codice_destinatario': codice_destinatario,
@@ -270,8 +303,9 @@ class AccountMove(models.Model):
             'get_vat_number': get_vat_number,
             'get_vat_country': get_vat_country,
             'in_eu': in_eu,
-            'rc_refund': rc_refund,
+            'rc_refund': reverse_charge_refund,
             'invoice_lines': invoice_lines,
+            'conversion_rate': conversion_rate,
         }
         return template_values
 

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
@@ -504,7 +504,7 @@ class TestItEdi(AccountEdiTestCommon):
         invoice_etree = self.with_applied_xpath(invoice_etree, "<xpath expr='.//Allegati' position='replace'/>")
         self.assertXmlTreeEqual(invoice_etree, expected_etree)
 
-    def test_non_latin_and_latin_inovice(self):
+    def test_non_latin_and_latin_invoice(self):
         invoice_etree = etree.fromstring(self.non_latin_and_latin_invoice._export_as_xml())
         expected_etree = self.with_applied_xpath(
             etree.fromstring(self.edi_basis_xml),

--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -97,3 +97,8 @@ class AccountMove(models.Model):
         # OVERRIDE
         self.ensure_one()
         return self.partner_shipping_id.id or super(AccountMove, self)._get_invoice_delivery_partner_id()
+
+    def _is_downpayment(self):
+        # OVERRIDE
+        self.ensure_one()
+        return self.line_ids.sale_line_ids and all(sale_line.is_downpayment for sale_line in self.line_ids.sale_line_ids) or False

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -232,3 +232,7 @@ class AccountMoveLine(models.Model):
         if currency_id and currency_id != order.currency_id:
             price_unit = currency_id._convert(price_unit, order.currency_id, order.company_id, order.date_order or fields.Date.today())
         return price_unit
+
+    def _get_downpayment_lines(self):
+        # OVERRIDE
+        return self.sale_line_ids.filtered('is_downpayment').invoice_lines.filtered(lambda line: line.move_id._is_downpayment())


### PR DESCRIPTION
### Refactor: l10n_it_edi: modify edi prepare function and template

Several fields in the l10n_it_edi XML template are adapted fairly often as work progresses on l10n_it_edi/l10n_it_edi_sdicoop. This refactor moves the computation of these field to the python code in _prepare_fattura_pa_export_values.

The computation is done for the:
(DettaglioLinee) Invoice Lines:
NumeroLinea (line number), Descrizione (description),
PrezzoUnitario (unit price), PrezzoTotale (line subtotal),

(DatiRiepilogo) Tax Lines:
Arrotondamento (tax rounding),
ImponibileImporto (tax base), Imposta (tax amount).

These are computed by the new functions _l10n_it_edi_prepare_line_details and _l10n_it_edi_prepare_tax_details and returned as lists of dictionaries, which are passed to the function that renders the template.

The template is modified on the above fields, to reference the above dictionaries, instead of performing the computation in situ.

Moving the computation of these fields to the python code has the benefit of:
a) easier, more concise computation of these terms
b) not requiring users to upgrade the l10n_it_edi module in order to
benefit from future changes to these fields (they will only need to
upgrade once).

### `_is_downpayment` method on account move
Currently there is no simple way of finding if an invoice is a downpayment.

Downpayments can be created from a sale order. An invoice is generated representing the downpayment. When the sale order is used to generate the complete invoice, the downpayment is deducted.

There is no fast way to distinguish a downpayment invoice. The only way of knowing is that the lines of the invoice will have sale_line_ids for which 'is_downpayment' (a boolean field on the sale order line) is true. 
_(although another way of telling that an invoice line is a downpayment is that, by default, the product 'Downpayment' is used for the invoice line representing the downpayment)_

This commit adds a helper method '_is_downpayment' to the account.move model, which will return False if sale is not installed, and True if sale is installed, and _is_downpayment is true of all the sale lines associated with all the lines of the invoice.

### TipoDocumento TD02 type (downpayment) in l10n_it_edi
The edi system does not properly represent the type when exporting downpayment invoices. The type (TipoDocumento) should be TD02, and instead it is TD04.

To fix this, a new key is added to the _l10n_it_document_type_mapping function that maps invoices for which _is_downpayment is true to the document type 'TD02'.

opw-2924728

### fix l10n_it_edi: use euros when reverse charge

The invoice line and tax line sections of the Italian edi should be reported in euros. Due to this, the line.balance is used instead of the line.price_subtotal when calculating the PrezzoTotale' (price_subtotal) of the line. The amount is then made negative if the line is representing a completed downpayment, or if it is a negative line on a reverse charge refund.

The unit price is calculated mostly the same way (using the new price_subtotal value). If the line has a discount of 100% then the unit price of the line is computed from the line.price_unit, by converting it to euros using the _convert method on the invoice currency.

The exchange rate and the original currency / original currency amount are listed on the lines using he 'AltriDatiGestionali' elements in the xml.

A mistake with the way a reverse charge invoice was calculated has been corrected too. Before reverse charge was determined by the document type being 'TD16', 'TD17' or 'TD18'. Where instead it should be 'TD17', 'TD18' or 'TD19'.

A typo (inovice -> invoice) has also be corrected in the tests.

ticket-id: 2952018








