### PR TITLE
[FIX] mail: fix traceback on rtc call

### DIFF
--- a/addons/mail/static/src/components/call_action_list/call_action_list.xml
+++ b/addons/mail/static/src/components/call_action_list/call_action_list.xml
@@ -47,7 +47,7 @@
                                 <i class="fa fa-video-camera fa-stack-1x" t-att-class="{ 'fa-lg': !callActionListView.isSmall, 'text-success': messaging.rtc.sendUserVideo }"/>
                             </div>
                         </button>
-                        <t t-if="!env.device.isMobileDevice">
+                        <t t-if="!messaging.device.isMobileDevice">
                             <button class="o_CallActionList_button o_CallActionList_videoButton btn d-flex m-1 border-0 rounded-circle bg-800 shadow-none"
                                 t-att-class="{
                                     'o-isActive': messaging.rtc.sendDisplay,


### PR DESCRIPTION
Since the PR hiding the screen sharing button on mobile [1], starting a
call result in tracebacks. The issue is that the code is using `env.device`
which is only available in the legacy env while discuss works with the wowlEnv.
In order to solve this issue, let's use `messaging.device` instead.

[1] : https://github.com/odoo/odoo/pull/97947
