### PR TITLE
[FIX] web_editor: properly remove image loading attribute

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -123,6 +123,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         this.$content.find('.o_layout').addBack().data('name', 'Mailing');
         // We don't want to drop snippets directly within the wysiwyg.
         this.$content.removeClass('o_editable');
+        this.wysiwyg.getEditable().find('img').attr('loading', '');
     },
     /**
      * Returns true if the editable area is empty.
@@ -158,11 +159,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
             this.value = this.recordData[this.nodeOptions['inline-field']];
         }
         return this._super.apply(this, arguments);
-    },
-    _createWysiwygInstance: async function () {
-        const res = await this._super(...arguments);
-        this.wysiwyg.getEditable().find('img').attr('loading', '');
-        return res;
     },
 
     /**


### PR DESCRIPTION
The fix that removed the loading attribute of images was targeting
the wrong method `_createWysiwygInstance`.
In 15.0, the method does have a typo (`_createWysiwygIntance`).



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
