### PR TITLE
[FIX][15.0] base: fix helpstring

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -25339,7 +25339,6 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_res_currency__inverse_rate
 #: model:ir.model.fields,help:base.field_res_currency_rate__company_rate
-#: model:ir.model.fields,help:base.field_res_currency_rate__inverse_company_rate
 msgid "The currency of rate 1 to the rate of the currency."
 msgstr ""
 
@@ -25593,7 +25592,8 @@ msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_currency_rate__rate
-msgid "The rate of the currency to the currency of rate 1"
+#: model:ir.model.fields,help:base.field_res_currency_rate__inverse_company_rate
+msgid "The rate of the currency to the currency of rate 1 "
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -330,7 +330,7 @@ class CurrencyRate(models.Model):
         compute="_compute_inverse_company_rate",
         inverse="_inverse_inverse_company_rate",
         group_operator="avg",
-        help="The currency of rate 1 to the rate of the currency.",
+        help="The rate of the currency to the currency of rate 1 ",
     )
     currency_id = fields.Many2one('res.currency', string='Currency', readonly=True, required=True, ondelete="cascade")
     company_id = fields.Many2one('res.company', string='Company',


### PR DESCRIPTION
While testing Odoo application, I have the following problem:

Currently: helpstring of 2 fields "Unit per USD" and "USD per unit" are the same, displayed as
"The currency of rate 1 to the rate of the currency."
Desired: Modify the helpstring of the USD per unit field.
=> help="The rate of the currency to the currency of rate 1"

https://user-images.githubusercontent.com/91191721/185864805-bf2fcc1c-a4fd-486c-83bf-6c9cdf24591c.mp4
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
