### PR TITLE
[FIX] website_sale: keep "sorting by" on searching by attributes

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -282,6 +282,7 @@ class WebsiteSale(http.Controller):
 
         values = {
             'search': search,
+            'order': post.get('order', ''),
             'category': category,
             'attrib_values': attrib_values,
             'attrib_set': attrib_set,

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -413,6 +413,7 @@
                 <form class="js_attributes mb-2" method="get">
                     <input t-if="category" type="hidden" name="category" t-att-value="category.id" />
                     <input type="hidden" name="search" t-att-value="search" />
+                    <input type="hidden" name="order" t-att-value="order"/>
                     <ul class="nav nav-pills flex-column">
                         <t t-foreach="attributes" t-as="a">
                             <li t-if="a.value_ids and len(a.value_ids) &gt; 1" class="nav-item">


### PR DESCRIPTION
Searching by attributes works via a separate form. It has a copy of other search
parameters (`category`, `search`), but not `order`.

STEPS

1) enable View "Products Attribute's Filters" in eCommerce
2) enable View "Show Sort by" in eCommerce
3) Set sorting to specific value
4) Change Product Filters Attribute values
5) as you can see, the sorting set in Pt3 is lost....

opw-2956280

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
