### PR TITLE
[IMP] mail, *: auto add implicit attributes of identifying fields

### DIFF
--- a/addons/calendar/static/src/models/calendar_event.js
+++ b/addons/calendar/static/src/models/calendar_event.js
@@ -25,8 +25,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         name: attr(),
         start: attr(),

--- a/addons/hr/static/src/models/employee.js
+++ b/addons/hr/static/src/models/employee.js
@@ -164,8 +164,6 @@ registerModel({
          */
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Partner related to this employee.

--- a/addons/im_livechat/static/src/models/chatbot.js
+++ b/addons/im_livechat/static/src/models/chatbot.js
@@ -158,8 +158,6 @@ registerModel({
         publicLivechatGlobalOwner: one('PublicLivechatGlobal', {
             identifying: true,
             inverse: 'chatbot',
-            readonly: true,
-            required: true,
         }),
         scriptId: attr({
             compute: '_computeScriptId',

--- a/addons/im_livechat/static/src/models/chatbot_step.js
+++ b/addons/im_livechat/static/src/models/chatbot_step.js
@@ -9,8 +9,6 @@ registerModel({
         chabotOwner: one('Chatbot', {
             identifying: true,
             inverse: 'currentStep',
-            readonly: true,
-            required: true,
         }),
         data: attr(),
     },

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category.js
@@ -10,7 +10,6 @@ addFields('DiscussSidebarCategory', {
     discussAsLivechat: one('Discuss', {
         identifying: true,
         inverse: 'categoryLivechat',
-        readonly: true,
     }),
 });
 

--- a/addons/im_livechat/static/src/models/livechat_button_view.js
+++ b/addons/im_livechat/static/src/models/livechat_button_view.js
@@ -610,8 +610,6 @@ registerModel({
         publicLivechatGlobalOwner: one('PublicLivechatGlobal', {
             identifying: true,
             inverse: 'livechatButtonView',
-            readonly: true,
-            required: true,
         }),
         serverUrl: attr({
             compute: '_computeServerUrl',

--- a/addons/im_livechat/static/src/models/livechat_operator.js
+++ b/addons/im_livechat/static/src/models/livechat_operator.js
@@ -8,8 +8,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         name: attr(),
     },

--- a/addons/im_livechat/static/src/models/public_livechat.js
+++ b/addons/im_livechat/static/src/models/public_livechat.js
@@ -94,8 +94,6 @@ registerModel({
         publicLivechatGlobalOwner: one('PublicLivechatGlobal', {
             identifying: true,
             inverse: 'publicLivechat',
-            readonly: true,
-            required: true,
         }),
         name: attr({
             compute: '_computeName',

--- a/addons/im_livechat/static/src/models/public_livechat_feedback_view.js
+++ b/addons/im_livechat/static/src/models/public_livechat_feedback_view.js
@@ -36,8 +36,6 @@ registerModel({
         publicLivechatGlobalOwner: one('PublicLivechatGlobal', {
             identifying: true,
             inverse: 'feedbackView',
-            readonly: true,
-            required: true,
         }),
         widget: attr(),
     },

--- a/addons/im_livechat/static/src/models/public_livechat_global_notification_handler.js
+++ b/addons/im_livechat/static/src/models/public_livechat_global_notification_handler.js
@@ -97,8 +97,6 @@ registerModel({
         publicLivechatGlobalOwner: one('PublicLivechatGlobal', {
             identifying: true,
             inverse: 'notificationHandler',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/im_livechat/static/src/models/public_livechat_message.js
+++ b/addons/im_livechat/static/src/models/public_livechat_message.js
@@ -25,8 +25,6 @@ registerModel({
         data: attr(),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         legacyPublicLivechatMessage: attr(),
     },

--- a/addons/im_livechat/static/src/models/public_livechat_view.js
+++ b/addons/im_livechat/static/src/models/public_livechat_view.js
@@ -21,8 +21,6 @@ registerModel({
         publicLivechatWindowOwner: one('PublicLivechatWindow', {
             identifying: true,
             inverse: 'publicLivechatView',
-            readonly: true,
-            required: true,
         }),
         widget: attr(),
     },

--- a/addons/im_livechat/static/src/models/public_livechat_window.js
+++ b/addons/im_livechat/static/src/models/public_livechat_window.js
@@ -44,8 +44,6 @@ registerModel({
         livechatButtonViewOwner: one('LivechatButtonView', {
             identifying: true,
             inverse: 'chatWindow',
-            readonly: true,
-            required: true,
         }),
         publicLivechatView: one('PublicLivechatView', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -21,6 +21,7 @@ export class ModelField {
         identifying = false,
         inverse,
         isCausal = false,
+        model,
         readonly = false,
         related,
         relationType,
@@ -69,6 +70,7 @@ export class ModelField {
          * relation is removed, the related record is automatically deleted.
          */
         this.isCausal = isCausal;
+        this.model = model;
         /**
          * Determines whether the field is read only. Read only field
          * can't be updated once the record is created.
@@ -137,6 +139,12 @@ export class ModelField {
          * model name this relation refers to.
          */
         this.to = to;
+        if (this.identifying) {
+            this.readonly = true;
+            if (model.identifyingMode === 'and') {
+                this.required = true;
+            }
+        }
     }
 
     /**

--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -289,8 +289,6 @@ registerModel({
         icon: attr(),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         isCurrentPartnerAssignee: attr({
             compute: '_computeIsCurrentPartnerAssignee',

--- a/addons/mail/static/src/models/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view.js
@@ -33,8 +33,6 @@ registerModel({
         chatter: one('Chatter', {
             identifying: true,
             inverse: 'activityBoxView',
-            readonly: true,
-            required: true,
         }),
         isActivityListVisible: attr({
             default: true,

--- a/addons/mail/static/src/models/activity_group.js
+++ b/addons/mail/static/src/models/activity_group.js
@@ -46,8 +46,6 @@ registerModel({
         irModel: one('ir.model', {
             identifying: true,
             inverse: 'activityGroup',
-            readonly: true,
-            required: true,
         }),
         overdue_count: attr({
             default: 0,

--- a/addons/mail/static/src/models/activity_group_view.js
+++ b/addons/mail/static/src/models/activity_group_view.js
@@ -79,14 +79,10 @@ registerModel({
         activityGroup: one('ActivityGroup', {
             identifying: true,
             inverse: 'activityGroupViews',
-            readonly: true,
-            required: true,
         }),
         activityMenuViewOwner: one('ActivityMenuView', {
             identifying: true,
             inverse: 'activityGroupViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/activity_mark_done_popover_content_view.js
+++ b/addons/mail/static/src/models/activity_mark_done_popover_content_view.js
@@ -106,8 +106,6 @@ registerModel({
         popoverViewOwner: one('PopoverView', {
             identifying: true,
             inverse: 'activityMarkDonePopoverContentView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/activity_type.js
+++ b/addons/mail/static/src/models/activity_type.js
@@ -12,8 +12,6 @@ registerModel({
         displayName: attr(),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/activity_view.js
+++ b/addons/mail/static/src/models/activity_view.js
@@ -170,14 +170,10 @@ registerModel({
         activity: one('Activity', {
             identifying: true,
             inverse: 'activityViews',
-            required: true,
-            readonly: true,
         }),
         activityBoxView: one('ActivityBoxView', {
             identifying: true,
             inverse: 'activityViews',
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines whether the details are visible.

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -330,8 +330,6 @@ registerModel({
         filename: attr(),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * States whether this attachment is deletable.

--- a/addons/mail/static/src/models/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view.js
@@ -36,8 +36,6 @@ registerModel({
         chatter: one('Chatter', {
             identifying: true,
             inverse: 'attachmentBoxView',
-            readonly: true,
-            required: true,
         }),
         /**
          * States the OWL component displaying this attachment box.

--- a/addons/mail/static/src/models/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card.js
@@ -49,8 +49,6 @@ registerModel({
          */
         attachment: one('Attachment', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         attachmentDeleteConfirmDialog: one('Dialog', {
             inverse: 'attachmentCardOwnerAsAttachmentDeleteConfirm',
@@ -62,8 +60,6 @@ registerModel({
         attachmentList: one('AttachmentList', {
             identifying: true,
             inverse: 'attachmentCards',
-            readonly: true,
-            required: true,
         }),
         hasMultipleActions: attr({
             compute: '_computeHasMultipleActions',

--- a/addons/mail/static/src/models/attachment_delete_confirm_view.js
+++ b/addons/mail/static/src/models/attachment_delete_confirm_view.js
@@ -85,8 +85,6 @@ registerModel({
         dialogOwner: one('Dialog', {
             identifying: true,
             inverse: 'attachmentDeleteConfirmView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image.js
@@ -115,8 +115,6 @@ registerModel({
          */
         attachment: one('Attachment', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         attachmentDeleteConfirmDialog: one('Dialog', {
             inverse: 'attachmentImageOwnerAsAttachmentDeleteConfirm',
@@ -128,8 +126,6 @@ registerModel({
         attachmentList: one('AttachmentList', {
             identifying: true,
             inverse: 'attachmentImages',
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines whether `this` should display a download button.

--- a/addons/mail/static/src/models/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list.js
@@ -139,7 +139,6 @@ registerModel({
         attachmentBoxViewOwner: one('AttachmentBoxView', {
             identifying: true,
             inverse: 'attachmentList',
-            readonly: true,
         }),
         /**
          * States the attachment cards that are displaying this nonImageAttachments.
@@ -174,7 +173,6 @@ registerModel({
         composerViewOwner: one('ComposerView', {
             identifying: true,
             inverse: 'attachmentList',
-            readonly: true,
         }),
         /**
          * States the attachment that are an image.
@@ -224,7 +222,6 @@ registerModel({
         messageViewOwner: one('MessageView', {
             identifying: true,
             inverse: 'attachmentList',
-            readonly: true,
         }),
         /**
          * States the attachment that are not an image.

--- a/addons/mail/static/src/models/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer.js
@@ -251,7 +251,6 @@ registerModel({
             identifying: true,
             inverse: 'attachmentViewer',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * Style of the image (scale + rotation).

--- a/addons/mail/static/src/models/attachment_viewer_viewable.js
+++ b/addons/mail/static/src/models/attachment_viewer_viewable.js
@@ -96,7 +96,6 @@ registerModel({
         attachmentOwner: one("Attachment", {
             identifying: true,
             inverse: 'attachmentViewerViewable',
-            readonly: true,
         }),
         accessToken: attr({
             compute: "_computeAccessToken",

--- a/addons/mail/static/src/models/autocomplete_input_view.js
+++ b/addons/mail/static/src/models/autocomplete_input_view.js
@@ -89,7 +89,6 @@ registerModel({
         chatWindowOwnerAsNewMessage: one('ChatWindow', {
             identifying: true,
             inverse: 'newMessageAutocompleteInputView',
-            readonly: true,
         }),
         component: attr(),
         customClass: attr({
@@ -99,12 +98,10 @@ registerModel({
         discussSidebarCategoryOwnerAsAddingItem: one('DiscussSidebarCategory', {
             identifying: true,
             inverse: 'addingItemAutocompleteInputView',
-            readonly: true,
         }),
         discussViewOwnerAsMobileAddItemHeader: one('DiscussView', {
             identifying: true,
             inverse: 'mobileAddItemHeaderAutocompleteInputView',
-            readonly: true,
         }),
         isFocusOnMount: attr({
             compute: '_computeIsFocusOnMount',
@@ -117,7 +114,6 @@ registerModel({
         messagingMenuOwnerAsMobileNewMessageInput: one('MessagingMenu', {
             identifying: true,
             inverse: 'mobileNewMessageAutocompleteInputView',
-            readonly: true,
         }),
         placeholder: attr({
             compute: '_computePlaceholder',

--- a/addons/mail/static/src/models/call_action_list_view.js
+++ b/addons/mail/static/src/models/call_action_list_view.js
@@ -151,8 +151,6 @@ registerModel({
         callMainView: one('CallMainView', {
             identifying: true,
             inverse: 'callActionListView',
-            readonly: true,
-            required: true,
         }),
         callView: one('CallView', {
             related: 'callMainView.callView',

--- a/addons/mail/static/src/models/call_demo_view.js
+++ b/addons/mail/static/src/models/call_demo_view.js
@@ -175,7 +175,6 @@ registerModel({
         welcomeView: one('WelcomeView', {
             identifying: true,
             inverse: 'callDemoView',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_invite_request_popup.js
+++ b/addons/mail/static/src/models/call_invite_request_popup.js
@@ -36,8 +36,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'callInviteRequestPopup',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_main_view.js
+++ b/addons/mail/static/src/models/call_main_view.js
@@ -164,8 +164,6 @@ registerModel({
         callView: one('CallView', {
             identifying: true,
             inverse: 'callMainView',
-            required: true,
-            readonly: true,
         }),
         channel: one('Thread', {
             related: 'callView.channel',

--- a/addons/mail/static/src/models/call_main_view_tile.js
+++ b/addons/mail/static/src/models/call_main_view_tile.js
@@ -10,13 +10,9 @@ registerModel({
         callMainViewOwner: one('CallMainView', {
             identifying: true,
             inverse: 'mainTiles',
-            readonly: true,
-            required: true,
         }),
         channelMember: one('ChannelMember', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         participantCard: one('CallParticipantCard', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/call_option_menu.js
+++ b/addons/mail/static/src/models/call_option_menu.js
@@ -68,8 +68,6 @@ registerModel({
         callActionListView: one('CallActionListView', {
             identifying: true,
             inverse: 'callOptionMenu',
-            readonly: true,
-            required: true,
         }),
         callView: one('CallView', {
             related: 'callActionListView.callView',

--- a/addons/mail/static/src/models/call_participant_card.js
+++ b/addons/mail/static/src/models/call_participant_card.js
@@ -170,7 +170,6 @@ registerModel({
         mainViewTileOwner: one('CallMainViewTile', {
             identifying: true,
             inverse: 'participantCard',
-            readonly: true,
         }),
         /**
          * Determines if this card has to be displayed in a minimized form.
@@ -206,7 +205,6 @@ registerModel({
         sidebarViewTileOwner: one('CallSidebarViewTile', {
             identifying: true,
             inverse: 'participantCard',
-            readonly: true,
         }),
         callParticipantVideoView: one('CallParticipantVideoView', {
             compute: '_computeCallParticipantVideoView',

--- a/addons/mail/static/src/models/call_participant_video_view.js
+++ b/addons/mail/static/src/models/call_participant_video_view.js
@@ -39,8 +39,6 @@ registerModel({
         callParticipantCardOwner: one('CallParticipantCard', {
             identifying: true,
             inverse: 'callParticipantVideoView',
-            readonly: true,
-            required: true,
         }),
         rtcSession: one('RtcSession', {
             compute: '_computeRtcSession',

--- a/addons/mail/static/src/models/call_settings_menu.js
+++ b/addons/mail/static/src/models/call_settings_menu.js
@@ -84,7 +84,6 @@ registerModel({
         userSetting: one('UserSetting', {
             identifying: true,
             inverse: 'callSettingsMenu',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_sidebar_view.js
+++ b/addons/mail/static/src/models/call_sidebar_view.js
@@ -19,8 +19,6 @@ registerModel({
         callView: one('CallView', {
             identifying: true,
             inverse: 'callSidebarView',
-            readonly: true,
-            required: true,
         }),
         sidebarTiles: many('CallSidebarViewTile', {
             compute: '_computeSidebarTiles',

--- a/addons/mail/static/src/models/call_sidebar_view_tile.js
+++ b/addons/mail/static/src/models/call_sidebar_view_tile.js
@@ -10,13 +10,9 @@ registerModel({
         callSidebarViewOwner: one('CallSidebarView', {
             identifying: true,
             inverse: 'sidebarTiles',
-            readonly: true,
-            required: true,
         }),
         channelMember: one('ChannelMember', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         participantCard: one('CallParticipantCard', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/call_systray_menu.js
+++ b/addons/mail/static/src/models/call_systray_menu.js
@@ -31,8 +31,6 @@ registerModel({
         rtc: one('Rtc', {
             identifying: true,
             inverse: 'callSystrayMenu',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_view.js
+++ b/addons/mail/static/src/models/call_view.js
@@ -230,8 +230,6 @@ registerModel({
         threadView: one('ThreadView', {
             identifying: true,
             inverse: 'callView',
-            readonly: true,
-            required: true,
         }),
     },
     onChanges: [

--- a/addons/mail/static/src/models/canned_response.js
+++ b/addons/mail/static/src/models/canned_response.js
@@ -71,8 +71,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          *  The keyword to use a specific canned response.

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -92,8 +92,6 @@ registerModel({
         channel_type: attr(),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         memberCount: attr({
             related: 'thread.memberCount',

--- a/addons/mail/static/src/models/channel_command.js
+++ b/addons/mail/static/src/models/channel_command.js
@@ -128,8 +128,6 @@ registerModel({
          */
         name: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         suggestable: one('ComposerSuggestable', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -238,7 +238,6 @@ registerModel({
         chatWindow: one('ChatWindow', {
             identifying: true,
             inverse: 'channelInvitationForm',
-            readonly: true,
         }),
         /**
          * States the OWL component of this channel invitation form.
@@ -275,7 +274,6 @@ registerModel({
             identifying: true,
             inverse: 'channelInvitationForm',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * States the OWL ref of the "search" input of this channel invitation

--- a/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
+++ b/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
@@ -19,14 +19,10 @@ registerModel({
         channelInvitationFormOwner: one('ChannelInvitationForm', {
             identifying: true,
             inverse: 'selectablePartnerViews',
-            readonly: true,
-            required: true,
         }),
         partner: one('Partner', {
             identifying: true,
             inverse: 'channelInvitationFormSelectablePartnerViews',
-            readonly: true,
-            required: true,
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',

--- a/addons/mail/static/src/models/channel_invitation_form_selected_partner_view.js
+++ b/addons/mail/static/src/models/channel_invitation_form_selected_partner_view.js
@@ -9,14 +9,10 @@ registerModel({
         channelInvitationFormOwner: one('ChannelInvitationForm', {
             identifying: true,
             inverse: 'selectedPartnerViews',
-            readonly: true,
-            required: true,
         }),
         partner: one('Partner', {
             identifying: true,
             inverse: 'channelInvitationFormSelectedPartnerViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/channel_member.js
+++ b/addons/mail/static/src/models/channel_member.js
@@ -81,8 +81,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         isStreaming: attr({
             compute: '_computeIsStreaming',

--- a/addons/mail/static/src/models/channel_member_list_category_view.js
+++ b/addons/mail/static/src/models/channel_member_list_category_view.js
@@ -79,12 +79,10 @@ registerModel({
         channelMemberListViewOwnerAsOffline: one('ChannelMemberListView', {
             identifying: true,
             inverse: 'offlineCategoryView',
-            readonly: true,
         }),
         channelMemberListViewOwnerAsOnline: one('ChannelMemberListView', {
             identifying: true,
             inverse: 'onlineCategoryView',
-            readonly: true,
         }),
         channelMemberViews: many('ChannelMemberView', {
             compute: '_computeChannelMemberViews',

--- a/addons/mail/static/src/models/channel_member_list_view.js
+++ b/addons/mail/static/src/models/channel_member_list_view.js
@@ -61,7 +61,6 @@ registerModel({
         chatWindowOwner: one('ChatWindow', {
             identifying: true,
             inverse: 'channelMemberListView',
-            readonly: true,
         }),
         offlineCategoryView: one('ChannelMemberListCategoryView', {
             compute: '_computeOfflineCategoryView',
@@ -76,7 +75,6 @@ registerModel({
         threadViewOwner: one('ThreadView', {
             identifying: true,
             inverse: 'channelMemberListView',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/channel_member_view.js
+++ b/addons/mail/static/src/models/channel_member_view.js
@@ -48,14 +48,10 @@ registerModel({
         channelMemberListCategoryViewOwner: one('ChannelMemberListCategoryView', {
             identifying: true,
             inverse: 'channelMemberViews',
-            readonly: true,
-            required: true,
         }),
         channelMember: one('ChannelMember', {
             identifying: true,
             inverse: 'channelMemberViews',
-            readonly: true,
-            required: true,
         }),
         hasOpenChat: attr({
             compute: '_computeHasOpenChat',

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -660,7 +660,6 @@ registerModel({
         managerAsNewMessage: one('ChatWindowManager', {
             identifying: true,
             inverse: 'newMessageChatWindow',
-            readonly: true,
         }),
         name: attr({
             compute: '_computeName',
@@ -684,7 +683,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'chatWindow',
-            readonly: true,
         }),
         /**
          * States the `ThreadView` displaying `this.thread`.

--- a/addons/mail/static/src/models/chat_window_header_view.js
+++ b/addons/mail/static/src/models/chat_window_header_view.js
@@ -29,8 +29,6 @@ registerModel({
         chatWindowOwner: one('ChatWindow', {
             identifying: true,
             inverse: 'chatWindowHeaderView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -439,8 +439,6 @@ registerModel({
          */
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Determiners whether the attachment box is visible initially.

--- a/addons/mail/static/src/models/chatter_topbar.js
+++ b/addons/mail/static/src/models/chatter_topbar.js
@@ -42,8 +42,6 @@ registerModel({
         chatter: one('Chatter', {
             identifying: true,
             inverse: 'topbar',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/clock.js
+++ b/addons/mail/static/src/models/clock.js
@@ -62,8 +62,6 @@ registerModel({
          */
         frequency: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         tickInterval: attr({
             compute: '_computeTickInterval',

--- a/addons/mail/static/src/models/clock_watcher.js
+++ b/addons/mail/static/src/models/clock_watcher.js
@@ -13,7 +13,6 @@ registerModel({
         activityViewOwner: one('ActivityView', {
             identifying: true,
             inverse: 'clockWatcher',
-            readonly: true,
         }),
         clock: one('Clock', {
             inverse: 'watchers',
@@ -22,7 +21,6 @@ registerModel({
         messageViewOwner: one('MessageView', {
             identifying: true,
             inverse: 'clockWatcher',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/composer.js
+++ b/addons/mail/static/src/models/composer.js
@@ -187,7 +187,6 @@ registerModel({
         messageViewInEditing: one('MessageView', {
             identifying: true,
             inverse: 'composerForEditing',
-            readonly: true,
         }),
         /**
          * Placeholder displayed in the composer textarea when it's empty
@@ -221,7 +220,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'composer',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/composer_suggestable.js
+++ b/addons/mail/static/src/models/composer_suggestable.js
@@ -10,12 +10,10 @@ registerModel({
         cannedResponse: one('CannedResponse', {
             identifying: true,
             inverse: 'suggestable',
-            readonly: true,
         }),
         channelCommand: one('ChannelCommand', {
             identifying: true,
             inverse: 'suggestable',
-            readonly: true,
         }),
         composerSuggestionListViewExtraComposerSuggestionViewItems: many('ComposerSuggestionListViewExtraComposerSuggestionViewItem', {
             inverse: 'suggestable',
@@ -28,12 +26,10 @@ registerModel({
         partner: one('Partner', {
             identifying: true,
             inverse: 'suggestable',
-            readonly: true,
         }),
         thread: one('Thread', {
             identifying: true,
             inverse: 'suggestable',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
@@ -64,8 +64,6 @@ registerModel({
         composerViewOwner: one('ComposerView', {
             identifying: true,
             inverse: 'composerSuggestedRecipientListView',
-            readonly: true,
-            required: true,
         }),
         hasShowMoreButton: attr({
             default: false,

--- a/addons/mail/static/src/models/composer_suggested_recipient_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_view.js
@@ -9,14 +9,10 @@ registerModel({
         composerSuggestedRecipientListViewOwner: one('ComposerSuggestedRecipientListView', {
             identifying: true,
             inverse: 'composerSuggestedRecipientViews',
-            readonly: true,
-            required: true,
         }),
         suggestedRecipientInfo: one('SuggestedRecipientInfo', {
             identifying: true,
             inverse: 'composerSuggestedRecipientViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/composer_suggestion_list_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view.js
@@ -121,8 +121,6 @@ registerModel({
         composerViewOwner: one('ComposerView', {
             identifying: true,
             inverse: 'composerSuggestionListView',
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines whether the currently active suggestion should be scrolled

--- a/addons/mail/static/src/models/composer_suggestion_list_view_extra_composer_suggestion_view_item.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view_extra_composer_suggestion_view_item.js
@@ -15,8 +15,6 @@ registerModel({
         composerSuggestionListViewOwner: one('ComposerSuggestionListView', {
             identifying: true,
             inverse: 'composerSuggestionListViewExtraComposerSuggestionViewItems',
-            readonly: true,
-            required: true,
         }),
         composerSuggestionView: one('ComposerSuggestionView', {
             default: insertAndReplace(),
@@ -28,8 +26,6 @@ registerModel({
         suggestable: one('ComposerSuggestable', {
             identifying: true,
             inverse: 'composerSuggestionListViewExtraComposerSuggestionViewItems',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/composer_suggestion_list_view_main_composer_suggestion_view_item.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view_main_composer_suggestion_view_item.js
@@ -15,8 +15,6 @@ registerModel({
         composerSuggestionListViewOwner: one('ComposerSuggestionListView', {
             identifying: true,
             inverse: 'composerSuggestionListViewMainComposerSuggestionViewItems',
-            readonly: true,
-            required: true,
         }),
         composerSuggestionView: one('ComposerSuggestionView', {
             default: insertAndReplace(),
@@ -28,8 +26,6 @@ registerModel({
         suggestable: one('ComposerSuggestable', {
             identifying: true,
             inverse: 'composerSuggestionListViewMainComposerSuggestionViewItems',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/composer_suggestion_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_view.js
@@ -117,12 +117,10 @@ registerModel({
         composerSuggestionListViewExtraComposerSuggestionViewItemOwner: one('ComposerSuggestionListViewExtraComposerSuggestionViewItem', {
             identifying: true,
             inverse: 'composerSuggestionView',
-            readonly: true,
         }),
         composerSuggestionListViewMainComposerSuggestionViewItemOwner: one('ComposerSuggestionListViewMainComposerSuggestionViewItem', {
             identifying: true,
             inverse: 'composerSuggestionView',
-            readonly: true,
         }),
         /**
          * The text that identifies this suggestion in a mention.

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -1379,7 +1379,6 @@ registerModel({
         chatter: one('Chatter', {
             identifying: true,
             inverse: 'composerView',
-            readonly: true,
         }),
         /**
          * States the OWL component of this composer view.
@@ -1545,7 +1544,6 @@ registerModel({
         messageViewInEditing: one('MessageView', {
             identifying: true,
             inverse: 'composerViewInEditing',
-            readonly: true,
         }),
         /**
          * This is the invisible textarea used to compute the composer height
@@ -1613,7 +1611,6 @@ registerModel({
         threadView: one('ThreadView', {
             identifying: true,
             inverse: 'composerView',
-            readonly: true,
         }),
         useDragVisibleDropZone: one('UseDragVisibleDropZone', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/country.js
+++ b/addons/mail/static/src/models/country.js
@@ -25,8 +25,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         name: attr(),
     },

--- a/addons/mail/static/src/models/delete_message_confirm_view.js
+++ b/addons/mail/static/src/models/delete_message_confirm_view.js
@@ -45,8 +45,6 @@ registerModel({
         dialogOwner: one('Dialog', {
             identifying: true,
             inverse: 'deleteMessageConfirmView',
-            readonly: true,
-            required: true,
         }),
         message: one('Message', {
             compute: '_computeMessage',

--- a/addons/mail/static/src/models/dialog.js
+++ b/addons/mail/static/src/models/dialog.js
@@ -184,7 +184,6 @@ registerModel({
         attachmentCardOwnerAsAttachmentDeleteConfirm: one('AttachmentCard', {
             identifying: true,
             inverse: 'attachmentDeleteConfirmDialog',
-            readonly: true,
         }),
         attachmentDeleteConfirmView: one('AttachmentDeleteConfirmView', {
             compute: '_computeAttachmentDeleteConfirmView',
@@ -194,12 +193,10 @@ registerModel({
         attachmentImageOwnerAsAttachmentDeleteConfirm: one('AttachmentImage', {
             identifying: true,
             inverse: 'attachmentDeleteConfirmDialog',
-            readonly: true,
         }),
         attachmentListOwnerAsAttachmentView: one('AttachmentList', {
             identifying: true,
             inverse: 'attachmentListViewDialog',
-            readonly: true,
         }),
         attachmentViewer: one('AttachmentViewer', {
             compute: '_computeAttachmentViewer',
@@ -224,7 +221,6 @@ registerModel({
         followerOwnerAsSubtypeList: one('Follower', {
             identifying: true,
             inverse: 'followerSubtypeListDialog',
-            readonly: true,
         }),
         followerSubtypeList: one('FollowerSubtypeList', {
             compute: '_computeFollowerSubtypeList',
@@ -243,7 +239,6 @@ registerModel({
         messageActionListOwnerAsDeleteConfirm: one('MessageActionList', {
             identifying: true,
             inverse: 'deleteConfirmDialog',
-            readonly: true,
         }),
         /**
          * Content of dialog that is directly linked to a record that models

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -379,12 +379,10 @@ registerModel({
         discussAsChannel: one('Discuss', {
             identifying: true,
             inverse: 'categoryChannel',
-            readonly: true,
         }),
         discussAsChat: one('Discuss', {
             identifying: true,
             inverse: 'categoryChat',
-            readonly: true,
         }),
         /**
          * Determines the filtered and sorted discuss sidebar category items

--- a/addons/mail/static/src/models/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item.js
@@ -227,8 +227,6 @@ registerModel({
         category: one('DiscussSidebarCategory', {
             identifying: true,
             inverse: 'categoryItems',
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines the contribution of this discuss sidebar category item to
@@ -290,8 +288,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'discussSidebarCategoryItem',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/discuss_sidebar_mailbox_view.js
+++ b/addons/mail/static/src/models/discuss_sidebar_mailbox_view.js
@@ -29,17 +29,14 @@ registerModel({
         discussViewOwnerAsHistory: one('DiscussView', {
             identifying: true,
             inverse: 'historyView',
-            readonly: true,
         }),
         discussViewOwnerAsInbox: one('DiscussView', {
             identifying: true,
             inverse: 'inboxView',
-            readonly: true,
         }),
         discussViewOwnerAsStarred: one('DiscussView', {
             identifying: true,
             inverse: 'starredView',
-            readonly: true,
         }),
         mailbox: one('Mailbox', {
             compute: '_computeMailbox',

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -137,8 +137,6 @@ registerModel({
         discuss: one('Discuss', {
             identifying: true,
             inverse: 'discussView',
-            readonly: true,
-            required: true,
         }),
         historyView: one('DiscussSidebarMailboxView', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/drop_zone_view.js
+++ b/addons/mail/static/src/models/drop_zone_view.js
@@ -96,12 +96,10 @@ registerModel({
         chatterOwner: one('Chatter', {
             identifying: true,
             inverse: 'dropZoneView',
-            readonly: true,
         }),
         composerViewOwner: one('ComposerView', {
             identifying: true,
             inverse: 'dropZoneView',
-            readonly: true,
         }),
         /**
          * Counts how many drag enter/leave happened on self and children. This

--- a/addons/mail/static/src/models/emoji.js
+++ b/addons/mail/static/src/models/emoji.js
@@ -38,8 +38,6 @@ registerModel({
         }),
         unicode: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/emoji_category.js
+++ b/addons/mail/static/src/models/emoji_category.js
@@ -11,8 +11,6 @@ registerModel({
         }),
         categoryName: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         emojiCategoryViews: many('EmojiCategoryView', {
             inverse: 'emojiCategory',

--- a/addons/mail/static/src/models/emoji_category_bar_view.js
+++ b/addons/mail/static/src/models/emoji_category_bar_view.js
@@ -59,8 +59,6 @@ registerModel({
         emojiPickerViewOwner: one('EmojiPickerView', {
             identifying: true,
             inverse: 'emojiCategoryBarView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/emoji_category_view.js
+++ b/addons/mail/static/src/models/emoji_category_view.js
@@ -30,14 +30,10 @@ registerModel({
         emojiCategory: one('EmojiCategory', {
             identifying: true,
             inverse: 'emojiCategoryViews',
-            readonly: true,
-            required: true,
         }),
         emojiCategoryBarViewOwner: one('EmojiCategoryBarView', {
             identifying: true,
             inverse: 'emojiCategoryViews',
-            readonly: true,
-            required: true,
         }),
         emojiCategoryBarViewOwnerAsActiveByUser: one('EmojiCategoryBarView', {
             inverse: 'activeByUserCategoryView',

--- a/addons/mail/static/src/models/emoji_grid_view.js
+++ b/addons/mail/static/src/models/emoji_grid_view.js
@@ -26,8 +26,6 @@ registerModel({
         emojiPickerViewOwner: one('EmojiPickerView', {
             identifying: true,
             inverse: 'emojiGridView',
-            readonly: true,
-            required: true,
         }),
         emojiViews: many('EmojiView', {
             compute: '_computeEmojiViews',

--- a/addons/mail/static/src/models/emoji_picker_view.js
+++ b/addons/mail/static/src/models/emoji_picker_view.js
@@ -24,8 +24,6 @@ registerModel({
         popoverViewOwner: one('PopoverView', {
             identifying: true,
             inverse: 'emojiPickerView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/emoji_view.js
+++ b/addons/mail/static/src/models/emoji_view.js
@@ -36,14 +36,10 @@ registerModel({
         emoji: one('Emoji', {
             identifying: true,
             inverse: 'emojiViews',
-            readonly: true,
-            required: true,
         }),
         emojiGridView: one('EmojiGridView', {
             identifying: true,
             inverse: 'emojiViews',
-            readonly: true,
-            required: true,
         }),
         isHovered: attr({
             default: false,

--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -190,22 +190,18 @@ registerModel({
         activityView: one('ActivityView', {
             identifying: true,
             inverse: 'fileUploader',
-            readonly: true,
         }),
         attachmentBoxView: one('AttachmentBoxView', {
             identifying: true,
             inverse: 'fileUploader',
-            readonly: true,
         }),
         chatterOwner: one('Chatter', {
             identifying: true,
             inverse: 'fileUploader',
-            readonly: true,
         }),
         composerView: one('ComposerView', {
             identifying: true,
             inverse: 'fileUploader',
-            readonly: true,
         }),
         fileInput: attr({
             compute: '_computeFileInput',

--- a/addons/mail/static/src/models/follow_button_view.js
+++ b/addons/mail/static/src/models/follow_button_view.js
@@ -65,7 +65,6 @@ registerModel({
         chatterOwner: one('Chatter', {
             identifying: true,
             inverse: 'followButtonView',
-            readonly: true,
         }),
         isDisabled: attr({
             compute: '_computeIsDisabled',

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -184,8 +184,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         isActive: attr({
             default: true,

--- a/addons/mail/static/src/models/follower_list_menu_view.js
+++ b/addons/mail/static/src/models/follower_list_menu_view.js
@@ -49,7 +49,6 @@ registerModel({
         chatterOwner: one('Chatter', {
             identifying: true,
             inverse: 'followerListMenuView',
-            readonly: true,
         }),
         followerViews: many('FollowerView', {
             compute: '_computeFollowerViews',

--- a/addons/mail/static/src/models/follower_subtype.js
+++ b/addons/mail/static/src/models/follower_subtype.js
@@ -43,8 +43,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         isDefault: attr({
             default: false,

--- a/addons/mail/static/src/models/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list.js
@@ -70,7 +70,6 @@ registerModel({
             identifying: true,
             inverse: 'followerSubtypeList',
             isCausal: true,
-            readonly: true,
         }),
         follower: one('Follower', {
             related: 'dialogOwner.followerOwnerAsSubtypeList',

--- a/addons/mail/static/src/models/follower_subtype_view.js
+++ b/addons/mail/static/src/models/follower_subtype_view.js
@@ -26,14 +26,10 @@ registerModel({
         followerSubtypeListOwner: one('FollowerSubtypeList', {
             identifying: true,
             inverse: 'followerSubtypeViews',
-            readonly: true,
-            required: true,
         }),
         subtype: one('FollowerSubtype', {
             identifying: true,
             inverse: 'followerSubtypeViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/follower_view.js
+++ b/addons/mail/static/src/models/follower_view.js
@@ -39,14 +39,10 @@ registerModel({
         follower: one('Follower', {
             identifying: true,
             inverse: 'followerViews',
-            readonly: true,
-            required: true,
         }),
         followerListMenuViewOwner: one('FollowerListMenuView', {
             identifying: true,
             inverse: 'followerViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/guest.js
+++ b/addons/mail/static/src/models/guest.js
@@ -47,8 +47,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            required: true,
-            readonly: true,
         }),
         im_status: attr(),
         isOnline: attr({

--- a/addons/mail/static/src/models/ir_model.js
+++ b/addons/mail/static/src/models/ir_model.js
@@ -28,8 +28,6 @@ registerModel({
         iconUrl: attr(),
         id: attr({
             identifying: true,
-            required: true,
-            readonly: true,
         }),
         model: attr({
             required: true,

--- a/addons/mail/static/src/models/mail_template.js
+++ b/addons/mail/static/src/models/mail_template.js
@@ -50,8 +50,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         name: attr(),
     },

--- a/addons/mail/static/src/models/mail_template_view.js
+++ b/addons/mail/static/src/models/mail_template_view.js
@@ -27,13 +27,9 @@ registerModel({
         activityViewOwner: one('ActivityView', {
             identifying: true,
             inverse: 'mailTemplateViews',
-            readonly: true,
-            required: true,
         }),
         mailTemplate: one('MailTemplate', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/mailbox.js
+++ b/addons/mail/static/src/models/mailbox.js
@@ -118,17 +118,14 @@ registerModel({
         messagingAsHistory: one('Messaging', {
             identifying: true,
             inverse: 'history',
-            readonly: true,
         }),
         messagingAsInbox: one('Messaging', {
             identifying: true,
             inverse: 'inbox',
-            readonly: true,
         }),
         messagingAsStarred: one('Messaging', {
             identifying: true,
             inverse: 'starred',
-            readonly: true,
         }),
         name: attr({
             compute: '_computeName',

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -690,8 +690,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         isCurrentUserOrGuestAuthor: attr({
             compute: '_computeIsCurrentUserOrGuestAuthor',

--- a/addons/mail/static/src/models/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list.js
@@ -187,8 +187,6 @@ registerModel({
         messageView: one('MessageView', {
             identifying: true,
             inverse: 'messageActionList',
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines the reaction popover that is active on this message action list.

--- a/addons/mail/static/src/models/message_author_prefix_view.js
+++ b/addons/mail/static/src/models/message_author_prefix_view.js
@@ -45,12 +45,10 @@ registerModel({
         threadNeedactionPreviewViewOwner: one('ThreadNeedactionPreviewView', {
             identifying: true,
             inverse: 'messageAuthorPrefixView',
-            readonly: true,
         }),
         threadPreviewViewOwner: one('ThreadPreviewView', {
             identifying: true,
             inverse: 'messageAuthorPrefixView',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view.js
@@ -61,8 +61,6 @@ registerModel({
         messageView: one('MessageView', {
             identifying: true,
             inverse: 'messageInReplyToView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/message_list_view.js
+++ b/addons/mail/static/src/models/message_list_view.js
@@ -126,8 +126,6 @@ registerModel({
         threadViewOwner: one('ThreadView', {
             identifying: true,
             inverse: 'messageListView',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/message_list_view_message_view_item.js
+++ b/addons/mail/static/src/models/message_list_view_message_view_item.js
@@ -17,14 +17,10 @@ registerModel({
         message: one('Message', {
             identifying: true,
             inverse: 'messageListViewMessageViewItems',
-            readonly: true,
-            required: true,
         }),
         messageListViewOwner: one('MessageListView', {
             identifying: true,
             inverse: 'messageListViewMessageViewItems',
-            readonly: true,
-            required: true,
         }),
         messageView: one('MessageView', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group.js
@@ -75,8 +75,6 @@ registerModel({
     fields: {
         content: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         count: attr({
             required: true,
@@ -93,8 +91,6 @@ registerModel({
             compute: '_computeMessage',
             identifying: true,
             inverse: 'messageReactionGroups',
-            readonly: true,
-            required: true,
         }),
         messageId: attr({
             readonly: true,

--- a/addons/mail/static/src/models/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator.js
@@ -258,8 +258,6 @@ registerModel({
          */
         message: one('Message', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         partnersThatHaveFetched: many('Partner', {
             compute: '_computePartnersThatHaveFetched',
@@ -277,8 +275,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'messageSeenIndicators',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/message_seen_indicator_view.js
+++ b/addons/mail/static/src/models/message_seen_indicator_view.js
@@ -25,8 +25,6 @@ registerModel({
         messageViewOwner: one('MessageView', {
             identifying: true,
             inverse: 'messageSeenIndicatorView',
-            readonly: true,
-            required: true,
         }),
         messageSeenIndicator: one('MessageSeenIndicator', {
             compute: '_computeMessageSeenIndicator',

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -473,7 +473,6 @@ registerModel({
         deleteMessageConfirmViewOwner: one('DeleteMessageConfirmView', {
             identifying: true,
             inverse: 'messageView',
-            readonly: true,
         }),
         /**
          * Determines whether this message view should be highlighted at next
@@ -600,7 +599,6 @@ registerModel({
         messageListViewMessageViewItemOwner: one('MessageListViewMessageViewItem', {
             identifying: true,
             inverse: 'messageView',
-            readonly: true,
         }),
         messageSeenIndicatorView: one('MessageSeenIndicatorView', {
             compute: '_computeMessageSeenIndicatorView',

--- a/addons/mail/static/src/models/mobile_messaging_navbar_view.js
+++ b/addons/mail/static/src/models/mobile_messaging_navbar_view.js
@@ -99,12 +99,10 @@ registerModel({
         discuss: one('Discuss', {
             identifying: true,
             inverse: 'mobileMessagingNavbarView',
-            readonly: true,
         }),
         messagingMenu: one('MessagingMenu', {
             identifying: true,
             inverse: 'mobileMessagingNavbarView',
-            readonly: true,
         }),
         /**
          * Ordered list of tabs that this navbar has.

--- a/addons/mail/static/src/models/notification.js
+++ b/addons/mail/static/src/models/notification.js
@@ -131,8 +131,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         isFailure: attr({
             compute: '_computeIsFailure',

--- a/addons/mail/static/src/models/notification_group.js
+++ b/addons/mail/static/src/models/notification_group.js
@@ -113,7 +113,6 @@ registerModel({
         }),
         notification_type: attr({
             identifying: true,
-            readonly: true,
         }),
         notifications: many('Notification', {
             inverse: 'notificationGroup',
@@ -124,11 +123,9 @@ registerModel({
         }),
         res_id: attr({
             identifying: true,
-            readonly: true,
         }),
         res_model: attr({
             identifying: true,
-            readonly: true,
         }),
         res_model_name: attr(),
         /**

--- a/addons/mail/static/src/models/notification_group_view.js
+++ b/addons/mail/static/src/models/notification_group_view.js
@@ -53,14 +53,10 @@ registerModel({
         notificationGroup: one('NotificationGroup', {
             identifying: true,
             inverse: 'notificationGroupViews',
-            readonly: true,
-            required: true,
         }),
         notificationListViewOwner: one('NotificationListView', {
             identifying: true,
             inverse: 'notificationGroupViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/notification_list_view.js
+++ b/addons/mail/static/src/models/notification_list_view.js
@@ -182,7 +182,6 @@ registerModel({
         discussOwner: one('Discuss', {
             identifying: true,
             inverse: 'notificationListView',
-            readonly: true,
         }),
         filter: attr({
             compute: '_computeFilter',
@@ -193,7 +192,6 @@ registerModel({
         messagingMenuOwner: one('MessagingMenu', {
             identifying: true,
             inverse: 'notificationListView',
-            readonly: true,
         }),
         notificationGroupViews: many('NotificationGroupView', {
             compute: '_computeNotificationGroupViews',

--- a/addons/mail/static/src/models/notification_request_view.js
+++ b/addons/mail/static/src/models/notification_request_view.js
@@ -37,8 +37,6 @@ registerModel({
         notificationListViewOwner: one('NotificationListView', {
             identifying: true,
             inverse: 'notificationRequestView',
-            required: true,
-            readonly: true,
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',

--- a/addons/mail/static/src/models/other_member_long_typing_in_thread_timer.js
+++ b/addons/mail/static/src/models/other_member_long_typing_in_thread_timer.js
@@ -15,14 +15,10 @@ registerModel({
         partner: one('Partner', {
             identifying: true,
             inverse: 'otherMemberLongTypingInThreadTimers',
-            readonly: true,
-            required: true,
         }),
         thread: one('Thread', {
             identifying: true,
             inverse: 'otherMembersLongTypingTimers',
-            readonly: true,
-            required: true,
         }),
         timer: one('Timer', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -409,8 +409,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         im_status: attr(),
         isImStatusSet: attr({

--- a/addons/mail/static/src/models/persona.js
+++ b/addons/mail/static/src/models/persona.js
@@ -43,7 +43,6 @@ registerModel({
         guest: one('Guest', {
             identifying: true,
             inverse: 'persona',
-            readonly: true,
         }),
         im_status: attr({
             compute: '_computeImStatus',
@@ -56,7 +55,6 @@ registerModel({
         partner: one('Partner', {
             identifying: true,
             inverse: 'persona',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/persona_im_status_icon_view.js
+++ b/addons/mail/static/src/models/persona_im_status_icon_view.js
@@ -46,37 +46,30 @@ registerModel({
         channelInvitationFormSelectablePartnerViewOwner: one('ChannelInvitationFormSelectablePartnerView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         channelMemberViewOwner: one('ChannelMemberView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         composerSuggestionViewOwner: one('ComposerSuggestionView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         messageViewOwner: one('MessageView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         notificationRequestViewOwner: one('NotificationRequestView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         threadNeedactionPreviewViewOwner: one('ThreadNeedactionPreviewView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         threadPreviewViewOwner: one('ThreadPreviewView', {
             identifying: true,
             inverse: 'personaImStatusIconView',
-            readonly: true,
         }),
         persona: one('Persona', {
             compute: '_computePersona',

--- a/addons/mail/static/src/models/popover_view.js
+++ b/addons/mail/static/src/models/popover_view.js
@@ -181,7 +181,6 @@ registerModel({
         activityViewOwnerAsMarkDone: one('ActivityView', {
             identifying: true,
             inverse: 'markDonePopoverView',
-            readonly: true,
         }),
         /**
          * HTML element that is used as anchor position for this popover view.
@@ -209,7 +208,6 @@ registerModel({
         composerViewOwnerAsEmoji: one('ComposerView', {
             identifying: true,
             inverse: 'emojisPopoverView',
-            readonly: true,
         }),
         /**
          * Determines the record that is content of this popover view.
@@ -254,7 +252,6 @@ registerModel({
         messageActionListOwnerAsReaction: one('MessageActionList', {
             identifying: true,
             inverse: 'reactionPopoverView',
-            readonly: true,
         }),
         /**
          * Position of the popover view relative to its anchor point.
@@ -270,7 +267,6 @@ registerModel({
         threadViewTopbarOwnerAsInvite: one('ThreadViewTopbar', {
             identifying: true,
             inverse: 'invitePopoverView',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/res_users_settings.js
+++ b/addons/mail/static/src/models/res_users_settings.js
@@ -11,8 +11,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         is_discuss_sidebar_category_channel_open: attr({
             default: true,

--- a/addons/mail/static/src/models/res_users_settings_volumes.js
+++ b/addons/mail/static/src/models/res_users_settings_volumes.js
@@ -31,8 +31,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         partner_id: one('Partner', {
             inverse: 'volumeSetting',

--- a/addons/mail/static/src/models/rtc_data_channel.js
+++ b/addons/mail/static/src/models/rtc_data_channel.js
@@ -18,8 +18,6 @@ registerModel({
         rtcSession: one('RtcSession', {
             identifying: true,
             inverse: 'rtcDataChannel',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/rtc_peer_connection.js
+++ b/addons/mail/static/src/models/rtc_peer_connection.js
@@ -60,8 +60,6 @@ registerModel({
         rtcSession: one('RtcSession', {
             identifying: true,
             inverse: 'rtcPeerConnection',
-            readonly: true,
-            required: true,
         }),
     },
     onChanges: [

--- a/addons/mail/static/src/models/rtc_peer_notification.js
+++ b/addons/mail/static/src/models/rtc_peer_notification.js
@@ -21,8 +21,6 @@ registerModel({
          */
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         payload: attr({
             readonly: true,

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -380,8 +380,6 @@ registerModel({
          */
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Channels on which this session is inviting the current partner,

--- a/addons/mail/static/src/models/sound_effect.js
+++ b/addons/mail/static/src/models/sound_effect.js
@@ -61,8 +61,6 @@ registerModel({
          */
         filename: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Path to the audio file.
@@ -70,8 +68,6 @@ registerModel({
         path: attr({
             default: '/mail/static/src/audio/',
             identifying: true,
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info.js
@@ -65,7 +65,6 @@ registerModel({
          */
         id: attr({
             identifying: true,
-            readonly: true,
         }),
         /**
          * Determines whether `this` will be added to recipients when posting a

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1949,8 +1949,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         invitationLink: attr({
             compute: '_computeInvitationLink',
@@ -2146,8 +2144,6 @@ registerModel({
         }),
         model: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         model_name: attr(),
         moduleIcon: attr(),

--- a/addons/mail/static/src/models/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache.js
@@ -360,8 +360,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'cache',
-            readonly: true,
-            required: true,
         }),
         /**
          * States the 'ThreadView' that are currently displaying `this`.

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -110,8 +110,6 @@ registerModel({
         notificationListViewOwner: one('NotificationListView', {
             identifying: true,
             inverse: 'threadNeedactionPreviewViews',
-            readonly: true,
-            required: true,
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
@@ -122,8 +120,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'threadNeedactionPreviewViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info.js
@@ -13,8 +13,6 @@ registerModel({
          */
         partner: one('Partner', {
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Thread (channel) that this seen info is related to.
@@ -22,8 +20,6 @@ registerModel({
         thread: one('Thread', {
             inverse: 'partnerSeenInfos',
             identifying: true,
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/thread_preview_view.js
+++ b/addons/mail/static/src/models/thread_preview_view.js
@@ -108,8 +108,6 @@ registerModel({
         notificationListViewOwner: one('NotificationListView', {
             identifying: true,
             inverse: 'threadPreviewViews',
-            readonly: true,
-            required: true,
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
@@ -120,8 +118,6 @@ registerModel({
         thread: one('Thread', {
             identifying: true,
             inverse: 'threadPreviewViews',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -527,8 +527,6 @@ registerModel({
         threadViewer: one('ThreadViewer', {
             identifying: true,
             inverse: 'threadView',
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines the top bar of this thread view, if any.

--- a/addons/mail/static/src/models/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar.js
@@ -698,8 +698,6 @@ registerModel({
         threadView: one('ThreadView', {
             identifying: true,
             inverse: 'topbar',
-            readonly: true,
-            required: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_viewer.js
@@ -75,12 +75,10 @@ registerModel({
         chatter: one('Chatter', {
             identifying: true,
             inverse: 'threadViewer',
-            readonly: true,
         }),
         chatWindow: one('ChatWindow', {
             identifying: true,
             inverse: 'threadViewer',
-            readonly: true,
         }),
         /**
          * true if the viewer is in a compact format, like in a chat window.
@@ -91,12 +89,10 @@ registerModel({
         discuss: one('Discuss', {
             identifying: true,
             inverse: 'threadViewer',
-            readonly: true,
         }),
         discussPublicView: one('DiscussPublicView', {
             identifying: true,
             inverse: 'threadViewer',
-            readonly: true,
         }),
         /**
          * Determines which extra class this thread view component should have.

--- a/addons/mail/static/src/models/throttle.js
+++ b/addons/mail/static/src/models/throttle.js
@@ -73,7 +73,6 @@ registerModel({
         threadAsThrottleNotifyCurrentPartnerTypingStatus: one('Thread', {
             identifying: true,
             inverse: 'throttleNotifyCurrentPartnerTypingStatus',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/timer.js
+++ b/addons/mail/static/src/models/timer.js
@@ -115,12 +115,10 @@ registerModel({
         callMainViewAsShowOverlay: one('CallMainView', {
             identifying: true,
             inverse: 'showOverlayTimer',
-            readonly: true,
         }),
         chatterOwnerAsAttachmentsLoader: one('Chatter', {
             identifying: true,
             inverse: 'attachmentsLoaderTimer',
-            readonly: true,
         }),
         /**
          * Duration, in milliseconds, until timer times out and calls the
@@ -134,38 +132,31 @@ registerModel({
         messagingOwnerAsFetchImStatusTimer: one('Messaging', {
             identifying: true,
             inverse: 'fetchImStatusTimer',
-            readonly: true,
         }),
         messageViewOwnerAsHighlight: one('MessageView', {
             identifying: true,
             inverse: 'highlightTimer',
-            readonly: true,
         }),
         otherMemberLongTypingInThreadTimerOwner: one('OtherMemberLongTypingInThreadTimer', {
             identifying: true,
             inverse: 'timer',
             isCausal: true,
-            readonly: true,
         }),
         rtcSessionOwnerAsBroadcast: one('RtcSession', {
             identifying: true,
             inverse: 'broadcastTimer',
-            readonly: true,
         }),
         threadAsCurrentPartnerInactiveTypingTimerOwner: one('Thread', {
             identifying: true,
             inverse: 'currentPartnerInactiveTypingTimer',
-            readonly: true,
         }),
         threadAsCurrentPartnerLongTypingTimerOwner: one('Thread', {
             identifying: true,
             inverse: 'currentPartnerLongTypingTimer',
-            readonly: true,
         }),
         throttleOwner: one('Throttle', {
             identifying: true,
             inverse: 'cooldownTimer',
-            readonly: true,
         }),
         /**
          * Internal reference of `setTimeout()` that is used to invoke function

--- a/addons/mail/static/src/models/tracking_value.js
+++ b/addons/mail/static/src/models/tracking_value.js
@@ -30,8 +30,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         messageOwner: one('Message', {
             inverse: 'trackingValues',

--- a/addons/mail/static/src/models/tracking_value_item.js
+++ b/addons/mail/static/src/models/tracking_value_item.js
@@ -92,12 +92,10 @@ registerModel({
         trackingValueAsNewValue: one('TrackingValue', {
             identifying: true,
             inverse: 'newValue',
-            readonly: true,
         }),
         trackingValueAsOldValue: one('TrackingValue', {
             identifying: true,
             inverse: 'oldValue',
-            readonly: true,
         }),
         /**
          * The original value of the tracking value item.

--- a/addons/mail/static/src/models/use_drag_visible_drop_zone.js
+++ b/addons/mail/static/src/models/use_drag_visible_drop_zone.js
@@ -71,12 +71,10 @@ registerModel({
         chatterOwner: one('Chatter', {
             identifying: true,
             inverse: 'useDragVisibleDropZone',
-            readonly: true,
         }),
         composerViewOwner: one('ComposerView', {
             identifying: true,
             inverse: 'useDragVisibleDropZone',
-            readonly: true,
         }),
         /**
          * Counts how many drag enter/leave happened globally. This is the only

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -177,8 +177,6 @@ registerModel({
         }),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Determines whether this user is an internal user. An internal user is

--- a/addons/mail/static/src/models/web_client_view_attachment_view.js
+++ b/addons/mail/static/src/models/web_client_view_attachment_view.js
@@ -57,8 +57,6 @@ registerModel({
         component: attr(),
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         iframeViewerPdfRef: attr(),
         thread: one('Thread', {

--- a/addons/mail/static/src/models/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view.js
@@ -137,8 +137,6 @@ registerModel({
         discussPublicView: one('DiscussPublicView', {
             identifying: true,
             inverse: 'welcomeView',
-            readonly: true,
-            required: true,
         }),
         /**
          * States the OWL ref the to input element containing the

--- a/addons/mail/static/tests/models/clock_watcher_qunit_tests.js
+++ b/addons/mail/static/tests/models/clock_watcher_qunit_tests.js
@@ -9,6 +9,5 @@ addFields('ClockWatcher', {
     qunitTestOwner: one('QUnitTest', {
         identifying: true,
         inverse: 'clockWatcher',
-        readonly: true,
     }),
 });

--- a/addons/mail/static/tests/models/test_models.js
+++ b/addons/mail/static/tests/models/test_models.js
@@ -9,8 +9,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         addressInfo: attr(),
         contact: one('TestContact', {
@@ -24,8 +22,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         address: one('TestAddress', {
             inverse: 'contact',
@@ -50,8 +46,6 @@ registerModel({
     fields: {
         description: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
     },
 });
@@ -61,8 +55,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         title: attr(),
         difficulty: attr({

--- a/addons/mail/static/tests/models/throttle_qunit_tests.js
+++ b/addons/mail/static/tests/models/throttle_qunit_tests.js
@@ -9,12 +9,10 @@ addFields('Throttle', {
     qunitTestOwner1: one('QUnitTest', {
         identifying: true,
         inverse: 'throttle1',
-        readonly: true,
     }),
     qunitTestOwner2: one('QUnitTest', {
         identifying: true,
         inverse: 'throttle2',
-        readonly: true,
     }),
 });
 

--- a/addons/mail/static/tests/models/timer_qunit_tests.js
+++ b/addons/mail/static/tests/models/timer_qunit_tests.js
@@ -9,12 +9,10 @@ addFields('Timer', {
     qunitTestOwner1: one('QUnitTest', {
         identifying: true,
         inverse: 'timer1',
-        readonly: true,
     }),
     qunitTestOwner2: one('QUnitTest', {
         identifying: true,
         inverse: 'timer2',
-        readonly: true,
     }),
 });
 

--- a/addons/rating/static/src/models/rating.js
+++ b/addons/rating/static/src/models/rating.js
@@ -8,8 +8,6 @@ registerModel({
     fields: {
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         ratingImageUrl: attr({
             readonly: true,

--- a/addons/snailmail/static/src/models/dialog.js
+++ b/addons/snailmail/static/src/models/dialog.js
@@ -10,7 +10,6 @@ addFields('Dialog', {
     messageViewOwnerAsSnailmailError: one('MessageView', {
         identifying: true,
         inverse: 'snailmailErrorDialog',
-        readonly: true,
     }),
     snailmailErrorView: one('SnailmailErrorView', {
         compute: '_computeSnailmailErrorView',

--- a/addons/snailmail/static/src/models/snailmail_error_view.js
+++ b/addons/snailmail/static/src/models/snailmail_error_view.js
@@ -60,8 +60,6 @@ registerModel({
         dialogOwner: one('Dialog', {
             identifying: true,
             inverse: 'snailmailErrorView',
-            readonly: true,
-            required: true,
         }),
         hasCreditsError: attr({
             compute: '_computeHasCreditsError',

--- a/addons/website_livechat/static/src/models/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor.js
@@ -108,8 +108,6 @@ registerModel({
          */
         id: attr({
             identifying: true,
-            readonly: true,
-            required: true,
         }),
         /**
          * Determine whether the visitor is connected or not.


### PR DESCRIPTION
Automatically add `required` and `readonly` on identifying fields and remove them from field definition.

Task-2955910.
\* = calendar, hr, im_livechat, rating, snailmail, website_livechat

Enterprise: odoo/enterprise#30511