### PR TITLE
[FIX] web: Fix binary field

### DIFF
--- a/addons/web/static/src/views/fields/binary/binary_field.js
+++ b/addons/web/static/src/views/fields/binary/binary_field.js
@@ -17,35 +17,25 @@ export class BinaryField extends Component {
     setup() {
         this.notification = useService("notification");
         this.state = useState({
-            fileName: this.fileName || "",
-            isValid: true,
+            fileName: this.props.record.data[this.props.fileNameField] || "",
         });
         onWillUpdateProps((nextProps) => {
             if (nextProps.readonly) {
-                this.state.fileName = "";
+                this.state.fileName = nextProps.record.data[nextProps.fileNameField] || "";
             }
         });
     }
 
     get fileName() {
-        return this.props.record.data[this.props.fileNameField];
-    }
-    get file() {
-        return {
-            data: this.props.value,
-            name: this.state.fileName || this.props.value || null,
-        };
-    }
-    get isDownloadable() {
-        return !(
-            this.props.record.isReadonly(this.props.name) && this.props.record.mode === "edit"
-        );
+        return this.state.fileName || this.props.value || "";
     }
 
-    update(file) {
-        const changes = { [this.props.name]: file.data || false };
-        if (this.props.fileNameField && this.props.fileNameField !== this.props.name) {
-            changes[this.props.fileNameField] = file.name || false;
+    update({ data, name }) {
+        this.state.fileName = name || "";
+        const { fileNameField, record } = this.props;
+        const changes = { [this.props.name]: data || false };
+        if (fileNameField in record.fields && record.data[fileNameField] !== name) {
+            changes[fileNameField] = name || false;
         }
         return this.props.record.update(changes);
     }
@@ -56,27 +46,12 @@ export class BinaryField extends Component {
                 model: this.props.record.resModel,
                 id: this.props.record.resId,
                 field: this.props.name,
-                filename_field: this.file.name,
-                filename: this.file.name || "",
+                filename_field: this.fileName,
+                filename: this.fileName || "",
                 download: true,
                 data: isBinarySize(this.props.value) ? null : this.props.value,
             },
             url: "/web/content",
-        });
-    }
-    onFileRemove() {
-        this.state.isValid = true;
-        this.update(false);
-    }
-    onFileUploaded(file) {
-        this.state.fileName = file.name;
-        this.state.isValid = true;
-        this.update(file);
-    }
-    onLoadFailed() {
-        this.state.isValid = false;
-        this.notification.add(this.env._t("Could not display the selected binary"), {
-            type: "danger",
         });
     }
 }

--- a/addons/web/static/src/views/fields/binary/binary_field.xml
+++ b/addons/web/static/src/views/fields/binary/binary_field.xml
@@ -3,45 +3,47 @@
 
     <t t-name="web.BinaryField" owl="1">
         <t t-if="!props.readonly">
-            <t t-if="file.data">
-                <FileUploader
-                    acceptedFileExtensions="props.acceptedFileExtensions"
-                    file="file"
-                    onUploaded.bind="onFileUploaded"
-                >
-                    <t t-set-slot="toggler">
-                        <span class="mx-2" t-esc="file.name"/>
+            <t t-if="props.value">
+                <div class="w-100 d-inline-flex">
+                    <FileUploader
+                        acceptedFileExtensions="props.acceptedFileExtensions"
+                        file="{ data: props.value, name: fileName }"
+                        onUploaded.bind="update"
+                    >
+                        <t t-set-slot="toggler">
+                            <input type="text" class="o_input" t-att-value="fileName" readonly="readonly" />
+                            <button
+                                class="btn btn-secondary fa fa-pencil o_select_file_button"
+                                data-tooltip="Edit"
+                                aria-label="Edit"
+                            />
+                        </t>
                         <button
-                            class="btn btn-secondary fa fa-pencil o_select_file_button"
-                            data-tooltip="Edit"
-                            aria-label="Edit"
+                            class="btn btn-secondary fa fa-trash o_clear_file_button"
+                            data-tooltip="Clear"
+                            aria-label="Clear"
+                            t-on-click="() => this.update({})"
                         />
