### PR TITLE
[IMP] sale_expense: Add stat button from expense sheet to linked SO

### DIFF
--- a/addons/sale_expense/__manifest__.py
+++ b/addons/sale_expense/__manifest__.py
@@ -18,6 +18,7 @@ This module allow to reinvoice employee expense, by setting the SO directly on t
         'views/product_view.xml',
         'views/hr_expense_views.xml',
         'views/sale_order_views.xml',
+        'views/hr_expense_sheet_views.xml',
     ],
     'demo': ['data/sale_expense_demo.xml'],
     'installable': True,

--- a/addons/sale_expense/models/__init__.py
+++ b/addons/sale_expense/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import hr_expense
+from . import hr_expense_sheet
 from . import hr_expense_split
 from . import sale_order
 from . import product_template

--- a/addons/sale_expense/models/hr_expense_sheet.py
+++ b/addons/sale_expense/models/hr_expense_sheet.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class HrExpenseSheet(models.Model):
+    _inherit = "hr.expense.sheet"
+
+    sale_order_count = fields.Integer(compute='_compute_sale_order_count')
+
+    def _compute_sale_order_count(self):
+        for sheet in self:
+            sheet.sale_order_count = len(sheet.expense_line_ids.sale_order_id)
+
+    def action_open_sale_orders(self):
+        self.ensure_one()
+        if self.sale_order_count == 1:
+            return {
+                'type': 'ir.actions.act_window',
+                'res_model': 'sale.order',
+                'views': [(self.env.ref("sale.view_order_form").id, 'form')],
+                'view_mode': 'form',
+                'target': 'current',
+                'name': self.expense_line_ids.sale_order_id.display_name,
+                'res_id': self.expense_line_ids.sale_order_id.id,
+            }
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.order',
+            'views': [(self.env.ref('sale.view_order_tree').id, 'list'), (self.env.ref("sale.view_order_form").id, 'form')],
+            'view_mode': 'list,form',
+            'target': 'current',
+            'name': _('Reinvoiced Sales Orders'),
+            'domain': [('id', 'in', self.expense_line_ids.sale_order_id.ids)],
+        }

--- a/addons/sale_expense/views/hr_expense_sheet_views.xml
+++ b/addons/sale_expense/views/hr_expense_sheet_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="hr_expense_sheet_view_form" model="ir.ui.view">
+        <field name="name">hr.expense.sheet.view.form.inherit.sale.expense</field>
+        <field name="model">hr.expense.sheet</field>
+        <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form"/>
+        <field name="arch" type="xml">
+            <button name="action_get_expense_view" position="after">
+                <button name="action_open_sale_orders"
+                    class="oe_stat_button"
+                    icon="fa-money"
+                    type="object"
+                    attrs="{'invisible': [('sale_order_count', '=', 0)]}">
+                    <field name="sale_order_count" widget="statinfo" string="Sales Orders"/>
+                </button>
+            </button>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose
=======

Make it easier to navigate between an expense report and the sales orders it impacted.

TaskID: 2948615

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
