### PR TITLE
[FIX] website: remove an option from the facebook block

### DIFF
--- a/addons/website/static/src/xml/website.facebook_page.xml
+++ b/addons/website/static/src/xml/website.facebook_page.xml
@@ -43,7 +43,8 @@
                     Hide Cover Photo
                 </label>
                 </div>
-                <div class="offset-md-3 mt16 col-md-9">
+                <!-- TODO: Remove this option in master (in the meantime we hide it). -->
+                <div class="offset-md-3 mt16 col-md-9 d-none">
                 <label class="o_switch">
                     <input name="show_facepile" type="checkbox" t-att-checked="widget.fbData.show_facepile or None"/>
                     <span/>


### PR DESCRIPTION
Facebook no longer supports the option to see the profile pictures of
friends who have liked the page. So this commit removes the option
(which was no longer useful). See [same issue at WordPress].

[same issue at WordPress]: https://wordpress.org/support/topic/facebook-likebox-disappearance-of-the-faces-of-friends-who-like-the-page/

task-2950329
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
