### PR TITLE
[FIX] web: restore order-* for some `oe_stat_button`

### DIFF
--- a/addons/web/static/src/libs/bootstrap/utilities_custom.scss
+++ b/addons/web/static/src/libs/bootstrap/utilities_custom.scss
@@ -40,6 +40,17 @@ $utilities-sizes: map-merge(
     )
 );
 
+$order-array: (
+    first: -1,
+    last: $grid-columns + 1,
+) !default;
+@for $i from 1 through $grid-columns {
+    $order-array: map-merge(
+        $order-array,
+        (#{$i}: $i)
+    );
+}
+
 
 $utilities: () !default;
 $utilities: map-merge(
@@ -110,6 +121,12 @@ $utilities: map-merge(
                     map-get(map-get($utilities, "font-family"), "values"),
                     (sans-serif: var(--#{$variable-prefix}font-sans-serif)),
                 ),
+            ),
+        ),
+        "order": map-merge(
+            map-get($utilities, "order"),
+            (
+                values: $order-array,
             ),
         ),
     ),


### PR DESCRIPTION
In BS4, the classes utilities order was set from `-1` (first) to
`13` (last). This commit restores the old behaviour.
In BS5, you only have a range from `-1` to `6`.

These classes are used in Odoo to order the `oe_stat_button`
particularly for UTM campaign. The order is set using CSS as there no
simple way to do it using `XPath` as there are many module (installed or
not) targeting the `oe_stat_button`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
