### PR TITLE
[FIX] web: fix action dropdown not closing on click in mobile

### DIFF
--- a/addons/web/static/src/views/view_button/view_button.xml
+++ b/addons/web/static/src/views/view_button/view_button.xml
@@ -15,7 +15,7 @@
         t-att-data-tooltip-info="hasBigTooltip ? tooltip : false"
         t-att-data-tooltip="hasSmallToolTip ? props.title : false"
         t-att-tabindex="props.tabindex"
-        t-on-click.stop="onClick"
+        t-on-click="onClick"
     >
       <t t-if="icon" t-tag="icon.tag" t-att-class="icon.class" t-att-src="icon.src"/>
       <t t-slot="contents"><t t-esc="props.string"/></t>


### PR DESCRIPTION
In mobile, when there are too many action buttons in the control panel,
they are put inside of a dropdown menu. Because view buttons call
preventDefault on their click event, this event can't bubble up to the
dropdown and allow it to close, which is undesirable. This commit fixes
that.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
