### PR TITLE
[IMP] hr_timesheet: add delete wizard for employee

### DIFF
--- a/addons/hr_timesheet/__init__.py
+++ b/addons/hr_timesheet/__init__.py
@@ -4,6 +4,7 @@
 from . import controllers
 from . import models
 from . import report
+from . import wizard
 
 from odoo import api, fields, SUPERUSER_ID, _
 

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -39,6 +39,7 @@ up a management by affair.
         'views/project_sharing_views.xml',
         'views/rating_rating_views.xml',
         'views/project_update_views.xml',
+        'wizard/hr_employee_delete_wizard_views.xml',
     ],
     'demo': [
         'data/hr_timesheet_demo.xml',

--- a/addons/hr_timesheet/models/__init__.py
+++ b/addons/hr_timesheet/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import hr_employee
 from . import hr_timesheet
 from . import ir_http
 from . import ir_ui_menu

--- a/addons/hr_timesheet/models/hr_employee.py
+++ b/addons/hr_timesheet/models/hr_employee.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    def action_unlink_wizard(self):
+        wizard = self.env['hr.employee.delete.wizard'].create({
+            'employee_ids': self.ids,
+        })
+        if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver') and wizard.has_timesheet and not wizard.has_active_employee:
+            raise UserError(_('You cannot delete employees who have timesheets.'))
+
+        return {
+            'name': _('Confirmation'),
+            'view_mode': 'form',
+            'res_model': 'hr.employee.delete.wizard',
+            'views': [(self.env.ref('hr_timesheet.hr_employee_delete_wizard_form').id, 'form')],
+            'type': 'ir.actions.act_window',
+            'res_id': wizard.id,
+            'target': 'new',
+            'context': self.env.context,
+        }

--- a/addons/hr_timesheet/security/ir.model.access.csv
+++ b/addons/hr_timesheet/security/ir.model.access.csv
@@ -6,3 +6,4 @@ access_project_project,project.project.timesheet.user,model_project_project,hr_t
 access_project_task,project.task.timesheet.user,model_project_task,hr_timesheet.group_hr_timesheet_user,1,1,0,0
 access_timesheets_analysis_report_manager,timesheets.analysis.report,model_timesheets_analysis_report,hr_timesheet.group_timesheet_manager,1,1,1,1
 access_timesheets_analysis_report_user,timesheets.analysis.report,model_timesheets_analysis_report,hr_timesheet.group_hr_timesheet_user,1,0,1,0
+access_hr_employee_delete_wizard,hr.employee.delete.wizard,model_hr_employee_delete_wizard,hr.group_hr_user,1,1,1,0

--- a/addons/hr_timesheet/views/hr_views.xml
+++ b/addons/hr_timesheet/views/hr_views.xml
@@ -34,12 +34,26 @@
         <field name="inherit_id" ref="hr_hourly_cost.view_employee_form"/>
         <field name="priority" eval="40"/>
         <field name="arch" type="xml">
+            <xpath expr="/form" position="attributes">
+                <attribute name="delete">0</attribute>
+            </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" type="action" name="%(timesheet_action_from_employee)d" icon="fa-calendar" groups="hr_timesheet.group_hr_timesheet_user">
                     <div class="o_stat_info">
                         <span class="o_stat_text">Timesheets</span>
                     </div>
                 </button>
+            </xpath>
+        </field>
+    </record>
+
+     <record id="view_employee_tree_inherit_timesheet" model="ir.ui.view">
+        <field name="name">hr.employee.tree.timesheet</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="/tree" position="attributes">
+                <attribute name="delete">0</attribute>
             </xpath>
         </field>
     </record>
@@ -59,5 +73,14 @@
                 </xpath>
             </data>
         </field>
+    </record>
+
+    <record id="unlink_employee_action" model="ir.actions.server">
+        <field name="name">Delete</field>
+        <field name="model_id" ref="hr.model_hr_employee"/>
+        <field name="binding_model_id" ref="hr.model_hr_employee"/>
+        <field name="binding_view_types">form,list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_unlink_wizard()</field>
     </record>
 </odoo>

--- a/addons/hr_timesheet/wizard/__init__.py
+++ b/addons/hr_timesheet/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import hr_employee_delete_wizard

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+
+
+class HrEmployeDeleteWizard(models.TransientModel):
+    _name = 'hr.employee.delete.wizard'
+    _description = 'Employee Delete Wizard'
+
+    employee_ids = fields.Many2many('hr.employee', string='Employees', context={'active_test': False})
+    has_active_employee = fields.Boolean(string='Has Active Employee', compute='_compute_has_active_employee')
+    has_timesheet = fields.Boolean(string='Has Timesheet', compute='_compute_has_timesheet', compute_sudo=True)
+
+    @api.depends('employee_ids')
+    def _compute_has_timesheet(self):
+        timesheet_read_group = self.env['account.analytic.line']._read_group([
+            ('employee_id', 'in', self.employee_ids.ids)],
+            ['employee_id'], ['employee_id'],
+        )
+        timesheet_employee_map = set(employee_info['employee_id'][0] for employee_info in timesheet_read_group)
+        for wizard in self:
+            wizard.has_timesheet = timesheet_employee_map & set(wizard.employee_ids.ids)
+
+    @api.depends('employee_ids')
+    def _compute_has_active_employee(self):
+        unarchived_employees = self.env['hr.employee'].search([('id', '=', self.employee_ids.ids)])
+        for wizard in self:
+            wizard.has_active_employee = any(emp in wizard.employee_ids for emp in unarchived_employees)
+
+    def action_archive(self):
+        self.ensure_one()
+        if len(self.employee_ids) != 1:
+            return self.employee_ids.toggle_active()
+        return {
+            'name': _('Employee Termination'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.departure.wizard',
+            'views': [[False, 'form']],
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'active_id': self.employee_ids.id,
+                'toggle_active': True,
+            }
+        }
+
+    def action_confirm_delete(self):
+        self.ensure_one()
+        self.employee_ids.unlink()
+        return self.env['ir.actions.act_window']._for_xml_id('hr.open_view_employee_list_my')
+
+    def action_open_timesheets(self):
+        self.ensure_one()
+        employees = self.with_context(active_test=False).employee_ids
+        action = {
+           'name': _('Employees\' Timesheets'),
+           'type': 'ir.actions.act_window',
+           'res_model': 'account.analytic.line',
+           'view_mode': 'tree,form',
+           'views': [(False, 'tree'), (False, 'form')],
+           'domain': [('employee_id', 'in', employees.ids), ('project_id', '!=', False)],
+        }
+        if len(employees) == 1:
+            action['name'] = _('Timesheets of %(name)s', name=employees.name)
+        return action

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="hr_employee_delete_wizard_form" model="ir.ui.view">
+            <field name="name">Delete Employee</field>
+            <field name="model">hr.employee.delete.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Delete Employee">
+                    <field name="has_timesheet" invisible="1"/>
+                    <field name="has_active_employee" invisible="1"/>
+                    <span attrs="{'invisible': [('has_timesheet', '=', False)]}">
+                        You cannot delete employees who have timesheets.
+                        <span attrs="{'invisible': [('has_active_employee', '=', False)]}">
+                            You can either archive these employees or first delete all of their timesheets.
+                        </span>
+                        <span attrs="{'invisible': [('has_active_employee', '=', True)]}" groups="hr_timesheet.group_hr_timesheet_approver">
+                            Please first delete all of their timesheets.
+                        </span>
+                    </span>
+                    <span attrs="{'invisible': [('has_timesheet', '=', True)]}">
+                        Are you sure you want to delete these employees ?
+                    </span>
+                    <footer attrs="{'invisible': [('has_timesheet', '=', False)]}">
+                        <button string="Archive Employees" type="object" name="action_archive" class="btn btn-primary"
+                            attrs="{'invisible': [('has_active_employee', '=', False)]}" data-hotkey="q"/>
+                        <button string="See Timesheets" type="object" name="action_open_timesheets" class="btn btn-primary" groups="hr_timesheet.group_hr_timesheet_approver"
+                            attrs="{'invisible': [('has_active_employee', '=', True)]}" data-hotkey="x"/>
+                        <button string="See Timesheets" type="object" name="action_open_timesheets" class="btn btn-secondary" groups="hr_timesheet.group_hr_timesheet_approver"
+                            attrs="{'invisible': [('has_active_employee', '=', False)]}" data-hotkey="x"/>
+                        <button string="Discard" special="cancel" data-hotkey="z"/>
+                    </footer>
+                    <footer attrs="{'invisible': [('has_timesheet', '=', True)]}">
+                        <button string="Ok" type="object" name="action_confirm_delete" class="btn btn-primary" data-hotkey="q"/>
+                        <button string="Cancel" special="cancel" data-hotkey="z"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Before this PR user can directly delete employees even though
employees have timesheets that make employee field in timesheet
black which is not right behavior because in timesheet employee
field is required.

This PR adds a delete wizard for employee delete action
if employees have any timesheet then user cannot delete that
employees without deleting timesheets instead user can archive
that employees.

task-2938632
