### PR TITLE
[FIX] hr_holidays: fix allocated days count on accrual plan

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -415,7 +415,7 @@ class HolidaysAllocation(models.Model):
                     allocation.nextcall = min(second_level_start_date, allocation.nextcall)
                 allocation._message_log(body=first_allocation)
             days_added_per_level = defaultdict(lambda: 0)
-            while allocation.nextcall <= today:
+            while allocation.lastcall < today:
                 (current_level, current_level_idx) = allocation._get_current_accrual_plan_level_id(allocation.nextcall)
                 nextcall = current_level._get_next_date(allocation.nextcall)
                 # Since _get_previous_date returns the given date if it corresponds to a call date


### PR DESCRIPTION
To Reproduce
=============
Being in 17 August 2022
- create a new Accrual Plan specifying 2.09 days per month for example, starting at the 1st of each month
- create an Allocation of type accrual with that created accrual plan, and dates from 01/06/2022

Problem
=======
The allocation duration is wrong (4.18 days), it should be 6.27 days (3 * 2.09) as we went through 3 beginnings of months
the compute of allocation duration was based on the `nextcall` which starts from 07/01/2022 (in our example),
so we don't take into consideration the Beginning of June.

Solution
=========
To solve the issue we compute the allocation duration using `lastcall` instead.

opw-2948609
