### PR TITLE
 [IMP] mail, rating: turn computes and relateds readonly by default

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.xml
+++ b/addons/mail/static/src/components/discuss/discuss.xml
@@ -43,7 +43,7 @@
                 record="discussView.discuss.threadView"
             />
         </t>
-        <t t-if="!discussView.discuss.thread and (!messaging.device.isSmall or discussView.discuss.activeMobileNavbarTabId === 'mailbox')">
+        <t t-if="!discussView.discuss.activeThread and (!messaging.device.isSmall or discussView.discuss.activeMobileNavbarTabId === 'mailbox')">
             <div class="o_Discuss_noThread d-flex flex-grow-1 align-items-center justify-content-center w-100 bg-white">
                 <h4 class="text-muted"><b><i>No conversation selected.</i></b></h4>
             </div>

--- a/addons/mail/static/src/components/discuss_container/discuss_container.js
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.js
@@ -34,7 +34,7 @@ export class DiscussContainer extends Component {
             await this.messaging.initializedPromise;
             if (!this.discuss.isInitThreadHandled) {
                 this.discuss.update({ isInitThreadHandled: true });
-                if (!this.discuss.thread) {
+                if (!this.discuss.activeThread) {
                     this.discuss.openInitThread();
                 }
             }

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection_item/discuss_mobile_mailbox_selection_item.xml
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection_item/discuss_mobile_mailbox_selection_item.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.DiscussMobileMailboxSelectionItem" owl="1">
         <button class="o_DiscussMobileMailboxSelectionItem btn btn-secondary flex-grow-1 p-2"
             t-att-class="{
-                'active o-active shadow-none': discussView.discuss.thread === mailbox.thread,
+                'active o-active shadow-none': discussView.discuss.activeThread === mailbox.thread,
             }" t-attf-class="{{ className }}" t-on-click="() => discussView.onClickMobileMailboxSelectionItem(mailbox)" t-att-data-mailbox-local-id="mailbox.localId" type="button" t-ref="root"
         >
             <t t-esc="mailbox.name"/>

--- a/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
@@ -3,8 +3,8 @@
     <t t-name="mail.DiscussSidebarMailbox" owl="1">
         <button class="o_DiscussSidebarMailbox btn d-flex align-items-center py-1 px-0 border-0 rounded-0 fw-normal text-dark"
             t-att-class="{
-                'bg-100': discussSidebarMailboxView.mailbox.thread !== messaging.discuss.thread,
-                'o-active bg-200': discussSidebarMailboxView.mailbox.thread === messaging.discuss.thread,
+                'bg-100': discussSidebarMailboxView.mailbox.thread !== messaging.discuss.activeThread,
+                'o-active bg-200': discussSidebarMailboxView.mailbox.thread === messaging.discuss.activeThread,
                 'o-starred-box': discussSidebarMailboxView.mailbox === messaging.starred,
             }" t-attf-class="{{ className }}" t-on-click="discussSidebarMailboxView.mailbox.thread.onClick" t-att-data-mailbox-local-id="discussSidebarMailboxView.mailbox.localId" t-att-data-mailbox-name="discussSidebarMailboxView.mailbox.name"
             t-ref="root"

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -140,11 +140,21 @@ export class ModelField {
          * model name this relation refers to.
          */
         this.to = to;
+        /**
+         * Automatically make identifying fields readonly (and required for AND
+         * identifying mode).
+         */
         if (this.identifying) {
             this.readonly = true;
             if (model.identifyingMode === 'and') {
                 this.required = true;
             }
+        }
+        /**
+         * Automatically make computes and relateds readonly.
+         */
+        if (this.compute || this.related) {
+            this.readonly = true;
         }
     }
 

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -491,17 +491,22 @@ export class ModelManager {
                     }
                 }
                 // 4. Computed field.
-                if (field.compute && !(typeof field.compute === 'string')) {
-                    throw new Error(`Property "compute" of field(${fieldName}) on ${model} must be a string (instance method name).`);
-                }
-                if (field.compute && !(model.prototype[field.compute])) {
-                    throw new Error(`Property "compute" of field(${fieldName}) on ${model} does not refer to an instance method of this model.`);
+                if (field.compute) {
+                    if (!(typeof field.compute === 'string')) {
+                        throw new Error(`Property "compute" of field(${fieldName}) on ${model} must be a string (instance method name).`);
+                    }
+                    if (!model.prototype[field.compute]) {
+                        throw new Error(`Property "compute" of field(${fieldName}) on ${model} does not refer to an instance method of this model.`);
+                    }
+                    if ('readonly' in field) {
+                        throw new Error(`Computed field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicit for computed fields).`);
+                    }
                 }
                 // 5. Related field.
-                if (field.compute && field.related) {
-                    throw new Error(`field(${fieldName}) on ${model} cannot be a related and compute field at the same time.`);
-                }
                 if (field.related) {
+                    if (field.compute) {
+                        throw new Error(`field(${fieldName}) on ${model} cannot be a related and compute field at the same time.`);
+                    }
                     if (!(typeof field.related === 'string')) {
                         throw new Error(`Property "related" of field(${fieldName}) on ${model} has invalid format.`);
                     }
@@ -542,6 +547,9 @@ export class ModelManager {
                         relatedField.to !== field.to
                     ) {
                         throw new Error(`Related field(${fieldName}) on ${model} has mismatched target model name with its related model field.`);
+                    }
+                    if ('readonly' in field) {
+                        throw new Error(`Related field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicit for related fields).`);
                     }
                 }
             }

