### PR TITLE
[IMP][15.0] mail: improved live chat feature when entering help command

### DIFF
--- a/addons/mail/i18n/vi.po
+++ b/addons/mail/i18n/vi.po
@@ -7815,6 +7815,12 @@ msgstr "Bạn đang trong một cuộc hội thoại riêng tư với <b>@%s</b>
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:0
 #, python-format
+msgid "Public user"
+msgstr "Người dùng công khai"
+
+#. module: mail
+#: code:addons/mail/models/mail_channel.py:0
+#, python-format
 msgid "You are in channel <b>#%s</b>."
 msgstr "Bạn đang ở kênh <b>#%s</b>."
 

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1204,7 +1204,7 @@ class Channel(models.Model):
         else:
             all_channel_partners = self.env['mail.channel.partner'].with_context(active_test=False)
             channel_partners = all_channel_partners.search([('partner_id', '!=', partner.id), ('channel_id', '=', self.id)])
-            msg = _("You are in a private conversation with <b>@%s</b>.", html_escape(channel_partners[0].partner_id.name if channel_partners else _('Anonymous')))
+            msg = _("You are in a private conversation with <b>@%s</b>.", html_escape(_(" @").join(_(partners.partner_id.name) for partners in channel_partners) if channel_partners else _('Anonymous')))
         msg += self._execute_command_help_message_extra()
 
         self._send_transient_message(partner, msg)


### PR DESCRIPTION
While testing the application, I get the following error:

[steps]:
In my conversation with Website Visitor, I invite Internal Users. When I enter the help command, OdooBot says "You are in a private conversation with @Public user"

[Actual] :
OdooBot says "You are in a private conversation with @Public user"
[org command help on livechat.webm](https://user-images.githubusercontent.com/30213355/184353720-6577e02e-20a7-4239-b926-5d9e04c45304.webm)

[Expected]:
OdooBot says "You are in a private conversation with @Public user @ Internal user A @ Internal user B ..."
Description of the issue/feature this PR addresses:
[Fix command help on live chat.webm](https://user-images.githubusercontent.com/30213355/184353765-120a09bd-201f-49b3-a647-f5aab62382bd.webm)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
