### PR TITLE
[FIX] payment_stripe: 3DS failure puts transaction in error

### DIFF
--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -55,6 +55,13 @@ class StripeController(http.Controller):
     def stripe_s2s_process_payment_intent(self, **post):
         return request.env['payment.transaction'].sudo().form_feedback(post, 'stripe')
 
+    @http.route('/payment/stripe/s2s/process_payment_error', type='json', auth='public', csrf=False)
+    def stripe_s2s_process_payment_error(self, **post):
+        transaction_sudo = request.env['payment.transaction'].sudo().search([('reference', '=', post['reference']),
+                                                                            ('provider', '=', 'stripe'),
+                                                                            ('stripe_payment_intent_secret', '=', post['stripe_payment_intent_secret'])])
+        transaction_sudo.write({'state': 'error', 'state_message': post['error']})
+
     @http.route('/payment/stripe/webhook', type='json', auth='public', csrf=False)
     def stripe_webhook(self, **kwargs):
         data = json.loads(request.httprequest.data)

--- a/addons/payment_stripe/static/src/js/payment_processing.js
+++ b/addons/payment_stripe/static/src/js/payment_processing.js
@@ -22,7 +22,12 @@ return PaymentProcessing.include({
         return stripe.handleCardPayment(tx.stripe_payment_intent_secret)
         .then(function(result) {
             if (result.error) {
-                return Promise.reject({"message": {"data": { "message": result.error.message}}});
+                return rpc.query({
+                    route: '/payment/stripe/s2s/process_payment_error',
+                    params: _.extend({}, {reference: tx.reference,
+                        stripe_payment_intent_secret: tx.stripe_payment_intent_secret,
+                        error: result.error.message})
+                }).then(()=> Promise.reject({"message": {"data": { "message": result.error.message}}}));
             }
             return rpc.query({
                 route: '/payment/stripe/s2s/process_payment_intent',


### PR DESCRIPTION
Problem:
When using a card requiring 3D secure authentication
The payment is confirmed as received by Odoo whereas the
authentication for 3DS is not completed yet. If we change
the payment flow to 'redirect to acquirer website', then
It's working as expected, Stripe only redirects to Odoo
when the authentication with 3DS is done.

Expected behavior:
The payment should be displayed as received only when the
authentication with 3DS Secure is completed!

opw-2909300