### PR TITLE
[FIX] website_sale_wishlist: fix undeterministic error in tour

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -105,6 +105,16 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
                     self.wishlistProductIDs.push(productId);
                     self._updateWishlistView();
                     wSaleUtils.animateClone($navButton, $el.closest('form'), 25, 40);
+                    // It might happen that `onChangeVariant` is called at the same time as this function.
+                    // In this case we need to set the button to disabled again.
+                    // Do this only if the productID is still the same.
+                    let currentProductId = $el.data('product-product-id');
+                    if ($el.hasClass('o_add_wishlist_dyn')) {
+                        currentProductId = parseInt($el.closest('.js_product').find('.product_id:checked').val());
+                    }
+                    if (productId === currentProductId) {
+                        $el.prop("disabled", true).addClass('disabled');
+                    }
                 }).guardedCatch(function () {
                     $el.prop("disabled", false).removeClass('disabled');
                 });


### PR DESCRIPTION
This commit attempts to fix an undeterministic error during one of
`website_sale_wishlist` tests.
Due to a race condition it may happen that the button to add to the
wishlist would be re enabled while it should be disabled (if the product
is already in the wishlist) causing the tour to fail.
