### PR TITLE
[FIX] [l10n_ar_]website_sale: always display b2b fields for argentina

### DIFF
--- a/addons/l10n_ar_website_sale/__init__.py
+++ b/addons/l10n_ar_website_sale/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import controllers
+from . import models

--- a/addons/l10n_ar_website_sale/i18n/es.po
+++ b/addons/l10n_ar_website_sale/i18n/es.po
@@ -26,6 +26,12 @@ msgid "AFIP Responsibility..."
 msgstr "Responsabilidad AFIP..."
 
 #. module: l10n_ar_website_sale
+#: code:addons/l10n_ar_website_sale/models/ir_ui_view.py:0
+#, python-format
+msgid "B2B fields must always be displayed with Argentinian website."
+msgstr "Los campos B2B deben aparecer siempre con el sitio web Argentino."
+
+#. module: l10n_ar_website_sale
 #: model_terms:ir.ui.view,arch_db:l10n_ar_website_sale.partner_info
 msgid ""
 "Changing AFIP Responsibility type is not allowed once document(s) have been "

--- a/addons/l10n_ar_website_sale/i18n/l10n_ar_website_sale.pot
+++ b/addons/l10n_ar_website_sale/i18n/l10n_ar_website_sale.pot
@@ -26,6 +26,12 @@ msgid "AFIP Responsibility..."
 msgstr ""
 
 #. module: l10n_ar_website_sale
+#: code:addons/l10n_ar_website_sale/models/ir_ui_view.py:0
+#, python-format
+msgid "B2B fields must always be displayed with Argentinian website."
+msgstr ""
+
+#. module: l10n_ar_website_sale
 #: model_terms:ir.ui.view,arch_db:l10n_ar_website_sale.partner_info
 msgid ""
 "Changing AFIP Responsibility type is not allowed once document(s) have been "

--- a/addons/l10n_ar_website_sale/models/__init__.py
+++ b/addons/l10n_ar_website_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_ui_view

--- a/addons/l10n_ar_website_sale/models/ir_ui_view.py
+++ b/addons/l10n_ar_website_sale/models/ir_ui_view.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class View(models.Model):
+    _inherit = 'ir.ui.view'
+
+    @api.constrains('active', 'key', 'website_id')
+    def _check_active(self):
+        for record in self:
+            if record.key == 'website_sale.address_b2b' and record.website_id:
+                if record.website_id.company_id.country_id.code == "AR" and not record.active:
+                    raise ValidationError(_("B2B fields must always be displayed with Argentinian website."))


### PR DESCRIPTION
Steps to reproduce:

  - Install `l10n_ar_website_sale` module

  - Go to shop (Argentinian website) and add a product to cart
  - Open cart and click on checkout
  - Click on Customize and disable `Show b2b fields` feature

Issue:

  Fields are no more displayed.

Cause:

  Since the b2b fields template (`address_b2b`) have customize_show set
  to `True`, it is possible for all countries to display/hide
  the b2b fields, but it should not.

  For Argentinian companies (for example), the b2b fields should always
  be displayed.

Solution:

  For frontend (Website shop): in address form, if website company
  country is Argentina, check if the address_b2b view is active and if
  not, enable it.
  For frontend and backend: on write of a view `address_b2b`, do not
  allow to disable it if have a website and website company
  country is Argentina.

opw-2941199