### PR TITLE
[FIX] web: fix kanban record content not taking entire width

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -53,6 +53,7 @@
         margin: 0 0 -1px;
 
         > div {
+            width: 100%;
             height: 100%;
         }
 
@@ -627,9 +628,6 @@
                 margin-bottom: 0;
                 padding: 0;
             }
-        }
-        .oe_kanban_vignette {
-            flex: 1 1 auto;
         }
     }
 


### PR DESCRIPTION
As we recently changed the structure of the DOM to wrap the content of
kanban card inside of kanban record instead of using the same div, some
of the rules were not properly applied. In fixing a previous bug, the
content was no longer taking up the entire width of the card. This
commit fixes that.
