### PR TITLE
[FIX] payment,website: Deletes and migrates col-*-offset- BS3 class

### DIFF
--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -100,7 +100,7 @@
                     <!-- Status page -->
                     <div name="o_payment_status">
                         <div name="o_payment_status_content"
-                             class="col-sm-6 col-sm-offset-3">
+                             class="col-sm-6 offset-sm-3">
                             <!-- The content is generated in JavaScript -->
                         </div>
                     </div>

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -156,7 +156,7 @@
                     </div>
                     <h2>SEO</h2>
                     <div class="row mt16 o_settings_container" id="website_settings" attrs="{'invisible': [('website_id', '=', False)]}">
-                        <div class="col-12 col-lg-offset-6 col-lg-6 o_setting_box" id="google_analytics_setting">
+                        <div class="col-12 col-lg-6 o_setting_box" id="google_analytics_setting">
                             <div class="o_setting_left_pane">
                                 <field name="has_google_analytics"/>
                             </div>
@@ -240,7 +240,7 @@
                                 <field name="social_default_image" widget="image" class="w-25 mt-2" attrs="{'invisible': [('has_default_share_image', '=', False)]}"/>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-offset-6 col-lg-6 o_setting_box" id="google_console_setting">
+                        <div class="col-12 col-lg-6 o_setting_box" id="google_console_setting">
                             <div class="o_setting_left_pane">
                                 <field name="has_google_search_console"/>
                             </div>
@@ -263,7 +263,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-offset-6 col-lg-6 o_setting_box" id="plausbile_setting">
+                        <div class="col-12 col-lg-6 o_setting_box" id="plausbile_setting">
                             <div class="o_setting_left_pane">
                                 <field name="has_plausible_shared_key"/>
                             </div>


### PR DESCRIPTION
This rule has no effect for a while!

In settings, we had to delete it because converting it would add
space in the first column.

In payment, it seems that this offset was used to center the content.
We prefer to convert it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
