### PR TITLE
[FIX] web_editor, *: make the disabled remove form field button red too

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -570,6 +570,7 @@ var SnippetEditor = Widget.extend({
         $optionsSection.on('mouseenter', this._onOptionsSectionMouseEnter.bind(this));
         $optionsSection.on('mouseleave', this._onOptionsSectionMouseLeave.bind(this));
         $optionsSection.on('click', 'we-title > span', this._onOptionsSectionClick.bind(this));
+        // TODO In master: restrict selectors to `:not(.o_disabled)`.
         $optionsSection.on('click', '.oe_snippet_clone', this._onCloneClick.bind(this));
         $optionsSection.on('click', '.oe_snippet_remove', this._onRemoveClick.bind(this));
         this._customize$Elements.push($optionsSection);

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1720,9 +1720,14 @@ body.editor_enable.editor_has_snippets {
                         color: $o-we-fg-lighter;
                     }
                 }
-                > .oe_snippet_remove {
+                // TODO In master: restore `.oe_snippet_remove`.
+                > .fa-trash {
                     margin-left: $o-we-sidebar-content-field-button-group-button-spacing;
-                    background-color: mix($o-we-color-danger, $o-we-sidebar-content-field-clickable-bg);;
+                    background-color: mix($o-we-color-danger, $o-we-sidebar-content-field-clickable-bg);
+                    // TODO In master: use `.o_disabled`.
+                    &:not(.oe_snippet_remove) {
+                        opacity: 0.5;
+                    }
                 }
                 > .o_overlay_move_options > .o_move_handle {
                     cursor: move;
@@ -1743,9 +1748,14 @@ body.editor_enable.editor_has_snippets {
                             }
                         }
                     }
-                    > .oe_snippet_remove:hover {
+                    // TODO In master: restore `.oe_snippet_remove`.
+                    > .fa-trash:hover {
                         border-color: mix($o-we-color-danger, $o-we-sidebar-content-field-pressed-bg, .4);
                         background-color: $o-we-color-danger;
+                        // TODO In master: use `.o_disabled`.
+                        &:not(.oe_snippet_remove) {
+                            opacity: 0.5;
+                        }
                     }
                 }
             }

--- a/addons/website_form/static/src/snippets/s_website_form/options.js
+++ b/addons/website_form/static/src/snippets/s_website_form/options.js
@@ -1341,6 +1341,7 @@ const DisableOverlayButtonOption = options.Class.extend({
         this.$overlay.add(this.$overlay.data('$optionsSection')).on('click', '.' + className, this.preventButton);
         const $button = this.$overlay.add(this.$overlay.data('$optionsSection')).find('.' + className);
         $button.attr('title', message).tooltip({delay: 0});
+        // TODO In master: add `o_disabled` but keep actual class.
         $button.removeClass(className); // Disable the functionnality
     },
 


### PR DESCRIPTION
*: website_form

The fields of a form that are mandatory because of the model they need
to be used in cannot be removed. When such a field is selected, the
remove button displays a tooltip giving this information.
Disabling the overlay button is done by removing the specific class -
which makes the event selector not linked to the button, but also
impacts the applied CSS rules.

In stable, this commit only updates the CSS to keep the look-and-feel of
the remove button when it is disabled.

In master, this commit will add an `o_disabled` CSS class upon disabling
buttons and adapt the event selectors accordingly - making it possible
to not impact any `oe_snippet_*`-specific CSS rule.

Steps to reproduce:
- Drop a "Form" block.
- Select the "Phone Number" field.
- The overlay's delete icon has a reddish background.
- Select the "Your Email" field.
=> The overlay's delete icon had a dark gray background instead of a
reddish one.

task-2950433
