### PR TITLE
[FIX] website_slides : page selector change embedded code

### DIFF
--- a/addons/website_slides/static/src/js/slides.js
+++ b/addons/website_slides/static/src/js/slides.js
@@ -100,7 +100,7 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
      */
     start: function (parent) {
         var defs = [this._super.apply(this, arguments)];
-        $('iframe.o_wslides_iframe_viewer').on('ready', this._onIframeViewerReady.bind(this));
+        $('iframe.o_wslides_iframe_viewer').ready(this._onIframeViewerReady.bind(this));
         return Promise.all(defs);
     },
 
@@ -115,8 +115,9 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
     _onIframeViewerReady: function (ev) {
         // TODO : make it work. For now, once the iframe is loaded, the value of #page_count is
         // still now set (the pdf is still loading)
-        var $iframe = $(ev.currentTarget);
-        var maxPage = $iframe.contents().find('#page_count').val();
+        var maxPage = parseInt(
+            $('iframe.o_wslides_iframe_viewer').contents().find('#page_count').text()
+        );
         new SlideSocialEmbed(this, maxPage).attachTo($('.oe_slide_js_embed_code_widget'));
     },
 });

--- a/addons/website_slides/static/src/js/slides_embed.js
+++ b/addons/website_slides/static/src/js/slides_embed.js
@@ -210,17 +210,6 @@ $(function () {
             }
         );
 
-        // embed widget page selector
-        $('.oe_slide_js_embed_code_widget input').on('change', function () {
-            var page = parseInt($(this).val());
-            if (!(page > 0 && page <= embeddedViewer.pdf_viewer.pdf_page_total)) {
-                page = 1;
-            }
-            var actualCode = embeddedViewer.$('.slide_embed_code').val();
-            var newCode = actualCode.replace(/(page=).*?([^\d]+)/, '$1' + page + '$2');
-            embeddedViewer.$('.slide_embed_code').val(newCode);
-        });
-
         // To avoid create a dependancy to openerpframework.js, we use JQuery AJAX to post data instead of ajax.jsonRpc
         $('.oe_slide_js_share_email button').on('click', function () {
             var widget = $('.oe_slide_js_share_email');


### PR DESCRIPTION
Steps to reproduce:

  1. Install website_slides
  2. Create a new course, add a pdf
  3. view the pdf
  4. exit fullscreen
  5. click on "share" at the bottom
  6. change the start page

Issue:

  The embedded code does not change

Cause:

  The scope of the JQuery selector was inside the iframe.

Solution:

  Escape the ifram by using the top.document

Improvement:

  Adding a max and min on the input, there is no sense to select a page < 1 or above the amount of pages in the pdf

opw-2948880