### PR TITLE
[FIX] website_sale: prevent adding empty fields

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1911,7 +1911,7 @@
                     <field name="shop_extra_field_ids" context="{'default_website_id': active_id}">
                         <tree editable="bottom">
                             <field name="sequence" widget="handle"/>
-                            <field name="field_id"/>
+                            <field name="field_id" required="1"/>
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Steps to reproduce:
1- install eCommerce app
2- go to Website > Configuration > Websites
3- on a website "product page extra fields" tab add an empty line and save
4- visit any product page on the website (500: internal server error)

Bug:
adding an empty field crashes the website server on the product page

Fix:
made the field required

opw-2945621