### PR TITLE
[FIX] mail: fix error open starred

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -481,7 +481,8 @@ class Message(models.Model):
         document_related_candidate_ids = [
             mid for mid, message in message_values.items()
             if (message.get('model') and message.get('res_id') and
-                message.get('message_type') != 'user_notification')
+                message.get('message_type') != 'user_notification' and
+                mid in list(messages_to_check))
         ]
         model_record_ids = _generate_model_record_ids(message_values, document_related_candidate_ids)
         for model, doc_ids in model_record_ids.items():


### PR DESCRIPTION
- When a user stars messages from a channel and messages from an unauthorized document.
- The check_access_rule function does not filter messages on the channel. This function then checks the read permission of the document. And raise an error
- This commit will remove the messages that have been checked above from the document_related_candidate_ids list




https://user-images.githubusercontent.com/55737816/185335551-a46ef072-eb78-4b15-ad82-00b013cbb177.mov



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
