### PR TITLE
[FIX] sale: portal: automatically open the popup for payment

### DIFF
--- a/addons/sale/static/src/js/sale_portal_sidebar.js
+++ b/addons/sale/static/src/js/sale_portal_sidebar.js
@@ -26,7 +26,7 @@ publicWidget.registry.SalePortalSidebar = PortalSidebar.extend({
         this._generateMenu();
         // After signature, automatically open the popup for payment
         if ($.bbq.getState('allow_payment') === 'yes' && this.$('#o_sale_portal_paynow').length) {
-            this.$('#o_sale_portal_paynow').trigger('click');
+            this.el.querySelector('#o_sale_portal_paynow').click();
             $.bbq.removeState('allow_payment');
         }
         return def;


### PR DESCRIPTION
Before this commit, the popup for payment wasn't open after signature.

This is because Bootstrap no longer uses jQuery and jQuery .trigger
only calls jQuery handlers.

See 'o_sale_portal_paynow' button with data-bs attributes on it.

