### PR TITLE
[IMP] website_sale: automatic abandoned cart email

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -16,6 +16,7 @@
         'data/mail_template_data.xml',
         'data/product_snippet_template_data.xml',
         'data/digest_data.xml',
+        'data/ir_cron_data.xml',
         'views/product_attribute_views.xml',
         'views/product_tag_views.xml',
         'views/product_views.xml',

--- a/addons/website_sale/data/ir_cron_data.xml
+++ b/addons/website_sale/data/ir_cron_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_cron_send_availability_email" model="ir.cron">
+        <field name="name">eCommerce: send email to customers about their abandoned cart</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False"/>
+        <field name="model_id" ref="model_website"/>
+        <field name="code">model._send_abandoned_cart_email()</field>
+        <field name="state">code</field>
+    </record>
+</odoo>

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -34,8 +34,8 @@ class ResConfigSettings(models.TransientModel):
 
     cart_recovery_mail_template = fields.Many2one('mail.template', string='Cart Recovery Email', domain="[('model', '=', 'sale.order')]",
                                                   related='website_id.cart_recovery_mail_template_id', readonly=False)
-    cart_abandoned_delay = fields.Float("Abandoned Delay", help="Number of hours after which the cart is considered abandoned.",
-                                        related='website_id.cart_abandoned_delay', readonly=False)
+    cart_abandoned_delay = fields.Float(string="Send After", related='website_id.cart_abandoned_delay', readonly=False)
+    send_abandoned_cart_email = fields.Boolean('Abandoned Email', related='website_id.send_abandoned_cart_email', readonly=False)
     add_to_cart_action = fields.Selection(related='website_id.add_to_cart_action', readonly=False)
     terms_url = fields.Char(compute='_compute_terms_url', string="URL", help="A preview will be available at this URL.")
 
@@ -146,4 +146,14 @@ class ResConfigSettings(models.TransientModel):
             'res_model': 'mail.template',
             'view_id': False,
             'view_mode': 'tree,form',
