### PR TITLE
[FIX] l10n_eg_edi_eta: avoid infinite loop by setting the blocking le…

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -348,7 +348,7 @@ class AccountEdiFormat(models.Model):
             return {
                 invoice: {
                     'error':  _("An error occured in created the ETA invoice, please retry signing"),
-                    'blocking_level': 'info'
+                    'blocking_level': 'error'
                 }
             }
         invoice_json = json.loads(invoice.l10n_eg_eta_json_doc_id.raw)['request']
@@ -356,7 +356,7 @@ class AccountEdiFormat(models.Model):
             return {
                 invoice: {
                     'error':  _("Please make sure the invoice is signed"),
-                    'blocking_level': 'info'
+                    'blocking_level': 'error'
                 }
             }
         return {invoice: self._l10n_eg_edi_post_invoice_web_service(invoice)}


### PR DESCRIPTION
…vel to error

If you have only blocking level warning/info and
the batch is bigger than 25, then it will generate
an infinite loop.  In order to avoid that, when an invoice
is still to be signed we put it in error, also because
a manual intervention of the user is required anyways.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
