### PR TITLE
[IMP] website: mobile view layout

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -282,7 +282,7 @@ body.editor_enable.editor_has_snippets {
             }
             &:focus, &:active, &:focus:active {
                 outline: none;
-                box-shadow: none;
+                box-shadow: none !important;
             }
         }
 

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -104,6 +104,23 @@ export class WebsitePreview extends Component {
                 window.removeEventListener('popstate', handleBackNavigation);
             };
         }, () => []);
+
+        const toggleIsMobile = () => {
+            const wrapwrapEl = this.iframe.el.contentDocument.querySelector('#wrapwrap');
+            if (wrapwrapEl) {
+                wrapwrapEl.classList.toggle('o_is_mobile', this.websiteContext.isMobile);
+            }
+        };
+        // Toggle the 'o_is_mobile' class on the wrapwrap when 'isMobile'
+        // changes in the context. (e.g. Click on mobile preview buttons)
+        useEffect(toggleIsMobile, () => [this.websiteContext.isMobile]);
+
+        // Toggle the 'o_is_mobile' class on the wrapwrap according to
+        // 'isMobile' on iframe load.
+        useEffect(() => {
+            this.iframe.el.addEventListener('OdooFrameContentLoaded', toggleIsMobile);
+            return () => this.iframe.el.removeEventListener('OdooFrameContentLoaded', toggleIsMobile);
+        }, () => []);
     }
 
     get websiteId() {

--- a/addons/website/static/src/client_actions/website_preview/website_preview.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.scss
@@ -33,25 +33,33 @@
             width: 100%;
             height: 100%;
         }
+    }
 
-        &.o_is_mobile {
+    &.o_is_mobile {
+        .o_we_website_top_actions button[data-action="mobile"] span.fa {
+            color: $o-we-color-success;
+        }
+
+        .o_iframe_container {
+            @extend %o-mobile-phone;
             @include media-breakpoint-up(md) {
-                @include o-iframe-position(720px);
-
-                @media(max-height: calc(720px + #{$o-navbar-height})) {
-                    @include o-iframe-position(520px);
-                }
-
-                iframe {
-                    border-radius: 25px;
-                    box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
-                }
-
-                .o_block_preview {
-                    border-radius: 25px;
+                @media(max-height: calc(800px + #{$o-navbar-height})) {
+                    // Below this height, we decrease the size of the mobile
+                    // preview (see in website.backend.scss) so we have to make
+                    // the image take the same size as its parent.
+                    div.o_mobile_preview_layout > img {
+                        width: 100%;
+                        height: 100%;
+                    }
                 }
             }
         }
+    }
+}
+
+.o_we_website_top_actions button[data-action="mobile"], .o_mobile_preview {
+    span.fa {
+        font-size: 20px;
     }
 }
 

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -9,9 +9,12 @@
 </t>
 
 <t t-name="website.WebsitePreview" owl="1">
-    <div class="o_website_preview" t-att-class="{ 'editor_enable editor_has_snippets': this.websiteContext.snippetsLoaded, 'o_is_blocked': this.blockedState.isBlocked }" t-ref="container">
+    <div class="o_website_preview" t-ref="container"
+         t-att-class="{ 'editor_enable editor_has_snippets': this.websiteContext.snippetsLoaded,
+                        'o_is_blocked': this.blockedState.isBlocked,
+                        'o_is_mobile': this.websiteContext.isMobile }">
         <BlockPreview t-if="this.blockedState.showLoader"/>
-        <div class="o_iframe_container" t-att-class="{ 'o_is_mobile': this.websiteContext.isMobile }">
+        <div class="o_iframe_container">
             <iframe t-if="!testMode"
                 t-att-src="iframeFallbackUrl"
                 class="o_ignore_in_tour"
@@ -23,6 +26,9 @@
                 t-on-load="_onPageLoaded"
                 is-ready="false"
                 t-att-data-load-wysiwyg="this.websiteService.isRestrictedEditor ? 'true': 'false'"/>
+            <div t-if="this.websiteContext.isMobile" class="o_mobile_preview_layout">
+                <img alt="phone" src="/website/static/src/img/phone.png"/>
+            </div>
         </div>
         <WebsiteEditorComponent t-if="websiteContext.edition"
             reloadIframe.bind="this.reloadIframe"

--- a/addons/website/static/src/components/fields/widget_iframe.xml
+++ b/addons/website/static/src/components/fields/widget_iframe.xml
@@ -3,7 +3,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.iframeWidget" owl="1">
-    <div t-if="props.value" class="h-100" t-att-class="this.state.isMobile and 'is_mobile'">
+    <div t-if="props.value" class="h-100" t-att-class="{ 'is_mobile': this.state.isMobile }">
         <iframe
             frameBorder="0"
             class="d-block"

--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -330,6 +330,41 @@
     }
 }
 
