### PR TITLE
[FIX] web, sale: fix spacing in stat button between amount and unit

### DIFF
--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -51,7 +51,7 @@
                     attrs="{'invisible': [('sale_ok', '=', False)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="sales_count" widget="statinfo" nolabel="1" class="mr4"/>
+                            <field name="sales_count" widget="statinfo" nolabel="1"/>
                             <field name="uom_name"/>
                         </span>
                         <span class="o_stat_text">Sold</span>
@@ -83,7 +83,7 @@
                     attrs="{'invisible': [('sale_ok', '=', False)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="sales_count" widget="statinfo" nolabel="1" class="mr4"/>
+                            <field name="sales_count" widget="statinfo" nolabel="1"/>
                             <field name="uom_name"/>
                         </span>
                         <span class="o_stat_text">Sold</span>

--- a/addons/web/static/src/views/fields/stat_info/stat_info_field.xml
+++ b/addons/web/static/src/views/fields/stat_info/stat_info_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.StatInfoField" owl="1">
-        <span class="o_stat_info o_stat_value" t-esc="formattedValue"/>
+        <span class="o_stat_info o_stat_value mr4" t-esc="formattedValue"/>
         <span t-if="!props.noLabel" class="o_stat_text" t-esc="label"/>
     </t>
 


### PR DESCRIPTION
Since fields are in display: contents, giving them spacing classes has
no effect. This commit fixes that by applying the class directly inside
the statinfo field.
