### PR TITLE
[FIX] product: Dymo report label adjustment

### DIFF
--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -104,12 +104,12 @@
                         <t t-if="barcode">
                             <!-- `quiet=0` to remove the left and right margins on the barcode -->
                             <div t-out="barcode" style="padding:0" t-options="{'widget': 'barcode', 'quiet': 0, 'symbology': 'auto', 'img_style': barcode_size}"/>
-                            <div class="o_label_name" style="line-height: 130%;height:2.0em;background-color: transparent;">
+                            <div class="o_label_name" style="height:1.7em;background-color: transparent;">
                                 <span t-out="barcode"/>
                             </div>
                         </t>
                     </div>
-                    <div class="o_label_name" style="line-height: 130%;height:2.0em;background-color: transparent;">
+                    <div class="o_label_name" style="line-height: 100%;height: 2.1em;background-color: transparent;padding-top: 1px;">
                         <span t-if="product.is_product_variant" t-field="product.display_name"/>
                         <span t-else="" t-field="product.name"/>
                     </div>


### PR DESCRIPTION
Steps to reproduce:

- Choose product with long name > product page > print labels
- choose Dymo from list + add extra content

When printing the label, the product name clips out of its bounding box.
This commit makes a small visual change so that the name fits.

If you need to further modify this, mind the extra content on the label.

opw-2944988
