### PR TITLE
[FIX] web: make formating and parsing monetary compatible

### DIFF
--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -354,10 +354,10 @@ function formatMonetary(value, field, options) {
     if (!currency || options.noSymbol) {
         return formatted_value;
     }
-    if (currency.position === "after") {
-        return formatted_value += NBSP + currency.symbol;
-    } else {
+    if (currency.position === "before") {
         return currency.symbol + NBSP + formatted_value;
+    } else {
+        return formatted_value += NBSP + currency.symbol;
     }
 }
 /**


### PR DESCRIPTION
Currency position setting allows empty value. Before this commit
`formatMonetary` and `parseMonetary` have different default position. This leads
to errors in Reconcilation page.

opw-2952334

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
