### PR TITLE
[FIX] sale_project: fix smart button

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -127,6 +127,7 @@ class SaleOrder(models.Model):
             'view_mode': 'kanban,form',
             'name': _('Projects'),
             'res_model': 'project.project',
+            "context": {'active_id': self.project_id.id}
         }
         if len(self.project_ids) == 1:
             action.update({'views': [(view_form_id, 'form')], 'res_id': self.project_ids.id})


### PR DESCRIPTION
Earlier when going to project from
sale order smart button task is
not opening

Now task is opening from project
when going from sale order smart
button

Taskid : 2942432

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
