### PR TITLE
Master UI division eres

### DIFF
--- a/addons/loyalty/__manifest__.py
+++ b/addons/loyalty/__manifest__.py
@@ -28,6 +28,7 @@
             'loyalty/static/src/js/loyalty_control_panel_widget.js',
             'loyalty/static/src/js/loyalty_list_view.js',
             'loyalty/static/src/scss/loyalty.scss',
+            'loyalty/static/src/js/filterable_selection_field/filterable_selection_field.js',
         ],
         'web.assets_qweb': [
             'loyalty/static/src/xml/loyalty_templates.xml',

--- a/addons/loyalty/static/src/js/filterable_selection_field/filterable_selection_field.js
+++ b/addons/loyalty/static/src/js/filterable_selection_field/filterable_selection_field.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { SelectionField } from "@web/views/fields/selection/selection_field";
+
+export class FilterableSelectionField extends SelectionField {
+    /**
+     * @override
+     */
+    get options() {
+        let options = super.options;
+        if (this.props.allowed_selection_values) {
+            options = options.filter((option) => {
+                return option[0] === this.props.value || this.props.allowed_selection_values.includes(option[0])
+            });
+        }
+        return options;
+    }
+};
+
+FilterableSelectionField.props = {
+    ...SelectionField.props,
+    allowed_selection_values: { type: Array, optional: true },
+};
+
+FilterableSelectionField.extractProps = ({ attrs }) => {
+    return {
+        ...SelectionField.extractProps({ attrs }),
+        allowed_selection_values: attrs.options.allowed_selection_values,
+    };
+};
+
+registry.category("fields").add("filterable_selection", FilterableSelectionField);

--- a/addons/loyalty/static/src/js/loyalty_list_view.js
+++ b/addons/loyalty/static/src/js/loyalty_list_view.js
@@ -16,6 +16,10 @@ export class LoyaltyActionHelper extends Component {
             this.loyaltyTemplateData = await this.orm.call(
                 "loyalty.program",
                 "get_program_templates",
+                [],
+                {
+                    context: this.env.model.root.context,
+                },
             );
         });
     }
@@ -36,7 +40,10 @@ LoyaltyActionHelper.template = "loyalty.LoyaltyActionHelper";
 
 export class LoyaltyListRenderer extends ListRenderer {};
 LoyaltyListRenderer.template = "loyalty.LoyaltyListRenderer";
-LoyaltyListRenderer.components.LoyaltyActionHelper = LoyaltyActionHelper;
+LoyaltyListRenderer.components = {
+    ...LoyaltyListRenderer.components,
+    LoyaltyActionHelper,
+};
 
 export const LoyaltyListView = {
     ...listView,

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="loyalty_program_view_form" model="ir.ui.view">
-        <field name="name">loyalty.program.view.form</field>
+
+<!-- DISCOUNT & LOYALTY -->
+    <record id="loyalty_program_discount_loyalty_view_form" model="ir.ui.view">
+        <field name="name">loyalty.program.discount.loyalty.view.form</field>
         <field name="model">loyalty.program</field>
         <field name="arch" type="xml">
-            <form string="Coupons &amp; Loyalty">
+            <form string="Discount &amp; Loyalty">
                 <header>
                     <button name="%(loyalty_generate_wizard_action)d" string="Generate Coupons" class="btn-primary" type="action"
                         attrs="{'invisible': [('program_type', '!=', 'coupons')]}"/>
-                    <button name="%(loyalty_generate_wizard_action)d" string="Generate Gift Cards" class="btn-primary" type="action"
-                        attrs="{'invisible': [('program_type', '!=', 'gift_card')]}"/>
-                    <button name="%(loyalty_generate_wizard_action)d" string="Generate eWallet" class="btn-primary" type="action"
-                        attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" context="{'default_mode': 'selected'}"/>
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -20,11 +18,10 @@
                                 <span class="o_stat_value">
                                     <field name="coupon_count"/>
                                 </span>
-                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'coupons')]}">Coupons</span>
-                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}">Gift Cards</span>
-                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}">eWallets</span>
+                                <span class="o_stat_text" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'coupons'), ('program_type', '!=', 'next_order_coupons')]}">Coupons</span>
                                 <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}">Loyalty Cards</span>
