### PR TITLE
[FIX] website_sale: Don't reset base_unit_count

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -51,7 +51,6 @@ class ProductTemplate(models.Model):
 
     @api.depends('product_variant_ids', 'product_variant_ids.base_unit_count')
     def _compute_base_unit_count(self):
-        self.base_unit_count = 0
         for template in self.filtered(lambda template: len(template.product_variant_ids) == 1):
             template.base_unit_count = template.product_variant_ids.base_unit_count
 


### PR DESCRIPTION
Steps to reproduce:

  - Install Ecommerce module
  - Enable in settings `Product Reference Price`
  - Create a Product X:
    - Base unit count = 1
    - Add a variant with some attributes
  - Go to shop, select product X and ensure base price unit is displayed.
  - Go back to edit the product X
  - Add a variants with some attributes to product X
  - Go to shop, select product X

Issue:

  Base unit price of all variants is not displayed anymore.

Cause:

  When adding new variants, we recompute the base_unit_count (field that
  allow to display base_unit_price or not) on the product template to
  set the value of the product variants if have
  only one variant, else we set it to 0.

Solution:

  Don't set base_unit_count to 0.

opw-2930566