### PR TITLE
[FIX] sale_timesheet: correct qty_delivered_method computation

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -205,7 +205,7 @@ class SaleOrderLine(models.Model):
         """ Sale Timesheet module compute delivered qty for product [('type', 'in', ['service']), ('service_type', '=', 'timesheet')] """
         super(SaleOrderLine, self)._compute_qty_delivered_method()
         for line in self:
-            if not line.is_expense and line.product_id.type == 'service' and line.product_id.service_type == 'timesheet':
+            if not line.is_expense and line.product_id.type == 'service' and (line.product_id.service_type == 'timesheet' or line.product_id.service_policy == 'ordered_timesheet'):
                 line.qty_delivered_method = 'timesheet'
 
     @api.depends('analytic_line_ids.project_id', 'project_id.pricing_type')


### PR DESCRIPTION
The `qty_delivered_method` field controls whether user can edit Delivered Qty field
or not.

The `qty_delivered_method` field is computed based on product's `service_type` field.

The `service_type` field must correspond to product's `service_policy` field
[1]. If you change `service_policy` value to another one and then back to
`ordered_timesheet` ('Prepaid/Fixed Price' - default value for Delivery
product), then `service_policy` is set to `timesheet` and hence
`qty_delivered_method` is set to `timesheet`. It means that Delivered Qty will
be switched from editable mode to non-editable.

The correct behavior is keeping Delivered Qty not editable for Delivery
products, because "delivery product is never delivered" [3].

As a quick solution, this commit fixes computation of `qty_delivered_method` field.

[1]: https://github.com/odoo/odoo/blob/89ecb17f56b34b7e3875fa36cde70a2666dca4d8/addons/sale_timesheet/models/product.py#L50-L61
[2]: opw-2820133
[3]: https://github.com/odoo/odoo/pull/62345

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
