### PR TITLE
[FIX] website: fix height of facebook block

### DIFF
--- a/addons/website/static/src/snippets/s_facebook_page/options.js
+++ b/addons/website/static/src/snippets/s_facebook_page/options.js
@@ -17,9 +17,9 @@ options.registry.facebookPage = options.Class.extend({
             height: 215,
             width: 350,
             tabs: '',
-            small_header: true,
-            hide_cover: true,
-            show_facepile: false,
+            small_header: 'true',
+            hide_cover: 'true',
+            show_facepile: 'false',
         };
         this.fbData = _.defaults(_.pick(this.$target[0].dataset, _.keys(defaults)), defaults);
 
@@ -101,9 +101,9 @@ options.registry.facebookPage = options.Class.extend({
             if (this.fbData.tabs) {
                 this.fbData.height = this.fbData.tabs === 'events' ? 300 : 500;
             } else if (this.fbData.small_header) {
-                this.fbData.height = this.fbData.show_facepile ? 165 : 70;
+                this.fbData.height = this.fbData.show_facepile === 'true' ? 165 : 70;
             } else {
-                this.fbData.height = this.fbData.show_facepile ? 225 : 150;
+                this.fbData.height = this.fbData.show_facepile === 'true' ? 225 : 150;
             }
             _.each(this.fbData, (value, key) => {
                 this.$target[0].dataset[key] = value;


### PR DESCRIPTION
Since [this commit], the values of the data attributes of the facebook
block are no longer read with JQuerry so that when the block has a
`data-x="false"` it is now interpreted in javascript as a character
string containing the word "false" and not as a boolean This caused
errors in the height of the block on the page.

Steps to reproduce the bug:
- drop a snippet
- drop a Facebook snippet in it
- grab it and move it somewhere else

=> the height of the block is too high.

[this commit]: https://github.com/odoo/odoo/commit/03c552690b15cbf2e7d6b7812386ac64042219af

task-2950329
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