+        }
+
+    def action_open_abandoned_cart_mail_template(self):
+        return {
+            'name': _('Customize Email Templates'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'mail.template',
+            'view_id': False,
+            'view_mode': 'form',
+            'res_id': 15
         }

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -9,6 +9,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.osv import expression
+from odoo.tools import float_is_zero
 
 
 class SaleOrder(models.Model):
@@ -413,3 +414,44 @@ class SaleOrder(models.Model):
     def _is_reorder_allowed(self):
         self.ensure_one()
         return self.state == 'sale' and any(line._is_reorder_allowed() for line in self.order_line)
+
+    def _filter_can_send_abandoned_cart_mail(self):
+        self.website_id.ensure_one()
+        abandoned_datetime = datetime.utcnow() - relativedelta(hours=self.website_id.cart_abandoned_delay)
+
+        sales_after_abandoned_date = self.env['sale.order'].search([
+            ('state', '=', 'sale'),
+            ('partner_id', 'in', self.partner_id.ids),
+            ('create_date', '>=', abandoned_datetime),
+            ('website_id', '=', self.website_id.id),
+        ])
+        latest_create_date_per_partner = dict()
+        for sale in self:
+            if sale.partner_id not in latest_create_date_per_partner:
+                latest_create_date_per_partner[sale.partner_id] = sale.create_date
+            else:
+                latest_create_date_per_partner[sale.partner_id] = max(latest_create_date_per_partner[sale.partner_id], sale.create_date)
+        has_later_sale_order = dict()
+        for sale in sales_after_abandoned_date:
+            if has_later_sale_order.get(sale.partner_id, False):
+                continue
+            has_later_sale_order[sale.partner_id] = latest_create_date_per_partner[sale.partner_id] <= sale.date_order
+
+        # Customer needs to be signed in otherwise the mail address is not known.
+        # We therefore consider only sales with a known mail address.
+
+        # If a payment processing error occurred when the customer tried to complete their checkout,
+        # then the email won't be sent.
+
+        # If all the products in the checkout are free, and the customer does not visit the shipping page to add a
+        # shipping fee or the shipping fee is also free, then the email won't be sent.
+
+        # If a potential customer creates one or more abandoned sale order and then completes a sale order before
+        # the recovery email gets sent, then the email won't be sent.
+
+        return self.filtered(lambda abandoned_sale_order:
+            abandoned_sale_order.partner_id.email
+            and not any(transaction.state == 'error' for transaction in abandoned_sale_order.transaction_ids)
+            and any(not float_is_zero(line.price_unit, precision_rounding=line.currency_id.rounding) for line in abandoned_sale_order.order_line)
+            and not has_later_sale_order.get(abandoned_sale_order.partner_id, False)
+        )

--- a/addons/website_sale/tests/test_website_sale_cart_abandoned.py
+++ b/addons/website_sale/tests/test_website_sale_cart_abandoned.py
@@ -3,42 +3,44 @@
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-
+from unittest.mock import patch
 from odoo.tests import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
+from odoo.addons.mail.models.mail_template import MailTemplate
 
 
-@tagged('post_install', '-at_install')
-class TestWebsiteSaleCartAbandoned(HttpCaseWithUserPortal):
-    def setUp(self):
-        res = super(TestWebsiteSaleCartAbandoned, self).setUp()
+class TestWebsiteSaleCartAbandonedCommon(HttpCaseWithUserPortal):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         now = datetime.utcnow()
-        self.customer = self.env['res.partner'].create({
+        cls.customer = cls.env['res.partner'].create({
             'name': 'a',
             'email': 'a@example.com',
         })
-        self.public_partner = self.env['res.partner'].create({
+        cls.public_partner = cls.env['res.partner'].create({
             'name': 'public',
             'email': 'public@example.com',
         })
-        self.public_user = self.env['res.users'].create({
+        cls.public_user = cls.env['res.users'].create({
             'name': 'Foo', 'login': 'foo',
-            'partner_id': self.public_partner.id,
+            'partner_id': cls.public_partner.id,
         })
-        self.website0 = self.env['website'].create({
+        cls.website0 = cls.env['website'].create({
             'name': 'web0',
             'cart_abandoned_delay': 1.0,  # 1 hour
         })
-        self.website1 = self.env['website'].create({
+        cls.website1 = cls.env['website'].create({
             'name': 'web1',
             'cart_abandoned_delay': 0.5,  # 30 minutes
         })
-        self.website2 = self.env['website'].create({
+        cls.website2 = cls.env['website'].create({
             'name': 'web2',
             'cart_abandoned_delay': 24.0,  # 1 day
-            'user_id': self.public_user.id,  # specific public user
+            'user_id': cls.public_user.id,  # specific public user
         })
-        product = self.env['product.product'].create({
+        product = cls.env['product.product'].create({
             'name': 'The Product'
         })
         add_order_line = [[0, 0, {
@@ -46,67 +48,79 @@ class TestWebsiteSaleCartAbandoned(HttpCaseWithUserPortal):
             'product_id': product.id,
             'product_uom_qty': 1,
         }]]
-        self.so0before = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
-            'website_id': self.website0.id,
+        cls.so0before = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'website_id': cls.website0.id,
             'state': 'draft',
             'date_order': (now - relativedelta(hours=1)) - relativedelta(minutes=1),
             'order_line': add_order_line,
         })
-        self.so0after = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
-            'website_id': self.website0.id,
+        cls.so0after = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'website_id': cls.website0.id,
             'state': 'draft',
             'date_order': (now - relativedelta(hours=1)) + relativedelta(minutes=1),
             'order_line': add_order_line,
         })
-        self.so1before = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
-            'website_id': self.website1.id,
+        cls.so1before = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'website_id': cls.website1.id,
             'state': 'draft',
             'date_order': (now - relativedelta(minutes=30)) - relativedelta(minutes=1),
             'order_line': add_order_line,
         })
-        self.so1after = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
-            'website_id': self.website1.id,
+        cls.so1after = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'website_id': cls.website1.id,
             'state': 'draft',
             'date_order': (now - relativedelta(minutes=30)) + relativedelta(minutes=1),
             'order_line': add_order_line,
         })
-        self.so2before = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
-            'website_id': self.website2.id,
+        cls.so2before = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'website_id': cls.website2.id,
             'state': 'draft',
             'date_order': (now - relativedelta(hours=24)) - relativedelta(minutes=1),
             'order_line': add_order_line,
         })
-        self.so2after = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
-            'website_id': self.website2.id,
+        cls.so2after = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'website_id': cls.website2.id,
             'state': 'draft',
             'date_order': (now - relativedelta(hours=24)) + relativedelta(minutes=1),
             'order_line': add_order_line,
         })
-        self.so2before_but_public = self.env['sale.order'].create({
-            'partner_id': self.public_partner.id,
-            'website_id': self.website2.id,
+        cls.so2before_but_public = cls.env['sale.order'].create({
+            'partner_id': cls.public_partner.id,
+            'website_id': cls.website2.id,
             'state': 'draft',
             'date_order': (now - relativedelta(hours=24)) - relativedelta(minutes=1),
             'order_line': add_order_line,
         })
 
         # Must behave like so1before because public partner is not the one of website1
-        self.so1before_but_other_public = self.env['sale.order'].create({
-            'partner_id': self.public_partner.id,
-            'website_id': self.website1.id,
+        cls.so1before_but_other_public = cls.env['sale.order'].create({
+            'partner_id': cls.public_partner.id,
+            'website_id': cls.website1.id,
             'state': 'draft',
             'date_order': (now - relativedelta(minutes=30)) - relativedelta(minutes=1),
             'order_line': add_order_line,
         })
 
-        return res
+    def send_mail_patched(self, sale_order_id):
+        email_got_sent = False
 
+        def check_send_mail_called(this, res_id, email_values, *args, **kwargs):
+            nonlocal email_got_sent
+            if res_id == sale_order_id:
+                email_got_sent = True
+
+        with patch.object(MailTemplate, 'send_mail', check_send_mail_called):
+            self.env['website']._send_abandoned_cart_email()
+        return email_got_sent
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleCartAbandoned(TestWebsiteSaleCartAbandonedCommon):
     def test_search_abandoned_cart(self):
         """Make sure the search for abandoned carts uses the delay and public partner specified in each website."""
         SaleOrder = self.env['sale.order']
@@ -129,3 +143,117 @@ class TestWebsiteSaleCartAbandoned(HttpCaseWithUserPortal):
         self.assertTrue(self.so1after.id in non_abandoned)
         self.assertTrue(self.so2after.id in non_abandoned)
         self.assertFalse(self.so2before_but_public.id in abandoned)
+
+    def test_website_sale_abandoned_cart_email(self):
+        """Make sure the send_abandoned_cart_email method sends the correct emails."""
+
+        website = self.env['website'].get_current_website()
+        website.send_abandoned_cart_email = True
+
+        product = self.env['product.product'].create({
+            'name': 'The Product'
+        })
+        order_line = [[0, 0, {
+            'name': 'The Product',
+            'product_id': product.id,
+            'product_uom_qty': 1,
+        }]]
+        abandoned_sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(minutes=1),
+            'order_line': order_line
+        })
+        self.assertTrue(abandoned_sale_order.is_abandoned_cart)
+
+        self.assertTrue(self.send_mail_patched(abandoned_sale_order.id))
+
+        # Test that no mail is sent if the partner has no email address.
+        self.customer.email = False
+        self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(
+                minutes=1),
+            'order_line': order_line
+        })
+        self.assertFalse(self.send_mail_patched(abandoned_sale_order.id))
+
+        # Test that no mail is sent if the recovery email of the sale order has already been sent.
+        self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(
+                minutes=1),
+            'order_line': order_line,
+            'cart_recovery_email_sent': True
+        })
+        self.assertFalse(self.send_mail_patched(abandoned_sale_order.id))
+
+        # Test that no email is sent if the sale order contains product that are free.
+        free_product_template = self.env['product.template'].create({
+            'list_price': 0.0,
+            'name': 'free_product'
+        })
+        free_product_product = self.env['product.product'].create({
+            'list_price': 0.0,
+            'name': 'free_product',
+            'product_tmpl_id': free_product_template.id
+        })
+        order_line = [[0, 0, {
+            'name': 'The Product',
+            'product_id': free_product_product.id,
+            'product_uom_qty': 1,
+        }]]
+        self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(
+                minutes=1),
+            'order_line': order_line
+        })
+        self.assertFalse(self.send_mail_patched(abandoned_sale_order.id))
+
+        # Test that no email is sent if the sale order has no error in its transaction.
+        abandoned_sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(
+                minutes=1),
+            'order_line': order_line,
+        })
+        transaction = self.env['payment.transaction'].create({
+            'acquirer_id': 15,
+            'partner_id': self.customer.id,
+            'reference': abandoned_sale_order.name,
+            'amount': abandoned_sale_order.amount_total,
+            'state': 'error',
+            'currency_id': self.env.ref('base.EUR').id,
+
+        })
+        abandoned_sale_order.transaction_ids += transaction
+        self.assertFalse(self.send_mail_patched(abandoned_sale_order.id))
+
+        # Test that if the partner of the abandoned cart made an order ulterior to the abandoned cart create date,
+        # no email is sent.
+        self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(
+                minutes=1),
+            'order_line': order_line,
+        })
+        self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': datetime.utcnow(),
+            'order_line': order_line,
+        })
+        self.assertFalse(self.send_mail_patched(abandoned_sale_order.id))

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -413,20 +413,32 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xs-12 col-lg-6 o_setting_box" id="abandoned_carts_setting" title="Abandoned carts are all carts left unconfirmed by website visitors. You can find them in *Website > Orders > Abandoned Carts*. From there you can send recovery emails to visitors who entered their contact details.">
-                    <div class="o_setting_left_pane"/>
+                <div class="col-xs-12 col-lg-6 o_setting_box" id="abandoned_carts_setting" title="Customer needs to be signed in otherwise the mail address is not known.
+    &#10;&#10;- If a potential customer creates one or more abandoned checkouts and then completes a sale before the recovery email gets sent, then the email won't be sent.
+    &#10;&#10;- If user has manually sent a recovery email, the mail will not be sent a second time
+    &#10;&#10;- If a payment processing error occurred when the customer tried to complete their checkout, then the email won't be sent.
+    &#10;&#10;- If your shop does not support shipping to the customer's address, then the email won't be sent.
+    &#10;&#10;- If none of the products in the checkout are available for purchase (empty inventory, for example), then the email won't be sent.
+    &#10;&#10;- If all the products in the checkout are free, and the customer does not visit the shipping page to add a shipping fee or the shipping fee is also free, then the email won't be sent.">
+                    <div class="o_setting_left_pane">
+                        <field name="send_abandoned_cart_email"/>
+                    </div>
                     <div class="o_setting_right_pane">
