### PR TITLE
[IMP] web: graph: add group by many2many

### DIFF
--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -431,7 +431,7 @@ export class GraphModel extends Model {
                                     label = `${val}`; // toUpperCase?
                                 } else if (val === false) {
                                     label = this.env._t("Undefined");
-                                } else if (type === "many2one") {
+                                } else if (["many2many", "many2one"].includes(type)) {
                                     const [id, name] = val;
                                     const key = JSON.stringify([fieldName, name]);
                                     if (!numbering[key]) {
@@ -501,9 +501,10 @@ export class GraphModel extends Model {
         const processedGroupBy = [];
         for (const gb of groupBy) {
             const { fieldName, interval } = gb;
-            const { sortable, type } = fields[fieldName];
+            const { sortable, type, store } = fields[fieldName];
             if (
-                !sortable ||
+                // many2many is groupable precisely when it is stored (cf. groupable in odoo/fields.py)
+                (type === "many2many" ? !store : !sortable) ||
                 ["id", "__count"].includes(fieldName) ||
                 !GROUPABLE_TYPES.includes(type)
             ) {


### PR DESCRIPTION
The objective of this PR is to allow grouping by many2many fields in graph

### Current behaviour: 
It is possible to select m2m in the graph 'group by' but without any effect on the graph. 
### Expected behaviour by merging this PR 
- It is possible to select a m2m in the group by and it has an impact in the graph.

task-2721035