### PR TITLE
[IMP] website, *: make search options inheritable

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -55,7 +55,22 @@ class WebsiteBlog(http.Controller):
 
         return OrderedDict((year, [m for m in months]) for year, months in itertools.groupby(groups, lambda g: g['year']))
 
-    def _prepare_blog_values(self, blogs, blog=False, date_begin=False, date_end=False, tags=False, state=False, page=False, search=None):
+    def _get_blog_post_search_options(self, blog=None, active_tags=None, date_begin=None, date_end=None, state=None, **post):
+        return {
+            'displayDescription': True,
+            'displayDetail': False,
+            'displayExtraDetail': False,
+            'displayExtraLink': False,
+            'displayImage': False,
+            'allowFuzzy': not post.get('noFuzzy'),
+            'blog': str(blog.id) if blog else None,
+            'tag': ','.join([str(id) for id in active_tags.ids]),
+            'date_begin': date_begin,
+            'date_end': date_end,
+            'state': state,
+        }
+
+    def _prepare_blog_values(self, blogs, blog=False, date_begin=False, date_end=False, tags=False, state=False, page=False, search=None, **post):
         """ Prepare all values to display the blogs index page or one specific blog"""
         BlogPost = request.env['blog.post']
         BlogTag = request.env['blog.tag']
@@ -101,19 +116,14 @@ class WebsiteBlog(http.Controller):
             if use_cover and not fullwidth_cover:
                 offset += 1
 
-        options = {
-            'displayDescription': True,
-            'displayDetail': False,
-            'displayExtraDetail': False,
-            'displayExtraLink': False,
-            'displayImage': False,
-            'allowFuzzy': not request.params.get('noFuzzy'),
-            'blog': str(blog.id) if blog else None,
-            'tag': ','.join([str(id) for id in active_tags.ids]),
-            'date_begin': date_begin,
-            'date_end': date_end,
-            'state': state,
-        }
+        options = self._get_blog_post_search_options(
+            blog=blog,
+            active_tags=active_tags,
+            date_begin=date_begin,
+            date_end=date_end,
+            state=state,
+            **post
+        )
         total, details, fuzzy_search_term = request.website._search_with_fuzzy("blog_posts_only", search,
             limit=page * self._blog_post_per_page, order="is_published desc, post_date desc, id asc", options=options)
         posts = details[0].get('results', BlogPost)
@@ -197,7 +207,7 @@ class WebsiteBlog(http.Controller):
                 url = QueryURL('' if blog else '/blog', ['blog', 'tag'], blog=blog, tag=tags[0], date_begin=date_begin, date_end=date_end, search=search)()
                 return request.redirect(url, code=302)
 
-        values = self._prepare_blog_values(blogs=blogs, blog=blog, date_begin=date_begin, date_end=date_end, tags=tag, state=state, page=page, search=search)
+        values = self._prepare_blog_values(blogs=blogs, blog=blog, date_begin=date_begin, date_end=date_end, tags=tag, state=state, page=page, search=search, **opt)
 
         # in case of a redirection need by `_prepare_blog_values` we follow it
         if isinstance(values, werkzeug.wrappers.Response):

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -32,6 +32,20 @@ class WebsiteEventController(http.Controller):
     # EVENT LIST
     # ------------------------------------------------------------
 
+    def _get_events_search_options(self, **post):
+        return {
+            'displayDescription': False,
+            'displayDetail': False,
+            'displayExtraDetail': False,
+            'displayExtraLink': False,
+            'displayImage': False,
+            'allowFuzzy': not post.get('noFuzzy'),
+            'date': post.get('date'),
+            'tags': post.get('tags'),
+            'type': post.get('type'),
+            'country': post.get('country'),
+        }
+
     @http.route(['/event', '/event/page/<int:page>', '/events', '/events/page/<int:page>'], type='http', auth="public", website=True, sitemap=sitemap_event)
     def events(self, page=1, **searches):
         Event = request.env['event.event']
@@ -47,18 +61,7 @@ class WebsiteEventController(http.Controller):
 
         step = 12  # Number of events per page
 
