### PR TITLE
[FIX] web,*: adapt old BS4 classes

### DIFF
--- a/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
@@ -33,11 +33,11 @@
     <div class="d-flex flex-grow-1 align-items-start justify-content-between position-relative px-3">
         <a t-if="!is_self" t-att-href="employee.link" class="o_employee_redirect d-flex flex-column" t-att-data-employee-id="employee.id">
             <b class="o_media_heading m-0 fs-6" t-esc="employee.name"/>
-            <small class="text-muted font-weight-bold" t-esc="employee.job_title"/>
+            <small class="text-muted fw-bold" t-esc="employee.job_title"/>
         </a>
         <div t-if="is_self" class="d-flex flex-column">
             <h5 class="o_media_heading m-0" t-esc="employee.name"/>
-            <small class="text-muted font-weight-bold" t-esc="employee.job_title"/>
+            <small class="text-muted fw-bold" t-esc="employee.job_title"/>
         </div>
         <button t-if="employee.indirect_sub_count &gt; 0"
                 class="btn p-0 fs-3"

--- a/addons/l10n_gcc_invoice_stock_account/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice_stock_account/views/report_invoice.xml
@@ -16,7 +16,7 @@
                                  المنتج
                                 </span>
                             </th>
-                            <th class="text-right">
+                            <th class="text-end">
                                 <span>
                                     Quantity
                                 </span>
@@ -25,7 +25,7 @@
                                     الكمية
                                 </span>
                             </th>
-                            <th class="text-right">
+                            <th class="text-end">
                                 <span>
                                     SN/LN
                                 </span>
@@ -40,11 +40,11 @@
                         <t t-foreach="lot_values" t-as="snln_line">
                             <tr>
                                 <td><t t-esc="snln_line['product_name']"/></td>
-                                <td class="text-right">
+                                <td class="text-end">
                                     <t t-esc="snln_line['quantity']"/>
                                     <t t-esc="snln_line['uom_name']" groups="uom.group_uom"/>
                                 </td>
-                                <td class="text-right"><t t-esc="snln_line['lot_name']"/></td>
+                                <td class="text-end"><t t-esc="snln_line['lot_name']"/></td>
                             </tr>
                         </t>
                     </tbody>

