### PR TITLE
[IMP] mail: change identifyingmode of attachment viewer

### DIFF
--- a/addons/mail/static/src/models/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer.js
@@ -6,6 +6,7 @@ import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentViewer',
+    identifyingMode: 'xor',
     recordMethods: {
         /**
          * Close the dialog with this attachment viewer.


### PR DESCRIPTION
Part of the document B2B (see odoo/enterprise#29807 )

The attachment viewer can be opened without being a dialog in the
documents app now.

TaskId-2863861