-                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'promotion')]}">Promos</span>
+                                <span class="o_stat_text" attrs="{'invisible': ['&amp;', ('program_type', '!=', 'promotion'), ('program_type', '!=', 'buy_two_get_one')]}">Promos</span>
+                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'promo_code')]}">Discount</span>
                             </div>
                         </button>
                     </div>
@@ -33,69 +30,83 @@
                     <div class="oe_title">
                         <label for="name" string="Program Name"/>
                         <h1>
-                            <field name="name" class="text-break" placeholder="e.g. 10% discount on laptops"/>
+                            <field name="name" placeholder="e.g. 10% discount on laptops"/>
                         </h1>
                     </div>
-                    <group>
-                        <group>
-                            <label for="program_type"/>
-                            <div>
-                                <field name="program_type" widget="selection"/>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'coupons')]}" colspan="2">
-                                    Generate &amp; share coupon code manually.
-                                    <br/>
-                                    Rewards are provided when the user provides a coupon code in the eCommerce, Point of Sale or regular orders.
-                                    <br/>
-                                    Add triggers for constraints on coupon usage.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}" colspan="2">
-                                    Once a sale order is validated, the customers get Loyalty Points that can be used in the current order, or accumulated in future orders.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}" colspan="2">
-                                    Gift Cards are created and sent by email when the customer orders a product defined in your triggers.
-                                    <br/>
-                                    Then, Gift Cards can be used to pay orders.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'promotion')]}" colspan="2">
-                                    Set up triggers based on a promotional code and/or products purchased, that give access to reward on the current order.
-                                </p>
-                                <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" colspan="2">
-                                    Personal eWallet are created when the customer orders a product defined in the triggers.
-                                    <br/>
-                                    Then, eWallets are proposed during the checkout, to pay orders.
-                                </p>
-                            </div>
-                            <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="currency_id"/>
-                            <field name="currency_symbol" invisible="1"/>
-                        </group>
-                        <group>
-                            <field name="date_to"/>
-                            <label for="limit_usage"/>
-                            <span>
-                                <field name="limit_usage" class="oe_inline"/>
-                                <span attrs="{'invisible': [('limit_usage', '=', False)]}"> to <field name="max_usage" class="oe_inline"/> usages</span>
-                            </span>
-                            <label for="portal_visible" string="Show points"/>
-                            <span>
-                                <field name="portal_visible" class="oe_inline"/>
-                                <span attrs="{'invisible': [('portal_visible', '=', False)]}"> as <field name="portal_point_name" class="oe_inline"/></span>
-                            </span>
-                            <field name="applies_on" widget="radio" groups="base.group_no_one"/>
-                            <field name="trigger" widget="radio" groups="base.group_no_one" attrs="{'invisible': [('applies_on', '!=', 'current')]}"/>
-                        </group>
-                    </group>
 