--- a/addons/mail/static/src/components/channel_member/channel_member.scss
+++ b/addons/mail/static/src/components/channel_member/channel_member.scss
@@ -1,5 +1,5 @@
 .o_ChannelMember:hover {
-    background-color: gray('300');
+    background-color: map-get($grays, '300');
 }
 
 .o_ChannelMember_avatar {

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -183,7 +183,7 @@
                                         <p t-esc="messageView.message.subtype_description" class="mb-0"/>
                                     </t>
                                     <t t-if="messageView.message.trackingValues.length > 0">
-                                        <ul class="o_Message_trackingValues mb-0 pl-4">
+                                        <ul class="o_Message_trackingValues mb-0 ps-4">
                                            <t t-foreach="messageView.message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                                 <li>
                                                     <TrackingValue value="trackingValue"/>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -20,7 +20,7 @@
                 <div class="app_settings_block" data-string="Point of sale" string="Point of Sale" data-key="point_of_sale" groups="point_of_sale.group_pos_manager">
                     <div class="app_settings_header pt-1 pb-1" style="background-color: #FEF0D0;">
                         <div class="col-xs-12 col-md-6 ms-0 o_setting_box">
-                            <div class="o_setting_right_pane border-left-0 ms-0 ps-0">
+                            <div class="o_setting_right_pane border-start-0 ms-0 ps-0">
                                 <div class="content-group">
                                     <div class="row mt8">
                                         <label class="col align-self-center ml8" string="Point of Sale" for="pos_config_id"/>

--- a/addons/purchase/static/src/xml/purchase_dashboard.xml
+++ b/addons/purchase/static/src/xml/purchase_dashboard.xml
@@ -10,17 +10,17 @@
                         </div>
                         <div class="g-col-9 g-col-sm-10 grid gap-1">
                             <div class="o_dashboard_action g-col-4 p-0" title="All Draft RFQs" context='{"search_default_draft_rfqs": true}'>
-                                <a href="#" class="btn btn-primary w-100 h-100 border-0 rounded-0 text-capitalize font-weight-normal">
+                                <a href="#" class="btn btn-primary w-100 h-100 border-0 rounded-0 text-capitalize fw-normal">
                                     <h2 t-out="values['all_to_send']"/>To Send
                                 </a>
                             </div>
                             <div class="o_dashboard_action g-col-4 p-0" title="All Waiting RFQs" context='{"search_default_waiting_rfqs": true}'>
-                                <a href="#" class="btn btn-primary w-100 h-100 border-0 rounded-0 text-capitalize font-weight-normal">
+                                <a href="#" class="btn btn-primary w-100 h-100 border-0 rounded-0 text-capitalize fw-normal">
                                     <h2 t-out="values['all_waiting']"/>Waiting
                                 </a>
                             </div>
                             <div class="o_dashboard_action g-col-4 p-0" title="All Late RFQs" context='{"search_default_late_rfqs": true}'>
-                                <a href="#" class="btn btn-primary w-100 h-100 border-0 rounded-0 text-capitalize font-weight-normal">
+                                <a href="#" class="btn btn-primary w-100 h-100 border-0 rounded-0 text-capitalize fw-normal">
                                     <h2 t-out="values['all_late']"/>Late
                                 </a>
                             </div>
@@ -32,17 +32,17 @@
                         </div>
                         <div class="g-col-9 g-col-sm-10 grid gap-2">
                             <div class="o_dashboard_action g-col-4 p-0" title="My Draft RFQs" context='{"search_default_draft_rfqs": true, "search_default_my_purchases": true}'>
-                                <a href="#" class="btn btn-light d-flex align-items-center w-100 h-100 p-0 border-0 bg-100 font-weight-normal">
+                                <a href="#" class="btn btn-light d-flex align-items-center w-100 h-100 p-0 border-0 bg-100 fw-normal">
                                     <div class="w-100 p-2" t-out="values['my_to_send']"/>
                                 </a>
                             </div>
                             <div class="o_dashboard_action g-col-4 p-0" title="My Waiting RFQs" context='{"search_default_waiting_rfqs": true, "search_default_my_purchases": true}'>
-                                <a href="#" class="btn btn-light d-flex align-items-center w-100 h-100 p-0 border-0 bg-100 font-weight-normal">
+                                <a href="#" class="btn btn-light d-flex align-items-center w-100 h-100 p-0 border-0 bg-100 fw-normal">
                                     <div class="w-100 p-2" t-out="values['my_waiting']"/>
                                 </a>
                             </div>
                             <div class="o_dashboard_action g-col-4 p-0" title="My Late RFQs" context='{"search_default_late_rfqs": true, "search_default_my_purchases": true}'>
-                                <a href="#" class="btn btn-light d-flex align-items-center w-100 h-100 p-0 border-0 bg-100 font-weight-normal">
+                                <a href="#" class="btn btn-light d-flex align-items-center w-100 h-100 p-0 border-0 bg-100 fw-normal">
                                     <div class="w-100 p-2" t-out="values['my_late']"/>
                                 </a>
                             </div>

--- a/addons/web/static/src/legacy/xml/search_panel.xml
+++ b/addons/web/static/src/legacy/xml/search_panel.xml
@@ -86,7 +86,7 @@
             >
             <header
                 class="list-group-item list-group-item-action d-flex align-items-center p-0 border-0"
-                t-att-class="{'active text-900 font-weight-bold': state.active[section.id] === valueId}"
+                t-att-class="{'active text-900 fw-bold': state.active[section.id] === valueId}"
                 t-on-click="() => this._toggleCategory(section, value)"
                 >
                 <div
@@ -105,12 +105,12 @@
                     </button>
                     <span
                         class="o_search_panel_label_title text-truncate"
-                        t-att-class="{'font-weight-bold' : value.bold}"
+                        t-att-class="{'fw-bold' : value.bold}"
                         t-esc="value.display_name"
                         />
                 </div>
                 <small t-if="section.enableCounters and value.__count gt 0"
-                    class="o_search_panel_counter text-muted mx-2 font-weight-bold"
+                    class="o_search_panel_counter text-muted mx-2 fw-bold"
                     t-esc="value.__count"
                 />
             </header>

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -85,7 +85,7 @@
             >
             <header
                 class="list-group-item list-group-item-action d-flex align-items-center p-0 border-0"
-                t-att-class="{'active text-900 font-weight-bold': state.active[section.id] === valueId}"
+                t-att-class="{'active text-900 fw-bold': state.active[section.id] === valueId}"
                 t-on-click="() => this.toggleCategory(section, value)"
                 >
                 <div
@@ -104,12 +104,12 @@
                     </button>
                     <span
                         class="o_search_panel_label_title text-truncate"
-                        t-att-class="{'font-weight-bold' : value.bold}"
+                        t-att-class="{'fw-bold' : value.bold}"
                         t-esc="value.display_name"
                         />
                 </div>
                 <small t-if="section.enableCounters and value.__count gt 0"
-                    class="o_search_panel_counter text-muted mx-2 font-weight-bold"
+                    class="o_search_panel_counter text-muted mx-2 fw-bold"
                     t-esc="value.__count"
                 />
             </header>

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -14,7 +14,7 @@
     <t t-name="web.ExportDataItem" owl="1">
         <div t-att-data-field_id="props.field.name" t-attf-class="o_export_tree_item cursor-pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded mb-2' : '' }}" role="treeitem" t-on-click.stop="onClick" t-on-dblclick="(ev) => !props.isFieldExpandable(props.field) and !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)">
             <span t-if="props.isFieldExpandable(props.field)" t-attf-class="o_expand_parent d-inline-block position-absolute small fa {{ state.isExpanded ? 'fa-chevron-down' : 'fa-chevron-right' }}" role="img" aria-label="Show sub-fields" title="expandText" />
-            <div t-attf-class="o_tree_column d-flex justify-content-between align-items-center {{ props.field.required ? 'font-weight-bolder' : ''}}">
+            <div t-attf-class="o_tree_column d-flex justify-content-between align-items-center {{ props.field.required ? 'fw-bolder' : ''}}">
                 <span t-if="props.isDebug and props.field.id" class="overflow-hidden" t-esc="`${props.field.string} (${props.field.id})`" />
                 <span t-else="" class="overflow-hidden" t-esc="props.field.string" />
                 <span title="Select field" t-attf-class="fa fa-plus float-end m-1 o_add_field {{ isFieldSelected(props.field.name) ? 'o_inactive opacity-25' : '' }}" t-on-click.stop="(ev) => !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)" />
@@ -77,17 +77,17 @@
                     <div class="o_exported_lists">
                         <div class="input-group mb-3">
                             <t t-if="state.templateId === 'new_template'">
-                                <label class="pt-2 mb-0 font-weight-bold">Save as: </label>
+                                <label class="pt-2 mb-0 fw-bold">Save as: </label>
                                 <input t-ref="exportList" class="form-control ms-4 o_save_list_name" t-att-placeholder="newTemplateText" />
                             </t>
                             <t t-else="">
-                                <label class="pt-2 mb-0 font-weight-bold">Template: </label>
-                                <select class="form-control ms-4 o_exported_lists_select" t-on-change="onChangeExportList">
+                                <label class="pt-2 mb-0 fw-bold">Template: </label>
+                                <select class="form-select ms-4 o_exported_lists_select" t-on-change="onChangeExportList">
                                     <option />
                                     <t t-foreach="templates" t-as="template" t-key="template.id">
                                         <option t-att-value="template.id" t-esc="template.name or 'undefined'" t-att-selected="state.templateId === template.id" />
                                     </t>
-                                    <option class="font-italic" value="new_template">New template </option>
+                                    <option class="fst-italic" value="new_template">New template </option>
                                 </select>
                             </t>
                             <t t-if="state.isEditingTemplate">

--- a/addons/web/static/src/webclient/settings_form_view/highlight_text/settings_radio_field.xml
+++ b/addons/web/static/src/webclient/settings_form_view/highlight_text/settings_radio_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.SettingsRadioField" t-inherit="web.RadioField" t-inherit-mode="primary" owl="1">
         <xpath expr="//label" position="replace">
-            <FormLabelHighlightText className="'custom-control-label'" id="`${id}_${item[0]}`" string="item[1]"/>
+            <FormLabelHighlightText className="'form-check-label'" id="`${id}_${item[0]}`" string="item[1]"/>
         </xpath>
     </t>
 

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog_tests.js
@@ -234,7 +234,7 @@ QUnit.module("ViewDialogs", (hooks) => {
         );
         assert.hasClass(
             target.querySelector(".modal .o_export_tree_item:nth-child(2) .o_tree_column"),
-            "font-weight-bolder",
+            "fw-bolder",
             "required fields have the right style class"
         );
         // Remove field

--- a/addons/website/static/src/components/website_loader/website_loader.xml
+++ b/addons/website/static/src/components/website_loader/website_loader.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 <t t-name="website.website_loader" owl="1">
     <div t-if="state.isVisible" class="o_website_loader_container position-fixed fixed-top fixed-left
-        h-100 w-100 d-flex flex-column align-items-center text-white font-weight-bold text-center">
+        h-100 w-100 d-flex flex-column align-items-center text-white fw-bold text-center">
         <t t-if="state.title" t-esc="state.title"/>
         <t t-elif="state.showTips">Building your website...</t>
         <div class="o_website_loader"/>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -731,7 +731,7 @@
                     class="oe_unmovable oe_unremovable s_dynamic_snippet_products o_wsale_alternative_products s_dynamic pt32 pb32 o_colored_level s_product_product_borderless_1 d-none"
                     data-name="Alternative Products" style="background-image: none;" t-att-data-filter-id="product._get_alternative_product_filter()"
                     data-template-key="website_sale.dynamic_filter_template_product_product_borderless_1" data-product-category-id="all" data-number-of-elements="4"
-                    data-number-of-elements-small-devices="1" data-number-of-records="16" data-carousel-interval="5000" data-original-title="" title="">
+                    data-number-of-elements-small-devices="1" data-number-of-records="16" data-carousel-interval="5000" data-bs-original-title="" title="">
                     <div class="container o_not_editable">
                         <div class="css_non_editable_mode_hidden">
                             <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none o_default_snippet_text">
@@ -870,7 +870,7 @@
             </h3>
         </div>
         <div id="product_unavailable" t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}}">
