### PR TITLE
[FIX] account: add missing fields to mobile aml views

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -94,6 +94,7 @@
                 <kanban class="o_kanban_mobile" create="false" group_create="false">
                     <field name="company_currency_id"/>
                     <field name="partner_id"/>
+                    <field name="quantity"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click">
@@ -1048,6 +1049,8 @@
                                                 <field name="price_unit"/>
                                                 <field name="discount" string="Disc.%"/>
                                                 <field name="currency_id" invisible="1"/>
+                                                <field name="amount_currency" invisible="1"/>
+                                                <field name="recompute_tax_line" invisible="1" force_save="1"/>
                                             </group>
                                             <group>
                                                 <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>


### PR DESCRIPTION
Party is boring when some important guests are not invited. More precisely,
product quantity is not saved after editing an invoice.

In Odoo Mobile App [1], when we create a new Invoice in Accounting app, we can
add a product and input an amount. After saving adding the product and saving
the invoice, the quantity of the product saves correctly.

Next, Edit the Invoice again and add quantity -> Save adding product. We then
save the Invoice -> the quantity reverts back to the initial save and new
quantity is not updated.

A similar fix [2] was done for kanban view for `invoice_line_ids`, but not for `line_ids` field.

[1] The issue is also reproduced if we activate mobile device emulation in
browser

[2]: https://github.com/odoo/odoo/commit/358f6330281848e6c33f6d2e5a7f890eaa7b0e02

opw-2945805
opw-2806178
