### PR TITLE
Master bug fix helpdesk 1.0 pasa

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -106,9 +106,10 @@ class SaleOrderLine(models.Model):
         # generate task with hours=0.
         for line in lines:
             if line.state == 'sale' and not line.is_expense:
+                has_task = bool(line.task_id)
                 line.sudo()._timesheet_service_generation()
                 # if the SO line created a task, post a message on the order
-                if line.task_id:
+                if line.task_id and not has_task:
                     msg_body = _("Task Created (%s): %s", line.product_id.name, line.task_id._get_html_link())
                     line.order_id.message_post(body=msg_body)
         return lines


### PR DESCRIPTION
Before this commit, A 'task created' notification is generated each time the user adds a product from the FSM task even when the new task is not generated as it's directly linked with a particular fsm task.

So in this commit, check if the product is added from the fsm task then do not log a message on order chatter.

task-2926348