### PR TITLE
[FIX] account: accrued entry account with fiscal position

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -107,6 +107,13 @@ class AccruedExpenseRevenue(models.TransientModel):
                 },
             })
 
+    def _get_computed_account(self, order, product, is_purchase):
+        accounts = product.with_company(order.company_id).product_tmpl_id.get_product_accounts(fiscal_pos=order.fiscal_position_id)
+        if is_purchase:
+            return accounts['expense']
+        else:
+            return accounts['income']
+
     def _compute_move_vals(self):
         def _get_aml_vals(order, balance, amount_currency, account_id, label=""):
             if not is_purchase:
@@ -145,10 +152,7 @@ class AccruedExpenseRevenue(models.TransientModel):
             if len(orders) == 1 and self.amount and order.order_line:
                 total_balance = self.amount
                 order_line = order.order_line[0]
-                if is_purchase:
-                    account = order_line.product_id.property_account_expense_id or order_line.product_id.categ_id.property_account_expense_categ_id
-                else:
-                    account = order_line.product_id.property_account_income_id or order_line.product_id.categ_id.property_account_income_categ_id
+                account = self._get_computed_account(order, order_line.product_id, is_purchase)
                 values = _get_aml_vals(order, self.amount, 0, account.id, label=_('Manual entry'))
                 move_lines.append(Command.create(values))
             else:
@@ -175,17 +179,16 @@ class AccruedExpenseRevenue(models.TransientModel):
                 )
                 for order_line in lines:
                     if is_purchase:
-                        account = order_line.product_id.property_account_expense_id or order_line.product_id.categ_id.property_account_expense_categ_id
                         amount = self.company_id.currency_id.round(order_line.qty_to_invoice * order_line.price_unit / rate)
                         amount_currency = order_line.currency_id.round(order_line.qty_to_invoice * order_line.price_unit)
                         fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'invoice_lines']
                         label = _('%s - %s; %s Billed, %s Received at %s each', order.name, _ellipsis(order_line.name, 20), order_line.qty_invoiced, order_line.qty_received, formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id))
                     else:
-                        account = order_line.product_id.property_account_income_id or order_line.product_id.categ_id.property_account_income_categ_id
                         amount = self.company_id.currency_id.round(order_line.untaxed_amount_to_invoice / rate)
                         amount_currency = order_line.untaxed_amount_to_invoice
                         fnames = ['qty_to_invoice', 'untaxed_amount_to_invoice', 'qty_invoiced', 'qty_delivered', 'invoice_lines']
                         label = _('%s - %s; %s Invoiced, %s Delivered at %s each', order.name, _ellipsis(order_line.name, 20), order_line.qty_invoiced, order_line.qty_delivered, formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id))
+                    account = self._get_computed_account(order, order_line.product_id, is_purchase)
                     values = _get_aml_vals(order, amount, amount_currency, account.id, label=label)
                     move_lines.append(Command.create(values))
                     total_balance += amount

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+
 from odoo import fields, Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
@@ -87,4 +89,84 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             {'account_id': self.account_expense.id, 'debit': 5000 / 2, 'credit': 0, 'amount_currency': 5000},
             {'account_id': self.alt_exp_account.id, 'debit': 1000 / 2, 'credit': 0, 'amount_currency': 1000},
             {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 6000 / 2, 'amount_currency': 0.0},
+        ])
+
+    def test_accrued_order_account_with_fiscal_position(self):
+        expense_account_copy = self.account_expense.copy()
+
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'TEST FISCAL POSITION',
+            'company_id': self.env.company.id,
+        })
+
+        self.env['account.fiscal.position.account'].create([
+            {
+                'account_src_id': self.account_expense.id,
+                'account_dest_id': expense_account_copy.id,
+                'position_id': fiscal_position.id,
+            }
+        ])
+
+        partner = self.partner_a.copy({'property_account_position_id': fiscal_position.id})
+
+        order = self.purchase_order.copy({
+            'partner_id': partner.id,
+            'fiscal_position_id': partner.property_account_position_id.id,
+            'order_line': [
+                Command.create({
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_qty': 10.0,
+                    'product_uom': self.product_a.uom_id.id,
+                    'price_unit': self.product_a.list_price,
+                    'taxes_id': False,
+                    'qty_received': 10.0,
+                })
+            ]
+        })
+
+        order.button_confirm()
+
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'purchase.order',
+            'active_ids': order.ids
+        }).create({
+            'account_id': self.env['account.account'].create({
+                'name': 'Accrued test account',
+                'code': 'ATA',
+                'user_type_id': self.env.ref('account.data_account_type_current_liabilities').id,
+            }).id
+        })
+
+        wizard_lines = json.loads(wizard.preview_data)
+        account_to_check = wizard_lines['groups_vals'][0]['items_vals'][0][2]['account_id']
+
+        self.assertEqual(account_to_check, expense_account_copy.display_name)
+
+        entries = self.env['account.move'].search(wizard.create_entries()['domain'])
+
+        self.assertRecordValues(entries.filtered('reversed_entry_id').line_ids, [
+            {
+                'account_id': expense_account_copy.id,
+                'debit': 0.0,
+                'credit': order.amount_total,
+            },
+            {
+                'account_id': wizard.account_id.id,
+                'debit': order.amount_total,
+                'credit': 0.0,
+            }
+        ])
+
+        self.assertRecordValues(entries.filtered('reversal_move_id').line_ids, [
+            {
+                'account_id': expense_account_copy.id,
+                'debit': order.amount_total,
+                'credit': 0.0,
+            },
+            {
+                'account_id': wizard.account_id.id,
+                'debit': 0.0,
+                'credit': order.amount_total,
+            }
         ])


### PR DESCRIPTION
We take the accounts from fiscal position into account
when open accrued entry wizard.

Steps to reproduce:

- Create a product with income (INC) and expense (EXP) account set
- Create a fiscal position which map accounts like this:
  INC -> INC_2
  EXP -> EXP_2
- Create a partner with the fiscal position above.
- Create a purchase/sale order for the product, confirm and
  receive.
- On action menu, select "Accrued Expense/Revenue Entry"
-> The account for the product line on the wizard is not the one from
   fiscal position, it should be.

With this commit we take benefits of get_product_accounts method,
which take fiscal position into account.

opw-2926380
