### PR TITLE
[FIX] website_sale, product: function defined in child module

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1006,6 +1006,18 @@ class ProductTemplate(models.Model):
             'product_template_attribute_value_ids': [(6, 0, combination._without_no_variant_attributes().ids)]
         })
 
+    def _create_first_product_variant(self, log_warning=False):
+        """Create if necessary and possible and return the first product
+        variant for this template.
+
+        :param log_warning: whether a warning should be logged on fail
+        :type log_warning: bool
+
+        :return: the first product variant or none
+        :rtype: recordset of `product.product`
+        """
+        return self._create_product_variant(self._get_first_possible_combination(), log_warning)
+
     @tools.ormcache('self.id', 'frozenset(filtered_combination.ids)')
     def _get_variant_id_for_combination(self, filtered_combination):
         """See `_get_variant_for_combination`. This method returns an ID

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -279,18 +279,6 @@ class ProductTemplate(models.Model):
         # The list_price is always the price of one.
         return taxes.compute_all(price, pricelist.currency_id, 1, product, partner)[tax_display]
 
-    def _create_first_product_variant(self, log_warning=False):
-        """Create if necessary and possible and return the first product
-        variant for this template.
-
-        :param log_warning: whether a warning should be logged on fail
-        :type log_warning: bool
-
-        :return: the first product variant or none
-        :rtype: recordset of `product.product`
-        """
-        return self._create_product_variant(self._get_first_possible_combination(), log_warning)
-
     def _get_image_holder(self):
         """Returns the holder of the image to use as default representation.
         If the product template has an image it is the product template,


### PR DESCRIPTION
Reason:
The function _create_first_product_variant is used in the product module
but only defined in its child module website_sale

Fix: change the definition place to module product

opw-2790543

Related PR: https://github.com/odoo/odoo/pull/88075


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
