### PR TITLE
[FIX] sale: add a customer order date

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -81,6 +81,7 @@ class SaleOrder(models.Model):
         default='draft')
 
     client_order_ref = fields.Char(string="Customer Reference", copy=False)
+    client_order_date = fields.Char(string="Customer Reference Date", copy=False)
     create_date = fields.Datetime(  # Override of default create_date field from ORM
         string="Creation Date", index=True, readonly=True)
     commitment_date = fields.Datetime(

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -587,6 +587,7 @@
                                 <field name="require_payment"/>
                                 <field name="reference" readonly="1" attrs="{'invisible': [('reference', '=', False)]}"/>
                                 <field name="client_order_ref"/>
+                                <field name="client_order_date"/>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             </group>
                             <group name="sale_info" string="Invoicing and Payments">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Adds a client order date for its references

Current behavior before PR:
(Particularly in Chilean localization) there is no way to define a different date for the referenced PO date, which is required by several companies as a condition to process the payments. (Especially mining companies).

Desired behavior after PR is merged:
We have a way to add the PO date in the sale order form





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
