### PR TITLE
[IMP] base: remove `groups_id` from `ir.ui.view`

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -132,10 +132,9 @@
         <field name="name">account.invoice.report.search_analytic_accounting</field>
         <field name="model">account.invoice.report</field>
         <field name="inherit_id" ref="account.view_account_invoice_report_search"/>
-        <field name="groups_id" eval="[(4, ref('analytic.group_analytic_accounting'))]"/>
         <field name="arch" type="xml">
             <filter name="status" position="after">
-                <filter string="Analytic Account" name="analytic_account_id" context="{'group_by':'analytic_account_id'}"/>
+                <filter string="Analytic Account" name="analytic_account_id" context="{'group_by':'analytic_account_id'}" groups="analytic.group_analytic_accounting"/>
             </filter>
         </field>
     </record>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -142,10 +142,10 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="priority" eval="11"/>
-            <field name="groups_id" eval="[(4, ref('account.group_account_invoice')), (4, ref('account.group_account_readonly'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button type="object" class="oe_stat_button" icon="fa-pencil-square-o" name="action_view_partner_invoices"
+                        groups="account.group_account_invoice,account.group_account_readonly"
                         context="{'default_partner_id': active_id}">
                         <div class="o_form_field o_stat_info">
                             <span class="o_stat_value">
@@ -158,12 +158,14 @@
                 </div>
 
                 <page name="internal_notes" position="inside">
-                    <group colspan="2" col="2" groups="account.group_warning_account">
-                        <separator string="Warning on the Invoice" colspan="4"/>
-                        <field name="invoice_warn" nolabel="1" />
-                        <field name="invoice_warn_msg" colspan="3" nolabel="1"
-                            attrs="{'required':[('invoice_warn','!=', False), ('invoice_warn','!=','no-message')], 'invisible':[('invoice_warn','in',(False,'no-message'))]}"/>
-                    </group>
+                    <t groups="account.group_account_invoice,account.group_account_readonly">
+                        <group colspan="2" col="2" groups="account.group_warning_account">
+                            <separator string="Warning on the Invoice" colspan="4"/>
+                            <field name="invoice_warn" nolabel="1" />
+                            <field name="invoice_warn_msg" colspan="3" nolabel="1"
+                                attrs="{'required':[('invoice_warn','!=', False), ('invoice_warn','!=','no-message')], 'invisible':[('invoice_warn','in',(False,'no-message'))]}"/>
+                        </group>
+                    </t>
                 </page>
             </field>
         </record>
@@ -189,7 +191,6 @@
             <field name="model">res.partner</field>
             <field name="priority">2</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
-            <field name="groups_id" eval="[(5,)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//sheet" position="before">
                     <div groups="account.group_account_invoice,account.group_account_readonly" class="alert alert-warning" role="alert" style="margin-bottom:0px;"

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -17,10 +17,9 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="40"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-            <field name="groups_id" eval="[(4, ref('account.group_account_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <field name="country_code" invisible="1"/>
+                    <field name="country_code" invisible="1" groups="account.group_account_manager"/>
                     <div class="app_settings_block" data-string="Invoicing" string="Invoicing" data-key="account" groups="account.group_account_manager">
                         <field name="has_chart_of_accounts" invisible="1"/>
                         <field name="has_accounting_entries" invisible="1"/>

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="5"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="CRM" string="CRM" data-key="crm" groups="sales_team.group_sale_manager">

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -44,12 +44,6 @@
                             <field string="Opportunities" name="opportunity_count" widget="statinfo"/>
                         </button>
                     </div>
-                    <field name="parent_id" position="before">
-                        <field name="team_id" invisible="1"/>
-                    </field>
-                    <field name="parent_id" position="attributes">
-                        <attribute name="context">{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id, 'default_team_id': team_id}</attribute>
-                    </field>
                 </data>
             </field>
         </record>

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -7,13 +7,13 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
             <field name="priority" eval="10"/>
-            <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
                 <field name="mobile" position="after">
-                    <field name="opportunity_count"/>
+                    <field name="opportunity_count" groups="sales_team.group_sale_salesman"/>
                 </field>
                 <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
                     <a t-if="record.opportunity_count.value>0" href="#"
+                       groups="sales_team.group_sale_salesman"
                        data-type="object" data-name="action_view_opportunity"
                        class="oe_kanban_action oe_kanban_action_a me-1">
                         <span class="badge rounded-pill">

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -32,7 +32,6 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field eval="1" name="priority"/>
-            <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <div name="button_box" position="inside">

--- a/addons/event/views/res_config_settings_views.xml
+++ b/addons/event/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="65"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-            <field name="groups_id" eval="[(4, ref('event.group_event_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
                     <div class="app_settings_block" data-string="Events" string="Events" data-key="event" groups="event.group_event_manager">

--- a/addons/event/views/res_partner_views.xml
+++ b/addons/event/views/res_partner_views.xml
@@ -5,7 +5,6 @@
             <field name="name">view.res.partner.form.event.inherited</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
-            <field name="groups_id" eval="[(5,)]"/>
             <field name="priority" eval="6"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">

--- a/addons/fleet/views/res_config_settings_views.xml
+++ b/addons/fleet/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="90"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-            <field name="groups_id" eval="[(4, ref('fleet.fleet_group_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
                     <div class="app_settings_block" data-string="Fleet" id="fleet" string="Fleet" data-key="fleet" groups="fleet.fleet_group_manager">

--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -5,7 +5,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="70"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('hr.group_hr_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Employees" string="Employees" data-key="hr" groups="hr.group_hr_manager">

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -164,7 +164,7 @@ class HrEmployee(models.Model):
         action_message['hours_today'] = employee.hours_today
 
         if employee.user_id:
-            modified_attendance = employee.with_user(employee.user_id)._attendance_action_change()
+            modified_attendance = employee.with_user(employee.user_id).sudo()._attendance_action_change()
         else:
             modified_attendance = employee._attendance_action_change()
         action_message['attendance'] = modified_attendance.read()[0]

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -72,12 +72,12 @@
         </record>
 
         <record id="hr_attendance_rule_attendance_employee" model="ir.rule">
-            <field name="name">user: read and modify own attendance only</field>
+            <field name="name">user: read own attendance only</field>
             <field name="model_id" ref="model_hr_attendance"/>
             <field name="domain_force">[('employee_id.user_id','=',user.id)]</field>
             <field name="perm_read" eval="1"/>
-            <field name="perm_write" eval="1"/>
-            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_create" eval="0"/>
             <field name="perm_unlink" eval="0"/>
             <field name="groups" eval="[(4,ref('base.group_user'))]"/>
         </record>

--- a/addons/hr_attendance/security/ir.model.access.csv
+++ b/addons/hr_attendance/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_hr_attendance_user,hr.attendance.user,model_hr_attendance,hr_attendance.group_hr_attendance_user,1,1,1,1
-access_hr_attendance_system_user,hr.attendance.system.user,model_hr_attendance,base.group_user,1,1,1,0
+access_hr_attendance_officer,hr.attendance.user,model_hr_attendance,group_hr_attendance_user,1,1,1,1
+access_hr_attendance_user,hr.attendance.system.user,model_hr_attendance,group_hr_attendance,1,1,1,0
+access_hr_attendance_system_user,hr.attendance.system.user,model_hr_attendance,base.group_user,1,0,0,0
 access_hr_attendance_overtime_user,hr.attendance.overtime.user,model_hr_attendance_overtime,hr_attendance.group_hr_attendance_user,1,1,1,1
 access_hr_attendance_overtime_system_user,hr.attendance.overtime.system.user,model_hr_attendance_overtime,base.group_user,1,0,0,0
 access_hr_attendance_report_user,hr.attendance.report.user,model_hr_attendance_report,hr_attendance.group_hr_attendance_user,1,1,1,1

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -7,24 +7,11 @@
         <field name="name">hr.attendance.tree</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <tree string="Employee attendances" edit="0" sample="1">
+            <tree string="Employee attendances" editable="bottom" sample="1">
                 <field name="employee_id"/>
                 <field name="check_in"/>
                 <field name="check_out"/>
                 <field name="worked_hours" string="Work Hours" widget="float_time"/>
-            </tree>
-        </field>
-    </record>
-
-    <record id="view_attendance_tree_inherit" model="ir.ui.view">
-        <field name="name">hr.attendance.tree.inherit</field>
-        <field name="model">hr.attendance</field>
-        <field name="inherit_id" ref="hr_attendance.view_attendance_tree"/>
-        <field name="groups_id" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
-        <field name="arch" type="xml">
-            <tree position="attributes">
-                <attribute name="edit">1</attribute>
-                <attribute name="editable">bottom</attribute>
             </tree>
         </field>
     </record>
@@ -63,7 +50,7 @@
         <field name="name">hr.attendance.form</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <form string="Employee attendances" edit="0">
+            <form string="Employee attendances">
                 <sheet>
                     <group>
                         <field name="employee_id"/>
@@ -71,18 +58,6 @@
                         <field name="check_out"/>
                     </group>
                 </sheet>
-            </form>
-        </field>
-    </record>
-
-    <record id="hr_attendance_view_form_inherit" model="ir.ui.view">
-        <field name="name">hr.attendance.form.inherit</field>
-        <field name="model">hr.attendance</field>
-        <field name="inherit_id" ref="hr_attendance.hr_attendance_view_form"/>
-        <field name="groups_id" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
-        <field name="arch" type="xml">
-            <form position="attributes">
-                <attribute name="edit">1</attribute>
             </form>
         </field>
     </record>

--- a/addons/hr_attendance/views/hr_department_view.xml
+++ b/addons/hr_attendance/views/hr_department_view.xml
@@ -4,11 +4,10 @@
         <field name="name">hr.department.kanban.inherit</field>
         <field name="model">hr.department</field>
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
-        <field name="groups_id" eval="[(4,ref('hr_attendance.group_hr_attendance_user'))]"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
-                    <a role="menuitem" class="dropdown-item" name="%(hr_attendance_report_action_filtered)d" type="action">
+                    <a role="menuitem" class="dropdown-item" name="%(hr_attendance_report_action_filtered)d" type="action" groups="hr_attendance.group_hr_attendance_user">
                         Attendances
                     </a>
                 </xpath>

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -5,13 +5,7 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="priority">110</field>
-        <field name="groups_id" eval="[(4,ref('hr_attendance.group_hr_attendance_user'))]"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='hr_presence_status']" position="attributes">
-                <attribute name="attrs">
-                    {'invisible': ['|', '|', ('user_id', '=', False), ('hr_presence_state', '=', 'absent'), ('attendance_state', '=', 'checked_in')]}
-                </attribute>
-            </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="attendance_state" invisible="1"/>
                 <button name="%(hr_attendance_action)d"
@@ -19,7 +13,7 @@
                         icon="fa-clock-o"
                         type="action"
                         context="{'search_default_employee_id': id, 'search_default_check_in_filter': '1'}"
-                        groups="base.group_user"
+                        groups="hr_attendance.group_hr_attendance_user"
                         help="Worked hours last month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
@@ -35,7 +29,8 @@
                         icon="fa-history"
                         type="action"
                         attrs="{'invisible': [('total_overtime', '=', 0.0)]}"
-                        context="{'search_default_employee_id': active_id}">
+                        context="{'search_default_employee_id': active_id}"
+                        groups="hr_attendance.group_hr_attendance_user">
                     <div class="o_stat_info">
                         <span class="o_stat_value text-success" attrs="{'invisible': [('total_overtime', '&lt;', 0)]}">
                             <field name="total_overtime" widget="float_time"/>

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -5,7 +5,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="80"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('hr_attendance.group_hr_attendance_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Attendances" string="Attendances" data-key="hr_attendance" groups="hr_attendance.group_hr_attendance_manager">

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -137,7 +137,8 @@
             <field name="arch" type="xml">
                 <form string="Current Contract">
                     <header>
-                        <field name="state" widget="statusbar"/>
+                        <field name="state" groups="!hr_contract.group_hr_contract_manager" widget="statusbar"/>
+                        <field name="state" groups="hr_contract.group_hr_contract_manager" widget="statusbar" options="{'clickable': '1'}"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box"/>
@@ -145,7 +146,8 @@
                         <div class="oe_title pe-0" name="title">
                             <h1 class="d-flex flex-row justify-content-between">
                                 <field name="name" class="text-truncate" placeholder="Contract Reference"/>
-                                <field name="kanban_state" widget="state_selection" readonly="1"/>
+                                <field name="kanban_state" groups="!hr_contract.group_hr_contract_manager" widget="state_selection" readonly="1"/>
+                                <field name="kanban_state" groups="hr_contract.group_hr_contract_manager" widget="state_selection" readonly="0"/>
                             </h1>
                             <h2>
                                 <field name="company_id" groups="base.group_multi_company" invisible="1"/>
@@ -161,11 +163,13 @@
                                 <field name="date_end" string="Contract End Date"/>
                                 <field name="company_country_id" invisible="1"/>
                                 <field name="country_code" invisible="1"/>
-                                <field name="structure_type_id" domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="structure_type_id" groups="!hr_contract.group_hr_contract_manager" domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="structure_type_id" groups="hr_contract.group_hr_contract_manager" domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
                                 <field name="calendar_mismatch" invisible="1"/>
                                 <label for="resource_calendar_id"/>
                                 <div id="resource_calendar_warning">
-                                    <field name="resource_calendar_id" required="1" nolabel="1" options="{'no_open': True, 'no_create': True}"/>
+                                    <field name="resource_calendar_id" groups="!hr_contract.group_hr_contract_manager" required="1" nolabel="1" options="{'no_open': True, 'no_create': True}"/>
+                                    <field name="resource_calendar_id" groups="hr_contract.group_hr_contract_manager" required="1" nolabel="1"/>
                                     <span attrs="{'invisible': ['|', ('calendar_mismatch', '=', False), ('state', '!=', 'open')]}"
                                         class="fa fa-exclamation-triangle text-danger o_calendar_warning ms-3"
                                         data-tooltip-template="hr_contract.CalendarMismatch"
@@ -176,9 +180,12 @@
                                 </div>
                             </group>
                             <group name="top_info_right">
-                                <field name="department_id" options="{'no_open': True, 'no_create': True}"/>
-                                <field name="job_id" options="{'no_open': True, 'no_create': True}"/>
-                                <field name="contract_type_id" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="department_id" groups="!hr_contract.group_hr_contract_manager" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="department_id" groups="hr_contract.group_hr_contract_manager"/>
+                                <field name="job_id" groups="!hr_contract.group_hr_contract_manager" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="job_id" groups="hr_contract.group_hr_contract_manager"/>
+                                <field name="contract_type_id" groups="!hr_contract.group_hr_contract_manager" options="{'no_open': True, 'no_create': True}"/>
+                                <field name="contract_type_id" groups="hr_contract.group_hr_contract_manager"/>
                                 <field name="hr_responsible_id" required="1"/>
                             </group>
                         </group>
@@ -209,36 +216,6 @@
                         <field name="message_ids"/>
                     </div>
                 </form>
-            </field>
-        </record>
-
-        <record id="hr_contract_manager_view_form" model="ir.ui.view">
-            <field name="name">hr.contract.manager.view.form</field>
-            <field name="model">hr.contract</field>
-            <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
-            <field name="groups_id" eval="[(4,ref('hr_contract.group_hr_contract_manager'))]"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='structure_type_id']" position="attributes">
-                    <attribute name="options">{}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='resource_calendar_id']" position="attributes">
-                    <attribute name="options">{}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='department_id']" position="attributes">
-                    <attribute name="options">{}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='job_id']" position="attributes">
-                    <attribute name="options">{}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='contract_type_id']" position="attributes">
-                    <attribute name="options">{}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='state']" position="attributes">
-                    <attribute name="options">{'clickable': '1'}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='kanban_state']" position="attributes">
-                    <attribute name="readonly">0</attribute>
-                </xpath>
             </field>
         </record>
 

