### PR TITLE
[FIX] stock: BOM unit in MO roundoff to 2 decimal places

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -82,16 +82,17 @@ class StockQuant(models.Model):
         readonly=True)
     inventory_quantity = fields.Float(
         'Inventoried Quantity', compute='_compute_inventory_quantity',
-        inverse='_set_inventory_quantity', groups='stock.group_stock_manager')
+        inverse='_set_inventory_quantity', groups='stock.group_stock_manager',
+        digits='Product Unit of Measure')
     reserved_quantity = fields.Float(
         'Reserved Quantity',
         default=0.0,
         help='Quantity of reserved products in this quant, in the default unit of measure of the product',
-        readonly=True, required=True)
+        readonly=True, required=True, digits='Product Unit of Measure')
     available_quantity = fields.Float(
         'Available Quantity',
         help="On hand quantity which hasn't been reserved on a transfer, in the default unit of measure of the product",
-        compute='_compute_available_quantity')
+        compute='_compute_available_quantity', digits='Product Unit of Measure')
     in_date = fields.Datetime('Incoming Date', readonly=True)
     tracking = fields.Selection(related='product_id.tracking', readonly=True)
     on_hand = fields.Boolean('On Hand', store=False, search='_search_on_hand')


### PR DESCRIPTION
Steps to reproduce the bug:
* Go to Technical > Decimal Accuracy > Set the product unit quantity to 7
* Go to any UOM and set the precision to 7 decimal places
* It turns to 5 decimal places (Why this behavior? Is this a limitation?)
* Set the accuracy as 5 0.00001
* Go to any product, set the quantity as 1.79864 it auto sets to 1.80

Solution:
The number of digits for float fields in xml are by default 2, just increase it
to 10 have more precision.

opw-2942825
