### PR TITLE
[IMP] project: modify the planning explanation in project settings

### DIFF
--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -91,7 +91,7 @@
                                 <div class="o_setting_right_pane">
                                     <label for="module_project_forecast"/>
                                     <div class="text-muted" name="project_forecast_msg">
-                                        Plan resource allocation across projects and tasks, and estimate deadlines more accurately
+                                        Plan resource allocation across projects and estimate deadlines more accurately
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
In this commit we have modified the planning explanation in the project settings
in order to accommodate the removal of tasks from the planning app

task-2941828

Related Enterprise PR: https://github.com/odoo/enterprise/pull/30404
