### PR TITLE
[FIX] web: prevent crash when serializing action button's context

### DIFF
--- a/addons/web/static/src/views/view_button/view_button_hook.js
+++ b/addons/web/static/src/views/view_button/view_button_hook.js
@@ -56,7 +56,7 @@ export function useViewButtons(model, ref, options = {}) {
                 let buttonContext = {};
                 if (clickParams.context) {
                     if (typeof clickParams.context === "string") {
-                        const valuesForEval = Object.assign({}, record.data, {
+                        const valuesForEval = Object.assign({}, record.evalContext, {
                             active_id: resId,
                             active_ids: resIds,
                         });

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -5940,6 +5940,47 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".oe_stat_button"));
     });
 
+    QUnit.test("clicking on a stat button with x2many in context", async function (assert) {
+        assert.expect(1);
+        serverData.models.partner.records[1].timmy = [12];
+
+        const actionService = {
+            start() {
+                return {
+                    doActionButton(args) {
+                        // button context should have been evaluated, the x2many
+                        // should be in the form of x2m commands when serialized
+                        assert.equal(
+                            JSON.stringify(args.buttonContext),
+                            '{"test":[[6,false,[12]]]}'
+                        );
+                    },
+                };
+            },
+        };
+        registry.category("services").add("action", actionService, { force: true });
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button class="oe_stat_button" type="action" name="1" context="{'test': timmy}">
+                                <field name="qux" widget="statinfo"/>
+                            </button>
+                        </div>
+                        <field name="timmy" invisible="1"/>
+                    </sheet>
+                </form>`,
+            resId: 2,
+            context: { some_context: true },
+        });
+        await click(target.querySelector(".oe_stat_button"));
+    });
+
     QUnit.test("clicking on a stat button with no context", async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
Previously, when evaluating a button's context from its attributes, we
would evaluate it with the record's data as context, this resulted in
x2many fields being evaluated as a datapoint (in particular, as
StaticList). When we then went to call doAction with that context, the
action service tries to serialize that context with JSON.stringify,
which crashes as the datapoint contains circular references. This is a
mistake, as contexts and domain that are to be evaluated from a
string/attribute should be evaluated using the record's evalContext, not
its data. This commit fixes that.
