### PR TITLE
[FIX] purchase: update analytic account on change of the line

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1010,7 +1010,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends('product_id', 'date_order')
     def _compute_account_analytic_id(self):
         for rec in self:
-            if not rec.account_analytic_id:
+            if not rec.display_type:
                 default_analytic_account = rec.env['account.analytic.default'].sudo().account_get(
                     product_id=rec.product_id.id,
                     partner_id=rec.order_id.partner_id.id,
@@ -1023,7 +1023,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends('product_id', 'date_order')
     def _compute_analytic_tag_ids(self):
         for rec in self:
-            if not rec.analytic_tag_ids:
+            if not rec.display_type:
                 default_analytic_account = rec.env['account.analytic.default'].sudo().account_get(
                     product_id=rec.product_id.id,
                     partner_id=rec.order_id.partner_id.id,

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1613,7 +1613,7 @@ class SaleOrderLine(models.Model):
     @api.depends('product_id', 'order_id.date_order', 'order_id.partner_id')
     def _compute_analytic_tag_ids(self):
         for line in self:
-            if not line.analytic_tag_ids:
+            if not line.display_type and line.state == 'draft':
                 default_analytic_account = line.env['account.analytic.default'].sudo().account_get(
                     product_id=line.product_id.id,
                     partner_id=line.order_id.partner_id.id,

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -697,3 +697,53 @@ class TestSaleOrder(TestSaleCommon):
         name_search_data = self.env['sale.order.line'].name_search(name=self.sale_order.name)
         sol_ids_found = dict(name_search_data).keys()
         self.assertEqual(list(sol_ids_found), self.sale_order.order_line.ids)
+
+    def test_sale_order_analytic_tag_change(self):
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_accounting')
+        self.env.user.groups_id += self.env.ref('analytic.group_analytic_tags')
+
+        analytic_account_super = self.env['account.analytic.account'].create({'name': 'Super Account'})
+        analytic_account_great = self.env['account.analytic.account'].create({'name': 'Great Account'})
+        analytic_tag_super = self.env['account.analytic.tag'].create({'name': 'Super Tag'})
+        analytic_tag_great = self.env['account.analytic.tag'].create({'name': 'Great Tag'})
+        super_product = self.env['product.product'].create({'name': 'Super Product'})
+        great_product = self.env['product.product'].create({'name': 'Great Product'})
+        product_no_account = self.env['product.product'].create({'name': 'Product No Account'})
+        self.env['account.analytic.default'].create([
+            {
+                'analytic_id': analytic_account_super.id,
+                'product_id': super_product.id,
+                'analytic_tag_ids': [analytic_tag_super.id],
+            },
+            {
+                'analytic_id': analytic_account_great.id,
+                'product_id': great_product.id,
+                'analytic_tag_ids': [analytic_tag_great.id],
+            },
+        ])
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        sol = self.env['sale.order.line'].create({
+            'name': super_product.name,
+            'product_id': super_product.id,
+            'order_id': sale_order.id,
+        })
+
+        self.assertEqual(sol.analytic_tag_ids.id, analytic_tag_super.id, "The analytic tag should be set to 'Super Tag'")
+        sol.write({'product_id': great_product.id})
+        self.assertEqual(sol.analytic_tag_ids.id, analytic_tag_great.id, "The analytic tag should be set to 'Great Tag'")
+        sol.write({'product_id': product_no_account.id})
+        self.assertFalse(sol.analytic_tag_ids.id, "The analytic account should not be set")
+
+        so_no_analytic_account = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        sol_no_analytic_account = self.env['sale.order.line'].create({
+            'name': super_product.name,
+            'product_id': super_product.id,
+            'order_id': so_no_analytic_account.id,
+            'analytic_tag_ids': False,
+        })
+        so_no_analytic_account.action_confirm()
+        self.assertFalse(sol_no_analytic_account.analytic_tag_ids.id, "The compute should not overwrite what the user has set.")


### PR DESCRIPTION
Steps to reproduce:
- create two products
- create two analytic accounts
- create two new analytic rules by assigning an account to a product
- Create a new PO and select on of the product
- On the same line, change the product to the other one

Issue:
- The analytic account won't be updated

Cause:
Bypass of the `account_analytic_id` whenever there is already on defined

Solution:
For the `Sale` fix, I added the `line.state == 'draft'`.
The reason? Because the compute is triggered after confirmation of the order due to:
https://github.com/odoo/odoo/blob/14.0/addons/sale/models/sale.py#L931-L935
Therefore, the compute won't also be triggered after confirmation of the SO.

opw-2948950