### PR TITLE
[IMP] website, *: rename group publisher to restricted_editor

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -175,7 +175,7 @@ class PortalChatter(http.Controller):
                 'message_count': message_data['message_count'],
                 'is_user_public': is_user_public,
                 'is_user_employee': request.env.user._is_internal(),
-                'is_user_publisher': request.env.user.has_group('website.group_website_publisher'),
+                'is_user_publisher': request.env.user.has_group('website.group_website_restricted_editor'),
                 'display_composer': display_composer,
                 'partner_id': request.env.user.partner_id.id
             }

--- a/addons/portal_rating/models/rating_rating.py
+++ b/addons/portal_rating/models/rating_rating.py
@@ -14,7 +14,7 @@ class Rating(models.Model):
 
     def write(self, values):
         if values.get('publisher_comment'):
-            if not self.env.user.has_group("website.group_website_publisher"):
+            if not self.env.user.has_group("website.group_website_restricted_editor"):
                 raise exceptions.AccessError(_("Only the publisher of the website can change the rating comment"))
             if not values.get('publisher_datetime'):
                 values['publisher_datetime'] = fields.Datetime.now()

--- a/addons/web_unsplash/models/res_users.py
+++ b/addons/web_unsplash/models/res_users.py
@@ -12,4 +12,4 @@ class ResUsers(models.Model):
         # of the overwrite done in 5ef8300.
         # So to avoid to create a new module bridge, with a lot of code, we prefer to make a check
         # here for website's user.
-        return self.has_group('base.group_erp_manager') or self.has_group('website.group_website_publisher')
+        return self.has_group('base.group_erp_manager') or self.has_group('website.group_website_restricted_editor')

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -270,11 +270,10 @@ class Website(Home):
     def website_configurator(self, step=1, **kwargs):
         if not request.env.user.has_group('website.group_website_designer'):
             raise werkzeug.exceptions.NotFound()
-        website_id = request.env['website'].get_current_website()
-        if website_id.configurator_done:
+        if request.website.configurator_done:
             return request.redirect('/')
