### PR TITLE
[FIX] res_currency: add order by to _select_companies_rates query

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -227,6 +227,7 @@ class Currency(models.Model):
                  LIMIT 1) AS date_end
             FROM res_currency_rate r
             JOIN res_company c ON (r.company_id is null or r.company_id = c.id)
+            ORDER BY date_end
         """
 
 


### PR DESCRIPTION
PG12 introduced an optimization for CTEs that automatically inlines
CTEs if they are only refered once in the parent query. Prior
to that CTEs were always materialized, meaning
that PG created a sort of temp table on the fly to store the result
of the CTE's evaluation.

Whereas this leads to performance improvements in general, in the particular
case of `_select_companies_rates` this inlining becomes a performance
bottleneck. This is because while the currency_rate CTE is
only refered once in both [purchase_report](https://github.com/odoo/odoo/blob/aa73409175869b296feeeb9360ee7d4f4e7b87e1/addons/purchase/report/purchase_report.py#L121) and [product_margin](https://github.com/odoo/odoo/blob/aa73409175869b296feeeb9360ee7d4f4e7b87e1/addons/product_margin/models/product_product.py#L130),
the Merge Join Filter `cr.date_end is null or cr.date_end > ...`
requires evaluating the CTE's date_end subquery twice. This, combined
with the fact that in PG12 the planner goes for a Merge Join instead
of a Hash Join in PG10 makes the performances of the whole query
much worse in PG12 than in PG10. [PG10 query plan](https://explain.dalibo.com/plan/15C) vs [PG12 query plan](https://explain.dalibo.com/plan/uO2). 

We can see on the PG12 Query Plan that the Merge Join Node 7 scans the CTE twice (SubPlan 1 and SubPlan 2).
An eazy solution would be to add the keyword `Materialized` before the CTE definition. This keyword, [introduced
in PG12](https://www.postgresql.org/docs/12/queries-with.html), forces the materialization of the CTE, avoiding its inlining and making the PG12 plan the same as the PG10 one. Unfortunately, `Materialized` wasn't there in PG10 so we cannot use this solution here since some Odoo instances still run on PG10.

Instead, this PR adds an `ORDER BY date_end` clause at the end of the CTE. Because Node 7 is a merge join, ordering
the CTE by the Join Filter condition changes the query plan and removes this double subquery evaluation, leading
to a faster query overall. [Ordered PG12 query plan](https://explain.dalibo.com/plan/7JA)

#### Speedup

Test DB with 7000 purchase_order, 2666 res_currency_rate and 6 active currencies.
Purchase_report query timings in PG12, changing the number of purchase_orders

| Number of POs | Before PR | After PR |
|:----------------:|:----------:|:---------:|
| 500 | 2s | 115ms |
| 2000 | 7s | 345ms |
| 4000 | 13.5s | 640ms |
| 7000 | 23s | 1.1s |

Changing the number of res_currency_rate

| Number of res_currency_rate | Before PR | After PR |
|:------------------------------:|:----------:|:---------:|
| 200 | 1.7s | 150ms |
| 500 | 4s | 270ms |
| 1000 | 6.8s | 488ms |
| 2666 | 23s |1.1s |

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
