### PR TITLE
[FIX] *: set correct type on html field in xml created records

### DIFF
--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -261,7 +261,7 @@
         <field name="name">Categories</field>
         <field name="res_model">fleet.vehicle.model.category</field>
         <field name="view_mode">tree</field>
-        <field name="help" type="xml">
+        <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new category
             </p>

--- a/addons/hr_recruitment/data/hr_recruitment_demo.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_demo.xml
@@ -338,7 +338,7 @@
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_advertisement"/>
         <field name="date" eval="DateTime.now() - relativedelta(days=3)"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello!<br />
             I will surely refer to this application as it is by your reference and <br />
             will try to conduct an interview within a very short time<br />
@@ -355,7 +355,7 @@
         <field name="subject">Refuse Application</field>
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_salesman0"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello,</p>
             <p>I have checked this application but it does not match with our requirements. We don't need to proceed further and we should refuse this application.</p>
             <p>Kind regards,</p>
@@ -368,7 +368,7 @@
         <field name="subject">Refuse Application</field>
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_dev0"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello,</p>
             <p>This applicant has excellent skills and would greatly fit in the RD Team!</p>
             <p>Kind regards,</p>
@@ -380,7 +380,7 @@
     <record id="msg_case_fresher0_aplicant" model="mail.message">
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_fresher0"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello,</p>
             <p>We should move further for this application as early as possible.</p>
             <p>Kind regards,</p>
@@ -392,7 +392,7 @@
     <record id="msg_case_advertisement_aplicant" model="mail.message">
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_advertisement"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello,</p>
             <p>The first interview was good. Skilled and open minded applicant.</p>
             <p>I think we should consider hiring him.</p>
@@ -405,7 +405,7 @@
     <record id="msg_case_mkt1_1" model="mail.message">
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_mkt1"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello,</p>
             <p>The first interview was good. I will propose a second interview</p>
             <p>Kind regards,</p>
@@ -417,7 +417,7 @@
     <record id="msg_case_mkt1_2" model="mail.message">
         <field name="model">hr.applicant</field>
         <field name="res_id" ref="hr_case_mkt1"/>
-        <field name="body" type="xml">
+        <field name="body" type="html">
             <p>Hello,</p>
             <p>After the second interview, I think we should consider hiring him.</p>
             <p>Kind regards,</p>

--- a/addons/sale_quotation_builder/data/sale_order_template_data.xml
+++ b/addons/sale_quotation_builder/data/sale_order_template_data.xml
@@ -6,7 +6,7 @@
             <field name="name">Default Template</field>
             <field name="number_of_days">30</field>
 
-            <field name="website_description" type="xml">
+            <field name="website_description" type="html">
                 <section data-snippet-id="title" class="mt32">
                     <h2 class="o_page_header">About us</h2>
                 </section>

--- a/addons/website_customer/data/res_partner_demo.xml
+++ b/addons/website_customer/data/res_partner_demo.xml
@@ -5,7 +5,7 @@
         <record id="base.res_partner_2" model="res.partner">
             <field name="is_published" eval="True"/>
             <field name="website_short_description">Deco Addict designs, develops, integrates and supports HR and Supply Chain processes in order to make our customers more productive, responsive and profitable.</field>
-            <field name="website_description" type="xml">
+            <field name="website_description" type="html">
                 <p>
                 Deco Addict designs, develops, integrates and supports HR and Supply
                 Chain processes in order to make our customers more productive,
@@ -35,7 +35,7 @@
         <record id="base.res_partner_3" model="res.partner">
             <field name="is_published" eval="True"/>
             <field name="website_short_description">A non-profit international educational and scientific organisation, hosting three departments (aeronautics and aerospace, environmental and applied fluid dynamics, and turbomachinery and propulsion).</field>