-        if request.env.lang != website_id.default_lang_id.code:
-            return request.redirect('/%s%s' % (website_id.default_lang_id.url_code, request.httprequest.path))
+        if request.env.lang != request.website.default_lang_id.code:
+            return request.redirect('/%s%s' % (request.website.default_lang_id.url_code, request.httprequest.path))
         action_url = '/web#action=website.website_configurator&menu_id=%s' % request.env.ref('website.menu_website_configuration').id
         if step > 1:
             action_url += '&step=' + str(step)

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -95,7 +95,7 @@ class Website(Home):
         different session.
         """
         if not (request.env.user.has_group('website.group_multi_website')
-           and request.env.user.has_group('website.group_website_publisher')):
+           and request.env.user.has_group('website.group_website_restricted_editor')):
             # The user might not be logged in on the forced website, so he won't
             # have rights. We just redirect to the path as the user is already
             # on the domain (basically a no-op as it won't change domain or
@@ -626,7 +626,7 @@ class Website(Home):
 
     @http.route(['/website/get_seo_data'], type='json', auth="user", website=True)
     def get_seo_data(self, res_id, res_model):
-        if not request.env.user.has_group('website.group_website_publisher'):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise werkzeug.exceptions.Forbidden()
 
         fields = ['website_meta_title', 'website_meta_description', 'website_meta_keywords', 'website_meta_og_img']

--- a/addons/website/data/digest_data.xml
+++ b/addons/website/data/digest_data.xml
@@ -4,7 +4,7 @@
         <record id="digest_tip_website_0" model="digest.tip">
             <field name="name">Tip: Engage with visitors to convert them into leads</field>
             <field name="sequence">1500</field>
-            <field name="group_id" ref="website.group_website_publisher" />
+            <field name="group_id" ref="website.group_website_restricted_editor"/>
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Engage with visitors to convert them into leads</p>
@@ -16,7 +16,7 @@
         <record id="digest_tip_website_1" model="digest.tip">
             <field name="name">Tip: Use royalty-free photos</field>
             <field name="sequence">1400</field>
-            <field name="group_id" ref="website.group_website_publisher" />
+            <field name="group_id" ref="website.group_website_restricted_editor"/>
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Use royalty-free photos</p>
@@ -28,7 +28,7 @@
         <record id="digest_tip_website_2" model="digest.tip">
             <field name="name">Tip: Search Engine Optimization (SEO)</field>
             <field name="sequence">1600</field>
-            <field name="group_id" ref="website.group_website_publisher" />
+            <field name="group_id" ref="website.group_website_restricted_editor"/>
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Search Engine Optimization (SEO)</p>
@@ -40,7 +40,7 @@
         <record id="digest_tip_website_3" model="digest.tip">
             <field name="name">Tip: Use illustrations to spice up your website</field>
             <field name="sequence">300</field>
-            <field name="group_id" ref="website.group_website_publisher" />
+            <field name="group_id" ref="website.group_website_restricted_editor"/>
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Use illustrations to spice up your website</p>
@@ -52,7 +52,7 @@
         <record id="digest_tip_website_4" model="digest.tip">
             <field name="name">Tip: Add shapes to energize your Website</field>
             <field name="sequence">400</field>
-            <field name="group_id" ref="website.group_website_publisher" />
+            <field name="group_id" ref="website.group_website_restricted_editor"/>
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Add shapes to energize your Website</p>

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -268,7 +268,7 @@ class Http(models.AbstractModel):
                 path += '?' + request.httprequest.query_string.decode('utf-8')
             return request.redirect(path, code=301)
 
-        if page and (request.website.is_publisher() or page.is_visible):
+        if page and (request.website.is_restricted_editor() or page.is_visible):
             _, ext = os.path.splitext(req_page)
             response = request.render(page.view_id.id, {
                 'main_object': page,
@@ -318,7 +318,7 @@ class Http(models.AbstractModel):
     @classmethod
     def _get_exception_code_values(cls, exception):
         code, values = super()._get_exception_code_values(exception)
-        if isinstance(exception, werkzeug.exceptions.NotFound) and request.website.is_publisher():
+        if isinstance(exception, werkzeug.exceptions.NotFound) and request.website.is_restricted_editor():
             code = 'page_404'
             values['path'] = request.httprequest.path[1:]
         if isinstance(exception, werkzeug.exceptions.Forbidden) and \
@@ -353,7 +353,7 @@ class Http(models.AbstractModel):
                     )
                     values['view'] = values['view'] and values['view'][0]
         # Needed to show reset template on translated pages (`_prepare_environment` will set it for main lang)
-        values['editable'] = request.uid and request.website.is_publisher()
+        values['editable'] = request.uid and request.website.is_restricted_editor()
         return values
 
     @classmethod
@@ -372,7 +372,7 @@ class Http(models.AbstractModel):
             'geoip_country_code': geoip_country_code,
             'geoip_phone_code': geoip_phone_code,
         })
-        if request.env.user.has_group('website.group_website_publisher'):
+        if request.env.user.has_group('website.group_website_restricted_editor'):
             session_info.update({
                 'website_id': request.website.id,
                 'website_company_id': request.website._get_cached('company_id'),

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -271,7 +271,6 @@ class Http(models.AbstractModel):
         if page and (request.website.is_publisher() or page.is_visible):
             _, ext = os.path.splitext(req_page)
             response = request.render(page.view_id.id, {
-                'deletable': True,
                 'main_object': page,
             }, mimetype=_guess_mimetype(ext))
             return response

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -268,7 +268,7 @@ class Http(models.AbstractModel):
                 path += '?' + request.httprequest.query_string.decode('utf-8')
             return request.redirect(path, code=301)
 
-        if page and (request.website.is_restricted_editor() or page.is_visible):
+        if page and (request.env.user.has_group('website.group_website_designer') or page.is_visible):
             _, ext = os.path.splitext(req_page)
             response = request.render(page.view_id.id, {
                 'main_object': page,
@@ -318,7 +318,7 @@ class Http(models.AbstractModel):
     @classmethod
     def _get_exception_code_values(cls, exception):
         code, values = super()._get_exception_code_values(exception)
-        if isinstance(exception, werkzeug.exceptions.NotFound) and request.website.is_restricted_editor():
+        if isinstance(exception, werkzeug.exceptions.NotFound) and request.env.user.has_group('website.group_website_designer'):
             code = 'page_404'
             values['path'] = request.httprequest.path[1:]
         if isinstance(exception, werkzeug.exceptions.Forbidden) and \
@@ -353,7 +353,7 @@ class Http(models.AbstractModel):
                     )
                     values['view'] = values['view'] and values['view'][0]
         # Needed to show reset template on translated pages (`_prepare_environment` will set it for main lang)
-        values['editable'] = request.uid and request.website.is_restricted_editor()
+        values['editable'] = request.uid and request.env.user.has_group('website.group_website_designer')
         return values
 
     @classmethod

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -59,7 +59,7 @@ class IrQWeb(models.AbstractModel):
         irQweb = super()._prepare_frontend_environment(values)
 
         Website = irQweb.env['website']
-        editable = request.website.is_restricted_editor()
+        editable = request.env.user.has_group('website.group_website_designer')
         translatable = editable and irQweb.env.context.get('lang') != irQweb.env['ir.http']._get_default_lang().code
         editable = editable and not translatable
 

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -59,14 +59,14 @@ class IrQWeb(models.AbstractModel):
         irQweb = super()._prepare_frontend_environment(values)
 
         Website = irQweb.env['website']
-        editable = request.website.is_publisher()
+        editable = request.website.is_restricted_editor()
         translatable = editable and irQweb.env.context.get('lang') != irQweb.env['ir.http']._get_default_lang().code
         editable = editable and not translatable
 
         current_website = Website.get_current_website()
 
-        has_group_publisher = irQweb.env.user.has_group('website.group_website_publisher')
-        if has_group_publisher and irQweb.env.user.has_group('website.group_multi_website'):
+        has_group_restricted_editor = irQweb.env.user.has_group('website.group_website_restricted_editor')
+        if has_group_restricted_editor and irQweb.env.user.has_group('website.group_multi_website'):
             values['multi_website_websites_current'] = lazy(lambda: current_website.name)
             values['multi_website_websites'] = lazy(lambda: [
                 {'website_id': website.id, 'name': website.name, 'domain': website.domain}
@@ -92,7 +92,7 @@ class IrQWeb(models.AbstractModel):
 
         if editable:
             # form editable object, add the backend configuration link
-            if 'main_object' in values and has_group_publisher:
+            if 'main_object' in values and has_group_restricted_editor:
                 func = getattr(values['main_object'], 'get_backend_menu_id', False)
                 values['backend_menu_id'] = lazy(lambda: func and func() or irQweb.env['ir.model.data']._xmlid_to_res_id('website.menu_website_configuration'))
 
@@ -104,7 +104,7 @@ class IrQWeb(models.AbstractModel):
             if editable:
                 # in edit mode add brancding on ir.ui.view tag nodes
                 irQweb = irQweb.with_context(inherit_branding=True)
-            elif has_group_publisher and not translatable:
+            elif has_group_restricted_editor and not translatable:
                 # will add the branding on fields (into values)
                 irQweb = irQweb.with_context(inherit_branding_auto=True)
 

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -58,19 +58,17 @@ class IrQWeb(models.AbstractModel):
         """
         irQweb = super()._prepare_frontend_environment(values)
 
