### PR TITLE
[FIX] website: fix image alignment in search results

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1471,6 +1471,11 @@ $ribbon-padding: 100px;
     display: none !important;
 }
 
+// Search results
+.o_search_result_item_detail {
+    flex: 1;
+}
+
 // Cookies Bar
 #website_cookies_bar {
     :not(.o_cookies_popup) {

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -21,7 +21,7 @@
                 <img t-if="result['image_url']" t-att-src="result['image_url']" class="flex-shrink-0 o_image_64_contain"/>
                 <i t-else="" t-attf-class="o_image_64_contain text-center pt16 fa #{result['_fa']}" style="font-size: 34px;"/>
             </t>
-            <div class="flex-grow-1 px-3">
+            <div class="o_search_result_item_detail px-3">
                 <t t-set="description" t-value="parts['description'] and widget.displayDescription and result['description']"/>
                 <t t-set="extra_link" t-value="parts['extra_link'] and widget.displayExtraLink and result['extra_link_url'] and result['extra_link']"/>
                 <t t-set="extra_link_html" t-value="parts['extra_link'] and widget.displayExtraLink and !result['extra_link_url'] and result['extra_link']"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2454,7 +2454,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
         <div class="d-flex align-items-center o_search_result_item">
             <img t-if="result.get('image_url')" t-att-src="result.get('image_url')" class="flex-shrink-0 o_image_64_contain"/>
             <i t-else="" t-att-class="'o_image_64_contain text-center pt16 fa %s' % result.get('_fa')" style="font-size: 34px;"/>
-            <div class="flex-grow-1 px-3">
+            <div class="o_search_result_item_detail px-3">
                 <t t-set="description" t-value="result.get('description')"/>
                 <t t-set="extra_link" t-value="result.get('extra_link_url') and result.get('extra_link')"/>
                 <t t-set="extra_link_html" t-value="not result.get('extra_link_url') and result.get('extra_link')"/>


### PR DESCRIPTION
Since [1] when Bootstrap 5 was introduced, the images of search results
are not aligned anymore. This is because the detail part of the result
has been set to `flex-grow-1`.

This commit restores the former flex parameterisation through a new
class. The fix is applied both on the autocomplete results template and
the hybrid results element template (used to render `/website/search`).

[1]: https://github.com/odoo/odoo/commit/971e5a91aab96d36129a823e03f1f9f1b1293968

task-2951028

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
