### PR TITLE
[IMP] mail: `Message`, remove note style

### DIFF
--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -148,7 +148,7 @@
                                     'w-100': !(messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms') and !messageView.isInChatWindow,
                                     'me-2': messageView.isInChatWindowAndIsAlignedLeft and !messageView.composerViewInEditing,
                                     'ms-2': messageView.isInChatWindowAndIsAlignedRight and !messageView.composerViewInEditing,
-                                    'p-3': messageView.message.prettyBody !== '' and !messageView.composerViewInEditing, 
+                                    'p-3': messageView.message.prettyBody !== '' and !messageView.composerViewInEditing and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'), 
                                     'p-2': messageView.composerViewInEditing, 
                                     'text-muted': messageView.message.is_note and messageView.message.message_type !== 'sms',
                                 }"
@@ -160,7 +160,6 @@
                                         'rounded-end-3': !messageView.isInChatWindowAndIsAlignedRight and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),
                                         'rounded-start-3': messageView.isInChatWindowAndIsAlignedRight and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),      
                                         'rounded-bottom-3 border': messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms',
-                                        'rounded-3 bg-100 opacity-50': messageView.message.is_note and messageView.message.message_type !== 'sms',
                                         'o-isAuthorNotCurrentUserOrGuest border-info bg-info-light': !messageView.message.isCurrentUserOrGuestAuthor and !messageView.message.isHighlighted and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'), 
                                         'border-success bg-success-light opacity-25': messageView.message.isCurrentUserOrGuestAuthor and !messageView.message.isHighlighted and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),
                                         'border-warning bg-warning-light opacity-50': messageView.message.isHighlighted and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),
@@ -201,19 +200,20 @@
                                     'position-absolute top-0': !messageView.isInDiscuss,
                                     'start-0 ms-3': messageView.isInChatWindowAndIsAlignedRight,
                                     'end-0 me-3': messageView.isInChatWindowAndIsAlignedLeft || messageView.isInChatter,
-                                    'mt-n4': messageView.isInChatter,
-                                    'mt-2': (messageView.isInDiscuss and messageView.message.isDiscussionOrNotification),
+                                    'mt-n4': messageView.isInChatter and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),
+                                    'mt-n5': messageView.isInChatter and !(messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),
+                                    'mt-2': messageView.isInDiscuss and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms'),
                                     'mt-n3': messageView.isInChatWindow,
                                     'ms-2': messageView.isInDiscuss,
                                 }"
                                 t-attf-class="{{ messageView.isActive ? 'visible' : 'invisible' }}"
                             >
-                                <MessageActionList record="messageView.messageActionList"/>
+                                <MessageActionList record="messageView.messageActionList" classNameObj="{ 'mt-3': messageView.isInChatter and !(messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms') }"/>
                             </div>
                         </div>
                         <AttachmentList t-if="messageView.attachmentList" record="messageView.attachmentList" className="'position-relative'"/>
-                        <div t-if="messageView.message.messageReactionGroups.length > 0" class="position-relative d-flex flex-wrap mt-n2"
-                        t-att-class="{ 'flex-row-reverse me-3': messageView.isInChatWindowAndIsAlignedRight, 'ms-3': !(messageView.isInChatWindowAndIsAlignedRight) }">
+                        <div t-if="messageView.message.messageReactionGroups.length > 0" class="position-relative d-flex flex-wrap"
+                        t-att-class="{ 'flex-row-reverse me-3': messageView.isInChatWindowAndIsAlignedRight, 'ms-3': !messageView.isInChatWindowAndIsAlignedRight and (messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms')}" t-attf-class="{{ messageView.message.isDiscussionOrNotification or messageView.message.message_type === 'sms' ? 'mt-n2' : 'mt-1' }}">
                             <t t-foreach="messageView.message.messageReactionGroups" t-as="messageReactionGroup" t-key="messageReactionGroup.localId">
                                 <MessageReactionGroup className="'mb-1'" classNameObj="{ 'ms-1': messageView.isInChatWindowAndIsAlignedRight, 'me-1': !(messageView.isInChatWindowAndIsAlignedRight) }" record="messageReactionGroup"/>
                             </t>

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -919,7 +919,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 100; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
             model: "mail.channel",
@@ -1373,7 +1373,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 100; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
             model: "mail.channel",
@@ -1521,7 +1521,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 100; i++) {
         pyEnv['mail.message'].create({
             body: "not empty",
             model: "mail.channel",


### PR DESCRIPTION
Prior to this commit, the note had its own style. This created too much
confusion with the other message types.

This commit removes the note style to improve the readability in the
chatter.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