--- a/addons/hr_expense/views/hr_department_views.xml
+++ b/addons/hr_expense/views/hr_department_views.xml
@@ -4,15 +4,14 @@
         <field name="name">hr.department.kanban.inherit</field>
         <field name="model">hr.department</field>
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
-        <field name="groups_id" eval="[(4,ref('hr_expense.group_hr_expense_team_approver'))]"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//templates" position="before">
-                    <field name="expense_sheets_to_approve_count"/>
+                    <field name="expense_sheets_to_approve_count" groups="hr_expense.group_hr_expense_team_approver"/>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
-                    <div t-if="record.expense_sheets_to_approve_count.raw_value > 0" class="row ml16">
+                    <div t-if="record.expense_sheets_to_approve_count.raw_value > 0" class="row ml16" groups="hr_expense.group_hr_expense_team_approver">
                         <div class="col">
                             <a name="%(action_hr_expense_sheet_department_to_approve)d" type="action">
                                 <t t-esc="record.expense_sheets_to_approve_count.raw_value"/> Expense Reports
@@ -22,7 +21,7 @@
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
-                    <a role="menuitem" class="dropdown-item" name="%(action_hr_expense_sheet_department_filtered)d" type="action">
+                    <a role="menuitem" class="dropdown-item" name="%(action_hr_expense_sheet_department_filtered)d" type="action" groups="hr_expense.group_hr_expense_team_approver">
                         Expenses
                     </a>
                 </xpath>

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="85"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-            <field name="groups_id" eval="[(4, ref('hr_expense.group_hr_expense_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
                     <div class="app_settings_block" data-string="Expenses" string="Expenses" data-key="hr_expense" groups="hr_expense.group_hr_expense_manager">

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -18,46 +18,51 @@
         <field name="name">hr.department.kanban.inherit</field>
         <field name="model">hr.department</field>
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
-        <field name="groups_id" eval="[(4,ref('hr_holidays.group_hr_holidays_user'))]"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//templates" position="before">
-                    <field name="leave_to_approve_count"/>
-                    <field name="allocation_to_approve_count"/>
-                    <field name="total_employee"/>
-                    <field name="absence_of_today"/>
+                    <t groups="hr_holidays.group_hr_holidays_user">
+                        <field name="leave_to_approve_count"/>
+                        <field name="allocation_to_approve_count"/>
+                        <field name="total_employee"/>
+                        <field name="absence_of_today"/>
+                    </t>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
-                    <div t-if="record.leave_to_approve_count.raw_value > 0" class="row ml16">
-                        <div class="col">
-                            <a name="%(hr_leave_action_action_approve_department)d" type="action">
-                                <field name="leave_to_approve_count"/> Time Off Requests
-                            </a>
+                    <t groups="hr_holidays.group_hr_holidays_user">
+                        <div t-if="record.leave_to_approve_count.raw_value > 0" class="row ml16">
+                            <div class="col">
+                                <a name="%(hr_leave_action_action_approve_department)d" type="action">
+                                    <field name="leave_to_approve_count"/> Time Off Requests
+                                </a>
+                            </div>
                         </div>
-                    </div>
-                    <div t-if="record.allocation_to_approve_count.raw_value > 0" class="row ml16">
-                        <div class="col">
-                            <a name="%(hr_leave_allocation_action_approve_department)d" type="action">
-                                <field name="allocation_to_approve_count"/> Allocation Requests
-                            </a>
+                        <div t-if="record.allocation_to_approve_count.raw_value > 0" class="row ml16">
+                            <div class="col">
+                                <a name="%(hr_leave_allocation_action_approve_department)d" type="action">
+                                    <field name="allocation_to_approve_count"/> Allocation Requests
+                                </a>
+                            </div>
                         </div>
-                    </div>
+                    </t>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_card_upper_content')]" position="after">
-                    <div class="row o_kanban_primary_bottom bottom_block">
-                        <div class="col-3">
-                            <a name="%(hr_employee_action_from_department)d" type="action" title="Absent Employee(s), Whose time off requests are either confirmed or validated on today">Absence</a>
+                    <t groups="hr_holidays.group_hr_holidays_user">
+                        <div class="row o_kanban_primary_bottom bottom_block">
+                            <div class="col-3">
+                                <a name="%(hr_employee_action_from_department)d" type="action" title="Absent Employee(s), Whose time off requests are either confirmed or validated on today">Absence</a>
+                            </div>
+                            <div class="col-9">
+                                <field name="absence_of_today" widget="progressbar" options="{'current_value': 'absence_of_today', 'max_value': 'total_employee', 'editable': false}"/>
+                            </div>
                         </div>
-                        <div class="col-9">
-                            <field name="absence_of_today" widget="progressbar" options="{'current_value': 'absence_of_today', 'max_value': 'total_employee', 'editable': false}"/>
-                        </div>
-                    </div>
+                    </t>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
-                    <a role="menuitem" class="dropdown-item" name="%(hr_leave_action_action_department)d" type="action">
+                    <a role="menuitem" class="dropdown-item" name="%(hr_leave_action_action_department)d" type="action" groups="hr_holidays.group_hr_holidays_user">
                         Time Off
                     </a>
                 </xpath>

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -4,10 +4,9 @@
         <field name="name">hr.employee.view.search</field>
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_filter"/>
-        <field name="groups_id" eval="[(4, ref('hr.group_hr_manager'))]"/>
         <field name="arch" type="xml">
             <filter name="group_manager" position="after">
-                <filter name="group_hr_presence_state" string="Presence" domain="[]" context="{'group_by':'hr_presence_state_display'}"/>
+                <filter name="group_hr_presence_state" string="Presence" domain="[]" context="{'group_by':'hr_presence_state_display'}" groups="hr.group_hr_manager"/>
             </filter>
         </field>
     </record>

--- a/addons/hr_recruitment/views/hr_department_views.xml
+++ b/addons/hr_recruitment/views/hr_department_views.xml
@@ -4,27 +4,31 @@
         <field name="name">hr.department.kanban.inherit</field>
         <field name="model">hr.department</field>
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
-        <field name="groups_id" eval="[(4,ref('hr_recruitment.group_hr_recruitment_user'))]"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//templates" position="before">
-                    <field name="new_applicant_count"/>
-                    <field name="new_hired_employee"/>
-                    <field name="expected_employee"/>
+                    <t groups="hr_recruitment.group_hr_recruitment_user">
+                        <field name="new_applicant_count"/>
+                        <field name="new_hired_employee"/>
+                        <field name="expected_employee"/>
+                    </t>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
-                    <div t-if="record.new_applicant_count.raw_value > 0" class="row ml16">
-                        <div class="col">
-                            <a name="%(hr_applicant_action_from_department)d" type="action">
-                                <field name="new_applicant_count"/> New Applicants
-                            </a>
+                    <t t-groups="hr_recruitment.group_hr_recruitment_user">
+                        <div t-if="record.new_applicant_count.raw_value > 0" class="row ml16">
+                            <div class="col">
+                                <a name="%(hr_applicant_action_from_department)d" type="action">
+                                    <field name="new_applicant_count"/> New Applicants
+                                </a>
+                            </div>
                         </div>
-                    </div>
+                    </t>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
-                    <a role="menuitem" class="dropdown-item" name="%(action_hr_recruitment_report_filtered_department)d" type="action">
+                    <a role="menuitem" class="dropdown-item" name="%(action_hr_recruitment_report_filtered_department)d"
+                        type="action" groups="hr_recruitment.group_hr_recruitment_user">
                         Recruitments
                     </a>
                 </xpath>

--- a/addons/hr_recruitment/views/res_config_settings_views.xml
+++ b/addons/hr_recruitment/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="75"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-            <field name="groups_id" eval="[(4, ref('hr_recruitment.group_hr_recruitment_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
                     <div class="app_settings_block" data-string="Recruitment" string="Recruitment" data-key="hr_recruitment" groups="hr_recruitment.group_hr_recruitment_manager">

--- a/addons/hr_timesheet/views/hr_views.xml
+++ b/addons/hr_timesheet/views/hr_views.xml
@@ -57,11 +57,12 @@
         <field name="name">hr.department.kanban.inherit</field>
         <field name="model">hr.department</field>
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
-        <field name="groups_id" eval="[(4,ref('hr_timesheet.group_timesheet_manager'))]"/>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
-                    <a name="%(act_hr_timesheet_report)d" type="action" context="{ 'search_default_department_id': [active_id], 'default_department_id': active_id}">
+                    <a name="%(act_hr_timesheet_report)d" type="action"
+                        groups="hr_timesheet.group_timesheet_manager"
+                        context="{ 'search_default_department_id': [active_id], 'default_department_id': active_id}">
                         Timesheets
                     </a>
                 </xpath>

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -109,23 +109,24 @@
             <field name="name">project.task.form.inherited</field>
             <field name="model">project.task</field>
             <field name="inherit_id" ref="project.view_task_form2" />
-            <field name="groups_id" eval="[(6,0, (ref('hr_timesheet.group_hr_timesheet_user'),))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='child_ids']/tree/field[@name='company_id']" position="after">
-                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
-                    <field name="subtask_effective_hours" string="Sub-tasks Hours Spent" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide"/>
-                    <field name="total_hours_spent" string="Total Hours" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100"/>
-                    <field name="progress" widget="progressbar" optional="hide"/>
+                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" string="Sub-tasks Hours Spent" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" string="Total Hours" widget="timesheet_uom" sum="Total Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" widget="progressbar" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
                 <xpath expr="//notebook/page[@name='description_page']" position="after">
-                    <field name="analytic_account_active" invisible="1"/>
                     <field name="allow_timesheets" invisible="1"/>
                     <field name="allow_subtasks" invisible="1"/>
-                    <field name="encode_uom_in_days" invisible="1"/>
-                    <field name="subtask_count" invisible="1"/>
-                    <page string="Timesheets" id="timesheets_tab" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
+                    <t groups="hr_timesheet.group_hr_timesheet_user">
+                        <field name="analytic_account_active" invisible="1"/>
+                        <field name="encode_uom_in_days" invisible="1"/>
+                        <field name="subtask_count" invisible="1"/>
+                    </t>
+                    <page string="Timesheets" id="timesheets_tab" attrs="{'invisible': [('allow_timesheets', '=', False)]}" groups="hr_timesheet.group_hr_timesheet_user">
                         <group>
                             <group>
                                 <div class="o_td_label">
@@ -242,13 +243,13 @@
                 </page>
                 </xpath>
                 <xpath expr="//field[@name='depend_on_ids']/tree//field[@name='company_id']" position="after">
