### PR TITLE
[IMP] website_sale: support html styling on sale_description

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -646,7 +646,7 @@
                                     </t>
                                 </a>
                             </t>
-                            <p t-field="product.description_sale" class="text-muted my-2" placeholder="A short description that will also appear on documents." />
+                            <div t-field="product.product_page_description" placeholder="A short description that will also appear on documents."/>
                             <form t-if="product._is_add_to_cart_possible()" action="/shop/cart/update" method="POST">
                                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                                 <div class="js_product js_main_product mb-3">


### PR DESCRIPTION
Prior to this commit there was no way of using styling on the
sale_description of a product.
A new HTML field has been added that will be empty until a designer
changes the field from the product's page. Which in that case will save
to the new field instead, directly supporting the styling.
Once the field has been set, `sale_description` should not be displayed
to the user anymore on the website.

TaskId-2906587