### PR TITLE
[FIX] project,web: 'bg-muted' doesn't exist anymore

### DIFF
--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -46,7 +46,7 @@
                 <field name="legend_done" invisible="1"/>
                 <field name="allow_milestones" />
                 <field name="has_late_and_unreached_milestone"/>
-                <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger", "normal": "muted"}'/>
+                <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger", "normal": "200"}'/>
                 <templates>
                 <t t-name="kanban-box">
                     <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1409,7 +1409,7 @@
                     <field name="rating_active"/>
                     <field name="has_late_and_unreached_milestone" />
                     <field name="allow_milestones" />
-                    <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger", "normal": "muted"}'/>
+                    <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger", "normal": "200"}'/>
                     <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -10419,7 +10419,9 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(getCardTexts()[0], "yop\nTOGGLER\nMENU");
     });
 
-    QUnit.test("'muted' already in progress bar colors", async (assert) => {
+    QUnit.test(
+        "Color '200' (gray) can be used twice (for false value and another value) in progress bar",
+        async (assert) => {
         serverData.models.partner.records.push({ id: 5, bar: true }, { id: 6, bar: false });
         await makeView({
             type: "kanban",
@@ -10429,7 +10431,7 @@ QUnit.module("Views", (hooks) => {
                 <kanban>
                     <field name="bar"/>
                     <field name="foo"/>
-                    <progressbar field="foo" colors='{"yop": "muted", "gnap": "warning", "blip": "danger"}'/>
+                    <progressbar field="foo" colors='{"yop": "200", "gnap": "warning", "blip": "danger"}'/>
                     <templates>
                         <t t-name="kanban-box">
                             <div>

--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -16,7 +16,7 @@ class TestReadProgressBar(common.TransactionCase):
         progressbar = {
             'field': 'type',
             'colors': {
-                'contact': 'success', 'private': 'danger', 'other': 'muted',
+                'contact': 'success', 'private': 'danger', 'other': '200',
             }
         }
         result = self.env['res.partner'].read_progress_bar([], 'category_id', progressbar)


### PR DESCRIPTION
`bg-muted` as been replaced by `bg-200` in odoo/odoo#97051, but there
are still non-converted ones.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
