### PR TITLE
[CHG] core: deprecate get_module_filetree

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -217,6 +217,11 @@ def get_module_path(module, downloaded=False, display_warning=True):
     return False
 
 def get_module_filetree(module, dir='.'):
+    warnings.warn(
+        "Since 16.0: use os.walk or a recursive glob or something",
+        DeprecationWarning,
+        stacklevel=2
+    )
     path = get_module_path(module)
     if not path:
         return False

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -6,6 +6,7 @@ Some functions related to the os and os.path module
 """
 import os
 import re
+import warnings
 import zipfile
 
 from os.path import join as opj
@@ -56,6 +57,7 @@ def listdir(dir, recursive=False):
     it follows leaves `dir`...
     """
     assert recursive, "use `os.listdir` or `pathlib.Path.iterdir`"
+    warnings.warn("Since 16.0, use os.walk or a recursive glob", DeprecationWarning, stacklevel=2)
     dir = os.path.normpath(dir)
 
     res = []


### PR DESCRIPTION
It's unused, not super useful, and fairly complicated.

Also deprecate `listdir` entirely since `get_module_filetree` is the only extant user of the recursive listdir (nb: will have to be rebased once #97987 is merged as it touches a similar location).
