### PR TITLE
[FIX] account: fix line label auto-reset

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1664,7 +1664,7 @@ class AccountMove(models.Model):
                         line.account_id = self.journal_id.default_credit_account_id
                     elif self.is_purchase_document(include_receipts=True):
                         line.account_id = self.journal_id.default_debit_account_id
-            if line.product_id and not line._cache.get('name'):
+            if line.product_id and not line._cache.get('name') and not line._origin:
                 line.name = line._get_computed_name()
 
             # Compute the account before the partner_id


### PR DESCRIPTION
To Reporduce
=============
- create a customer invoice
- add a line and customize the label "test" for example and save
- add an other line by Server Action
```py
partner = env['res.partner'].search([], limit=1)
products = env['product.product'].search([], limit=2)
invoice = env['account.move'].search([('id', '=', 10)]) # replace the invoice id
invoice.write({
'partner_id': partner.id,
'invoice_line_ids': [(0, 0, {
'product_id': products[0].id,
'price_unit': 100.0,
})]
})
```

Problem
=======

After running the server action, the label "test" of the first line is reset to default value.

The issue comes from this line :
https://github.com/odoo/odoo/blob/ec719b166635df9ed31c9c2b47fedadd2311765c/addons/account/models/account_move.py#L1668
where we reset the `name` field

Solution
=========
to solve the issue we don't set `name` field if it already has a value

opw-2920820
