### PR TITLE
[FIX] account: ignore non-posted invoices when computing an account's balance

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -309,7 +309,7 @@ class AccountAccount(models.Model):
         balances = {
             read['account_id'][0]: read['balance']
             for read in self.env['account.move.line'].read_group(
-                domain=[('account_id', 'in', self.ids)],
+                domain=[('account_id', 'in', self.ids), ('parent_state', '=', 'posted')],
                 fields=['balance', 'account_id'],
                 groupby=['account_id'],
             )

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -153,3 +153,45 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         group.code_prefix_end = 401000
 
         self.assertRecordValues(account_1 + account_2, [{'group_id': group.id}, {'group_id': False}])
+
+    def test_compute_current_balance(self):
+        """ Test if an account's current_balance is computed correctly """
+
+        account_payable = self.company_data['default_account_payable']
+        account_receivable = self.company_data['default_account_receivable']
+
+        payable_debit_move = {
+            'line_ids': [
+                (0, 0, {'name': 'debit', 'account_id': account_payable.id, 'debit': 100.0, 'credit': 0.0}),
+                (0, 0, {'name': 'credit', 'account_id': account_receivable.id, 'debit': 0.0, 'credit': 100.0}),
+            ],
+        }
+        payable_credit_move = {
+            'line_ids': [
+                (0, 0, {'name': 'credit', 'account_id': account_payable.id, 'debit': 0.0, 'credit': 100.0}),
+                (0, 0, {'name': 'debit', 'account_id': account_receivable.id, 'debit': 100.0, 'credit': 0.0}),
+            ],
+        }
+
+        self.assertEqual(account_payable.current_balance, 0)
+
+        self.env['account.move'].create(payable_debit_move).action_post()
+        account_payable._compute_current_balance()
+        self.assertEqual(account_payable.current_balance, 100)
+
+        self.env['account.move'].create(payable_credit_move).action_post()
+        account_payable._compute_current_balance()
+        self.assertEqual(account_payable.current_balance, 0)
+
+        self.env['account.move'].create(payable_credit_move).action_post()
+        account_payable._compute_current_balance()
+        self.assertEqual(account_payable.current_balance, -100)
+
+        self.env['account.move'].create(payable_credit_move).button_cancel()
+        account_payable._compute_current_balance()
+        self.assertEqual(account_payable.current_balance, -100, 'Canceled invoices/bills should not be used when computing the balance')
+
+        # draft invoice
+        self.env['account.move'].create(payable_credit_move)
+        account_payable._compute_current_balance()
+        self.assertEqual(account_payable.current_balance, -100, 'Draft invoices/bills should not be used when computing the balance')


### PR DESCRIPTION
Currently, computing an account's current balance takes canceled and draft invoices into account.
Only posted invoices should be considered.

opw-2896728