### PR TITLE
[FIX] profiler: manage frame without lineno 

### DIFF
--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -561,6 +561,8 @@ class Profiler:
             if line != '':
                 continue
             # retrieve file lines from the filecache
+            if not lineno:
+                continue
             try:
                 filelines = self.filecache[filename]
             except KeyError:


### PR DESCRIPTION
In some cases the frame may have a filename and corresponding file but
no lineno. This may lead to an error

File ".../odoo/tools/profiler.py", line 571, in _add_file_lines
    line = filelines[lineno - 1]
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'

This commit simply fixes this by skipping the logic if we have no lineno
