### PR TITLE
[REF] web: Make list and kanban sortable handlers overridable

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -116,23 +116,13 @@ export class ListRenderer extends Component {
             handle: ".o_handle_cell",
             cursor: "grabbing",
             // Hooks
-            onStart: (_group, element) => {
+            onStart: (params) => {
+                const { element } = params;
                 dataRowId = element.dataset.id;
-                element.classList.add("o_dragged");
+                return this.onSortStart(params);
             },
-            onStop: (_group, element) => element.classList.remove("o_dragged"),
-            onDrop: async ({ element, previous }) => {
-                if (this.props.list.editedRecord) {
-                    this.props.list.unselectRecord(true);
-                }
-                element.classList.remove("o_row_draggable");
-                const refId = previous ? previous.dataset.id : null;
-                this.resequencePromise = this.props.list.resequence(dataRowId, refId, {
-                    handleField: this.props.archInfo.handleField,
-                });
-                await this.resequencePromise;
-                element.classList.add("o_row_draggable");
-            },
+            onStop: this.onSortStop,
+            onDrop: (params) => this.onSortDrop(dataRowId, params),
         });
 
         if (this.env.searchModel) {
@@ -1761,6 +1751,46 @@ export class ListRenderer extends Component {
     }
     onRowTouchMove(record) {
         this.resetLongTouchTimer();
+    }
+
+    /**
+     * @param {string} dataRowId
+     * @param {Object} params
+     * @param {HTMLElement} params.element
+     * @param {HTMLElement} [params.group]
+     * @param {HTMLElement} [params.next]
+     * @param {HTMLElement} [params.parent]
+     * @param {HTMLElement} [params.previous]
+     */
+    async onSortDrop(dataRowId, { element, previous }) {
+        if (this.props.list.editedRecord) {
+            this.props.list.unselectRecord(true);
+        }
+        element.classList.remove("o_row_draggable");
+        const refId = previous ? previous.dataset.id : null;
+        this.resequencePromise = this.props.list.resequence(dataRowId, refId, {
+            handleField: this.props.archInfo.handleField,
+        });
+        await this.resequencePromise;
+        element.classList.add("o_row_draggable");
+    }
+
+    /**
+     * @param {Object} params
+     * @param {HTMLElement} params.element
+     * @param {HTMLElement} [params.group]
+     */
+    onSortStart({ element }) {
+        element.classList.add("o_dragged");
+    }
+
+    /**
+     * @param {Object} params
+     * @param {HTMLElement} params.element
+     * @param {HTMLElement} [params.group]
+     */
+    onSortStop({ element }) {
+        element.classList.remove("o_dragged");
     }
 }
 

--- a/addons/web/static/tests/core/utils/ui_tests.js
+++ b/addons/web/static/tests/core/utils/ui_tests.js
@@ -95,22 +95,22 @@ QUnit.module("UI", ({ beforeEach }) => {
                 useSortable({
                     ref: useRef("root"),
                     elements: ".item",
-                    onStart(group, element) {
+                    onStart({ element, group }) {
                         assert.step("start");
                         assert.notOk(group);
                         assert.strictEqual(element.innerText, "1");
                     },
-                    onElementEnter(element) {
+                    onElementEnter({ element }) {
                         assert.step("elemententer");
                         assert.strictEqual(element.innerText, "2");
                     },
-                    onStop(group, element) {
+                    onStop({ element, group }) {
                         assert.step("stop");
                         assert.notOk(group);
                         assert.strictEqual(element.innerText, "1");
                         assert.containsN(target, ".item", 4);
                     },
-                    onDrop({ group, element, previous, next, parent }) {
+                    onDrop({ element, group, previous, next, parent }) {
                         assert.step("drop");
                         assert.notOk(group);
                         assert.strictEqual(element.innerText, "1");
@@ -151,21 +151,21 @@ QUnit.module("UI", ({ beforeEach }) => {
                     elements: ".item",
                     groups: ".list",
                     connectGroups: true,
-                    onStart(group, element) {
+                    onStart({ element, group }) {
                         assert.step("start");
                         assert.hasClass(group, "list2");
                         assert.strictEqual(element.innerText, "2 1");
                     },
-                    onGroupEnter(group) {
+                    onGroupEnter({ group }) {
                         assert.step("groupenter");
                         assert.hasClass(group, "list1");
                     },
-                    onStop(group, element) {
+                    onStop({ element, group }) {
                         assert.step("stop");
                         assert.hasClass(group, "list2");
                         assert.strictEqual(element.innerText, "2 1");
                     },
-                    onDrop({ group, element, previous, next, parent }) {
+                    onDrop({ element, group, previous, next, parent }) {
                         assert.step("drop");
                         assert.hasClass(group, "list2");
                         assert.strictEqual(element.innerText, "2 1");


### PR DESCRIPTION
This PR moves the inline handlers of the `useSortable` hook
calls in the list and kanban renderers to proper class methods.

This allows said handlers to be overridden in child classes.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
