### PR TITLE
[FIX] test_website: fix test when trigram psql extention is installed.

### DIFF
--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -44,7 +44,7 @@ class TestAutoComplete(TransactionCase):
         # => Find exact match through the fallback
         self._autocomplete('REF3000', 1, False)
         # => No exact match => Find fuzzy within first 1000 (distance=3: replace D by F, move 3, add 1)
-        self._autocomplete('RED3000', 1, 'ref1003')
+        self._autocomplete('RED3000', 1, 'ref3000' if self.env.registry.has_trigram else 'ref1003')
         # => Find exact match through the fallback
         self._autocomplete('REF300', 10, False)
         # => Find exact match through the fallback


### PR DESCRIPTION
When we want to activate trigram psql extension for odoo/odoo#97294
on runbot. But one test fails (`test_01_many_records`) with it because the website fuzzy search behavior depends on trigram extension presence.
