### PR TITLE
[FIX] l10n_ar_website_sale: display error message for required fields

### DIFF
--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -41,6 +41,8 @@ class L10nARWebsiteSale(WebsiteSale):
         # Identification type and AFIP Responsibility Combination
         if request.website.sudo().company_id.country_id.code == "AR":
             if mode[1] == 'billing':
+                if error and any(field in error for field in ['l10n_latam_identification_type_id', 'l10n_ar_afip_responsibility_type_id']):
+                    return error, error_message
                 id_type_id = data.get("l10n_latam_identification_type_id")
                 afip_resp_id = data.get("l10n_ar_afip_responsibility_type_id")
 


### PR DESCRIPTION
Steps to reproduce:

  - Install l10n_ar_website_sale
  - Go to shop and add a product to cart
  - Go to cart and click on `Checkout`
  - Ensure `AFIP Responsibility` is not field
  - Click on `Next`

Issue:

  Traceback raised.

Cause:

  During the validation of the form, even if the pre-validation (by
  calling super) returns an error for the afip fields because there
  are empty while they are required, we still try to get the code
  of the afip responsibility.

Solution:

  Raise an error if the afip fields are empty before continuing the
  validation.

opw-2941199