+                    <group col="2">
+                        <group col="1">
+                            <group col="1">
+                                <group>
+                                    <label for="program_type"/>
+                                    <div>
+                                        <field name="program_type" widget="selection" attrs="{'readonly': [('coupon_count', '!=', 0)]}"/>                                   
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'coupons')]}" colspan="2">
+                                            Generate &amp; share coupon codes manually. It can be used in eCommerce, Point of Sale or regular orders to claim the Reward. You can define constraints on its usage through conditional rule.
+                                            <div groups="base.group_no_one">
+                                                When generating coupon, you can define a specific points value that can be exchanged for rewards. 
+                                            </div>
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}" colspan="2">
+                                            When customers make an order, they accumulate points they can exchange for rewards on the current order or on a future one.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'promotion')]}" colspan="2">
+                                            Set up conditional rules on the order that will give access to rewards for customers                                            
+                                            <div groups="base.group_no_one">
+                                                Each rule can grant points to the customer he will be able to exchange against rewards
+                                            </div>
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'promo_code')]}" colspan="2">
+                                            Define Discount codes on conditional rules then share it with your customers for rewards.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'buy_two_get_one')]}" colspan="2">
+                                            Grant 1 credit for each item bought then reward the customer with Y items in exchange of X credits.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'next_order_coupons')]}" colspan="2">
+                                            Drive repeat purchases by sending a unique, single-use coupon code for the next purchase when a customer buys something in your store.
+                                        </p>
+                                    </div>
+                                </group>
+
+                                <group>
+                                    <field name="currency_id"/>
+                                    <field name="currency_symbol" invisible="1"/>
+                                </group>
+                            </group>
+                            <group>
+                                <field name="portal_point_name" attrs="{'invisible': [('program_type', '=', 'loyalty')]}" string="Points Unit" groups="base.group_no_one"/>
+                                <field name="portal_point_name" attrs="{'invisible': [('program_type', '!=', 'loyalty')]}" string="Points Unit"/>
+                                <field name="portal_visible" groups="base.group_no_one" string="Show points Unit"/>
+                                <field name="trigger" string="Program trigger" groups="base.group_no_one" widget="selection" readonly="1" force_save="1"/>                            
+                                <field name="applies_on" string="Use points on" groups="base.group_no_one" widget="radio" readonly="1" force_save="1"/>
+                            </group>
+                        </group>
+
+                        <group col="1">
+                            <group>
+                                <field name="date_to"/>
+                                <label for="limit_usage"/>
+                                <span>
+                                    <field name="limit_usage" class="oe_inline"/>
+                                    <span attrs="{'invisible': [('limit_usage', '=', False)]}"> to <field name="max_usage" class="oe_inline"/> usages</span>
+                                </span>
+                            </group>
+                            <group>
+                                <field name="company_id" groups="base.group_multi_company"/>
+                            </group>
+                        </group>  
+                    </group>
+                    
                     <notebook>
-                        <page string="Triggers &amp; Rewards" name="rules_rewards">
+                        <page string="Rules &amp; Rewards" name="rules_rewards">
                             <group>
                                 <group>
-                                    <field name="rule_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a trigger"
+                                    <field name="rule_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a rule"
                                         class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol}"/>
                                 </group>
                                 <group>
                                     <field name="reward_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a reward"
-                                        class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol}"/>
+                                      class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol}"/>
                                 </group>
                             </group>
                         </page>
@@ -108,41 +119,166 @@
         </field>
     </record>
 
-    <record id="loyalty_program_view_tree" model="ir.ui.view">
-        <field name="name">loyalty.program.view.tree</field>
+    <record id="loyalty_program_discount_loyalty_view_tree" model="ir.ui.view">
+        <field name="name">loyalty.program.discount.loyalty.view.tree</field>
         <field name="model">loyalty.program</field>
         <field name="arch" type="xml">
             <tree js_class="loyalty_program_list_view">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="program_type"/>
-                <field name="active"/>
+                <field name="concatenate_count" string="Items"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
     </record>
 
-    <record id="loyalty_program_view_search" model="ir.ui.view">
-        <field name="name">loyalty.program.view.search</field>
-        <field name="model">loyalty.program</field>
-        <field name="arch" type="xml">
-            <search>
-                <field name="name"/>
-                <separator/>
-                <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-            </search>
-        </field>
-    </record>
-
-    <record id="loyalty_program_action" model="ir.actions.act_window">
-        <field name="name">Promotions, Gift Card, Loyalty</field>
+    <record id="loyalty_program_discount_loyalty_action" model="ir.actions.act_window">
+        <field name="name">Discount &amp; Loyalty</field>
         <field name="res_model">loyalty.program</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'menu_type': 'discount_loyalty'}</field>
+        <field name="domain">['&amp;', ('program_type', '!=', 'gift_card'), ('program_type', '!=', 'ewallet')]</field>
         <field name="help" type="html">
             <div class="o_loyalty_not_found container">
                 <h1>No loyalty program found.</h1>
-                <p class="lead fw-light">Create a new one from scratch, or use one of the templates below.</p>
+                <p class="lead">Create a new one from scratch, or use one of the templates below.</p>
             </div>
         </field>