-            <h3 class="font-italic" t-field="website.prevent_zero_price_sale_text"/>
+            <h3 class="fst-italic" t-field="website.prevent_zero_price_sale_text"/>
         </div>
     </template>
 

--- a/addons/website_sale_autocomplete/static/src/xml/autocomplete.xml
+++ b/addons/website_sale_autocomplete/static/src/xml/autocomplete.xml
@@ -8,7 +8,7 @@
                t-att-data-google-place-id="result['google_place_id']">
                 <t t-out="result['formatted_address']"/>
             </a>
-            <img class="float-right pr-1" src="/website_sale_autocomplete/static/src/img/powered_by_google_on_white.png" alt="Powered by Google"/>
+            <img class="float-end pe-1" src="/website_sale_autocomplete/static/src/img/powered_by_google_on_white.png" alt="Powered by Google"/>
         </div>
     </t>
 </templates>

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -12,7 +12,7 @@
         <!-- Certification Attempts -->
         <xpath expr="//ul[hasclass('o_wprofile_nav_tabs')]" position="inside">
             <li t-if="show_certification_tab" class="nav-item">
-                <a role="tab" aria-controls="certification" href="#profile_tab_content_certification" t-attf-class="nav-link #{ 'active' if active_tab == 'certification' else '' }" data-toggle="tab">
+                <a role="tab" aria-controls="certification" href="#profile_tab_content_certification" t-attf-class="nav-link #{ 'active' if active_tab == 'certification' else '' }" data-bs-toggle="tab">
                     <t t-if="user_inputs" t-out="len(user_inputs)" /> Certification Attempts
                 </a>
             </li>
@@ -52,7 +52,7 @@
                             Attempt n°<t t-out="user_input.attempts_number"/>
                         </div>
                         <div class="col-sm-2">
-                            <span t-attf-class="badge #{ 'badge-primary' if user_input.scoring_success else 'badge-danger'}">
+                            <span t-attf-class="badge #{ 'text-bg-primary' if user_input.scoring_success else 'text-bg-danger'}">
                                 <t t-out="user_input.scoring_percentage"/>%
                             </span>
                         </div>


### PR DESCRIPTION
*: hr_org_chart,l10n_gcc_invoice_stock_account,mail,point_of_sale,
   purchase,website,website_sale,website_sale_autocomplete,
   website_slides_survey

Some commit have added old Bootstrap 4 classes after the merge of
Bootstrap 5.

Note that it's not possible anymore as the merge bot is now able to
detect it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
