### PR TITLE
[FIX] account: update invoice date when previous to tax lock date 

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -416,6 +416,7 @@ class AccountMove(models.Model):
             accounting_date = self._get_accounting_date(self.invoice_date, has_tax)
             if accounting_date != self.date:
                 self.date = accounting_date
+                self.invoice_date = accounting_date
                 self._onchange_currency()
             else:
                 self._onchange_recompute_dynamic_lines()


### PR DESCRIPTION
Steps to reproduce:
1-Set a tax lock date
2-Create an invoice prior to the lock date

Bug:
The invoice date (accounting date) changes,
but appears to not have changed in the list and form view

Fix:
updated the invoice date when accounting date is modified

opw-2930324