-                        <span class="o_form_label">Remind Abandoned Carts</span>
+                        <span class="o_form_label">Automatically send abandoned checkout emails</span>
                         <div class="text-muted">
-                            Email to authenticated customers who did not complete the checkout
+                            Mail only sent to signed in customers with items available for sale in their cart.
                         </div>
-                        <div class="content-group" title="Carts are flagged as abandoned after this delay.">
+
+                        <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="content-group" title="Carts are flagged as abandoned after this delay.">
                             <div class="row mt16">
                                 <div class="col-12">
                                   <label for="cart_abandoned_delay" string="Send after" class="o_light_label"/>
-                                  <field class="col-2" name="cart_abandoned_delay" widget="float_time" /> hours.
+                                  <field class="col-2" name="cart_abandoned_delay" widget="float_time" /> Hours.
                                 </div>
                             </div>
+                        </div>
+                        <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="mt8">
+                            <button type="object" name="action_open_abandoned_cart_mail_template" string="Customize Abandoned Email Template" class="btn-link" icon="fa-arrow-right"/>
                         </div>
                     </div>
                 </div>

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -83,3 +83,34 @@ class SaleOrder(models.Model):
             desired_qty=desired_qty, new_qty=new_qty
         )
         return self.shop_warning
+
+    def _get_cache_key_for_line(self, line):
+        return line.product_id
+
+    def _get_context_for_line(self, line):
+        return {
+            'website_sale_stock_get_quantity': True,
+        }
+
+    def _filter_can_send_abandoned_cart_mail(self):
+        """ Filter sale orders on their product availability. """
+        self = super()._filter_can_send_abandoned_cart_mail()
+        combination_info_cache = {}
+
+        def _are_all_product_available_for_purchase(sale_order):
+            for line in sale_order.order_line:
+                product = line.product_id
+                if product.type != 'product':
+                    continue
+                cache_key = self._get_cache_key_for_line(line)
+                combination_info = combination_info_cache.get(cache_key)
+                if not combination_info:
+                    combination_info = product.with_context(**self._get_context_for_line(line))._get_combination_info_variant(add_qty=line.product_uom_qty)
+                    combination_info_cache[cache_key] = combination_info
+                if not product.allow_out_of_stock_order and combination_info['free_qty'] == 0:
+                    return False
+            return True
+
+        # If none of the products in the checkout are available for purchase (empty inventory, for example),
+        # then the email won't be sent.
+        return self.filtered(_are_all_product_available_for_purchase)

