### PR TITLE
[IMP][15.0] mail: Improved live chat feature when entering help command

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1204,7 +1204,7 @@ class Channel(models.Model):
         else:
             all_channel_partners = self.env['mail.channel.partner'].with_context(active_test=False)
             channel_partners = all_channel_partners.search([('partner_id', '!=', partner.id), ('channel_id', '=', self.id)])
-            msg = _("You are in a private conversation with <b>@%s</b>.", html_escape(channel_partners[0].partner_id.name if channel_partners else _('Anonymous')))
+            msg = _("You are in a private conversation with <b>@%s</b>.", html_escape(_(" @").join(_(partners.partner_id.name) for partners in channel_partners) if channel_partners else _('Anonymous')))
         msg += self._execute_command_help_message_extra()
 
         self._send_transient_message(partner, msg)


### PR DESCRIPTION
While testing the application, I get the following error:

[Steps]:
In my conversation with Website Visitor, I invite Internal Users. When I enter the help command, OdooBot says "You are in a private conversation with @Public user"

[Actual] :
OdooBot says "You are in a private conversation with @Public user"
[org command help on livechat.webm](https://user-images.githubusercontent.com/30213355/184463549-02792e70-59a0-49ac-b34d-c83c07cd8264.webm)

[Expected]:
OdooBot says "You are in a private conversation with @Public user @Internal user A @Internal user B ..."
[Fix command help on live chat.webm](https://user-images.githubusercontent.com/30213355/184463555-6212db7d-445a-4f99-bca5-d4357db2e87b.webm)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr