### PR TITLE
[FIX] account: recursive computation with out-of-order bank statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -125,7 +125,11 @@ class AccountBankStatement(models.Model):
     # won't be called and therefore the other field will have a value of 0 and we don't want that.
     @api.depends('previous_statement_id', 'previous_statement_id.balance_end_real')
     def _compute_starting_balance(self):
-        for statement in self:
+        # When a bank statement is inserted out-of-order several fields needs to be recomputed.
+        # As the records to recompute are ordered by id, it may occur that the first record
+        # to recompute start a recursive recomputation of field balance_end_real
+        # To avoid this we sort the records by date
+        for statement in self.sorted(key=lambda s: s.date):
             if statement.previous_statement_id.balance_end_real != statement.balance_start:
                 statement.balance_start = statement.previous_statement_id.balance_end_real
             else:


### PR DESCRIPTION
Have a sequence of bank statement out of order
i.e.
|id|  date  |
|--|--------|
|01|20/07/22|
|02|21/07/22|
|03|22/07/22|
|04|18/07/22|
|05|17/07/22|
|06|16/07/22|
|07|15/07/22|

Adding more out-of-order bank statement will trigger recomputation in
all the next (chronologically) statements.
As the records to recompute are ordered by id, it may occur that the
first statements to recompute have the highest date and cause a
recomputation recursion exceeding the limits

opw-2925984

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
