### PR TITLE
 [REF] website, *: make _search_get_details extensible

### DIFF
--- a/addons/test_website/models/website.py
+++ b/addons/test_website/models/website.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo.addons.website.models.website import SEARCH_TYPE_MODELS
 
-
-class Website(models.Model):
-    _inherit = "website"
-
-    def _search_get_details(self, search_type, order, options):
-        result = super()._search_get_details(search_type, order, options)
-        if search_type in ['test']:
-            result.append(self.env['test.model']._search_get_detail(self, order, options))
-        return result
+SEARCH_TYPE_MODELS['test'] |= 'test.model',

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -5,7 +5,11 @@ import hashlib
 import inspect
 import json
 import logging
+import operator
 import re
+from collections import defaultdict
+from functools import reduce
+
 import requests
 
 from lxml import etree, html
@@ -26,7 +30,7 @@ from odoo.http import request
 from odoo.modules.module import get_resource_path, get_manifest
 from odoo.osv.expression import AND, OR, FALSE_DOMAIN, get_unaccent_wrapper
 from odoo.tools.translate import _
-from odoo.tools import escape_psql, pycompat
+from odoo.tools import escape_psql, OrderedSet, pycompat
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +46,10 @@ DEFAULT_CDN_FILTERS = [
 ]
 
 DEFAULT_ENDPOINT = 'https://website.api.odoo.com'
+
+SEARCH_TYPE_MODELS = defaultdict(OrderedSet)
+# Create or add to an OrderedSet by providing a tuple.
+SEARCH_TYPE_MODELS['pages'] |= 'website.page',
 
 
 class Website(models.Model):
@@ -1518,10 +1526,13 @@ class Website(models.Model):
 
         :return: list of search details obtained from the `website.searchable.mixin`'s `_search_get_detail()`
         """
-        result = []
-        if search_type in ['pages', 'all']:
-            result.append(self.env['website.page']._search_get_detail(self, order, options))
-        return result
+        if search_type == 'all':
+            model_names = reduce(operator.ior, SEARCH_TYPE_MODELS.values())
+        else:
+            model_names = SEARCH_TYPE_MODELS[search_type]
+
+        return list(self.env[model_name]._search_get_detail(self, order, options)
+                    for model_name in model_names)
 
     def _search_with_fuzzy(self, search_type, search, limit, order, options):
         """

--- a/addons/website_blog/models/website.py
+++ b/addons/website_blog/models/website.py
@@ -5,6 +5,11 @@ from markupsafe import Markup
 
 from odoo import api, models, _
 from odoo.addons.http_routing.models.ir_http import url_for
+from odoo.addons.website.models.website import SEARCH_TYPE_MODELS
+
+SEARCH_TYPE_MODELS['blogs'] |= 'blog.blog', 'blog.post'
+SEARCH_TYPE_MODELS['blogs_only'] |= 'blog.blog',
+SEARCH_TYPE_MODELS['blog_posts_only'] |= 'blog.post',
 
 
 class Website(models.Model):
@@ -85,11 +90,3 @@ class Website(models.Model):
             else:
                 self.env['website.menu'].create(blog_menu_values)
         super().configurator_set_menu_links(menu_company, module_data)
-
-    def _search_get_details(self, search_type, order, options):
-        result = super()._search_get_details(search_type, order, options)
-        if search_type in ['blogs', 'blogs_only', 'all']:
-            result.append(self.env['blog.blog']._search_get_detail(self, order, options))
-        if search_type in ['blogs', 'blog_posts_only', 'all']:
-            result.append(self.env['blog.post']._search_get_detail(self, order, options))
-        return result

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -3,6 +3,10 @@
 
 from odoo import models, _
 from odoo.addons.http_routing.models.ir_http import url_for
+from odoo.addons.website.models.website import SEARCH_TYPE_MODELS
+
+SEARCH_TYPE_MODELS['events'] |= 'event.event',
+
 
 class Website(models.Model):
     _inherit = "website"
@@ -18,9 +22,3 @@ class Website(models.Model):
             cta_btn_text = _('Next Events')
             return {'cta_btn_text': cta_btn_text, 'cta_btn_href': '/event'}
         return cta_data
-
-    def _search_get_details(self, search_type, order, options):
-        result = super()._search_get_details(search_type, order, options)
-        if search_type in ['events', 'all']:
-            result.append(self.env['event.event']._search_get_detail(self, order, options))
-        return result

