### PR TITLE
[IMP] website_sale,mondialrelay: add mondial relay setting

### DIFF
--- a/addons/delivery_mondialrelay/models/delivery_carrier.py
+++ b/addons/delivery_mondialrelay/models/delivery_carrier.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import _, fields, models, api
+from odoo.exceptions import UserError
 
 
 class DeliveryCarrierMondialRelay(models.Model):
     _inherit = 'delivery.carrier'
 
-    is_mondialrelay = fields.Boolean(compute='_compute_is_mondialrelay')
+    is_mondialrelay = fields.Boolean(compute='_compute_is_mondialrelay', search='_search_is_mondialrelay')
     mondialrelay_brand = fields.Char(string='Brand Code', default='BDTEST  ')
     mondialrelay_packagetype = fields.Char(default="24R", groups="base.group_system")  # Advanced
 
@@ -15,6 +16,13 @@ class DeliveryCarrierMondialRelay(models.Model):
     def _compute_is_mondialrelay(self):
         for c in self:
             c.is_mondialrelay = c.product_id.default_code == "MR"
+
+    def _search_is_mondialrelay(self, operator, value):
+        if operator not in ('=', '!=') or not isinstance(value, bool):
+            raise UserError(_("Operation not supported"))
+        if not value:
+            operator = '!=' if operator == '=' else '='
+        return [('product_id.default_code', operator, 'MR')]
 
     def fixed_get_tracking_link(self, picking):
         return self.base_on_rule_get_tracking_link(picking)

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -41,6 +41,7 @@ class ResConfigSettings(models.TransientModel):
 
     module_delivery = fields.Boolean(
         compute='_compute_module_delivery', store=True, readonly=False)
+    module_delivery_mondialrelay = fields.Boolean("Mondial Relay Connector")
     module_website_sale_delivery = fields.Boolean(
         compute='_compute_module_delivery', store=True, readonly=False)
     group_product_pricelist = fields.Boolean(

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -325,6 +325,17 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_mondialrelay_setting">
+                        <div class="o_setting_left_pane">
+                            <field name="module_delivery_mondialrelay" widget="upgrade_boolean"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label string="Mondial Relay" for="module_delivery_mondialrelay"/>
+                            <div class="text-muted" id="website_delivery_mondialrelay">
+                                Let the customer select a Mondial Relay shipping point
+                            </div>
+                        </div>
+                    </div>
                     <div class="col-12 col-lg-6 o_setting_box" id="onsite_payment_setting">
                         <div class="o_setting_left_pane">
                             <field name="module_website_sale_picking"/>

--- a/addons/website_sale_delivery_mondialrelay/__manifest__.py
+++ b/addons/website_sale_delivery_mondialrelay/__manifest__.py
@@ -10,6 +10,8 @@
     'version': '0.1',
     'depends': ['website_sale_delivery', 'delivery_mondialrelay'],
     'data': [
+        'views/delivery_carrier_views.xml',
+        'views/res_config_settings_views.xml',
         'views/templates.xml',
     ],
     'assets': {

--- a/addons/website_sale_delivery_mondialrelay/views/delivery_carrier_views.xml
+++ b/addons/website_sale_delivery_mondialrelay/views/delivery_carrier_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="delivery_carrier_view_search_inherit_website_sale_delivery_mondialrelay" model="ir.ui.view">
+        <field name="name">delivery.carrier.view.search.inherit.website.sale.delivery.mondial.relay</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='inactive']" position="before">
+                <filter string="Mondial Relay" name="is_mondialrelay" domain="[('is_mondialrelay', '=', True)]"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/website_sale_delivery_mondialrelay/views/res_config_settings_views.xml
+++ b/addons/website_sale_delivery_mondialrelay/views/res_config_settings_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit_website_sale_delivery_mondial_relay" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.website.sale.delivery.mondial.relay</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <div id="website_delivery_mondialrelay" position="after">
+                <div class="content-group">
+                    <div class="mt8" attrs="{'invisible': [('module_delivery_mondialrelay', '=', False)]}">
+                        <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="Mondial Relay Shipping Methods" class="btn-link" context="{'search_default_is_mondialrelay': True}"/>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds a setting to enable mondialrelay from the settings just like the
other shipping methods and a way to access the configuration of such
shipping methods more easily.

TaskId-2845799
