### PR TITLE
[IMP] survey: set a code fallback instead of default field values

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -189,8 +189,8 @@
                                         attrs="{'invisible': ['|', ('question_type', '!=', 'datetime'), ('validation_required', '=', False)]}"/>
 
                                     <field name="validation_error_msg" attrs="{
-                                        'required': [('validation_required', '=', True)],
-                                        'invisible': [('validation_required', '=', False)]}"/>
+                                        'invisible': [('validation_required', '=', False)]}"
+                                        placeholder="The answer you entered is not valid."/>
 
                                     <field name="matrix_subtype" attrs="{'invisible':[('question_type','not in',['matrix'])],'required':[('question_type','=','matrix')]}"/>
                                     <field name="question_placeholder"
@@ -198,7 +198,8 @@
                                         placeholder="Help Participants know what to write"/>
                                     <field name='comments_allowed' attrs="{'invisible':[('question_type','not in',['simple_choice','multiple_choice', 'matrix'])]}"/>
                                     <field name='comments_message'
-                                        attrs="{'invisible': ['|', ('question_type', 'not in', ['simple_choice','multiple_choice', 'matrix']), ('comments_allowed', '=', False)]}"/>
+                                        attrs="{'invisible': ['|', ('question_type', 'not in', ['simple_choice','multiple_choice', 'matrix']), ('comments_allowed', '=', False)]}"
+                                        placeholder="If other, please specify:"/>
                                 </group>
                                 <group string="Layout">
                                     <field name="is_conditional" attrs="{'invisible': [('questions_selection', '=', 'random')]}"/>
@@ -212,7 +213,9 @@
                             <group>
                                 <group string="Constraints">
                                     <field name="constr_mandatory" string="Mandatory Answer"/>
-                                    <field name="constr_error_msg" attrs="{'invisible': [('constr_mandatory', '=', False)]}"/>
+                                    <field name="constr_error_msg"
+                                        attrs="{'invisible': [('constr_mandatory', '=', False)]}"
+                                        placeholder="This question requires an answer."/>
                                 </group>
                                 <group string="Live Sessions">
                                     <label for="is_time_limited" string="Question Time Limit"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -320,10 +320,13 @@
         <t t-set="useKeySelection" t-value="len(question.suggested_answer_ids) &lt; len(letters) and survey.questions_layout == 'page_per_question'"/>
         <!-- Extra 'right' margin is added on layouts that are not "page_per_question" to align with choices questions, since all choices have a me-2 class (pixel perfect yay...) -->
         <t t-set="extra_right_margin" t-value="survey.questions_layout != 'page_per_question' and question.question_type not in ['simple_choice', 'multiple_choice']"/>
+        <t t-set="default_constr_error_msg">This question requires an answer.</t>
+        <t t-set="default_validation_error_msg">The answer you entered is not valid.</t>
+        <t t-set="default_comments_message">If other, please specify:</t>
         <div t-att-class="'js_question-wrapper pb-4 %s %s' % ('d-none' if not display_question else '', 'me-2' if extra_right_margin else '')"
              t-att-id="question.id" t-att-data-required="question.constr_mandatory"
-             t-att-data-constr-error-msg="question.constr_error_msg"
-             t-att-data-validation-error-msg="question.validation_error_msg">
+             t-att-data-constr-error-msg="question.constr_error_msg or default_constr_error_msg"
+             t-att-data-validation-error-msg="question.validation_error_msg or default_validation_error_msg">
             <div class="mb-4">
                 <h3 t-if="not hide_question_title">
                     <span t-field='question.title' />
@@ -465,7 +468,7 @@
                                t-att-name='question.id'
                                t-att-checked="comment_line and 'checked' or None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
-                        <span class="ms-2" t-field="question.comments_message" />
+                        <span class="ms-2" t-out="question.comments_message or default_comments_message" />
                         <i class="fa fa-check-circle float-end mt-1 position-relative"></i>
                         <i class="fa fa-circle-thin float-end mt-1 position-relative"></i>
                     </label>
@@ -477,7 +480,7 @@
             </div>
             <div t-if='question.comments_allowed and not question.comment_count_as_answer' class="col-lg-12 o_survey_comment_container mx-1 mt-3 ps-3 pe-4">
                 <textarea type="text" class="form-control o_survey_comment o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
-                          t-att-placeholder="question.comments_message if not survey_form_readonly else ''"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
+                          t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
             </div>
         </div>
     </template>
@@ -534,7 +537,7 @@
                                t-att-name="question.id"
                                t-att-checked="comment_line and 'checked' or None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
-                        <span class="ms-2" t-field="question.comments_message" />
+                        <span class="ms-2" t-out="question.comments_message or default_comments_message" />
                         <i class="fa fa-check-circle float-end mt-1 position-relative"></i>
                         <i class="fa fa-circle-thin float-end mt-1 position-relative"></i>
                     </label>
@@ -546,7 +549,7 @@
             </div>
             <div t-if='question.comments_allowed and not question.comment_count_as_answer' class="col-lg-12 o_survey_comment_container mx-1 mt-3 py-0 ps-3 pe-4">
                 <textarea type="text" class="form-control o_survey_comment o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
-                          t-att-placeholder="question.comments_message if not survey_form_readonly else ''"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
+                          t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
             </div>
         </div>
     </template>
@@ -595,7 +598,7 @@
         </table>
         <div t-if='question.comments_allowed'>
             <textarea type="text" class="form-control o_survey_question_text_box o_survey_comment bg-transparent text-dark rounded-0 p-0 mt-3"
-                      t-att-placeholder="question.comments_message if not survey_form_readonly else ''"
+                      t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"
                       t-att-name="'%s_%s' % (question.id, 'comment')"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
         </div>
     </template>


### PR DESCRIPTION
Currently, in a survey question, 'comments_message', 'validation_error_msg',
and 'constr_error_msg' fields have a default value. Because of it, they are
considered "user input" and not translated by default. So, the strings are
always printed in the source language and needs to be translated everytime.

This commit improves the behavior by removing the default strings, and instead
set them as code fallback wherever the fields are used, so that they only needs
to be translated once. Also, the same strings are added as a placeholder on
respective fields to make it more clear to the users that what should the value
in these fields look like. Apart from that, considering we now use a fallback
value, the "validation_error_msg" field does not need to be mandatory anymore.

task-2906052

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
