### PR TITLE
[IMP] point_of_sale: Add unit on order line receipt

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -88,6 +88,8 @@
                             <span class="price_display pos-receipt-right-align">
                                 <t t-esc="env.pos.format_currency_no_symbol(line.price_display)" />
                             </span>
+                            /
+                            <t t-esc="line.unit_name" />
                         </div>
                     </t>
                     <t t-if="line.pack_lot_lines">


### PR DESCRIPTION
This is the continuation of https://github.com/odoo/odoo/pull/98332

As auditors want to have same display between POS and receipt, this fixes that.

POS (current display):

![image](https://user-images.githubusercontent.com/19529533/185589637-13d0d383-d0cd-49ac-91ef-d1680d9d28ca.png)


Receipt (this change):

![image](https://user-images.githubusercontent.com/19529533/185589791-c4dcf0de-14d2-472d-b1ba-7f749b20de15.png)


@pimodoo Thanks. The other one merged too fast :sweat_smile: 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
