### PR TITLE
[FIX] base: asset bundles should escape '\r'

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -414,7 +414,7 @@ class AssetsBundle(object):
                     window.alert(message);
                 }
             })("%s");
-        """ % message.replace('"', '\\"').replace('\n', '&NewLine;')
+        """ % message.replace('"', '\\"').replace('\n', '&NewLine;').replace('\r', '')
 
     def _get_assets_domain_for_already_processed_css(self, assets):
         """ Method to compute the attachments' domain to search the already process assets (css).


### PR DESCRIPTION
Before this commit:
If an error was happening on the asset processing and this error was containing a `\r` character, it will cause a JS error as it can't load the error message correctly. The error is due to \r that create a new line in the middle of our string. This creates a syntax error: `Invalid or unexpected token (at web:X:Y)`.
As a consequence, the regular asset error won't show in the usual modal dialog box to inform the user of the issue.
![image](https://user-images.githubusercontent.com/60775325/185406145-bbc38141-102d-4a3c-934d-1a7d668a841c.png)

After this commit:
The error is displayed with the `\r` visible in it
![image](https://user-images.githubusercontent.com/60775325/185406318-a8bcd676-2961-4bf9-93cd-958875909774.png)


OPW-2954737

--

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
