### PR TITLE
[FIX] point_of_sale: load partners based on email and ref with search

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -191,7 +191,11 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
         async getNewClient() {
             var domain = [];
             if(this.state.query) {
-                domain = [["name", "ilike", this.state.query + "%"]];
+                domain = [
+                    '|','|',
+                    ["display_name", "ilike", this.state.query],
+                    ["email", "ilike", this.state.query],
+                    ];
             }
             var fields = _.find(this.env.pos.models, function(model){ return model.label === 'load_partners'; }).fields;
             var result = await this.rpc({


### PR DESCRIPTION
Before this commit: if the limited partner load option was enabled, when a
user tried to load a user by searching, it would only search based on the
name. In several cases, it's necessary to search based on the email or
reference like when you are searching in the contact in the backend.

The solution is to add other fields to the domain of search.

opw-2952814


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
