### PR TITLE
[FIX] core: apply user's tz on formatting Datetime field as Date

### DIFF
--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -276,6 +276,18 @@ class TestFormatLangDate(TransactionCase):
         self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part, time_format='short', lang_code='zh_CN'), '\u4e0b\u53484:30')
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part, time_format='medium', lang_code='fr_FR'), '16:30:22')
 
+    def test_02_tz(self):
+        self.env.user.tz = 'Europe/Brussels'
+        datetime_str = '2016-12-31 23:55:00'
+        date_datetime = datetime.datetime.strptime(datetime_str, "%Y-%m-%d %H:%M:%S")
+
+        # While London is still in 2016, Brussels is already in 2017
+        self.assertEqual(misc.format_date(self.env, date_datetime), '01/01/2017')
+
+        # Force London timezone
+        date_datetime = date_datetime.replace(tzinfo=pytz.UTC)
+        self.assertEqual(misc.format_date(self.env, date_datetime), '12/31/2016', "User's tz must be ignored when tz is specifed in datetime object")
+
 
 class TestCallbacks(BaseCase):
     def test_callback(self):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1389,6 +1389,9 @@ def format_date(env, value, lang_code=False, date_format=False):
             value = odoo.fields.Datetime.context_timestamp(env['res.lang'], value)
         else:
             value = odoo.fields.Datetime.from_string(value)
+    elif isinstance(value, datetime.datetime) and not value.tzinfo:
+        # a datetime, convert to correct timezone
+        value = odoo.fields.Datetime.context_timestamp(env['res.lang'], value)
 
     lang = get_lang(env, lang_code)
     locale = babel_locale_parse(lang.code)


### PR DESCRIPTION
STEPS in v14:

1. Set user's timezone to Asia/Qatar
2. Inventory > Config > Setting > Enable Lots & Serial Numbers, Expiration Dates, Display Lots & Serial Numbers on Delivery Slips, Display Expiration Dates on Delivery Slips
3. Create a product (storable, tracking by lots, expiration date)
4. Manually update the on-hand quantity for the product
5. Create a lot for the product created in Step 3 > Set the expiration date to 3/30/2025 00:00:00
6. Create an SO with the product > Confirm it to Delivery
7. Validate the Delivery > Print the Delivery Slip

Before this commit the expiration date is rendered as 03/29/2025 instead of 03/30/2025

opw-2901367

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