-        Website = irQweb.env['website']
+        current_website = request.website
         editable = request.env.user.has_group('website.group_website_designer')
         translatable = editable and irQweb.env.context.get('lang') != irQweb.env['ir.http']._get_default_lang().code
         editable = editable and not translatable
-
-        current_website = Website.get_current_website()
 
         has_group_restricted_editor = irQweb.env.user.has_group('website.group_website_restricted_editor')
         if has_group_restricted_editor and irQweb.env.user.has_group('website.group_multi_website'):
             values['multi_website_websites_current'] = lazy(lambda: current_website.name)
             values['multi_website_websites'] = lazy(lambda: [
                 {'website_id': website.id, 'name': website.name, 'domain': website.domain}
-                for website in Website.search([('id', '!=', current_website.id)])
+                for website in current_website.search([('id', '!=', current_website.id)])
             ])
 
             cur_company = irQweb.env.company

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -228,7 +228,7 @@ class WebsitePublishedMixin(models.AbstractModel):
         return self.create(kwargs).website_url
 
     def _compute_can_publish(self):
-        """ This method can be overridden if you need more complex rights management than just 'website_publisher'
+        """ This method can be overridden if you need more complex rights management than just 'website_restricted_editor'
         The publish widget will be hidden and the user won't be able to change the 'website_published' value
         if this method sets can_publish False """
         for record in self:

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1041,7 +1041,7 @@ class Website(models.Model):
             request.session['force_website_id'] = website_id and str(website_id).isdigit() and int(website_id)
 
     @api.model
-    def is_publisher(self):
+    def is_restricted_editor(self):
         return self.env['ir.model.access'].check('ir.ui.view', 'write', False)
 
     @api.model

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1045,10 +1045,6 @@ class Website(models.Model):
         return self.env['ir.model.access'].check('ir.ui.view', 'write', False)
 
     @api.model
-    def is_user(self):
-        return self.env['ir.model.access'].check('ir.ui.menu', 'read', False)
-
-    @api.model
     def is_public_user(self):
         return request.env.user.id == request.website._get_cached('user_id')
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1041,10 +1041,6 @@ class Website(models.Model):
             request.session['force_website_id'] = website_id and str(website_id).isdigit() and int(website_id)
 
     @api.model
-    def is_restricted_editor(self):
-        return self.env['ir.model.access'].check('ir.ui.view', 'write', False)
-
-    @api.model
     def is_public_user(self):
         return request.env.user.id == request.website._get_cached('user_id')
 

--- a/addons/website/security/ir.model.access.csv
+++ b/addons/website/security/ir.model.access.csv
@@ -7,7 +7,7 @@ access_website_rewrite,access_website_rewrite,model_website_rewrite,,0,0,0,0
 access_website_rewrite_designer,Web Rewrite Manager,model_website_rewrite,group_website_designer,1,1,1,1
 access_website_page,access_website_page,model_website_page,,0,0,0,0
 access_website_page_designer,Web Page Manager,model_website_page,group_website_designer,1,1,1,1
-access_website_ir_ui_view_publisher,access_website_ir_ui_view_publisher,model_ir_ui_view,group_website_publisher,1,0,0,0
+access_website_ir_ui_view_restricted_editor,access_website_ir_ui_view_restricted_editor,model_ir_ui_view,group_website_restricted_editor,1,0,0,0
 access_website_ir_ui_view_designer,access_website_ir_ui_view_designer,model_ir_ui_view,group_website_designer,1,1,1,1
 access_website_ir_asset_designer,access_website_ir_asset_designer,model_ir_asset,group_website_designer,1,1,1,1
 access_seo_public,access_seo_public,model_website_seo_metadata,,1,0,0,0

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -4,14 +4,14 @@
         <field name="sequence">23</field>
     </record>
 
-    <record id="group_website_publisher" model="res.groups">
+    <record id="group_website_restricted_editor" model="res.groups">
         <field name="name">Restricted Editor</field>
         <field name="category_id" ref="base.module_category_website_website"/>
     </record>
     <record id="group_website_designer" model="res.groups">
         <field name="name">Editor and Designer</field>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
-        <field name="implied_ids" eval="[(4, ref('group_website_publisher')), (4, ref('base.group_sanitize_override'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_website_restricted_editor')), (4, ref('base.group_sanitize_override'))]"/>
         <field name="category_id" ref="base.module_category_website_website"/>
     </record>
 

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -174,7 +174,7 @@ export class WebsitePreview extends Component {
     }
 
     addWelcomeMessage() {
-        if (this.websiteService.isPublisher) {
+        if (this.websiteService.isRestrictedEditor) {
             const $wrap = $(this.iframe.el.contentDocument.querySelector('#wrapwrap.homepage')).find('#wrap');
             if ($wrap.length && $wrap.html().trim() === '') {
                 this.$welcomeMessage = $(core.qweb.render('website.homepage_editor_welcome_message'));

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -25,7 +25,7 @@
                 t-ref="iframe"
                 t-on-load="_onPageLoaded"
                 is-ready="false"
-                t-att-data-load-wysiwyg="this.websiteService.isPublisher ? 'true': 'false'"/>
+                t-att-data-load-wysiwyg="this.websiteService.isRestrictedEditor ? 'true': 'false'"/>
         </div>
         <WebsiteEditorComponent t-if="websiteContext.edition"
             reloadIframe.bind="this.reloadIframe"

--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -60,7 +60,7 @@ patch(NavBar.prototype, 'website_navbar', {
         const filteredSections = [];
         for (const section of sections) {
             const isWebsiteCustomMenu = this.websiteEditingMenus[section.xmlid];
-            const displayWebsiteCustomMenu = isWebsiteCustomMenu && this.websiteService.isPublisher && this.websiteEditingMenus[section.xmlid].isDisplayed();
+            const displayWebsiteCustomMenu = isWebsiteCustomMenu && this.websiteService.isRestrictedEditor && this.websiteEditingMenus[section.xmlid].isDisplayed();
             if (!isWebsiteCustomMenu || displayWebsiteCustomMenu) {
                 let subSections = [];
                 if (section.childrenTree.length) {
@@ -76,7 +76,7 @@ patch(NavBar.prototype, 'website_navbar', {
      * @override
      */
     get systrayItems() {
-        if (this.websiteService.currentWebsite && this.websiteService.isPublisher) {
+        if (this.websiteService.currentWebsite && this.websiteService.isRestrictedEditor) {
             return websiteSystrayRegistry
                 .getEntries()
                 .map(([key, value], index) => ({ key, ...value, index }))

--- a/addons/website/static/src/js/content/website_root_instance.js
+++ b/addons/website/static/src/js/content/website_root_instance.js
@@ -6,7 +6,7 @@ import { loadWysiwyg } from "web_editor.loader";
 
 export default createPublicRoot(WebsiteRoot).then(rootInstance => {
     // This data attribute is set by the WebsitePreview client action for a
-    // publisher user.
+    // restricted editor user.
     if (window.frameElement && window.frameElement.dataset.loadWysiwyg === 'true') {
         loadWysiwyg(['website.compiled_assets_wysiwyg']).then(() => {
             window.dispatchEvent(new CustomEvent('PUBLIC-ROOT-READY', {detail: {rootInstance}}));

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -35,7 +35,7 @@ export const websiteService = {
         let editedObjectPath;
         let websiteRootInstance;
         let Wysiwyg;
-        let isPublisher;
+        let isRestrictedEditor;
         let isDesigner;
         let hasMultiWebsites;
         let actionJsId;
@@ -142,8 +142,8 @@ export const websiteService = {
             get editedObjectPath() {
                 return editedObjectPath;
             },
-            get isPublisher() {
-                return isPublisher === true;
+            get isRestrictedEditor() {
+                return isRestrictedEditor === true;
             },
             get isDesigner() {
                 return isDesigner === true;
@@ -175,8 +175,8 @@ export const websiteService = {
             },
             async fetchWebsites() {
                 // Fetch user groups, before fetching the websites.
-                [isPublisher, isDesigner, hasMultiWebsites] = await Promise.all([
-                    user.hasGroup('website.group_website_publisher'),
+                [isRestrictedEditor, isDesigner, hasMultiWebsites] = await Promise.all([
+                    user.hasGroup('website.group_website_restricted_editor'),
                     user.hasGroup('website.group_website_designer'),
                     user.hasGroup('website.group_multi_website'),
                 ]);

--- a/addons/website/static/tests/website_service_mock.js
+++ b/addons/website/static/tests/website_service_mock.js
@@ -13,7 +13,7 @@ function makeFakeWebsiteService() {
                 get context() {
                     return {};
                 },
-                get isPublisher() {
+                get isRestrictedEditor() {
                     return true;
                 },
                 get hasMultiWebsites() {

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -137,7 +137,7 @@ class TestUi(odoo.tests.HttpCase):
             'password': 'restricted',
             'groups_id': [(6, 0, [
                 self.ref('base.group_user'),
-                self.ref('website.group_website_publisher')
+                self.ref('website.group_website_restricted_editor')
             ])]
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'restricted_editor', login='restricted')

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -890,7 +890,7 @@ class TestCowViewSaving(TestViewSavingCommon):
             'name': 'Main layout',
             'mode': 'extension',
             'inherit_id': base_view.id,
-            'arch': '<xpath expr="//t[@t-set=\'head_website\']" position="replace"><t t-call-assets="assets_summernote" t-js="false" groups="website.group_website_publisher"/></xpath>',
+            'arch': '<xpath expr="//t[@t-set=\'head_website\']" position="replace"><t t-call-assets="assets_summernote" t-js="false" groups="website.group_website_restricted_editor"/></xpath>',
             'key': '_website.layout',
         })
 

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<template id="website.compiled_assets_wysiwyg" name="Website Editor Assets (used in website editor)" groups="website.group_website_publisher">
+<template id="website.compiled_assets_wysiwyg" name="Website Editor Assets (used in website editor)" groups="website.group_website_restricted_editor">
     <t t-call-assets="website.assets_wysiwyg"/>
 </template>
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -169,7 +169,7 @@
 
     <!-- Page options -->
     <xpath expr="//div[@id='wrapwrap']" position="before">
-        <t groups="website.group_website_publisher">
+        <t groups="website.group_website_restricted_editor">
             <t t-foreach="['header_overlay', 'header_color', 'header_visible', 'footer_visible']" t-as="optionName">
                 <!-- Firefox autocomplete is too aggressive and works on hidden inputs,
                 so we need to disable it (https://bugzilla.mozilla.org/show_bug.cgi?id=520561) -->
@@ -188,7 +188,7 @@
                        t-as="menu" t-foreach="env['ir.ui.menu'].load_menus_root()['children']"
                        t-attf-href="/web#menu_id=#{menu['id']}&amp;action=#{menu['action'] and menu['action'].split(',')[1] or ''}"/>
                 </div>
-                <a groups="website.group_website_publisher" href="#" title="Edit this content" class="o_frontend_to_backend_edit_btn px-3 d-flex align-items-center justify-content-center text-decoration-none">
+                <a groups="website.group_website_restricted_editor" href="#" title="Edit this content" class="o_frontend_to_backend_edit_btn px-3 d-flex align-items-center justify-content-center text-decoration-none">
                     <i class="fa fa-pencil me-1"/>Edit
                 </a>
             </div>
@@ -1895,7 +1895,7 @@
 
 <template id="language_selector_add_language">
     <a t-attf-class="o_add_language d-none #{dropdown and 'd-sm-block dropdown-item' or 'd-sm-inline-block list-inline-item'}"
-       groups="website.group_website_publisher"
+       groups="website.group_website_restricted_editor"
        t-attf-href="/web#action=base.action_view_base_language_install&amp;website_id=#{website.id if website else ''}&amp;url_return=#{quote_plus(url_for('', '[lang]') + '?' + keep_query())}">
         <i class="fa fa-plus-circle"/>
         <span>Add a language...</span>
@@ -1958,7 +1958,7 @@
     </xpath>
     <xpath expr="//t[@t-call='website.language_selector_add_language']" position="replace">
         <span class="o_add_language list-inline-item"
-            groups="website.group_website_publisher">|</span>
+            groups="website.group_website_restricted_editor">|</span>
         <t t-call="website.language_selector_add_language">
             <t t-set="dropdown" t-value="False"/>
         </t>
@@ -2046,7 +2046,7 @@
 
 <!-- Util template -->
 <template id="publish_management">
-    <div groups="website.group_website_publisher" t-ignore="true" class="float-end css_editable_mode_hidden" t-att-style="style or None">
+    <div groups="website.group_website_restricted_editor" t-ignore="true" class="float-end css_editable_mode_hidden" t-att-style="style or None">
         <div t-attf-class="btn-group #{btn_class} js_publish_management #{object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="object.id" t-att-data-object="object._name" t-att-data-description="env['ir.model']._get(object._name).display_name" t-att-data-controller="publish_controller">
             <button class="btn btn-danger js_publish_btn">Unpublished</button>
             <button class="btn btn-success js_publish_btn">Published</button>
@@ -2098,7 +2098,7 @@
                     Information about the <t t-esc="res_company.name"/> instance of Odoo, the <a target="_blank" href="https://www.odoo.com">Open Source ERP</a>.
                 </p>
 
-                <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_publisher" role="status">
+                <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_restricted_editor" role="status">
                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                    <p>
                      Note: To hide this page, uncheck it from the Customize tab in edit mode.

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -214,7 +214,7 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
         search = post.get('search', '')
 
         base_partner_domain = [('is_company', '=', True), ('grade_id', '!=', False), ('website_published', '=', True)]
-        if not request.env['res.users'].has_group('website.group_website_publisher'):
+        if not request.env['res.users'].has_group('website.group_website_restricted_editor'):
             base_partner_domain += [('grade_id.website_published', '=', True)]
         if search:
             base_partner_domain += ['|', ('name', 'ilike', search), ('website_description', 'ilike', search)]
@@ -321,8 +321,8 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
             current_country = request.env['res.country'].browse(int(country_id)).exists()
         if partner_id:
             partner = request.env['res.partner'].sudo().browse(partner_id)
-            is_website_publisher = request.env['res.users'].has_group('website.group_website_publisher')
-            if partner.exists() and (partner.website_published or is_website_publisher):
+            is_website_restricted_editor = request.env['res.users'].has_group('website.group_website_restricted_editor')
+            if partner.exists() and (partner.website_published or is_website_restricted_editor):
                 values = {
                     'main_object': partner,
                     'partner': partner,

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -157,7 +157,7 @@ class WebsiteEventController(http.Controller):
             # page not found
             values['path'] = re.sub(r"^website_event\.", '', page)
             values['from_template'] = 'website_event.default_page'  # .strip('website_event.')
-            page = request.website.is_restricted_editor() and 'website.page_404' or 'http_routing.404'
+            page = request.env.user.has_group('website.group_website_designer') and 'website.page_404' or 'http_routing.404'
 
         return request.render(page, values)
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -157,7 +157,7 @@ class WebsiteEventController(http.Controller):
             # page not found
             values['path'] = re.sub(r"^website_event\.", '', page)
             values['from_template'] = 'website_event.default_page'  # .strip('website_event.')
-            page = request.website.is_publisher() and 'website.page_404' or 'http_routing.404'
+            page = request.website.is_restricted_editor() and 'website.page_404' or 'http_routing.404'
 
         return request.render(page, values)
 

--- a/addons/website_event/security/event_security.xml
+++ b/addons/website_event/security/event_security.xml
@@ -36,6 +36,6 @@
     </data>
 
     <record id="event.group_event_manager" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('website.group_website_publisher'))]"/>
+        <field name="implied_ids" eval="[(4, ref('website.group_website_restricted_editor'))]"/>
     </record>
 </odoo>

--- a/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
+++ b/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
@@ -45,6 +45,6 @@
 
 
     <record id="hr_recruitment.group_hr_recruitment_manager" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('website.group_website_publisher'))]"/>
+        <field name="implied_ids" eval="[(4, ref('website.group_website_restricted_editor'))]"/>
     </record>
 </odoo>

--- a/addons/website_partner/controllers/main.py
+++ b/addons/website_partner/controllers/main.py
@@ -13,8 +13,8 @@ class WebsitePartnerPage(http.Controller):
         _, partner_id = unslug(partner_id)
         if partner_id:
             partner_sudo = request.env['res.partner'].sudo().browse(partner_id)
-            is_website_publisher = request.env['res.users'].has_group('website.group_website_publisher')
-            if partner_sudo.exists() and (partner_sudo.website_published or is_website_publisher):
+            is_website_restricted_editor = request.env['res.users'].has_group('website.group_website_restricted_editor')
+            if partner_sudo.exists() and (partner_sudo.website_published or is_website_restricted_editor):
                 values = {
                     'main_object': partner_sudo,
                     'partner': partner_sudo,

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -29,7 +29,7 @@
     <div class="col-lg-8 mt32">
         <t t-if="partner">
             <div t-field="partner.website_description"/>
-            <t groups="website.group_website_publisher">
+            <t groups="website.group_website_restricted_editor">
                 <h2 class="css_non_editable_mode_hidden o_not_editable">Short Description for List View</h2>
                 <div class="css_non_editable_mode_hidden" t-field="partner.website_short_description"/>
             </t>

--- a/addons/website_profile/security/ir.model.access.csv
+++ b/addons/website_profile/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
-gamification_karma_rank_access_website_publisher,gamification.karma.rank.access.website.publisher,gamification.model_gamification_karma_rank,website.group_website_publisher,1,1,1,1
+gamification_karma_rank_access_restricted_editor,gamification.karma.rank.access.website.restricted_editor,gamification.model_gamification_karma_rank,website.group_website_restricted_editor,1,1,1,1

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -464,7 +464,7 @@ class WebsiteSale(http.Controller):
         """
 
         if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_publisher')):