-                    <field name="allow_subtasks" invisible="1" />
-                    <field name="progress" invisible="1"/>
-                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" attrs="{'invisible' : [('allow_subtasks', '=', False)]}" optional="hide"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" attrs="{'invisible' : [('allow_subtasks', '=', False)]}" optional="hide"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100"/>
+                    <field name="allow_subtasks" invisible="1" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" invisible="1" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" attrs="{'invisible' : [('allow_subtasks', '=', False)]}" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" attrs="{'invisible' : [('allow_subtasks', '=', False)]}" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="progress" widget="progressbar" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
             </field>

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -5,7 +5,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="55"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('hr_timesheet.group_timesheet_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Timesheets" string="Timesheets" data-key="hr_timesheet" groups="hr_timesheet.group_timesheet_manager" id="timesheets">

--- a/addons/lunch/views/res_config_settings.xml
+++ b/addons/lunch/views/res_config_settings.xml
@@ -5,7 +5,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="90"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('lunch.group_lunch_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Lunch" string="Lunch" data-key="lunch" groups="lunch.group_lunch_manager">

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -5,7 +5,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="60"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-            <field name="groups_id" eval="[(4, ref('mass_mailing.group_mass_mailing_user'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
                     <div class="app_settings_block" data-string="Email Marketing" string="Email Marketing" data-key="mass_mailing" groups="mass_mailing.group_mass_mailing_user">

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -92,18 +92,20 @@
             <field name="name">product.template.procurement</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="stock.product_template_form_view_procurement_button"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_open_product_lot']" position="after">
                     <button class="oe_stat_button" name="%(template_open_bom)d" type="action"
+                        groups="mrp.group_mrp_user"
                         attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}" icon="fa-flask">
                         <field string="Bill of Materials" name="bom_count" widget="statinfo" />
                     </button>
                     <button class="oe_stat_button" name="action_used_in_bom" type="object"
+                        groups="mrp.group_mrp_user"
                         attrs="{'invisible':['|',('type', 'not in', ['product', 'consu']), ('used_in_bom_count', '=', 0)]}" icon="fa-level-up">
                         <field string="Used In" name="used_in_bom_count" widget="statinfo" />
                     </button>
                     <button class="oe_stat_button" name="action_view_mos" type="object"
+                        groups="mrp.group_mrp_user"
                         attrs="{'invisible': ['|', '|', ('type', 'not in', ['product', 'consu']), ('bom_count', '=', 0), ('mrp_product_qty', '=', 0)]}" icon="fa-list-alt" help="Manufactured in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">
@@ -121,18 +123,20 @@
             <field name="name">product.product.procurement</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="stock.product_form_view_procurement_button"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_open_product_lot']" position="after">
                     <button class="oe_stat_button" name="action_view_bom" type="object"
+                        groups="mrp.group_mrp_user"
                         attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}" icon="fa-flask">
                         <field string="Bill of Materials" name="bom_count" widget="statinfo" />
                     </button>
                     <button class="oe_stat_button" name="action_used_in_bom" type="object"
+                        groups="mrp.group_mrp_user"
                         attrs="{'invisible':['|',('type', 'not in', ['product', 'consu']), ('used_in_bom_count', '=', 0)]}" icon="fa-level-up">
                         <field string="Used In" name="used_in_bom_count" widget="statinfo" />
                     </button>
                     <button class="oe_stat_button" name="action_view_mos" type="object"
+                        groups="mrp.group_mrp_user"
                         attrs="{'invisible': ['|', '|', ('type', 'not in', ['product', 'consu']), ('bom_count', '=', 0), ('mrp_product_qty', '=', 0)]}" icon="fa-list-alt" help="Manufactured in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="35"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside">
                     <div class="app_settings_block" data-string="Manufacturing" string="Manufacturing" data-key="mrp" groups="mrp.group_mrp_manager">

--- a/addons/mrp_account/views/analytic_account_views.xml
+++ b/addons/mrp_account/views/analytic_account_views.xml
@@ -5,14 +5,15 @@
         <field name="model">account.analytic.account</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
         <field eval="14" name="priority"/>
-        <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button class="oe_stat_button" type="object" name="action_view_mrp_production"
+                    groups="mrp.group_mrp_user"
                     icon="fa-wrench" attrs="{'invisible': [('production_count', '=', 0)]}">
                     <field string="Manufacturing Orders" name="production_count" widget="statinfo"/>
                 </button>
                 <button class="oe_stat_button" type="object" name="action_view_mrp_bom"
+                    groups="mrp.group_mrp_user"
                     icon="fa-flask" attrs="{'invisible': [('bom_count', '=', 0)]}">
                     <field string="Bills of Materials" name="bom_count" widget="statinfo"/>
                 </button>

--- a/addons/mrp_account/views/mrp_production_views.xml
+++ b/addons/mrp_account/views/mrp_production_views.xml
@@ -14,24 +14,27 @@
         <field name="name">mrp.production.view.inherited</field>
         <field name="model">mrp.production</field>
         <field name="inherit_id" ref="mrp.mrp_production_form_view" />
-        <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="before">
-                <field name="show_valuation" invisible="1"/>
+                <field name="show_valuation" invisible="1" groups="stock.group_stock_manager"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button string="Valuation" type="object"
-                    name="action_view_stock_valuation_layers"
-                    class="oe_stat_button" icon="fa-dollar" groups="base.group_no_one"
-                    attrs="{'invisible': [('show_valuation', '=', False)]}" />
-                <button class="oe_stat_button" type="object"
-                    name="action_view_analytic_account"
-                    string="Analytic Account" icon="fa-bar-chart-o"
-                    attrs="{'invisible': ['|', ('analytic_account_id', '=', False), ('state', 'in', ['draft', 'cancel'])]}"
-                    groups="analytic.group_analytic_accounting"/>
+                <t groups="stock.group_stock_manager">
+                    <button string="Valuation" type="object"
+                        name="action_view_stock_valuation_layers"
+                        class="oe_stat_button" icon="fa-dollar" groups="base.group_no_one"
+                        attrs="{'invisible': [('show_valuation', '=', False)]}" />
+                    <button class="oe_stat_button" type="object"
+                        name="action_view_analytic_account"
+                        string="Analytic Account" icon="fa-bar-chart-o"
+                        attrs="{'invisible': ['|', ('analytic_account_id', '=', False), ('state', 'in', ['draft', 'cancel'])]}"
+                        groups="analytic.group_analytic_accounting"/>
+                </t>
             </xpath>
             <xpath expr="//page[@name='miscellaneous']//field[@name='date_deadline']" position="after">
-                <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+                <t groups="stock.group_stock_manager">
+                    <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+                </t>
             </xpath>
         </field>
     </record>

--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -47,22 +47,23 @@
             <field name="name">product.product.product.view.form.easy.bom.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                 <xpath expr="//field[@name='standard_price']" position="replace">
-                    <field name="bom_count" invisible="1"/>
-                    <field name="cost_method" invisible="1"/>
-                    <field name="valuation" invisible="1"/>
                     <label for="standard_price"/>
                     <div>
                         <field name="standard_price" widget='monetary' options="{'currency_field': 'cost_currency_id'}"/>
-                        <button name="button_bom_cost"
-                            string="Compute Price from BoM"
-                            type="object"
-                            attrs="{'invisible': ['|', ('bom_count', '=', 0), '&amp;', ('valuation', '=', 'real_time'), ('cost_method', '=', 'fifo')]}"
-                            help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
-                            class="oe_link oe_read_only pt-0"/>
+                        <t groups="mrp.group_mrp_manager">
+                            <field name="bom_count" invisible="1"/>
+                            <field name="cost_method" invisible="1"/>
+                            <field name="valuation" invisible="1"/>
+                            <button name="button_bom_cost"
+                                string="Compute Price from BoM"
+                                type="object"
+                                attrs="{'invisible': ['|', ('bom_count', '=', 0), '&amp;', ('valuation', '=', 'real_time'), ('cost_method', '=', 'fifo')]}"
+                                help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
+                                class="oe_link oe_read_only pt-0"/>
+                        </t>
                     </div>
                 </xpath>
                 </data>

--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -5,16 +5,18 @@
             <field name="model">product.template</field>
             <field name="priority">3</field>
             <field name="inherit_id" ref="product.product_template_only_form_view" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='standard_price_uom']" position="inside">
-                    <field name="cost_method" invisible="1"/>
-                    <field name="valuation" invisible="1"/>
-                    <button name="button_bom_cost"
-                        string="Compute Price from BoM" type="object"
-                        attrs="{'invisible': ['|', ('bom_count', '=', 0), '&amp;', ('valuation', '=', 'real_time'), ('cost_method', '=', 'fifo')]}"
-                        help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
-                        class="oe_link oe_read_only pt-0"/>
+                    <t groups="mrp.group_mrp_manager">
+                        <field name="bom_count" invisible="1"/>
+                        <field name="cost_method" invisible="1"/>
+                        <field name="valuation" invisible="1"/>
+                        <button name="button_bom_cost"
+                            string="Compute Price from BoM" type="object"
+                            attrs="{'invisible': ['|', ('bom_count', '=', 0), '&amp;', ('valuation', '=', 'real_time'), ('cost_method', '=', 'fifo')]}"
+                            help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
+                            class="oe_link oe_read_only pt-0"/>
+                        </t>
                 </xpath>
             </field>
         </record>
@@ -24,17 +26,19 @@
             <field name="model">product.product</field>
             <field name="priority">4</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='standard_price_uom']" position="inside">
-                    <field name="cost_method" invisible="1"/>
-                    <field name="valuation" invisible="1"/>
-                    <button name="button_bom_cost"
-                        string="Compute Price from BoM" type="object"
-                        attrs="{'invisible': ['|', ('bom_count', '=', 0), '&amp;', ('valuation', '=', 'real_time'), ('cost_method', '=', 'fifo')]}"
-                        help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
-                        class="oe_link oe_read_only pt-0"
-                        colspan="2"/>
+                    <t groups="mrp.group_mrp_manager">
+                        <field name="bom_count" invisible="1"/>
+                        <field name="cost_method" invisible="1"/>
+                        <field name="valuation" invisible="1"/>
+                        <button name="button_bom_cost"
+                            string="Compute Price from BoM" type="object"
+                            attrs="{'invisible': ['|', ('bom_count', '=', 0), '&amp;', ('valuation', '=', 'real_time'), ('cost_method', '=', 'fifo')]}"
+                            help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
+                            class="oe_link oe_read_only pt-0"
+                            colspan="2"/>
+                    </t>
                 </xpath>
             </field>
         </record>

--- a/addons/mrp_subcontracting/views/product_views.xml
+++ b/addons/mrp_subcontracting/views/product_views.xml
@@ -5,10 +5,9 @@
             <field name="name">mrp.subcontracting.product.template.search</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_search_view" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='filter_to_purchase']" position="after">
-                    <filter string="Can be Subcontracted" name="filter_can_be_subcontracted" domain="[('bom_ids.type', '=', 'subcontract')]" />
+                    <filter string="Can be Subcontracted" name="filter_can_be_subcontracted" domain="[('bom_ids.type', '=', 'subcontract')]" groups="mrp.group_mrp_user"/>
                 </xpath>
             </field>
         </record>

--- a/addons/mrp_subcontracting/views/res_partner_views.xml
+++ b/addons/mrp_subcontracting/views/res_partner_views.xml
@@ -15,11 +15,10 @@
         <field name="name">res.partner.select.inherit</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_res_partner_filter" />
-        <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='inactive']" position="before">
-                <filter string="Subcontractors" name="type_subcontractors" domain="[('is_subcontractor', '=', True)]" />
-                <separator/>
+                <filter string="Subcontractors" name="type_subcontractors" domain="[('is_subcontractor', '=', True)]" groups="mrp.group_mrp_user"/>
+                <separator groups="mrp.group_mrp_user"/>
             </xpath>
         </field>
     </record>

--- a/addons/mrp_subcontracting/views/stock_quant_views.xml
+++ b/addons/mrp_subcontracting/views/stock_quant_views.xml
@@ -5,10 +5,9 @@
             <field name="name">stock.quant.subcontracting.search</field>
             <field name="model">stock.quant</field>
             <field name="inherit_id" ref="stock.quant_search_view" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='transit_loc']" position="after">
-                    <filter string="Subcontracting Locations" name="is_subcontract" domain="[('is_subcontract', '=', True)]" />
+                    <filter string="Subcontracting Locations" name="is_subcontract" domain="[('is_subcontract', '=', True)]" groups="mrp.group_mrp_user"/>
                 </xpath>
             </field>
         </record>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -5,17 +5,18 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="95"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form" />
-        <field name="groups_id" eval="[(4, ref('point_of_sale.group_pos_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
-                <field name="pos_selectable_categ_ids" invisible="1"/>
-                <field name="pos_has_active_session" invisible="1"/>
-                <field name="pos_allowed_pricelist_ids" invisible="1"/>
-                <field name="pos_cash_control" invisible="1"/>
-                <field name="pos_iface_print_via_proxy" invisible="1"/>
-                <field name="pos_company_has_template" invisible="1"/>
-                <field name="is_default_pricelist_displayed" invisible="1"/>
-                <field name="group_cash_rounding" invisible="1"/>
+                <t groups="point_of_sale.group_pos_manager">
+                    <field name="pos_selectable_categ_ids" invisible="1"/>
+                    <field name="pos_has_active_session" invisible="1"/>
+                    <field name="pos_allowed_pricelist_ids" invisible="1"/>
+                    <field name="pos_cash_control" invisible="1"/>
+                    <field name="pos_iface_print_via_proxy" invisible="1"/>
+                    <field name="pos_company_has_template" invisible="1"/>
+                    <field name="is_default_pricelist_displayed" invisible="1"/>
+                    <field name="group_cash_rounding" invisible="1"/>
+                </t>
 
                 <div class="app_settings_block" data-string="Point of sale" string="Point of Sale" data-key="point_of_sale" groups="point_of_sale.group_pos_manager">
                     <div class="app_settings_header pt-1 pb-1" style="background-color: #FEF0D0;">

--- a/addons/point_of_sale/views/res_partner_view.xml
+++ b/addons/point_of_sale/views/res_partner_view.xml
@@ -5,10 +5,10 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="priority" eval="4"/>
-            <field name="groups_id" eval="[(4, ref('group_pos_user'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="object" name="action_view_pos_order"
+                        groups="point_of_sale.group_pos_user"
                         context="{'default_partner_id': active_id}"
                         attrs="{'invisible': [('pos_order_count', '=', 0)]}"
                         icon="fa-shopping-bag">
