### PR TITLE
[IMP] resource: add constraint to worked hours

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -840,6 +840,12 @@ class ResourceCalendarAttendance(models.Model):
         # avoid wrong order
         self.hour_to = max(self.hour_to, self.hour_from)
 
+    @api.constrains('hour_from', 'hour_to')
+    def _check_closing_date(self):
+        for attendance in self:
+            if attendance.hour_to == attendance.hour_from:
+                raise ValidationError(_("Attended time spent should be at least 1 hour."))
+
     def _copy_attendance_vals(self):
         self.ensure_one()
         return {


### PR DESCRIPTION
Current behaviour allows users to create entry in resource_calendar_attendance table.
It causes issues when `_boundarises` function is invoked:
https://github.com/odoo/odoo/blob/657fd6653705255f319756cba6406cefed9649d4/addons/resource/models/resource.py#L78

Impacted versions:

 - 14.0 (I think all versions are impacted where `resource.calendar.attendance` model is defined.

Steps to reproduce:

 1. Install Planning module
 2. follow steps: Configuration -> Resources -> Edit resource
 3. Edit/Create resource with 0 working time (`Work from` and `Work to` fields should be same)

Current behavior:

 - 0 working time is allowed.

Expected behavior:

 - Raise error: Attended time spent should be at least 1 hour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
