### PR TITLE
[FIX] requirements.txt: Fix compatibility of cryptography with pyopenssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
+cryptography==2.8
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5


### PR DESCRIPTION
The pinned pyopenssl==19.0.0 is not compatible with latest version of cryptography

pyopenssl==19.0.0 requires cryptography>=2.3

Currently, it is installing latest version cryptography-37.0.4 for a fresh environment

But using the l10n_mx_edi module it is raising the following error:

    INFO db odoo.modules.loading: Module l10n_mx_edi: loading demo
    INFO db odoo.modules.loading: loading l10n_mx_edi/demo/demo_cfdi.xml
    File "/usr/local/lib/python3.8/dist-packages/OpenSSL/__init__.py", line 8, in <module>
        from OpenSSL import crypto, SSL
    File "/usr/local/lib/python3.8/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
        class X509StoreFlags(object):
    File "/usr/local/lib/python3.8/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
        CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
    AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'

The debian:bullseye is using cryptography==3.3.2 same for docker image odoo:14.0
Based on apt package python3-cryptography

Even if ubuntu:20.04 and odoo-sh are using cryptography==2.8 both versions are compatible with pyopenssl==19.0.0

`pip install -U cryptography==37.0.4`

`psql test -c "UPDATE ir_module_module SET demo=True WHERE name='l10n_mx_edi'" && ~/instance/odoo/odoo-bin -d test -i l10n_mx_edi --stop-after-init --log-level=warn; pip3 freeze |grep -i "pyopenssl\|cryptography"`

Now, repeat the last command but using:
`pip install -U cryptography==2.8`

Result:
 - <img width="1280" alt="Screen Shot 2022-08-17 at 9 00 58" src="https://user-images.githubusercontent.com/6644187/185153699-1a1f209c-1d81-4855-8d53-10078978e28a.png">


The debian:bullseye is using cryptography==3.3.2 same for docker image odoo:14.0
Based on apt package python3-cryptography

But ubuntu:20.04 and odoo-sh are using cryptography==2.8

both versions are compatible with pyopenssl==19.0.0

Using the smallest one because of Odoo criteria
