### PR TITLE
[FIX] account_edi_ubl_cii: allow the import of customer invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -244,6 +244,7 @@ class AccountEdiCommon(models.AbstractModel):
         move_type, qty_factor = self._get_import_document_amount_sign(filename, tree)
         if not move_type or (existing_invoice and existing_invoice.move_type != move_type):
             return
+        move_type = self._context.get('default_move_type', move_type)
 
         invoice = existing_invoice or self.env['account.move']
         invoice_form = Form(invoice.with_context(

--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -174,6 +174,12 @@ class AccountEdiFormat(models.Model):
         # EXTENDS account_edi
         self.ensure_one()
 
+        context_move_type = self._context.get('default_move_type', None)
+        if context_move_type:
+            last_move = self.env['account.move'].search([('move_type', '=', context_move_type)], limit=1)
+            if last_move:
+                journal = last_move.journal_id
+
         if not journal:
             # infer the journal
             journal = self.env['account.journal'].search([


### PR DESCRIPTION
Before this commit:
- Go to Accounting / Customer Invoices
- Upload a PDF with Factur-X XML embedded
- The document is uploaded as a Vendor Bill

This should not be the case anymore since we want to allow the import of customer invoices (that can be generated elsewhere)

This commit makes sure that we check from where we import the PDF (Upload button of Customer Invoices or Vendor Bills) to determine in which journal the generated invoice should go.

task-id 2950177
