### PR TITLE
[ADD] l10n_nl_reports_sbr: Send Tax Report to the Dutch gov

### DIFF
--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -30,6 +30,7 @@
         'data/menuitem.xml',
         'views/res_partner_views.xml',
         'views/res_company_views.xml',
+        'views/res_config_settings_view.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_nl/views/res_config_settings_view.xml
+++ b/addons/l10n_nl/views/res_config_settings_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="res_config_settings_view_form">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='account']/div" position="after">
+                <div id="dutch_localization_section" invisible="1">
+                    <h2 attrs="{'invisible':[('country_code', '!=', 'NL')]}">Dutch Localization</h2>
+                    <div class="row mt16 o_settings_container" id="dutch_localization" attrs="{'invisible':[('country_code', '!=', 'NL')]}">
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ xlrd==1.2.0; python_version >= '3.8'
 XlsxWriter==1.1.2
 xlwt==1.3.*
 zeep==3.4.0
+xmlsec==1.3.12


### PR DESCRIPTION
Add a new section in the settings dedicated for Dutch company settings.
Used in the new Dutch SBR module (l10n_nl_reports_sbr)