### PR TITLE
[FIX] base: remove `ResLang.action_archive` override

### DIFF
--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -256,10 +256,6 @@ class Lang(models.Model):
         langs = self.with_context(active_test=True).search([])
         return sorted([(lang.code, lang.name) for lang in langs], key=itemgetter(1))
 
-    def action_archive(self):
-        self.ensure_one()
-        self.active = False
-
     def toggle_active(self):
         super().toggle_active()
         # Automatically load translation


### PR DESCRIPTION
Override doesn't work with multiple records so breaks the built-in bulk archive/unarchive action of the list view, and it's completely
unnecessary since `BaseModel` has a builtin `action_archive` which works out of the box if the model has an `active` field (or `x_active`, or a boolean field explicitely set as `_active_name`).
