### PR TITLE
[FIX] web: use different hotkeys for 'ADD' and 'SAVE' buttons

### DIFF
--- a/addons/web/static/src/legacy/js/views/view_dialogs.js
+++ b/addons/web/static/src/legacy/js/views/view_dialogs.js
@@ -133,7 +133,7 @@ var FormViewDialog = ViewDialog.extend({
                 options.buttons.unshift({
                     text: options.save_text || (multi_select ? _t("Save & Close") : _t("Save")),
                     classes: "btn-primary",
-                    hotkey: 'c',
+                    hotkey: 's',
                     click: function () {
                         self._save().then(self.close.bind(self));
                     }


### PR DESCRIPTION
A modal using the 'ADD' and 'SAVE' buttons will have the same keyboard
shortcut for both of these buttons

Steps to reproduce:
1. Install Inventory
2. Go to Inventory > Operations > Transfers and open a transfer with a
contact and in status 'Ready'
3. Click on 'EDIT' and open the contact in the Delivery Address with the
quick edit button
4. Push on 'Alt' key: the 'ADD' and 'SAVE' buttons use the same shortcut

Solution:
Modify the current hotkey used for button 'SAVE'

opw-2954146