### PR TITLE
[IMP] pos: add some indexes to speedup Tax Report

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -241,7 +241,7 @@ class PosOrder(models.Model):
         [('draft', 'New'), ('cancel', 'Cancelled'), ('paid', 'Paid'), ('done', 'Posted'), ('invoiced', 'Invoiced')],
         'Status', readonly=True, copy=False, default='draft')
 
-    account_move = fields.Many2one('account.move', string='Invoice', readonly=True, copy=False)
+    account_move = fields.Many2one('account.move', string='Invoice', readonly=True, copy=False, index=True)
     picking_ids = fields.One2many('stock.picking', 'pos_order_id')
     picking_count = fields.Integer(compute='_compute_picking_count')
     failed_pickings = fields.Boolean(compute='_compute_picking_count')

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -93,7 +93,7 @@ class PosSession(models.Model):
         help="Auto-generated session for orphan orders, ignored in constraints",
         readonly=True,
         copy=False)
-    move_id = fields.Many2one('account.move', string='Journal Entry')
+    move_id = fields.Many2one('account.move', string='Journal Entry', index=True)
     payment_method_ids = fields.Many2many('pos.payment.method', related='config_id.payment_method_ids', string='Payment Methods')
     total_payments_amount = fields.Float(compute='_compute_total_payments_amount', string='Total Payments Amount')
     is_in_company_currency = fields.Boolean('Is Using Company Currency', compute='_compute_is_in_company_currency')


### PR DESCRIPTION
Tax Report `_compute_from_amls_grids`' query calls
two method overriden in pos_account_reports.

The resulting query contains EXISTS subqueries on `pos_session.move_id`
and `pos_order.account_move`. Because these two fields are not indexed
by default, the cost of the query can skyrocket in large databases,
leading to slow tax report generation.

#### Cost/speedup

Customer DB with 2.75M account_move, 11k pos_session and 1M pos_order.

Cost Estimation: 1.38M -> 162000.
Tax Report Generation: +15min (timeout) -> 1s.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
