### PR TITLE
[FIX] product: duplicate product with variant (multi-company)

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -553,7 +553,6 @@ class ProductTemplate(models.Model):
         return prices
 
     def _create_variant_ids(self):
-        self.flush()
         Product = self.env["product.product"]
 
         variants_to_create = []
@@ -646,7 +645,6 @@ class ProductTemplate(models.Model):
         # (eg. product.template: product_variant_ids)
         # We can't rely on existing invalidate_cache because of the savepoint
         # in _unlink_or_archive.
-        self.flush()
         self.invalidate_cache()
         return True
 


### PR DESCRIPTION
Steps to reproduce:
1-Create a product with attributes (on runbot use for example Customizable Desk (CONFIG)).
2-Duplicate this product and rename it for readability -> Customizable Desk (CONFIG) 2.
3-Set a company on product "Customizable Desk (CONFIG) 2".
4-set yourself on a company different from the one you set on product "Customizable Desk (CONFIG) 2".
5-duplicate "Customizable Desk (CONFIG)" You get a multi company error.

Bug:
creating the new variants try to do read on every product link to those attributes.
If one of the product belongs to another company we have a read access denied.

Fix:
removed the call to flush

opw 2950290

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
