### PR TITLE
[FIX] web: improve error message when missing the format type of field

### DIFF
--- a/addons/web/static/src/js/fields/abstract_field.js
+++ b/addons/web/static/src/js/fields/abstract_field.js
@@ -388,8 +388,12 @@ var AbstractField = Widget.extend({
      * @returns {string}
      */
     _formatValue: function (value, formatType) {
+        formatType = formatType || this.formatType;
+        if (!formatType) {
+            throw new Error(`Missing format type for '${this.name}' value from the '${this.model}' model`);
+        }
         var options = _.extend({}, this.nodeOptions, { data: this.recordData }, this.formatOptions);
-        return field_utils.format[formatType || this.formatType](value, this.field, options);
+        return field_utils.format[formatType](value, this.field, options);
     },
     /**
      * Returns the className corresponding to a given decoration. A


### PR DESCRIPTION
To reproduce:
1. Create a (incorrect) view manually. For example, inherit from `res.config.settings.view.form` and do add the following view architecture:
```xml
<data>
  <xpath expr="//div[hasclass('settings')]" position="inside">
    <field name="field-dont-exist" widget="upgrade_boolean"/>
  </xpath>
</data>
```
(In practice, Odoo will refuse to let us save the view if it is incorrect (we can bypass that by pushing directly in the database for testing) )

-> When trying to open the settings app, you will have a cryptic JS error:
`TypeError: field_utils.format[(formatType || this.formatType)] is not a function`
The goal of this PR is to improve the error to ease its correction.

Note: This issue can happen in practice after an upgrade or a failed uninstallation of a module.

OPW-2952309

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
