### PR TITLE
[FIX] web: disable timezone convert for Date field custom filters

### DIFF
--- a/addons/web/static/src/search/filter_menu/custom_filter_item.js
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.js
@@ -91,17 +91,25 @@ const parseField = (field, value, opts = {}) => {
         return value;
     }
     const type = field.type === "id" ? "integer" : field.type;
+    const options = { field, ...opts };
+    if (["date", "datetime"].includes(type)) {
+        options.timezone = type === "datetime";
+    }
     const parse = parsers.contains(type) ? parsers.get(type) : (v) => v;
-    return parse(value, { field, ...opts });
+    return parse(value, options);
 };
 
 const formatField = (field, value, opts = {}) => {
     if (FIELD_TYPES[field.type] === "char") {
         return value;
     }
+    const options = { field, ...opts };
     const type = field.type === "id" ? "integer" : field.type;
+    if (["date", "datetime"].includes(type)) {
+        options.timezone = type === "datetime";
+    }
     const format = formatters.contains(type) ? formatters.get(type) : (v) => v;
-    return format(value, { field, ...opts });
+    return format(value, options);
 };
 
 export class CustomFilterItem extends Component {
@@ -220,7 +228,7 @@ export class CustomFilterItem extends Component {
                 domainValue = condition.value.map(serialize);
                 descriptionArray.push(
                     `"${condition.value
-                        .map((val) => formatField(field, val, { timezone: true }))
+                        .map((val) => formatField(field, val))
                         .join(" " + this.env._t("and") + " ")}"`
                 );
             } else {

--- a/addons/web/static/tests/search/custom_filter_item_tests.js
+++ b/addons/web/static/tests/search/custom_filter_item_tests.js
@@ -441,6 +441,37 @@ QUnit.module("Search", (hooks) => {
         }
     );
 
+    QUnit.test("custom filter date with equal operator", async function (assert) {
+        assert.expect(2);
+
+        const originalZoneName = luxon.Settings.defaultZoneName;
+        luxon.Settings.defaultZoneName = new luxon.FixedOffsetZone.instance(-240);
+        registerCleanup(() => {
+            luxon.Settings.defaultZoneName = originalZoneName;
+        });
+
+        patchDate(2017, 1, 22, 12, 30, 0);
+
+        const controlPanel = await makeWithSearch({
+            serverData,
+            resModel: "foo",
+            Component: ControlPanel,
+            searchViewId: false,
+            searchMenuTypes: ["filter"],
+        });
+
+        await toggleFilterMenu(controlPanel);
+        await toggleAddCustomFilter(controlPanel);
+
+        await editConditionField(controlPanel, 0, "date_field");
+        await editConditionOperator(controlPanel, 0, "=");
+        await editConditionValue(controlPanel, 0, "01/01/2017");
+        await applyFilter(controlPanel);
+
+        assert.deepEqual(getFacetTexts(controlPanel), ['A date is equal to "01/01/2017"']);
+        assert.deepEqual(getDomain(controlPanel), [["date_field", "=", "2017-01-01"]]);
+    });
+
     QUnit.test("custom filter datetime with equal operator", async function (assert) {
         assert.expect(5);
 


### PR DESCRIPTION
Reproduction:
1. Install Timesheet, and load demo data
2. Mimic a timezone in browser (Chrome): Right click->Inspect->Sensors,
in the Location-> choose Other…, type “America/Puerto_Rico” in Timezone
ID, refresh the page
3. Go to Timesheets->Timesheets->All timesheets, choose pivot view
4. Add custom filter, Date is between 1st/Aug/2022 and 5th/Aug/2022,
apply
5. The filter result is correct but the tag in the search bar is “Date
is between 31/07/2022 and 04/08/2022”

This also happens to other fields with type Date, but not Datetime. For
example, in Accounting->Reporting->Invoices Analysis->Pivot view, the
same issue happens with Due Date filter. For Datetime field, it doesn’t
have the issue, for example in CRM->Sales->My pipeline, change to pivot
view, the custom filter for Assignment Date doesn’t have the time zone
issue.

Note: reproduction usually works during the daytime in Brussels.

Reason: miswriting when rewrote custom_filter_item from V14 to V15. The
value pushed to descriptionArray should not be changed on time zone.

Fix: add type check for Date and Datetime in parseField and formatField.
When it’s Datetime, with timezone converting. When it’s a Date, no
timezone converting. Add test for the Date filters

Related PR: https://github.com/odoo-dev/odoo/commit/aeb8e49972f871b0c9b07c507987ee77cf5e8abd?diff=unified#diff-6d9230cfcd007b087b2851cbf0b4a33b26dc3c91087853da6fe7ce8c2b60e42f

Reference code in V14: https://github.com/odoo/odoo/blob/14.0/addons/web/static/src/js/control_panel/custom_filter_item.js#L170-L173

opw-2941231

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
