### PR TITLE
[FIX] stock: search tranfers for archived users via company

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -329,6 +329,9 @@ class Picking(models.Model):
         'res.partner', 'Contact',
         check_company=True,
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]})
+    partner_company_id = fields.Many2one(
+        "res.partner", related="partner_id.parent_id", store=True, readonly=True
+    )
     company_id = fields.Many2one(
         'res.company', string='Company', related='picking_type_id.company_id',
         readonly=True, store=True, index=True)

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -410,7 +410,7 @@
             <field name="arch" type="xml">
                 <search string="Picking Lists">
                     <field name="name" string="Transfer" filter_domain="['|', ('name', 'ilike', self), ('origin', 'ilike', self)]"/>
-                    <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
+                    <field name="partner_id" filter_domain="['|', ('partner_id', 'child_of', self), ('partner_company_id', 'child_of', self)]"/>
                     <field name="origin"/>
                     <field name="product_id"/>
                     <field name="picking_type_id"/>


### PR DESCRIPTION
Step to reproduce:
1- create a stock tranfer to a contact that has an associated company
2- archive the user
3- search the stock tranfers using company name
4- the new tranfer doesn't show up

Bug:
once a contact is archived it is impossible to search for stock trnasfers
even if the company still exist

Fix:
stored the company_id in the database and added it to the search this way
even if the user is archived it is still possible fo find stock transfrs
using the company name

opw-2947860
