### PR TITLE
[FIX] project: fix default at time of record creation

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -422,7 +422,7 @@
                 (0, 0, {'view_mode': 'tree', 'view_id': ref('view_project')}),
                 (0, 0, {'view_mode': 'kanban', 'view_id': ref('project_view_kanban')})]"/>
             <field name="search_view_id" ref="view_project_project_filter"/>
-            <field name="context">{}</field>
+            <field name="context">{'default_allow_billable': True}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     Create a new project


### PR DESCRIPTION
Earlier allow_billable was not default
True ar rime of creating project

Now allow_billable is default True
at time of creating project

Taskid : 2942432

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
