### PR TITLE
[IMP] web: make names available in search model

### DIFF
--- a/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
@@ -64,6 +64,7 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
      *          > @prop {string} fieldType 'date' or 'datetime', type of the corresponding field
      *      @else
      *          > @prop {string} domain
+     *      @prop {string} [name] 'name' attribute set in arch
      *
      * • type 'groupBy':
      *      @prop {string} fieldName
@@ -78,6 +79,7 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
      *      @if hasOptions=true
      *          > @prop {string} defaultOptionId option identifier (see INTERVAL_OPTIONS)
      *                           default set to DEFAULT_INTERVAL.
+     *      @prop {string} [name] 'name' attribute set in arch
      *
      * • type 'field':
      *      @prop {string} fieldName
@@ -945,6 +947,9 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
                     if (filter.isDefault) {
                         filter.defaultRank = -5;
                     }
+                    if (attrs.name) {
+                        filter.name = attrs.name;
+                    }
                     break;
                 case 'groupBy':
                     filter.fieldName = attrs.fieldName;
@@ -955,6 +960,9 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
                     }
                     if (filter.isDefault) {
                         filter.defaultRank = attrs.defaultRank;
+                    }
+                    if (attrs.name) {
+                        filter.name = attrs.name;
                     }
                     break;
                 case 'field': {

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -224,7 +224,7 @@ export class SearchArchParser extends XMLParser {
             const modifiers = JSON.parse(node.getAttribute("modifiers"));
             if (modifiers.invisible) {
                 preSearchItem.invisible = true;
-                let fieldName = preSearchItem.fieldName;
+                const fieldName = preSearchItem.fieldName;
                 if (fieldName && !this.fields[fieldName]) {
                     // In some case when a field is limited to specific groups
                     // on the model, we need to ensure to discard related filter
@@ -236,6 +236,7 @@ export class SearchArchParser extends XMLParser {
         preSearchItem.groupNumber = this.groupNumber;
         if (node.hasAttribute("name")) {
             const name = node.getAttribute("name");
+            preSearchItem.name = name;
             if (name in this.searchDefaults) {
                 preSearchItem.isDefault = true;
                 if (["groupBy", "dateGroupBy"].includes(preSearchItem.type)) {

--- a/addons/web/static/tests/legacy/control_panel/control_panel_model_extension_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/control_panel_model_extension_tests.js
@@ -113,6 +113,7 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                 {
                     description: "Hello",
                     domain: "[]",
+                    name: "filter",
                     type: "filter",
                 },
             ]);
@@ -135,6 +136,7 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                     fieldType: "date",
                     isDateFilter: true,
                     hasOptions: true,
+                    name: "date_filter",
                     type: "filter"
                   },
                   {
@@ -167,6 +169,7 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                     fieldName: "date_field",
                     fieldType: "date",
                     hasOptions: true,
+                    name: "groupby",
                     type: "groupBy",
                 },
             ]);
@@ -185,11 +188,13 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                 {
                     description: "Hello One",
                     domain: "[]",
+                    name: "filter_1",
                     type: "filter",
                 },
                 {
                     description: "Hello Two",
                     domain: "[('bar', '=', 3)]",
+                    name: "filter_2",
                     type: "filter",
                 },
             ]);
@@ -209,11 +214,13 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                 {
                     description: "Hello One",
                     domain: "[]",
+                    name: "filter_1",
                     type: "filter",
                 },
                 {
                     description: "Hello Two",
                     domain: "[('bar', '=', 3)]",
+                    name: "filter_2",
                     type: "filter",
                 },
             ]);
@@ -232,6 +239,7 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                 {
                     description: "Hello",
                     domain: "[]",
+                    name: "filter",
                     type: "filter",
                 },
                 {
@@ -377,6 +385,7 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                 {
                     description: 'Hello',
                     domain: "[]",
+                    name: "filter",
                     type: 'filter',
                 },
                 {
@@ -391,6 +400,7 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
                     fieldName: 'foo',
                     fieldType: 'char',
                     isDefault: true,
+                    name: "groupby",
                     type: 'groupBy',
                 },
             ]);

--- a/addons/web/static/tests/search/search_model_tests.js
+++ b/addons/web/static/tests/search/search_model_tests.js
@@ -226,6 +226,7 @@ QUnit.module("Search", (hooks) => {
             {
                 description: "Hello",
                 domain: "[]",
+                name: "filter",
                 type: "filter",
             },
         ]);
@@ -248,6 +249,7 @@ QUnit.module("Search", (hooks) => {
                 description: "Date",
                 fieldName: "date_field",
                 fieldType: "date",
+                name: "date_filter",
                 type: "dateFilter",
             },
             {
@@ -281,6 +283,7 @@ QUnit.module("Search", (hooks) => {
                 description: "Hi",
                 fieldName: "date_field",
                 fieldType: "date",
+                name: "groupby",
                 type: "dateGroupBy",
             },
         ]);
@@ -301,11 +304,13 @@ QUnit.module("Search", (hooks) => {
             {
                 description: "Hello One",
                 domain: "[]",
+                name: "filter_1",
                 type: "filter",
             },
             {
                 description: "Hello Two",
                 domain: "[('bar', '=', 3)]",
+                name: "filter_2",
                 type: "filter",
             },
         ]);
@@ -327,11 +332,13 @@ QUnit.module("Search", (hooks) => {
             {
                 description: "Hello One",
                 domain: "[]",
+                name: "filter_1",
                 type: "filter",
             },
             {
                 description: "Hello Two",
                 domain: "[('bar', '=', 3)]",
+                name: "filter_2",
                 type: "filter",
             },
         ]);
@@ -352,6 +359,7 @@ QUnit.module("Search", (hooks) => {
             {
                 description: "Hello",
                 domain: "[]",
+                name: "filter",
                 type: "filter",
             },
             {
@@ -605,6 +613,7 @@ QUnit.module("Search", (hooks) => {
                 description: "Foo",
                 fieldName: "foo",
                 fieldType: "char",
+                name: "group_by",
                 type: "groupBy",
                 isDefault: true,
             },
@@ -823,6 +832,7 @@ QUnit.module("Search", (hooks) => {
                 description: "Foo",
                 fieldName: "foo",
                 fieldType: "char",
+                name: "foo",
                 type: "groupBy",
             },
             {
@@ -882,11 +892,11 @@ QUnit.module("Search", (hooks) => {
             serverData,
             searchViewArch,
             context: {
-                "my_date": "2021-09-17"
-            }
+                my_date: "2021-09-17",
+            },
         });
 
         model.toggleSearchItem(1);
-        assert.deepEqual(model.domain, [['date_deadline', '<', "2021-09-17"]]);
+        assert.deepEqual(model.domain, [["date_deadline", "<", "2021-09-17"]]);
     });
 });


### PR DESCRIPTION
The "name" attributes set on the filter nodes in a search arch are now
kept in the search items created from them. This will allow an easier
manipulation of search items (e.g. toggle a filter with a given name).