### PR TITLE
[FIX] account_edi: send & print - prevent duplicating attachments

### DIFF
--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -8,14 +8,24 @@ class MailTemplate(models.Model):
 
     def _get_edi_attachments(self, document):
         """
-        Will return the information about the attachment of the edi document for adding the attachment in the mail.
+        Will either return the information about the attachment of the edi document for adding the attachment in the
+        mail, or the attachment id to be linked to the 'send & print' wizard.
         Can be overridden where e.g. a zip-file needs to be sent with the individual files instead of the entire zip
+        IMPORTANT:
+        * If the attachment's id is returned, no new attachment will be created, the existing one on the move is linked
+        to the wizard (see _onchange_template_id in mail.compose.message).
+        * If the attachment's content is returned, a new one is created and linked to the wizard. Thus, when sending
+        the mail (clicking on 'send & print' in the wizard), a new attachment is added to the move (see
+        _action_send_mail in mail.compose.message).
         :param document: an edi document
-        :return: list with a tuple with the name and base64 content of the attachment
+        :return: dict:
+            {'attachments': tuple with the name and base64 content of the attachment}
+            OR
+            {'attachment_ids': list containing the id of the attachment}
         """
         if not document.attachment_id:
-            return []
-        return [(document.attachment_id.name, document.attachment_id.datas)]
+            return {}
+        return {'attachment_ids': [document.attachment_id.id]}
 
     def generate_email(self, res_ids, fields):
         res = super().generate_email(res_ids, fields)
@@ -33,6 +43,8 @@ class MailTemplate(models.Model):
             record_data = (res[record.id] if multi_mode else res)
             for doc in record.edi_document_ids:
                 record_data.setdefault('attachments', [])
-                record_data['attachments'] += self._get_edi_attachments(doc)
+                attachments = self._get_edi_attachments(doc)
+                record_data['attachment_ids'] += attachments.get('attachment_ids', [])
+                record_data['attachments'] += attachments.get('attachments', [])
 
         return res

--- a/addons/account_edi_ubl_cii/models/__init__.py
+++ b/addons/account_edi_ubl_cii/models/__init__.py
@@ -10,3 +10,4 @@ from . import account_edi_xml_ubl_xrechnung
 from . import account_edi_xml_ubl_nlcius
 from . import account_edi_xml_ubl_efff
 from . import ir_actions_report
+from . import mail_template

--- a/addons/account_edi_ubl_cii/models/mail_template.py
+++ b/addons/account_edi_ubl_cii/models/mail_template.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class MailTemplate(models.Model):
+    _inherit = "mail.template"
+
+    def _get_edi_attachments(self, document):
+        # EXTENDS account_edi
+        # Avoid having factur-x.xml in the 'send & print' wizard
+        if document.edi_format_id.code == 'facturx_1_0_05':
+            return {}
+        return super()._get_edi_attachments(document)

--- a/addons/l10n_it_edi/models/mail_template.py
+++ b/addons/l10n_it_edi/models/mail_template.py
@@ -14,5 +14,5 @@ class MailTemplate(models.Model):
         :return: list with a tuple with the name and base64 content of the attachment
         """
         if document.edi_format_id.code == 'fattura_pa':
-            return []
+            return {}
         return super()._get_edi_attachments(document)


### PR DESCRIPTION
Currently, the EDI attachments *content* is passed to the Send & Print wizard.
Then, the wizard re-creates these attachments and link them to itself. At the
end of the flow, when clicking 'Send & Print' button on the 'Send & Print' wizard,
the attachments of the wizard are copied on the move.
Thus, the EDI attachments are duplicated.

Passing the ids of the EDI attachments rather than the content solved the issue,
since they are simply linked to the wizard, without being re-created.

task-2957823

see https://github.com/odoo/enterprise/pull/30596