### PR TITLE
[FIX] website_sale_delivery: a draft transaction prevents payment

### DIFF
--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -26,8 +26,8 @@ class WebsiteSaleDelivery(WebsiteSale):
     def update_eshop_carrier(self, **post):
         order = request.website.sale_get_order()
         carrier_id = int(post['carrier_id'])
-        if order:
-            if any(tx.state not in ("canceled", "error") for tx in order.transaction_ids):
+        if order and carrier_id != order.carrier_id.id:
+            if any(tx.state not in ("canceled", "error", "draft") for tx in order.transaction_ids):
                 raise UserError(_('It seems that there is already a transaction for your order, you can not change the delivery method anymore'))
             order._check_carrier_quotation(force_carrier_id=carrier_id)
         return self._update_website_sale_delivery_return(order, **post)

--- a/addons/website_sale_delivery/tests/test_controller.py
+++ b/addons/website_sale_delivery/tests/test_controller.py
@@ -20,3 +20,10 @@ class TestWebsiteSaleDeliveryController(PaymentCommon):
             order.transaction_ids = self.create_transaction(flow='redirect', state='pending')
             with self.assertRaises(UserError):
                 self.Controller.update_eshop_carrier(carrier_id=1)
+
+    # test that changing the carrier while there is a draft transaction doesn't raise an error
+    def test_controller_change_carrier_when_draft_transaction(self):
+        with MockRequest(self.env, website=self.website):
+            order = self.website.sale_get_order(force_create=True)
+            order.transaction_ids = self.create_transaction(flow='redirect', state='draft')
+            self.Controller.update_eshop_carrier(carrier_id=1)


### PR DESCRIPTION
Steps to reproduce:
- go to ecommerce try to pay with paypal and after stripe with more than one delivery methode

Current behavior:
You get an error message

Expected behavior:
You have no error message

Explanation:
When /shop/update_carrier is called we check if there is a transaction
that is not error or canceled mode and raise an error if this the case
we should add the draft state to the list. We also add a condition so
that the error can be raised only if the carrier was changed.

opw-2956571