+            request.env.user.has_group('website.group_website_restricted_editor')):
             raise NotFound()
 
         image_ids = request.env["ir.attachment"].browse(i['id'] for i in images)
@@ -500,7 +500,7 @@ class WebsiteSale(http.Controller):
         Unlinks all images from the product.
         """
         if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_publisher')):
+            request.env.user.has_group('website.group_website_restricted_editor')):
             raise NotFound()
 
         product_product = request.env['product.product'].browse(int(product_product_id)) if product_product_id else False
@@ -520,7 +520,7 @@ class WebsiteSale(http.Controller):
         Delete or clear the product's image.
         """
         if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_publisher')) or\
+            request.env.user.has_group('website.group_website_restricted_editor')) or\
             image_res_model not in ['product.product', 'product.template', 'product.image']:
             raise NotFound()
 
@@ -535,7 +535,7 @@ class WebsiteSale(http.Controller):
     @http.route(['/shop/product/resequence-image'], type='json', auth='user', website=True)
     def resequence_product_image(self, image_res_model, image_res_id, move):
         if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_publisher')) or\
+            request.env.user.has_group('website.group_website_restricted_editor')) or\
             image_res_model not in ['product.product', 'product.template', 'product.image'] or\
             move not in ['first', 'left', 'right', 'last']:
             raise NotFound()