-                    </t>
-                    <button
-                        class="btn btn-secondary fa fa-trash o_clear_file_button"
-                        data-tooltip="Clear"
-                        aria-label="Clear"
-                        t-on-click="onFileRemove"
-                    />
-                </FileUploader>
+                    </FileUploader>
+                </div>
             </t>
             <t t-else="">
                 <label class="o_select_file_button btn btn-primary">
                     <FileUploader
                         acceptedFileExtensions="props.acceptedFileExtensions"
-                        onUploaded.bind="onFileUploaded"
+                        onUploaded.bind="update"
                     >
                         <t t-set-slot="toggler">
-                            <span t-esc="'Upload your file'"/>
+                            Upload your file
                         </t>
                     </FileUploader>
                 </label>
             </t>
         </t>
-        <t t-elif="file.data and isDownloadable">
-            <span t-esc="file.name"/>
-            <a class="o_form_uri mx-2" href="javascript:void(0)" t-on-click.prevent="onFileDownload">
-                <span class="fa fa-download"/>
+        <t t-elif="props.record.resId and props.value">
+            <a class="o_form_uri" href="#" t-on-click.prevent="onFileDownload">
+                <span class="fa fa-download me-2" />
+                <t t-if="state.fileName" t-esc="state.fileName" />
             </a>
         </t>
     </t>

