### PR TITLE
[FIX] survey: show live session ending screen

### DIFF
--- a/addons/survey/i18n/survey.pot
+++ b/addons/survey/i18n/survey.pot
@@ -3695,6 +3695,7 @@ msgstr ""
 
 #. module: survey
 #: model_terms:ir.ui.view,arch_db:survey.survey_fill_form_done
+#: model_terms:ir.ui.view,arch_db:survey.user_input_session_manage_content
 msgid "Thank you!"
 msgstr ""
 

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -160,13 +160,8 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend({
                 this.$('.o_survey_session_navigation_next').addClass('d-none');
             }
             this.leaderBoard.showLeaderboard(true, this.isScoredQuestion);
-        } else {
-            if (!this.isLastQuestion) {
-                this._nextQuestion();
-            } else if (!this.sessionShowLeaderboard) {
-                // If we have no leaderboard to show, directly end the session
-                this.$('.o_survey_session_close').click();
-            }
+        } else if (!this.isLastQuestion || !this.sessionShowLeaderboard) {
+            this._nextQuestion(); 
         }
 
         this.currentScreen = screenToDisplay;
@@ -361,7 +356,11 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend({
                 });
             } else {
                 self.$('.o_survey_session_close').click();
-            }
+                self.$('.o_survey_question_header').addClass('invisible');
+                self.$('.o_survey_session_results, .o_survey_session_navigation_previous, .o_survey_session_navigation_next')
+                    .addClass('d-none');
+                self.$('.o_survey_session_description_done').removeClass('d-none');
+                }
         });
     },
 

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -98,6 +98,10 @@
                 </div>
             </div>
             <div class="container px-4 pb-3 pt96 d-flex flex-column o_survey_session_manage_container">
+                <div class="o_survey_session_description_done d-none">
+                    <h1>Thank you!</h1>
+                    <div t-field="survey.description_done"/>
+                </div>
                 <a role="button"
                     class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
                 <a role="button"


### PR DESCRIPTION
### Steps to reproduce
- create a survey
- start a live session of your survey
- click the right arrow util you get to the last question
- click the arrow again to finish the live session

You should see that you're stuck on the last question.

This is only a front end problem; in the backend, the live session is being closed as it should be.

Note: this issue is specific to version 15.0

Partial backport of f1b1286393aeb690ac2d8f410d260f8615ebd718


opw-2925628