### PR TITLE
[FIX] web: form label with empty string

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -79,8 +79,8 @@ export class FormCompiler extends ViewCompiler {
             fieldInfo: `props.archInfo.fieldNodes['${fieldId}']`,
             className: `"${label.className}"`,
         };
-        let labelText = label.textContent || fieldString;
-        labelText = labelText
+        let labelText = label.textContent != null ? label.textContent : fieldString;
+        labelText = labelText != null
             ? toStringExpression(labelText)
             : `props.record.fields['${fieldName}'].string`;
         const formLabel = createElement("FormLabel", {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -1640,6 +1640,29 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(target.querySelector("label.o_form_label").textContent, "customstring");
     });
 
+    QUnit.only("label uses an empty string attribute", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <label for="bar" string=""/>
+                            <div>
+                                <field name="bar"/>
+                            </div>
+                        </group>
+                    </sheet>
+                </form>`,
+            resId: 2,
+        });
+
+        assert.containsOnce(target, "label.o_form_label");
+        assert.strictEqual(target.querySelector("label.o_form_label").textContent, "");
+    });
+
     QUnit.test(
         "label is not rendered when invisible and not at top-level in a group",
         async function (assert) {


### PR DESCRIPTION
Steps to reproduce:

  - Go to product variants > water
  - The product tooltip label should be hidden