### PR TITLE
[IMP] auth_signup: Add Account Activation by Email For Free Signup

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -49,7 +49,7 @@ class AuthSignupHome(Home):
 
                     # new user created with b2c_email_activate_enabled, still inactive
                     if not qcontext.get('token'):
-                        User =  User.with_context(active_test=False)
+                        User = User.with_context(active_test=False)
 
                     user_sudo = User.sudo().search(
                         User._get_login_domain(qcontext.get('login')), order=User._get_login_order(), limit=1

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -6,6 +6,7 @@ from werkzeug.urls import url_encode
 
 from odoo import http, tools, _
 from odoo.addons.auth_signup.models.res_users import SignupError
+from odoo.addons.auth_signup.models.res_partner import now
 from odoo.addons.web.controllers.home import ensure_db, Home, SIGN_UP_REQUEST_PARAMS, LOGIN_SUCCESSFUL_PARAMS
 from odoo.addons.base_setup.controllers.main import BaseSetup
 from odoo.exceptions import UserError
@@ -43,13 +44,23 @@ class AuthSignupHome(Home):
             try:
                 self.do_signup(qcontext)
                 # Send an account creation confirmation email
-                if qcontext.get('token'):
+                if qcontext.get('token') or qcontext.get('b2c_email_activate_enabled'):
                     User = request.env['res.users']
+
+                    # new user created with b2c_email_activate_enabled, still inactive
+                    if not qcontext.get('token'):
+                        User =  User.with_context(active_test=False)
+
                     user_sudo = User.sudo().search(
                         User._get_login_domain(qcontext.get('login')), order=User._get_login_order(), limit=1
                     )
                     template = request.env.ref('auth_signup.mail_template_user_signup_account_created', raise_if_not_found=False)
                     if user_sudo and template:
+
+                        # new user created with b2c_email_activate_enabled, inactive, need an activation token
+                        if not qcontext.get('token'):
+                            return self._send_activation_email(user_sudo, qcontext)
+
                         template.sudo().send_mail(user_sudo.id, force_send=True)
                 return self.web_login(*args, **kw)
             except UserError as e:
@@ -109,17 +120,43 @@ class AuthSignupHome(Home):
         response.headers['Content-Security-Policy'] = "frame-ancestors 'self'"
         return response
 
+    @http.route('/web/activate', type='http', auth='public', website=True, sitemap=False)
+    def web_auth_activate(self, *args, **kw):
+        qcontext = self.get_auth_signup_qcontext(include_inactive=True)
+        partner = request.env['res.partner'].sudo().with_context(active_test=False)\
+            .search([('signup_token', '=', qcontext.get('token')), ('email', '=', qcontext.get('login'))], limit=1)
+        partner_user = partner.user_ids[0]
+        if not qcontext.get('token') or 'error' in qcontext or not partner or not partner_user:
+            raise werkzeug.exceptions.NotFound()
+
+        partner_user.sudo().write({'active': True})
+        partner.write({'signup_token': False})
+
+        # notify about new account creation, if it set
+        notification_receiver_email = request.env['ir.config_parameter'].sudo()\
+            .get_param('auth_signup.account_activated_notification_receiver')
+        notification_receiver_partner = request.env['res.partner'].sudo().\
+            search([('email', '=', notification_receiver_email)], limit=1)
+        if notification_receiver_partner:
+            template = request.env.ref('auth_signup.account_activated_notification_email')
+            template.sudo().send_mail(partner_user.id, force_send=True,
+                                      email_values={'recipient_ids': [notification_receiver_partner[0].id]})
+
+        return request.redirect('/web/login')
+
     def get_auth_signup_config(self):
         """retrieve the module config (which features are enabled) for the login page"""
 
         get_param = request.env['ir.config_parameter'].sudo().get_param
+        signup_invitation_scope = request.env['res.users']._get_signup_invitation_scope()
         return {
             'disable_database_manager': not tools.config['list_db'],
-            'signup_enabled': request.env['res.users']._get_signup_invitation_scope() == 'b2c',
+            'signup_enabled': signup_invitation_scope in ('b2c', 'b2c_email_activate'),
+            'b2c_email_activate_enabled': signup_invitation_scope == 'b2c_email_activate',
             'reset_password_enabled': get_param('auth_signup.reset_password') == 'True',
         }
 
-    def get_auth_signup_qcontext(self):
+    def get_auth_signup_qcontext(self, include_inactive=False):
         """ Shared helper returning the rendering context for signup and reset password """
         qcontext = {k: v for (k, v) in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         qcontext.update(self.get_auth_signup_config())
@@ -128,7 +165,7 @@ class AuthSignupHome(Home):
         if qcontext.get('token'):
             try:
                 # retrieve the user info (name, login or email) corresponding to a signup token
-                token_infos = request.env['res.partner'].sudo().signup_retrieve_info(qcontext.get('token'))
+                token_infos = request.env['res.partner'].sudo().signup_retrieve_info(qcontext.get('token'), include_inactive)
                 for k, v in token_infos.items():
                     qcontext.setdefault(k, v)
             except:
@@ -151,15 +188,28 @@ class AuthSignupHome(Home):
     def do_signup(self, qcontext):
         """ Shared helper that creates a res.partner out of a token """
         values = self._prepare_signup_values(qcontext)
-        self._signup_with_values(qcontext.get('token'), values)
+        self._signup_with_values(qcontext.get('token'), values, qcontext.get('b2c_email_activate_enabled'))
         request.env.cr.commit()
 
-    def _signup_with_values(self, token, values):
+    def _signup_with_values(self, token, values, b2c_email_activate_enabled):
         login, password = request.env['res.users'].sudo().signup(values, token)
         request.env.cr.commit()     # as authenticate will use its own cursor we need to commit the current transaction
+        if b2c_email_activate_enabled and not token:
+            return
         pre_uid = request.session.authenticate(request.db, login, password)
         if not pre_uid:
             raise SignupError(_('Authentication Failed.'))
+
+    def _send_activation_email(self, user_sudo, qcontext):
+        user_sudo.mapped('partner_id').signup_prepare(signup_type="activate", expiration=now(weeks=+1))
+        template = request.env.ref('auth_signup.account_activate_email')
+        template.sudo().send_mail(user_sudo.id, force_send=True)
+
+        qcontext['message'] = _("Account activation instructions sent to your email")
+        response = request.render('auth_signup.activate_account', qcontext)
+        response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+        response.headers['Content-Security-Policy'] = "frame-ancestors 'self'"
+        return response
 
 class AuthBaseSetup(BaseSetup):
     @http.route('/base_setup/data', type='json', auth='user')

--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -337,5 +337,193 @@
             <field name="auto_delete" eval="True"/>
         </record>
 
+        <!-- Email template for activate account -->
+        <record id="account_activate_email" model="mail.template">
+            <field name="name">Auth Signup: Activate Account</field>
+            <field name="model_id" ref="base.model_res_users"/>
+            <field name="subject">Activate account</field>
+            <field name="email_from">"{{ object.company_id.name }}" &lt;{{ (object.company_id.email or user.email) }}&gt;</field>
+            <field name="email_to">{{ object.email_formatted }}</field>
+            <field name="body_html" type="html">
+<table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #FFFFFF; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
+<table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">
+<tbody>
+    <!-- HEADER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
+                <tr><td valign="middle">
+                    <span style="font-size: 10px;">Your Account</span><br/>
+                    <span style="font-size: 20px; font-weight: bold;">
+                        <t t-out="object.name or ''">Marc Demo</t>
+                    </span>
+                </td><td valign="middle" align="right">
+                    <img t-attf-src="/logo.png?company={{ object.company_id.id }}" style="padding: 0px; margin: 0px; height: auto; width: 80px;" t-att-alt="object.company_id.name"/>
+                </td></tr>
+                <tr><td colspan="2" style="text-align:center;">
+                  <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- CONTENT -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
+                <tr><td valign="top" style="font-size: 13px;">
+                    <div>
+                        Dear <t t-out="object.name or ''">Marc Demo</t>,<br/><br/>
+                        An account has been created with this email on
+                        <span style="font-size: 20px; font-weight: bold;">
+                            <t t-out="object.company_id.name or ''">Odoo</t>
+                        </span>
+                        You may activate your account by following this link which will remain valid for a week:<br/>
+                        <div style="margin: 16px 0px 16px 0px;">
+                            <a t-att-href="object.signup_url"
+                                style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
+                                Activate account
+                            </a>
+                        </div>
+                        If you do not expect this, you can safely ignore this email.<br/><br/>
+                        Thanks,
+                        <t t-if="user.signature">
+                            <br/>
+                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                        </t>
+                    </div>
+                </td></tr>
+                <tr><td style="text-align:center;">
+                  <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- FOOTER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; font-size: 11px; padding: 0px 8px 0px 8px; border-collapse:separate;">
+                <tr><td valign="middle" align="left">
+                    <t t-out="object.company_id.name or ''">YourCompany</t>
+                </td></tr>
+                <tr><td valign="middle" align="left" style="opacity: 0.7;">
+                    <t t-out="object.company_id.phone or ''">+1 650-123-4567</t>
+
+                    <t t-if="object.company_id.email">
+                        | <a t-att-href="'mailto:%s' % object.company_id.email" style="text-decoration:none; color: #454748;" t-out="object.company_id.email or ''">info@yourcompany.com</a>
+                    </t>
+                    <t t-if="object.company_id.website">
+                        | <a t-att-href="'%s' % object.company_id.website" style="text-decoration:none; color: #454748;" t-out="object.company_id.website or ''">http://www.example.com</a>
+                    </t>
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+</tbody>
+</table>
+</td></tr>
+<!-- POWERED BY -->
+<tr><td align="center" style="min-width: 590px;">
+    <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;">
+      <tr><td style="text-align: center; font-size: 13px;">
+        Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=auth" style="color: #875A7B;">Odoo</a>
+      </td></tr>
+    </table>
+</td></tr>
+</table>
+            </field>
+            <field name="lang">{{ object.lang }}</field>
+            <field name="auto_delete" eval="True"/>
+        </record>
+
+        <!-- Email template for new activated account notification
+            To notify the company about new account activation-->
+        <record id="account_activated_notification_email" model="mail.template">
+            <field name="name">Auth Signup: New Account Activated Notification</field>
+            <field name="model_id" ref="base.model_res_users"/>
+            <field name="subject">New Account Activated</field>
+            <field name="email_from">"{{ object.company_id.name }}" &lt;{{ (object.company_id.email or user.email) }}&gt;</field>
+            <field name="email_to"></field>
+            <field name="body_html" type="html">
+<table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #FFFFFF; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
+<table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: #FFFFFF; color: #454748; border-collapse:separate;">
+<tbody>
+    <!-- HEADER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
+                <tr><td valign="middle">
+                    <span style="font-size: 10px;">A New Account</span><br/>
+                    <span style="font-size: 20px; font-weight: bold;">
+                        <t t-out="object.name or ''">Marc Demo</t>
+                    </span>
+                </td><td valign="middle" align="right">
+                    <img t-attf-src="/logo.png?company={{ object.company_id.id }}" style="padding: 0px; margin: 0px; height: auto; width: 80px;" t-att-alt="object.company_id.name"/>
+                </td></tr>
+                <tr><td colspan="2" style="text-align:center;">
+                  <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- CONTENT -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;">
+                <tr><td valign="top" style="font-size: 13px;">
+                    <div>
+                        Dear <t t-out="object.name or ''">Marc Demo</t>,<br/><br/>
+                        An account has been activated with this email
+                        <span style="font-size: 20px; font-weight: bold;">
+                            <t t-out="object.email_formatted or ''">example@odoo.com</t>
+                        </span>
+                        <t t-if="user.signature">
+                            <br/>
+                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                        </t>
+                    </div>
+                </td></tr>
+                <tr><td style="text-align:center;">
+                  <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- FOOTER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; font-size: 11px; padding: 0px 8px 0px 8px; border-collapse:separate;">
+                <tr><td valign="middle" align="left">
+                    <t t-out="object.company_id.name or ''">YourCompany</t>
+                </td></tr>
+                <tr><td valign="middle" align="left" style="opacity: 0.7;">
+                    <t t-out="object.company_id.phone or ''">+1 650-123-4567</t>
+
+                    <t t-if="object.company_id.email">
+                        | <a t-att-href="'mailto:%s' % object.company_id.email" style="text-decoration:none; color: #454748;" t-out="object.company_id.email or ''">info@yourcompany.com</a>
+                    </t>
+                    <t t-if="object.company_id.website">
+                        | <a t-att-href="'%s' % object.company_id.website" style="text-decoration:none; color: #454748;" t-out="object.company_id.website or ''">http://www.example.com</a>
+                    </t>
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+</tbody>
+</table>
+</td></tr>
+<!-- POWERED BY -->
+<tr><td align="center" style="min-width: 590px;">
+    <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;">
+      <tr><td style="text-align: center; font-size: 13px;">
+        Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=auth" style="color: #875A7B;">Odoo</a>
+      </td></tr>
+    </table>
+</td></tr>
+</table>
+            </field>
+            <field name="lang">{{ object.lang }}</field>
+            <field name="auto_delete" eval="True"/>
+        </record>
+
     </data>
 </odoo>

--- a/addons/auth_signup/models/res_config_settings.py
+++ b/addons/auth_signup/models/res_config_settings.py
@@ -14,6 +14,7 @@ class ResConfigSettings(models.TransientModel):
         selection=[
             ('b2b', 'On invitation'),
             ('b2c', 'Free sign up'),
+            ('b2c_email_activate', 'Free sign up with email activation'),
         ],
         string='Customer Account',
         default='b2c',

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -136,13 +136,19 @@ class ResPartner(models.Model):
         return True
 
     @api.model
-    def _signup_retrieve_partner(self, token, check_validity=False, raise_exception=False):
+    def _signup_retrieve_partner(self, token, check_validity=False, raise_exception=False, include_inactive=False):
         """ find the partner corresponding to a token, and possibly check its validity
             :param token: the token to resolve
             :param check_validity: if True, also check validity
             :param raise_exception: if True, raise exception instead of returning False
+            :param include_inactive: if True, the request is to activate a user who has just signed up and his account
+            has not been activated yet
             :return: partner (browse record) or False (if raise_exception is False)
         """
+        #
+        if include_inactive:
+            self = self.with_context(active_test=False)
+
         partner = self.search([('signup_token', '=', token)], limit=1)
         if not partner:
             if raise_exception:
@@ -155,7 +161,7 @@ class ResPartner(models.Model):
         return partner
 
     @api.model
-    def signup_retrieve_info(self, token):
+    def signup_retrieve_info(self, token, include_inactive=False):
         """ retrieve the user info about the token
             :return: a dictionary with the user information:
                 - 'db': the name of the database
@@ -164,7 +170,7 @@ class ResPartner(models.Model):
                 - 'login': the user login, if the user already exists
                 - 'email': the partner email, if the user does not exist
         """
-        partner = self._signup_retrieve_partner(token, raise_exception=True)
+        partner = self._signup_retrieve_partner(token, raise_exception=True, include_inactive=include_inactive)
         res = {'db': self.env.cr.dbname}
         if partner.signup_valid:
             res['token'] = token

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -145,7 +145,9 @@ class ResUsers(models.Model):
         # create a copy of the template user (attached to a specific partner_id if given)
         # if b2c_email_activate_enabled, make the user inactive
         b2c_email_activate_enabled = self._get_signup_invitation_scope() == 'b2c_email_activate'
-        values['active'] = not b2c_email_activate_enabled
+        # In case the user is signing up using token, values['active'] would be set to True in the above signup method
+        # So the user will always be active when there is a token
+        values['active'] = values.get('active', None) or not b2c_email_activate_enabled
         try:
             with self.env.cr.savepoint():
                 return template_user.with_context(no_reset_password=True).copy(values)

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -56,6 +56,7 @@ class ResUsers(models.Model):
     def signup(self, values, token=None):
         """ signup a user, to either:
             - create a new user (no token), or
+            - Create a new user (no token and qcontext['b2c_email_activate'] is True), with active=False
             - create a user for a partner (with token, but no user for partner), or
             - change the password of a user (with token, and existing user).
             :param values: a dictionary with field values that are written on user
@@ -64,6 +65,8 @@ class ResUsers(models.Model):
         """
         if token:
             # signup with a token: find the corresponding partner id
+            # or activate a user by setting active=True
+            values['active'] = True
             partner = self.env['res.partner']._signup_retrieve_partner(token, check_validity=True, raise_exception=True)
             # invalidate signup token
             partner.write({'signup_token': False, 'signup_type': False, 'signup_expiration': False})
@@ -114,7 +117,7 @@ class ResUsers(models.Model):
 
         # check that uninvited users may sign up
         if 'partner_id' not in values:
-            if self._get_signup_invitation_scope() != 'b2c':
+            if not (self._get_signup_invitation_scope() in ('b2c', 'b2c_email_activate')):
                 raise SignupError(_('Signup is not allowed for uninvited users'))
         return self._create_user_from_template(values)
 
@@ -140,7 +143,9 @@ class ResUsers(models.Model):
             raise ValueError(_('Signup: no name or partner given for new user'))
 
         # create a copy of the template user (attached to a specific partner_id if given)
-        values['active'] = True
+        # if b2c_email_activate_enabled, make the user inactive
+        b2c_email_activate_enabled = self._get_signup_invitation_scope() == 'b2c_email_activate'
+        values['active'] = not b2c_email_activate_enabled
         try:
             with self.env.cr.savepoint():
                 return template_user.with_context(no_reset_password=True).copy(values)

--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -103,4 +103,15 @@
 
             </t>
         </template>
+
+        <template id="auth_signup.activate_account" name="Activate Account">
+            <t t-call="web.login_layout">
+                <div t-if="message" class="oe_login_form clearfix">
+                    <p class="alert alert-success" t-if="message" role="status">
+                        <t t-esc="message"/>
+                    </p>
+                    <a href="/web/login" class="btn btn-link btn-sm float-start" role="button">Back to Login</a>
+                </div>
+            </t>
+        </template>
 </odoo>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -139,6 +139,7 @@ class Website(models.Model):
     auth_signup_uninvited = fields.Selection([
         ('b2b', 'On invitation'),
         ('b2c', 'Free sign up'),
+        ('b2c_email_activate', 'Free sign up with email activation'),
     ], string='Customer Account', default='b2b')
 
     @api.onchange('language_ids')

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -379,7 +379,7 @@
             <div id="cart_redirect_setting" position="after">
                 <div id="website_login_documents" position="move"/>
             </div>
-            <xpath expr="//div[@id='website_login_documents']/div[hasclass('o_setting_right_pane')]" position="replace">
+            <xpath expr="//div[@id='website_login_documents']/div[hasclass('o_setting_right_pane')]" position="after">
                 <div class="o_setting_right_pane">
                     <label for="account_on_checkout" string="Sign in/up at checkout"/>
                     <div class="text-muted">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1818,7 +1818,7 @@
                                         </h2>
                                     </div>
                                 </t>
-                                <t t-if="request.env['res.users']._get_signup_invitation_scope() == 'b2c' and request.website.is_public_user()">
+                                <t t-if="request.env['res.users']._get_signup_invitation_scope() in ('b2c', 'b2c_email_activate') and request.website.is_public_user()">
                                     <p class="alert alert-info mt-3" role="status">
                                         <a role="button" t-att-href='order.partner_id.signup_prepare() and order.partner_id.with_context(relative_url=True).signup_url' class='btn btn-primary'>Sign Up</a>
                                          to follow your order.

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -665,7 +665,7 @@ class WebsiteSlides(WebsiteProfile):
     @http.route(['/slides/channel/join'], type='json', auth='public', website=True)
     def slide_channel_join(self, channel_id):
         if request.website.is_public_user():
-            return {'error': 'public_user', 'error_signup_allowed': request.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'}
+            return {'error': 'public_user', 'error_signup_allowed': request.env['res.users'].sudo()._get_signup_invitation_scope() in ('b2c', 'b2c_email_activate')}
         success = request.env['slide.channel'].browse(channel_id).action_add_member()
         if not success:
             return {'error': 'join_done'}
@@ -774,7 +774,7 @@ class WebsiteSlides(WebsiteProfile):
 
         values['channel'] = slide.channel_id
         values = self._prepare_additional_channel_values(values, **kwargs)
-        values['signup_allowed'] = request.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'
+        values['signup_allowed'] = request.env['res.users'].sudo()._get_signup_invitation_scope() in ('b2c', 'b2c_email_activate')
 
         if kwargs.get('fullscreen') == '1':
             values.update(self._slide_channel_prepare_review_values(slide.channel_id))
@@ -875,7 +875,7 @@ class WebsiteSlides(WebsiteProfile):
     @http.route('/slides/slide/like', type='json', auth="public", website=True)
     def slide_like(self, slide_id, upvote):
         if request.website.is_public_user():
-            return {'error': 'public_user', 'error_signup_allowed': request.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'}
+            return {'error': 'public_user', 'error_signup_allowed': request.env['res.users'].sudo()._get_signup_invitation_scope() in ('b2c', 'b2c_email_activate')}
         # check slide access
         fetch_res = self._fetch_slide(slide_id)
         if fetch_res.get('error'):

--- a/doc/cla/individual/m-azzain.md
+++ b/doc/cla/individual/m-azzain.md
@@ -1,0 +1,9 @@
+Sudan, 2022-08-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Mohamed Azzain m.alzain248@gmail.com https://github.com/m-azzain


### PR DESCRIPTION
This feature is for people who want to activate the free signup and at the same time need to have some control over it.
It won't affect the signup with an invitation token. A user who signed up without an invitation token his account will be created inactive, and then he will activate it by clicking a link in his email, as most websites do.

To avoid many changes to the code, code-wise, this signup process will be integrated with the other signup methods (by invitation or free signup). There will be a new controller method for the activation process.
The main changes are:
- Add a third signup option(in the setting app) to the already existing ones(b2b, b2c). This one will be b2c_email_activate.
When a user selects the b2c_email_activate option, b2c will still be enabled and the workflow will continue as if it's b2c, and b2c_email_activate will only be checked to set the active field to false.
- Add a controller method for activation, it will be the target of the link that will be sent to the user email. It will set the user active field to True.
This method will also send a notification email to a specific user. This option is disabled by default, it can be enabled by setting a configuration parameter ("auth_signup.account_activated_notification_receiver") to an email that will be notified.
- Add two email templates, one to send the activation link, and the other for the notification.

Description of the issue/feature this PR addresses:

Current behavior before PR:
The current behavior of the free signup the user will be immediately signed up even if a fake email has been used. 

Desired behavior after PR is merged:
There will be a third option for signing up, constraining the signing up user to use a real email, in addition to optional email notification when the user activate his account.


It may also be reasonable to just change the configuration of the current b2c to activate an account only after email confirmation. But some users may already find the current setup of b2c more suitable, so we decided to add a new option.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