+// Mobile preview
+%o-mobile-phone {
+    @include media-breakpoint-up(md) {
+        height: 735px !important;
+        width: 362px;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+
+        // Below the following height, the preview size decreases to ensure it
+        // will always be fully visible.
+        @media(max-height: calc(800px + #{$o-navbar-height})) {
+            height: 602px !important;
+            width: 310px;
+
+            div.o_mobile_preview_layout, img.img_mobile {
+                height: 659px;
+                width: 342px;
+                top: -30px;
+                left: -17px;
+            }
+        }
+
+        .o_mobile_preview_layout, .img_mobile {
+            position: absolute;
+            pointer-events: none;
+            // The mobile phone image placed on top of the iframe must be moved
+            // to align the outlines of the iframe with the outlines of the
+            // mobile screen.
+            top: -36px;
+            left: -20px;
+        }
+    }
+}
+
 .o_view_form_theme_preview_controller {
     div.o_form_nosheet {
         padding: 0px;
@@ -337,26 +372,14 @@
         width:100%;
     }
 
-    .o_field_iframe{
+    .o_field_iframe {
         width: 100%;
         height: 100%;
+
         div.is_mobile {
+            @extend %o-mobile-phone;
             @include media-breakpoint-up(md) {
-                // mobile frame is rounded
-                margin: auto !important;
-                padding: 53px 11px 58px 28px;
-                width: 416px;
-                iframe {
-                    height: 735px;
-                    border-radius: 15px;
-                }
-                .img_mobile {
-                    pointer-events: none;
-                    display: block;
-                    position: absolute;
-                    top: 16px;
-                    left: calc(50% - 200px)
-                }
+                position: relative;
             }
         }
     }

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -116,3 +116,28 @@ body {
 .post_link:not(.o_post_link_js_loaded) {
     pointer-events: none;
 }
+
+// Mobile preview
+#wrapwrap.o_is_mobile {
+    // Scrollbar
+    &, .modal {
+        $-foreground-color: #999;
+        $-background-color: rgba(255, 255, 255, 0.5);
+
+        // For Chrome & Safari
+        &::-webkit-scrollbar {
+            width: 5px;
+            height: 5px;
+        }
+        &::-webkit-scrollbar-thumb {
+            background: $-foreground-color;
+        }
+        &::-webkit-scrollbar-track {
+            background: $-background-color;
+        }
+
+        // Standard version (Firefox only for now)
+        scrollbar-color: $-foreground-color $-background-color;
+        scrollbar-width: thin;
+    }
+}

--- a/addons/website/static/src/systray_items/mobile_preview.js
+++ b/addons/website/static/src/systray_items/mobile_preview.js
@@ -3,11 +3,12 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
-const { Component } = owl;
+const { Component, useState } = owl;
 
 class MobilePreviewSystray extends Component {
     setup() {
         this.websiteService = useService('website');
+        this.state = useState(this.websiteService.context);
     }
 }
 MobilePreviewSystray.template = "website.MobilePreviewSystray";

--- a/addons/website/static/src/systray_items/mobile_preview.scss
+++ b/addons/website/static/src/systray_items/mobile_preview.scss
@@ -1,0 +1,5 @@
+.o_mobile_preview_active {
+    span.fa {
+        color: $o-we-color-success;
+    }
+}

--- a/addons/website/static/src/systray_items/mobile_preview.xml
+++ b/addons/website/static/src/systray_items/mobile_preview.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 <t t-name="website.MobilePreviewSystray" owl="1">
-    <div class="o_mobile_preview o_menu_systray_item d-none d-md-block" t-on-click="() => this.websiteService.context.isMobile = !this.websiteService.context.isMobile">
-        <a href="#" accesskey="v"><span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-lg fa-mobile"/></a>
+    <div class="o_mobile_preview o_menu_systray_item d-none d-md-block"
+         t-on-click="() => this.websiteService.context.isMobile = !this.websiteService.context.isMobile"
+         t-att-class="{ 'o_mobile_preview_active': this.state.isMobile }">
+        <a href="#" accesskey="v">
+            <span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-lg fa-mobile"/>
+        </a>
     </div>
 </t>
 </templates>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -4,7 +4,7 @@
 <!-- Snippets menu -->
 <template id="snippets" inherit_id="web_editor.snippets" primary="True" groups="base.group_user">
     <xpath expr="//button[@data-action='cancel']" position="before">
-        <button type="button" class="btn btn-secondary" data-action="mobile" title="Mobile Preview" accesskey="v"><span class="fa fa-mobile" style="font-size: 18px;"/></button>
+        <button type="button" class="btn btn-secondary" data-action="mobile" title="Mobile Preview" accesskey="v"><span class="fa fa-mobile"/></button>
     </xpath>
     <xpath expr="//div[@id='snippets_menu']" position="inside">
         <button type="button" tabindex="3" class="o_we_customize_theme_btn text-uppercase"

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -81,7 +81,7 @@ odoo.define("website_blog.tour", function (require) {
         position: "bottom",
     }, {
         trigger: ".o_menu_systray_item.o_mobile_preview",
-        extra_trigger: '.o_website_preview .o_is_mobile',
+        extra_trigger: '.o_website_preview.o_is_mobile',
         content: _t("Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"),
         position: "right",
     }, {


### PR DESCRIPTION
[IMP] website: mobile view layout
This commit improves the mobile preview of websites. A mobile phone
image has been added around the iframe during the mobile preview. This
image was already used for the themes mobile preview, this is why the
css code has been unified to be used in these 2 mobile previews.
Parallel to this commit, we have modified the websites displayed in the
iframe of the preview of the themes so that the scrollbar of these is
visible (before it was hidden behind the image of the phone) but with a
smaller width in mobile mode.

This commit also improves the button to switch to mobile preview by
coloring it green when mobile preview is active.

task-2890050