### PR TITLE
[FIX] project: force project active_id in view tasks action

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -743,7 +743,7 @@ class Project(models.Model):
         favorite_projects.write({'favorite_user_ids': [(3, self.env.uid)]})
 
     def action_view_tasks(self):
-        action = self.env['ir.actions.act_window']._for_xml_id('project.act_project_project_2_project_task_all')
+        action = self.env['ir.actions.act_window'].with_context({'active_id': self.id})._for_xml_id('project.act_project_project_2_project_task_all')
         action['display_name'] = _("%(name)s", name=self.name)
         context = action['context'].replace('active_id', str(self.id))
         context = ast.literal_eval(context)


### PR DESCRIPTION
Steps to reproduce
------------------

1. Install sale_project.
2. Create a product that creates a project on order.
3. Create a Sales Order with this project and confirm it.
4. Click on the 'Projects' stat button on the SO.
5. Try to click on one of the projects, you should get an error.

---

This commit fixes this error by properly using the id of the project
as `active_id` in the action to view its tasks.

Task-2957905