+    </record>
+
+    <record id="action_loyalty_program_tree1" model="ir.actions.act_window.view">
+        <field name="view_mode">tree</field>
+        <field name="sequence">1</field>
+        <field name="view_id" ref="loyalty_program_discount_loyalty_view_tree"/>
+        <field name="act_window_id" ref="loyalty_program_discount_loyalty_action"/>
+    </record>
+    
+    <record id="action_loyalty_program_form1" model="ir.actions.act_window.view">
+        <field name="view_mode">form</field>
+        <field name="sequence">2</field>
+        <field name="view_id" ref="loyalty_program_discount_loyalty_view_form"/>
+        <field name="act_window_id" ref="loyalty_program_discount_loyalty_action"/>
+    </record>
+
+<!-- GIFT & EWALLET -->
+    <record id="loyalty_program_gift_ewallet_view_form" model="ir.ui.view">
+        <field name="name">loyalty.program.gift.ewallet.view.form</field>
+        <field name="model">loyalty.program</field>
+        <field name="arch" type="xml">
+            <form string="Gift Card &amp; eWallet">
+                <header>
+                    <button name="%(loyalty_generate_wizard_action)d" string="Generate Gift Cards" class="btn-primary" type="action"
+                        attrs="{'invisible': [('program_type', '!=', 'gift_card')]}"/>
+                    <button name="%(loyalty_generate_wizard_action)d" string="Generate eWallet" class="btn-primary" type="action"
+                        attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" context="{'default_mode': 'selected'}"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="action" name="%(loyalty_card_action)d" icon="fa-tags">
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_value">
+                                    <field name="coupon_count"/>
+                                </span>
+                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}">Gift Cards</span>
+                                <span class="o_stat_text" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}">eWallets</span>
+                            </div>
+                        </button>
+                    </div>
+                    <field name="active" invisible="1"/>
+                    <div class="oe_title">
+                        <label for="name" string="Program Name"/>
+                        <h1>
+                            <field name="name" placeholder="e.g. 10% discount on laptops"/>
+                        </h1>
+                    </div>
+
+                    <group col="2">
+                        <group col="1">
+                            <group col="1">
+                                <group>
+                                    <label for="program_type"/>
+                                    <div>
+                                        <field name="program_type" widget="selection" attrs="{'readonly': [('coupon_count', '!=', 0)]}"/>                                   
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}" colspan="2">
+                                            Gift Cards are created manually or automatically sent by email when the customer orders a gift card product.
+                                            <br/>
+                                            Then, Gift Cards can be used to pay orders.
+                                        </p>
+                                        <p class="text-muted" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}" colspan="2">
+                                            eWallets are created manually or automatically when the customer orders a eWallet product.
+                                            <br/>
+                                            Then, eWallets are proposed during the checkout, to pay orders.
+                                        </p>
+                                    </div>
+                                </group>
+
+                                <group>
+                                    <field name="currency_id"/>
+                                    <field name="currency_symbol" invisible="1"/>
+                                </group>
+
+                                <group colspan="2" col="1">
+                                    <field name="mail_template_id" widget="many2one_tags"/>
+                                    <field name="product_gift" string="Gift Card Products" widget="many2many_tags" attrs="{'invisible': [('program_type', '!=', 'gift_card')]}"/>
+                                    <field name="product_gift" string="eWallet Products" widget="many2many_tags" attrs="{'invisible': [('program_type', '!=', 'ewallet')]}"/>
+                                </group>
+                            </group>
+                        </group>
+
+                        <group col="1">
+                            <group>
+                                <field name="currency_symbol" string="Displayed as" groups="base.group_no_one"/>
+                            </group>
+                            <group>
+                                <field name="company_id" groups="base.group_multi_company"/>
+                            </group>
+                        </group>  
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="loyalty_program_gift_ewallet_view_tree" model="ir.ui.view">
+        <field name="name">loyalty.program.gift.ewallet.view.tree</field>
+        <field name="model">loyalty.program</field>
+        <field name="arch" type="xml">
+            <tree js_class="loyalty_program_list_view">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="program_type"/>
+                <field name="concatenate_count" string="Items"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+            </tree>
+        </field>
+    </record> 
+
+    <record id="loyalty_program_gift_ewallet_action" model="ir.actions.act_window">
+        <field name="name">Gift cards &amp; eWallet</field>
+        <field name="res_model">loyalty.program</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'menu_type': 'gift_ewallet'}</field>
+        <field name="domain">['|',('program_type', '=', 'gift_card'),('program_type', '=', 'ewallet')]</field>
+        <field name="help" type="html">
+            <div class="o_loyalty_not_found container">
+                <h1>No loyalty program found.</h1>
+                <p class="lead">Create a new one from scratch, or use one of the templates below.</p>
+            </div>
+        </field>
+    </record>
+
+    <record id="action_loyalty_program_tree2" model="ir.actions.act_window.view">
+        <field name="view_mode">tree</field>
+        <field name="sequence">1</field>
+        <field name="view_id" ref="loyalty_program_gift_ewallet_view_tree"/>
+        <field name="act_window_id" ref="loyalty_program_gift_ewallet_action"/>
+    </record>
+
+    <record id="action_loyalty_program_form2" model="ir.actions.act_window.view">
+        <field name="view_mode">form</field>
+        <field name="sequence">2</field>
+        <field name="view_id" ref="loyalty_program_gift_ewallet_view_form"/>
+        <field name="act_window_id" ref="loyalty_program_gift_ewallet_action"/>
     </record>
 </odoo>

