### PR TITLE
[FIX] hr_expense: User with account permission but no employee permission can't register payment

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1196,7 +1196,7 @@ class HrExpenseSheet(models.Model):
             'context': {
                 'active_model': 'account.move',
                 'active_ids': self.account_move_id.ids,
-                'default_partner_bank_id': self.employee_id.bank_account_id.id,
+                'default_partner_bank_id': self.employee_id.sudo().bank_account_id.id,
             },
             'target': 'new',
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
- A user has accounting permission but no employee permission, when that user register payment in spending it gives an error that does not have access to the bank_account_id field
- This commit allows the user to read the bank_account_id field when register payment




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
