### PR TITLE
[FIX] web, web_editor: fix utils wherever the main page scroll is

### DIFF
--- a/addons/web/static/src/js/core/dom.js
+++ b/addons/web/static/src/js/core/dom.js
@@ -560,7 +560,9 @@ var dom = {
                 offsetTop = $el.offset().top;
                 el.classList.add('d-none');
             }
-            const elPosition = $scrollable[0].scrollTop + (offsetTop - $scrollable.offset().top);
+            const isDocScrollingEl = $scrollable.is(el.ownerDocument.scrollingElement);
+            const elPosition = offsetTop
+                - ($scrollable.offset().top - (isDocScrollingEl ? 0 : $scrollable[0].scrollTop));
             let offset = options.forcedOffset;
             if (offset === undefined) {
                 offset = (isTopScroll ? dom.scrollFixedOffset() : 0) + (options.extraOffset || 0);

--- a/addons/web/static/src/js/core/dom.js
+++ b/addons/web/static/src/js/core/dom.js
@@ -537,7 +537,10 @@ var dom = {
         return size;
     },
     /**
-     * @param {HTMLElement} el - the element to stroll to
+     * @param {HTMLElement} el - the element to stroll to (limitation: if the
+     *      element is using a fixed position, this function cannot work except
+     *      if is the header (with the "top" id) or the footer (with the
+     *      "bottom" id) for which exceptions have been made)
      * @param {number} [options] - same as animate of jQuery
      * @param {number} [options.extraOffset=0]
      *      extra offset to add on top of the automatic one (the automatic one
@@ -554,6 +557,13 @@ var dom = {
         const isTopScroll = $scrollable.is($topLevelScrollable);
 
         function _computeScrollTop() {
+            if (el.id === 'top') {
+                return 0;
+            }
+            if (el.id === 'bottom') {
+                return $scrollable[0].scrollHeight - $scrollable[0].clientHeight;
+            }
+
             let offsetTop = $el.offset().top;
             if (el.classList.contains('d-none')) {
                 el.classList.remove('d-none');

--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -123,11 +123,23 @@ $.fn.extend({
         });
     },
     /**
+     * @todo Should really be converted to no jQuery and probably even removed
+     * from jQuery utilities in master
      * @return {jQuery}
      */
     closestScrollable() {
+        const document = this.length ? this[0].ownerDocument : window.document;
+
         let $el = this;
         while ($el[0] !== document.scrollingElement) {
+            if (!$el.length || $el[0] instanceof Document) {
+                // Ensure that $().closestScrollable() -> $() and handle the
+                // case of elements not attached to the DOM.
+                // Also, .parent() used to loop through ancestors can
+                // theoretically reach the document if nothing up to the HTML
+                // included is not scrollable.
+                return $();
+            }
             if ($el.isScrollable()) {
                 return $el;
             }
@@ -194,9 +206,13 @@ $.fn.extend({
      * @returns {boolean}
      */
     isScrollable() {
+        if (!this.length) {
+            return false;
+        }
         const overflow = this.css('overflow-y');
+        const el = this[0];
         return overflow === 'auto' || overflow === 'scroll'
-            || (overflow === 'visible' && this === document.scrollingElement);
+            || (overflow === 'visible' && el === el.ownerDocument.scrollingElement);
     },
 });
 

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1175,6 +1175,9 @@ var SnippetsMenu = Widget.extend({
         // Hide the active overlay when scrolling.
         // Show it again and recompute all the overlays after the scroll.
         this.$scrollingElement = $().getScrollingElement();
+        this.$scrollingTarget = this.$scrollingElement.is(this.ownerDocument.scrollingElement)
+            ? $(this.ownerDocument.defaultView)
+            : this.$scrollingElement;
         this._onScrollingElementScroll = _.throttle(() => {
             for (const editor of this.snippetEditors) {
                 editor.toggleOverlayVisibility(false);
@@ -1192,7 +1195,7 @@ var SnippetsMenu = Widget.extend({
         // Setting capture to true allows to take advantage of event bubbling
         // for events that otherwise don’t support it. (e.g. useful when
         // scrolling a modal)
-        this.$scrollingElement[0].addEventListener('scroll', this._onScrollingElementScroll, {capture: true});
+        this.$scrollingTarget[0].addEventListener('scroll', this._onScrollingElementScroll, {capture: true});
 
         // Auto-selects text elements with a specific class and remove this
         // on text changes
@@ -1257,7 +1260,10 @@ var SnippetsMenu = Widget.extend({
             this.$snippetEditorArea.remove();
             this.$window.off('.snippets_menu');
             this.$document.off('.snippets_menu');
-            this.$scrollingElement[0].removeEventListener('scroll', this._onScrollingElementScroll, {capture: true});
+
+            if (this.$scrollingTarget) {
+                this.$scrollingTarget[0].removeEventListener('scroll', this._onScrollingElementScroll, {capture: true});
+            }
         }
         core.bus.off('deactivate_snippet', this, this._onDeactivateSnippet);
         delete this.cacheSnippetTemplate[this.options.snippets];


### PR DESCRIPTION
With [1], the frontend main scrollbar was moved to the #wrapwrap element
and with that change came many scroll utils and code adaptation. The
goal was for the code to be generic but after multiple bug fixes, only
the case of #wrapwrap being the element which scrolls (this stable
version's standard case) was actually working. As the scroll is being
moved back out the #wrapwrap in master (see [2]), those non-properly
generic features were found. This commit solves the stable utils in
preparation for that master merge. Indeed even if the standard 14.0 case
were not impacted by those faulty utils, they were still wrong and could
impact users migrated from 13.0 and earlier.

Note: some adaptation actually handles the case of multi-documents in
the page (like triggering a scroll in an iframe from out-of-the-iframe
JS code). This is not needed here in 14.0 but will be in the forward-
ported version in master for the 'website-in-backend' features merged
at [3].

[1]: https://github.com/odoo/odoo/commit/4e7be69825163c0a0ff41c882a196fc7f3158fb3
[2]: https://github.com/odoo/odoo/pull/98429
[3]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b
