### PR TITLE
[FIX] website, survey: correct the aria-labelledby

### DIFF
--- a/addons/survey/static/src/xml/survey_image_zoomer_templates.xml
+++ b/addons/survey/static/src/xml/survey_image_zoomer_templates.xml
@@ -3,7 +3,7 @@
 
     <t t-name="survey.survey_image_zoomer">
         <div role="dialog" class="o_survey_img_zoom_modal modal fade d-flex align-items-center p-0"
-            data-bs-backdrop="false" aria-labbelledby="Image Zoom Dialog" tabindex="-1">
+            data-bs-backdrop="false" aria-label="Image Zoom Dialog" tabindex="-1">
             <div class="o_survey_img_zoom_dialog modal-dialog h-100 w-100 mw-100 py-0" role="Picture Enlarged">
                 <div class="modal-content h-100 bg-transparent">
                     <div class="o_survey_img_zoom_body modal-body h-100 bg-transparent d-flex justify-content-center">

--- a/addons/website/static/src/snippets/s_image_gallery/000.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/000.xml
@@ -53,7 +53,7 @@
         ========================================================================
     -->
     <t t-name="website.gallery.slideshow.lightbox">
-        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-labbelledby="Image Gallery Dialog">
+        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-label="Image Gallery Dialog">
             <div class="modal-dialog m-0" role="Picture Gallery"
                 t-attf-style="">
                 <div class="modal-content bg-transparent">


### PR DESCRIPTION
The attribute `aria-labelledby` was used erroneously and was misspelled.
This commit corrects that by replacing it with the aria-label attribute.

task-2937538
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