--- a/addons/website_forum/models/website.py
+++ b/addons/website_forum/models/website.py
@@ -3,6 +3,11 @@
 
 from odoo import models, fields, api, _
 from odoo.addons.http_routing.models.ir_http import url_for
+from odoo.addons.website.models.website import SEARCH_TYPE_MODELS
+
+SEARCH_TYPE_MODELS['forums'] |= 'forum.forum', 'forum.post'
+SEARCH_TYPE_MODELS['forums_only'] |= 'forum.forum',
+SEARCH_TYPE_MODELS['forum_posts_only'] |= 'forum.post',
 
 
 class Website(models.Model):
@@ -29,11 +34,3 @@ class Website(models.Model):
         forum_menu = self.env['website.menu'].search([('url', '=', '/forum'), ('website_id', '=', self.id)])
         forum_menu.unlink()
         super().configurator_set_menu_links(menu_company, module_data)
-
-    def _search_get_details(self, search_type, order, options):
-        result = super()._search_get_details(search_type, order, options)
-        if search_type in ['forums', 'forums_only', 'all']:
-            result.append(self.env['forum.forum']._search_get_detail(self, order, options))
-        if search_type in ['forums', 'forum_posts_only', 'all']:
-            result.append(self.env['forum.post']._search_get_detail(self, order, options))
-        return result

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -8,6 +8,11 @@ from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.http import request
 from odoo.osv import expression
 from odoo.addons.http_routing.models.ir_http import url_for
+from odoo.addons.website.models.website import SEARCH_TYPE_MODELS
+
+SEARCH_TYPE_MODELS['products'] |= 'product.public.category', 'product.template'
+SEARCH_TYPE_MODELS['product_categories_only'] |= 'product.public.category',
+SEARCH_TYPE_MODELS['products_only'] |= 'product.template',
 
 _logger = logging.getLogger(__name__)
 
@@ -479,14 +484,6 @@ class Website(models.Model):
         suggested_controllers = super(Website, self).get_suggested_controllers()
         suggested_controllers.append((_('eCommerce'), url_for('/shop'), 'website_sale'))
         return suggested_controllers
-
-    def _search_get_details(self, search_type, order, options):
-        result = super()._search_get_details(search_type, order, options)
-        if search_type in ['products', 'product_categories_only', 'all']:
-            result.append(self.env['product.public.category']._search_get_detail(self, order, options))
-        if search_type in ['products', 'products_only', 'all']:
-            result.append(self.env['product.template']._search_get_detail(self, order, options))
-        return result
 
     def _get_product_page_proportions(self):
         """

--- a/addons/website_slides/models/website.py
+++ b/addons/website_slides/models/website.py
@@ -3,6 +3,11 @@
 
 from odoo import fields, models, _
 from odoo.addons.http_routing.models.ir_http import url_for
+from odoo.addons.website.models.website import SEARCH_TYPE_MODELS
+
+SEARCH_TYPE_MODELS['slides'] |= 'slide.channel', 'slide.slide'
+SEARCH_TYPE_MODELS['slide_channels_only'] |= 'slide.channel',
+SEARCH_TYPE_MODELS['slides_only'] |= 'slide.slide',
 
 
 class Website(models.Model):
@@ -14,11 +19,3 @@ class Website(models.Model):
         suggested_controllers = super(Website, self).get_suggested_controllers()
         suggested_controllers.append((_('Courses'), url_for('/slides'), 'website_slides'))
         return suggested_controllers
-
-    def _search_get_details(self, search_type, order, options):
-        result = super()._search_get_details(search_type, order, options)
-        if search_type in ['slides', 'slide_channels_only', 'all']:
-            result.append(self.env['slide.channel']._search_get_detail(self, order, options))
-        if search_type in ['slides', 'slides_only', 'all']:
-            result.append(self.env['slide.slide']._search_get_detail(self, order, options))
-        return result


### PR DESCRIPTION
* = test_website, website_blog, website_event, website_forum, website_sale,
website_slides

`_search_get_details` extension in other modules can now be performed with
fewer lines of code by updating a search type-to-model mapping, without the
need for method override.

This will also have the benefit of slightly reducing the call stack length,
avoiding some unnecessary `if` statements and list lookups at runtime.

Task-2957361