### PR TITLE
[FIX] web_editor, website: update invisible elements panel on undo

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1472,6 +1472,8 @@ var SnippetsMenu = Widget.extend({
                 const target = selection.getRangeAt(0).startContainer.parentElement;
                 this._activateSnippet($(target));
             }
+
+            this._updateInvisibleDOM();
         }, 500);
         this.options.wysiwyg.odooEditor.addEventListener('historyUndo', refreshSnippetEditors);
         this.options.wysiwyg.odooEditor.addEventListener('historyRedo', refreshSnippetEditors);

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -27,4 +27,28 @@ tour.register('snippet_popup_add_remove', {
     in_modal: false,
     trigger: '#wrap.o_editable:not(:has([data-snippet="s_popup"]))',
     run: () => null,
+},
+// Test that undoing dropping the snippet removes the invisible elements panel.
+{
+    content: "Drop the snippet again.",
+    trigger: '#oe_snippets .oe_snippet:has(> [data-snippet="s_popup"]) .oe_snippet_thumbnail',
+    run: "drag_and_drop #wrap",
+}, {
+    content: "The popup should be in the invisible elements panel.",
+    in_modal: false,
+    trigger: '.o_we_invisible_el_panel .o_we_invisible_entry',
+    run: () => null, // It's a check.
+}, {
+    content: "Click on the 'undo' button.",
+    in_modal: false,
+    trigger: '#oe_snippets button[data-action="undo"]',
+}, {
+    content: "Check that the s_popup was removed.",
+    in_modal: false,
+    trigger: '#wrap.o_editable:not(:has([data-snippet="s_popup"]))',
+    run: () => null, // It's a check.
+}, {
+    content: "The invisible elements panel should also be removed.",
+    trigger: '#oe_snippets:has(.o_we_invisible_el_panel.d-none)',
+    run: () => null, // It's a check.
 }]);


### PR DESCRIPTION
Before this commit, after:
- Drop a popup,
- Click on the undo button,
=> The invisible elements panel was still displayed, with the popup
entry.

To fix that, the panel visibility is updated on the
'historyUndo'/'historyRedo' events alongside refreshing the snippets
editors.

task-2687506

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
