### PR TITLE
[FIX] web: fix clickbot click timeout inconsistency

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -337,10 +337,6 @@
         if (BLACKLISTED_MENUS.includes(element.dataset.menuXmlid)) {
             return Promise.resolve(); // Skip black listed menus
         }
-        let menuTimeLimit = 10000;
-        if (element.innerText.trim() === "Settings") {
-            menuTimeLimit = 20000;
-        }
         const startActionCount = actionCount;
         await triggerClick(element, `menu item "${element.innerText.trim()}"`);
         let isModal = false;
@@ -359,7 +355,7 @@
                 return true;
             }
             return startActionCount !== actionCount;
-        }, menuTimeLimit)
+        })
             .then(() => {
                 if (!isModal) {
                     return testFilters();

--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -14,7 +14,7 @@ class TestMenusAdmin(odoo.tests.HttpCase):
         for app_id in menus['root']['children']:
             with self.subTest(app=menus[app_id]['name']):
                 _logger.runbot('Testing %s', menus[app_id]['name'])
-                self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % menus[app_id]['xmlid'], "odoo.isReady === true", login="admin", timeout=300)
+                self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % menus[app_id]['xmlid'], "odoo.isReady === true", login="admin", timeout=600)
                 self.terminate_browser()
 
 
@@ -27,7 +27,7 @@ class TestMenusDemo(odoo.tests.HttpCase):
         for app_id in menus['root']['children']:
             with self.subTest(app=menus[app_id]['name']):
                 _logger.runbot('Testing %s', menus[app_id]['name'])
-                self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % menus[app_id]['xmlid'], "odoo.isReady === true", login="demo", timeout=300)
+                self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % menus[app_id]['xmlid'], "odoo.isReady === true", login="demo", timeout=600)
                 self.terminate_browser()
 
 @odoo.tests.tagged('post_install', '-at_install')


### PR DESCRIPTION
The clickbot click default timeout was increased in #98495, but missed
the fact that the default was overridden for the "Settings" menu to a
lower value.

With this commit, the "Settings" exception is completely removed as the
default timeout is higher. Also, checking that the text contains
"Settings" was a bit weak.

While at it, the timeout for the global testing of an app is also
increased to 10 minutes instead of 5 as this limit is reached by the
Field Service app.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
