### PR TITLE
[IMP] mail: Add notifications for mass mails

### DIFF
--- a/addons/mail/static/src/core/common/message_notification_popover.xml
+++ b/addons/mail/static/src/core/common/message_notification_popover.xml
@@ -11,6 +11,7 @@
                     <t t-esc="props.message.getPersonaName(notification.res_partner_id)"/>
                     <t t-if="notification.res_partner_id.email and !notification.isFailure"> (<t t-out="notification.res_partner_id.email"/>)</t>
                 </span>
+                <span t-elif="notification.mail_email_address" t-out="notification.mail_email_address"/>
                 <span class="ms-1 text-muted" t-if="notification.isFailure">(<t t-esc="notification.failureMessage"/>)</span>
             </div>
             <div t-if="props.message.incoming_email_cc or props.message.incoming_email_to" t-foreach="(props.message.incoming_email_cc || []).concat(props.message.incoming_email_to || [])" t-as="incomingEmail" t-key="incomingEmail_index">
@@ -24,6 +25,7 @@
                     <t t-esc="props.message.getPersonaName(notification.res_partner_id)"/>
                     <t t-if="notification.res_partner_id.email and !notification.isFailure"> (<t t-out="notification.res_partner_id.email"/>)</t>
                 </span>
+                <span t-elif="notification.mail_email_address" t-out="notification.mail_email_address"/>
                 <span class="ms-1 text-muted" t-if="notification.isFailure">(<t t-esc="notification.failureMessage"/>)</span>
             </div>
         </div>

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -17,6 +17,7 @@ export class Notification extends Record {
     notification_status;
     /** @type {string} */
     notification_type;
+    mail_email_address;
     failure = fields.One("Failure", {
         inverse: "notifications",
         /** @this {import("models").Notification} */

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -62,6 +62,25 @@ export class Notification extends Record {
     }
     res_partner_id = fields.One("res.partner");
 
+    /**
+     * Get the translate string of the failure type only
+     * when it corresponds to a failure type
+     * that is automatically cancelled before sending.
+     *
+     * @returns {string}
+     */
+    get autoCanceledFailureType() {
+        switch (this.failure_type) {
+            case "mail_bl":
+                return _t("Blacklisted Address");
+            case "mail_dup":
+                return _t("Duplicated Email");
+            case "mail_optout":
+                return _t("Opted Out");
+        }
+        return "";
+    }
+
     get isFailure() {
         return ["exception", "bounce"].includes(this.notification_status);
     }
@@ -98,6 +117,9 @@ export class Notification extends Record {
             case "ready":
                 return `fa ${!this.isFollowerNotification ? "fa-send-o" : "fa-user-o"}`;
             case "canceled":
+                if (this.autoCanceledFailureType) {
+                    return "fa fa-remove";
+                }
                 return "fa fa-trash-o";
         }
         return "";
@@ -118,7 +140,7 @@ export class Notification extends Record {
             case "ready":
                 return _t("Ready");
             case "canceled":
-                return _t("Cancelled");
+                return this.autoCanceledFailureType || _t("Cancelled");
         }
         return "";
     }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
@@ -33,6 +33,7 @@ export class MailNotification extends models.ServerModel {
     get _to_store_defaults() {
         return [
             "failure_type",
+            "mail_email_address",
             "mail_message_id",
             "notification_status",
             "notification_type",

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1494,7 +1494,7 @@ class MailCase(common.TransactionCase, MockEmail):
         """
         partners = self.env['res.partner'].sudo().concat(*list(p['partner'] for i in recipients_info for p in i['notif'] if p.get('partner')))
         email_addrs = [email for i in recipients_info for p in i['notif'] for email in p.get('email_to', []) if not p.get('partner')]
-        base_domain = ['|', ('res_partner_id', 'in', partners.ids), ('res_partner_id.email_normalized', 'in', email_addrs)]
+        base_domain = ['|', ('res_partner_id', 'in', partners.ids), ('mail_email_address', 'in', email_addrs)]
         if messages is not None:
             base_domain += [('mail_message_id', 'in', messages.ids)]
         notifications = self.env['mail.notification'].sudo().search(base_domain)
@@ -1590,7 +1590,7 @@ class MailCase(common.TransactionCase, MockEmail):
                 # find notification
                 notif = notifications.filtered(
                     lambda n: n.mail_message_id == message
-                    and ((partner and n.res_partner_id == partner) or n.res_partner_id.email_normalized in email_to_lst)
+                    and ((partner and n.res_partner_id == partner) or n.mail_email_address in email_to_lst)
                     and n.notification_type == ntype
                 )
                 self.assertEqual(len(notif), 1,

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -32,7 +32,7 @@ from odoo.addons.mail.tools.discuss import Store
 from odoo.tests import common, RecordCapturer, new_test_user
 from odoo.tools import mute_logger
 from odoo.tools.mail import (
-    email_normalize, email_split_and_format_normalize, formataddr
+    email_normalize, email_normalize_all, email_split, email_split_and_format_normalize, formataddr
 )
 from odoo.tools.translate import code_translations
 
@@ -553,6 +553,41 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             )
         return mail
 
+    def _find_mail_mail_wemails(self, email_to_all, status, mail_message=None, author=None, content=None, email_from=None):
+        """ Find a mail.mail record based on various parameters, notably a list
+        of email to (string emails).
+
+        :param email_to_all: comma-separated or python list of email addresses comprising either
+          all email_to addresses of the message, all emails of the recipients or all emails of both;
+
+        :return mail: a ``mail.mail`` record generated during the mock and matching
+          given parameters and filters;
+        """
+        filtered = self._filter_mail(status=status, mail_message=mail_message, author=author, content=content, email_from=email_from)
+
+        if isinstance(email_to_all, str):
+            email_to_all = email_split(email_to_all)
+        email_to = (
+            {email_normalize(email) or email for email in email_to_all or []} - {''}
+        ) or ([email_to_all] if email_to_all else set())
+
+        for mail in filtered:
+            mail_email_addrs = set(email_normalize_all(mail.email_to or '')) or ({mail.email_to} if mail.email_to else set())
+            mail_partner_email_addrs = {email_normalize(email) or email for email in mail.recipient_ids.mapped('email')}
+
+            if email_to == mail_email_addrs | mail_partner_email_addrs:
+                break
+        else:
+            debug_info = '\n'.join(
+                f'From: {mail.author_id} ({mail.email_from}) - To: {mail.email_to} / {sorted(mail.recipient_ids.mapped("email"))} (State: {mail.state})'
+                for mail in self._new_mails
+            )
+            raise AssertionError(
+                f'mail.mail not found for message {mail_message} / status {status} / email_to {email_to} / '
+                f'author {author} ({email_from})\n{debug_info}'
+            )
+        return mail
+
     def _find_mail_mail_wrecord(self, record, status=None, mail_message=None, author=None, content=None, email_from=None):
         """ Find a mail.mail record based on model / res_id of a record.
 
@@ -577,8 +612,9 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
     # ------------------------------------------------------------
 
     def _assertMailMail(self, mail, recipients_list, status,
-                        email_to_recipients=None, author=None,
-                        content=None, fields_values=None, email_values=None):
+                        email_to_all=None, email_to_recipients=None,
+                        author=None, content=None,
+                        fields_values=None, email_values=None):
         """ Assert mail.mail record values and maybe related emails. Allow
         asserting their content. Records to check are the one generated when
         using mock (mail.mail and outgoing emails).
@@ -594,6 +630,9 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
           being partners it nos easy (e.g. multi emails, ...);
         :param author: see ``_find_mail_mail_wpartners``;
         :param content: if given, check it is contained within mail html body;
+        :param email_to_all: list of email addresses used in email_to, checking
+        all of them are in the same email. This is in addition to checking recipients
+        individually.;
         :param fields_values: if given, should be a dictionary of field names /
           values allowing to check ``mail.mail`` additional values (subject,
           reply_to, ...);
@@ -663,9 +702,14 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                         recipient,
                         **(email_values or {})
                     )
+            if email_to_all:
+                self.assertSentEmail(
+                    email_values['email_from'] if email_values and email_values.get('email_from') else author,
+                    email_to_all,
+                    **(email_values or {}))
 
     def assertMailMail(self, recipients, status,
-                       email_to_recipients=None,
+                       email_to_recipients=None, email_to_all=None,
                        mail_message=None, author=None,
                        content=None, fields_values=None, email_values=None):
         """ Assert mail.mail records are created and maybe sent as emails. This
@@ -674,22 +718,23 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
 
         :param recipients: a ``res.partner`` recordset. See
           ``_find_mail_mail_wpartners``;
+        :param email_to_all: list of email addresses. See ``_find_mail_mail_wemail``;
         :param mail_message: used to find the related email;
 
         See '_assertMailMail' for more details about other parameters.
         """
-        found_mail = self._find_mail_mail_wpartners(
-            recipients, status, mail_message=mail_message,
-            author=author,
-            content=content,
-            email_from=(fields_values or {}).get('email_from')
-        )
+        email_from = (fields_values or {}).get('email_from')
+        if recipients:
+            found_mail = self._find_mail_mail_wpartners(recipients, status, mail_message=mail_message, author=author, content=content, email_from=email_from)
+        else:
+            found_mail = self._find_mail_mail_wemail(email_to_all, status, mail_message=mail_message, author=author, content=content, email_from=email_from)
+
         self.assertTrue(bool(found_mail))
         self._assertMailMail(
             found_mail, recipients, status,
             email_to_recipients=email_to_recipients,
             author=author, content=content,
-            fields_values=fields_values, email_values=email_values,
+            email_to_all=email_to_all, fields_values=fields_values, email_values=email_values,
         )
         return found_mail
 
@@ -805,14 +850,17 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                         f'Message: expected {fvalue} for {fname}, got {message[fname]}',
                     )
 
-    def assertNoMail(self, recipients, mail_message=None, author=None):
+    def assertNoMail(self, recipients, email_to=None, mail_message=None, author=None):
         """ Check no mail.mail and email was generated during gateway mock. """
         try:
-            self._find_mail_mail_wpartners(recipients, False, mail_message=mail_message, author=author)
+            if recipients:
+                self._find_mail_mail_wpartners(recipients, False, mail_message=mail_message, author=author)
+            elif email_to is not None:
+                self._find_mail_mail_wemail(email_to, False, mail_message=mail_message, author=author)
         except AssertionError:
             pass
         else:
-            raise AssertionError('mail.mail exists for message %s / recipients %s but should not exist' % (mail_message, recipients.ids))
+            raise AssertionError('mail.mail exists for message %s / recipients %s / emails %s but should not exist' % (mail_message, recipients.ids, email_to or '/'))
         finally:
             self.assertNotSentEmail(recipients)
 
@@ -1426,9 +1474,8 @@ class MailCase(common.TransactionCase, MockEmail):
             'notif': list of notified recipients: [
               {
                 'check_send': whether outgoing stuff has to be checked;
-                'email': NOT SUPPORTED YET,
+                'email_to': email if sent without partner,
                 'email_to_recipients': propagated to 'assertMailMail';
-                'failure_reason': failure_reason on mail.notification;
                 'failure_type': 'failure_type' on mail.notification;
                 'is_read': 'is_read' on mail.notification;
                 'partner': res.partner record (may be empty),
@@ -1446,7 +1493,8 @@ class MailCase(common.TransactionCase, MockEmail):
           and therefore we are able to check outgoing emails;
         """
         partners = self.env['res.partner'].sudo().concat(*list(p['partner'] for i in recipients_info for p in i['notif'] if p.get('partner')))
-        base_domain = [('res_partner_id', 'in', partners.ids)]
+        email_addrs = [email for i in recipients_info for p in i['notif'] for email in p.get('email_to', []) if not p.get('partner')]
+        base_domain = ['|', ('res_partner_id', 'in', partners.ids), ('res_partner_id.email_normalized', 'in', email_addrs)]
         if messages is not None:
             base_domain += [('mail_message_id', 'in', messages.ids)]
         notifications = self.env['mail.notification'].sudo().search(base_domain)
@@ -1474,13 +1522,14 @@ class MailCase(common.TransactionCase, MockEmail):
                 raise ValueError(f'Unsupported values: {extra_keys}')
 
             mbody, mtype = message_info.get('content', ''), message_info.get('message_type', 'comment')
+            message_values = message_info.get('message_values', {})
             msubtype = message_info.get('message_values', {}).get('subtype_id', self.env.ref(message_info.get('subtype', 'mail.mt_comment')))
 
             # find message
             if messages:
                 message = messages.filtered(lambda message: (
                     mbody in message.body and message.message_type == mtype and
-                    message.subtype_id == msubtype
+                    msubtype == message.subtype_id
                 ))
             else:
                 message = self.env['mail.message'].sudo().search([
@@ -1488,10 +1537,9 @@ class MailCase(common.TransactionCase, MockEmail):
                     ('message_type', '=', mtype),
                     ('subtype_id', '=', msubtype.id)
                 ], limit=1, order='id DESC')
-            self.assertTrue(message, 'Mail: not found message (content: %s, message_type: %s, subtype: %s)' % (mbody, mtype, msubtype.name))
+            self.assertTrue(message, 'Mail: not found message (content: %s, message_type: %s, subtype: %s)' % (mbody, mtype, msubtype and msubtype.name))
 
             # check message values
-            message_values = message_info.get('message_values', {})
             if message_values:
                 self.assertMessageFields(message, message_values)
 
@@ -1506,6 +1554,7 @@ class MailCase(common.TransactionCase, MockEmail):
                 # sanity check
                 extra_keys = set(recipient.keys()) - {
                     'check_send',
+                    'email_to',
                     'email_to_recipients',
                     'is_read',
                     'failure_reason',
@@ -1526,7 +1575,7 @@ class MailCase(common.TransactionCase, MockEmail):
 
                 if not ngroup:
                     ngroup = 'user'
-                    if partner and not partner.user_ids:
+                    if (partner and not partner.user_ids) or (not partner and email_to_lst):
                         ngroup = 'customer'
                     elif partner and partner.partner_share:
                         ngroup = 'portal'
@@ -1539,20 +1588,20 @@ class MailCase(common.TransactionCase, MockEmail):
                     }
 
                 # find notification
-                partner_notif = notifications.filtered(lambda n: (
-                    n.mail_message_id == message and
-                    n.res_partner_id == partner and
-                    n.notification_type == ntype
-                ))
-                self.assertEqual(len(partner_notif), 1,
-                                 f'Mail: not found notification for {partner} (type: {ntype}, message: {message.id})\n{debug_info}')
-                self.assertEqual(partner_notif.author_id, partner_notif.mail_message_id.author_id)
-                self.assertEqual(partner_notif.is_read, nis_read)
+                notif = notifications.filtered(
+                    lambda n: n.mail_message_id == message
+                    and ((partner and n.res_partner_id == partner) or n.res_partner_id.email_normalized in email_to_lst)
+                    and n.notification_type == ntype
+                )
+                self.assertEqual(len(notif), 1,
+                                 f'Mail: not found notification for {partner or email_to_lst} (type: {ntype}, message: {message.id})\n{debug_info}')
+                self.assertEqual(notif.author_id, notif.mail_message_id.author_id)
+                self.assertEqual(notif.is_read, nis_read)
                 if 'failure_reason' in recipient:
-                    self.assertEqual(partner_notif.failure_reason, recipient['failure_reason'])
+                    self.assertEqual(notif.failure_reason, recipient['failure_reason'])
                 if 'failure_type' in recipient:
-                    self.assertEqual(partner_notif.failure_type, recipient['failure_type'])
-                self.assertEqual(partner_notif.notification_status, nstatus)
+                    self.assertEqual(notif.failure_type, recipient['failure_type'])
+                self.assertEqual(notif.notification_status, nstatus)
 
                 # prepare further asserts
                 if ntype == 'email':
@@ -1579,7 +1628,7 @@ class MailCase(common.TransactionCase, MockEmail):
                     else:
                         raise NotImplementedError()
 
-                done_notifs |= partner_notif
+                done_notifs |= notif
             done_msgs |= message
 
             # check bus notifications that should be sent (hint: message author, multiple notifications)
@@ -1610,27 +1659,34 @@ class MailCase(common.TransactionCase, MockEmail):
                     mail_status = 'outgoing'
                 if email_to_lst and all(p in status_groups['outgoing']['email_lst'] for p in email_to_lst):
                     mail_status = 'outgoing'
-                if not self.mail_unlink_sent and partners:
+                if not self.mail_unlink_sent and (partners or email_to_lst):
                     self.assertMailMail(
                         partners,
                         mail_status,
                         author=message_info.get('mail_mail_values', {}).get('author_id', message.author_id),
                         content=mbody,
+                        email_to_all=email_to_lst,
                         email_to_recipients=group['email_to_recipients'] or None,
                         email_values=email_values,
                         fields_values=message_info.get('mail_mail_values'),
                         mail_message=message,
                     )
                 else:
-                    for recipient in partners:
+                    for partner in partners:
                         self.assertSentEmail(
                             message.author_id if message.author_id else message.email_from,
-                            [recipient],
+                            partner,
                             **email_values
+                        )
+                    if email_to_lst:
+                        self.assertSentEmail(
+                            message.author_id if message.author_id else message.email_from,
+                            email_to_lst,
+                            **email_values,
                         )
 
             if not any(p for recipients in email_groups.values() for p in recipients):
-                self.assertNoMail(partners, mail_message=message, author=message.author_id)
+                self.assertNoMail(partners, email_to=email_addrs, mail_message=message, author=message.author_id)
 
         return done_msgs, done_notifs
 

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -116,12 +116,12 @@ class MailMail(models.Model):
             })
         return email_list
 
-    def _postprocess_sent_message(self, success_pids, failure_reason=False, failure_type=None):
+    def _postprocess_sent_message(self, success_pids, success_emails, failure_reason=False, failure_type=None):
         if failure_type:  # we consider that a recipient error is a failure with mass mailing and show them as failed
             self.filtered('mailing_id').mailing_trace_ids.set_failed(failure_type=failure_type)
         else:
             self.filtered('mailing_id').mailing_trace_ids.set_sent()
-        return super()._postprocess_sent_message(success_pids, failure_reason=failure_reason, failure_type=failure_type)
+        return super()._postprocess_sent_message(success_pids, success_emails, failure_reason=failure_reason, failure_type=failure_type)
 
     @api.autovacuum
     def _gc_canceled_mail_mail(self):

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -25,6 +25,18 @@ class MailComposeMessage(models.TransientModel):
             self.mass_mailing_id = mass_mailing.id
         return super()._action_send_mail(auto_commit=auto_commit)
 
+    def _invalid_email_state(self):
+        """Always cancel invalid emails for mailings due to likely untractable number of failures."""
+        if self.mass_mailing_name or self.mass_mailing_id:
+            return 'cancel'
+        return super()._invalid_email_state()
+
+    def _generate_mail_notification_values(self, mails):
+        """Prevent notification creation as traces are generated."""
+        if self.mass_mailing_name or self.mass_mailing_id:
+            return []
+        return super()._generate_mail_notification_values(mails)
+
     def _prepare_mail_values(self, res_ids):
         # When being in mass mailing mode, add 'mailing.trace' values directly in the o2m field of mail.mail.
         mail_values_all = super()._prepare_mail_values(res_ids)

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1570,6 +1570,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         last_message = channel._get_last_messages()
         if channel == self.channel_channel_public_1:
             return {
+                "mail_email_address": False,
                 "failure_type": False,
                 "id": last_message.notification_ids.id,
                 "mail_message_id": last_message.id,

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1612,8 +1612,9 @@ class TestMessagePostHelpers(TestMessagePostCommon):
 
         # sent emails (mass mail mode)
         for test_record in test_records:
+            all_partners = new_partners + self.partner_1 + self.partner_2 + test_record.customer_id
             self.assertMailMail(
-                new_partners + self.partner_1 + self.partner_2 + test_record.customer_id,
+                all_partners,
                 'sent',
                 author=self.user_employee.partner_id,
                 email_values={
@@ -1632,7 +1633,7 @@ class TestMessagePostHelpers(TestMessagePostCommon):
                     'is_notification': True,  # auto_delete_keep_log -> keep underlying mail.message
                     'message_type': 'email_outgoing',
                     'model': test_record._name,
-                    'notified_partner_ids': self.env['res.partner'],
+                    'notified_partner_ids': all_partners,
                     'subtype_id': self.env['mail.message.subtype'],
                     'reply_to': formataddr((self.partner_employee.name, f'{self.alias_catchall}@{self.alias_domain}')),
                     'res_id': test_record.id,
@@ -1671,10 +1672,10 @@ class TestMessagePostHelpers(TestMessagePostCommon):
                     'auto_delete': False,
                     'email_from': self.partner_employee.email_formatted,
                     'is_internal': False,
-                    'is_notification': False,  # no to_delete -> no keep_log
+                    'is_notification': True,  # no to_delete -> notification created
                     'message_type': 'email_outgoing',
                     'model': test_record._name,
-                    'notified_partner_ids': self.env['res.partner'],
+                    'notified_partner_ids': test_record.customer_id,
                     'recipient_ids': test_record.customer_id,
                     'subtype_id': self.env['mail.message.subtype'],
                     'reply_to': formataddr((self.partner_employee.name, f'{self.alias_catchall}@{self.alias_domain}')),

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -499,7 +499,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=55, employee=55), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=77, employee=77), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)
@@ -1272,7 +1272,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=31, employee=31):
+        with self.assertQueryCount(admin=34, employee=34):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1557,6 +1557,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ],
                             "mail.notification": [
                                 {
+                                    "mail_email_address": False,
                                     "failure_type": False,
                                     "id": notif_1.id,
                                     "mail_message_id": message.id,
@@ -1565,6 +1566,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "res_partner_id": self.user_emp_inbox.partner_id.id,
                                 },
                                 {
+                                    "mail_email_address": False,
                                     "failure_type": False,
                                     "id": notif_2.id,
                                     "mail_message_id": message.id,
@@ -1660,6 +1662,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ],
                             "mail.notification": [
                                 {
+                                    "mail_email_address": False,
                                     "failure_type": False,
                                     "id": notif_1.id,
                                     "mail_message_id": message.id,
@@ -1668,6 +1671,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "res_partner_id": self.user_emp_inbox.partner_id.id,
                                 },
                                 {
+                                    "mail_email_address": False,
                                     "failure_type": False,
                                     "id": notif_2.id,
                                     "mail_message_id": message.id,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -75,7 +75,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=104):  # tmf: 101
+        with self.assertQueryCount(employee=104):  # test_mail_full: 102
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -90,11 +90,11 @@ class TestMassMailing(TestMailFullCommon):
                 elif recipient in (recipient_dup_1, recipient_dup_2, recipient_dup_4):
                     recipient_info['trace_status'] = "cancel"
                     recipient_info['failure_type'] = "mail_dup"
-                # void: error (failed mail)
+                # void: cancel (cancel mail)
                 elif recipient == recipient_void_1:
                     recipient_info['trace_status'] = 'cancel'
                     recipient_info['failure_type'] = "mail_email_missing"
-                # falsy: error (failed mail)
+                # falsy: cancel (cancel mail)
                 elif recipient == recipient_falsy_1:
                     recipient_info['trace_status'] = "cancel"
                     recipient_info['failure_type'] = "mail_email_invalid"

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -49,8 +49,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         # runbot needs +101 compared to local
         with (
             self.mock_mail_gateway(mail_unlink_sent=True),
-            # contains notably 1 query / record for unlink in mail
-            self.assertQueryCount(__system__=1377, marketing=1379),  # 1229, 1230
+            self.assertQueryCount(__system__=1377, marketing=1379),  # 1326, 1328
         ):
             mailing.action_send_mail()
 
@@ -93,9 +92,8 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        # runbot needs +153 compared to local
-        # contains notably 1 query / record for unlink in mail
-        with self.assertQueryCount(__system__=1408, marketing=1410):  # 1256, 1258
+        # runbot needs +52 compared to local
+        with self.assertQueryCount(__system__=1408, marketing=1410):  # 1356, 1358
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
Currently using the composer to send a message to multiple recipients
leads to messages being simply logged on the chatter with no indication
of their status.

This commit adds a step at the end of the composer mail generation logic
to create notifications in batch, preserving much of the efficiency of
batch messaging.

As mass recipients may be arbitrary emails we also add support for
partner-less notifications that only have a string "email" field.
This also required accomodations to the notification update logic for
bouncing.

Finally missing/erroneous email is now considered a failure in batch
mode as auto-cancelling it would make it appear as though there is no
issue with the message. This is not the case for mass mailings where we
usually expect a number of records to be unreachable, as they're not
individually selected.


Task-2199202
