### PR TITLE
[FIX] core: in ir.model.fields, discard deleted fields from registry

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -14,7 +14,7 @@ from psycopg2 import sql
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import pycompat, unique
+from odoo.tools import pycompat, unique, OrderedSet
 from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
 
 _logger = logging.getLogger(__name__)
@@ -826,16 +826,15 @@ class IrModelFields(models.Model):
         self._prepare_update()
 
         # determine registry fields corresponding to self
-        fields = []
+        fields = OrderedSet()
         for record in self:
             try:
-                fields.append(self.pool[record.model]._fields[record.name])
+                fields.add(self.pool[record.model]._fields[record.name])
             except KeyError:
                 pass
 
-        model_names = self.mapped('model')
-        self._drop_column()
-        res = super(IrModelFields, self).unlink()
+        # clean the registry from the fields to remove
+        self.pool.registry_invalidated = True
 
         # discard the removed fields from field triggers
         def discard_fields(tree):
@@ -850,7 +849,18 @@ class IrModelFields(models.Model):
                     discard_fields(subtree)
 
         discard_fields(self.pool.field_triggers)
-        self.pool.registry_invalidated = True
+
+        # discard the removed fields from field inverses
+        for Model in self.pool.values():
+            Model._field_inverses.discard_keys_and_values(fields)
+
+        # discard the removed fields from fields to compute
+        for field in fields:
+            self.env.all.tocompute.pop(field, None)
+
+        model_names = self.mapped('model')
+        self._drop_column()
+        res = super(IrModelFields, self).unlink()
 
         # The field we just deleted might be inherited, and the registry is
         # inconsistent in this case; therefore we reload the registry.

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1011,18 +1011,30 @@ class Collector(Mapping):
         for ``defaultdict(list)``.
     """
     __slots__ = ['_map']
+
     def __init__(self):
         self._map = {}
+
     def add(self, key, val):
         vals = self._map.setdefault(key, [])
         if val not in vals:
             vals.append(val)
+
     def __getitem__(self, key):
         return self._map.get(key, ())
+
     def __iter__(self):
         return iter(self._map)
+
     def __len__(self):
         return len(self._map)
+
+    def discard_keys_and_values(self, excludes):
+        self._map = {
+            key: [val for val in vals if val not in excludes]
+            for key, vals in self._map.items()
+            if key not in excludes
+        }
 
 
 class StackMap(MutableMapping):


### PR DESCRIPTION
This patch discard the fields to delete from data structures like field triggers, field inverses, and fields to compute.

This is quite useful when uninstalling modules.  This commit fixes the uninstallation of modules base_setup, bus, mail, web, web_tour.