### PR TITLE
[FIX] sale_project: reduce the activities displayed on project update

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -281,8 +281,8 @@ class Project(models.Model):
         } for sol_read in sols.with_context(with_price_unit=True).read(['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom'])]
 
     def _get_sale_items_domain(self, additional_domain=None):
-        sale_orders = self._get_sale_order_items().sudo().order_id
-        domain = [('order_id', 'in', sale_orders.ids), ('is_downpayment', '=', False), ('state', 'in', ['sale', 'done']), ('display_type', '=', False)]
+        sale_line_ids = self._fetch_sale_order_item_ids()
+        domain = [('id', 'in', sale_line_ids), ('is_downpayment', '=', False), ('state', 'in', ['sale', 'done']), ('display_type', '=', False)]
         if additional_domain:
             domain = expression.AND([domain, additional_domain])
         return domain

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -164,7 +164,7 @@ class TestSaleProject(TransactionCase):
         self.assertIn(task.sale_line_id, self.project_global._get_sale_order_items())
         self.assertEqual(self.project_global._get_sale_orders(), sale_order | sale_order_2)
 
-        sale_order_lines = sale_order.order_line + sale_line_1_order_2  # exclude the Section and Note Sales Order Items
+        sale_order_lines = so_line_order_task_in_global + sale_line_1_order_2  # exclude the Section and Note Sales Order Items, only choose the ones related to project_global
         sale_items_data = self.project_global._get_sale_items(with_action=False)
         self.assertEqual(sale_items_data['total'], len(sale_order_lines))
         expected_sale_line_dict = {


### PR DESCRIPTION
This commit changes the activities that are displayed on the project update.
(Both in the table of the project update form view and on the right panel in project update)
Specifically it reduces the sale order items to only the ones that are directly
related to the project (the project itself or its tasks)

A test was modified in order to accommodate the change.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
