### PR TITLE
[FIX][14.0] Project chatter with correct position

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -387,11 +387,10 @@
                             </div>
                         </page>
                     </notebook>
-
-                    <div class="oe_chatter">
-                        <field name="message_follower_ids" options="{'post_refresh':True}" help="Follow this project to automatically track the events associated to tasks and issues of this project." groups="base.group_user"/>
-                    </div>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" options="{'post_refresh':True}" help="Follow this project to automatically track the events associated to tasks and issues of this project." groups="base.group_user"/>
+                </div>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
Project chatter must be placed after the `</sheet>` tag and before the `</form>` tag.

**Description of the issue/feature this PR addresses:**
Chatter on project goes on the wrong position

**Current behavior before PR:**
If you inherit this view and adds messages to the chatter (for example) will be shown on wrong position

**Desired behavior after PR is merged:**
View is now ok. And the chatter can appear on the right side if you choose it on the preferences.

MT-1024 @moduon

OPW-2954551


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
