### PR TITLE
[FIX] web: don't apply TZ when serializing dates

### DIFF
--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -364,7 +364,7 @@ export function deserializeDateTime(value) {
  * @returns {string}
  */
 export function serializeDate(value) {
-    return value.setZone("utc").toFormat(SERVER_DATE_FORMAT, { numberingSystem: "latn" });
+    return value.toFormat(SERVER_DATE_FORMAT, { numberingSystem: "latn" });
 }
 
 /**

--- a/addons/web/static/tests/core/domain_selector_tests.js
+++ b/addons/web/static/tests/core/domain_selector_tests.js
@@ -194,9 +194,9 @@ QUnit.module("Components", (hooks) => {
                 value: `[("datetime", "=", "2017-03-27 15:42:00")]`,
                 readonly: false,
                 update: (newValue) => {
-                    assert.notStrictEqual(
+                    assert.strictEqual(
                         newValue,
-                        `[("datetime", "=", "2017-03-27 15:42:00")]`,
+                        `[("datetime", "=", "2017-02-26 15:42:00")]`,
                         "datepicker value should have changed"
                     );
                 },
@@ -211,7 +211,7 @@ QUnit.module("Components", (hooks) => {
             document.body.querySelector(
                 `.bootstrap-datetimepicker-widget :not(.today)[data-action="selectDay"]`
             )
-        );
+        ); // => February 26th
         await click(
             document.body.querySelector(`.bootstrap-datetimepicker-widget a[data-action="close"]`)
         );

--- a/addons/web/static/tests/core/l10n/dates_tests.js
+++ b/addons/web/static/tests/core/l10n/dates_tests.js
@@ -194,7 +194,7 @@ QUnit.module(
                 parseDateTime("invalid value");
             }, /is not a correct/);
 
-            let expected = "2019-01-13T10:05:45.000Z";
+            const expected = "2019-01-13T10:05:45.000Z";
             let dateStr = "01/13/2019 10:05:45";
             assert.equal(parseDateTime(dateStr).toISO(), expected, "Date with leading 0");
             dateStr = "1/13/2019 10:5:45";
@@ -411,11 +411,7 @@ QUnit.module(
             patchDate(2022, 1, 21, 0, 0, 0);
             const date = DateTime.now();
             assert.strictEqual(date.toFormat("yyyy-MM-dd"), "2022-02-21");
-            assert.strictEqual(
-                serializeDate(date),
-                "2022-02-20",
-                "serializeDate should output an UTC converted string"
-            );
+            assert.strictEqual(serializeDate(date), "2022-02-21");
         });
 
         QUnit.test("serializeDate with different numbering system", async (assert) => {
@@ -531,7 +527,7 @@ QUnit.module(
                 };
                 Object.assign(legacy.session, sessionPatch);
                 registerCleanup(() => {
-                    for (let key in sessionPatch) {
+                    for (const key in sessionPatch) {
                         delete legacy.session[key];
                     }
                     Object.assign(legacy.session, initialSession);


### PR DESCRIPTION
# [FIX] web: don't apply TZ when serializing dates
## Before this commit
Serializing a date would apply the TZ offset of
the luxon's DateTime object in which it is contained.
This sometimes led to output the wrong date.

## After this commit
Serializing a date contained in a luxon's DateTime object
will not apply any TZ offset and will output a serialized version as-is.

## Note
If you still want to apply the TZ offset, you should do it manually:

    const toSerialize = date.setZone("utc");
    const value = serializeDateTime(toSerialize);