### PR TITLE
[FIX] point_of_sale: allow selection of pricelist when creating contact

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
@@ -15,6 +15,8 @@ odoo.define('point_of_sale.ClientDetailsEdit', function(require) {
                 'country_id': partner.country_id && partner.country_id[0],
                 'state_id': partner.state_id && partner.state_id[0],
             };
+            if (!partner.property_product_pricelist)
+                this.changes['property_product_pricelist'] = this.env.pos.default_pricelist.id;
         }
         mounted() {
             this.env.bus.on('save-customer', this, this.saveChanges);

--- a/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientDetailsEdit.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientDetailsEdit.xml
@@ -105,7 +105,7 @@
                             <t t-foreach="env.pos.pricelists" t-as="pricelist"
                                t-key="pricelist.id">
                                 <option t-att-value="pricelist.id"
-                                        t-att-selected="props.partner.property_product_pricelist ? (pricelist.id === props.partner.property_product_pricelist[0] ? true : false) : false">
+                                        t-att-selected="props.partner.property_product_pricelist ? (pricelist.id === props.partner.property_product_pricelist[0] ? true : undefined) : pricelist.id === env.pos.default_pricelist.id ? true : undefined">
                                     <t t-esc="pricelist.display_name" />
                                 </option>
                             </t>


### PR DESCRIPTION
Steps to reproduce:
1. create additional pricelist `p1`
2. add `p1` to available pricelists in PoS, remove default pricelist
3. open the session, create a new contact, don't change the pricelist
4. the created contact will have default pricelist and there is no
way to use `p1` as its pricelist

The problem is that when creating contacts, if the pricelist had not
been changed, it is not passed to be processed and so the contact is
created with the default pricelist, even though the default pricelist
is not available in the PoS.

To fix the problem, we can use the default pricelist of the PoS as the
default when creating new contacts and pass it as well.

opw-2930778

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
