### PR TITLE
[FIX] project: grouping by date_deadline access error

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1630,7 +1630,9 @@ class Task(models.Model):
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
         fields_list = ([f.split(':')[0] for f in fields] or [])
         if groupby:
-            fields_list += [groupby] if isinstance(groupby, str) else groupby
+            fields_groupby = [groupby] if isinstance(groupby, str) else groupby
+            # only take field name when having ':' e.g 'date_deadline:week' => 'date_deadline'
+            fields_list += [f.split(':')[0] for f in fields_groupby]
         if domain:
             fields_list += [term[0].split('.')[0] for term in domain if isinstance(term, (tuple, list))]
         self._ensure_fields_are_accessible(fields_list)


### PR DESCRIPTION
To Reproduce
=============

- share a project with a portal user (with editing rights)
- connect to portal with this user and try to group tasks by deadline

Problem
=======

An access error is raised stating that this user doesn't have right to read
`deadline_field:week` field.

The issue comes from this line :
https://github.com/odoo/odoo/blob/42cb8ad0a31162d9d1b93e4eae0562c89685fe3c/addons/project/models/project.py#L1621

where `fields` contains `date_deadline:week` but `self.SELF_READABLE_FIELDS` contains `date_deadline`
that's why `date_deadline:week` will remain in `unauthorized_fields` .

Solution
=========

To solve the issue we take only the field name from the groupby when computing `fields_list` that
will be checked by `_ensure_fields_are_accessible`

opw-2949047
