### PR TITLE
[FIX] web: Fix input style in editable list

### DIFF
--- a/addons/web/static/src/views/list/list_controller.scss
+++ b/addons/web/static/src/views/list/list_controller.scss
@@ -279,6 +279,8 @@
                 .o_input {
                     border: none;
                     padding: 0;
+                    margin: 0;
+                    width: 100%;
                 }
                 &.o_field_text {
                     vertical-align: top;


### PR DESCRIPTION
This commit fixes a visual issue with the input element of field widgets
in editable lists: the inputs were too narrow and offset to the left.

These inputs should now take the whole width of their containing cells.

> *Example view: CRM / Configuration / Tags*

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