@@ -1377,7 +1377,7 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/config/product'], type='json', auth='user')
     def change_product_config(self, product_id, **options):
-        if not request.env.user.has_group('website.group_website_publisher'):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
         product = request.env['product.template'].browse(product_id)
@@ -1396,7 +1396,7 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/config/attribute'], type='json', auth='user')
     def change_attribute_config(self, attribute_id, **options):
-        if not request.env.user.has_group('website.group_website_publisher'):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
         attribute = request.env['product.attribute'].browse(attribute_id)
@@ -1405,7 +1405,7 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/config/website'], type='json', auth='user')
     def _change_website_config(self, **options):
-        if not request.env.user.has_group('website.group_website_publisher'):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
         current_website = request.env['website'].get_current_website()

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -463,8 +463,7 @@ class WebsiteSale(http.Controller):
         :raises NotFound : If the user is not allowed to access Attachment model
         """
 
-        if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_restricted_editor')):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
         image_ids = request.env["ir.attachment"].browse(i['id'] for i in images)
@@ -499,8 +498,7 @@ class WebsiteSale(http.Controller):
         """
         Unlinks all images from the product.
         """
-        if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_restricted_editor')):
+        if not request.env.user.has_group('website.group_website_restricted_editor'):
             raise NotFound()
 
         product_product = request.env['product.product'].browse(int(product_product_id)) if product_product_id else False
@@ -519,9 +517,10 @@ class WebsiteSale(http.Controller):
         """
         Delete or clear the product's image.
         """
-        if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_restricted_editor')) or\
-            image_res_model not in ['product.product', 'product.template', 'product.image']:
+        if (
+            not request.env.user.has_group('website.group_website_restricted_editor')
+            or image_res_model not in ['product.product', 'product.template', 'product.image']
+        ):
             raise NotFound()
 
         image_res_id = int(image_res_id)
@@ -534,10 +533,11 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/product/resequence-image'], type='json', auth='user', website=True)
     def resequence_product_image(self, image_res_model, image_res_id, move):
-        if not (request.env.user.has_group('website.group_website_designer') or\
-            request.env.user.has_group('website.group_website_restricted_editor')) or\
-            image_res_model not in ['product.product', 'product.template', 'product.image'] or\
-            move not in ['first', 'left', 'right', 'last']:
+        if (
+            not request.env.user.has_group('website.group_website_restricted_editor')
+            or image_res_model not in ['product.product', 'product.template', 'product.image']
+            or move not in ['first', 'left', 'right', 'last']
+        ):
             raise NotFound()
 
         image_res_id = int(image_res_id)

--- a/addons/website_sale/security/ir.model.access.csv
+++ b/addons/website_sale/security/ir.model.access.csv
@@ -19,9 +19,9 @@ access_fiscal_position_public,fiscal position public,account.model_account_fisca
 access_payment_term,payment term public,account.model_account_payment_term,base.group_portal,1,0,0,0
 access_account_tax_user,account.tax,account.model_account_tax,base.group_public,1,0,0,0
 access_product_image_public,product.image public,model_product_image,,1,0,0,0
-access_product_image_publisher,product.image wbesite publisher,model_product_image,website.group_website_publisher,1,1,1,1
+access_product_image_restricted_editor,product.image wbesite restricted_editor,model_product_image,website.group_website_restricted_editor,1,1,1,1
 access_product_image_sale,product.image sale,model_product_image,sales_team.group_sale_manager,1,1,1,1
 access_ecom_extra_fields_public,access_ecom_extra_field public,model_website_sale_extra_field,,1,0,0,0
-access_ecom_extra_fields_publisher,access_ecom_extra_field publisher,model_website_sale_extra_field,website.group_website_publisher,1,1,1,1
+access_ecom_extra_fields_restricted_editor,access_ecom_extra_field restricted_editor,model_website_sale_extra_field,website.group_website_restricted_editor,1,1,1,1
 access_website_base_unit_public,website.base.unit public,model_website_base_unit,,1,0,0,0
 access_website_base_unit_sale_manager,website.base.unit sale manager,model_website_base_unit,sales_team.group_sale_manager,1,1,1,1

--- a/addons/website_sale/security/website_sale.xml
+++ b/addons/website_sale/security/website_sale.xml
@@ -23,7 +23,7 @@
     </record>
 
     <record id="sales_team.group_sale_manager" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('website.group_website_publisher'))]"/>
+        <field name="implied_ids" eval="[(4, ref('website.group_website_restricted_editor'))]"/>
     </record>
 
     <record id="base.group_user" model="res.groups">

--- a/addons/website_sale_wishlist/controllers/main.py
+++ b/addons/website_sale_wishlist/controllers/main.py
@@ -10,7 +10,7 @@ class WebsiteSaleWishlist(WebsiteSale):
 
     @route(['/shop/wishlist/add'], type='json', auth="public", website=True)
     def add_to_wishlist(self, product_id, **kw):
-        website = request.env['website'].get_current_website()
+        website = request.website
         pricelist = website.pricelist_id
         product = request.env['product.product'].browse(product_id)
 

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -140,8 +140,8 @@ class WebsiteSlides(WebsiteProfile):
                 'answer_ids': [{
                     'id': answer.id,
                     'text_value': answer.text_value,
-                    'is_correct': answer.is_correct if slide.user_has_completed or request.website.is_publisher() else None,
-                    'comment': answer.comment if request.website.is_publisher() else None
+                    'is_correct': answer.is_correct if slide.user_has_completed or request.website.is_restricted_editor() else None,
+                    'comment': answer.comment if request.website.is_restricted_editor() else None
                 } for answer in question.sudo().answer_ids],
             } for question in slide.question_ids]
         }
@@ -904,7 +904,7 @@ class WebsiteSlides(WebsiteProfile):
     @http.route('/slides/slide/archive', type='json', auth='user', website=True)
     def slide_archive(self, slide_id):
         """ This route allows channel publishers to archive slides.
