### PR TITLE
[IMP] core: warn about compute methods mixing stored and non-stored fields

### DIFF
--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -39,7 +39,6 @@ class ResConfigSettings(models.TransientModel):
     module_pos_preparation_display = fields.Boolean(string="Preparation Display", help="Show orders on the preparation display screen.")
     update_stock_quantities = fields.Selection(related="company_id.point_of_sale_update_stock_quantities", readonly=False)
     account_default_pos_receivable_account_id = fields.Many2one(string='Default Account Receivable (PoS)', related='company_id.account_default_pos_receivable_account_id', readonly=False)
-    is_default_pricelist_displayed = fields.Boolean(compute="_compute_pos_pricelist_id", compute_sudo=True)
     barcode_nomenclature_id = fields.Many2one('barcode.nomenclature', related='company_id.nomenclature_id', readonly=False)
     is_kiosk_mode = fields.Boolean(string="Is Kiosk Mode", default=False)
 
@@ -272,9 +271,6 @@ class ResConfigSettings(models.TransientModel):
                 else:
                     res_config.pos_available_pricelist_ids = res_config.pos_config_id.available_pricelist_ids
                     res_config.pos_pricelist_id = res_config.pos_config_id.pricelist_id
-
-            # TODO: Remove this field in master because it's always True.
-            res_config.is_default_pricelist_displayed = True
 
     @api.depends('pos_available_pricelist_ids', 'pos_use_pricelist')
     def _compute_pos_allowed_pricelist_ids(self):

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -15,7 +15,6 @@
                     <field name="pos_cash_control" invisible="1"/>
                     <field name="pos_iface_print_via_proxy" invisible="1"/>
                     <field name="pos_company_has_template" invisible="1"/>
-                    <field name="is_default_pricelist_displayed" invisible="1"/>
                     <field name="group_cash_rounding" invisible="1"/>
                 </t>
 
@@ -213,7 +212,7 @@
                                         <label string="Available" for="pos_available_pricelist_ids" class="col-lg-3 o_light_label"/>
                                         <field name="pos_available_pricelist_ids" widget="many2many_tags" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]" readonly="pos_has_active_session"/>
                                     </div>
-                                    <div class="row mt16" invisible="not is_default_pricelist_displayed">
+                                    <div class="row mt16">
                                         <label string="Default" for="pos_pricelist_id" class="col-lg-3 o_light_label"/>
                                         <field name="pos_pricelist_id" domain="[('id', 'in', pos_allowed_pricelist_ids)]" options="{'no_create': True}"/>
                                     </div>

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -4468,7 +4468,7 @@ class TestPrecomputeModel(common.TransactionCase):
         # see what happens if not both are precompute
         self.addCleanup(self.registry.reset_changes)
         self.patch(Model.upper, 'precompute', False)
-        with self.assertLogs('odoo.modules.registry', level='WARNING'):
+        with self.assertWarns(UserWarning):
             self.registry.setup_models(self.cr)
             self.registry.field_computed
 


### PR DESCRIPTION
We explicitly discourage a compute method used for both stored and non-stored fields, because it may be unexpectedly update the database. Indeed, we don't expect the computation of a non-stored field to update the database.  Allowing this kind of compute method makes reasoning about readonly code much more difficult, and would prevent readonly transactions with such fields.
    
For instance, consider a compute method for both fields F (non-stored) and G (stored), and assume that none of those fields are in cache. Whenever F is accessed, the compute method is invoked, and both fields are assigned, which potentially generates an SQL update for field G. This is problematic if we require the current transaction to be readonly.