### PR TITLE
[FIX] web: prevent wrong date format if picker used too soon on frontend

### DIFF
--- a/addons/web/static/lib/tempusdominus/tempusdominus.js
+++ b/addons/web/static/lib/tempusdominus/tempusdominus.js
@@ -45,7 +45,14 @@ var DateTimePicker = function ($, moment) {
         EVENT_KEY = '.' + DATA_KEY,
         DATA_API_KEY = '.data-api',
         Selector = {
-        DATA_TOGGLE: '[data-toggle="' + DATA_KEY + '"]'
+        // /!\ ODOO PATCH: ensure the datetimepickers can be toggled only after
+        // the Odoo lazy loader finished loading all lazy scripts. Another
+        // solution could have been to temporarily removing the data-toggle
+        // attributes during lazyloading but that would not have been stable as
+        // custom code could search for data-toggle elements while the lazy
+        // loading is being performed. Without this, clicking too soon on a
+        // datetimepicker would not use the right format and UI options.
+        DATA_TOGGLE: 'body:not(.o_lazy_js_waiting) [data-toggle="' + DATA_KEY + '"]'
     },
         ClassName = {
         INPUT: NAME + '-input'

--- a/addons/web/static/src/js/public/lazyloader.js
+++ b/addons/web/static/src/js/public/lazyloader.js
@@ -10,7 +10,7 @@ var blockFunction = function (ev) {
 var waitingLazy = false;
 
 /**
- * Blocks the DOM sections which explicitely require the lazy loaded JS to be
+ * Blocks the DOM sections which explicitly require the lazy loaded JS to be
  * working (those sections should be marked with the 'o_wait_lazy_js' class).
  *
  * @see stopWaitingLazy
@@ -28,6 +28,8 @@ function waitLazy() {
             element.addEventListener(evType, blockFunction);
         });
     }
+
+    document.body.classList.add('o_lazy_js_waiting');
 }
 /**
  * Unblocks the DOM sections blocked by @see waitLazy and removes the related
@@ -47,6 +49,8 @@ function stopWaitingLazy() {
         });
         element.classList.remove('o_wait_lazy_js');
     }
+
+    document.body.classList.remove('o_lazy_js_waiting');
 }
 
 // Start waiting for lazy loading as soon as the DOM is available


### PR DESCRIPTION
If datetimepickers were used too soon after page loading, they would use
the wrong format and UI options as the code in charge of initializing
those options was not fully lazy loaded yet.

With this patch, we prevent the tempusdominus lib to consider pickers
that are in a body that is marked by the lazyloader during the lazy
loading of JS files. We could potentially not add the lib attribute
(data-toggle="datetimepicker") on those elements and let the business
code initializing the pickers add it but that would not have been a
stable fix and it may be better this way as this works generically.

opw-2944720