### PR TITLE
[FIX] server: close socket when graceful shutdown

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -882,6 +882,8 @@ class PreforkServer(CommonServer):
             # FIXME make longpolling process handle SIGTERM correctly
             self.worker_kill(self.long_polling_pid, signal.SIGKILL)
             self.long_polling_pid = None
+        if self.socket:
+            self.socket.close()
         if graceful:
             _logger.info("Stopping gracefully")
             super().stop()
@@ -900,8 +902,6 @@ class PreforkServer(CommonServer):
             _logger.info("Stopping forcefully")
         for pid in self.workers:
             self.worker_kill(pid, signal.SIGTERM)
-        if self.socket:
-            self.socket.close()
 
     def run(self, preload, stop):
         self.start()


### PR DESCRIPTION
Previously, when gracefully stopping the server, incoming requests got
queued in the socket's backlog until the workers all finished their
requests, then the socket closes and backlogged requests get their
error response.

This would leave the system administrator with the awkward choice
between giving existing requests time to finish and not creating too
big a downtime for new incoming requests before forcefully shutting the
server down.

As the workers will stop accepting new connections on the graceful stop
call, we can close the socket so the binded address is freed as well.

This allows a cleaner graceful restart of the service as we can
gracefully quit the Odoo server, start a new server on the same address
and let the old service finish its requests for as long as we want.