### PR TITLE
[FIX] website_sale_stock_wishlist: improve checking out of stock

### DIFF
--- a/addons/website_sale_stock_wishlist/views/templates.xml
+++ b/addons/website_sale_stock_wishlist/views/templates.xml
@@ -2,11 +2,11 @@
 <odoo>
     <template id="product_wishlist" inherit_id="website_sale_wishlist.product_wishlist">
         <xpath expr="//button[hasclass('o_wish_rm')]" position="before">
-            <small class="text-danger d-md-block" t-if="wish.product_id.product_tmpl_id._is_sold_out()">Temporarily out of stock</small>
+            <small class="text-danger d-md-block" t-if="wish.product_id._is_sold_out()">Temporarily out of stock</small>
         </xpath>
         <xpath expr="//button[hasclass('o_wish_rm')]" position="after">
             <t t-set="notify" t-value="wish.stock_notification"/>
-            <button groups="base.group_user,base.group_portal" t-att-data-notify="notify" t-if="notify or wish.product_id.product_tmpl_id._is_sold_out()" type="button" class="btn btn-link o_notify_stock no-decoration">
+            <button groups="base.group_user,base.group_portal" t-att-data-notify="notify" t-if="notify or wish.product_id._is_sold_out()" type="button" class="btn btn-link o_notify_stock no-decoration">
                 <small><i t-attf-class="fa #{'fa-check-square-o' if notify else 'fa-square-o'}"></i> Be notified when back in stock</small>
             </button>
         </xpath>


### PR DESCRIPTION
Method `_is_sold_out` for `product.template` is just a reference to the same
method in `product.product` [1]. This unnecessary step might be a reason for
"Expected singleton" error, because `product_variant_id` might be computed to
empty value if the product is archived [2].

Issue: When a customer (portal user) adds a product to wishlist and an admin
archives that product, the portal user will now run into a 500 Internal Server
Error when they attempt to go to their wishlist.

[1]: https://github.com/odoo/odoo/blob/274f2ff81909fe20347d97e6aa0a21c969ef2dd7/addons/website_sale/models/product_template.py#L306-L307
[2]: https://github.com/odoo/odoo/blob/274f2ff81909fe20347d97e6aa0a21c969ef2dd7/addons/product/models/product_template.py#L176-L179

opw-2955171

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
