### PR TITLE
[FIX] web : drag and drop for kanban does not open record

### DIFF
--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -230,11 +230,6 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
      * @private
      */
     _openRecord: function () {
-        if (this.$el.hasClass('o_currently_dragged')) {
-            // this record is currently being dragged and dropped, so we do not
-            // want to open it.
-            return;
-        }
         var editMode = this.$el.hasClass('oe_kanban_global_click_edit');
         this.trigger_up('open_record', {
             id: this.db_id,
@@ -672,6 +667,11 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
      */
     _onGlobalClick: function (event) {
         if ($(event.target).parents('.o_dropdown_kanban').length) {
+            return;
+        }
+        if (this.$el.hasClass('o_currently_dragged')) {
+            // this record is currently being dragged and dropped, so we do not
+            // want to open it.
             return;
         }
         var trigger = true;


### PR DESCRIPTION
Steps to reproduce:
-Install Project
-Activate kanban view for projects in the settings
-On firefix do a drag and drop of a project between two stages

Current behavior:
You are redirect to the project record

Expected behavior:
The project changed stage but there is no redirection

Solution:
The check for the drag&drop case only happen inside the openRecord
function but the record should not be open in this situation and
hence the check should happen before the function is called in
onGlobalClick.

opw-2952389