--- a/addons/mail/static/src/models/activity_mark_done_popover_content_view.js
+++ b/addons/mail/static/src/models/activity_mark_done_popover_content_view.js
@@ -95,7 +95,6 @@ registerModel({
     fields: {
         activityViewOwner: one('ActivityView', {
             compute: '_computeActivityViewOwner',
-            readonly: true,
         }),
         component: attr(),
         feedbackTextareaRef: attr(),

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -408,7 +408,6 @@ registerModel({
         threadsAsAttachmentsInWebClientView: many('Thread', {
             compute: '_computeThreadsAsAttachmentsInWebClientView',
             inverse: 'attachmentsInWebClientView',
-            readonly: true,
         }),
         type: attr(),
         /**

--- a/addons/mail/static/src/models/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view.js
@@ -31,7 +31,6 @@ registerModel({
             compute: '_computeAttachmentList',
             inverse: 'attachmentBoxViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         chatter: one('Chatter', {
             identifying: true,

--- a/addons/mail/static/src/models/attachment_delete_confirm_view.js
+++ b/addons/mail/static/src/models/attachment_delete_confirm_view.js
@@ -72,7 +72,6 @@ registerModel({
     fields: {
         attachment: one('Attachment', {
             compute: '_computeAttachment',
-            readonly: true,
             required: true,
         }),
         body: attr({

--- a/addons/mail/static/src/models/call_participant_video_view.js
+++ b/addons/mail/static/src/models/call_participant_video_view.js
@@ -42,7 +42,6 @@ registerModel({
         }),
         rtcSession: one('RtcSession', {
             compute: '_computeRtcSession',
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_view.js
+++ b/addons/mail/static/src/models/call_view.js
@@ -171,7 +171,6 @@ registerModel({
             compute: '_computeCallSideBarView',
             inverse: 'callView',
             isCausal: true,
-            readonly: true,
         }),
         channel: one('Thread', {
             related: 'threadView.thread',

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -92,9 +92,10 @@ registerModel({
         id: attr({
             identifying: true,
         }),
-        memberCount: attr({
-            related: 'thread.memberCount',
-        }),
+        /**
+         * States the number of members in this channel according to the server.
+         */
+        memberCount: attr(),
         orderedOfflineMembers: many('ChannelMember', {
             inverse: 'channelAsOfflineMember',
             sort: '_sortMembers',
@@ -107,7 +108,6 @@ registerModel({
             compute: '_computeThread',
             inverse: 'channel',
             isCausal: true,
-            readonly: true,
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -316,7 +316,6 @@ registerModel({
          */
         thread: one('Thread', {
             compute: '_computeThread',
-            readonly: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
+++ b/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
@@ -28,7 +28,6 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'channelInvitationFormSelectablePartnerViewOwner',
             isCausal: true,
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/channel_member_list_view.js
+++ b/addons/mail/static/src/models/channel_member_list_view.js
@@ -56,7 +56,6 @@ registerModel({
     fields: {
         channel: one('Channel', {
             compute: '_computeChannel',
-            readonly: true,
         }),
         chatWindowOwner: one('ChatWindow', {
             identifying: true,

--- a/addons/mail/static/src/models/channel_member_view.js
+++ b/addons/mail/static/src/models/channel_member_view.js
@@ -63,7 +63,6 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'channelMemberViewOwner',
             isCausal: true,
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -697,7 +697,6 @@ registerModel({
             compute: '_computeThreadViewer',
             inverse: 'chatWindow',
             isCausal: true,
-            readonly: true,
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager.js
@@ -50,8 +50,7 @@ registerModel({
          *
          */
         closeAll() {
-            const chatWindows = this.allOrdered;
-            for (const chatWindow of chatWindows) {
+            for (const chatWindow of this.chatWindows) {
                 chatWindow.close();
             }
         },
@@ -140,16 +139,15 @@ registerModel({
          * @param {ChatWindow} chatWindow2
          */
         swap(chatWindow1, chatWindow2) {
-            const ordered = this.allOrdered;
-            const index1 = ordered.findIndex(chatWindow => chatWindow === chatWindow1);
-            const index2 = ordered.findIndex(chatWindow => chatWindow === chatWindow2);
+            const index1 = this.chatWindows.findIndex(chatWindow => chatWindow === chatWindow1);
+            const index2 = this.chatWindows.findIndex(chatWindow => chatWindow === chatWindow2);
             if (index1 === -1 || index2 === -1) {
                 return;
             }
-            const _newOrdered = [...this.allOrdered];
+            const _newOrdered = [...this.chatWindows];
             _newOrdered[index1] = chatWindow2;
             _newOrdered[index2] = chatWindow1;
-            this.update({ allOrdered: _newOrdered });
+            this.update({ chatWindows: _newOrdered });
             for (const chatWindow of [chatWindow1, chatWindow2]) {
                 if (chatWindow.threadView) {
                     chatWindow.threadView.addComponentHint('adjust-scroll');
@@ -260,7 +258,7 @@ registerModel({
             if (!this.messaging.device.isSmall && this.messaging.discuss.discussView) {
                 return visual;
             }
-            if (!this.allOrdered.length) {
+            if (!this.chatWindows.length) {
                 return visual;
             }
             const relativeGlobalWindowWidth = this.messaging.device.globalWindowInnerWidth - this.startGapWidth - this.endGapWidth;
@@ -273,10 +271,10 @@ registerModel({
                 maxAmountWithoutHidden = 1;
                 maxAmountWithHidden = 1;
             }
-            if (this.allOrdered.length <= maxAmountWithoutHidden) {
+            if (this.chatWindows.length <= maxAmountWithoutHidden) {
                 // all visible
-                for (let i = 0; i < this.allOrdered.length; i++) {
-                    const chatWindow = this.allOrdered[i];
+                for (let i = 0; i < this.chatWindows.length; i++) {
+                    const chatWindow = this.chatWindows[i];
                     const offset = this.startGapWidth + i * (this.chatWindowWidth + this.betweenGapWidth);
                     visual.visible.push({ chatWindow, offset });
                 }
@@ -284,24 +282,24 @@ registerModel({
             } else if (maxAmountWithHidden > 0) {
                 // some visible, some hidden
                 for (let i = 0; i < maxAmountWithHidden; i++) {
-                    const chatWindow = this.allOrdered[i];
+                    const chatWindow = this.chatWindows[i];
                     const offset = this.startGapWidth + i * (this.chatWindowWidth + this.betweenGapWidth);
                     visual.visible.push({ chatWindow, offset });
                 }
-                if (this.allOrdered.length > maxAmountWithHidden) {
+                if (this.chatWindows.length > maxAmountWithHidden) {
                     visual.isHiddenMenuVisible = !this.messaging.device.isSmall;
                     visual.hiddenMenuOffset = visual.visible[maxAmountWithHidden - 1].offset
                         + this.chatWindowWidth + this.betweenGapWidth;
                 }
-                for (let j = maxAmountWithHidden; j < this.allOrdered.length; j++) {
-                    visual.hiddenChatWindows.push(this.allOrdered[j]);
+                for (let j = maxAmountWithHidden; j < this.chatWindows.length; j++) {
+                    visual.hiddenChatWindows.push(this.chatWindows[j]);
                 }
                 visual.availableVisibleSlots = maxAmountWithHidden;
             } else {
                 // all hidden
                 visual.isHiddenMenuVisible = !this.messaging.device.isSmall;
                 visual.hiddenMenuOffset = this.startGapWidth;
-                visual.hiddenChatWindows.push(...this.allOrdered);
+                visual.hiddenChatWindows.push(...this.chatWindows);
                 console.warn('cannot display any visible chat windows (screen is too small)');
                 visual.availableVisibleSlots = 0;
             }
@@ -309,12 +307,6 @@ registerModel({
         },
     },
     fields: {
-        /**
-         * List of ordered chat windows.
-         */
-        allOrdered: many('ChatWindow', {
-            compute: '_computeAllOrdered',
-        }),
         allOrderedHidden: many('ChatWindow', {
             compute: '_computeAllOrderedHidden',
         }),

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -305,7 +305,7 @@ registerModel({
                         model: this.threadModel,
                     }),
                 });
-                this.thread.cache.update({ messages: link(message) });
+                this.thread.cache.update({ temporaryMessages: link(message) });
             }
         },
         /**
@@ -484,7 +484,6 @@ registerModel({
             compute: '_computeThreadViewer',
             inverse: 'chatter',
             isCausal: true,
-            readonly: true,
             required: true,
         }),
         topbar: one('ChatterTopbar', {

--- a/addons/mail/static/src/models/clock.js
+++ b/addons/mail/static/src/models/clock.js
@@ -9,22 +9,17 @@ import { attr, many } from '@mail/model/model_field';
 registerModel({
     name: 'Clock',
     lifecycleHooks: {
+        _created() {
+            // The date is set here rather than via a default value so that the
+            // date set at first is the time of the record creation, and not the
+            // time of the model initialization.
+            this.update({ date: new Date() });
+        },
         _willDelete() {
             this.messaging.browser.clearInterval(this.tickInterval);
         },
     },
     recordMethods: {
-        /**
-         * The date is set by a compute rather than using a default value. Thus,
-         * the date set at first is the time of the record creation, and not the
-         * time of the model initialization.
-         *
-         * @private
-         * @returns {Date}
-         */
-        _computeDate() {
-            return new Date();
-        },
         /**
          * @private
          * @returns {integer}
@@ -52,9 +47,7 @@ registerModel({
          * A Date object set to the current date at the time the record is
          * created, then updated at every tick.
          */
-        date: attr({
-            compute: '_computeDate',
-        }),
+        date: attr(),
         /**
          * An integer representing the frequency in milliseconds at which `date`
          * must be recomputed.

--- a/addons/mail/static/src/models/composer_suggestion_list_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view.js
@@ -12,7 +12,7 @@ registerModel({
          */
         setFirstSuggestionViewActive() {
             const firstSuggestionView = this.suggestionViews[0];
-            this.update({ activeSuggestionView: firstSuggestionView });
+            this.update({ rawActiveSuggestionView: firstSuggestionView });
         },
         /**
          * Sets the last suggestion as active. Main and extra records are
@@ -20,7 +20,7 @@ registerModel({
          */
         setLastSuggestionViewActive() {
             const { length, [length - 1]: lastSuggestionView } = this.suggestionViews;
-            this.update({ activeSuggestionView: lastSuggestionView });
+            this.update({ rawActiveSuggestionView: lastSuggestionView });
         },
         /**
          * Sets the next suggestion as active. Main and extra records are
@@ -36,7 +36,7 @@ registerModel({
                 return;
             }
             const nextSuggestionView = this.suggestionViews[activeElementIndex + 1];
-            this.update({ activeSuggestionView: nextSuggestionView });
+            this.update({ rawActiveSuggestionView: nextSuggestionView });
         },
         /**
          * Sets the previous suggestion as active. Main and extra records are
@@ -52,7 +52,7 @@ registerModel({
                 return;
             }
             const previousSuggestionView = this.suggestionViews[activeElementIndex - 1];
-            this.update({ activeSuggestionView: previousSuggestionView });
+            this.update({ rawActiveSuggestionView: previousSuggestionView });
         },
         /**
          * Adapts the active suggestion it if the active suggestion is no longer
@@ -62,8 +62,8 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeActiveSuggestionView() {
-            if (this.suggestionViews.includes(this.activeSuggestionView)) {
-                return;
+            if (this.suggestionViews.includes(this.rawActiveSuggestionView)) {
+                return this.rawActiveSuggestionView;
             }
             const firstSuggestionView = this.suggestionViews[0];
             return firstSuggestionView;
@@ -120,9 +120,9 @@ registerModel({
         hasToScrollToActiveSuggestionView: attr({
             default: false,
         }),
+        rawActiveSuggestionView: one('ComposerSuggestionView'),
         suggestionViews: many('ComposerSuggestionView', {
             compute: '_computeSuggestionViews',
-            readonly: true,
         })
     },
 });

--- a/addons/mail/static/src/models/composer_suggestion_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_view.js
@@ -20,7 +20,7 @@ registerModel({
          */
         onClick(ev) {
             ev.preventDefault();
-            this.composerSuggestionListViewOwner.update({ activeSuggestionView: this });
+            this.composerSuggestionListViewOwner.update({ rawActiveSuggestionView: this });
             const composerViewOwner = this.composerSuggestionListViewOwner.composerViewOwner;
             composerViewOwner.insertSuggestion();
             composerViewOwner.closeSuggestions();
@@ -132,11 +132,9 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'composerSuggestionViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         suggestable: one('ComposerSuggestable', {
             compute: '_computeSuggestable',
-            readonly: true,
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/delete_message_confirm_view.js
+++ b/addons/mail/static/src/models/delete_message_confirm_view.js
@@ -48,7 +48,6 @@ registerModel({
         }),
         message: one('Message', {
             compute: '_computeMessage',
-            readonly: true,
             required: true,
         }),
         /**
@@ -59,7 +58,6 @@ registerModel({
             compute: '_computeMessageView',
             inverse: 'deleteMessageConfirmViewOwner',
             isCausal: true,
-            readonly: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/dialog.js
+++ b/addons/mail/static/src/models/dialog.js
@@ -234,7 +234,6 @@ registerModel({
         manager: one('DialogManager', {
             compute: '_computeManager',
             inverse: 'dialogs',
-            readonly: true,
         }),
         messageActionViewOwnerAsDeleteConfirm: one('MessageActionView', {
             identifying: true,
@@ -248,7 +247,6 @@ registerModel({
         record: one('Record', {
             compute: '_computeRecord',
             isCausal: true,
-            readonly: true,
             required: true,
         }),
         style: attr({

--- a/addons/mail/static/src/models/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view.js
@@ -72,7 +72,6 @@ registerModel({
          * States the thread view linked to this discuss public view.
          */
         threadView: one('ThreadView', {
-            readonly: true,
             related: 'threadViewer.threadView',
         }),
         /**

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -53,7 +53,7 @@ registerModel({
          * @returns {FieldCommand}
          */
         _computeActiveItem() {
-            const channel = this.messaging.discuss.thread && this.messaging.discuss.thread.channel;
+            const channel = this.messaging.discuss.activeThread && this.messaging.discuss.activeThread.channel;
             if (channel && this.supportedChannelTypes.includes(channel.channel_type)) {
                 return {
                     thread: channel.thread,
@@ -389,7 +389,6 @@ registerModel({
          */
         filteredCategoryItems: many('DiscussSidebarCategoryItem', {
             compute: '_computeFilteredCategoryItems',
-            readonly: true,
         }),
         /**
          * Display name of the category.
@@ -465,7 +464,6 @@ registerModel({
         supportedChannelTypes: attr({
             compute: '_computeSupportedChannelTypes',
             required: true,
-            readonly: true,
         }),
     },
     onChanges: [

--- a/addons/mail/static/src/models/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item.js
@@ -96,7 +96,7 @@ registerModel({
          * @returns {boolean}
          */
         _computeIsActive() {
-            return this.messaging.discuss && this.thread === this.messaging.discuss.thread;
+            return this.messaging.discuss && this.thread === this.messaging.discuss.activeThread;
         },
         /**
          * @private
@@ -234,10 +234,8 @@ registerModel({
          */
         categoryCounterContribution: attr({
             compute: '_computeCategoryCounterContribution',
-            readonly: true,
         }),
         channel: one('Channel', {
-            readonly: true,
             related: 'thread.channel',
         }),
         /**

--- a/addons/mail/static/src/models/discuss_sidebar_mailbox_view.js
+++ b/addons/mail/static/src/models/discuss_sidebar_mailbox_view.js
@@ -40,7 +40,6 @@ registerModel({
         }),
         mailbox: one('Mailbox', {
             compute: '_computeMailbox',
-            readonly: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -111,7 +111,7 @@ registerModel({
         /**
          * @private
          */
-        _onDiscussThreadChanged() {
+        _onDiscussActiveThreadChanged() {
             this.env.services.router.pushState({
                 action: this.discuss.discussView.actionId,
                 active_id: this.discuss.activeId,
@@ -169,8 +169,8 @@ registerModel({
     },
     onChanges: [
         {
-            dependencies: ['discuss.thread'],
-            methodName: '_onDiscussThreadChanged',
+            dependencies: ['discuss.activeThread'],
+            methodName: '_onDiscussActiveThreadChanged',
         },
     ],
 });

--- a/addons/mail/static/src/models/emoji.js
+++ b/addons/mail/static/src/models/emoji.js
@@ -24,7 +24,6 @@ registerModel({
         emojiRegistry: one('EmojiRegistry', {
             compute: '_computeEmojiRegistry',
             inverse: 'allEmojis',
-            readonly: true,
             required: true,
         }),
         emojiViews: many('EmojiView', {

--- a/addons/mail/static/src/models/emoji_grid_view.js
+++ b/addons/mail/static/src/models/emoji_grid_view.js
@@ -26,7 +26,6 @@ registerModel({
         emojiViews: many('EmojiView', {
             compute: '_computeEmojiViews',
             inverse: 'emojiGridView',
-            readonly: true,
             isCausal: true,
         }),
     },

--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -208,7 +208,6 @@ registerModel({
         }),
         thread: one('Thread', {
             compute: '_computeThread',
-            readonly: true,
             required: true,
         })
     },

--- a/addons/mail/static/src/models/message_action.js
+++ b/addons/mail/static/src/models/message_action.js
@@ -90,12 +90,10 @@ registerModel({
     fields: {
         isNonCompactActionContribution: attr({
             compute: '_computeIsNonCompactActionContribution',
-            readonly: true,
         }),
         messageActionListOwner: one('MessageActionList', {
             compute: '_computeMessageActionListOwner',
             inverse: 'messageActions',
-            readonly: true,
             required: true,
         }),
         messageActionListOwnerAsDelete: one('MessageActionList', {
@@ -130,7 +128,6 @@ registerModel({
             compute: '_computeMessageActionView',
             inverse: 'messageAction',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * States the listing sequence of the action inside of the aciton list.

--- a/addons/mail/static/src/models/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list.js
@@ -166,14 +166,12 @@ registerModel({
         }),
         firstActionView: one('MessageActionView', {
             compute: '_computeFirstActionView',
-            readonly: true,
         }),
         isCompact: attr({
             default: true,
         }),
         lastActionView: one('MessageActionView', {
             compute: '_computeLastActionView',
-            readonly: true,
         }),
         /**
          * States the message on which this action message list operates.
@@ -186,7 +184,6 @@ registerModel({
             isCausal: true,
         }),
         messageActionViews: many('MessageActionView', {
-            readonly: true,
             related: 'messageActions.messageActionView',
             sort: '_sortMessageActionViews',
         }),

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -161,7 +161,7 @@ registerModel({
             const textInputContent = htmlDoc.body.textContent;
             this.update({
                 composerForEditing: {
-                    mentionedPartners: this.message.recipients,
+                    rawMentionedPartners: this.message.recipients,
                     textInputContent,
                     textInputCursorEnd: textInputContent.length,
                     textInputCursorStart: textInputContent.length,
@@ -434,7 +434,6 @@ registerModel({
             compute: '_computeAttachmentList',
             inverse: 'messageViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         authorTitleText: attr({
             compute: '_computeAuthorTitleText',
@@ -578,7 +577,6 @@ registerModel({
             compute: '_computeMessageActionList',
             inverse: 'messageView',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * Determines the message that is displayed by this message view.
@@ -586,7 +584,6 @@ registerModel({
         message: one('Message', {
             compute: '_computeMessage',
             inverse: 'messageViews',
-            readonly: true,
             required: true,
         }),
         /**
@@ -597,7 +594,6 @@ registerModel({
             compute: '_computeMessageInReplyToView',
             inverse: 'messageView',
             isCausal: true,
-            readonly: true,
         }),
         messageListViewMessageViewItemOwner: one('MessageListViewMessageViewItem', {
             identifying: true,
@@ -615,7 +611,6 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'messageViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * States whether this message view is the last one of its thread view.

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -14,6 +14,7 @@ registerModel({
     lifecycleHooks: {
         _created() {
             odoo.__DEBUG__.messaging = this;
+            this.refreshIsNotificationPermissionDefault();
         },
         _willDelete() {
             this.env.bus.removeEventListener('window_focus', this._handleGlobalWindowFocus);
@@ -200,7 +201,10 @@ registerModel({
          * provide an API to detect when this value changes.
          */
         refreshIsNotificationPermissionDefault() {
-            this.update({ isNotificationPermissionDefault: this._computeIsNotificationPermissionDefault() });
+            const browserNotification = this.messaging.browser.Notification;
+            this.update({
+                isNotificationPermissionDefault: Boolean(browserNotification) && browserNotification.permission === 'default',
+            });
         },
         async startFetchImStatus() {
             this.update({
@@ -275,14 +279,6 @@ registerModel({
                 return; // avoid overwrite if already provided (example in tests)
             }
             return new EventBus();
-        },
-        /**
-         * @private
-         * @returns {boolean}
-         */
-        _computeIsNotificationPermissionDefault() {
-            const browserNotification = this.messaging.browser.Notification;
-            return browserNotification ? browserNotification.permission === 'default' : false;
         },
         /**
          * @private
@@ -402,7 +398,6 @@ registerModel({
         initializedPromise: attr({
             compute: '_computeInitializedPromise',
             required: true,
-            readonly: true,
         }),
         initializer: one('MessagingInitializer', {
             default: {},
@@ -426,9 +421,7 @@ registerModel({
          * 'default' state. This means it is allowed to make a request to the
          * user to enable notifications.
          */
-        isNotificationPermissionDefault: attr({
-            compute: '_computeIsNotificationPermissionDefault',
-        }),
+        isNotificationPermissionDefault: attr(),
         locale: one('Locale', {
             default: {},
             isCausal: true,
@@ -446,7 +439,6 @@ registerModel({
          */
         messagingBus: attr({
             compute: '_computeMessagingBus',
-            readonly: true,
             required: true,
         }),
         messagingMenu: one('MessagingMenu', {
@@ -456,7 +448,6 @@ registerModel({
         notificationHandler: one('MessagingNotificationHandler', {
             compute: '_computeNotificationHandler',
             isCausal: true,
-            readonly: true,
         }),
         outOfFocusUnreadMessageCounter: attr({
             default: 0,

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -328,8 +328,8 @@ registerModel({
             }
             if (this.messaging.currentPartner && this.messaging.currentPartner.id === partner_id) {
                 channel.thread.update({
-                    lastSeenByCurrentPartnerMessageId: last_message_id,
                     pendingSeenMessageId: undefined,
+                    rawLastSeenByCurrentPartnerMessageId: last_message_id,
                 });
             }
         },

--- a/addons/mail/static/src/models/mobile_messaging_navbar_view.js
+++ b/addons/mail/static/src/models/mobile_messaging_navbar_view.js
@@ -19,7 +19,7 @@ registerModel({
                 this.discuss.update({ activeMobileNavbarTabId: tabId });
                 if (
                     this.discuss.activeMobileNavbarTabId === 'mailbox' &&
-                    (!this.discuss.thread || !this.discuss.thread.mailbox)
+                    (!this.discuss.activeThread || !this.discuss.activeThread.mailbox)
                 ) {
                     this.discuss.update({ thread: this.messaging.inbox.thread });
                 }

--- a/addons/mail/static/src/models/notification_request_view.js
+++ b/addons/mail/static/src/models/notification_request_view.js
@@ -42,7 +42,6 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'notificationRequestViewOwner',
             isCausal: true,
-            readonly: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -340,10 +340,16 @@ registerModel({
         },
         /**
          * @private
-         * @returns {string|undefined}
+         * @returns {string|FieldCommand}
          */
         _computeDisplayName() {
-            return this.display_name || this.user && this.user.display_name;
+            if (this.display_name) {
+                return this.display_name;
+            }
+            if (this.user && this.user.displayName) {
+                return this.user.displayName;
+            }
+            return clear();
         },
         /**
          * @private
@@ -364,7 +370,7 @@ registerModel({
          * @returns {string|undefined}
          */
         _computeNameOrDisplayName() {
-            return this.name || this.display_name;
+            return this.name || this.displayName;
         },
     },
     fields: {
@@ -392,7 +398,8 @@ registerModel({
          * And if a specific name format is required, it should be computed from
          * relevant fields instead.
          */
-        display_name: attr({
+        display_name: attr(),
+        displayName: attr({
             compute: '_computeDisplayName',
             default: "",
         }),
@@ -413,7 +420,6 @@ registerModel({
         im_status: attr(),
         isImStatusSet: attr({
             compute: '_computeIsImStatusSet',
-            readonly: true,
         }),
         /**
          * States whether this partner is online.

--- a/addons/mail/static/src/models/persona.js
+++ b/addons/mail/static/src/models/persona.js
@@ -46,11 +46,9 @@ registerModel({
         }),
         im_status: attr({
             compute: '_computeImStatus',
-            readonly: true,
         }),
         name: attr({
             compute: '_computeName',
-            readonly: true,
         }),
         partner: one('Partner', {
             identifying: true,

--- a/addons/mail/static/src/models/persona_im_status_icon_view.js
+++ b/addons/mail/static/src/models/persona_im_status_icon_view.js
@@ -73,7 +73,6 @@ registerModel({
         }),
         persona: one('Persona', {
             compute: '_computePersona',
-            readonly: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/popover_view.js
+++ b/addons/mail/static/src/models/popover_view.js
@@ -176,7 +176,6 @@ registerModel({
             compute: '_computeActivityMarkDonePopoverContentView',
             inverse: 'popoverViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         activityViewOwnerAsMarkDone: one('ActivityView', {
             identifying: true,
@@ -196,7 +195,6 @@ registerModel({
             compute: '_computeChannelInvitationForm',
             inverse: 'popoverViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * States the OWL component of this popover view.
@@ -239,12 +237,10 @@ registerModel({
             compute: '_computeEmojiPickerView',
             inverse: 'popoverViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         manager: one('PopoverManager', {
             compute: '_computeManager',
             inverse: 'popoverViews',
-            readonly: true,
         }),
         /**
          * If set, this popover view is owned by a message action view.

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -99,9 +99,6 @@ registerModel({
                 });
                 data2.serverLastMessage = insert(messageData);
             }
-            if ('memberCount' in data) {
-                data2.memberCount = data.memberCount;
-            }
             if ('message_needaction_counter' in data) {
                 data2.message_needaction_counter = data.message_needaction_counter;
             }
@@ -115,7 +112,7 @@ registerModel({
                 data2.public = data.public;
             }
             if ('seen_message_id' in data) {
-                data2.lastSeenByCurrentPartnerMessageId = data.seen_message_id || 0;
+                data2.rawLastSeenByCurrentPartnerMessageId = data.seen_message_id;
             }
             if ('uuid' in data) {
                 data2.uuid = data.uuid;
@@ -1358,15 +1355,15 @@ registerModel({
             const firstMessage = this.orderedMessages[0];
             if (
                 firstMessage &&
-                this.lastSeenByCurrentPartnerMessageId &&
-                this.lastSeenByCurrentPartnerMessageId < firstMessage.id
+                this.rawLastSeenByCurrentPartnerMessageId &&
+                this.rawLastSeenByCurrentPartnerMessageId < firstMessage.id
             ) {
                 // no deduction can be made if there is a gap
-                return this.lastSeenByCurrentPartnerMessageId;
+                return this.rawLastSeenByCurrentPartnerMessageId;
             }
-            let lastSeenByCurrentPartnerMessageId = this.lastSeenByCurrentPartnerMessageId;
+            let lastSeenByCurrentPartnerMessageId = this.rawLastSeenByCurrentPartnerMessageId;
             for (const message of this.orderedMessages) {
-                if (message.id <= this.lastSeenByCurrentPartnerMessageId) {
+                if (message.id <= this.rawLastSeenByCurrentPartnerMessageId) {
                     continue;
                 }
                 if (
@@ -1784,7 +1781,6 @@ registerModel({
             compute: '_computeComposer',
             inverse: 'thread',
             isCausal: true,
-            readonly: true,
         }),
         correspondent: one('Partner', {
             compute: '_computeCorrespondent',
@@ -1852,7 +1848,6 @@ registerModel({
             compute: '_computeDiscussSidebarCategoryItem',
             inverse: 'thread',
             isCausal: true,
-            readonly: true,
         }),
         displayName: attr({
             compute: '_computeDisplayName',
@@ -2080,12 +2075,6 @@ registerModel({
             inverse: 'thread',
         }),
         mainAttachment: one('Attachment'),
-        /**
-         * States the number of members in this thread according to the server.
-         * Guests are excluded from the count.
-         * Only makes sense if this thread is a channel.
-         */
-        memberCount: attr(),
         members: many('Partner', {
             sort: '_sortPartnerMembers',
         }),
@@ -2135,12 +2124,10 @@ registerModel({
         messagingAsRingingThread: one('Messaging', {
             compute: '_computeMessagingAsRingingThread',
             inverse: 'ringingThreads',
-            readonly: true,
         }),
         messagingMenuAsPinnedAndUnreadChannel: one('MessagingMenu', {
             compute: '_computeMessagingMenuAsPinnedAndUnreadChannel',
             inverse: 'pinnedAndUnreadChannels',
-            readonly: true,
         }),
         model: attr({
             identifying: true,
@@ -2218,6 +2205,9 @@ registerModel({
          */
         pendingSeenMessageId: attr(),
         public: attr(),
+        rawLastSeenByCurrentPartnerMessageId: attr({
+            default: 0,
+        }),
         /**
          * If set, the current thread is the thread that hosts the current RTC call.
          */

--- a/addons/mail/static/src/models/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, link, unlink } from '@mail/model/model_field_command';
+import { clear, link } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadCache',
@@ -62,19 +62,13 @@ registerModel({
         },
         /**
          * @private
-         * @returns {Message[]}
+         * @returns {FieldCommand|Message[]}
          */
         _computeFetchedMessages() {
             if (!this.thread) {
                 return clear();
             }
-            const toUnlinkMessages = [];
-            for (const message of this.fetchedMessages) {
-                if (!this.thread.messages.includes(message)) {
-                    toUnlinkMessages.push(message);
-                }
-            }
-            return unlink(toUnlinkMessages);
+            return this.rawFetchedMessages.filter(m => this.thread.messages.includes(m));
         },
         /**
          * @private
@@ -120,7 +114,7 @@ registerModel({
                     message.id > this.lastFetchedMessage.id
                 );
             }
-            return this.fetchedMessages.concat(newerMessages);
+            return [...this.fetchedMessages, ...this.temporaryMessages, ...newerMessages];
         },
         /**
          * @private
@@ -219,7 +213,7 @@ registerModel({
                 return;
             }
             this.update({
-                fetchedMessages: link(messages),
+                rawFetchedMessages: link(messages),
                 hasLoadingFailed: false,
                 isLoaded: true,
                 isLoading: false,
@@ -356,6 +350,8 @@ registerModel({
         orderedNonEmptyMessages: many('Message', {
             compute: '_computeOrderedNonEmptyMessages',
         }),
+        rawFetchedMessages: many('Message'),
+        temporaryMessages: many('Message'),
         thread: one('Thread', {
             identifying: true,
             inverse: 'cache',

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -87,15 +87,12 @@ registerModel({
         inlineLastNeedactionMessageAsOriginThreadBody: attr({
             compute: '_computeInlineLastNeedactionMessageAsOriginThreadBody',
             default: "",
-            readonly: true,
         }),
         isEmpty: attr({
             compute: '_computeIsEmpty',
-            readonly: true,
         }),
         lastTrackingValue: one('TrackingValue', {
             compute: '_computeLastTrackingValue',
-            readonly: true,
         }),
         /**
          * Reference of the "mark as read" button. Useful to disable the
@@ -115,7 +112,6 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'threadNeedactionPreviewViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         thread: one('Thread', {
             identifying: true,

--- a/addons/mail/static/src/models/thread_preview_view.js
+++ b/addons/mail/static/src/models/thread_preview_view.js
@@ -85,15 +85,12 @@ registerModel({
         inlineLastMessageBody: attr({
             compute: '_computeInlineLastMessageBody',
             default: "",
-            readonly: true,
         }),
         isEmpty: attr({
             compute: '_computeIsEmpty',
-            readonly: true,
         }),
         lastTrackingValue: one('TrackingValue', {
             compute: '_computeLastTrackingValue',
-            readonly: true,
         }),
         /**
          * Reference of the "mark as read" button. Useful to disable the
@@ -113,7 +110,6 @@ registerModel({
             compute: '_computePersonaImStatusIconView',
             inverse: 'threadPreviewViewOwner',
             isCausal: true,
-            readonly: true,
         }),
         thread: one('Thread', {
             identifying: true,

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -119,7 +119,7 @@ registerModel({
          */
         _computeHasComposerThreadName() {
             if (this.threadViewer.discuss) {
-                return this.threadViewer.discuss.thread === this.messaging.inbox.thread;
+                return this.threadViewer.discuss.activeThread === this.messaging.inbox.thread;
             }
             return clear();
         },
@@ -448,7 +448,6 @@ registerModel({
         lastMessageView: one('MessageView', {
             compute: '_computeLastMessageView',
             inverse: 'threadViewOwnerAsLastMessageView',
-            readonly: true,
         }),
         /**
          * Most recent message in this ThreadView that has been shown to the
@@ -482,14 +481,12 @@ registerModel({
             compute: '_computeCallView',
             inverse: 'threadView',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * Determines the `Thread` currently displayed by `this`.
          */
         thread: one('Thread', {
             inverse: 'threadViews',
-            readonly: true,
             related: 'threadViewer.thread',
         }),
         /**
@@ -497,7 +494,6 @@ registerModel({
          */
         threadCache: one('ThreadCache', {
             inverse: 'threadViews',
-            readonly: true,
             related: 'threadViewer.threadCache',
         }),
         threadCacheInitialScrollHeight: attr({
@@ -534,7 +530,6 @@ registerModel({
             compute: '_computeTopbar',
             inverse: 'threadView',
             isCausal: true,
-            readonly: true,
         }),
     },
     onChanges: [

--- a/addons/mail/static/src/models/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar.js
@@ -484,7 +484,6 @@ registerModel({
         avatarUrl: attr({
             compute: '_computeAvatarUrl',
             default: '',
-            readonly: true,
         }),
         /**
          * Determines whether the guest name input needs to be focused.
@@ -583,7 +582,6 @@ registerModel({
          */
         hasGuestNameChanged: attr({
             compute: '_computeHasGuestNameChanged',
-            readonly: true,
         }),
         /**
          * Determines whether description area should display on top bar.

--- a/addons/mail/static/src/models/throttle.js
+++ b/addons/mail/static/src/models/throttle.js
@@ -63,7 +63,6 @@ registerModel({
          */
         duration: attr({
             compute: '_computeDuration',
-            readonly: true,
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/timer.js
+++ b/addons/mail/static/src/models/timer.js
@@ -121,7 +121,6 @@ registerModel({
          */
         duration: attr({
             compute: '_computeDuration',
-            readonly: true,
             required: true,
         }),
         messagingOwnerAsFetchImStatusTimer: one('Messaging', {

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -158,10 +158,16 @@ registerModel({
         },
         /**
          * @private
-         * @returns {string|undefined}
+         * @returns {string|FieldCommand}
          */
         _computeDisplayName() {
-            return this.display_name || this.partner && this.partner.display_name;
+            if (this.display_name) {
+                return this.display_name;
+            }
+            if (this.partner && this.partner.displayName) {
+                return this.partner.displayName;
+            }
+            return clear();
         },
         /**
          * @private
@@ -184,8 +190,10 @@ registerModel({
          * `share` field in python.
          */
         isInternalUser: attr(),
-        display_name: attr({
+        display_name: attr(),
+        displayName: attr({
             compute: '_computeDisplayName',
+            default: "",
         }),
         model: attr({
             default: 'res.user',

--- a/addons/mail/static/src/models/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view.js
@@ -151,7 +151,6 @@ registerModel({
          */
         guestNameInputUniqueId: attr({
             compute: '_computeGuestNameInputUniqueId',
-            readonly: true,
         }),
         /**
          * Determines whether the guest's name has been updated.
@@ -161,7 +160,6 @@ registerModel({
          */
         hasGuestNameChanged: attr({
             compute: '_computeHasGuestNameChanged',
-            readonly: true,
         }),
         /**
          * Determines whether the 'guestNameInput' should be focused the next
@@ -184,7 +182,6 @@ registerModel({
             compute: '_computeCallDemoView',
             inverse: 'welcomeView',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * States the name the guest had when landing on the welcome view.

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1003,6 +1003,7 @@ patch(MockServer.prototype, 'mail', {
             const channelData = {
                 channel_type: channel.channel_type,
                 id: channel.id,
+                memberCount: channel.member_count,
             };
             const res = Object.assign({}, channel, {
                 last_message_id: lastMessageId,

--- a/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
@@ -90,7 +90,7 @@ QUnit.test('create', async function (assert) {
     assert.strictEqual(channel.name, "General");
     const partner = messaging.models['Partner'].findFromIdentifyingData({ id: 5 });
     assert.ok(partner);
-    assert.strictEqual(partner.display_name, "Demo");
+    assert.strictEqual(partner.displayName, "Demo");
     assert.strictEqual(partner.id, 5);
 });
 

--- a/addons/rating/static/src/models/thread_needaction_preview_view.js
+++ b/addons/rating/static/src/models/thread_needaction_preview_view.js
@@ -26,6 +26,5 @@ addRecordMethods('ThreadNeedactionPreviewView', {
 addFields('ThreadNeedactionPreviewView', {
     isRating: attr({
         compute: '_computeIsRating',
-        readonly: true,
     }),
 });

--- a/addons/rating/static/src/models/thread_preview_view.js
+++ b/addons/rating/static/src/models/thread_preview_view.js
@@ -26,6 +26,5 @@ addRecordMethods('ThreadPreviewView', {
 addFields('ThreadPreviewView', {
     isRating: attr({
         compute: '_computeIsRating',
-        readonly: true,
     }),
 });

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -122,6 +122,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_general.id,
+                        'memberCount': len(self.group_user.users | self.user_root),
                     },
                     'create_uid': self.user_root.id,
                     'custom_channel_name': False,
@@ -134,7 +135,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_general.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_general._channel_last_message_ids()),
-                    'memberCount': len(self.group_user.users | self.user_root),
                     'message_needaction_counter': 0,
                     'message_unread_counter': 5,
                     'name': 'general',
@@ -150,6 +150,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_channel_public_1.id,
+                        'memberCount': 5,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -163,7 +164,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'last_interest_dt': self.channel_channel_public_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_channel_public_1._channel_last_message_ids()),
                     'message_needaction_counter': 1,
-                    'memberCount': 5,
                     'message_unread_counter': 0,
                     'name': 'public 1',
                     'public': 'public',
@@ -178,6 +178,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_channel_public_2.id,
+                        'memberCount': 5,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -190,7 +191,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_channel_public_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_channel_public_2._channel_last_message_ids()),
-                    'memberCount': 5,
                     'message_needaction_counter': 0,
                     'message_unread_counter': 0,
                     'name': 'public 2',
@@ -206,6 +206,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_channel_group_1.id,
+                        'memberCount': 5,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -218,7 +219,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_channel_group_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_channel_group_1._channel_last_message_ids()),
-                    'memberCount': 5,
                     'message_needaction_counter': 0,
                     'message_unread_counter': 0,
                     'name': 'group 1',
@@ -234,6 +234,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_channel_group_2.id,
+                        'memberCount': 5,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -246,7 +247,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_channel_group_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_channel_group_2._channel_last_message_ids()),
-                    'memberCount': 5,
                     'message_needaction_counter': 0,
                     'message_unread_counter': 0,
                     'name': 'group 2',
@@ -262,6 +262,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_channel_private_1.id,
+                        'memberCount': 5,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -274,7 +275,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_channel_private_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_channel_private_1._channel_last_message_ids()),
-                    'memberCount': 5,
                     'message_needaction_counter': 0,
                     'message_unread_counter': 0,
                     'name': 'private 1',
@@ -290,6 +290,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'channel',
                         'id': self.channel_channel_private_2.id,
+                        'memberCount': 5,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -302,7 +303,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_channel_private_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_channel_private_2._channel_last_message_ids()),
-                    'memberCount': 5,
                     'message_needaction_counter': 0,
                     'message_unread_counter': 0,
                     'name': 'private 2',
@@ -318,6 +318,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'group',
                         'id': self.channel_group_1.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -331,7 +332,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_group_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': False,
-                    'memberCount': 2,
                     'members': [
                         {
                             'active': True,
@@ -385,6 +385,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'chat',
                         'id': self.channel_chat_1.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -398,7 +399,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_chat_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': False,
-                    'memberCount': 2,
                     'members': [
                         {
                             'active': True,
@@ -452,6 +452,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'chat',
                         'id': self.channel_chat_2.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -465,7 +466,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_chat_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': False,
-                    'memberCount': 2,
                     'members': [
                         {
                             'active': True,
@@ -519,6 +519,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'chat',
                         'id': self.channel_chat_3.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -532,7 +533,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_chat_3.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': False,
-                    'memberCount': 2,
                     'members': [
                         {
                             'active': True,
@@ -586,6 +586,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'chat',
                         'id': self.channel_chat_4.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -599,7 +600,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_chat_4.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': False,
-                    'memberCount': 2,
                     'members': [
                         {
                             'active': True,
@@ -653,6 +653,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'livechat',
                         'id': self.channel_livechat_1.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.user.id,
                     'custom_channel_name': False,
@@ -666,7 +667,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_livechat_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_livechat_1._channel_last_message_ids()),
-                    'memberCount': 2,
                     'livechat_visitor': {
                         'country': False,
                         'id': self.users[1].partner_id.id,
@@ -720,6 +720,7 @@ class TestDiscussFullPerformance(TransactionCase):
                     'channel': {
                         'channel_type': 'livechat',
                         'id': self.channel_livechat_2.id,
+                        'memberCount': 2,
                     },
                     'create_uid': self.env.ref('base.public_user').id,
                     'custom_channel_name': False,
@@ -733,7 +734,6 @@ class TestDiscussFullPerformance(TransactionCase):
                     'is_pinned': True,
                     'last_interest_dt': self.channel_livechat_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_livechat_2._channel_last_message_ids()),
-                    'memberCount': 2,
                     'livechat_visitor': {
                         'country': (self.env.ref('base.be').id, 'Belgium'),
                         'id': False,


### PR DESCRIPTION
Automatically add readonly on computed and related fields. This commit required to rewrite some preexisting fields to make them readonly.

Task-2955927.
Enterprise: https://github.com/odoo/enterprise/pull/30625