### PR TITLE
[FIX] hr_timesheet: specify aliases for columns: planned_hours, remaning_hours

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -14,16 +14,16 @@ class ReportProjectTaskUser(models.Model):
 
     def _select(self):
         return super(ReportProjectTaskUser, self)._select() + """,
-            (t.effective_hours * 100) / NULLIF(planned_hours, 0) as progress,
+            (t.effective_hours * 100) / NULLIF(t.planned_hours, 0) as progress,
             t.effective_hours as hours_effective,
             t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
-            NULLIF(planned_hours, 0) as hours_planned"""
+            NULLIF(t.planned_hours, 0) as hours_planned"""
 
     def _group_by(self):
         return super(ReportProjectTaskUser, self)._group_by() + """,
-            remaining_hours,
+            t.remaining_hours,
             t.effective_hours,
-            planned_hours
+            t.planned_hours
             """
 
     @api.model


### PR DESCRIPTION
Before this commit, in the project report, when the `planned_hours` or `remaining_hours` column
is selected, it causes confusion and errors such as: psycopg2.errors.AmbiguousColumn: column reference "planned_hours" is ambiguous.
It happens especially when clients add their own columns to the `project.project` table.

This commit fixes the issue by adding the alias variables to columns: `planned_hours` and `remaining_hours`.

Steps to reproduce
------------------

1) add a `planned_hours` field or `remaining_hours` field in the `project.project` model.
2) install the `industry_fsm` module.

Expected behavior
-----------------

Odoo instance should be correctly launched and the Project Manager should see the
report without any issue.

Current behavior
----------------

A traceback is occurred saying the `planned_hours` column is ambiguous since the
column exists in the `project_task` and `project_project` tables.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