--- a/addons/pos_loyalty/views/pos_loyalty_menu_views.xml
+++ b/addons/pos_loyalty/views/pos_loyalty_menu_views.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <menuitem
-        id="menu_coupon_type_config"
-        action="loyalty.loyalty_program_action"
-        name="Coupons &amp; Loyalty"
+        id="menu_discount_loyalty_type_config"
+        action="loyalty.loyalty_program_discount_loyalty_action"
+        name="Discount &amp; Loyalty"
         parent="point_of_sale.pos_config_menu_catalog"
         groups="point_of_sale.group_pos_manager"
         sequence="91"
+    />
+
+    <menuitem
+        id="menu_gift_ewallet_type_config"
+        action="loyalty.loyalty_program_gift_ewallet_action"
+        name="Gift cards &amp; eWallet"
+        parent="point_of_sale.pos_config_menu_catalog"
+        groups="point_of_sale.group_pos_manager"
+        sequence="92"
     />
 </odoo>

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -103,14 +103,14 @@
                        </div>
                         <div class="col-12 col-lg-6 o_setting_box"
                             id="coupon_settings"
-                            title="Boost your sales with two kinds of discount programs: promotions and coupon codes. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products.">
+                            title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products.">
                             <div class="o_setting_left_pane">
                                 <field name="module_sale_loyalty"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <label for="module_sale_loyalty"/>
+                                <label for="module_sale_loyalty" string="Discounts, Loyalty &amp; Gift Card"/>
                                 <div class="text-muted" id="sale_coupon">
-                                    Manage promotion &amp; coupon programs
+                                    Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet
                                 </div>
                             </div>
                         </div>

--- a/addons/sale_loyalty/views/loyalty_program_views.xml
+++ b/addons/sale_loyalty/views/loyalty_program_views.xml
@@ -1,11 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <menuitem
-        id="menu_loyalty_config"
-        action="loyalty.loyalty_program_action"
+        id="menu_discount_loyalty_type_config"
+        action="loyalty.loyalty_program_discount_loyalty_action"
+        name="Discount &amp; Loyalty"
         parent="sale.product_menu_catalog"
-        name="Coupons &amp; Loyalty"
         groups="sales_team.group_sale_manager"
         sequence="5"
     />
+
+    <menuitem
+        id="menu_gift_ewallet_type_config"
+        action="loyalty.loyalty_program_gift_ewallet_action"
+        name="Gift cards &amp; eWallet"
+        parent="sale.product_menu_catalog"
+        groups="sales_team.group_sale_manager"
+        sequence="6"
+    />
+<!-- 
+    <record id="loyalty_program_discount_loyalty_view_tree_inherit_sale_loyalty" model="ir.ui.view">
+        <field name="name">loyalty.program.discount.loyalty.view.tree.inherit.sale.loyalty</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.loyalty_program_discount_loyalty_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <button name="action_program_share" string="Share" type="object" icon="fa-share-alt"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="loyalty_program_gift_ewallet_view_tree_inherit_sale_loyalty" model="ir.ui.view">
+        <field name="name">loyalty.program.gift.ewallet.view.tree.inherit.sale.loyalty</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.loyalty_program_gift_ewallet_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <button name="action_program_share" string="Share" type="object" icon="fa-share-alt"/>
+            </field>
+        </field>
+    </record> -->
 </odoo>

