### PR TITLE
[IMP] website_sale_stock_wishlist: prevent user adding to cart item out of stock

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -83,9 +83,6 @@ class Product(models.Model):
         # the template extra images here
         return variant_images + self.product_tmpl_id._get_images()[1:]
 
-    def _is_sold_out(self):
-        combination_info = self.with_context(website_sale_stock_get_quantity=True).product_tmpl_id._get_combination_info(product_id=self.id)
-        return combination_info['product_type'] == 'product' and combination_info['free_qty'] <= 0
 
     def _website_show_quick_add(self):
         website = self.env['website'].get_current_website()

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -374,8 +374,6 @@ class ProductTemplate(models.Model):
             if product.id:
                 product.website_url = "/shop/%s" % slug(product)
 
-    def _is_sold_out(self):
-        return self.product_variant_id._is_sold_out()
 
     def _get_website_ribbon(self):
         if self.website_ribbon_id:

--- a/addons/website_sale_stock/models/product_product.py
+++ b/addons/website_sale_stock/models/product_product.py
@@ -17,3 +17,7 @@ class ProductProduct(models.Model):
                     cart._get_common_product_lines(product=self).mapped('product_uom_qty')
                 )
         return 0
+
+    def _is_sold_out(self):
+        combination_info = self.with_context(website_sale_stock_get_quantity=True).product_tmpl_id._get_combination_info(product_id=self.id)
+        return combination_info['product_type'] == 'product' and combination_info['free_qty'] <= 0

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -48,3 +48,6 @@ class ProductTemplate(models.Model):
             })
 
         return combination_info
+
+    def _is_sold_out(self):
+        return self.product_variant_id._is_sold_out()

--- a/addons/website_sale_stock_wishlist/__manifest__.py
+++ b/addons/website_sale_stock_wishlist/__manifest__.py
@@ -13,7 +13,7 @@ Allow the user to select if he wants to receive email notifications when a produ
         'website_sale_wishlist',
     ],
     'data': [
-        'views/templates.xml',
+        'views/website_sale_stock_wishlist_templates.xml',
         'data/template_email.xml',
         'data/ir_cron_data.xml',
     ],

--- a/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
+++ b/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
@@ -10,5 +10,15 @@
                 <small><i t-attf-class="fa #{'fa-check-square-o' if notify else 'fa-square-o'}"></i> Be notified when back in stock</small>
             </button>
         </xpath>
+        <xpath expr="//button[@id='add_to_cart_button']" position="replace">
+            <t t-set="is_sold_out"
+               t-value="not wish.product_id.allow_out_of_stock_order and wish.product_id._is_sold_out()"/>
+            <button id="add_to_cart_button"
+                    class="btn btn-secondary btn-block o_wish_add mb4"
+                    t-att-disabled="is_sold_out">
+                Add
+                <span class='d-none d-md-inline'>to Cart</span>
+            </button>
+        </xpath>
     </template>
 </odoo>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -200,7 +200,7 @@
                                         <td class='text-center td-wish-btn align-middle'>
                                             <input name="product_id" t-att-value="wish.product_id.id" type="hidden"/>
                                             <a t-if="combination_info['prevent_zero_price_sale']" t-att-href="website.contact_us_button_url" class="btn btn-primary btn_cta">Contact Us</a>
-                                            <button t-else="" type="button" role="button" class="btn btn-secondary btn-block o_wish_add mb4" >
+                                            <button id="add_to_cart_button" t-else="" type="button" role="button" class="btn btn-secondary btn-block o_wish_add mb4" >
                                                 Add <span class='d-none d-md-inline'>to Cart</span>
                                             </button>
                                         </td>


### PR DESCRIPTION
This PR greys out the add to cart button on the `wishlist` page when a product of type `product` is out of stock

task-id 2907659