### PR TITLE
[FIX] core: apply user's tz on formatting Datetime field as Date

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1250,6 +1250,9 @@ def format_date(env, value, lang_code=False, date_format=False):
             value = odoo.fields.Datetime.context_timestamp(env['res.lang'], value)
         else:
             value = odoo.fields.Datetime.from_string(value)
+    elif isinstance(value, datetime.datetime):
+        # a datetime, convert to correct timezone
+        value = odoo.fields.Datetime.context_timestamp(env['res.lang'], value)
 
     lang = get_lang(env, lang_code)
     locale = babel_locale_parse(lang.code)


### PR DESCRIPTION
STEPS in v14:

1. Set user's timezone to Asia/Qatar
2. Inventory > Config > Setting > Enable Lots & Serial Numbers, Expiration Dates, Display Lots & Serial Numbers on Delivery Slips, Display Expiration Dates on Delivery Slips
3. Create a product (storable, tracking by lots, expiration date)
4. Manually update the on-hand quantity for the product
5. Create a lot for the product created in Step 3 > Set the expiration date to 3/30/2025 00:00:00
6. Create an SO with the product > Confirm it to Delivery
7. Validate the Delivery > Print the Delivery Slip

Before this commit the expiration date is rendered as 03/29/2025 instead of 03/30/2025

opw-2901367

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
