### PR TITLE
[FIX] stock: document print problem

### DIFF
--- a/addons/stock/i18n/ca.po
+++ b/addons/stock/i18n/ca.po
@@ -170,7 +170,7 @@ msgstr "'comtat Full'"
 msgid ""
 "'Delivery Slip - %s - %s' % (object.partner_id.name or '', object.name)"
 msgstr ""
-"'Delipació Slip - %s - %s' % (objecte. partner_ id. nom o ', object. nom)"
+"'Albarà d'entrega - %s - %s' % (object.partner_id.name or '', object.name)"
 
 #. module: stock
 #: model:ir.actions.report,print_report_name:stock.action_report_location_barcode
@@ -197,8 +197,7 @@ msgstr ""
 msgid ""
 "'Picking Operations - %s - %s' % (object.partner_id.name or '', object.name)"
 msgstr ""
-"Operacions 'Picking - %s - %s' % (objecte. partner_ id. nom o ', object. "
-"nom)"
+"'Albarà d'operacions - %s - %s' % (object.partner_id.name or '', object.name)"
 
 #. module: stock
 #: code:addons/stock/models/stock_lot.py:0


### PR DESCRIPTION
Steps:
- Set the language to Catalan
- Go to inventory -> operations -> Transfers
- Try to print a picking operation or a delivery slip, you get an error

solution:
Just a bad translation of expression to evaluate when trying to generate template

opw-2951985
