### PR TITLE
[FIX] website_event_track: Prevent title from flickering

### DIFF
--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -164,13 +164,15 @@
                     <field name="legend_normal" invisible="1"/>
                     <field name="legend_done" invisible="1"/>
                     <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
-                    <field name="kanban_state" widget="state_selection" class="ms-3 float-end"/>
-                    <field name="website_image" widget="image" class="oe_avatar"/>
-                    <div class="oe_title">
-                        <label for="name"/>
-                        <h1>
-                            <field name="name" placeholder="e.g. Inspiring Business Talk"/>
-                        </h1>
+                    <div class="d-flex gap-4 mb-3">
+                        <div class="flex-grow-1">
+                            <label for="name"/>
+                            <h1>
+                                <field name="name" placeholder="e.g. Inspiring Business Talk"/>
+                            </h1>
+                        </div>
+                        <field name="website_image" widget="image" class="oe_avatar"/>
+                        <field name="kanban_state" widget="state_selection"/>
                     </div>
                     <group>
                         <group>


### PR DESCRIPTION
Fixing the display of long track names by taking all the
width for the title in edit mode and forcing line breaks in
read mode.

Task-2941724
