### PR TITLE
[FIX] web: mobile: highlight for selected record in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -586,6 +586,9 @@ export class ListRenderer extends Component {
         if (record.isInEdition) {
             classNames.push("o_selected_row");
         }
+        if (record.selected) {
+            classNames.push("o_data_row_selected");
+        }
         if (this.props.list.model.useSampleModel) {
             classNames.push("o_sample_data_disabled");
         }


### PR DESCRIPTION
Steps to reproduce:

  - Load odoo on a mobile view
  - Go to Inventory > Products > Products Variants
  - Switch to the list view
  - Long press a record to enter the selection mode
  → The selected records should be highlighted in blue
  
  Enterprise PR: https://github.com/odoo/enterprise/pull/30465