### PR TITLE
[IMP] l10n_es: Add taxes for 'ISP Bienes de Inversión'

### DIFF
--- a/addons/l10n_es/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_es/data/account_fiscal_position_template_data.xml
@@ -3574,7 +3574,7 @@
         <record id="fptt_ispn_p_iva4_bi" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva4_bi"/>
-            <field name="tax_dest_id" ref="account_tax_template_p_iva4_isp"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva4_isp_bi"/>
         </record>
         <record id="fptt_ispn_p_iva10_bc" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>
@@ -3589,7 +3589,7 @@
         <record id="fptt_ispn_p_iva10_bi" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva10_bi"/>
-            <field name="tax_dest_id" ref="account_tax_template_p_iva10_isp"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva10_isp_bi"/>
         </record>
         <record id="fptt_ispn_p_iva21_bc" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>
@@ -3604,7 +3604,7 @@
         <record id="fptt_ispn_p_iva21_bi" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva21_bi"/>
-            <field name="tax_dest_id" ref="account_tax_template_p_iva21_isp"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva21_isp_bi"/>
         </record>
         <record id="fptt_ispn_s_iva4b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_ispn"/>

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -9,6 +9,7 @@
      © 2015 Vicent Cubells
      © 2013-2020 Pedro M. Baeza
      © 2020 Harald Panten - Sygel Technology
+     © 2022 Omar Castiñeira - Comunitea
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
@@ -3844,6 +3845,156 @@
                 'repartition_type': 'tax',
                 'account_id': ref('l10n_es.account_common_472'),
                 'tag_ids': [ref('mod_303_29')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_13')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_41')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva4_isp_bi" model="account.tax.template">
+        <field name="name">IVA 4% ISP (bienes de inversión)</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount_type">percent</field>
+        <field name="amount" eval="4"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="tax_group_id" ref="tax_group_iva_4"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_30'), ref('mod_303_12')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_31')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_13')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_41')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva10_isp_bi" model="account.tax.template">
+        <field name="name">IVA 10% ISP (bienes de inversión)</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount_type">percent</field>
+        <field name="amount" eval="10"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="tax_group_id" ref="tax_group_iva_10"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_30'), ref('mod_303_12')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_31')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_13')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_41')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva21_isp_bi" model="account.tax.template">
+        <field name="name">IVA 21% ISP (bienes de inversión)</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount_type">percent</field>
+        <field name="amount" eval="21"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="tax_group_id" ref="tax_group_iva_21"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_30'), ref('mod_303_12')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_31')],
             }),
 
             (0,0, {

--- a/doc/cla/corporate/comunitea.md
+++ b/doc/cla/corporate/comunitea.md
@@ -1,0 +1,19 @@
+Spain, 2022-08-12
+
+Comunitea Servicios Tecnológicos S.L.
+agrees to the terms of the Odoo Corporate Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Omar Castiñeira Saavedra omar@comunitea.com https://github.com/omar7r
+
+List of contributors:
+
+Omar Castiñeira Saavedra omar@comunitea.com https://github.com/omar7r
+Javier Colmenero Fernández javier@comunitea.com https://github.com/javierjcf
+Francisco José Sánchez Álvarez kiko@comunitea.com https://github.com/kikosanchez
+Santiago Argüeso Armesto santi@comunitea.com https://github.com/Roodin
+Vicente Gutiérrez Fernández vicente@comunitea.com https://github.com/vicentecom


### PR DESCRIPTION
Hi,

When we purchase 'bienes de inversión' with ISP (Inversión de sujetos pasivo) the base and tax amounts must be declared in 303 in two gaps different of current National ISP, that it fits only 'bienes corrientes and servicios corrientes'. In addition, we have to mark the invoice as 'BienInversion' to SII, like @jco-odoo said here https://github.com/OCA/l10n-spain/issues/1793, but it will be the next PR.

Please @pedrobaeza @acysos @rafaelbn @HaraldPanten @AlbertCabedo  etc. check this

Paste AEAT answer about this question:
En cuanto al Modelo 303, una factura recibida correspondiente a un bien de inversión debe con Inversión del Sujeto Pasivo debe declararse tanto en las casillas 12 y 13 del IVA devengado como en las casillas 30 y 31 del IVA deducible (siempre que la adquisición o construcción, en su caso, de dicho bien de inversión se encuentre afecto a la actividad empresarial o profesional y se cumplan el resto de requisitos de deducción de las cuotas de IVA establecidos en los artículos 94 y siguientes de la Ley de IVA).

Regards

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
