### PR TITLE
[FIX] account: register payment method multiple partners

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -913,16 +913,41 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_payment_method_different_type_single_batch_not_grouped(self):
         """ Test payment methods when paying a bill and a refund with separated payments (1000 + -2000)."""
-        in_refund = self.env['account.move'].create({
-            'move_type': 'in_refund',
-            'date': '2017-01-01',
-            'invoice_date': '2017-01-01',
-            'partner_id': self.partner_a.id,
-            'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 1600.0})],
-        })
-        in_refund.action_post()
+        invoice_1 = self.in_invoice_1
+        invoice_2 = invoice_1.copy({'invoice_date': invoice_1.invoice_date, 'partner_id': self.partner_b.id})
+        refund_1, refund_2 = self.env['account.move'].create([
+            {
+                'move_type': 'in_refund',
+                'date': '2017-01-01',
+                'invoice_date': '2017-01-01',
+                'partner_id': self.partner_a.id,
+                'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 1600.0})],
+            },
+            {
+                'move_type': 'in_refund',
+                'date': '2017-01-01',
+                'invoice_date': '2017-01-01',
+                'partner_id': self.partner_b.id,
+                'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 1600.0})],
+            },
+        ])
+        (invoice_2 + refund_1 + refund_2).action_post()
 
-        active_ids = (self.in_invoice_1 + in_refund).ids
+        for moves in ((invoice_1 + invoice_2), (refund_1 + refund_2)):
+            wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=moves.ids).create({
+                'group_payment': False,
+            })
+
+            expected_available_payment_methods = wizard.journal_id.inbound_payment_method_ids if moves[0].move_type == 'in_refund' else wizard.journal_id.outbound_payment_method_ids
+
+            self.assertRecordValues(wizard, [
+                {
+                    'available_payment_method_ids': expected_available_payment_methods.ids,
+                    'payment_method_id': expected_available_payment_methods[:1].id,
+                }
+            ])
+
+        active_ids = (invoice_1 + invoice_2 + refund_1 + refund_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'group_payment': False,
         })._create_payments()
@@ -937,14 +962,30 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertRecordValues(payments[1], [
             {
+                'ref': 'BILL/2017/01/0004',
+                'payment_method_id': self.bank_journal_1.outbound_payment_method_ids[0].id,
+                'payment_type': 'outbound',
+            }
+        ])
+
+        self.assertRecordValues(payments[2], [
+            {
                 'ref': 'RBILL/2017/01/0001',
                 'payment_method_id': self.bank_journal_1.inbound_payment_method_ids[0].id,
                 'payment_type': 'inbound',
             },
         ])
 
+        self.assertRecordValues(payments[3], [
+            {
+                'ref': 'RBILL/2017/01/0002',
+                'payment_method_id': self.bank_journal_1.inbound_payment_method_ids[0].id,
+                'payment_type': 'inbound',
+            },
+        ])
+
         self.assertRecordValues(payments[0].line_ids.sorted('balance'), [
-            # == Payment 1: to pay in_invoice_1 ==
+            # == Payment 1: to pay invoice_1 ==
             # Liquidity line:
             {
                 'debit': 0.0,
@@ -962,8 +1003,49 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'reconciled': True,
             },
         ])
+
         self.assertRecordValues(payments[1].line_ids.sorted('balance'), [
-            # == Payment 2: to pay in_refund_1 ==
+            # == Payment 2: to pay invoice_2 ==
+            # Liquidity line:
+            {
+                'debit': 0.0,
+                'credit': 1000.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': -1000.0,
+                'reconciled': False,
+            },
+            # Payable line:
+            {
+                'debit': 1000.0,
+                'credit': 0.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': 1000.0,
+                'reconciled': True,
+            },
+        ])
+
+        self.assertRecordValues(payments[2].line_ids.sorted('balance'), [
+            # == Payment 3: to pay refund_1 ==
+            # Payable line:
+            {
+                'debit': 0.0,
+                'credit': 1600.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': -1600.0,
+                'reconciled': True,
+            },
+            # Liquidity line:
+            {
+                'debit': 1600.0,
+                'credit': 0.0,
+                'currency_id': self.company_data['currency'].id,
+                'amount_currency': 1600.0,
+                'reconciled': False,
+            },
+        ])
+
+        self.assertRecordValues(payments[3].line_ids.sorted('balance'), [
+            # == Payment 4: to pay refund_2 ==
             # Payable line:
             {
                 'debit': 0.0,

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -360,12 +360,8 @@ class AccountPaymentRegister(models.TransientModel):
                  'journal_id.outbound_payment_method_ids')
     def _compute_payment_method_fields(self):
         for wizard in self:
-            if wizard.can_edit_wizard:
-                wizard.available_payment_method_ids = wizard._get_batch_available_payment_methods(wizard.journal_id, wizard.payment_type)
-                wizard.hide_payment_method = len(wizard.available_payment_method_ids) == 1 and wizard.available_payment_method_ids.code == 'manual'
-            else:
-                wizard.available_payment_method_ids = None
-                wizard.hide_payment_method = False
+            wizard.available_payment_method_ids = wizard._get_batch_available_payment_methods(wizard.journal_id, wizard.payment_type)
+            wizard.hide_payment_method = len(wizard.available_payment_method_ids) == 1 and wizard.available_payment_method_ids.code == 'manual'
 
     @api.depends('payment_type',
                  'journal_id.inbound_payment_method_ids',
@@ -373,7 +369,7 @@ class AccountPaymentRegister(models.TransientModel):
     def _compute_payment_method_id(self):
         for wizard in self:
             available_payment_methods = wizard._get_batch_available_payment_methods(wizard.journal_id, wizard.payment_type)
-            if wizard.can_edit_wizard and available_payment_methods:
+            if available_payment_methods:
                 wizard.payment_method_id = available_payment_methods[:1]
             else:
                 wizard.payment_method_id = False


### PR DESCRIPTION
Improvement of https://github.com/odoo/odoo/commit/e66663b52920ad5a647b03a8fd9ade4070f09158

The commit mentioned above introduced a bug, which
prevent the user to select payment method when register
a payment for multiple partners, even if the payments
were from the same type.

The solution here is to allow the selection of payment method
in any case, the _create_payment_vals_from_batch method will
change the payment method if it is not available on the journal.

opw-2954325
