### PR TITLE
[FIX] website: fix website page url on write

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -175,8 +175,14 @@ class Page(models.Model):
         return super(Page, self).unlink()
 
     def write(self, vals):
-        if 'url' in vals and not vals['url'].startswith('/'):
-            vals['url'] = '/' + vals['url']
+        if 'url' in vals:
+            if not vals['url']:
+                # The url field is not declared as required, but we don't want
+                # to have empty URL field. The field is required in 16.0, until
+                # then this will prevent to unset the URL and fallback to `/`
+                vals['url'] = '/'
+            elif not vals['url'].startswith('/'):
+                vals['url'] = '/' + vals['url']
         return super(Page, self).write(vals)
 
     def get_website_meta(self):


### PR DESCRIPTION
Issue:

- Technical > Edit a website page view > Edit the related website page
record.
- Set an empty value as page URL > Save > Traceback

The goal of this PR is to fix this behaviour by tweaking the code
in 'website.page > write()' to handle an update with url = False.