### PR TITLE
[FIX] purchase_requisition,purchase_requisition_stock: Fix Test case

### DIFF
--- a/addons/purchase_requisition/tests/common.py
+++ b/addons/purchase_requisition/tests/common.py
@@ -67,4 +67,3 @@ class TestPurchaseRequisitionCommon(common.TransactionCase):
         cls.res_partner_1 = cls.env['res.partner'].create({
             'name': 'Wood Corner',
         })
-        cls.env.user.company_id.currency_id = cls.env.ref("base.USD").id

--- a/addons/purchase_requisition_stock/tests/test_purchase_requisition_stock.py
+++ b/addons/purchase_requisition_stock/tests/test_purchase_requisition_stock.py
@@ -96,7 +96,7 @@ class TestPurchaseRequisitionStock(TestPurchaseRequisitionCommon):
             'line_ids': [line1],
             'type_id': requisition_type.id,
             'vendor_id': vendor2.id,
-            'currency_id': self.env.ref("base.USD").id,
+            'currency_id': self.env.user.company_id.currency_id.id,
         })
         requisition_blanket.action_in_progress()
 
@@ -182,13 +182,13 @@ class TestPurchaseRequisitionStock(TestPurchaseRequisitionCommon):
             'line_ids': [line1],
             'type_id': requisition_type.id,
             'vendor_id': vendor1.id,
-            'currency_id': self.env.ref("base.USD").id,
+            'currency_id': self.env.user.company_id.currency_id.id,
         })
         requisition_2 = self.env['purchase.requisition'].create({
             'line_ids': [line2],
             'type_id': requisition_type.id,
             'vendor_id': vendor1.id,
-            'currency_id': self.env.ref("base.USD").id,
+            'currency_id': self.env.user.company_id.currency_id.id,
         })
         requisition_1.action_in_progress()
         requisition_2.action_in_progress()


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

How to reproduce the problem:
- Install the purchase_requistion, purchase_requistion_stock, and any Localization modules such as l10n_be or l10n_in
  (apart from USD currency any localization module)
- Error caught only when at the time of module installation but it must have a different currency_id apart from USD

https://watch.screencastify.com/v/1C7GQKHBASyiluGGkFfV

Cause of the problem:

Static values Currency USD cause the problem.
The following module will set the currency value to:

-  `l10n_be` - `EUR`
- `l10n_in` - `INR`
- `l10n_br` - `BRL`
 when we installed the following modules then `cls.env.user.company_id.currency_id` values get changes accordingly

  will lead to this error while the test cases for `purchase_requisition` will run
```
  Traceback (most recent call last):
  File /home/odoo/src/odoo/addons/purchase_requisition/tests/common.py, line 70, in setUpClass
    cls.env.user.company_id.currency_id = cls.env.ref(base.USD).id
  File /home/odoo/src/odoo/odoo/fields.py, line 1217, in __set__
    records.write({self.name: write_value})
  File /home/odoo/src/odoo/addons/account/models/company.py, line 301, in write
    raise UserError(_('You cannot change the currency of the company since some journal items already exist'))
  odoo.exceptions.UserError: You cannot change the currency of the company since some journal items already exist
```
Current behavior before PR:

- Standard test cases failed of the `purchase_requisition` module  while installing any localization module such as `l10n_be`, `l10n_in`

Desired behavior after PR is merged:
- standard test case of the `purchase_requisition` module get resolve



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
