### PR TITLE
[IMP] account: add default filter to journal items when coming from an account

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1135,7 +1135,7 @@
         <act_window
             id="action_move_line_select"
             name="Journal Items"
-            context="{'search_default_account_id': [active_id]}"
+            context="{'search_default_account_id': [active_id], 'search_default_posted': 1}"
             res_model="account.move.line"/>
 
         <act_window


### PR DESCRIPTION
This PR adds the 'posted' filter by default on the journal items list view, when coming from an account's form view.

opw-2896728