### PR TITLE
[FIX] web_editor: fix code textarea size in Firefox

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
@@ -72,6 +72,8 @@ body.o_in_iframe {
         bottom: 0;
         left: 0;
         right: 291px;
+        width: calc(100% - 291px);
+        height: 100%;
         border: none;
     }
 


### PR DESCRIPTION
On Chrome, the textarea is automatically resized to use all the
available space. On Firefox, this is not the case. Since the css rules
only set the position of the textarea and not its size, the textarea in
Firefox was ridiculously small and unusable.

task-id 2950108