### PR TITLE
[FIX][15.0] hr_holidays: Fix the wrong timezone display

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -762,13 +762,15 @@ class HolidaysRequest(models.Model):
                             )
                         ))
                     else:
+                        user_tz = timezone(leave.tz)
+                        date_from_utc = leave.date_from.astimezone(user_tz).date()
                         res.append((
                             leave.id,
                             _("%(person)s on %(leave_type)s: %(duration).2f hours on %(date)s",
                                 person=target,
                                 leave_type=leave.holiday_status_id.name,
                                 duration=leave.number_of_hours_display,
-                                date=fields.Date.to_string(leave.date_from),
+                                date=fields.Date.to_string(date_from_utc),
                             )
                         ))
                 else:


### PR DESCRIPTION
While testing the application, I get the following error:

When the new creation is complete and raise message the user to display the wrong time zone selected
I do this PR to correct that error, help show correct local time zone.

[steps]:

(My UTC +7, Asia/Saigon)
1.

- Access the Time Off module (Dashboard)
- Create holidays (Type = Unpaid, Custom Time = True, From = 12:00AM)
- Check the created holiday on the dashboard is not the same as the created date

2.

- Create a holiday with the same date you just created (Type = Unpaid, Custom Time = True, From = 12:00AM)
- Raise message field 'date_from' wrong time zone and creation date
- 
[Actual] :
- showing screen wrong timezone field 'date_from' (showing UTC+0)

[Expected]:
- Display the correct time zone screen to the user



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
