### PR TITLE
Batch of website in backend fixes: drop a popup, text selection with columns option, re-enable edition buttons on validation error, remove website systray for replayed actions

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3295,7 +3295,14 @@ var SnippetsMenu = Widget.extend({
         }
         delete data._toMutex;
         ev.stopPropagation();
-        this._buttonClick(() => this._execWithLoadingEffect(() => {
+        this._buttonClick((after) => this._execWithLoadingEffect(() => {
+            const oldOnFailure = data.onFailure;
+            data.onFailure = () => {
+                if (oldOnFailure) {
+                    oldOnFailure();
+                }
+                after();
+            };
             this.trigger_up('request_save', data);
         }, true), this.$el[0].querySelector('button[data-action=save]'));
     },

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -31,9 +31,11 @@ const {
     createDataURL,
     isGif,
 } = require('web_editor.image_processing');
+const OdooEditorLib = require('@web_editor/js/editor/odoo-editor/src/OdooEditor');
 
 var qweb = core.qweb;
 var _t = core._t;
+const preserveCursor = OdooEditorLib.preserveCursor;
 
 /**
  * @param {HTMLElement} el
@@ -4603,7 +4605,9 @@ registry.layout_column = SnippetOptionWidget.extend({
         const previousNbColumns = this.$('> .row').children().length;
         let $row = this.$('> .row');
         if (!$row.length) {
+            const restoreCursor = preserveCursor(this.$target[0].ownerDocument);
             $row = this.$target.contents().wrapAll($('<div class="row"><div class="col-lg-12"/></div>')).parent().parent();
+            restoreCursor();
         }
 
         const nbColumns = parseInt(widgetValue);
@@ -4613,7 +4617,9 @@ registry.layout_column = SnippetOptionWidget.extend({
         // TODO: make this more generic in activate_snippet event handler.
         await new Promise(resolve => setTimeout(resolve));
         if (nbColumns === 0) {
+            const restoreCursor = preserveCursor(this.$target[0].ownerDocument);
             $row.contents().unwrap().contents().unwrap();
+            restoreCursor();
             this.trigger_up('activate_snippet', {$snippet: this.$target});
         } else if (previousNbColumns === 0) {
             this.trigger_up('activate_snippet', {$snippet: this.$('> .row').children().first()});

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -8,7 +8,7 @@ import { WebsiteEditorComponent } from '../../components/editor/editor';
 import { WebsiteTranslator } from '../../components/translator/translator';
 import {OptimizeSEODialog} from '@website/components/dialog/seo';
 
-const { Component, onWillStart, useRef, useEffect, useState } = owl;
+const { Component, onWillStart, onMounted, onWillUnmount, useRef, useEffect, useState } = owl;
 
 class BlockIframe extends Component {
     setup() {
@@ -95,22 +95,22 @@ export class WebsitePreview extends Component {
             if (this.props.action.context.params && this.props.action.context.params.with_loader) {
                 this.websiteService.showLoader({ showTips: true });
             }
-
-            return () => {
-                this.websiteService.currentWebsiteId = null;
-                this.websiteService.websiteRootInstance = undefined;
-                this.websiteService.pageDocument = null;
-            };
         }, () => [this.props.action.context.params]);
 
-        useEffect(() => {
+        onMounted(() => {
             this.websiteService.blockIframe(true, 0, 'load-iframe');
             this.iframe.el.addEventListener('load', () => this.websiteService.unblockIframe('load-iframe'), { once: true });
             // For a frontend page, it is better to use the
             // OdooFrameContentLoaded event to unblock the iframe, as it is
             // triggered faster than the load event.
             this.iframe.el.addEventListener('OdooFrameContentLoaded', () => this.websiteService.unblockIframe('load-iframe'), { once: true });
-        }, () => []);
+        });
+
+        onWillUnmount(() => {
+            this.websiteService.currentWebsiteId = null;
+            this.websiteService.websiteRootInstance = undefined;
+            this.websiteService.pageDocument = null;
+        });
     }
 
     get websiteId() {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -586,7 +586,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             };
         }
         if (this._isDirty()) {
-            return this.save().then(callback);
+            return this.save().then(callback, event.data.onFailure);
         } else {
             return callback();
         }

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -10,7 +10,9 @@ wTourUtils.registerEditionTour('snippet_editor_panel_options', {
 wTourUtils.dragNDrop({
     id: 's_text_image',
     name: 'Text - Image',
-}), {
+}),
+// Test keeping the text selection when using the width option.
+{
     content: "Click on the first paragraph.",
     trigger: 'iframe .s_text_image p',
 }, {
@@ -42,7 +44,9 @@ wTourUtils.dragNDrop({
             console.error("The paragraph text selection was lost.");
         }
     },
-}, {
+},
+// Test the anchor option.
+{
     content: "Click on the anchor option",
     trigger: '#oe_snippets .snippet-option-anchor we-button',
     run() {
@@ -71,6 +75,76 @@ wTourUtils.dragNDrop({
         const snippetId = iframeDocument.querySelector('.s_text_image').id;
         if (!url || url.indexOf(snippetId) < 0) {
             console.error('The anchor option does not target the correct snippet.');
+        }
+    },
+},
+// Test keeping the text selection when adding columns to a snippet with none.
+wTourUtils.goBackToBlocks(),
+wTourUtils.dragNDrop({
+    id: 's_text_block',
+    name: 'Text',
+}),
+{
+    content: "Click on the first paragraph.",
+    trigger: 'iframe .s_text_block p',
+}, {
+    content: "The text toolbar should be visible. The paragraph should be selected.",
+    trigger: '#oe_snippets .o_we_customize_panel > #o_we_editor_toolbar_container',
+    run() {
+        const iframeDocument = document.querySelector('.o_iframe').contentDocument;
+        const pText = iframeDocument.querySelector('.s_text_block p').textContent;
+        const selection = iframeDocument.getSelection().toString();
+        if (pText !== selection) {
+            console.error("The paragraph was not correctly selected.");
+        }
+    },
+}, {
+    content: "Click on the columns option.",
+    trigger: '.snippet-option-layout_column we-select',
+},
+{
+    content: "Change the number of columns.",
+    trigger: '.snippet-option-layout_column [data-select-count="3"]',
+}, {
+    content: "The snippet should have the correct number of columns.",
+    trigger: 'iframe .s_text_block .container > .row',
+    run() {
+        if (this.$anchor[0].childElementCount !== 3) {
+            console.error("The snippet does not have the correct number of columns");
+        }
+    },
+}, {
+    content: "The text toolbar should still be visible, and the text still selected.",
+    trigger: '#oe_snippets .o_we_customize_panel > #o_we_editor_toolbar_container',
+    run() {
+        const iframeDocument = document.querySelector('.o_iframe').contentDocument;
+        const pText = iframeDocument.querySelector('.s_text_block p').textContent;
+        const selection = iframeDocument.getSelection().toString();
+        if (pText !== selection) {
+            console.error("The paragraph text selection was lost.");
+        }
+    },
+},
+// Test keeping the text selection when removing all columns of a snippet.
+{
+    content: "Click on the columns option.",
+    trigger: '.snippet-option-layout_column we-select',
+},
+{
+    content: "Change the number of columns.",
+    trigger: '.snippet-option-layout_column [data-select-count="0"]',
+}, {
+    content: "The snippet should have the correct number of columns.",
+    trigger: 'iframe .s_text_block .container:not(:has(.row))',
+}, {
+    content: "The text toolbar should still be visible, and the text still selected.",
+    trigger: '#oe_snippets .o_we_customize_panel > #o_we_editor_toolbar_container',
+    run() {
+        const iframeDocument = document.querySelector('.o_iframe').contentDocument;
+        const pText = iframeDocument.querySelector('.s_text_block p').textContent;
+        const selection = iframeDocument.getSelection().toString();
+        if (pText !== selection) {
+            console.error("The paragraph text selection was lost.");
         }
     },
 }]);


### PR DESCRIPTION
[FIX] web_editor, website: unlock save/discard buttons on save failure

Before this commit, when saving a page website would fail (for a
validation error, for example), the "Save" and "Discard" buttons of the
SnippetsMenu were not re-enabled, and the edition was lost.

This was visible following this flow:
- Go on a job form view,
- Duplicate it,
- Go to its website page,
- Edit the title to remove "(copy)",
- Click on save,
=> There is a validation error (there cannot be two jobs with the same
title), the page was not saved and the user cannot access the
"Save" and "Discard" buttons to continue the edition anymore.

To fix that, the "after" callback of the SnippetsMenu _buttonClicked
method (which will re-enable the buttons) is added after or as the
onFailure callback of the "request_save" event.

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] website: correctly remove website systray on replayed action

[1] added a way to detect a replayed action, and returns early the
effect that parses the action's params to ignore them.

This implementation is an error, as the return value of the effect was
not consistent: for a replayed action, it was not returning the cleanup
function that resets the pageDocument, websiteRootInstance and
currentwebsiteId.

This was leading to such behaviour, with enterprise modules:
- Go to the website,
- Click on the top left 'home' button,
- Click on the top left arrow to replay the action,
- Click on the top left 'home' button again,
=> The website systray is still there.

To fix that, the cleanup function is moved to an onWillUnmount hook.

Also, blocking the iframe until its first load event is called in an
onMounted hook, as it is the same as using a useEffect hook with no
dependency and no cleanup function, but it is clearer.

[1]: https://github.com/odoo/odoo/commit/83501e38a338cabd5a064dd0db9f70df08a3aadc

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[FIX] web_editor, website: keep the text selection when changing columns

It was decided with [1] to keep the text selection, if there was one,
when changing a snippet's option.
It was not working for the layout_column option:
- Drop a text snippet,
- Click on the first paragraph (the text is selected),
- Change the number of columns,
=> The text selection is lost.

To add some columns on snippets like the s_text_block which has no rows
and columns, the layout_column option will first wrap its content into a
set of row and column, which will remove the selection.
To fix that, the selection is restored after wrapping the snippet's
content.

The same thing is done when removing all columns from a snippet (and
unwrapping its content).

Related to https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

[1]: https://github.com/odoo/odoo/commit/e8112e2865ca449c4df9cd6147e9e24c4c6dcd41

task-2687506


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
