### PR TITLE
[FIX] [15.0] website_event_track_quiz: fix security group in field

### DIFF
--- a/addons/website_event_track_quiz/views/event_track_views.xml
+++ b/addons/website_event_track_quiz/views/event_track_views.xml
@@ -9,13 +9,15 @@
                 <field name="quiz_id" invisible="1"/>
                 <button name="action_add_quiz"
                     type="object" class="btn btn-primary" string="Add Quiz"
-                    attrs="{'invisible': [('quiz_id', '!=', False)]}" >
+                    attrs="{'invisible': [('quiz_id', '!=', False)]}"
+                    groups="event.group_event_user">
                 </button>
             </field>
             <field name='is_published' position="before">
                 <button name="action_view_quiz" type="object" class="oe_stat_button"
                     string="Go to Quiz" icon="fa-question-circle" widget="stat_info"
-                    attrs="{'invisible': [('quiz_id', '=', False)]}">
+                    attrs="{'invisible': [('quiz_id', '=', False)]}"
+                    groups="event.group_event_user">
                 </button>
             </field>
         </field>


### PR DESCRIPTION
While testing Odoo application, I have the following problem:

1) On Odoo, go to the Events module

2) Go to the Tracks menu

3) View appears by default in Kanban view. 
Click to select the existing event:

[Actual]:
- Login with Administrator and User group is not error.
- Login with Registration Desk group is an error no access

[Solutions]:
I add group event.group_event_user to the buttons action_add_quiz and action_view_quiz

[Screencast from 19-08-2022 11:24:10.webm](https://user-images.githubusercontent.com/91191721/185545350-26bd2d6f-ace0-44c4-b638-a43eb852303a.webm)
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
