### PR TITLE
[IMP] web: view metadata - multi xmlids

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -71,9 +71,16 @@
                 <tr>
                     <th>XML ID:</th>
                     <td>
-                        <t t-esc="state.xmlid or '/'"/>
-                        <t t-if="!state.xmlid">
-                            <a t-on-click="onClickCreateXmlid"> (create)</a>
+                        <t t-if='state.xmlids.length > 1'>
+                            <t t-foreach="state.xmlids" t-as="imd" t-key="imd['xmlid']">
+                                <div
+                                    t-att-class='"p-0 " + (imd["xmlid"] === state.xmlid ? "fw-bolder " : "") + (imd["noupdate"] === true ? "fst-italic " : "")'
+                                    t-esc="imd['xmlid']" />
+                            </t>
+                        </t>
+                        <t t-elif="state.xmlid" t-esc="state.xmlid"/>
+                        <t t-else="">
+                            / <a t-on-click="onClickCreateXmlid"> (create)</a>
                         </t>
                     </td>
                 </tr>

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -155,6 +155,7 @@ class GetMetadataDialog extends Component {
         const metadata = result[0];
         this.state.id = metadata.id;
         this.state.xmlid = metadata.xmlid;
+        this.state.xmlids = metadata.xmlids;
         this.state.noupdate = metadata.noupdate;
         this.state.creator = formatMany2one(metadata.create_uid);
         this.state.lastModifiedBy = formatMany2one(metadata.write_uid);


### PR DESCRIPTION
In case several xml_ids target the same record, now we show an icon with
other xml_ids (not the first one) as tooltip.

task-2954293



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
