### PR TITLE
[FIX] website_slides: fix typo on method call

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -134,7 +134,7 @@ class WebsiteSlides(WebsiteProfile):
                     'id': answer.id,
                     'text_value': answer.text_value,
                     'is_correct': answer.is_correct if slide_completed or request.website.is_publisher() else None,
-                    'comment': answer.comment if request.website.is_publisher else None
+                    'comment': answer.comment if request.website.is_publisher() else None
                 } for answer in question.sudo().answer_ids],
             } for question in slide.question_ids]
         }


### PR DESCRIPTION
Since [1], the call to the method was missing the `()`, thus always
being truthy.

[1]: https://github.com/odoo/odoo/commit/e42ee496f89a830c938a20389a9fc645dfbf96c8