-            <field name="website_description" type="xml">
+            <field name="website_description" type="html">
                 <p>
                     A non-profit international educational and scientific
                     organisation, hosting three departments (aeronautics and
@@ -63,7 +63,7 @@
         <record id="base.res_partner_4" model="res.partner">
             <field name="is_published" eval="True"/>
             <field name="website_short_description">Deco Addict designs, develops, integrates and supports HR and Supply Chain processes in order to make our customers more productive, responsive and profitable.</field>
-            <field name="website_description" type="xml">
+            <field name="website_description" type="html">
                 <p>
                 Deco Addict designs, develops, integrates and supports HR and Supply
                 Chain processes in order to make our customers more productive,
@@ -93,7 +93,7 @@
         <record id="base.res_partner_3" model="res.partner">
             <field name="is_published" eval="True"/>
             <field name="website_short_description">A non-profit international educational and scientific organisation, hosting three departments (aeronautics and aerospace, environmental and applied fluid dynamics, and turbomachinery and propulsion).</field>
-            <field name="website_description" type="xml">
+            <field name="website_description" type="html">
                 <p>
                     A non-profit international educational and scientific
                     organisation, hosting three departments (aeronautics and

--- a/addons/website_event/data/res_partner_demo.xml
+++ b/addons/website_event/data/res_partner_demo.xml
@@ -214,7 +214,7 @@
     <record id="base.res_partner_address_15" model="res.partner">
         <field name="is_published" eval="True"/>
         <field name="website">http://azure.example.com</field>
-        <field name="website_description" type="xml">
+        <field name="website_description" type="html">
             <p>
                 Brandon works in IT sector <b>since 10 years</b>. He is known
                 notably for selling mouse traps. With that trick he cut
@@ -225,7 +225,7 @@
     <record id="base.res_partner_address_16" model="res.partner">
         <field name="is_published" eval="True"/>
         <field name="website">http://azure.example.com</field>
-        <field name="website_description" type="xml">
+        <field name="website_description" type="html">
             <p>
                 Nicole works in IT sector <b>since 20 years</b>. She
                 develops software to help develop websites.  She sold her
@@ -241,7 +241,7 @@
     <record id="base.res_partner_address_28" model="res.partner">
         <field name="is_published" eval="True"/>
         <field name="website">http://azure.example.com</field>
-        <field name="website_description" type="xml">
+        <field name="website_description" type="html">
             <p>
                 Colleen Diaz works in IT sector <b>since 10 years</b>. He is known
                 notably for selling mouse traps. With that trick he cut
@@ -254,7 +254,7 @@
     <record id="base.res_partner_address_17" model="res.partner">
         <field name="is_published" eval="True"/>
         <field name="website">http://jackson.group.example.com</field>
-        <field name="website_description" type="xml">
+        <field name="website_description" type="html">
             <p>
                 Toni Rhodes works in IT sector <b>since 10 years</b>. He is known
                 notably for selling mouse traps. With that trick he cut
@@ -266,7 +266,7 @@
     <record id="base.res_partner_address_18" model="res.partner">
         <field name="is_published" eval="True"/>
         <field name="website">http://jackson.group.example.com</field>
-        <field name="website_description" type="xml">
+        <field name="website_description" type="html">
             <p>
                 Gordon Owens works in IT sector <b>since 10 years</b>. He is known
                 notably for selling mouse traps. With that trick he cut

--- a/addons/website_sale_picking/data/website_sale_picking_data.xml
+++ b/addons/website_sale_picking/data/website_sale_picking_data.xml
@@ -12,7 +12,7 @@
         <field name="state">enabled</field>
         <field name="is_onsite_acquirer">true</field>
         <field name="redirect_form_view_id" ref="payment_transfer.redirect_form"/>
-        <field name="pending_msg" type="xml">
+        <field name="pending_msg" type="html">
             <p>
                 <i>Your order has been saved.</i> Please come to the store to pay for your products
             </p>

--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -33,7 +33,7 @@
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="login">demo</field>
             <field name="password">demo</field>
-            <field name="signature" type="xml"><span>-- <br/>+Mr Demo</span></field>
+            <field name="signature" type="html"><span>-- <br/>+Mr Demo</span></field>
             <field name="company_id" ref="main_company"/>
             <field name="groups_id" eval="[Command.set([ref('base.group_user'), ref('base.group_partner_manager'), ref('base.group_allow_export')])]"/>
             <field name="image_1920" type="base64" file="base/static/img/user_demo-image.jpg"/>
@@ -59,7 +59,7 @@
         </record>
 
         <record id="base.user_admin" model="res.users">
-            <field name="signature" type="xml"><span>-- <br/>Mitchell Admin</span></field>
+            <field name="signature" type="html"><span>-- <br/>Mitchell Admin</span></field>
         </record>
 
         <!-- Portal : partner and user -->

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -585,6 +585,9 @@ form: module.record_id""" % (xml_id,)
                             # We do not want to write on the field since we will write
                             # on the childrens' parents later
                             continue
+                    elif field_type == 'html':
+                        if field.get('type') == 'xml':
+                            _logger.warning('HTML field %r is declared as `type="xml"`', f_name)
             res[f_name] = f_val
         if extra_vals:
             res.update(extra_vals)


### PR DESCRIPTION
When a record is created through xml data, its HTML fields should
receive a `type="html"` attribute, not a `type="xml"` attribute.

When important XML data with XML type instead of HTML type will have 2
differences:
- The field value will be prefixed by `<?xml version="1.0"/>`
- If the HTML contains multiple root nodes, the value will be wrapped in
  a `<data/>` tag.

See `_fix_multiple_roots()` and the `xml_import` class for more details.
