### PR TITLE
[FIX] calendar,appointment: wrong day in email templates

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -59,7 +59,7 @@
                 <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='EEEE', lang_code=object.env.lang) or ''">Tuesday</t>
             </div>
             <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
-                <t t-out="str(object.event_id.start.day) or ''">4</t>
+                <t t-out="format_datetime(dt=object.event_id.start, tz=mail_tz if not object.event_id.allday else None, dt_format='d', lang_code=object.event_id.env.lang) or ''">4</t>
             </div>
             <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
                 <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='MMMM y', lang_code=object.env.lang) or ''">May 2021</t>
@@ -187,7 +187,7 @@
                 <t t-out='format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang) or ""'>Tuesday</t>
             </div>
             <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
-                <t t-out="str(object.event_id.start.day) or ''">4</t>
+                <t t-out="format_datetime(dt=object.event_id.start, tz=mail_tz if not object.event_id.allday else None, dt_format='d', lang_code=object.event_id.env.lang) or ''">4</t>
             </div>
             <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
                 <t t-out='format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="MMMM y", lang_code=object.env.lang) or ""'>May 2021</t>
@@ -288,7 +288,7 @@
                 <t t-out='format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang) or ""'>Tuesday</t>
             </div>
             <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
-                <t t-out="str(object.event_id.start.day) or ''">4</t>
+                <t t-out="format_datetime(dt=object.event_id.start, tz=mail_tz if not object.event_id.allday else None, dt_format='d', lang_code=object.event_id.env.lang) or ''">4</t>
             </div>
             <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
                 <t t-out='format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="MMMM y", lang_code=object.env.lang) or ""'>May 2021</t>


### PR DESCRIPTION
Steps to reproduce:

1. install appointment, calendar
2. go to calendar app, online appointments
3. create a new appointment with date 30/12/2021 01:00 am
4. in the invitation email, the day is 29 not 30

Bug:

Odoo runs on UTC while the email/form runs on user's time zone.
The time is converted to the right time zone but the day isn't

Fix:
make the day dependant on the timezone

OPW-2887339