--- a/addons/web/static/src/views/fields/file_handler.js
+++ b/addons/web/static/src/views/fields/file_handler.js
@@ -47,7 +47,9 @@ export class FileUploader extends Component {
      * @param {Event} ev
      */
     async onFileChange(ev) {
-        if (!ev.target.files.length) return;
+        if (!ev.target.files.length) {
+            return;
+        }
         for (const file of ev.target.files) {
             if (file.size > this.maxUploadSize) {
                 this.notification.add(
@@ -90,5 +92,6 @@ export class FileUploader extends Component {
         this.fileInputRef.el.click();
     }
 }
+
 FileUploader.template = "web.FileUploader";
 FileUploader.nextId = 0;

--- a/addons/web/static/src/views/fields/file_handler.xml
+++ b/addons/web/static/src/views/fields/file_handler.xml
@@ -2,20 +2,18 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FileUploader" owl="1">
-        <span>
-            <span t-if="state.isUploading" class="btn btn-primary" t-esc="'Uploading...'"/>
-            <span t-else="" t-on-click.prevent="onSelectFileButtonClick">
-                <t t-slot="toggler"/>
-            </span>
-            <t t-slot="default"/>
-            <input
-                type="file"
-                t-ref="fileInput"
-                t-attf-class="o_input_file o_hidden {{ props.fileUploadClass or '' }}"
-                t-att-multiple="props.multiUpload ? 'multiple' : false" t-att-accept="props.acceptedFileExtensions or '*'"
-                t-on-change="onFileChange"
-            />
+        <t t-if="state.isUploading">Uploading...</t>
+        <span t-else="" t-on-click.prevent="onSelectFileButtonClick" style="display:contents">
+            <t t-slot="toggler"/>
         </span>
+        <t t-slot="default"/>
+        <input
+            type="file"
+            t-ref="fileInput"
+            t-attf-class="o_input_file o_hidden {{ props.fileUploadClass or '' }}"
+            t-att-multiple="props.multiUpload ? 'multiple' : false" t-att-accept="props.acceptedFileExtensions or '*'"
+            t-on-change="onFileChange"
+        />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.js
+++ b/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.js
@@ -13,56 +13,60 @@ export class PdfViewerField extends Component {
     setup() {
         this.notification = useService("notification");
         this.state = useState({
-            fileName: this.fileName || "",
+            fileName: this.props.record.data[this.props.fileNameField] || "",
             isValid: true,
             objectUrl: "",
         });
         onWillUpdateProps((nextProps) => {
             if (nextProps.readonly) {
-                this.state.fileName = "";
+                this.state.fileName = nextProps.record.data[nextProps.fileNameField] || "";
                 this.state.objectUrl = "";
             }
         });
     }
-    get defaultPage() {
-        return this.props.record.data[`${this.props.name}_page`];
-    }
+
     get fileName() {
-        return this.props.record.data[this.props.fileNameField];
+        return this.state.fileName || this.props.value || "";
     }
-    get file() {
-        return {
-            data: this.props.value || "",
-            name: this.state.fileName || this.props.value || null,
-        };
-    }
+
     get url() {
-        if (this.state.isValid && this.props.value) {
-            return (
-                "/web/static/lib/pdfjs/web/viewer.html?file=" +
-                encodeURIComponent(
-                    this.state.objectUrl ||
-                        url("/web/content", {
-                            model: this.props.record.resModel,
-                            id: this.props.record.resId,
-                            field: this.props.previewImage || this.props.name,
-                        })
-                ) +
-                `#page=${this.props.defaultPage || 1}`
-            );
+        if (!this.state.isValid || !this.props.value) {
+            return null;
         }
-        return null;
+        const page = this.props.record.data[`${this.props.name}_page`] || 1;
+        const file = encodeURIComponent(
+            this.state.objectUrl ||
+                url("/web/content", {
+                    model: this.props.record.resModel,
+                    field: this.props.previewImage || this.props.name,
+                    id: this.props.record.resId,
+                })
+        );
+        return `/web/static/lib/pdfjs/web/viewer.html?file=${file}#page=${page}`;
     }
+
+    update({ data, name }) {
+        this.state.fileName = name || "";
+        const { fileNameField, record } = this.props;
+        const changes = { [this.props.name]: data || false };
+        if (fileNameField in record.fields && record.data[fileNameField] !== name) {
+            changes[fileNameField] = name || false;
+        }
+        return this.props.record.update(changes);
+    }
+
     onFileRemove() {
         this.state.isValid = true;
-        this.props.update(false);
+        this.update({});
     }
-    onFileUploaded(file) {
-        this.state.fileName = file.name;
+
+    onFileUploaded({ data, name, objectUrl }) {
+        this.state.fileName = name;
         this.state.isValid = true;
-        this.props.update(file.data);
-        this.state.objectUrl = file.objectUrl;
+        this.state.objectUrl = objectUrl;
+        this.update({ data, name });
     }
+
     onLoadFailed() {
         this.state.isValid = false;
         this.notification.add(this.env._t("Could not display the selected pdf"), {

--- a/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.xml
+++ b/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.xml
@@ -3,42 +3,43 @@
 
     <t t-name="web.PdfViewerField" owl="1">
         <t t-if="!props.readonly">
-            <t t-if="file.data">
-                <FileUploader
-                    acceptedFileExtensions="'.pdf'"
-                    file="file"
-                    onUploaded.bind="onFileUploaded"
-                >
-                    <t t-set-slot="toggler">
-                        <span class="mx-2" t-esc="file.name"/>
-                        <button
-                            class="btn btn-secondary fa fa-pencil o_select_file_button"
-                            data-tooltip="Edit"
-                            aria-label="Edit"
-                        />
-                    </t>
-                    <button
-                        class="btn btn-secondary fa fa-trash o_clear_file_button"
-                        data-tooltip="Clear"
-                        aria-label="Clear"
-                        t-on-click="onFileRemove"
-                    />
-                </FileUploader>
-            </t>
-            <t t-else="">
-                <label class="o_select_file_button btn btn-primary">
+            <div  class="o_form_pdf_controls">
+                <t t-if="props.value">
                     <FileUploader
                         acceptedFileExtensions="'.pdf'"
+                        file="{ data: props.value, name: fileName }"
                         onUploaded.bind="onFileUploaded"
                     >
                         <t t-set-slot="toggler">
-                            <span t-esc="'Upload your file'"/>
+                            <button
+                                class="btn btn-secondary fa fa-pencil o_select_file_button"
+                                data-tooltip="Edit"
+                                aria-label="Edit"
+                            />
                         </t>
+                        <button
+                            class="btn btn-secondary fa fa-trash o_clear_file_button"
+                            data-tooltip="Clear"
+                            aria-label="Clear"
+                            t-on-click="onFileRemove"
+                        />
                     </FileUploader>
-                </label>
-            </t>
+                </t>
+                <t t-else="">
+                    <label class="o_select_file_button btn btn-primary">
+                        <FileUploader
+                            acceptedFileExtensions="'.pdf'"
+                            onUploaded.bind="onFileUploaded"
+                        >
+                            <t t-set-slot="toggler">
+                                Upload your file
+                            </t>
+                        </FileUploader>
+                    </label>
+                </t>
+            </div>
         </t>
-        <t t-if="file.data">
+        <t t-if="props.value">
             <iframe class="o_pdfview_iframe"
                 alt="PDF file"
                 t-att-src="url"

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -297,12 +297,12 @@ export function triggerEvent(el, selector, eventType, eventAttrs = {}, options =
     return event;
 }
 
-export async function triggerEvents(el, querySelector, events) {
+export async function triggerEvents(el, querySelector, events, options) {
     for (let e = 0; e < events.length; e++) {
         if (Array.isArray(events[e])) {
-            triggerEvent(el, querySelector, events[e][0], events[e][1]);
+            triggerEvent(el, querySelector, events[e][0], events[e][1], options);
         } else {
-            triggerEvent(el, querySelector, events[e]);
+            triggerEvent(el, querySelector, events[e], {}, options);
         }
     }
     await nextTick();
@@ -329,7 +329,9 @@ export async function triggerScroll(
     const isScrollable =
         (target.scrollHeight > target.clientHeight && target.clientHeight > 0) ||
         (target.scrollWidth > target.clientWidth && target.clientWidth > 0);
-    if (!isScrollable && !canPropagate) return;
+    if (!isScrollable && !canPropagate) {
+        return;
+    }
     if (isScrollable) {
         const canScrollFrom = {
             left:
@@ -351,7 +353,9 @@ export async function triggerScroll(
         target.scrollTo(scrollCoordinates);
         target.dispatchEvent(new UIEvent("scroll"));
         await nextTick();
-        if (!canPropagate || !Object.entries(coordinates).length) return;
+        if (!canPropagate || !Object.entries(coordinates).length) {
+            return;
+        }
     }
     target.parentElement
         ? triggerScroll(target.parentElement, coordinates)
@@ -429,15 +433,36 @@ export async function mouseEnter(el, selector, coordinates) {
 
 export async function editInput(el, selector, value) {
     const input = findElement(el, selector);
-    if (
-        !["INPUT", "TEXTAREA"].includes(input.tagName) ||
-        !["text", "textarea", "email", "number", "search", "color"].includes(input.type)
-    ) {
-        throw new Error("Only inputs tag and textarea tag can be edited with editInput.");
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) {
+        throw new Error("Only 'input' and 'textarea' elements can be edited with 'editInput'.");
     }
-    input.value = value;
-    await triggerEvent(input, null, "input");
-    return triggerEvent(input, null, "change");
+    if (!["text", "textarea", "email", "search", "color", "number", "file"].includes(input.type)) {
+        throw new Error(`Type "${input.type}" not supported by 'editInput'.`);
+    }
+
+    const eventOpts = {};
+    if (input.type === "file") {
+        const files = Array.isArray(value) ? value : [value];
+        const dataTransfer = new DataTransfer();
+        for (const file of files) {
+            if (!(file instanceof File)) {
+                throw new Error(`File input value should be one or several File objects.`);
+            }
+            dataTransfer.items.add(file);
+        }
+        input.files = dataTransfer.files;
+        eventOpts.skipVisibilityCheck = true;
+    } else {
+        input.value = value;
+    }
+
+    await triggerEvents(input, null, ["input", "change"], eventOpts);
+
+    if (input.type === "file") {
+        // Need to wait for the file to be loaded by the input
+        await nextTick();
+        await nextTick();
+    }
 }
 
 export function editSelect(el, selector, value) {


### PR DESCRIPTION
This PR aims to make the `BinaryField` and `PdfViewerField` appear and
act the same way as they did before their conversion to Owl.

This mostly consists of a few tweaks in the conditional rendering of
certain elements in the template, and the rest of the changes are meant
to clean and simplify the values the component is working with.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
