### PR TITLE
[Fix]  No attribute 'NumberConverter'

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -68,9 +68,8 @@ class ModelsConverter(werkzeug.routing.BaseConverter):
         return ",".join(value.ids)
 
 
-class SignedIntConverter(werkzeug.routing.NumberConverter):
+class SignedIntConverter(werkzeug.routing.IntegerConverter):
     regex = r'-?\d+'
-    num_convert = int
 
 
 class IrHttp(models.AbstractModel):


### PR DESCRIPTION
On server starting, following error :
odoo.modules.module: module 'werkzeug.routing' has no attribute 'NumberConverter'


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
