### PR TITLE
[FIX] website: fix hr opacity and vertical header template

### DIFF
--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -96,10 +96,6 @@ $lead-font-size: 1.125rem !default;
 
 $text-muted: mute-color($body-color) !default;
 
-// HR
-$hr-color: $black !default;
-$hr-opacity: 0.1 !default;
-
 // Buttons
 //
 // For each of Bootstrap's buttons, define text, background, and border color.

--- a/addons/website/static/src/snippets/s_hr/000.scss
+++ b/addons/website/static/src/snippets/s_hr/000.scss
@@ -7,5 +7,9 @@
         border-top: 1px solid currentColor;
         margin: 0;
         color: inherit;
+        // As BS5 added "opacity" and "background-color" on hr tag, we remove
+        // that here to let users set the color as they want.
+        opacity: 1;
+        background-color: transparent;
     }
 }

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -504,7 +504,7 @@
                         </t>
                         <!-- Nav -->
                         <t t-call="website.navbar_nav">
-                            <t t-set="_nav_class" t-valuef="mx-auto order-first order-lg-12"/>
+                            <t t-set="_nav_class" t-valuef="mx-auto order-first order-lg-5"/>
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
                                 <t t-call="website.submenu">


### PR DESCRIPTION
This commit fixes 2 bugs:
(These bugs were introduced by the migration to Bootstrap 5)

- Since version 5, Bootstrap adds opacity on the `<hr>`, so we have to
override it in Web to not have opacity but rather a black with an
opacity as it was in version 4 of Bootstrap.

- In version 5 of Bootstrap, the class "order-lg-12" no longer exists,
this class was used in the vertical template header and this one was
therefore broken. This commit replaces this class with "order-lg-5" to
fix that.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
