### PR TITLE
[FIX] web: create record with x2m invisible

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -247,7 +247,7 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         });
     }
 
-    if (fieldInfo.modifiers.invisible !== true && X2M_TYPES.includes(field.type)) {
+    if (X2M_TYPES.includes(field.type)) {
         const views = {};
         for (const child of node.children) {
             const viewType = child.tagName === "tree" ? "list" : child.tagName;


### PR DESCRIPTION
Before this commit, when creating a record containing an invisible
x2many, the fields related to this x2many were not asked during the
creation onchange.

Problem:
Some required values were missing when igniting a new record.

Cause:
The arch related to an invisible x2many was ignored.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
