### PR TITLE
[IMP] web_editor: improve replacing a snippet image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6227,7 +6227,9 @@ registry.ImageTools = ImageHandlerOption.extend({
     async _onImageChanged(ev) {
         this.trigger_up('snippet_edition_request', {exec: async () => {
             await this._autoOptimizeImage();
-            this.trigger_up('cover_update');
+            this.trigger_up('cover_update', {
+                overlayVisible: true,
+            });
         }});
     },
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1352,19 +1352,29 @@ const Wysiwyg = Widget.extend({
         }
 
         if (params.node) {
-            params.node.replaceWith(element);
+            const changedImage = params.node.tagName === element.tagName && element.tagName === 'IMG';
+            if (changedImage) {
+                // Instead of replacing an image with another one and
+                // recreating its snippet editor, its attributes are
+                // changed, and the snippet editor is kept.
+                for (const attribute of params.node.attributes) {
+                    params.node.removeAttribute(attribute.nodeName);
+                }
+                for (const attribute of element.attributes) {
+                    params.node.setAttribute(attribute.nodeName, attribute.nodeValue);
+                }
+                $(params.node).trigger('image_changed');
+            } else {
+                params.node.replaceWith(element);
+            }
             this.odooEditor.unbreakableStepUnactive();
             this.odooEditor.historyStep();
         } else {
-            return this.odooEditor.execCommand('insert', element);
+            this.odooEditor.execCommand('insert', element);
         }
 
         if (this.snippetsMenu) {
-            this.snippetsMenu.activateSnippet($(element)).then(() => {
-                if (element.tagName === 'IMG') {
-                    $(element).trigger('image_changed');
-                }
-            });
+            this.snippetsMenu.activateSnippet($(element));
         }
     },
     getInSelection(selector) {


### PR DESCRIPTION
Before this commit, when replacing an image from the media dialog, its
snippet editor was fully replaced with a newly computed one.

It is not needed, the options are still valid if an 'image_changed'
event is triggered. Instead, the image old attributes (src,
data-original-src, ...) can be replaced with the ones from the new
element coming from the media dialog, and the snippet editor is
preserved. This allows for a faster image replacement.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
