### PR TITLE
[FIX] web_editor: restore button and link commands

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -69,6 +69,8 @@ const Wysiwyg = Widget.extend({
         recordInfo: {context: {}},
         document: document,
         allowCommandVideo: true,
+        allowCommandImage: true,
+        allowCommandLink: true,
         insertParagraphAfterColumns: true,
     },
     init: function (parent, options) {

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -137,10 +137,8 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 resizable: true,
                 userGeneratedContent: true,
             };
-            if (hasFullEdit) {
-                options.allowCommandLink = true;
-                options.allowCommandImage = true;
-            }
+            options.allowCommandLink = hasFullEdit;
+            options.allowCommandImage = hasFullEdit;
             wysiwygLoader.loadFromTextarea(self, $textarea[0], options).then(wysiwyg => {
                 if (!hasFullEdit) {
                     wysiwyg.toolbar.$el.find('#link, #media').remove();


### PR DESCRIPTION
Commit [1] introduced an option to enable link and button commands. The goal was to be able to disable it in website_forum when the user doesn't have the proper privileges. Instead, it disabled it everywhere except in website_forum (and then indeed only enabled it when the user had said privileges). The same is true of images and videos.

This enables these commands by default instead, and disables them only specifically for website_forum under the appropriate circumstances.

[1] e10493711879c7f0cc8832db3f1936c622ea605c

task-2917285

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