@@ -16,7 +16,7 @@
                     </button>
                 </div>
                 <xpath expr="//group[@name='purchase']" position="after">
-                    <group string="Point Of Sale" name="point_of_sale">
+                    <group string="Point Of Sale" name="point_of_sale" groups="point_of_sale.group_pos_user">
                         <field name="barcode"/>
                     </group>
                 </xpath>
@@ -27,13 +27,13 @@
             <field name="name">res.partner.pos.kanban.inherit</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
-            <field name="groups_id" eval="[(4, ref('group_pos_user'))]"/>
             <field name="arch" type="xml">
                 <field name="state_id" position="before">
-                    <field name="pos_order_count"/>
+                    <field name="pos_order_count" groups="point_of_sale.group_pos_user"/>
                 </field>
                 <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
                     <a t-if="record.pos_order_count.value>0" data-type="object" data-name="action_view_pos_order"
+                       groups="point_of_sale.group_pos_user"
                        href="#" class="oe_kanban_action oe_kanban_action_a me-1">
                         <span class="badge rounded-pill">
                             <i class="fa fa-fw fa-shopping-bag" role="img" aria-label="Shopping cart" title="Shopping cart"/>

--- a/addons/pos_sale/views/sales_team_views.xml
+++ b/addons/pos_sale/views/sales_team_views.xml
@@ -34,11 +34,10 @@
         <field name="name">crm.team.view.kanban.dashboard.inherit.pos</field>
         <field name="model">crm.team</field>
         <field name="inherit_id" ref="sales_team.crm_team_view_kanban_dashboard"/>
-        <field name="groups_id" eval="[(4, ref('point_of_sale.group_pos_user'))]"/>
         <field name="arch" type="xml">
         <data>
             <xpath expr="//t[@name='first_options']" position="before">
-                <div class="row" t-if="record.pos_sessions_open_count.raw_value">
+                <div class="row" t-if="record.pos_sessions_open_count.raw_value" groups="point_of_sale.group_pos_user">
                     <div class="col-8">
                         <a name="%(pos_session_action_from_crm_team)d" type="action">
                             <field name="pos_sessions_open_count"/>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -73,7 +73,7 @@
                     <notebook>
                         <page name="pricelist_rules" string="Price Rules">
                             <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}">
-                                <tree string="Pricelist Rules" editable="bottom">
+                                <tree groups="!product.group_sale_pricelist" string="Pricelist Rules" editable="bottom">
                                     <field name="product_tmpl_id" string="Products" required="1"/>
                                     <field name="product_id" string="Variants"
                                     groups="product.group_product_variant"
@@ -90,6 +90,21 @@
                                     <field name="applied_on" invisible="1"/>
                                     <field name="company_id" invisible="1"/>
                                 </tree>
+                                <!-- When in advanced pricelist mode : pricelist rules
+                                    Should open in a form view and not be editable inline anymore.
+                                -->
+                                <tree groups="product.group_sale_pricelist" string="Pricelist Rules">
+                                    <field name="product_tmpl_id" invisible="1"/>
+                                    <field name="name" string="Applicable On"/>
+                                    <field name="min_quantity"/>
+                                    <field name="price" string="Price"/>
+                                    <field name="date_start"/>
+                                    <field name="date_end"/>
+                                    <field name="base" invisible="1"/>
+                                    <field name="price_discount" invisible="1"/>
+                                    <field name="applied_on" invisible="1"/>
+                                    <field name="compute_price" invisible="1"/>
+                                </tree>
                             </field>
                         </page>
                         <page name="pricelist_config" string="Configuration">
@@ -105,34 +120,6 @@
                     </notebook>
                 </sheet>
             </form>
-        </field>
-    </record>
-
-    <record id="product_pricelist_view_inherit" model="ir.ui.view">
-        <field name="name">product.pricelist.form.inherit</field>
-        <field name="model">product.pricelist</field>
-        <field name="inherit_id" ref="product.product_pricelist_view"/>
-        <field name="groups_id" eval="[(4, ref('product.group_sale_pricelist'))]"/>
-        <field name="arch" type="xml">
-            <!-- When in advanced pricelist mode : pricelist rules
-                Should open in a form view and not be editable inline anymore.
-            -->
-            <field name="item_ids" position="replace">
-                <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}" groups="product.group_product_pricelist">
-                    <tree string="Pricelist Rules">
-                        <field name="product_tmpl_id" invisible="1"/>
-                        <field name="name" string="Applicable On"/>
-                        <field name="min_quantity"/>
-                        <field name="price" string="Price"/>
-                        <field name="date_start"/>
-                        <field name="date_end"/>
-                        <field name="base" invisible="1"/>
-                        <field name="price_discount" invisible="1"/>
-                        <field name="applied_on" invisible="1"/>
-                        <field name="compute_price" invisible="1"/>
-                    </tree>
-                </field>
-            </field>
         </field>
     </record>
 

--- a/addons/product/views/res_partner_views.xml
+++ b/addons/product/views/res_partner_views.xml
@@ -4,7 +4,6 @@
             <field name="name">res.partner.product.property.form.inherit</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
-            <field name="groups_id" eval="[(4, ref('product.group_product_pricelist'))]"/>
             <field name="arch" type="xml">
                 <group name="sale">
                     <field name="property_product_pricelist" groups="product.group_product_pricelist" attrs="{'invisible': [('is_company','=',False),('parent_id','!=',False)]}"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -529,7 +529,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="user_id" string="Project Manager" widget="many2one_avatar_user" attrs="{'readonly':[('active','=',False)]}" domain="[('share', '=', False)]"/>
-                            <label for="date_start" string="Dates"/>
+                            <label for="date_start" string="Planned Date"/>
                             <div name="dates" class="o_row">
                                 <field name="date_start" widget="daterange" options='{"related_end_date": "date"}'/>
                                 <i class="fa fa-long-arrow-right mx-2 oe_edit_only" aria-label="Arrow icon" title="Arrow"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -962,25 +962,13 @@
             </field>
         </record>
 
-        <record id="view_project_kanban_inherit" model="ir.ui.view">
-            <field name="name">project.kanban.inherit.project</field>
-            <field name="model">project.project</field>
-            <field name="groups_id" eval="[Command.link(ref('project.group_project_stages'))]"/>
-            <field name="inherit_id" ref="view_project_kanban"/>
-            <field name="arch" type="xml">
-                <xpath expr="//kanban" position="attributes">
-                    <attribute name="default_group_by">stage_id</attribute>
-                </xpath>
-            </field>
-        </record>
-
         <!-- Please update both act_window when modifying one (open_view_project_all or open_view_project_all_group_stage) as one or the other is used in the menu menu_project -->
         <record id="open_view_project_all" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
             <field name="domain">[]</field>
             <field name="view_mode">kanban,tree,form</field>
-            <field name="view_id" ref="view_project_kanban_inherit"/>
+            <field name="view_id" ref="view_project_kanban"/>
             <field name="search_view_id" ref="view_project_project_filter"/>
             <field name="target">main</field>
             <field name="help" type="html">
@@ -997,9 +985,10 @@
         <record id="open_view_project_all_group_stage" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
+            <field name="context">{'search_default_groupby_stage': 1}</field>
             <field name="domain">[]</field>
             <field name="view_mode">kanban,tree,form,calendar,activity</field>
-            <field name="view_id" ref="view_project_kanban_inherit"/>
+            <field name="view_id" ref="view_project_kanban"/>
             <field name="search_view_id" ref="view_project_project_filter"/>
             <field name="target">main</field>
             <field name="help" type="html">

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -5,7 +5,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="50"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form" />
-            <field name="groups_id" eval="[(4, ref('project.group_project_manager'), 0)]"/>
             <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Project" string="Project" data-key="project" groups="project.group_project_manager">

--- a/addons/project/views/res_partner_views.xml
+++ b/addons/project/views/res_partner_views.xml
@@ -7,10 +7,10 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="priority" eval="7"/>
-            <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="action" name="%(project_task_action_from_partner)d"
+                        groups="project.group_project_user"
                         context="{'search_default_partner_id': active_id, 'default_partner_id': active_id}" attrs="{'invisible': [('task_count', '=', 0)]}"
                         icon="fa-tasks">
                         <field  string="Tasks" name="task_count" widget="statinfo"/>

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -4,39 +4,41 @@
         <field name="name">account.move.inherit.purchase</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
         <field name="arch" type="xml">
             <!-- Auto-complete could be done from either a bill either a purchase order -->
             <field name="invoice_vendor_bill_id" position="after">
-                <field name="purchase_id" invisible="1"/>
-                <label for="purchase_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
-                       attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}" />
-                <field name="purchase_vendor_bill_id" nolabel="1"
-                       attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
-                       class="oe_edit_only"
-                       domain="partner_id and [('company_id', '=', company_id), ('partner_id.commercial_partner_id', '=', commercial_partner_id)] or [('company_id', '=', company_id)]"
-                       placeholder="Select a purchase order or an old bill"
-                       context="{'show_total_amount': True}"
-                       options="{'no_create': True, 'no_open': True}"/>
+                <t groups="purchase.group_purchase_user">
+                    <field name="purchase_id" invisible="1"/>
+                    <label for="purchase_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
+                        attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}" />
+                    <field name="purchase_vendor_bill_id" nolabel="1"
+                        attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
+                        class="oe_edit_only"
+                        domain="partner_id and [('company_id', '=', company_id), ('partner_id.commercial_partner_id', '=', commercial_partner_id)] or [('company_id', '=', company_id)]"
+                        placeholder="Select a purchase order or an old bill"
+                        context="{'show_total_amount': True}"
+                        options="{'no_create': True, 'no_open': True}"/>
+                </t>
             </field>
             <label name="invoice_vendor_bill_id_label" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="groups">!purchase.group_purchase_user</attribute>
             </label>
             <field name="invoice_vendor_bill_id" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="groups">!purchase.group_purchase_user</attribute>
             </field>
             <!-- Add link to purchase_line_id to account.move.line -->
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='company_id']" position="after">
-                <field name="purchase_line_id" invisible="1"/>
-                <field name="purchase_order_id" attrs="{'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional="hide"/>
+                <field name="purchase_line_id" groups="purchase.group_purchase_user" invisible="1"/>
+                <field name="purchase_order_id" groups="purchase.group_purchase_user" attrs="{'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional="hide"/>
             </xpath>
             <xpath expr="//field[@name='line_ids']/tree/field[@name='company_id']" position="after">
-                <field name="purchase_line_id" invisible="1"/>
+                <field name="purchase_line_id" groups="purchase.group_purchase_user" invisible="1"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button"
                         name="action_view_source_purchase_orders"
                         type="object"
+                        groups="purchase.group_purchase_user"
                         icon="fa-pencil-square-o"
                         attrs="{'invisible': ['|', ('purchase_order_count', '=', 0), ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}">
                     <field string="Purchases" name="purchase_order_count" widget="statinfo"/>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -98,10 +98,10 @@
             <field name="name">product.template.purchase.button.inherit</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
-            <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
+                        groups="purchase.group_purchase_user"
                         type="object" icon="fa-credit-card" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">
@@ -130,10 +130,10 @@
             <field name="name">product.product.purchase.order</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
-            <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
+                        groups="purchase.group_purchase_user"
                         type="object" icon="fa-credit-card" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">

