### PR TITLE
[FIX] account: do not show alert on posted invoice/bill

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1653,7 +1653,7 @@ class AccountMove(models.Model):
     @api.depends('currency_id')
     def _compute_display_inactive_currency_warning(self):
         for move in self.with_context(active_test=False):
-            move.display_inactive_currency_warning = move.currency_id and not move.currency_id.active
+            move.display_inactive_currency_warning = move.state == 'draft' and move.currency_id and not move.currency_id.active
 
     def _compute_payments_widget_to_reconcile_info(self):
         for move in self:


### PR DESCRIPTION
Steps to reproduce:
* Activate multi-currency (Company currency `USD`, another currency activated 'EUR') 
* Create invoice/bill in `EUR` and post it
* Archive `EUR`
* Open Invoice/Bill

Issue:
* Alert for inactivated currency is always displayed

Fix:
* Alert for inactivated currency should be displayed in draft state only

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
