### PR TITLE
[IMP] crm_iap_mine: Return listview, listcontroller, kanbanview, kanbancontroller

### DIFF
--- a/addons/crm_iap_mine/static/src/js/leads_tree_generate_leads.js
+++ b/addons/crm_iap_mine/static/src/js/leads_tree_generate_leads.js
@@ -73,4 +73,11 @@ odoo.define('crm.leads.tree', function (require) {
 
     viewRegistry.add('crm_iap_lead_mining_request_tree', LeadMiningRequestListView);
     viewRegistry.add('crm_iap_lead_mining_request_kanban', LeadMiningRequestKanbanView);
+    
+    return {
+        LeadMiningRequestListView : LeadMiningRequestListView,
+        LeadMiningRequestListController : LeadMiningRequestListController,
+        LeadMiningRequestKanbanView : LeadMiningRequestKanbanView,
+        LeadMiningRequestKanbanController : LeadMiningRequestKanbanController,
+    }
 });


### PR DESCRIPTION
Delegation inheritance with `crm.lead` leads to the necessity to override `_onOpenRecord` method of the controller.

If `js_class` need to be added on the tree and kanban view of model crm.lead, it already has one `odoo.define('crm.leads.tree'` without returning controller and view object.

A return statement to function as reusing `crm_iap_lead_mining_request_tree` and `crm_iap_lead_mining_request_kanban` views




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
