### PR TITLE
[IMP] point_of_sale: pos_bill support for both US and EU

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -76,6 +76,12 @@
             <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
+        <record model="pos.bill" id="0_25">
+            <field name="name">0.25</field>
+            <field name="value">0.25</field>
+            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
+        </record>
+
         <record model="pos.bill" id="0_50">
             <field name="name">0.50</field>
             <field name="value">0.50</field>
@@ -127,12 +133,6 @@
         <record model="pos.bill" id="200_00">
             <field name="name">200.00</field>
             <field name="value">200.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
-        </record>
-
-        <record model="pos.bill" id="500_00">
-            <field name="name">500.00</field>
-            <field name="value">500.00</field>
             <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 

--- a/addons/point_of_sale/static/src/css/popups/money_details_popup.css
+++ b/addons/point_of_sale/static/src/css/popups/money_details_popup.css
@@ -1,6 +1,6 @@
 .pos .popup.money-details {
     width: 350px;
-    max-height: 400px;
+    max-height: 440px;
 }
 
 .pos .money-details.invisible {
@@ -8,7 +8,7 @@
 }
 
 .pos .money-details .body {
-    max-height: 306px;
+    max-height: 350px;
 }
 
 .pos .money-details .money-details-title {
@@ -22,7 +22,7 @@
     display: flex;
     justify-content: space-between;
     overflow: auto;
-    max-height: 235px;
+    max-height: 280px;
     padding: 0 15px;
 }
 

--- a/addons/point_of_sale/static/src/js/Popups/MoneyDetailsPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/MoneyDetailsPopup.js
@@ -25,11 +25,11 @@ odoo.define('point_of_sale.MoneyDetailsPopup', function(require) {
         }
         get firstHalfMoneyDetails() {
             const moneyDetailsKeys = Object.keys(this.state.moneyDetails).sort((a, b) => a - b);
-            return moneyDetailsKeys.slice(0, moneyDetailsKeys.length/2);
+            return moneyDetailsKeys.slice(0, Math.ceil(moneyDetailsKeys.length/2));
         }
         get lastHalfMoneyDetails() {
             const moneyDetailsKeys = Object.keys(this.state.moneyDetails).sort((a, b) => a - b);
-            return moneyDetailsKeys.slice(moneyDetailsKeys.length/2, moneyDetailsKeys.length);
+            return moneyDetailsKeys.slice(Math.ceil(moneyDetailsKeys.length/2), moneyDetailsKeys.length);
         }
         updateMoneyDetailsAmount() {
             let total = Object.entries(this.state.moneyDetails).reduce((total, money) => total + money[0] * money[1], 0);


### PR DESCRIPTION
In order to support US and EU at the same time, we're
adding 0.25 as `pos_bill` and removing the 500 one.
Increasing the height of the `MoneyDetailsPopup` to avoid
having a scroll bar while having default data.