### PR TITLE
[FIX][15.0] hr_holidays: fix bug there are 2 timeoffs in the same time

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -308,24 +308,25 @@ class HolidaysType(models.Model):
                         sorted_available_allocations += available_allocations.filtered(lambda allocation: not allocation.date_to)
                         leave_intervals = leaves_interval_by_status[holiday_status_id]._items
                         for leave_interval in leave_intervals:
-                            leave = leave_interval[2]
-                            if leave.leave_type_request_unit in ['day', 'half_day']:
-                                leave_duration = leave.number_of_days
-                                leave_unit = 'days'
-                            else:
-                                leave_duration = leave.number_of_hours_display
-                                leave_unit = 'hours'
-                            for available_allocation in sorted_available_allocations:
-                                virtual_remaining_leaves = (available_allocation.number_of_days if leave_unit == 'days' else available_allocation.number_of_hours_display) - allocations_days_consumed[employee_id][holiday_status_id][available_allocation]['virtual_leaves_taken']
-                                max_leaves = min(virtual_remaining_leaves, leave_duration)
-                                days_consumed[available_allocation]['virtual_leaves_taken'] += max_leaves
-                                if leave.state == 'validate':
-                                    days_consumed[available_allocation]['leaves_taken'] += max_leaves
-                                leave_duration -= max_leaves
-                            if leave_duration > 0:
-                                # There are not enough allocation for the number of leaves
-                                days_consumed[False]['virtual_remaining_leaves'] -= leave_duration
-                                return allocations_days_consumed
+                            leaves = leave_interval[2]
+                            for leave in leaves:
+                                if leave.leave_type_request_unit in ['day', 'half_day']:
+                                    leave_duration = leave.number_of_days
+                                    leave_unit = 'days'
+                                else:
+                                    leave_duration = leave.number_of_hours_display
+                                    leave_unit = 'hours'
+                                for available_allocation in sorted_available_allocations:
+                                    virtual_remaining_leaves = (available_allocation.number_of_days if leave_unit == 'days' else available_allocation.number_of_hours_display) - allocations_days_consumed[employee_id][holiday_status_id][available_allocation]['virtual_leaves_taken']
+                                    max_leaves = min(virtual_remaining_leaves, leave_duration)
+                                    days_consumed[available_allocation]['virtual_leaves_taken'] += max_leaves
+                                    if leave.state == 'validate':
+                                        days_consumed[available_allocation]['leaves_taken'] += max_leaves
+                                    leave_duration -= max_leaves
+                                if leave_duration > 0:
+                                    # There are not enough allocation for the number of leaves
+                                    days_consumed[False]['virtual_remaining_leaves'] -= leave_duration
+                                    return allocations_days_consumed
 
         # Future available leaves
         for employee_id, allocation_intervals_by_status in allocation_employees.items():


### PR DESCRIPTION
Current:
With the allocated timeoff type, an employee who takes leave at the same
time will get an error

For example:
Two timeoff in the same day

Bug:
Expected singleton

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
