### PR TITLE
[FIX] web_editor: fix sizing issues with card conversion

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -159,6 +159,11 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         return this._super.apply(this, arguments);
     },
+    _createWysiwygInstance: async function () {
+        const res = await this._super(...arguments);
+        this.wysiwyg.getEditable().find('img').attr('loading', '');
+        return res;
+    },
 
     /**
      * @override


### PR DESCRIPTION
- Card dimensions were not properly preserved on mailing conversion.
- If images are lazy loaded in mass_mailing they risk not being converted properly. This removes the loading attribute from all previously added images when the editor loads.

opw-2850967

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
