### PR TITLE
[FIX] web: increase clickbot click timeout

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -122,7 +122,7 @@
      * @param {function} stopCondition a function that returns a boolean
      * @returns {Promise} that is rejected if the timeout is exceeded
      */
-    function waitForCondition(stopCondition, tl = 10000) {
+    function waitForCondition(stopCondition, tl = 30000) {
         return new Promise(function (resolve, reject) {
             const interval = 250;
             let timeLimit = tl;


### PR DESCRIPTION
It happens that some pages are exceeding the click timeout of ten
seconds. Notably the settings, and as the settings are linked to
different menu's, it's difficult to black-list them.