-        It has to be done in sudo mode since only website_publishers can write on slides in ACLs """
+        It has to be done in sudo mode since only restricted_editors can write on slides in ACLs """
         slide = request.env['slide.slide'].browse(int(slide_id))
         if slide.channel_id.can_publish:
             slide.sudo().active = False

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -133,6 +133,7 @@ class WebsiteSlides(WebsiteProfile):
         return slide._compute_quiz_info(request.env.user.partner_id, quiz_done=quiz_done)[slide.id]
 
     def _get_slide_quiz_data(self, slide):
+        is_designer = request.env.user.has_group('website.group_website_designer')
         values = {
             'slide_questions': [{
                 'id': question.id,
@@ -140,8 +141,8 @@ class WebsiteSlides(WebsiteProfile):
                 'answer_ids': [{
                     'id': answer.id,
                     'text_value': answer.text_value,
-                    'is_correct': answer.is_correct if slide.user_has_completed or request.website.is_restricted_editor() else None,
-                    'comment': answer.comment if request.website.is_restricted_editor() else None
+                    'is_correct': answer.is_correct if slide.user_has_completed or is_designer else None,
+                    'comment': answer.comment if is_designer else None
                 } for answer in question.sudo().answer_ids],
             } for question in slide.question_ids]
         }

--- a/addons/website_slides/security/website_slides_security.xml
+++ b/addons/website_slides/security/website_slides_security.xml
@@ -7,7 +7,7 @@
         <record id="group_website_slides_officer" model="res.groups">
             <field name="name">Officer</field>
             <field name="category_id" ref="base.module_category_website_elearning"/>