--- a/addons/purchase/views/res_config_settings_views.xml
+++ b/addons/purchase/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="25"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('purchase.group_purchase_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Purchase" string="Purchase" data-key="purchase" groups="purchase.group_purchase_manager">

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -47,14 +47,14 @@
             <field name="name">res.partner.kanban.purchaseorder.inherit</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
-            <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
                 <field name="mobile" position="after">
-                    <field name="purchase_order_count"/>
+                    <field name="purchase_order_count" groups="purchase.group_purchase_user"/>
                 </field>
                 <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
                     <a t-if="record.purchase_order_count.value>0" data-type="action" data-name="%(purchase.act_res_partner_2_purchase_order)d"
-                       href="#" class="oe_kanban_action oe_kanban_action_a me-1">
+                        groups="purchase.group_purchase_user"
+                        href="#" class="oe_kanban_action oe_kanban_action_a me-1">
                         <span class="badge rounded-pill">
                             <i class="fa fa-fw fa-credit-card" role="img" aria-label="Purchases" title="Purchases"/>
                             <t t-out="record.purchase_order_count.value"/>
@@ -87,7 +87,6 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="priority" eval="9"/>
-            <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(purchase.act_res_partner_2_purchase_order)d" type="action"
@@ -97,12 +96,14 @@
                     </button>
                 </div>
                 <page name="internal_notes" position="inside">
-                    <group colspan="2" col="2" groups="purchase.group_warning_purchase">
-                        <separator string="Warning on the Purchase Order" colspan="4"/>
-                        <field name="purchase_warn" nolabel="1" />
-                        <field name="purchase_warn_msg" colspan="3" nolabel="1"
-                            attrs="{'required':[('purchase_warn','!=', False), ('purchase_warn','!=','no-message')], 'invisible':[('purchase_warn','in',(False,'no-message'))]}"/>
-                    </group>
+                    <t groups="purchase.group_purchase_user">
+                        <group colspan="2" col="2" groups="purchase.group_warning_purchase">
+                            <separator string="Warning on the Purchase Order" colspan="4"/>
+                            <field name="purchase_warn" nolabel="1" />
+                            <field name="purchase_warn_msg" colspan="3" nolabel="1"
+                                attrs="{'required':[('purchase_warn','!=', False), ('purchase_warn','!=','no-message')], 'invisible':[('purchase_warn','in',(False,'no-message'))]}"/>
+                        </group>
+                    </t>
                 </page>
             </field>
         </record>
@@ -112,10 +113,10 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="priority" eval="12"/>
-            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(purchase.act_res_partner_2_supplier_invoices)d" type="action"
+                        groups="account.group_account_invoice"
                         icon="fa-pencil-square-o" help="Vendor Bills">
                         <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
                     </button>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -39,7 +39,6 @@
         <field name="name">product.product.sale.order</field>
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button class="oe_stat_button"
@@ -59,11 +58,13 @@
                 </button>
             </div>
             <group name="description" position="after">
-                <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
-                    <field name="sale_line_warn" nolabel="1"/>
-                    <field name="sale_line_warn_msg" colspan="3" nolabel="1"
-                            attrs="{'required':[('sale_line_warn','!=','no-message')],'readonly':[('sale_line_warn','=','no-message')]}"/>
-                </group>
+                <t groups="sales_team.group_sale_salesman">
+                    <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
+                        <field name="sale_line_warn" nolabel="1"/>
+                        <field name="sale_line_warn_msg" colspan="3" nolabel="1"
+                                attrs="{'required':[('sale_line_warn','!=','no-message')],'readonly':[('sale_line_warn','=','no-message')]}"/>
+                    </group>
+                </t>
             </group>
         </field>
     </record>
@@ -72,7 +73,6 @@
         <field name="name">product.template.sale.order.button</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button class="oe_stat_button"
@@ -91,11 +91,13 @@
                 </button>
             </div>
             <group name="description" position="after">
-                <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
-                    <field name="sale_line_warn" nolabel="1"/>
-                    <field name="sale_line_warn_msg" colspan="3" nolabel="1"
-                            attrs="{'required':[('sale_line_warn','!=','no-message')],'readonly':[('sale_line_warn','=','no-message')], 'invisible':[('sale_line_warn','=','no-message')]}"/>
-                </group>
+                <t groups="sales_team.group_sale_salesman">
+                    <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
+                        <field name="sale_line_warn" nolabel="1"/>
+                        <field name="sale_line_warn_msg" colspan="3" nolabel="1"
+                                attrs="{'required':[('sale_line_warn','!=','no-message')],'readonly':[('sale_line_warn','=','no-message')], 'invisible':[('sale_line_warn','=','no-message')]}"/>
+                    </group>
+                </t>
             </group>
         </field>
     </record>

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="10"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block o_not_app"

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -21,13 +21,13 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.res_partner_kanban_view"/>
         <field name="priority" eval="20"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="arch" type="xml">
             <field name="mobile" position="after">
-                <field name="sale_order_count"/>
+                <field name="sale_order_count" groups="sales_team.group_sale_salesman"/>
             </field>
             <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
                 <a t-if="record.sale_order_count.value>0" data-type="object" data-name="action_view_sale_order"
+                   groups="sales_team.group_sale_salesman"
                    href="#" class="oe_kanban_action oe_kanban_action_a me-1">
                     <span class="badge rounded-pill">
                         <i class="fa fa-fw fa-usd" role="img" aria-label="Sale orders" title="Sales orders"/>
@@ -43,7 +43,6 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="priority" eval="3"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button class="oe_stat_button" type="object" name="action_view_sale_order"
@@ -53,7 +52,7 @@
                 </button>
             </div>
             <page name="internal_notes" position="inside">
-                <group colspan="2" col="2" groups="sale.group_warning_sale">
+                <group colspan="2" col="2" groups="sale.group_warning_sale,sales_team.group_sale_salesman">
                     <separator string="Warning on the Sales Order" colspan="4" />
                     <field name="sale_warn" nolabel="1" />
                     <field name="sale_warn_msg" colspan="3" nolabel="1"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -654,15 +654,16 @@
         <field name="name">sale.order.form</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
-        <field name="groups_id" eval="[(4, ref('sale.group_auto_done_setting'))]"/>
         <field name="arch" type="xml">
             <button name="action_draft" position="after">
-                <button name="action_done" type="object" string="Lock"
-                    states="sale"
-                    help="If the sale is locked, you can not modify it anymore. However, you will still be able to invoice or deliver." groups="sales_team.group_sale_manager"/>
-                <button name="action_unlock" type="object" string="Unlock"
-                    states="done"
-                    groups="sales_team.group_sale_manager"/>
+                <t groups="sale.group_auto_done_setting">
+                    <button name="action_done" type="object" string="Lock"
+                        states="sale"
+                        help="If the sale is locked, you can not modify it anymore. However, you will still be able to invoice or deliver." groups="sales_team.group_sale_manager"/>
+                    <button name="action_unlock" type="object" string="Unlock"
+                        states="done"
+                        groups="sales_team.group_sale_manager"/>
+                </t>
             </button>
         </field>
     </record>

--- a/addons/sale_expense/views/hr_expense_views.xml
+++ b/addons/sale_expense/views/hr_expense_views.xml
@@ -7,7 +7,22 @@
         <field name="priority">30</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='analytic_account_id']" position="before">
-                <field name="sale_order_id" attrs="{'invisible': [('can_be_reinvoiced', '=', False)], 'readonly': [('sheet_is_editable', '=', False)]}" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" context="{'sale_show_partner_name': True, 'sale_expense_all_order': True}" widget="sale_order_many2one"/>
+                <field name="sale_order_id" groups="!sales_team.group_sale_salesman,!account.group_account_manager"
+                    attrs="{'invisible': [('can_be_reinvoiced', '=', False)], 'readonly': [('sheet_is_editable', '=', False)]}"
+                    options="{'no_create_edit': True, 'no_create': True, 'no_open': True}"
+                    context="{'sale_show_partner_name': True, 'sale_expense_all_order': True}"
+                    widget="sale_order_many2one"/>
+                <field name="sale_order_id" groups="sales_team.group_sale_salesman,!account.group_account_manager"
+                    attrs="{'invisible': [('can_be_reinvoiced', '=', False)], 'readonly': [('sheet_is_editable', '=', False)]}"
+                    options="{'no_create_edit': True, 'no_create': True}"
+                    context="{'sale_show_partner_name': True, 'sale_expense_all_order': True}"
+                    widget="many2one"/>
+                <field name="sale_order_id" groups="account.group_account_manager"
+                    widget="many2one"
+                    attrs="{'invisible':[['can_be_reinvoiced','=',False]],'readonly':['|', ['state','in',['done']], ['sheet_is_editable', '=', False]]}"
+                    options="{'no_create_edit': True, 'no_create': True, 'no_open': True}"
+                    context="{'sale_show_partner_name': True, 'sale_expense_all_order': True}"
+                    />
                 <field name="can_be_reinvoiced" invisible="1"/>
             </xpath>
         </field>
@@ -22,30 +37,6 @@
                 <field name="can_be_reinvoiced" invisible="1" readonly="1"/>
             </xpath>
         </field>
-    </record>
-    <record id="hr_expense_form_view_inherit_account_manager" model="ir.ui.view">
-        <field name="name">hr.expense.form.inherit.sale.expense</field>
-        <field name="model">hr.expense</field>
-        <field name="inherit_id" ref="sale_expense.hr_expense_form_view_inherit_sale_expense"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='sale_order_id']" position="attributes">
-                <attribute name="attrs">{'invisible':[['can_be_reinvoiced','=',False]],'readonly':['|', ['state','in',['done']], ['sheet_is_editable', '=', False]]}</attribute>
-                <attribute name="widget">many2one</attribute>
-            </xpath>
-        </field>
-        <field name="groups_id" eval="[(6, 0, [ref('account.group_account_manager')])]"/>
-    </record>
-    <record id="hr_expense_form_view_inherit_saleman" model="ir.ui.view">
-        <field name="name">hr.expense.form.inherit.saleman</field>
-        <field name="model">hr.expense</field>
-        <field name="inherit_id" ref="sale_expense.hr_expense_form_view_inherit_sale_expense"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='sale_order_id']" position="attributes">
-                <attribute name="options">{'no_create_edit': True, 'no_create': True}</attribute>
-                <attribute name="widget">many2one</attribute>
-            </xpath>
-        </field>
-        <field name="groups_id" eval="[(6, 0, [ref('sales_team.group_sale_salesman')])]"/>
     </record>
 
     <record id="hr_expense_split_view_inherit_sale_expense" model="ir.ui.view">

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -136,26 +136,12 @@
                 <field name="allow_billable" invisible="1"/>
                 <group attrs="{'invisible': [('allow_billable', '=', False)]}">
                     <field name="project_partner_id" invisible="1"/>
-                    <field name="sale_line_id" options="{'no_open': True}" readonly="1"/>
-                    <field name="quantity_percentage" widget="percentage" readonly="1"/>
+                    <field name="sale_line_id" groups="!sales_team.group_sale_salesman" options="{'no_open': True}" readonly="1"/>
+                    <field name="sale_line_id" groups="sales_team.group_sale_salesman" options="{'no_create': True}" readonly="0"/>
+                    <field name="quantity_percentage" groups="!sales_team.group_sale_salesman" widget="percentage" readonly="1"/>
+                    <field name="quantity_percentage" groups="sales_team.group_sale_salesman" widget="percentage" readonly="0"/>
                 </group>
             </xpath>
-        </field>
-    </record>
-
-    <record id="project_milestone_view_form_salesman" model="ir.ui.view">
-        <field name="name">project.milestone.view.form.inherit.salesman</field>
-        <field name="model">project.milestone</field>
-        <field name="inherit_id" ref="project_milestone_view_form"/>
-        <field name="groups_id" eval="[Command.link(ref('sales_team.group_sale_salesman'))]"/>
-        <field name="arch" type="xml">
-            <field name="sale_line_id" position="attributes">
-                <attribute name="options">{'no_create': True}</attribute>
-                <attribute name="readonly">0</attribute>
-            </field>
-            <field name="quantity_percentage" position="attributes">
-                <attribute name="readonly">0</attribute>
-            </field>
         </field>
     </record>
 

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -181,8 +181,10 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="project_partner_id" invisible="1"/>
                 <field name="allow_billable" invisible="1"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1"/>
-                <field name="quantity_percentage" optional="hide" widget="percentage" readonly="1"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" optional="hide" options="{'no_create': True}" groups="sales_team.group_sale_salesman"/>
+                <field name="quantity_percentage" optional="hide" widget="percentage" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                <field name="quantity_percentage" optional="hide" widget="percentage" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>
@@ -193,28 +195,19 @@
         <field name="inherit_id" ref="sale_project.project_milestone_view_tree"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <field name="sale_line_id" position="attributes">
+            <xpath expr="//field[@name='sale_line_id'][1]" position="attributes">
                 <attribute name="optional">show</attribute>
-            </field>
-            <field name="quantity_percentage" position="attributes">
+            </xpath>
+            <xpath expr="//field[@name='sale_line_id'][2]" position="attributes">
                 <attribute name="optional">show</attribute>
-            </field>
+            </xpath>
+            <xpath expr="//field[@name='quantity_percentage'][1]" position="attributes">
+                <attribute name="optional">show</attribute>
+            </xpath>
+            <xpath expr="//field[@name='quantity_percentage'][2]" position="attributes">
+                <attribute name="optional">show</attribute>
+            </xpath>
         </field>
     </record>
 
-    <record id="project_milestone_view_tree_salesman" model="ir.ui.view">
-        <field name="name">project.milestone.view.tree.inherit.salesman</field>
-        <field name="model">project.milestone</field>
-        <field name="inherit_id" ref="project_milestone_view_tree"/>
-        <field name="groups_id" eval="[Command.link(ref('sales_team.group_sale_salesman'))]"/>
-        <field name="arch" type="xml">
-            <field name="sale_line_id" position="attributes">
-                <attribute name="options">{'no_create': True}</attribute>
-                <attribute name="readonly">0</attribute>
-            </field>
-            <field name="quantity_percentage" position="attributes">
-                <attribute name="readonly">0</attribute>
-            </field>
-        </field>
-    </record>
 </odoo>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -91,7 +91,6 @@
     <record id="view_sale_project_inherit_form" model="ir.ui.view">
         <field name="name">project.task.view.inherit</field>
         <field name="model">project.task</field>
-        <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
         <field name="inherit_id" ref="project.view_task_form2"/>
         <field name="arch" type="xml">
             <xpath expr="//span[@id='start_rating_buttons']" position="before">

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -106,23 +106,11 @@
             </xpath>
             <xpath expr="//field[@name='partner_phone']" position="after">
                 <field name="sale_order_id" attrs="{'invisible': True}" groups="sales_team.group_sale_salesman"/>
-                <field name="sale_line_id" string="Sales Order Item" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}"/>
+                <field name="sale_line_id" groups="!sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}"/>
+                <field name="sale_line_id" groups="sales_team.group_sale_salesman" string="Sales Order Item" options='{"no_create": True}' readonly="0" context="{'create': False, 'edit': False, 'delete': False}"/>
                 <field name="commercial_partner_id" invisible="1" />
             </xpath>
         </field>
-    </record>
-
-    <record id="project_task_view_form_inherit_sale_line_editable" model="ir.ui.view">
-        <field name="name">project.task.form.inherit.sale.line.editable.salesman</field>
-        <field name="model">project.task</field>
-        <field name="inherit_id" ref="view_sale_project_inherit_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='sale_line_id']" position="attributes">
-                <attribute name="options">{"no_create": True}</attribute>
-                <attribute name="readonly">0</attribute>
-            </xpath>
-        </field>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
     </record>
 
     <record id="project_task_view_search" model="ir.ui.view">

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -39,13 +39,12 @@
     <record id="hr_timesheet_line_tree_inherit" model="ir.ui.view">
         <field name="name">account.analytic.line.tree.inherit</field>
         <field name="model">account.analytic.line</field>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//tree/field[@name='name']" position="after">
