### PR TITLE
[FIX] web_editor: prevent sizing to trigger changes events on focus

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4274,12 +4274,6 @@ registry.sizing = SnippetOptionWidget.extend({
 
         return def;
     },
-    /**
-     * @override
-     */
-    onFocus: function () {
-        this._onResize();
-    },
 
     //--------------------------------------------------------------------------
     // Public
@@ -4288,8 +4282,17 @@ registry.sizing = SnippetOptionWidget.extend({
     /**
      * @override
      */
+    async updateUI() {
+        this._updateSizingHandles();
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
     setTarget: function () {
         this._super(...arguments);
+        // TODO master: _onResize should not be called here, need to check if
+        // updateUI is called when the target is changed
         this._onResize();
     },
 
@@ -4320,6 +4323,13 @@ registry.sizing = SnippetOptionWidget.extend({
      * @param {integer} [current] - current increment in this.grid
      */
     _onResize: function (compass, beginClass, current) {
+        this._updateSizingHandles();
+        this._notifyResizeChange();
+    },
+    /**
+     * @private
+     */
+    _updateSizingHandles: function () {
         var self = this;
 
         // Adapt the resize handles according to the classes and dimensions
@@ -4360,6 +4370,11 @@ registry.sizing = SnippetOptionWidget.extend({
             var direction = $handle.hasClass('n') ? 'top' : 'bottom';
             $handle.height(self.$target.css('padding-' + direction));
         });
+    },
+    /**
+     * @override
+     */
+    async _notifyResizeChange() {
         this.$target.trigger('content_changed');
     },
 });
@@ -4455,6 +4470,12 @@ registry['sizing_x'] = registry.sizing.extend({
                 this.$target.addClass('offset-lg-' + offset);
             }
         }
+        this._super.apply(this, arguments);
+    },
+    /**
+     * @override
+     */
+    async _notifyResizeChange() {
         this.trigger_up('option_update', {
             optionName: 'StepsConnector',
             name: 'change_column_size',

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -92,7 +92,8 @@
                     <t t-snippet="website.s_product_list" t-thumbnail="/website/static/src/img/snippets_thumbs/s_product_list.svg"/>
                     <t t-snippet="website.s_tabs" t-thumbnail="/website/static/src/img/snippets_thumbs/s_tabs.svg"/>
                     <t t-snippet="website.s_timeline" t-thumbnail="/website/static/src/img/snippets_thumbs/s_timeline.svg"/>
-                    <t t-snippet="website.s_process_steps" t-thumbnail="/website/static/src/img/snippets_thumbs/s_process_steps.svg"/>
+                    <t t-snippet="website.s_process_steps" t-thumbnail="/website/static/src/img/snippets_thumbs/s_process_steps.svg"
+                       t-forbid-sanitize="true"/>
                     <t t-snippet="website.s_quotes_carousel" t-thumbnail="/website/static/src/img/snippets_thumbs/s_quotes_carousel.svg">
                         <keywords>testimonials</keywords>
                     </t>


### PR DESCRIPTION
Before this commit, when one was clicking/focusing an element which was
receiving the sizing option(s), it would directly trigger some onchanges
internal events, even if no changes were done yet.
One of those events was `change_column_size` directly called on the
steps snippets options.

That event was then listened by the steps options and was making the
connector to be reloaded.

While it was useless as there were no real changes yet (just focused),
it was also leading to a traceback if one was clicking on an outdated
steps snippet, for instance after a migration from v15.
In v15, the connectors were improved with [1] and became svg elements
instead of pseudo elements.
The internal method reloading the connector thus can't find those
selectors on an outdated snippet.

This commit now splits the code in 2, to extract the firing of the
onchange events when there is actually some changes.

This will allow to click on outdated steps snippet without having a
traceback as the code won't try to reload the connectors anymore.
That outdated block will then be marked as such in the right panel and
the user will be able to delete it to recreate it if needed.

Remember than without this commit, since there would be a traceback, the
whole current page edition / changes would simply be lost.

[1]: https://github.com/odoo/odoo/commit/aba31e9f2d8a44ce1586403f2a621a6caeed57b4

opw-2895569