### PR TITLE
[FIX] account: revert do not create exchange entry when using the credit note wizard

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5333,9 +5333,9 @@ class AccountMoveLine(models.Model):
         # Fix residual amounts.
         to_reconcile = _add_lines_to_exchange_difference_vals(self, exchange_diff_move_vals)
 
-        # Fix cash basis entries, only if not coming from the move reversal wizard.
+        # Fix cash basis entries.
         is_cash_basis_needed = self[0].account_internal_type in ('receivable', 'payable')
-        if is_cash_basis_needed and not self._context.get('move_reverse_cancel'):
+        if is_cash_basis_needed:
             _add_cash_basis_lines_to_exchange_difference_vals(self, exchange_diff_move_vals)
 
         # ==========================================================================


### PR DESCRIPTION

This commit was meant to only be merged in v14 and not past 15.0.

This reverts commit c0195d00fe453a646e0cf1710594c760c68d1d3c.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
