### PR TITLE
[FIX] l10n_latam_invoice_document: Avoid error on field assignation

### DIFF
--- a/addons/l10n_latam_invoice_document/__manifest__.py
+++ b/addons/l10n_latam_invoice_document/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     "name": "LATAM Document",
-    "version": "1.0",
+    "version": "1.1",
     "author": "ADHOC SA",
     'category': 'Accounting/Localizations',
     "summary": "LATAM Document Types",

--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
@@ -8,7 +8,7 @@ class AccountMoveReversal(models.TransientModel):
     _inherit = "account.move.reversal"
 
     l10n_latam_use_documents = fields.Boolean(compute='_compute_document_type')
-    l10n_latam_document_type_id = fields.Many2one('l10n_latam.document.type', 'Document Type', ondelete='cascade', domain="[('id', 'in', l10n_latam_available_document_type_ids)]", compute='_compute_document_type', readonly=False, inverse='_inverse_document_type')
+    l10n_latam_document_type_id = fields.Many2one('l10n_latam.document.type', 'Document Type', ondelete='cascade', domain="[('id', 'in', l10n_latam_available_document_type_ids)]", compute='_compute_document_type', readonly=False, inverse='_inverse_document_type', store=True)
     l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_document_type')
     l10n_latam_document_number = fields.Char(string='Document Number')
     l10n_latam_manual_document_number = fields.Boolean(compute='_compute_l10n_latam_manual_document_number', string='Manual Number')
@@ -39,7 +39,6 @@ class AccountMoveReversal(models.TransientModel):
     @api.depends('move_ids')
     def _compute_document_type(self):
         self.l10n_latam_available_document_type_ids = False
-        self.l10n_latam_document_type_id = False
         self.l10n_latam_use_documents = False
         for record in self:
             if len(record.move_ids) > 1:
@@ -56,6 +55,7 @@ class AccountMoveReversal(models.TransientModel):
                     'partner_id': record.move_ids.partner_id.id,
                     'company_id': record.move_ids.company_id.id,
                 })
+                refund.l10n_latam_document_type_id = self.l10n_latam_document_type_id or refund.l10n_latam_document_type_id
                 record.l10n_latam_document_type_id = refund.l10n_latam_document_type_id
                 record.l10n_latam_available_document_type_ids = refund.l10n_latam_available_document_type_ids
 


### PR DESCRIPTION
The document type on move reversal could be changed to use the correct
type to be generated.

In this case, in Peru, the document type for credit note could be:
- Nota de credito
- Nota de credito boleta
And the type to be used could be set in the wizard that allows creating a
credit note from an invoice.

Without this change, if you use the second type (Nota de credito
boleta), the refund is created with (Nota de credito) because ignore
that was forced a type on the wizard.

opw#853 latam




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
