### PR TITLE
[FIX] website: display website in ir.ui.view relation fields

### DIFF
--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -119,7 +119,7 @@
                             <group>
                                 <field name="name"/>
                                 <field name="url"/>
-                                <field name="view_id" context="{'display_website': True}"/>
+                                <field name="view_id" context="{'display_website': True}" options="{'always_reload': True}"/>
                                 <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                                 <field name="track"/>
                             </group>
@@ -267,6 +267,7 @@
             <field name="arch" type="xml">
                 <field name="inherit_id" position="attributes">
                     <attribute name="context">{'display_website': True}</attribute>
+                    <attribute name="options">{'always_reload': True}</attribute>
                 </field>
                 <field name="type" position="after">
                     <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>


### PR DESCRIPTION
Since [1], the ir.ui.view name_get can suffix the name with the website,
something like `Main Layout [Website 1]` instead of just `Main Layout`.
This is fundamental when managing a DB as with the multi website / COW
mechanism, views are duplicated, making it impossible to know which one
is coming from which website (or is the generic one) when selecting a
new record in a field input.

While it worked great for the autocomplete list, the default value when
loading the form/list views were still not displaying the website.
You thus have the same issue: you have to navigate to that view to
figure which one it is.
When managing multi website DBs, this is becoming tricky.

This commit also adds that behavior to the value shown when loading a
form/tree view.

[1]: https://github.com/odoo/odoo/commit/ea3a2ab6788980a8961d9b9a3f88bc13c15a3c46