-                <field name="commercial_partner_id" invisible="1"/>
-                <field name="is_so_line_edited" invisible="1"/>
-                <field name="so_line" widget="so_line_many2one" optional="hide" options="{'no_create': True}" context="{'create': False, 'edit': False, 'delete': False}"/>
+                <field name="commercial_partner_id" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="is_so_line_edited" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" widget="so_line_many2one" optional="hide" options="{'no_create': True}" context="{'create': False, 'edit': False, 'delete': False}" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>
@@ -53,13 +52,12 @@
     <record id="hr_timesheet_line_form_inherit" model="ir.ui.view">
         <field name="name">account.analytic.line.form.inherit</field>
         <field name="model">account.analytic.line</field>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='task_id']" position="after">
-                <field name="commercial_partner_id" invisible="1"/>
-                <field name="is_so_line_edited" invisible="1" />
-                <field name="so_line" widget="so_line_many2one" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False}"/>
+                <field name="commercial_partner_id" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="is_so_line_edited" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" widget="so_line_many2one" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False}" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -117,17 +117,16 @@
         <record id="view_sale_service_inherit_form2" model="ir.ui.view">
             <field name="name">sale.service.form.view.inherit</field>
             <field name="model">project.task</field>
-            <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
             <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
             <field name="arch" type="xml">
-                <xpath expr="//header" position='inside'>
+                <xpath expr="//header" position="inside">
                     <field name="allow_billable" invisible="1"/>
                 </xpath>
-                <xpath expr="//field[@name='child_ids']/tree/field[@name='remaining_hours']" position="after">
-                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide"/>
+                <xpath expr="//field[@name='child_ids']/tree//field[@name='remaining_hours']" position="after">
+                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide" groups="base.group_user"/>
                 </xpath>
-                <xpath expr="//field[@name='depend_on_ids']/tree/field[@name='remaining_hours']" position="after">
-                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide"/>
+                <xpath expr="//field[@name='depend_on_ids']/tree//field[@name='remaining_hours']" position="after">
+                    <field name="remaining_hours_so" string="Remaining Hours on SO" widget="timesheet_uom" optional="hide" groups="base.group_user"/>
                 </xpath>
 
             </field>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -147,60 +147,58 @@
             <field name="name">project.task.form.inherit.timesheet</field>
             <field name="model">project.task</field>
             <field name="inherit_id" ref="project.view_task_form2"/>
-            <field name="groups_id" eval="[(6,0, (ref('hr_timesheet.group_hr_timesheet_user'),))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
+                    <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->
                     <attribute name="decoration-muted">timesheet_invoice_id != False</attribute>
                 </xpath>
                 <xpath expr="//field[@name='user_ids']" position="after">
-                    <field name="is_project_map_empty" invisible="1"/>
-                    <field name="has_multi_sol" invisible="1"/>
+                    <field name="is_project_map_empty" invisible="1" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="has_multi_sol" invisible="1" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
                  <xpath expr="//field[@name='partner_phone']" position="after">
-                    <field name="pricing_type" invisible="1"/>
+                    <field name="pricing_type" invisible="1" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']" position="attributes">
+                    <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->
                     <attribute name="widget">so_line_one2many</attribute>
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
+                    <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->
                     <field name="is_so_line_edited" invisible="1" />
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']" position="before">
+                    <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->
                     <field name="timesheet_invoice_id" invisible="1"/>
-                    <field name="so_line"
+                    <field name="so_line" groups="!sales_team.group_sale_salesman"
                         attrs="{'column_invisible': [('parent.allow_billable', '=', False)]}"
                         context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
                         domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.commercial_partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]"
                         optional="hide"/>
+                    <field name="so_line" groups="sales_team.group_sale_salesman"
+                        attrs="{'column_invisible': [('parent.allow_billable', '=', False)]}"
+                        context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True}"
+                        domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.commercial_partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]"
+                        optional="hide"/>
                 </xpath>
                 <xpath expr="//field[@name='remaining_hours']" position="after">
-                    <field name="sale_order_id" invisible="1"/>
-                    <field name="remaining_hours_available" invisible="1"/>
-                    <span id="remaining_hours_so_label" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}">
-                        <label class="fw-bold" for="remaining_hours_so" string="Remaining Hours on SO"
-                               attrs="{'invisible': ['|', ('encode_uom_in_days', '=', True), ('remaining_hours_so', '&lt;', 0)]}"/>
-                        <label class="fw-bold" for="remaining_hours_so" string="Remaining Days on SO"
-                               attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&lt;', 0)]}"/>
-                        <label class="fw-bold text-danger" for="remaining_hours_so" string="Remaining Hours on SO"
-                               attrs="{'invisible': ['|', ('encode_uom_in_days', '=', True), ('remaining_hours_so', '&gt;=', 0)]}"/>
-                        <label class="fw-bold text-danger" for="remaining_hours_so" string="Remaining Days on SO"
-                               attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&gt;=', 0)]}"/>
-                    </span>
-                    <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}"></field>
+                    <t groups="hr_timesheet.group_hr_timesheet_user">
+                        <field name="sale_order_id" invisible="1"/>
+                        <field name="remaining_hours_available" invisible="1"/>
+                        <span id="remaining_hours_so_label" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}">
+                            <label class="fw-bold" for="remaining_hours_so" string="Remaining Hours on SO"
+                                attrs="{'invisible': ['|', ('encode_uom_in_days', '=', True), ('remaining_hours_so', '&lt;', 0)]}"/>
+                            <label class="fw-bold" for="remaining_hours_so" string="Remaining Days on SO"
+                                attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&lt;', 0)]}"/>
+                            <label class="fw-bold text-danger" for="remaining_hours_so" string="Remaining Hours on SO"
+                                attrs="{'invisible': ['|', ('encode_uom_in_days', '=', True), ('remaining_hours_so', '&gt;=', 0)]}"/>
+                            <label class="fw-bold text-danger" for="remaining_hours_so" string="Remaining Days on SO"
+                                attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&gt;=', 0)]}"/>
+                        </span>
+                        <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}"></field>
+                    </t>
                 </xpath>
             </field>
-        </record>
-
-        <record id="project_task_view_form_inherit_sale_timesheet_editable" model="ir.ui.view">
-            <field name="name">project.task.form.view.form.inherit.sale.timesheet.editable</field>
-            <field name="model">project.task</field>
-            <field name="inherit_id" ref="project_task_view_form_inherit_sale_timesheet"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='so_line']" position="attributes">
-                    <attribute name="options">{'no_create': True}</attribute>
-                </xpath>
-            </field>
-            <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         </record>
 
         <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -31,7 +31,8 @@
                             <field name="pricing_type" invisible="1" widget="radio"/>
                             <field name="timesheet_product_id" string="Default Service" invisible="1" context="{'default_detailed_type': 'service', 'default_service_policy': 'delivered_timesheet', 'default_service_type': 'timesheet'}"/>
                             <field name="sale_order_id" invisible="1" options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>
-                            <field name="sale_line_id" string="Default Sales Order Item" options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>
+                            <field name="sale_line_id" groups="!sales_team.group_sale_salesman" string="Default Sales Order Item" options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>
+                            <field name="sale_line_id" groups="sales_team.group_sale_salesman" string="Default Sales Order Item" options="{'no_create': True, 'no_edit': True, 'delete': False}"/>
                         </group>
                     </group>
                     <field name="sale_line_employee_ids">
@@ -49,18 +50,6 @@
                     </field>
                 </page>
             </xpath>
-        </field>
-    </record>
-
-    <record id="project_project_view_form_salesman" model="ir.ui.view">
-        <field name="name">project.project.form.inherit.salesman</field>
-        <field name="model">project.project</field>
-        <field name="inherit_id" ref="sale_timesheet.project_project_view_form"/>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
-        <field name="arch" type="xml">
-            <field name="sale_line_id" position="attributes">
-                <attribute name="options">{'no_create': True, 'no_edit': True, 'delete': False}</attribute>
-            </field>
         </field>
     </record>
 

--- a/addons/sales_team/views/res_partner_views.xml
+++ b/addons/sales_team/views/res_partner_views.xml
@@ -6,8 +6,12 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales_purchases']//field[@name='user_id']" position="after">
+                <field name="team_id" invisible="1"/>
                 <field name="team_id" groups="base.group_no_one" />
             </xpath>
+            <field name="parent_id" position="attributes">
+                <attribute name="context">{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id, 'default_team_id': team_id}</attribute>
+            </field>
         </field>
     </record>
 </odoo>

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -103,11 +103,27 @@ class ResConfigSettings(models.TransientModel):
         if self.group_stock_multi_locations and not previous_group.get('group_stock_multi_locations'):
             # override active_test that is false in set_values
             warehouse_obj.with_context(active_test=True).search([]).int_type_id.active = True
+            # Disable the views removing the create button from the location list and form.
+            # Be resilient if the views have been deleted manually.
+            for view in (
+                self.env.ref('stock.stock_location_view_tree2_editable', raise_if_not_found=False),
+                self.env.ref('stock.stock_location_view_form_editable', raise_if_not_found=False),
+            ):
+                if view:
+                    view.active = False
         elif not self.group_stock_multi_locations and previous_group.get('group_stock_multi_locations'):
             warehouse_obj.search([
                 ('reception_steps', '=', 'one_step'),
                 ('delivery_steps', '=', 'ship_only')
             ]).int_type_id.active = False
+            # Enable the views removing the create button from the location list and form.
+            # Be resilient if the views have been deleted manually.
+            for view in (
+                self.env.ref('stock.stock_location_view_tree2_editable', raise_if_not_found=False),
+                self.env.ref('stock.stock_location_view_form_editable', raise_if_not_found=False),
+            ):
+                if view:
+                    view.active = True
 
         if not was_operations_showed and self.env['stock.picking.type'].with_user(SUPERUSER_ID)._default_show_operations():
             self.env['stock.picking.type'].with_context(active_test=False).sudo().search([

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -236,7 +236,6 @@
         <record model="ir.ui.view" id="product_form_view_procurement_button">
             <field name="name">product.product.procurement</field>
             <field name="model">product.product</field>
-            <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="arch" type="xml">
                 <data>
@@ -252,82 +251,84 @@
                             attrs="{'invisible': [('type', 'not in', ['consu', 'product'])]}"/>
                     </header>
                     <div name="button_box" position="inside">
-                        <field name="tracking" invisible="1"/>
-                        <field name="show_on_hand_qty_status_button" invisible="1"/>
-                        <field name="show_forecasted_qty_status_button" invisible="1"/>
-                        <button class="oe_stat_button"
-                               name="action_open_quants"
-                               icon="fa-cubes"
-                               type="object"
-                               attrs="{'invisible':[('show_on_hand_qty_status_button', '=', False)]}">
-                               <div class="o_field_widget o_stat_info">
+                        <t groups="stock.group_stock_user">
+                            <field name="tracking" invisible="1"/>
+                            <field name="show_on_hand_qty_status_button" invisible="1"/>
+                            <field name="show_forecasted_qty_status_button" invisible="1"/>
+                            <button class="oe_stat_button"
+                                name="action_open_quants"
+                                icon="fa-cubes"
+                                type="object"
+                                attrs="{'invisible':[('show_on_hand_qty_status_button', '=', False)]}">
+                                <div class="o_field_widget o_stat_info">
+                                        <span class="o_stat_value">
+                                            <field name="qty_available" widget="statinfo" nolabel="1" class="mr4"/>
+                                            <field name="uom_name"/>
+                                        </span>
+                                        <span class="o_stat_text">On Hand</span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name="action_product_forecast_report"
+                                attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
+                                context="{'default_product_id': id}"
+                                class="oe_stat_button" icon="fa-cubes">
+                                <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value">
-                                        <field name="qty_available" widget="statinfo" nolabel="1" class="mr4"/>
+                                        <field name="virtual_available" widget="statinfo" nolabel="1" class="mr4"/>
                                         <field name="uom_name"/>
                                     </span>
-                                    <span class="o_stat_text">On Hand</span>
-                               </div>
-                        </button>
-                        <button type="object"
-                            name="action_product_forecast_report"
-                            attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
-                            context="{'default_product_id': id}"
-                            class="oe_stat_button" icon="fa-cubes">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value">
-                                    <field name="virtual_available" widget="statinfo" nolabel="1" class="mr4"/>
-                                    <field name="uom_name"/>
-                                </span>
-                                <span class="o_stat_text">Forecasted</span>
-                            </div>
-                        </button>
-                        <button type="object"
-                            name= "action_view_stock_move_lines"
-                            attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
-                            class="oe_stat_button" icon="fa-exchange"
-                            groups="stock.group_stock_user">
-                            <div class="o_field_widget o_stat_info mr4">
-                                <span class="o_stat_text">In:</span>
-                                <span class="o_stat_text">Out:</span>
-                            </div>
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="nbr_moves_in"/></span>
-                                <span class="o_stat_value"><field name="nbr_moves_out"/></span>
-                            </div>
-                        </button>
-                        <button name="action_view_orderpoints" type="object"
-                            attrs="{'invisible':['|',('type', 'not in', ['product', 'consu']),('nbr_reordering_rules', '!=', 1)]}"
-                            class="oe_stat_button" icon="fa-refresh">
-                            <div class="o_field_widget o_stat_info mr4">
-                                <span class="o_stat_text">Min:</span>
-                                <span class="o_stat_text">Max:</span>
-                            </div>
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="reordering_min_qty"/></span>
-                                <span class="o_stat_value"><field name="reordering_max_qty"/></span>
-                            </div>
-                        </button>
-                        <button type="object"
-                            name="action_view_orderpoints"
-                            attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '==', 1)]}"
-                            class="oe_stat_button" icon="fa-refresh">
-                            <field name="nbr_reordering_rules" widget="statinfo"/>
-                        </button>
-                        <button string="Lot/Serial Numbers" type="object"
-                            name="action_open_product_lot"
-                            attrs="{'invisible': [('tracking', '=', 'none')]}"
-                            class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
-                        <button string="Putaway Rules" type="object"
-                            name="action_view_related_putaway_rules"
-                            class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
-                            attrs="{'invisible': [('type', '=', 'service')]}"
-                            context="{'invisible_handle': True, 'single_product': True}"/>
-                        <button type="object" string="Storage Capacities"
-                            name="action_view_storage_category_capacity"
-                            groups="stock.group_stock_storage_categories"
-                            attrs="{'invisible':[('type', '=', 'service')]}"
-                            class="oe_stat_button"
-                            icon="fa-cubes"/>
+                                    <span class="o_stat_text">Forecasted</span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name= "action_view_stock_move_lines"
+                                attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
+                                class="oe_stat_button" icon="fa-exchange"
+                                groups="stock.group_stock_user">
+                                <div class="o_field_widget o_stat_info mr4">
+                                    <span class="o_stat_text">In:</span>
+                                    <span class="o_stat_text">Out:</span>
+                                </div>
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value"><field name="nbr_moves_in"/></span>
+                                    <span class="o_stat_value"><field name="nbr_moves_out"/></span>
+                                </div>
+                            </button>
+                            <button name="action_view_orderpoints" type="object"
+                                attrs="{'invisible':['|',('type', 'not in', ['product', 'consu']),('nbr_reordering_rules', '!=', 1)]}"
+                                class="oe_stat_button" icon="fa-refresh">
+                                <div class="o_field_widget o_stat_info mr4">
+                                    <span class="o_stat_text">Min:</span>
+                                    <span class="o_stat_text">Max:</span>
+                                </div>
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value"><field name="reordering_min_qty"/></span>
+                                    <span class="o_stat_value"><field name="reordering_max_qty"/></span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name="action_view_orderpoints"
+                                attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '==', 1)]}"
+                                class="oe_stat_button" icon="fa-refresh">
+                                <field name="nbr_reordering_rules" widget="statinfo"/>
+                            </button>
+                            <button string="Lot/Serial Numbers" type="object"
+                                name="action_open_product_lot"
+                                attrs="{'invisible': [('tracking', '=', 'none')]}"
+                                class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
+                            <button string="Putaway Rules" type="object"
+                                name="action_view_related_putaway_rules"
+                                class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
+                                attrs="{'invisible': [('type', '=', 'service')]}"
+                                context="{'invisible_handle': True, 'single_product': True}"/>
+                            <button type="object" string="Storage Capacities"
+                                name="action_view_storage_category_capacity"
+                                groups="stock.group_stock_storage_categories"
+                                attrs="{'invisible':[('type', '=', 'service')]}"
+                                class="oe_stat_button"
+                                icon="fa-cubes"/>
+                        </t>
                     </div>
                     <xpath expr="//button[@name='%(action_open_routes)d']" position="attributes">
                         <attribute name="context">

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -343,7 +343,6 @@
         <record model="ir.ui.view" id="product_template_form_view_procurement_button">
             <field name="name">product.template_procurement</field>
             <field name="model">product.template</field>
