### PR TITLE
[IMP] website_sale: edit feature name

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1138,7 +1138,7 @@
         </t>
     </template>
 
-    <template id="suggested_products_list" inherit_id="website_sale.cart_lines" customize_show="True" name="Alternative Products in my cart">
+    <template id="suggested_products_list" inherit_id="website_sale.cart_lines" customize_show="True" name="Accessory Products in my cart">
         <xpath expr="//table[@id='cart_products']" position="after">
             <h5 class='text-muted js_cart_lines' t-if="suggested_products">Suggested Accessories:</h5>
             <table t-if="suggested_products" id="suggested_products" class="js_cart_lines table table-striped table-sm">


### PR DESCRIPTION
While testing the application, I get the following error:

[Step]:

- Select a product A
- On tab `eComerce` choose Field `Accessory Products` : Select a product is accessory products for product A.
- Click button `Go to Website`.
- Click button `Add to Cart`.
- Click `Alternative Products in my cart` on menu `Customize`.

[Expected]:

- This function will add the `accessory product` of product A to the cart, so the name of this function should be `Accessory Products in my cart`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