--- a/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
+++ b/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
@@ -33,7 +33,7 @@
                     <!-- No rewards -->
                     <button special="cancel" string="Discard" class="btn btn-primary"
                         attrs="{'invisible': [('reward_ids', '!=', [])]}" data-hotkey="z"/>
-                    <button type="action" name="%(loyalty.loyalty_program_action)d" string="Coupons &amp; Loyalty" class="btn btn-secondary float-end"
+                    <button type="action" name="%(loyalty.loyalty_program_discount_loyalty_action)d" string="Coupons &amp; Loyalty" class="btn btn-secondary float-end"
                         attrs="{'invisible': [('reward_ids', '!=', [])]}" groups="sales_team.group_sale_manager" data-hotkey="q"/>
                 </footer>
             </form>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -187,9 +187,9 @@
                             <field name="module_sale_loyalty" />
                         </div>
                         <div class="o_setting_right_pane">
-                            <label for="module_sale_loyalty" string="Promotions, Coupons, Gift Card &amp; Loyalty Program"/>
+                            <label for="module_sale_loyalty" string="Discounts, Loyalty &amp; Gift Card"/>
                             <div class="text-muted" id="website_sale_loyalty">
-                                Manage promotion that will grant customers discounts or gifts
+                                Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet
                             </div>
                         </div>
                     </div>

--- a/addons/website_sale_loyalty/views/loyalty_program_views.xml
+++ b/addons/website_sale_loyalty/views/loyalty_program_views.xml
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <menuitem
-        id="menu_promotion_type_config"
-        action="loyalty.loyalty_program_action"
-        name="Coupons &amp; Loyalty"
+        id="menu_discount_loyalty_type_config"
+        action="loyalty.loyalty_program_discount_loyalty_action"
+        name="Discount &amp; Loyalty"
         parent="website_sale.menu_catalog"
         groups="sales_team.group_sale_manager"
         sequence="50"
     />
 
-    <record id="loyalty_program_view_form_inherit_website_sale_loyalty" model="ir.ui.view">
-        <field name="name">loyalty.program.view.form.inherit.website.sale.loyalty</field>
+    <menuitem
+        id="menu_gift_ewallet_type_config"
+        action="loyalty.loyalty_program_gift_ewallet_action"
+        name="Gift cards &amp; eWallet"
+        parent="website_sale.menu_catalog"
+        groups="sales_team.group_sale_manager"
+        sequence="51"
+    />
+
+    <record id="loyalty_program_discount_loyalty_view_form_inherit_website_sale_loyalty" model="ir.ui.view">
+        <field name="name">loyalty.program.discount.loyalty.view.form.inherit.website.sale.loyalty</field>
         <field name="model">loyalty.program</field>
-        <field name="inherit_id" ref="loyalty.loyalty_program_view_form"/>
+        <field name="inherit_id" ref="loyalty.loyalty_program_discount_loyalty_view_form"/>
         <field name="arch" type="xml">
             <field name="currency_id" position="after">
                 <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
@@ -20,13 +29,40 @@
         </field>
     </record>
 
-    <record id="loyalty_program_view_tree_inherit_website_sale_loyalty" model="ir.ui.view">
-        <field name="name">loyalty.program.view.tree.inherit.website.sale.loyalty</field>
+    <record id="loyalty_program_gift_ewallet_view_form_inherit_website_sale_loyalty" model="ir.ui.view">
+        <field name="name">loyalty.program.gift.ewallet.view.form.inherit.website.sale.loyalty</field>
         <field name="model">loyalty.program</field>
-        <field name="inherit_id" ref="loyalty.loyalty_program_view_tree"/>
+        <field name="inherit_id" ref="loyalty.loyalty_program_gift_ewallet_view_form"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <field name="currency_id" position="after">
+                <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="loyalty_program_discount_loyalty_view_tree_inherit_website_sale_loyalty" model="ir.ui.view">
+        <field name="name">loyalty.program.discount.loyalty.view.tree.inherit.website.sale.loyalty</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.loyalty_program_discount_loyalty_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="concatenate_count" position="after">
                 <field name="website_id" groups="website.group_multi_website"/>
