### PR TITLE
[IMP] account_edi: remove dead function _is_account_edi_ubl_cii_avail…

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -638,6 +638,3 @@ class AccountEdiFormat(models.Model):
     def _format_error_message(self, error_title, errors):
         bullet_list_msg = ''.join('<li>%s</li>' % html_escape(msg) for msg in errors)
         return '%s<ul>%s</ul>' % (error_title, bullet_list_msg)
-
-    def _is_account_edi_ubl_cii_available(self):
-        return hasattr(self, '_infer_xml_builder_from_tree')


### PR DESCRIPTION
…able

This function was used to check the presence of the new module
`account_edi_ubl_cii`. The purpose was to use this module to render the xmls
for the existing modules: l10n_be_edi, l10n_no_edi, l10n_nl_edi... which used
outdated qweb templates (see https://github.com/odoo/odoo/commit/72c4972efd3f31bd86d100f160a530cc70400617).

After version saas-15.4, these old modules were removed and `account_edi_ubl_cii`
is used instead. Thus, `_is_account_edi_ubl_cii_available` is no longer used.
