### PR TITLE
[FIX] web: BooleanField style

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -48,7 +48,7 @@
                         </h1>
                     </div>
                     <style>
-                        div[name="options"] .o_field_boolean {
+                        div[name="options"] .o_field_boolean > div {
                             margin-left: 10px;
                             margin-right: 0px;
                         }

--- a/addons/web/static/src/views/fields/boolean/boolean_field.xml
+++ b/addons/web/static/src/views/fields/boolean/boolean_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.BooleanField" owl="1">
-        <CheckBox id="props.id" value="props.value or false" disabled="isReadonly" onChange.bind="onChange" />
+        <CheckBox id="props.id" value="props.value or false" className="'d-inline-block me-2'" disabled="isReadonly" onChange.bind="onChange" />
     </t>
 
 </templates>


### PR DESCRIPTION
The field style was broken in form views since it
uses the display: contents rule. this commit
fixes the style of the field as it is now correctly
displayed inline.
