### PR TITLE
[FIX] web: Display translation ribbon correctly

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -14,6 +14,7 @@ import { escape } from "@web/core/utils/strings";
 import { mapDoActionOptionAPI } from "@web/legacy/backend_utils";
 import { Model } from "@web/views/model";
 import { evalDomain } from "@web/views/utils";
+import { localization } from "@web/core/l10n/localization";
 import BasicModel from "web.BasicModel";
 import Context from "web.Context";
 import fieldRegistry from "web.field_registry";
@@ -300,6 +301,9 @@ export class Record extends DataPoint {
     }
 
     get translatableFields() {
+        if (!localization.multiLang) {
+            return [];
+        }
         return Object.values(this.fields)
             .filter((f) => f.translate)
             .map((f) => this.activeFields[f.name]);

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -19,6 +19,7 @@ import {
     makeSeparator,
 } from "@web/views/view_compiler";
 import { ViewCompiler } from "../view_compiler";
+import { localization } from "@web/core/l10n/localization";
 
 const compilersRegistry = registry.category("form_compilers");
 
@@ -223,6 +224,20 @@ export class FormCompiler extends ViewCompiler {
                 }
             }
             append(form, compiledList);
+        }
+        if (localization.multiLang) {
+            const statusBar = form.querySelector(".o_form_statusbar");
+            const translateAlert = createElement("t", {
+                "t-if": "props.translateAlert",
+                "t-call": "web.TranslateAlert",
+            });
+            if (statusBar) {
+                statusBar.parentElement.insertBefore(translateAlert, statusBar.nextSibling);
+            } else if (form.querySelector(".o_form_sheet_bg")) {
+                form.querySelector(".o_form_sheet_bg").prepend(translateAlert);
+            } else {
+                form.prepend(translateAlert);
+            }
         }
         return form;
     }

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -4,7 +4,6 @@
     <t t-name="web.FormView" owl="1">
         <div t-att-class="className" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
-                <t t-if="showingTranslateAlert[model.root.resId]" t-call="web.TranslateAlert" />
                 <t t-set-slot="layout-buttons">
                     <t t-if="footerArchInfo and env.inDialog">
                         <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="footerArchInfo"/>
@@ -26,7 +25,7 @@
                     </t>
                 </t>
                 <t t-set-slot="control-panel-bottom-right"> </t>
-                <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="archInfo"/>
+                <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="archInfo" translateAlert="translateAlert"/>
             </Layout>
         </div>
     </t>
@@ -52,14 +51,14 @@
         </div>
     </t>
 
+    <!-- Used in FormRenderer -->
     <t t-name="web.TranslateAlert" owl="1">
         <div class="alert alert-info alert-dismissible" role="alertdialog">
             Please update translations of :
-            <t t-foreach="Array.from(this.translateAlertData[this.model.root.resId])" t-as="field" t-key="field.name">
+            <t t-foreach="Array.from(props.translateAlert.fields)" t-as="field" t-key="field.name">
                 <strong><a class="o_field_translate" t-att-name="field.name" href="#"><t t-esc="field.string"/><t t-if="!field_last">, </t></a></strong>
             </t>
-            <button t-on-click="() => this.closeTranslateAlert()" type="button" class="btn-close" aria-label="Close"></button>
+            <button t-on-click="props.translateAlert.close" type="button" class="btn-close" aria-label="Close"></button>
         </div>
     </t>
-
 </templates>

--- a/addons/web/static/tests/views/form/form_compiler_tests.js
+++ b/addons/web/static/tests/views/form/form_compiler_tests.js
@@ -5,6 +5,7 @@ import { FormCompiler } from "@web/views/form/form_compiler";
 import { registry } from "@web/core/registry";
 import { click, getFixture, patchWithCleanup } from "../../helpers/utils";
 import { createElement } from "@web/core/utils/xml";
+import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
 
 function compileTemplate(arch) {
     const parser = new DOMParser();
@@ -28,7 +29,11 @@ QUnit.assert.areContentEquivalent = function (template, content) {
     QUnit.assert.areEquivalent(templateContent, content);
 };
 
-QUnit.module("Form Compiler", () => {
+QUnit.module("Form Compiler", (hooks) => {
+    hooks.beforeEach(() => {
+        // compiler generates a piece of template for the translate alert in multilang
+        registry.category("services").add("localization", makeFakeLocalizationService());
+    });
     QUnit.test("properly compile simple div", async (assert) => {
         const arch = /*xml*/ `<form><div>lol</div></form>`;
         const expected = /*xml*/ `

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -8129,6 +8129,9 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: `
                 <form>
+                    <header>
+                        <button string="Additionnal button" class="btn btn-primary"/>
+                    </header>
                     <sheet>
                         <group>
                             <field name="foo"/>
@@ -8158,6 +8161,13 @@ QUnit.module("Views", (hooks) => {
             2,
             "should have two translate fields in translation alert"
         );
+        const statusBarY = target.querySelector(".o_form_statusbar").getBoundingClientRect().top;
+        const translateAlertY = target
+            .querySelector(".alert .o_field_translate")
+            .getBoundingClientRect().top;
+        assert.ok(translateAlertY > statusBarY, "translation alert should be below status bar");
+        await click(target, ".alert .btn-close");
+        assert.containsNone(target, ".alert", "should have closed the translate alert");
     });
 
     QUnit.test("can save without any dirty translatable fields", async function (assert) {


### PR DESCRIPTION
Sometimes the translation ribbon can be displayed  above buttons instead
of being below.

For example in Calendar/Online Appointment
![image](https://user-images.githubusercontent.com/77889661/185585520-6034b673-abc0-4714-84b0-027da3bddfea.png)


To fix it we have to manually add the translation notification in the
FormCompiler

LNA: Appointment -> Shouldn't the translation ribbon appear
below the buttons? https://tinyurl.com/23z4rbn8