### PR TITLE
[IMP] calendar: improve behavior of allday events

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -96,8 +96,8 @@
                 <t t-if="recurrent">
                     <li>When: <t t-out="object.recurrence_id.name or ''">Every 1 Weeks, for 3 events</t></li>
                 </t>
-                <t t-if="not object.event_id.allday and object.event_id.duration">
-                    <li>Duration: <t t-out="('%dH%02d' % (object.event_id.duration,round(object.event_id.duration*60)%60)) or ''">0H30</t></li>
+                <t t-if="object.event_id.duration">
+                    <li>Duration: <t t-out="object.event_id.duration" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/></li>
                 </t>
                 <li>Attendees
                 <ul>
@@ -238,8 +238,8 @@
                 <t t-if="recurrent">
                     <li>When: <t t-out="object.recurrence_id.name or ''">Every 1 Weeks, for 3 events</t></li>
                 </t>
-                <t t-if="not object.event_id.allday and object.event_id.duration">
-                    <li>Duration: <t t-out="('%dH%02d' % (object.event_id.duration,round(object.event_id.duration*60)%60)) or ''">0H30</t></li>
+                <t t-if="object.event_id.duration">
+                    <li>Duration: <t t-out="object.event_id.duration" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/></li>
                 </t>
                 <li>Attendees
                 <ul>
@@ -345,8 +345,8 @@
                 <t t-if="recurrent">
                     <li>When: <t t-out="object.recurrence_id.name or ''">Every 1 Weeks, for 3 events</t></li>
                 </t>
-                <t t-if="not object.event_id.allday and object.event_id.duration">
-                    <li>Duration: <t t-out="('%dH%02d' % (object.event_id.duration,round(object.event_id.duration*60)%60)) or ''">0H30</t></li>
+                <t t-if="object.event_id.duration">
+                    <li>Duration: <t t-out="object.event_id.duration" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/></li>
                 </t>
                 <li>Attendees
                 <ul>
@@ -456,9 +456,9 @@
                         <t t-if="recurrent">
                             <li>When: <t t-out="object.recurrence_id.name or ''">Every 1 Weeks, for 3 events</t></li>
                         </t>
-                        <t t-if="not object.allday and object.duration">
+                        <t t-if="object.duration">
                             <li>Duration:
-                                <t t-out="('%dH%02d' % (object.duration,round(object.duration*60)%60))">0H30</t>
+                                <t t-out="object.duration" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}">30 minutes</t>
                             </li>
                         </t>
                     </ul>

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -301,10 +301,13 @@ class Meeting(models.Model):
                 meeting.start_date = False
                 meeting.stop_date = False
 
-    @api.depends('stop', 'start')
+    @api.depends('allday', 'start', 'stop', 'start_date', 'stop_date')
     def _compute_duration(self):
         for event in self:
-            event.duration = self._get_duration(event.start, event.stop)
+            if not event.allday:
+                event.duration = self._get_duration(event.start, event.stop)
+            else:
+                event.duration = self._get_duration(event.start_date, event.stop_date + timedelta(days=1))
 
     @api.depends('start', 'duration')
     def _compute_stop(self):

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -272,10 +272,10 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
     def test_ambiguous_full_day(self):
         """ Test date stays the same, regardless of DST changes """
         self.event.write({
+            'allday': True,
             'start': datetime(2020, 3, 23, 0, 0),
             'stop': datetime(2020, 3, 23, 23, 59),
         })
-        self.event.allday = True
         self.event._apply_recurrence_values({
             'interval': 1,
             'rrule_type': 'weekly',

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -272,6 +272,9 @@ export class CalendarModel extends Model {
 
         if (this.meta.fieldMapping.date_delay) {
             if (this.meta.scale !== "month" || !options.moved) {
+                if (partialRecord.isAllDay) {
+                    end = end.plus({ days: 1})
+                }
                 data[this.meta.fieldMapping.date_delay] = end.diff(start, "hours").hours;
             }
         }


### PR DESCRIPTION
- We now avoid to write after the creation of an allday event if there is no need to. This was leading to sending 2 emails (creation and update one) when booking an allday online appointment.
- We also display now the duration for allday event in mail template.

task-2822534
ENT PR: odoo/enterprise#26858