-            <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="priority" eval="15"/>
             <field name="arch" type="xml">
@@ -360,90 +359,92 @@
                             attrs="{'invisible': [('type', 'not in', ['consu', 'product'])]}"/>
                     </header>
                     <div name="button_box" position="inside">
-                        <field name="tracking" invisible="1"/>
-                        <field name="show_on_hand_qty_status_button" invisible="1"/>
-                        <field name="show_forecasted_qty_status_button" invisible="1"/>
-                        <button type="object"
-                            name="action_open_quants"
-                            attrs="{'invisible':[('show_on_hand_qty_status_button', '=', False)]}"
-                            class="oe_stat_button" icon="fa-cubes">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value" widget="statinfo">
-                                    <field name="qty_available" widget="statinfo" nolabel="1" class="mr4"/>
-                                    <field name="uom_name"/>
-                                </span>
-                                <span class="o_stat_text">On Hand</span>
-                            </div>
-                        </button>
-                        <button type="object"
-                            name="action_product_tmpl_forecast_report"
-                            attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
-                            context="{'default_product_tmpl_id': id}"
-                            class="oe_stat_button" icon="fa-cubes">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value">
-                                    <field name="virtual_available" widget="statinfo" nolabel="1" class="mr4"/>
-                                    <field name="uom_name"/>
-                                </span>
-                                <span class="o_stat_text">Forecasted</span>
-                            </div>
-                        </button>
-                        <button type="object"
-                            name= "action_view_stock_move_lines"
-                            attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
-                            class="oe_stat_button" icon="fa-exchange"
-                            groups="stock.group_stock_user">
-                            <div class="o_field_widget o_stat_info mr4">
-                                <span class="o_stat_text">In:</span>
-                                <span class="o_stat_text">Out:</span>
-                            </div>
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="nbr_moves_in"/></span>
-                                <span class="o_stat_value"><field name="nbr_moves_out"/></span>
-                            </div>
-                        </button>
-                        <button type="object"
-                            name="action_view_orderpoints"
-                            attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '!=', 1)]}"
-                            class="oe_stat_button" icon="fa-refresh">
-                            <div class="o_field_widget o_stat_info mr4">
-                                <span class="o_stat_text">Min:</span>
-                                <span class="o_stat_text">Max:</span>
-                            </div>
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_value"><field name="reordering_min_qty"/></span>
-                                <span class="o_stat_value"><field name="reordering_max_qty"/></span>
-                            </div>
-                        </button>
-                        <button type="object"
-                            name="action_view_orderpoints"
-                            attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '==', 1)]}"
-                            class="oe_stat_button"
-                            icon="fa-refresh">
-                            <field name="nbr_reordering_rules" widget="statinfo"/>
-                         </button>
-                        <button string="Lot/Serial Numbers" type="object"
-                            name="action_open_product_lot"
-                            attrs="{'invisible': [('tracking', '=', 'none')]}"
-                            class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
-                        <button string="Putaway Rules" type="object"
-                            name="action_view_related_putaway_rules"
-                            class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
-                            attrs="{'invisible': [('type', '=', 'service')]}"
-                            context="{
-                                'invisible_handle': True,
-                                'single_product': product_variant_count == 1,
-                            }"/>
-                        <button type="object" string="Storage Capacities"
-                            name="action_view_storage_category_capacity"
-                            groups="stock.group_stock_storage_categories"
-                            attrs="{'invisible':[('type', '=', 'service')]}"
-                            class="oe_stat_button"
-                            icon="fa-cubes"/>
+                        <t groups="stock.group_stock_user">
+                            <field name="tracking" invisible="1"/>
+                            <field name="show_on_hand_qty_status_button" invisible="1"/>
+                            <field name="show_forecasted_qty_status_button" invisible="1"/>
+                            <button type="object"
+                                name="action_open_quants"
+                                attrs="{'invisible':[('show_on_hand_qty_status_button', '=', False)]}"
+                                class="oe_stat_button" icon="fa-cubes">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value" widget="statinfo">
+                                        <field name="qty_available" widget="statinfo" nolabel="1" class="mr4"/>
+                                        <field name="uom_name"/>
+                                    </span>
+                                    <span class="o_stat_text">On Hand</span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name="action_product_tmpl_forecast_report"
+                                attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
+                                context="{'default_product_tmpl_id': id}"
+                                class="oe_stat_button" icon="fa-cubes">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value">
+                                        <field name="virtual_available" widget="statinfo" nolabel="1" class="mr4"/>
+                                        <field name="uom_name"/>
+                                    </span>
+                                    <span class="o_stat_text">Forecasted</span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name= "action_view_stock_move_lines"
+                                attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
+                                class="oe_stat_button" icon="fa-exchange"
+                                groups="stock.group_stock_user">
+                                <div class="o_field_widget o_stat_info mr4">
+                                    <span class="o_stat_text">In:</span>
+                                    <span class="o_stat_text">Out:</span>
+                                </div>
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value"><field name="nbr_moves_in"/></span>
+                                    <span class="o_stat_value"><field name="nbr_moves_out"/></span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name="action_view_orderpoints"
+                                attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '!=', 1)]}"
+                                class="oe_stat_button" icon="fa-refresh">
+                                <div class="o_field_widget o_stat_info mr4">
+                                    <span class="o_stat_text">Min:</span>
+                                    <span class="o_stat_text">Max:</span>
+                                </div>
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value"><field name="reordering_min_qty"/></span>
+                                    <span class="o_stat_value"><field name="reordering_max_qty"/></span>
+                                </div>
+                            </button>
+                            <button type="object"
+                                name="action_view_orderpoints"
+                                attrs="{'invisible':['|',('type', '!=', 'product'),('nbr_reordering_rules', '==', 1)]}"
+                                class="oe_stat_button"
+                                icon="fa-refresh">
+                                <field name="nbr_reordering_rules" widget="statinfo"/>
+                            </button>
+                            <button string="Lot/Serial Numbers" type="object"
+                                name="action_open_product_lot"
+                                attrs="{'invisible': [('tracking', '=', 'none')]}"
+                                class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
+                            <button string="Putaway Rules" type="object"
+                                name="action_view_related_putaway_rules"
+                                class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
+                                attrs="{'invisible': [('type', '=', 'service')]}"
+                                context="{
+                                    'invisible_handle': True,
+                                    'single_product': product_variant_count == 1,
+                                }"/>
+                            <button type="object" string="Storage Capacities"
+                                name="action_view_storage_category_capacity"
+                                groups="stock.group_stock_storage_categories"
+                                attrs="{'invisible':[('type', '=', 'service')]}"
+                                class="oe_stat_button"
+                                icon="fa-cubes"/>
+                        </t>
                     </div>
 
                     <xpath expr="//label[@for='weight']" position="before">
-                        <field name="responsible_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                        <field name="responsible_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" groups="stock.group_stock_user"/>
                     </xpath>
                 </data>
             </field>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -442,12 +442,6 @@
                             icon="fa-cubes"/>
                     </div>
 
-                    <!-- change attrs of fields added in view_template_property_form
-                    to restrict the display for templates -->
-                    <xpath expr="//group[@name='group_lots_and_weight']" position="attributes">
-                        <attribute name="attrs">{'invisible': [('type', 'not in', ['product', 'consu'])]}</attribute>
-                    </xpath>
-
                     <xpath expr="//label[@for='weight']" position="before">
                         <field name="responsible_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                     </xpath>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -6,7 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="priority" eval="30"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form" />
-            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'), 0)]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('settings')]" position="inside" >
                     <div class="app_settings_block" data-string="Inventory" string="Inventory" data-key="stock" groups="stock.group_stock_manager">

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -14,7 +14,7 @@
         <field name="name">stock.location.form</field>
         <field name="model">stock.location</field>
         <field name="arch" type="xml">
-            <form string="Stock Location" create="false">
+            <form string="Stock Location">
                 <field name="company_id" invisible="1"/>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -61,10 +61,9 @@
         <field name="name">stock.location.form.editable</field>
         <field name="model">stock.location</field>
         <field name="inherit_id" ref="stock.view_location_form"/>
-        <field name="groups_id" eval="[(4, ref('stock.group_stock_multi_locations'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//form" position="attributes">
-                <attribute name="create">true</attribute>
+                <attribute name="create">false</attribute>
             </xpath>
         </field>
     </record>
@@ -91,7 +90,7 @@
         <field name="model">stock.location</field>
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
-            <tree string="Stock Location" decoration-info="usage=='view'" decoration-danger="usage=='internal'" create="false" multi_edit="1">
+            <tree string="Stock Location" decoration-info="usage=='view'" decoration-danger="usage=='internal'" multi_edit="1">
                 <field name="active" invisible="1"/>
                 <field name="complete_name" string="Location"/>
                 <field name="usage"/>
@@ -105,10 +104,9 @@
         <field name="name">stock.location.tree2.editable</field>
         <field name="model">stock.location</field>
         <field name="inherit_id" ref="stock.view_location_tree2"/>
-        <field name="groups_id" eval="[(4, ref('stock.group_stock_multi_locations'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//tree" position="attributes">
-                <attribute name="create">true</attribute>
+                <attribute name="create">false</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -49,3 +49,11 @@ class SaleOrderLine(models.Model):
             return qty
         else:
             return super(SaleOrderLine, self)._get_qty_procurement(previous_product_uom_qty=previous_product_uom_qty)
+
+    @api.depends('purchase_line_count')
+    def _compute_product_updatable(self):
+        super()._compute_product_updatable()
+        if self.env.user.has_group('purchase.group_purchase_user'):
+            for line in self:
+                if line.purchase_line_count > 0:
+                    line.product_updatable = False

--- a/addons/stock_dropshipping/views/sale_order_views.xml
+++ b/addons/stock_dropshipping/views/sale_order_views.xml
@@ -5,28 +5,17 @@
             <field name="name">sale.order.form.sale.dropshipping</field>
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
-                <xpath expr="//page/field[@name='order_line']/form//field[@name='product_updatable']" position="after">
-                    <field name="purchase_line_count" invisible="1"/>
-                </xpath>
-                <xpath expr="//page/field[@name='order_line']/form//field[@name='product_id']" position="attributes">
-                   <attribute name="attrs">{'readonly': ['|', ('product_updatable', '=', False), ('purchase_line_count', '&gt;', 0)], 'required': [('display_type', '=', False)],}</attribute>
-                </xpath>
-                <xpath expr="//page/field[@name='order_line']/tree/field[@name='product_updatable']" position="after">
-                    <field name="purchase_line_count" invisible="1"/>
-                </xpath>
-                <xpath expr="//page/field[@name='order_line']/tree/field[@name='product_id']" position="attributes">
-                    <attribute name="attrs">{'readonly': ['|', ('product_updatable', '=', False), ('purchase_line_count', '&gt;', 0)], 'required': [('display_type', '=', False)],}</attribute>
-                </xpath>
                 <xpath expr="//button[@name='action_view_delivery']" position="before">
