### PR TITLE
[FIX] web: allow validating column quick creating with enter in kanban

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -233,7 +233,7 @@ export const hotkeyService = {
             let winner = candidates.shift();
             if (winner && winner.area) {
                 // If there is an area, find the closest one
-                for (const candidate of candidates) {
+                for (const candidate of candidates.filter((c) => Boolean(c.area))) {
                     if (candidate.area() && winner.area().contains(candidate.area())) {
                         winner = candidate;
                     }

--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.js
@@ -37,8 +37,11 @@ export class KanbanColumnQuickCreate extends Component {
         );
 
         // Key Navigation
-        // FIXME ? Maybe it will also validate even if enter is pressed outside of the quick create machin
-        useHotkey("enter", () => this.validate());
+        const inputRef = useRef("autofocus");
+        useHotkey("enter", () => this.validate(), {
+            area: () => inputRef.el,
+            bypassEditableProtection: true,
+        });
         useHotkey("escape", () => this.fold());
     }
 

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -40,7 +40,7 @@ QUnit.test("register / unregister", async (assert) => {
     triggerHotkey(key);
     await nextTick();
 
-    let removeHotkey = hotkey.add(key, () => assert.step(key));
+    const removeHotkey = hotkey.add(key, () => assert.step(key));
     await nextTick();
 
     triggerHotkey(key);
@@ -1094,4 +1094,21 @@ QUnit.test("operation area with validating option", async (assert) => {
     triggerHotkey("Space");
     await nextTick();
     assert.verifySteps(["RGNTDJÛ!"]);
+});
+
+QUnit.test("mixing hotkeys with and without operation area", async (assert) => {
+    class A extends Component {
+        setup() {
+            const areaRef = useRef("area");
+            useHotkey("space", () => assert.step("withoutArea"));
+            useHotkey("space", () => assert.step("withArea"), { area: () => areaRef.el });
+        }
+    }
+    A.template = xml`<div class="root" tabindex="0" t-ref="area"/>`;
+    await mount(A, target, { env });
+
+    target.querySelector(".root").focus();
+    triggerHotkey("Space");
+    await nextTick();
+    assert.verifySteps(["withArea"]);
 });

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -5312,6 +5312,30 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group", 4);
     });
 
+    QUnit.test("quick create column with enter", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch:
+                "<kanban>" +
+                '<field name="product_id"/>' +
+                '<templates><t t-name="kanban-box">' +
+                '<div><field name="foo"/></div>' +
+                "</t></templates>" +
+                "</kanban>",
+            groupBy: ["product_id"],
+        });
+
+        // add a new column
+        await createColumn();
+        await editColumnName("New Column 1");
+        await triggerEvent(target, ".o_column_quick_create input", "keydown", {
+            key: "Enter",
+        });
+        assert.containsN(target, ".o_kanban_group", 3, "should now have three columns");
+    });
+
     QUnit.test("quick create column and examples", async (assert) => {
         serviceRegistry.add("dialog", dialogService, { force: true });
         registry.category("kanban_examples").add("test", {


### PR DESCRIPTION
With the conversion of the kanban view, it was no longer possible to
validate the quick-creation of a column using enter while within the
quick-create input, this is because the hotkey service ignores hotkeys
being pressed while within an editable element by default except for the
escape key. This commit fixes that by configuring the enter hotkey that
is registered to bypass the editable protection.