### PR TITLE
[FIX] web: click on ViewButton will close parent Dropdown

### DIFF
--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -1,5 +1,6 @@
 /** @odoo-module */
 
+import { DROPDOWN } from "@web/core/dropdown/dropdown";
 import { debounce as debounceFn } from "@web/core/utils/timing";
 
 const { Component } = owl;
@@ -84,6 +85,11 @@ export class ViewButton extends Component {
         this.env.onClickViewButton({
             clickParams: this.clickParams,
             record: this.props.record,
+            beforeExecute: () => {
+                if (this.env[DROPDOWN]) {
+                    this.env[DROPDOWN].close();
+                }
+            },
         });
     }
 


### PR DESCRIPTION
# Issue
A Dropdown is not closed when a child ViewButton is clicked.

# Solution
Make the ViewButton close the Dropdown.

# Note
Usually, a dropdown is closed by a DropdownItem component.
This is not the case here, because the clicks on view buttons are stopped
(see the view button template). Letting them bubble would close their
eventual parent dropdown, but it brings other issues (e.g. for a view button
in a list renderer's group row, or view buttons that could get interpreted
as action links under some conditions <a type="action" .../>).

Instead of looking in the env to close the parent dropdown if any,
an alternative solution would be to extend the ViewButton component,
wrap it in a DropdownItem component, and reroute its `onClick` handler
to the DropdownItem's `onSelected` prop.
But this requires some preparation at the form compiler level
(when compiling the status bar buttons), which we thought was overengineering
at the time of writing.