### PR TITLE
[FIX] website_event: prevent send Register form as HTTP POST request

### DIFF
--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -23,7 +23,8 @@ var EventRegistrationForm = Widget.extend({
                 .off('click')
                 .click(function (ev) {
                     self.on_click(ev);
-                });
+                })
+                .prop('disabled', false);
         });
         return res;
     },

--- a/addons/website_event/views/event_templates.xml
+++ b/addons/website_event/views/event_templates.xml
@@ -580,7 +580,7 @@
             </div>
         </div>
         <div class="col-lg-4 pt-3 pt-lg-0 pl-2 pl-lg-0">
-            <button type="submit" class="btn btn-primary o_wait_lazy_js btn-block a-submit" t-attf-id="#{event.id}">Register</button>
+            <button type="submit" class="btn btn-primary o_wait_lazy_js btn-block a-submit" t-attf-id="#{event.id}" disabled="disabled">Register</button>
         </div>
     </div>
     <div t-if="description" class="row mx-0">


### PR DESCRIPTION
To reproduce:
Video: https://drive.google.com/file/d/1bAh7KA_5UhhIrr-qF5A5gOVWhk3_9clj/view
 1. Have multi-language website
 2. Event with one ticket
 3. Reload page and click the "Register" button
 -> in some cases there is a traceback
 `/event/great-reno-ballon-race-2/registration/new: Function declared as capable of handling request of type 'json' but called with a request of type 'http'`

 Reason of the issue:
 As the button "Register" in the form is defined with `type="submit"` it will send the form as plain HTTP if clicked.
 This behavior is modified in the JavaScript to prevent this default behavior.
 However, if the button is clicked before the JS load, the HTTP behavior is used which does create the above traceback (as the `registration/new` route accept only `json` type).

 Solution proposed:
 Prevent the button default behavior and make it deactivated and let the JS activate it when it is ready

 Note on stability:
 As JS code and XML view is modified, this fix was thought so that the JS won't have an impact if the view isn't updated.
 There is theoretically no way that the XML view would be updated without the JS being updated (except manual modification in the view or rollback on the version revision after performing a module update on odoo.sh). If it was the case then the button will be deactivated until the user change the number of ticket.

 OPW-2946706
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
