### PR TITLE
[FIX] pos_mercury: correctly escape the request

### DIFF
--- a/addons/pos_mercury/models/pos_mercury_transaction.py
+++ b/addons/pos_mercury/models/pos_mercury_transaction.py
@@ -6,6 +6,7 @@ from datetime import date, timedelta
 import requests
 
 from html import unescape
+from markupsafe import Markup
 
 from odoo import models, api, service
 from odoo.tools.translate import _
@@ -47,14 +48,19 @@ class MercuryTransaction(models.Model):
         data['memo'] = "Odoo " + service.common.exp_version()['server_version']
 
     def _do_request(self, template, data):
-        xml_transaction = self.env.ref(template)._render(data)
-
         if not data['merchant_id'] or not data['merchant_pwd']:
             return "not setup"
 
-        soap_header = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:mer="http://www.mercurypay.com"><soapenv:Header/><soapenv:Body><mer:CreditTransaction><mer:tran>'
-        soap_footer = '</mer:tran><mer:pw>' + data['merchant_pwd'] + '</mer:pw></mer:CreditTransaction></soapenv:Body></soapenv:Envelope>'
-        xml_transaction = soap_header + misc.html_escape(xml_transaction) + soap_footer
+        # transaction is str()'ed so it's escaped inside of <mer:tran>
+        xml_transaction = Markup('''<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:mer="http://www.mercurypay.com">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <mer:CreditTransaction>
+      <mer:tran>{transaction}</mer:tran>
+      <mer:pw>{password}</mer:pw>
+    </mer:CreditTransaction>
+  </soapenv:Body>
+</soapenv:Envelope>''').format(transaction=str(self.env.ref(template)._render(data)), password=data['merchant_pwd'])
 
         response = ''
 


### PR DESCRIPTION
in v14 `_render()` on `ir.ui.view` returned `str`. In v15 it returns
`Markup` instead. This inadvertently changed the behavior of
`_do_request()`. The rendered view stored in `xml_transaction` is
added to the request as the SOAP body and is supposed to be
escaped. This is done by `html_escape(xml_transaction)` but since
`xml_transaction` is already `Markup` it won't escape. On top of that
concatenating the `soap_header` and `soap_footer` `str`s causes them
to be escaped when they shouldn't be.

This commit first turns the rendered view into an escaped
`Markup`. `soap_header` is entirely hardcoded and is also marked
safe. The hardcoded part of `soap_footer` is marked safe and the
dynamic `merchant_pwd` is escaped. This has the added benefit of
solving an issue when the password includes a character with a special
meaning, although I'm not aware of a real case where this happened.

opw-2919085