### PR TITLE
[FIX][I18N][15.0] account: Fix translation file for Vietnamese

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -4445,7 +4445,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:account.res_partner_view_search
 #, python-format
-msgid "Customer Invoices"
+msgid "Customer"
 msgstr ""
 
 #. module: account
@@ -14603,7 +14603,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:account.res_partner_view_search
 #, python-format
-msgid "Vendor Bills"
+msgid "Vendor"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/vi.po
+++ b/addons/account/i18n/vi.po
@@ -4802,8 +4802,8 @@ msgstr "Hóa đơn khách hàng"
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:account.res_partner_view_search
 #, python-format
-msgid "Customer Invoices"
-msgstr "Hóa đơn khách hàng"
+msgid "Customer"
+msgstr "Khách hàng"
 
 #. module: account
 #: code:addons/account/models/account_payment.py:0
@@ -15612,8 +15612,8 @@ msgstr "Công nợ nhà cung cấp đã tạo"
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:account.res_partner_view_search
 #, python-format
-msgid "Vendor Bills"
-msgstr "Hoá đơn Nhà cung cấp"
+msgid "Vendor"
+msgstr "Nhà cung cấp"
 
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_invoice_report__move_type__in_refund

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -246,8 +246,8 @@
             <field name="inherit_id" ref="base.view_res_partner_filter"/>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='inactive']" position="before">
-                   <filter string="Customer Invoices" name="customer" domain="[('customer_rank','>', 0)]"/>
-                   <filter string="Vendor Bills" name="supplier" domain="[('supplier_rank','>', 0)]"/>
+                   <filter string="Customer" name="customer" domain="[('customer_rank','>', 0)]"/>
+                   <filter string="Vendor" name="supplier" domain="[('supplier_rank','>', 0)]"/>
                    <separator/>
                 </xpath>
             </field>


### PR DESCRIPTION
[FIX][I18N] account: Fix translation file for Vietnamese

Description of the issue/feature this PR addresses:

Current behavior before PR:
- When in Purchase/Orders/Vendor the filter show Vendor Bills and Customer Invoices which is not correct for its purpose 

Desired behavior after PR is merged:
- Change `Customer Invoices` into `Customer`
- Change `Vendor Bills` into `Vendor`


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
