### PR TITLE
[FIX] point_of_sale: remove "willstart" for a performance issue

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/Chrome.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/Chrome.js
@@ -13,7 +13,8 @@ odoo.define('l10n_fr_pos_cert.Chrome', function (require) {
                     let limitDate = new Date(this.env.pos.pos_session.start_at);
                     limitDate.setDate(limitDate.getDate() + 1);
                     if (limitDate < now) {
-                        this.showPopup('ClosePosPopup');
+                        const info = await this.env.pos.getClosePosInfo();
+                        this.showPopup('ClosePosPopup', { info: info });
                     }
                 }
             }

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/HeaderButton.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/HeaderButton.js
@@ -7,8 +7,9 @@ odoo.define('point_of_sale.HeaderButton', function(require) {
     // Previously HeaderButtonWidget
     // This is the close session button
     class HeaderButton extends PosComponent {
-        onClick() {
-            this.showPopup('ClosePosPopup');
+        async onClick() {
+            const info = await this.env.pos.getClosePosInfo();
+            this.showPopup('ClosePosPopup', { info: info });
         }
     }
     HeaderButton.template = 'HeaderButton';

--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -15,44 +15,11 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
         constructor() {
             super(...arguments);
             this.manualInputCashCount = false;
-            this.cashControl = this.env.pos.config.cash_control;
             this.moneyDetailsRef = useRef('moneyDetails');
             this.closeSessionClicked = false;
             this.moneyDetails = null;
             this.state = useState({});
-        }
-        async willStart() {
-            try {
-                const closingData = await this.rpc({
-                    model: 'pos.session',
-                    method: 'get_closing_control_data',
-                    args: [[this.env.pos.pos_session.id]]
-                });
-                this.ordersDetails = closingData.orders_details;
-                this.paymentsAmount = closingData.payments_amount;
-                this.payLaterAmount = closingData.pay_later_amount;
-                this.openingNotes = closingData.opening_notes;
-                this.defaultCashDetails = closingData.default_cash_details;
-                this.otherPaymentMethods = closingData.other_payment_methods;
-                this.isManager = closingData.is_manager;
-                this.amountAuthorizedDiff = closingData.amount_authorized_diff;
-
-                // component state and refs definition
-                const state = {notes: '', acceptClosing: false, payments: {}};
-                if (this.cashControl) {
-                    state.payments[this.defaultCashDetails.id] = {counted: 0, difference: -this.defaultCashDetails.amount, number: 0};
-                }
-                if (this.otherPaymentMethods.length > 0) {
-                    this.otherPaymentMethods.forEach(pm => {
-                        if (pm.type === 'bank') {
-                            state.payments[pm.id] = {counted: this.env.pos.round_decimals_currency(pm.amount), difference: 0, number: pm.number}
-                        }
-                    })
-                }
-                Object.assign(this.state, state);
-            } catch (error) {
-                this.error = error;
-            }
+            Object.assign(this, this.props.info)
         }
         /*
          * Since this popup need to be self dependent, in case of an error, the popup need to be closed on its own.

--- a/addons/point_of_sale/static/src/js/Popups/ProductInfoPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ProductInfoPopup.js
@@ -16,38 +16,7 @@ odoo.define('point_of_sale.ProductInfoPopup', function(require) {
     class ProductInfoPopup extends AbstractAwaitablePopup {
         constructor() {
             super(...arguments);
-        }
-        async willStart() {
-            const order = this.env.pos.get_order();
-            try {
-                // check back-end method `get_product_info_pos` to see what it returns
-                // We do this so it's easier to override the value returned and use it in the component template later
-                this.productInfo = await this.rpc({
-                    model: 'product.product',
-                    method: 'get_product_info_pos',
-                    args: [[this.props.product.id],
-                        this.props.product.get_price(order.pricelist, this.props.quantity),
-                        this.props.quantity,
-                        this.env.pos.config.id],
-                    kwargs: {context: this.env.session.user_context},
-                });
-
-                const priceWithoutTax = this.productInfo['all_prices']['price_without_tax'];
-                const margin = priceWithoutTax - this.props.product.standard_price;
-                const orderPriceWithoutTax = order.get_total_without_tax();
-                const orderCost = order.get_total_cost();
-                const orderMargin = orderPriceWithoutTax - orderCost;
-
-                this.costCurrency = this.env.pos.format_currency(this.props.product.standard_price);
-                this.marginCurrency = this.env.pos.format_currency(margin);
-                this.marginPercent = priceWithoutTax ? Math.round(margin/priceWithoutTax * 10000) / 100 : 0;
-                this.orderPriceWithoutTaxCurrency = this.env.pos.format_currency(orderPriceWithoutTax);
-                this.orderCostCurrency = this.env.pos.format_currency(orderCost);
-                this.orderMarginCurrency = this.env.pos.format_currency(orderMargin);
-                this.orderMarginPercent = orderPriceWithoutTax ? Math.round(orderMargin/orderPriceWithoutTax * 10000) / 100 : 0;
-            } catch (error) {
-                this.error = error;
-            }
+            Object.assign(this, this.props.info)
         }
         /*
          * Since this popup need to be self dependent, in case of an error, the popup need to be closed on its own.

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/ProductInfoButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/ProductInfoButton.js
@@ -11,12 +11,13 @@ odoo.define('point_of_sale.ProductInfoButton', function(require) {
             super(...arguments);
             useListener('click', this.onClick);
         }
-        onClick() {
+        async onClick() {
             const orderline = this.env.pos.get_order().get_selected_orderline();
             if (orderline) {
                 const product = orderline.get_product();
                 const quantity = orderline.get_quantity();
-                this.showPopup('ProductInfoPopup', { product, quantity });
+                const info = await this.env.pos.getProductInfo(product, quantity);
+                this.showPopup('ProductInfoPopup', { info: info , product: product });
             }
         }
     }

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductItem.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductItem.js
@@ -40,8 +40,9 @@ odoo.define('point_of_sale.ProductItem', function(require) {
                 return formattedUnitPrice;
             }
         }
-        onProductInfoClick() {
-            this.showPopup('ProductInfoPopup', { product: this.props.product, quantity: 1 });
+        async onProductInfoClick() {
+            const info = await this.env.pos.getProductInfo(this.props.product, 1);
+            this.showPopup('ProductInfoPopup', { info: info , product: this.props.product });
         }
     }
     ProductItem.template = 'ProductItem';

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -526,6 +526,79 @@ class PosGlobalState extends PosModel {
             i += 1;
         } while(partners.length);
     }
+    async getProductInfo(product, quantity) {
+        const order = this.get_order();
+        try {
+            // check back-end method `get_product_info_pos` to see what it returns
+            // We do this so it's easier to override the value returned and use it in the component template later
+            const productInfo = await this.env.services.rpc({
+                model: 'product.product',
+                method: 'get_product_info_pos',
+                args: [[product.id],
+                    product.get_price(order.pricelist, quantity),
+                    quantity,
+                    this.config.id],
+                kwargs: {context: this.env.session.user_context},
+            });
+
+            const priceWithoutTax = productInfo['all_prices']['price_without_tax'];
+            const margin = priceWithoutTax - product.standard_price;
+            const orderPriceWithoutTax = order.get_total_without_tax();
+            const orderCost = order.get_total_cost();
+            const orderMargin = orderPriceWithoutTax - orderCost;
+
+            const costCurrency = this.format_currency(product.standard_price);
+            const marginCurrency = this.format_currency(margin);
+            const marginPercent = priceWithoutTax ? Math.round(margin/priceWithoutTax * 10000) / 100 : 0;
+            const orderPriceWithoutTaxCurrency = this.format_currency(orderPriceWithoutTax);
+            const orderCostCurrency = this.format_currency(orderCost);
+            const orderMarginCurrency = this.format_currency(orderMargin);
+            const orderMarginPercent = orderPriceWithoutTax ? Math.round(orderMargin/orderPriceWithoutTax * 10000) / 100 : 0;
+            return {
+            costCurrency, marginCurrency, marginPercent, orderPriceWithoutTaxCurrency,
+            orderCostCurrency, orderMarginCurrency, orderMarginPercent,productInfo
+            }
+        } catch (error) {
+            return { error }
+        }
+    }
+    async getClosePosInfo() {
+        try {
+            const closingData = await this.env.services.rpc({
+                model: 'pos.session',
+                method: 'get_closing_control_data',
+                args: [[this.pos_session.id]]
+            });
+            const ordersDetails = closingData.orders_details;
+            const paymentsAmount = closingData.payments_amount;
+            const payLaterAmount = closingData.pay_later_amount;
+            const openingNotes = closingData.opening_notes;
+            const defaultCashDetails = closingData.default_cash_details;
+            const otherPaymentMethods = closingData.other_payment_methods;
+            const isManager = closingData.is_manager;
+            const amountAuthorizedDiff = closingData.amount_authorized_diff;
+            const cashControl = this.config.cash_control;
+
+            // component state and refs definition
+            const state = {notes: '', acceptClosing: false, payments: {}};
+            if (cashControl) {
+                state.payments[defaultCashDetails.id] = {counted: 0, difference: -defaultCashDetails.amount, number: 0};
+            }
+            if (otherPaymentMethods.length > 0) {
+                otherPaymentMethods.forEach(pm => {
+                    if (pm.type === 'bank') {
+                        state.payments[pm.id] = {counted: this.round_decimals_currency(pm.amount), difference: 0, number: pm.number}
+                    }
+                })
+            }
+            return {
+            ordersDetails, paymentsAmount, payLaterAmount, openingNotes, defaultCashDetails, otherPaymentMethods,
+            isManager, amountAuthorizedDiff, state, cashControl
+            }
+        } catch (error) {
+            return { error }
+        }
+    }
     set_start_order(){
         if (this.orders.length && !this.selectedOrder) {
             this.selectedOrder = this.orders[0]

--- a/addons/pos_sale_product_configurator/static/src/js/models.js
+++ b/addons/pos_sale_product_configurator/static/src/js/models.js
@@ -21,7 +21,9 @@ odoo.define('pos_sale_product_configurator.models', function (require) {
                     }
                 );
                 if (isProductLoaded) {
-                    Gui.showPopup('ProductInfoPopup', {product, quantity: this.get_selected_orderline().get_quantity()});
+                    const quantity = this.get_selected_orderline().get_quantity();
+                    const info = await this.env.pos.getProductInfo(product, quantity);
+                    Gui.showPopup('ProductInfoPopup', {info: info , product: product});
                 }
             }
         }


### PR DESCRIPTION
Before this commit: if the number of contacts is enormous, and the
"Limited Partners Loading" with "Load all remaining partners in the
background" is enabled, clicking on the product information button would
take lots of time to reload. Also, it would cause the same issue for the
"ClosePoSPopup".

The problem is that when "willstart" takes time more than the background
process it would call it again, and for every call.

The solution is to prepare the "willstart" function's data and pass it to the
constructor.

opw-2956104

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
