### PR TITLE
[FIX] mail, website_*,base: Update data-toggle to data-bs-toggle

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -342,7 +342,7 @@ var BasicActivity = AbstractField.extend({
         var previousActivityTypeID = $markDoneBtn.data('previous-activity-type-id') || false;
         var chainingTypeActivity = $markDoneBtn.data('chaining-type-activity');
 
-        if ($markDoneBtn.data('toggle') === 'collapse') {
+        if ($markDoneBtn[0].dataset.bsToggle === 'collapse') {
             var $actLi = $markDoneBtn.parents('.o_log_activity');
             var $panel = self.$('#o_activity_form_' + activityID);
 
@@ -462,7 +462,7 @@ var BasicActivity = AbstractField.extend({
             ev.stopPropagation();
             if ($btn.data('bs.popover')) {
                 $btn.popover('hide');
-            } else if ($btn.data('toggle') === 'collapse') {
+            } else if ($btn[0].dataset.bsToggle === 'collapse') {
                 self.$('#o_activity_form_' + activityID).collapse('hide');
             }
         });

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -436,7 +436,7 @@
     <xpath expr="//a[hasclass('o_wevent_registration_btn')]" position="attributes">
         <attribute
             name="class">btn btn-primary o_wevent_registration_btn collapsed ms-auto</attribute>
-        <attribute name="data-toggle">collapse</attribute>
+        <attribute name="data-bs-toggle">collapse</attribute>
     </xpath>
 </template>
 

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -1161,7 +1161,7 @@
                         </a>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <a t-attf-class="btn px-2 border #{not question.can_comment and 'karma_required text-muted'}" t-att-data-karma="question.karma_comment" t-att-data-toggle="question.can_comment and 'collapse' or None"
+                        <a t-attf-class="btn px-2 border #{not question.can_comment and 'karma_required text-muted'}" t-att-data-karma="question.karma_comment" t-att-data-bs-toggle="question.can_comment and 'collapse' or None"
                             t-attf-href="##{_question_comment_collapse_uid}">
                             <i class=" fa fa-comment text-muted me-1"/>Comment
                         </a>
@@ -1343,7 +1343,7 @@
                         <div class="btn-group btn-group-sm">
                             <a t-attf-class="btn border px-2 #{not answer.can_comment and 'karma_required text-muted'}"
                                 t-attf-data-karma="#{not answer.can_comment and answer.karma_comment or 0}"
-                                t-att-data-toggle="answer.can_comment and 'collapse' or None"
+                                t-att-data-bs-toggle="answer.can_comment and 'collapse' or None"
                                 t-attf-data-bs-target="##{_answer_comment_collapse_uid}">
                                 <i t-attf-class="fa fa-comment text-muted #{not answer.can_comment and 'karma_required'}"/>
                                 Comment

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1690,13 +1690,13 @@ actual arch.
                 if vnames:
                     name_manager.must_have_fields(vnames, f"{attr}={expr}")
 
-            elif attr == 'data-toggle' and expr == 'tab':
+            elif attr == 'data-bs-toggle' and expr == 'tab':
                 if node.get('role') != 'tab':
-                    msg = 'tab link (data-toggle="tab") must have "tab" role'
+                    msg = 'tab link (data-bs-toggle="tab") must have "tab" role'
                     self._log_view_warning(msg, node)
                 aria_control = node.get('aria-controls') or node.get('t-att-aria-controls')
                 if not aria_control and not node.get('t-attf-aria-controls'):
-                    msg = 'tab link (data-toggle="tab") must have "aria_control" defined'
+                    msg = 'tab link (data-bs-toggle="tab") must have "aria_control" defined'
                     self._log_view_warning(msg, node)
                 if aria_control and '#' in aria_control:
                     msg = 'aria-controls in tablink cannot contains "#"'

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2543,10 +2543,10 @@ class TestViews(ViewCase):
         self.assertWarning('<form><div class="nav-tabs"/></form>')
 
     def test_valid_simili_tab(self):
-        self.assertValid('<form><a data-toggle="tab" role="tab" aria-controls="test"/></form>')
-        self.assertWarning('<form><a data-toggle="tab" aria-controls="test"/></form>')
-        self.assertWarning('<form><a data-toggle="tab" role="tab"/></form>')
-        self.assertWarning('<form><a data-toggle="tab" role="tab" aria-controls="#test"/></form>')
+        self.assertValid('<form><a data-bs-toggle="tab" role="tab" aria-controls="test"/></form>')
+        self.assertWarning('<form><a data-bs-toggle="tab" aria-controls="test"/></form>')
+        self.assertWarning('<form><a data-bs-toggle="tab" role="tab"/></form>')
+        self.assertWarning('<form><a data-bs-toggle="tab" role="tab" aria-controls="#test"/></form>')
 
     def test_valid_focusable_button(self):
         self.assertValid('<form><a class="btn" role="button"/></form>')


### PR DESCRIPTION
in bootstrap 5.x the toggle attribute changed from `data-toggle` to
`data-bs-toggle`, so we have to change `data("toggle")` by
`data("bs-toggle")`

https://getbootstrap.com/docs/4.6/components/collapse/
https://getbootstrap.com/docs/5.1/components/collapse/


Also using `$el[0].dataset.bsToggle` instead of `$el.data("toggle")` is
better since `data()` can be confusing

```js
const a = document.createElement("a");
> <a></a>
a.setAttribute("data-bs-toggle", "dropdown")
> <a data-bs-toggle="dropdown"></a>
a.dataset
> DOMStringMap {toggle: 'dropdown', bsToggle: 'dropdown'}
$(a).data()
> {}
```


https://pad.odoo.com/p/wowl_views
[aju] https://watch.screencastify.com/v/XuuQTkKRFX3lJh1vnvt9 project.task
kanban view > schedule an activity > mark it as done > traceback
https://pastebin.com/i96Krxrb

enterprise: https://github.com/odoo/enterprise/pull/30558
