### PR TITLE
[FIX] auth_totp: fix the incomplete fix

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -59,6 +59,17 @@ function closeProfileDialog({content, totp_state}) {
                 $modal.find('button[name=preference_cancel]').click()
             }
         }
+    }, {
+        trigger: 'body',
+        async run() {
+            while (document.querySelector('.o_dialog_container .o_dialog')) {
+                await Promise.resolve();
+            }
+            this.$anchor.addClass('dialog-closed');
+        },
+    }, {
+        trigger: 'body.dialog-closed',
+        run() {},
     }];
 }
 


### PR DESCRIPTION
The previous pass in #97567 missed a small window of race condition
in *closing the fecking dialog*. Apparently that's still not
instantaneous enough and it's possible to have the check trigger in
the interval between clicking the button and the dialog being
completely torn down.

Add an explicit test for this to the existing `closeProfileDialog`
utility function.