-            <field name="implied_ids" eval="[(4, ref('website.group_website_publisher'))]"/>
+            <field name="implied_ids" eval="[(4, ref('website.group_website_restricted_editor'))]"/>
         </record>
 
         <record id="group_website_slides_manager" model="res.groups">

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -4,7 +4,7 @@ import tour from 'web_tour.tour';
 
 /**
  * Global use case:
- * an user (either employee, website publisher or portal) joins a public
+ * an user (either employee, website restricted editor or portal) joins a public
     course;
  * they have access to the full course content when they are a member of the
     course;

--- a/addons/website_slides/static/tests/tours/slides_course_member_yt.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_yt.js
@@ -21,7 +21,7 @@ FullScreen.include({
 
 /**
  * Global use case:
- * an user (either employee, website publisher or portal) joins a public
+ * an user (either employee, website restricted editor or portal) joins a public
     course;
  * they have access to the full course content when they are a member of the
     course;

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -5,7 +5,7 @@ import slidesTourTools from '@website_slides/../tests/tours/slides_tour_tools';
 
 /**
  * Global use case:
- * a user (website publisher) creates a course;
+ * a user (website restricted editor) creates a course;
  * they update it;
  * they create some lessons in it;
  * they publishe it;

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -4,7 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 /**
  * Global use case:
- * - a user (website publisher) lands on the fullscreen view of a course ;
+ * - a user (website restricted editor) lands on the fullscreen view of a course ;
  * - they click on the website editor "Edit" button ;
  * - they are redirected to the non-fullscreen view with the editor opened.
  *

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -134,11 +134,11 @@ class TestUi(TestUICommon):
             'odoo.__DEBUG__.services["web_tour.tour"].tours.course_member.ready',
             login=user_portal.login)
 
-    def test_full_screen_edition_website_publisher(self):
+    def test_full_screen_edition_website_restricted_editor(self):
         # group_website_designer
         user_demo = self.env.ref('base.user_demo')
         user_demo.write({
-            'groups_id': [(5, 0), (4, self.env.ref('base.group_user').id), (4, self.env.ref('website.group_website_publisher').id)]
+            'groups_id': [(5, 0), (4, self.env.ref('base.group_user').id), (4, self.env.ref('website.group_website_restricted_editor').id)]
         })
 
         self.browser_js(

--- a/addons/website_twitter/controllers/main.py
+++ b/addons/website_twitter/controllers/main.py
@@ -17,7 +17,7 @@ class Twitter(http.Controller):
         key = request.website.twitter_api_key
         secret = request.website.twitter_api_secret
         screen_name = request.website.twitter_screen_name
-        debug = request.env['res.users'].has_group('website.group_website_publisher')
+        debug = request.env['res.users'].has_group('website.group_website_restricted_editor')
         if not key or not secret:
             if debug:
                 return {"error": _("Please set the Twitter API Key and Secret in the Website Settings.")}

--- a/addons/website_twitter/security/ir.model.access.csv
+++ b/addons/website_twitter/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_website_twitter_tweet_public,access of twitter snippet,website_twitter.model_website_twitter_tweet,,1,0,0,0
-access_website_twitter_tweet_manage,manage tweets,website_twitter.model_website_twitter_tweet,website.group_website_publisher,1,1,1,1
+access_website_twitter_tweet_manage,manage tweets,website_twitter.model_website_twitter_tweet,website.group_website_restricted_editor,1,1,1,1


### PR DESCRIPTION
* portal, web_unsplash, website_*

This commit renames the `website.group_website_publisher` into
`website.group_website_restricted_editor`.

While the change in itself might look unuseful, it will help the dev and
tech community figuring which group is related to which feature.

Even internally when we discuss specs, we always have to remind which
group is the restricted editor: the publisher one or the designer one?

While it is probably, after all those years, now anchored in some dev
mind, there is no easy way to directly figure which of those 2 groups is
the restricted editor one.
Note that I myself always got confused about it.

Now, the "Restricted Editor" right will be reflected in its technical
name `group_website_restricted_editor`.
Same as for the "Editor & Designer" which technical name is
`group_website_designer`.

As we would like to have a fully working and ready system in v17 for the
community to be able to build themes easily, removing that dubious part
is a nice to have.

https://github.com/odoo/enterprise/pull/30691
https://github.com/odoo/upgrade/pull/3808