### PR TITLE
[FIX] account: fix early payment discount configurations

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -27,8 +27,8 @@ class AccountPaymentTerm(models.Model):
     has_early_payment = fields.Boolean(string="Apply Early Payment Discount", compute="_compute_has_early_payment", readonly=False, store=True)
     percentage_to_discount = fields.Float("Discount", digits='Discount', default=2)
     discount_computation = fields.Selection([
-        ('included', 'Tax included'),
-        ('excluded', 'Tax excluded'),
+        ('included', 'Impact base and tax'),
+        ('excluded', 'Impact base only'),
        ], string='Computation', default='included')
     discount_days = fields.Integer(string='Availability', required=True, default=7)
     discount_account_id = fields.Many2one(comodel_name='account.account', string='Counterpart Account')

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -421,7 +421,7 @@ class AccountPaymentRegister(models.TransientModel):
 
     def _get_early_pay_cash_discount_account(self, payment_values):
         self.ensure_one()
-        if payment_values['payment_type'] == 'inbound':
+        if payment_values['payment_type'] == 'outbound':
             writeoff_account_id = self.company_id.account_journal_cash_discount_income_id
         else:
             writeoff_account_id = self.company_id.account_journal_cash_discount_expense_id


### PR DESCRIPTION
While offering an early payment discount to a customer via a specific payment term, then Registering a Payment,

the default account displayed were inverted (Cash discount expense account was the default for an invoice, cash discount income account was the default for a bill).

This commit fixes this behaviour and also changes the default tax computation labels so they're more specific.

Part of task-2957279

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
