### PR TITLE
[FIX] account_edi_ubl_cii: Don't attach edi document to on confirm

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -118,9 +118,9 @@ class AccountEdiFormat(models.Model):
                 'raw': xml_content,
                 'mimetype': 'application/xml',
             }
-            # we don't want the Factur-X and E-FFF xml to appear in the attachment of the invoice when confirming it
-            # E-FFF will appear after the pdf is generated, Factur-X will never appear (it's contained in the PDF)
-            if self.code not in ['facturx_1_0_05', 'efff_1']:
+            # we don't want the Factur-X, E-FFF and NLCIUS xml to appear in the attachment of the invoice when confirming it
+            # E-FFF and NLCIUS will appear after the pdf is generated, Factur-X will never appear (it's contained in the PDF)
+            if self.code not in ['facturx_1_0_05', 'efff_1', 'nlcius_1']:
                 attachment_create_vals.update({'res_id': invoice.id, 'res_model': 'account.move'})
 
             attachment = self.env['ir.attachment'].create(attachment_create_vals)


### PR DESCRIPTION
Steps to reproduce:

  - Install Netherlands localization module
  - In the `Customer Invoice` journal, activate `NLCIUS (Netherlands)`
    as Electronic Invoicing
  - Create a new invoice and confirm

Issue:

  XML generated and available as attachment and if we click on
  `Send & print`, a second one is added to attachments.

Cause:

  If it's not a factur-x or e-fff edi documents, we will generate the
  XML file add it as attachment on confirm.

Solution:

  Don't add as attachment of the invoice when confirming invoice if
  code is `nlcius_1` (like for factur-x and e-fff edi documents),
  only when generating invoice PDF (`Sent & Print`).

opw-2751148