### PR TITLE
[FIX] account: cash basis entry date

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -472,6 +472,7 @@ class AccountPartialReconcile(models.Model):
         :return: The newly created journal entries.
         '''
         tax_cash_basis_values_per_move = self._collect_tax_cash_basis_values()
+        today = fields.Date.context_today(self)
 
         moves_to_create = []
         to_reconcile_after = []
@@ -483,9 +484,10 @@ class AccountPartialReconcile(models.Model):
                 partial = partial_values['partial']
 
                 # Init the journal entry.
+                move_date = partial.max_date if partial.max_date > (move.company_id.period_lock_date or date.min) else today
                 move_vals = {
                     'move_type': 'entry',
-                    'date': partial.max_date,
+                    'date': move_date,
                     'ref': move.name,
                     'journal_id': partial.company_id.tax_cash_basis_journal_id.id,
                     'line_ids': [],


### PR DESCRIPTION
Create an invoice in date1 with a tax due based on payment (cash basis)
Create a credit note in date2 for the invoice (with date2 > date1)
Set tax lock date in date3 (with today > date3 > date2 > date1)
In the invoice add the credit note as payment

The system will block the action, because the created cash basis
entry would use as date the most recent between invoice and credit note,
which is previous to the lock date.

opw-2730106


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
