### PR TITLE
[FIX] website_slides: fix broken one2many in form view

### DIFF
--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -6,7 +6,7 @@
             <field name="name">slide.channel.view.form</field>
             <field name="model">slide.channel</field>
             <field name="arch" type="xml">
-                <form string="Channels">
+                <form string="Channels" js_class="legacy_form">
                     <header>
                         <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight" attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
                     </header>


### PR DESCRIPTION
With the conversion to the new views, legacy x2many fields go through a
thin and incomplete compatibility layer to talk to the new model. This
compatibility layer is not very robust and as such most custom x2many
fields are broken in this configuration, in this case the field
"slide_category_one2many".

The proper fix is to convert this field widget, but in the mean time,
the simple fix is to force this view to keep using the legacy view
instead of the new view.