+            </field>
+            <field name="company_id" position="after">
+                <button name="action_program_share" string="Share" type="object" icon="fa-share-alt" attrs="{ 'invisible' : [('program_type', '=', 'coupons')]}"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="loyalty_program_gift_ewallet_view_tree_inherit_website_sale_loyalty" model="ir.ui.view">
+        <field name="name">loyalty.program.gift.ewallet.view.tree.inherit.website.sale.loyalty</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.loyalty_program_gift_ewallet_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="concatenate_count" position="after">
+                <field name="website_id" groups="website.group_multi_website"/>
+            </field>
+            <field name="company_id" position="after">
                 <button name="action_program_share" string="Share" type="object" icon="fa-share-alt"/>
             </field>
         </field>

--- a/addons/website_sale_loyalty/views/res_config_settings_views.xml
+++ b/addons/website_sale_loyalty/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//div[@id='website_sale_loyalty']" position="after">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_sale_loyalty', '=', False)]}">
-                        <button name="%(loyalty.loyalty_program_action)d" icon="fa-arrow-right" type="action" string="Loyalty Programs" class="btn-link"/>
+                        <button name="%(loyalty.loyalty_program_discount_loyalty_action)d" icon="fa-arrow-right" type="action" string="Loyalty Programs" class="btn-link"/>
                     </div>
                 </div>
             </xpath>

--- a/addons/website_sale_loyalty/wizard/sale_coupon_share.py
+++ b/addons/website_sale_loyalty/wizard/sale_coupon_share.py
@@ -85,7 +85,7 @@ class SaleCouponShare(models.TransientModel):
             raise UserError(_("Provide either a coupon or a program."))
 
         return {
-            'name': _('Share Coupon'),
+            'name': _('Share') + ' %s' % (program and dict(program._fields['program_type'].selection).get(program.program_type) or dict(coupon._fields['program_type'].selection).get(coupon.program_type)),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'coupon.share',

--- a/addons/website_sale_loyalty/wizard/sale_coupon_share_views.xml
+++ b/addons/website_sale_loyalty/wizard/sale_coupon_share_views.xml
@@ -14,13 +14,14 @@
                             It will be applied at checkout when the customer uses this link.
                         </p>
                     </div>
-                    <field name="share_link" widget="CopyClipboardURL" nolabel="1"/>
                 </group>
-                <hr attrs="{'invisible': ['|', ('website_id', '=', False), ('id', '!=', False)]}"/>
                 <group attrs="{'invisible': [('id', '!=', False)]}">
+                    <group>
                     <field name="website_id" groups="website.group_multi_website" widget="selection"
                            attrs="{'invisible': [('program_website_id', '!=', False)]}"/>
                     <field name="redirect"/>
+                    <field name="share_link" widget="CopyClipboardURL"/>
+                    </group>
                 </group>
                 <footer>
                     <button string="Done" class="btn-primary" special="cancel" data-hotkey="z"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Since the V15.3, we centralized Gift Cards & eWallet with all the discounts programs. Unfortunately, It has led to a very confusing form view for gift cards (and eWallet) that should be more simple to create. It is also confusing to find Gift Cards & eWallet program alongside coupon, promotions & loyalty cards. 

Current behavior before PR:
One menu for every type of program. No homogeneity between the modules (pos, website and sale).

Desired behavior after PR is merged:
In order to improve the UX we would like to :

create 2 menu items
one for "Discounts & Loyalty"         
program types: promotions, coupons, Loyalty program 
One for  "Gift Cards & eWallet"
program types: Gift Cards, eWallet
With a very simplified Form view.
With an adapted "generate modal" 
automatically update the "point units" label when changing the currency
Change the order of columns in the list view for "loyalty.program" model (see mockUp)
make sure to put the "share" only for types that support it
Make sure to display the sharable link when opening the modal or force the selection of the website
Put the link underother properties with a placeholder when no link is generated (because no website selected)
remove "coupon" from modal title.
Add a new column "Usage" in the  list view for "loyalty.program" model

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
