### PR TITLE
[IMP] delivery: carrier is not set after delivery generated

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -59,6 +59,10 @@ class SaleOrder(models.Model):
         self._remove_delivery_line()
         for order in self:
             order.carrier_id = carrier.id
+            if order.state in ('sale', 'done'):
+                pending_deliverys = order.picking_ids.filtered(
+                    lambda p: p.state not in ('done', 'cancel') and p.location_id == p.picking_type_id.warehouse_id.lot_stock_id)
+                pending_deliverys.carrier_id = carrier.id
             order._create_delivery_line(carrier, amount)
         return True
 

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -59,10 +59,6 @@ class SaleOrder(models.Model):
         self._remove_delivery_line()
         for order in self:
             order.carrier_id = carrier.id
-            if order.state in ('sale', 'done'):
-                pending_deliverys = order.picking_ids.filtered(
-                    lambda p: p.state not in ('done', 'cancel') and p.location_id == p.picking_type_id.warehouse_id.lot_stock_id)
-                pending_deliverys.carrier_id = carrier.id
             order._create_delivery_line(carrier, amount)
         return True
 

--- a/addons/stock_delivery/models/sale_order.py
+++ b/addons/stock_delivery/models/sale_order.py
@@ -30,3 +30,11 @@ class SaleOrder(models.Model):
         else:
             post = u'\N{NO-BREAK SPACE}{symbol}'.format(symbol=self.currency_id.symbol or '')
         return u' {pre}{0}{post}'.format(amount, pre=pre, post=post)
+
+    def set_delivery_line(self, carrier, amount):
+        for order in self:
+            if order.state in ('sale', 'done'):
+                pending_deliverys = order.picking_ids.filtered(
+                    lambda p: p.state not in ('done', 'cancel') and p.location_id == p.picking_type_id.warehouse_id.lot_stock_id)
+                pending_deliverys.carrier_id = carrier.id
+        return super().set_delivery_line(carrier, amount)

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -181,3 +181,60 @@ class StockMoveInvoice(AccountTestInvoicingCommon):
         choose_delivery_carrier.button_confirm()
 
         self.assertEqual(so.invoice_status, 'no', 'The status should still be "Nothing To Invoice"')
+
+    def test_delivery_carrier_from_confirm_so(self):
+        '''Test if add shipping method in sale order after conform
+           will it add in pickings too or not"'''
+
+        sale_prepaid = self.SaleOrder.create({
+            'partner_id': self.partner_18.id,
+            'partner_invoice_id': self.partner_18.id,
+            'partner_shipping_id': self.partner_18.id,
+            'order_line': [(0, 0, {
+                'name': 'Cable Management Box',
+                'product_id': self.product_cable_management_box.id,
+                'product_uom_qty': 2,
+                'product_uom': self.product_uom_unit.id,
+                'price_unit': 750.00,
+            })],
+        })
+
+        # Confirm the SO.
+        sale_prepaid.action_confirm()
+
+        # Validate picking
+        wiz_act = sale_prepaid.picking_ids.button_validate()
+        Form(self.env[wiz_act['res_model']].with_context(wiz_act['context'])).save().process()
+
+        # Return picking
+        return_form = Form(self.env['stock.return.picking'].with_context(active_id=sale_prepaid.picking_ids.id, active_model='stock.picking'))
+        return_wizard = return_form.save()
+        action = return_wizard.create_returns()
+        return_picking = self.env['stock.picking'].browse(action['res_id'])
+
+        #add new product so new picking is created
+        sale_prepaid.write({
+            'order_line': [(0, 0, {
+                'name': 'Another product to deliver',
+                'product_id': self.product_11.id,
+                'product_uom_qty': 2,
+                'product_uom': self.product_uom_unit.id,
+                'price_unit': 750.00,
+            })],
+        })
+
+        # Add delivery cost in Sales order
+        delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
+            'default_order_id': sale_prepaid.id,
+            'default_carrier_id': self.normal_delivery.id,
+        }))
+        choose_delivery_carrier = delivery_wizard.save()
+        choose_delivery_carrier.button_confirm()
+
+        # Check the carrier in picking after conform sale order
+        delivery_for_product_11 = sale_prepaid.picking_ids.filtered(lambda p: self.product_11 in p.move_ids.product_id)
+        self.assertEqual(delivery_for_product_11.carrier_id, self.normal_delivery, 'The shipping method should be set in pending deliveries.')
+
+        done_delivery = sale_prepaid.picking_ids.filtered(lambda p: p.state == "done")
+        self.assertFalse(done_delivery.carrier_id.id, 'The shipping method should not be set in done deliveries.')
+        self.assertFalse(return_picking.carrier_id.id, 'The shipping method should not set in return picking')


### PR DESCRIPTION
Before this commit
==================
when SO is confirmed and Delivery is created then add the shipping method
in SO, in this case, the shipping carrier is not set in the existing undelivered
delivery of that SO.

After this commit
=================
So in this commit, we set the shipping carrier for that delivery.

TaskId: 2946360