-                    <button type="object"
-                        name="action_view_dropship"
-                        class="oe_stat_button"
-                        icon="fa-truck"
-                        attrs="{'invisible': [('dropship_picking_count', '=', 0)]}" groups="stock.group_stock_user">
-                        <field name="dropship_picking_count" widget="statinfo" string="Dropship"/>
-                    </button>
+                    <t groups="purchase.group_purchase_user">
+                        <button type="object"
+                            name="action_view_dropship"
+                            class="oe_stat_button"
+                            icon="fa-truck"
+                            attrs="{'invisible': [('dropship_picking_count', '=', 0)]}" groups="stock.group_stock_user">
+                            <field name="dropship_picking_count" widget="statinfo" string="Dropship"/>
+                        </button>
+                    </t>
                 </xpath>
            </field>
         </record>

--- a/addons/stock_landed_costs/views/account_move_views.xml
+++ b/addons/stock_landed_costs/views/account_move_views.xml
@@ -4,29 +4,32 @@
         <field name="name">account.view.move.form.inherited</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="groups_id" eval="[(4,ref('stock.group_stock_manager'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <field name="landed_costs_ids" invisible="1"/>
-                <button string="Landed Costs" type="object"
-                    name="action_view_landed_costs"
-                    class="oe_stat_button" icon="fa-plus-square" groups="stock.group_stock_manager"
-                    attrs="{'invisible': [('landed_costs_ids', '=', [])]}" />
+                <t groups="stock.group_stock_manager">
+                    <field name="landed_costs_ids" invisible="1"/>
+                    <button string="Landed Costs" type="object"
+                        name="action_view_landed_costs"
+                        class="oe_stat_button" icon="fa-plus-square"
+                        attrs="{'invisible': [('landed_costs_ids', '=', [])]}"/>
+                </t>
             </xpath>
 
             <field name="state" position="before">
-                <field name="landed_costs_visible" invisible="1"/>
-                <button name="button_create_landed_costs" class="oe_highlight" string="Create Landed Costs" data-hotkey="l" type="object" groups="account.group_account_invoice" attrs="{'invisible': [('landed_costs_visible', '!=', True)]}"/>
+                <t groups="stock.group_stock_manager">
+                    <field name="landed_costs_visible" invisible="1" />
+                    <button name="button_create_landed_costs" class="oe_highlight" string="Create Landed Costs" data-hotkey="l" type="object" groups="account.group_account_invoice" attrs="{'invisible': [('landed_costs_visible', '!=', True)]}"/>
+                </t>
             </field>
 
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">
-                <field name="product_type" invisible="1"/>
-                <field name="is_landed_costs_line" string="Landed Costs" attrs="{'readonly': [('product_type', '!=', 'service')], 'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional="show"/>
+                <field name="product_type" invisible="1" groups="stock.group_stock_manager"/>
+                <field name="is_landed_costs_line" string="Landed Costs" attrs="{'readonly': [('product_type', '!=', 'service')], 'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional="show" groups="stock.group_stock_manager"/>
             </xpath>
 
             <xpath expr="//field[@name='line_ids']/tree/field[@name='name']" position="after">
-                <field name="product_type" invisible="1"/>
-                <field name="is_landed_costs_line" invisible="1"/>
+                <field name="product_type" invisible="1" groups="stock.group_stock_manager"/>
+                <field name="is_landed_costs_line" invisible="1" groups="stock.group_stock_manager"/>
             </xpath>
         </field>
     </record>

--- a/addons/survey/views/res_partner_views.xml
+++ b/addons/survey/views/res_partner_views.xml
@@ -12,11 +12,11 @@
         <field name="name">res.partner.view.form.inherit.survey</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
-        <field name="groups_id" eval="[(4, ref('survey.group_survey_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" type="object"
                     icon="fa-trophy" name="action_view_certifications"
+                     groups="survey.group_survey_user"
                     attrs="{'invisible': ['|', ('certifications_count', '=', 0), ('is_company', '=', True)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value"><field name="certifications_count" /></span>
@@ -26,6 +26,7 @@
                 </button>
                 <button class="oe_stat_button" type="object"
                     icon="fa-trophy" name="action_view_certifications"
+                    groups="survey.group_survey_user"
                     attrs="{'invisible': ['|', ('certifications_company_count', '=', 0), ('is_company', '=', False)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value"><field name="certifications_company_count" /></span>

--- a/addons/web/static/src/legacy/js/views/form/form_renderer.js
+++ b/addons/web/static/src/legacy/js/views/form/form_renderer.js
@@ -652,14 +652,19 @@ var FormRenderer = BasicRenderer.extend({
     _renderHeaderButtons: function (node) {
         var self = this;
         var buttons = [];
-        _.each(node.children, function (child) {
+        var children = [...node.children];
+        while(children.length) {
+            var child = children.shift();
             if (child.tag === 'button') {
                 buttons.push(self._renderHeaderButton(child));
             }
             if (child.tag === 'widget') {
                 buttons.push(self._renderTagWidget(child));
             }
-        });
+            if (child.children){
+                children.push(...child.children);
+            }
+        }
         return this._renderStatusbarButtons(buttons);
     },
     /**

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -2209,6 +2209,36 @@ QUnit.module('LegacyViews', {
         form.destroy();
     });
 
+    QUnit.test("nested buttons in form view header", async function (assert) {
+        assert.expect(4);
+
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:
+                '<form string="Partners">' +
+                    '<header>' +
+                        '<button name="0"/>' +
+                        '<button name="1"/>' +
+                        '<div>' +
+                            '<button name="2"/>' +
+                            '<button name="3"/>' +
+                        '</div>' +
+                    '</header>' +
+                '</form>',
+            res_id: 2,
+        });
+
+        var buttons = form.$('.o_form_statusbar button');
+        assert.hasAttrValue(buttons[0], 'name', '0');
+        assert.hasAttrValue(buttons[1], 'name', '1');
+        assert.hasAttrValue(buttons[2], 'name', '2');
+        assert.hasAttrValue(buttons[3], 'name', '3');
+
+        form.destroy();
+    });
+
     QUnit.test('button in form view and long willStart', async function (assert) {
         assert.expect(6);
 

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -2644,6 +2644,32 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("nested buttons in form view header", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <header>
+                        <button name="0"/>
+                        <button name="1"/>
+                        <div>
+                            <button name="2"/>
+                            <button name="3"/>
+                        </div>
+                    </header>
+                </form>`,
+            resId: 2,
+        });
+
+        const buttons = target.querySelectorAll('.o_form_statusbar button');
+        assert.strictEqual(buttons[0].attributes.name.textContent, "0");
+        assert.strictEqual(buttons[1].attributes.name.textContent, "1");
+        assert.strictEqual(buttons[2].attributes.name.textContent, "2");
+        assert.strictEqual(buttons[3].attributes.name.textContent, "3");
+    });
+
     QUnit.test("button in form view and long willStart", async function (assert) {
         const mockedActionService = {
             start() {

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -17,7 +17,6 @@
         <field name="model">res.config.settings</field>
         <field name="priority" eval="20"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('website.group_website_designer'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Website" string="Website" data-key="website" groups="website.group_website_designer">

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -5,10 +5,9 @@
         <field name="name">res.config.settings.view.form.inherit.account.web.terms</field>
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[Command.link(ref('website.group_website_designer'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_update_terms']" position="replace">
-                <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
+                <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}" groups="website.group_website_designer">
                     <strong class="align-top">URL: </strong><field name="terms_url"/>
                     <div>
                         <button name='action_update_terms' icon="fa-arrow-right" type="object" string="Edit in Website Builder" class="btn-link"/>

--- a/addons/website_slides/views/res_config_settings_views.xml
+++ b/addons/website_slides/views/res_config_settings_views.xml
@@ -4,10 +4,9 @@
         <field name="name">res.config.settings.view.form.inherit.website.slides</field>
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
-        <field name="groups_id" eval="[(4, ref('website_slides.group_website_slides_manager'), 0)]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='website_marketing_automation']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="slides_install_setting">
+                <div class="col-12 col-lg-6 o_setting_box" id="slides_install_setting" groups="website_slides.group_website_slides_manager">
                     <div class="o_setting_right_pane">
                         <span class="o_form_label">Slides</span>
                         <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
@@ -29,7 +28,7 @@
                 </div>
             </xpath>
             <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="eLearning" string="eLearning" data-key="website_slides">
+                <div class="app_settings_block" data-string="eLearning" string="eLearning" data-key="website_slides" groups="website_slides.group_website_slides_manager">
                     <h2>eLearning</h2>
                     <div class="row mt16 o_settings_container" id="website_slides_selection_settings">
                         <group>

--- a/addons/website_slides/views/res_partner_views.xml
+++ b/addons/website_slides/views/res_partner_views.xml
@@ -5,11 +5,11 @@
         <field name="name">res.partner.view.form.inherit.slides</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
-        <field name="groups_id" eval="[(4, ref('website_slides.group_website_slides_officer'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" type="object"
                     icon="fa-graduation-cap" name="action_view_courses"
+                    groups="website_slides.group_website_slides_officer"
                     attrs="{'invisible': ['|', ('slide_channel_count', '=', 0), ('is_company', '=', True)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value"><field name="slide_channel_count"/></span>
@@ -18,6 +18,7 @@
                 </button>
                 <button class="oe_stat_button" type="object"
                     icon="fa-graduation-cap" name="action_view_courses"
+                    groups="website_slides.group_website_slides_officer"
                     attrs="{'invisible': ['|', ('slide_channel_company_count', '=', 0), ('is_company', '=', False)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value"><field name="slide_channel_company_count" /></span>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -452,11 +452,10 @@ actual arch.
     @api.constrains('type', 'groups_id', 'inherit_id')
     def _check_groups(self):
         for view in self:
-            if (view.type == 'qweb' and
-                view.groups_id and
+            if (view.groups_id and
                 view.inherit_id and
                 view.mode != 'primary'):
-                raise ValidationError(_("Inherited Qweb view cannot have 'Groups' define on the record. Use 'groups' attributes inside the view definition"))
+                raise ValidationError(_("Inherited view cannot have 'Groups' define on the record. Use 'groups' attributes inside the view definition"))
 
     @api.constrains('inherit_id')
     def _check_000_inheritance(self):
@@ -629,8 +628,7 @@ actual arch.
                       AND ({where_clause})
             )
             SELECT
-                v.id, v.inherit_id, v.mode,
-                ARRAY(SELECT r.group_id FROM ir_ui_view_group_rel r WHERE r.view_id=v.id)
+                v.id, v.inherit_id, v.mode
             FROM ir_ui_view_inherits v
             ORDER BY v.priority, v.id
         """
@@ -644,11 +642,6 @@ actual arch.
 
         self.env.cr.execute(query, [tuple(self.ids)] + where_params + where_params)
         rows = self.env.cr.fetchall()
-
-        # filter out forbidden views
-        if any(row[3] for row in rows):
-            user_groups = set(self.env.user.groups_id.ids)
-            rows = [row for row in rows if not (row[3] and user_groups.isdisjoint(row[3]))]
 
         views = self.browse(row[0] for row in rows)
 

--- a/odoo/addons/base/tests/test_res_config.py
+++ b/odoo/addons/base/tests/test_res_config.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
+from lxml import etree
 import logging
 
 from odoo import exceptions, Command
@@ -155,7 +156,7 @@ class TestResConfigExecute(TransactionCase):
         # Check user has access to all models of relational fields in view
         # because the webclient makes a name_get request for all specified records
         # even if they are not shown to the user.
-        settings_view_arch = self.settings_view.with_user(user)._get_combined_arch()
+        settings_view_arch = etree.fromstring(settings.get_view(view_id=self.settings_view.id)['arch'])
         seen_fields = set()
         for node in settings_view_arch.iterdescendants(tag='field'):
             seen_fields.add(node.get('name'))

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -180,7 +180,7 @@
                             <field name="parent_id"
                                 widget="res_partner_many2one"
                                 placeholder="Company Name..."
-                                domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True}"
+                                domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
                                 attrs="{'invisible': ['|', '&amp;', ('is_company','=', True),('parent_id', '=', False),('company_name', '!=', False),('company_name', '!=', '')]}"/>
                                 <field name="company_name" attrs="{'invisible': ['|', '|', ('company_name', '=', False), ('company_name', '=', ''), ('is_company', '=', True)]}"/>
                                 <button name="create_company" icon="fa-plus-square" string="Create company"


### PR DESCRIPTION
The goal of this revision is to get rid of the `groups_id` field of the model `ir.ui.view`.

- This feature wasn't really known or used by most developers,
   and not straight-forward to understand.
   Removing it allows one less complicated thing to learn for developers.
   Besides, thanks to odoo/odoo#95729,
   changing the behavior of the `groups=` attribute, 
   we can easily get rid of this `groups_id` feature
   by simply adding `groups=` in the elements of the views
   using the `groups_id` field, it will have the same effect:
   adding the elements in the view only for the users part of the specified group.

- By getting rid of the groups_id many2many field on ir.ui.view,
   it makes possible to cache the view architecture without
   requiring to use the groups in the cache key.
   Currently, if we want to cache the view architecture,
  it would be required to use the intersection of the user
  groups with the groups_id groups of the view,
  making it costly to compute the cache key,
  therefore altering the performance point to cache the view
  architectures.

