### PR TITLE
[FIX] web: many2many_tags field support createDomain to be Boolean

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -145,7 +145,9 @@ export class Many2ManyTagsField extends Component {
     }
 
     onBadgeClick(ev, record) {
-        if (!this.canOpenColorDropdown) return;
+        if (!this.canOpenColorDropdown) {
+            return;
+        }
         const isClosed = !document.querySelector(".o_tag_popover");
         if (isClosed) {
             this.currentPopoverEl = null;
@@ -284,7 +286,7 @@ Many2ManyTagsField.props = {
     canEditColor: { type: Boolean, optional: true },
     canQuickCreate: { type: Boolean, optional: true },
     colorField: { type: String, optional: true },
-    createDomain: { type: Array, optional: true },
+    createDomain: { type: [Array, Boolean], optional: true },
     placeholder: { type: String, optional: true },
     relation: { type: String },
     nameCreateField: { type: String, optional: true },

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -481,7 +481,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         // First checks that default color 0 is rendered as 0 color
-        let badgeNode = target.querySelector(".o_tag.badge");
+        const badgeNode = target.querySelector(".o_tag.badge");
         assert.strictEqual(badgeNode.dataset.color, "0", "first tag color should be 0");
 
         // Update the color in readonly => write automatically
@@ -1538,6 +1538,25 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(
             target.querySelector(".o_field_widget[name='timmy'] input").placeholder,
             "Placeholder"
+        );
+    });
+
+    QUnit.test("Many2ManyTagsField supports 'create' props to be a Boolean", async (assert) => {
+        patchWithCleanup(AutoComplete, {
+            timeout: 0,
+        });
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><field name="timmy" widget="many2many_tags" placeholder="Placeholder" options="{'create': False }"/></form>`,
+        });
+
+        await click(target.querySelector(".o_field_many2many_tags input"));
+        assert.strictEqual(
+            target.querySelector(".o_field_many2many_tags .o-autocomplete--dropdown-menu")
+                .textContent,
+            "goldsilver"
         );
     });
 });


### PR DESCRIPTION
Pass the options: `{'create': False}` to the a many2many_tags field in some arch

Before this commit, there was a crash because the API of the field's props did not
account for that use case.

After this commit, it does.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
