### PR TITLE
[FIX] sale: set studio default value for invoice line sequence

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -724,7 +724,7 @@ class SaleOrder(models.Model):
         if len(invoice_vals_list) < len(self):
             SaleOrderLine = self.env['sale.order.line']
             for invoice in invoice_vals_list:
-                sequence = 1
+                sequence = self.env['account.move.line'].default_get(['sequence']).get('sequence')
                 for line in invoice['invoice_line_ids']:
                     line[2]['sequence'] = SaleOrderLine._get_invoice_line_sequence(new=sequence, old=line[2]['sequence'])
                     sequence += 1
@@ -1513,7 +1513,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         res = {
             'display_type': self.display_type,
-            'sequence': self.sequence,
+            'sequence': self.env['account.move.line'].default_get(['sequence']).get('sequence'),
             'name': self.name,
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,


### PR DESCRIPTION
### Steps to reproduce
- Activate developer mode
- Go to Settings > Technical > Data Structure > Fields
- Create a new field with the following parameters:
  - Field Name = whatever you want
  - Field Label = whatever you want
  - Model = Journal Item
  - Field Type = integer
  - Related Field = sequence
  - Dependencies = sequence
- Save and go to any invoice
- Switch to Studio mode and add the field you just created to the invoice lines list view
- Still in Studio, set a new default value for the sequence field of invoice lines
- Close Studio. You should see the field you created on the invoice lines. This new field lets you display the sequence number of invoice lines.
- Now if you go to Accounting > Customers > Invoices, and creates a new invoice, you should see that the sequence number of the invoice lines is equal to the value you set in Studio.

However, if you create an invoice through a sale order, the default value you set is not taken into account.

opw-2919210