### PR TITLE
[FIX] web: allow the use of the "load" kwarg in orm searchRead and read

### DIFF
--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -133,7 +133,7 @@ export class ORM {
         return this.call(model, "name_get", [ids], { context: ctx });
     }
 
-    read(model, ids, fields, ctx) {
+    read(model, ids, fields, ctx, load) {
         validatePrimitiveList("ids", "number", ids);
         if (fields) {
             validatePrimitiveList("fields", "string", fields);
@@ -141,7 +141,11 @@ export class ORM {
         if (!ids.length) {
             return Promise.resolve([]);
         }
-        return this.call(model, "read", [ids, fields], { context: ctx });
+        const kwargs = { context: ctx };
+        if (load !== undefined) {
+            kwargs.load = load;
+        }
+        return this.call(model, "read", [ids, fields], kwargs);
     }
 
     readGroup(model, domain, fields, groupby, options = {}, ctx = {}) {
@@ -173,7 +177,7 @@ export class ORM {
             validatePrimitiveList("fields", "string", fields);
         }
         const kwargs = { context: ctx, domain, fields };
-        assignOptions(kwargs, options, ["offset", "limit", "order"]);
+        assignOptions(kwargs, options, ["offset", "limit", "order", "load"]);
         return this.call(model, "search_read", [], kwargs);
     }
 


### PR DESCRIPTION
Prior to this commit, the load kwarg was not available on the orm
service's `searchRead` and 'read' methods. The load kwarg allows for a
call to the read method where a name_get is not performed on the m2o
fields.

This commit whitelists the kwarg for `searchRead` and adds the argument
for `read`.