--- a/addons/website_sale_stock/tests/__init__.py
+++ b/addons/website_sale_stock/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_website_sale_stock_abandoned_cart_email
 from . import test_website_sale_stock_product_warehouse
 from . import test_website_sale_stock_stock_notification
 from . import test_website_sale_stock_reorder_from_portal

--- a/addons/website_sale_stock/tests/test_website_sale_stock_abandoned_cart_email.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_abandoned_cart_email.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from odoo.addons.website_sale.tests.test_website_sale_cart_abandoned import TestWebsiteSaleCartAbandonedCommon
+from odoo.tests.common import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleStockAbandonedCartEmail(TestWebsiteSaleCartAbandonedCommon):
+    def test_website_sale_stock_abandoned_cart_email(self):
+        """Make sure the send_abandoned_cart_email method sends the correct emails."""
+
+        website = self.env['website'].get_current_website()
+        website.send_abandoned_cart_email = True
+
+        storable_product_template = self.env['product.template'].create({
+            'name': 'storable_product_template',
+            'type': 'product',
+            'allow_out_of_stock_order': False
+        })
+        storable_product_product = self.env['product.product'].create({
+            'name': 'storable_product_product',
+            'product_tmpl_id': storable_product_template.id,
+        })
+        order_line = [[0, 0, {
+            'name': 'The Product',
+            'product_id': storable_product_product.id,
+            'product_uom_qty': 1,
+        }]]
+        customer = self.env['res.partner'].create({
+            'name': 'a',
+            'email': 'a@example.com',
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': customer.id,
+            'website_id': website.id,
+            'state': 'draft',
+            'date_order': (datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)) - relativedelta(
+                minutes=1),
+            'order_line': order_line
+        })
+
+        self.assertFalse(self.send_mail_patched(sale_order.id))
+        # Reset cart_recovery sent state
+        sale_order.cart_recovery_email_sent = False
+
+        # Replenish the stock of the product
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': storable_product_product.id,
+            'inventory_quantity': 10.0,
+            'location_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
+        }).action_apply_inventory()
+
+        self.assertTrue(self.send_mail_patched(sale_order.id))


### PR DESCRIPTION
This PR adds automatic emailing for abandoned sales orders. 📫 
You need to enable automatic emails in your website settings, set an abandoned delay of your choice, and then the following conditions must be met:
  
1.  The customer must be logged in, otherwise the email address is not known.
2.  If a potential customer creates one or more abandoned carts and then makes a sale before the recovery email is sent, the email will not be sent.
3. If the user has manually sent a recovery email, the email will not be sent a second time.
4. If a payment processing error occurred when the customer tried to complete the order, the email will not be sent.
5. If your store does not support shipping to the customer's address, the email will not be sent.
6. If none of the products in the checkout are available for sale (e.g. empty inventory), the email will not be sent.
7. If all the products in the checkout are free and the customer does not go to the shipping page to add shipping costs or the shipping costs are also free, the email will not be sent.


Task-id: 2907692