### PR TITLE
[FIX] web: fix layout of kanban record and vignette

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -608,6 +608,7 @@
         padding: $o-kanban-record-margin ($o-horizontal-padding - $o-kanban-record-margin);
 
         .o_kanban_record {
+            display: flex;
             flex: 1 1 auto;
             width: $o-kanban-default-record-width;
             margin: ($o-kanban-record-margin * 0.5) $o-kanban-record-margin;
@@ -626,6 +627,9 @@
                 margin-bottom: 0;
                 padding: 0;
             }
+        }
+        .oe_kanban_vignette {
+            flex: 1 1 auto;
         }
     }
 


### PR DESCRIPTION
With the new kanban view, we have altered the structure of the DOM
slightly, and the kanban record is now a wrapper around the kanban
vignette. To restore the previous layout, some css rules need to apply
to the vignette. This commit adds those rules.
