### PR TITLE
[FIX] CopyButton: copied indicator and style

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -95,7 +95,7 @@ tour.register('totp_tour_setup', {
     content: "Get secret from collapsed div",
     trigger: 'a:contains("Cannot scan it?")',
     async run(helpers) {
-        const $secret = this.$anchor.closest('div').find('[name=secret] > span');
+        const $secret = this.$anchor.closest('div').find('[name=secret] span:first-child');
         const $copyBtn = $secret.find('button');
         $copyBtn.remove();
         const token = await ajax.jsonRpc('/totphook', 'call', {

--- a/addons/web/static/src/core/browser/browser.js
+++ b/addons/web/static/src/core/browser/browser.js
@@ -31,7 +31,7 @@ export const browser = {
     cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
     console: window.console,
     history: window.history,
-    navigator: navigator,
+    navigator,
     Notification: window.Notification,
     open: window.open.bind(window),
     SharedWorker: window.SharedWorker,

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_button.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_button.js
@@ -1,33 +1,43 @@
 /** @odoo-module **/
 
-const { Component, useEffect, useState } = owl;
+import { browser } from "@web/core/browser/browser";
+import { Tooltip } from "@web/core/tooltip/tooltip";
+import { useService } from "@web/core/utils/hooks";
 
+const { Component, useRef } = owl;
 export class CopyButton extends Component {
     setup() {
-        this.state = useState({
-            isCopied: false,
-        });
-        useEffect(
-            () => {
-                return () => clearTimeout(this.timeoutId);
-            },
-            () => [this.state.isCopied]
+        this.button = useRef("button");
+        this.popover = useService("popover");
+    }
+
+    showTooltip() {
+        const closeTooltip = this.popover.add(
+            this.button.el,
+            Tooltip,
+            { tooltip: this.props.successText },
         );
+        browser.setTimeout(() => {
+            closeTooltip();
+        }, 800);
     }
 
     async onClick() {
-        // any kind of content can be copied into the clipboard using
-        // the appropriate native methods
-        if (typeof this.props.content === "string") {
-            navigator.clipboard.writeText(this.props.content).then(() => {
-                this.state.isCopied = true;
-            });
-        } else {
-            navigator.clipboard.write(this.props.content).then(() => {
-                this.state.isCopied = true;
-            });
+        try {
+            // any kind of content can be copied into the clipboard using
+            // the appropriate native methods
+            if (typeof this.props.content === "string") {
+                browser.navigator.clipboard.writeText(this.props.content).then(() => {
+                    this.showTooltip();
+                });
+            } else {
+                browser.navigator.clipboard.write(this.props.content).then(() => {
+                    this.showTooltip();
+                });
+            }
+        } catch {
+            return browser.console.warn("This browser doesn't allow to copy to clipboard");
         }
-        this.timeoutId = setTimeout(() => (this.state.isCopied = false), 800);
     }
 }
 CopyButton.template = "web.CopyButton";

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_button.xml
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_button.xml
@@ -3,17 +3,13 @@
 
     <t t-name="web.CopyButton" owl="1">
         <button
-            t-attf-class="btn btn-sm btn-primary o_clipboard_button {{ props.className || '' }} {{state.isCopied ? 'bg-success' : ''}}"
+            class="text-nowrap"
+            t-ref="button"
+            t-attf-class="btn btn-sm btn-primary o_clipboard_button {{ props.className || '' }}"
             t-on-click.stop="onClick"
         >
-            <t t-if="!state.isCopied">
-                <span class="fa fa-clipboard mx-1"/>
-                <span t-esc="props.copyText"/>
-            </t>
-            <t t-else="">
-                <span class="fa fa-check mx-1"/>
-                <span t-esc="props.successText"/>
-            </t>
+            <span class="fa fa-clipboard mx-1"/>
+            <span t-esc="props.copyText"/>
         </button>
     </t>
 

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.scss
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.scss
@@ -1,19 +1,13 @@
 .o_field_CopyClipboardText, .o_field_CopyClipboardURL, .o_field_CopyClipboardChar {
-    display: flex !important;
-    flex-wrap: nowrap;
-    width: fit-content !important;
-    border-radius: 5px;
-    border: 1px solid $primary;
-    font-size: $font-size-sm;
-    color: $o-brand-primary;
-    font-weight: $badge-font-weight;
+    > div {
+        border: 1px solid $primary;
+        font-size: $font-size-sm;
+        color: $o-brand-primary;
+        font-weight: $badge-font-weight;
 
-    &.o_field_empty {
-        display: none !important;
-    }
-    
-    > span {
-        padding: 0 5px;
-        text-align: center;
+        > span:first-child, a {
+            text-align: center;
+            flex: auto;
+        }
     }
 }

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CopyClipboardField" owl="1">
-        <t t-if="props.value">
+        <div t-if="props.value" class="d-flex flex-nowrap align-items-center rounded-3 overflow-hidden justify-content-end">
             <Field t-props="props"/>
             <CopyButton className="`o_btn_${props.type}_copy`" content="props.value" copyText="copyText" successText="successText"/>
-        </t>
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/tests/views/fields/copy_clipboard_field_tests.js
+++ b/addons/web/static/tests/views/fields/copy_clipboard_field_tests.js
@@ -1,13 +1,16 @@
 /** @odoo-module **/
 
-import { getFixture } from "@web/../tests/helpers/utils";
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+import { click, getFixture, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
+const serviceRegistry = registry.category("services");
 let serverData;
 let target;
 
 QUnit.module("Fields", (hooks) => {
-    hooks.beforeEach(() => {
+    hooks.beforeEach((assert) => {
         serverData = {
             models: {
                 partner: {
@@ -37,6 +40,19 @@ QUnit.module("Fields", (hooks) => {
         };
         target = getFixture();
         setupViewRegistries();
+        const fakePopoverService = {
+            async start() {
+                return {
+                    add(el, comp, params) {
+                        assert.strictEqual(el.textContent, "Copy", "button has the right text");
+                        assert.deepEqual(params, { tooltip: "Copied" }, "tooltip has the right parameters");
+                        assert.step("copied tooltip");
+                    }
+                }
+            }
+        }
+        serviceRegistry.remove("popover");
+        serviceRegistry.add("popover", fakePopoverService);
     });
 
     QUnit.module("CopyClipboardField");
@@ -121,4 +137,79 @@ QUnit.module("Fields", (hooks) => {
             );
         }
     );
+
+    QUnit.test("CopyClipboard fields: display a tooltip on click", async function (assert) {
+        patchWithCleanup(browser, {
+            navigator: {
+                clipboard: {
+                    writeText: (text) => {
+                        assert.strictEqual(
+                            text,
+                            "My little txt Value\nHo-ho-hoooo Merry Christmas",
+                            "copied text is equal to displayed text"
+                        );
+                        return Promise.resolve();
+                    },
+                },
+            }
+        });
+
+        await makeView({
+            serverData,
+            type: "form",
+            resModel: "partner",
+            arch: `
+                <form string="Partners">
+                    <sheet>
+                        <div>
+                            <field name="text_field" widget="CopyClipboardText"/>
+                        </div>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+
+        assert.containsOnce(
+            target,
+            ".o_clipboard_button.o_btn_text_copy",
+            "should have copy button on text type field"
+        );
+
+        await click(target, ".o_clipboard_button");
+        await nextTick();
+        assert.verifySteps(["copied tooltip"]);
+    });
+
+    QUnit.test("CopyClipboard fields with clipboard not available", async function (assert) {
+        patchWithCleanup(browser, {
+            console: {
+                warn: (msg) => assert.step(msg),
+            },
+            navigator: {
+                clipboard: undefined,
+            },
+        });
+
+        await makeView({
+            serverData,
+            type: "form",
+            resModel: "partner",
+            arch: `
+                <form string="Partners">
+                    <sheet>
+                        <div>
+                            <field name="text_field" widget="CopyClipboardText"/>
+                        </div>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+
+        await click(target, ".o_clipboard_button");
+        await nextTick();
+        assert.verifySteps(
+            ["This browser doesn't allow to copy to clipboard"],
+            "console simply displays a warning on failure"
+        );
+    });
 });


### PR DESCRIPTION
This commit fixes the style of the field, which was
pretty broken since the use of display: contents.
It also bring back the tooltip (as in legacy) when
the button is clicked.

The tooltip service now support the ability to
show a tooltip during a breif moment, using the
show method and the right parameters.

Tests have been added to assert those behaviors.

With this commit: 
<img width="132" alt="image" src="https://user-images.githubusercontent.com/35101914/185302645-d3c58079-7a6a-4fc9-b37a-b028ad7cb34c.png">

Before this commit (stuck on green state + wrongly adapted because tooltip couldn't be shown on click, but only on hover): 
<img width="99" alt="image" src="https://user-images.githubusercontent.com/35101914/185302787-81873aab-81f1-4fdd-8644-01960a71e0a7.png">

Legacy: 
<img width="76" alt="image" src="https://user-images.githubusercontent.com/35101914/185303105-c462d3e8-47f8-48eb-b854-cca76951f971.png">

