### PR TITLE
[FIX] web_editor: specify a custom color in the text input of the col…

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1951,7 +1951,7 @@ export class OdooEditor extends EventTarget {
         if (!sel.anchorNode) {
             show = false;
         }
-        if (this.options.autohideToolbar) {
+        if (this.options.autohideToolbar && !this.toolbar.contains(sel.anchorNode)) {
             if (show !== undefined && !this.isMobile) {
                 this.toolbar.style.visibility = show ? 'visible' : 'hidden';
             }
@@ -2068,7 +2068,7 @@ export class OdooEditor extends EventTarget {
         undoButton && undoButton.classList.toggle('disabled', !this.historyCanUndo());
         const redoButton = this.toolbar.querySelector('#redo');
         redoButton && redoButton.classList.toggle('disabled', !this.historyCanRedo());
-        if (this.options.autohideToolbar && !this.isMobile) {
+        if (this.options.autohideToolbar && !this.isMobile && !this.toolbar.contains(sel.anchorNode)) {
             this._positionToolbar();
         }
     }


### PR DESCRIPTION
**Current behavior before PR:**

It's impossible to specify a custom color in the text input of the color picker
for the selected text.

**Desired behavior after PR is merged:**

It's possible to specify a custom color in the text input of the color picker
for the selected text.

Task-2896109





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