-        options = {
-            'displayDescription': False,
-            'displayDetail': False,
-            'displayExtraDetail': False,
-            'displayExtraLink': False,
-            'displayImage': False,
-            'allowFuzzy': not searches.get('noFuzzy'),
-            'date': searches.get('date'),
-            'tags': searches.get('tags'),
-            'type': searches.get('type'),
-            'country': searches.get('country'),
-        }
+        options = self._get_events_search_options(**searches)
         order = 'date_begin'
         if searches.get('date', 'upcoming') == 'old':
             order = 'date_begin desc'

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -97,6 +97,20 @@ class WebsiteForum(WebsiteProfile):
             if not qs or qs.lower() in loc:
                 yield {'loc': loc}
 
+    def _get_forum_port_search_options(self, forum=None, tag=None, filters=None, my=None, **post):
+        return {
+            'displayDescription': False,
+            'displayDetail': False,
+            'displayExtraDetail': False,
+            'displayExtraLink': False,
+            'displayImage': False,
+            'allowFuzzy': not post.get('noFuzzy'),
+            'forum': str(forum.id) if forum else None,
+            'tag': str(tag.id) if tag else None,
+            'filters': filters,
+            'my': my,
+        }
+
     @http.route(['/forum/<model("forum.forum"):forum>',
                  '/forum/<model("forum.forum"):forum>/page/<int:page>',
                  '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions''',
@@ -117,18 +131,13 @@ class WebsiteForum(WebsiteProfile):
         if not sorting:
             sorting = forum.default_order
 
-        options = {
-            'displayDescription': False,
-            'displayDetail': False,
-            'displayExtraDetail': False,
-            'displayExtraLink': False,
-            'displayImage': False,
-            'allowFuzzy': not post.get('noFuzzy'),
-            'forum': str(forum.id) if forum else None,
-            'tag': str(tag.id) if tag else None,
-            'filters': filters,
-            'my': my,
-        }
+        options = self._get_forum_port_search_options(
+            forum=forum,
+            tag=tag,
+            filters=filters,
+            my=my,
+            **post
+        )
         question_count, details, fuzzy_search_term = request.website._search_with_fuzzy("forum_posts_only", search,
             limit=page * self._post_per_page, order=sorting, options=options)
         question_ids = details[0].get('results', Post)

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -345,6 +345,19 @@ class WebsiteSlides(WebsiteProfile):
 
         return request.render('website_slides.courses_home', render_values)
 
+    def _get_slide_channel_search_options(self, my=None, slug_tags=None, slide_category=None, **post):
+        return {
+            'displayDescription': True,
+            'displayDetail': False,
+            'displayExtraDetail': False,
+            'displayExtraLink': False,
+            'displayImage': False,
+            'allowFuzzy': not post.get('noFuzzy'),
+            'my': my,
+            'tag': slug_tags or post.get('tag'),
+            'slide_category': slide_category,
+        }
+
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True)
     def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
         if slug_tags and request.httprequest.method == 'GET':
@@ -375,17 +388,12 @@ class WebsiteSlides(WebsiteProfile):
 
            * ``search``: filter on course description / name;
         """
-        options = {
-            'displayDescription': True,
-            'displayDetail': False,
-            'displayExtraDetail': False,
-            'displayExtraLink': False,
-            'displayImage': False,
-            'allowFuzzy': not post.get('noFuzzy'),
-            'my': my,
-            'tag': slug_tags or post.get('tag'),
-            'slide_category': slide_category,
-        }
+        options = self._get_slide_channel_search_options(
+            my=my,
+            slug_tags=slug_tags,
+            slide_category=slide_category,
+            **post
+        )
         search = post.get('search')
         order = self._channel_order_by_criterion.get(post.get('sorting'))
         _, details, fuzzy_search_term = request.website._search_with_fuzzy("slide_channels_only", search,


### PR DESCRIPTION
*: website_blog, website_event, website_forum, website_slides

With [1] it has been made easier for partners to extend search options.

This task introduces similar inheritable functions for blog posts,
events, forum posts, slides, pages and hybrid results.

[1]: https://github.com/odoo/odoo/commit/d29f2f3ac5f8c3e8109287e0933609bdbe0cadb1

task-2897924
