### PR TITLE
Fixes for the daterange field

### DIFF
--- a/addons/web/static/src/core/datepicker/datepicker.js
+++ b/addons/web/static/src/core/datepicker/datepicker.js
@@ -4,6 +4,7 @@ import {
     areDateEquals,
     formatDate,
     formatDateTime,
+    luxonToMomentFormat,
     parseDate,
     parseDateTime,
 } from "@web/core/l10n/dates";
@@ -31,14 +32,6 @@ let datePickerId = 0;
  */
 function luxonDateToMomentDate(date) {
     return window.moment(String(date));
-}
-
-/**
- * @param {string} format
- * @returns {string}
- */
-function luxonFormatToMomentFormat(format) {
-    return format.replace(/[dy]/g, (x) => x.toUpperCase());
 }
 
 /**
@@ -198,7 +191,7 @@ export class DatePicker extends Component {
             const params = {
                 ...commandOrParams,
                 date: this.date || null,
-                format: luxonFormatToMomentFormat(format),
+                format: luxonToMomentFormat(format),
                 locale: commandOrParams.locale || (this.date && this.date.locale),
             };
             for (const prop in params) {

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -44,6 +44,14 @@ const normalizeFormatTable = {
     X: "HH:mm:ss",
 };
 
+const luxonToMomentFormatTable = {
+    c: "d",
+    d: "D",
+    o: "DDDD",
+    a: "A",
+    y: "Y",
+};
+
 const smartDateUnits = {
     d: "days",
     m: "months",
@@ -141,6 +149,19 @@ export const strftimeToLuxonFormat = memoize(function strftimeToLuxonFormat(valu
         inToken = false;
     }
     return output.join("");
+});
+
+/**
+ * Converts a Luxon format to a moment.js format.
+ * NB: this is not a complete conversion, only the supported tokens are converted.
+ *
+ * @param {string} value original format
+ * @returns {string} valid moment.js format
+ */
+export const luxonToMomentFormat = memoize(function luxonToMomentFormat(format) {
+    return format.replace(alphaRegex, (match) => {
+        return luxonToMomentFormatTable[match] || match;
+    });
 });
 
 // -----------------------------------------------------------------------------

--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -22,6 +22,8 @@ export class DateRangeField extends Component {
         useEffect(
             (el) => {
                 if (el) {
+                    const start = this.formattedStartDate;
+                    const end = this.formattedEndDate;
                     window.$(el).daterangepicker({
                         timePicker: this.isDateTime,
                         timePicker24Hour: true,
@@ -34,8 +36,8 @@ export class DateRangeField extends Component {
                                 ? localization.dateTimeFormat
                                 : localization.dateFormat,
                         },
-                        startDate: window.moment(this.formattedStartDate),
-                        endDate: window.moment(this.formattedEndDate),
+                        startDate: start ? window.moment(start) : window.moment(),
+                        endDate: end ? window.moment(end) : window.moment(),
                     });
                     this.pickerContainer = window.$(el).data("daterangepicker").container[0];
 
@@ -122,8 +124,8 @@ export class DateRangeField extends Component {
     }
 
     async onPickerApply(ev, picker) {
-        let start = this.isDateTime ? picker.startDate : picker.startDate.startOf("day");
-        let end = this.isDateTime ? picker.endDate : picker.endDate.startOf("day");
+        const start = this.isDateTime ? picker.startDate : picker.startDate.startOf("day");
+        const end = this.isDateTime ? picker.endDate : picker.endDate.startOf("day");
         const format = this.isDateTime ? localization.dateTimeFormat : localization.dateFormat;
         const parser = parsers.get(this.props.formatType);
         const dates = [start, end].map((date) => {

--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -3,6 +3,7 @@
 import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { loadJS } from "@web/core/assets";
+import { luxonToMomentFormat } from "@web/core/l10n/dates";
 import { useService } from "@web/core/utils/hooks";
 import { standardFieldProps } from "../standard_field_props";
 
@@ -16,6 +17,9 @@ export class DateRangeField extends Component {
         this.root = useRef("root");
         this.isPickerShown = false;
         this.pickerContainer;
+        this.momentFormat = luxonToMomentFormat(
+            this.isDateTime ? localization.dateTimeFormat : localization.dateFormat
+        );
 
         useExternalListener(window, "scroll", this.onWindowScroll, { capture: true });
         onWillStart(() => loadJS("/web/static/lib/daterangepicker/daterangepicker.js"));
@@ -32,9 +36,6 @@ export class DateRangeField extends Component {
                         locale: {
                             applyLabel: this.env._t("Apply"),
                             cancelLabel: this.env._t("Cancel"),
-                            format: this.isDateTime
-                                ? localization.dateTimeFormat
-                                : localization.dateFormat,
                         },
                         startDate: start ? window.moment(start) : window.moment(),
                         endDate: end ? window.moment(end) : window.moment(),
@@ -126,10 +127,9 @@ export class DateRangeField extends Component {
     async onPickerApply(ev, picker) {
         const start = this.isDateTime ? picker.startDate : picker.startDate.startOf("day");
         const end = this.isDateTime ? picker.endDate : picker.endDate.startOf("day");
-        const format = this.isDateTime ? localization.dateTimeFormat : localization.dateFormat;
         const parser = parsers.get(this.props.formatType);
         const dates = [start, end].map((date) => {
-            return parser(date.format(format.toUpperCase()), {
+            return parser(date.format(this.momentFormat), {
                 timezone: this.isDateTime,
             });
         });

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -191,6 +191,27 @@ QUnit.module("Fields", (hooks) => {
                 "30",
                 "active end date minute should be '30' in date range picker"
             );
+
+            // Select a new range and check that inputs are updated
+            await triggerEvent(datepicker, ".start-date", "mousedown"); // 02/08/2017
+            await triggerEvent(datepicker, ".start-date + .available", "mousedown"); // 02/09/2017
+            await click(datepicker, ".applyBtn");
+            assert.equal(
+                target.querySelector("[name=datetime] input").value,
+                "02/08/2017 15:30:00"
+            );
+            assert.equal(
+                target.querySelector("[name=datetime_end] input").value,
+                "02/09/2017 05:30:00"
+            );
+
+            // Save
+            await click(target, ".o_form_button_save");
+            fields = target.querySelectorAll(".o_field_daterange");
+
+            // Check date after save
+            assert.strictEqual(fields[0].textContent, "02/08/2017 15:30:00");
+            assert.strictEqual(fields[fields.length - 1].textContent, "02/09/2017 05:30:00");
         }
     );
 

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -4,6 +4,7 @@ import {
     click,
     editInput,
     getFixture,
+    patchDate,
     patchTimeZone,
     triggerEvent,
     triggerScroll,
@@ -501,6 +502,53 @@ QUnit.module("Fields", (hooks) => {
             assert.hasClass(target.querySelector(".o_notification"), "border-danger");
         }
     );
+
+    QUnit.test("Render with initial empty value: date field", async function (assert) {
+        // 2014-08-14 12:34:56 -> the day E. Zuckerman, who invented pop-up ads, has apologised.
+        patchDate(2014, 7, 14, 12, 34, 56);
+        serverData.models.partner.fields.date_end = { string: "Date End", type: "date" };
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="date" widget="daterange" options="{'related_end_date': 'date_end'}"/>
+                    <field name="date_end" widget="daterange" options="{'related_start_date': 'date'}"/>
+                </form>`,
+        });
+
+        await click(document.body, ".o_field_daterange[name=date] input");
+        assert.containsN(document.body, ".month", 2);
+        assert.equal(document.body.querySelectorAll(".month")[0].textContent, "Aug 2014");
+        assert.equal(document.body.querySelectorAll(".month")[1].textContent, "Sep 2014");
+    });
+
+    QUnit.test("Render with initial empty value: datetime field", async function (assert) {
+        // 2014-08-14 12:34:56 -> the day E. Zuckerman, who invented pop-up ads, has apologised.
+        patchDate(2014, 7, 14, 12, 34, 56);
+        serverData.models.partner.fields.datetime_end = {
+            string: "Datetime End",
+            type: "datetime",
+        };
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="datetime" widget="daterange" options="{'related_end_date': 'datetime_end'}"/>
+                    <field name="datetime_end" widget="daterange" options="{'related_start_date': 'datetime'}"/>
+                </form>`,
+        });
+
+        await click(document.body, ".o_field_daterange[name=datetime] input");
+        assert.containsN(document.body, ".month", 2);
+        assert.equal(document.body.querySelectorAll(".month")[0].textContent, "Aug 2014");
+        assert.equal(document.body.querySelectorAll(".month")[1].textContent, "Sep 2014");
+    });
 
     QUnit.test("Datetime field with option format type is 'date'", async function (assert) {
         serverData.models.partner.fields.datetime_end = {


### PR DESCRIPTION
>  [FIX] web: make daterange field work with empty initial value
> 
> - Before this commit
> Using a daterange field with an empty start/end date(time) will result in an unusable field.
> The datepickers shown are set with invalid moment.js objects.
> 
> - Explanation
> A formatted empty value yields an empty string.
> Calling `moment("")` results in an invalid moment objet.
> 
> - After this commit
> When the formatted empty value yields to a falsy value (i.e. an empty string), we call the global moment function without arguments.
> Calling `moment()` results in a valid moment object representing the current date and time.
> This is what we are looking for, and thus our issue is resolved.


> [FIX] web: use right datetime format in daterange field
> 
> - First issue
> The format passed to the daterangepicker locale options could have been
> wrong as the daterangepicker lib uses moment and we would pass to it
> the date(time) format expressed with luxon's format tokens.
> Furthermore, there was no need to pass the format to the daterangepicker
> library as the DateRangeField component already handles this.
> 
> - Second issue
> There was also another issue with the DateRangeField component:
> When applying the daterangepicker values, the conversion between a
> moment object to a luxon DateTime object was wrong because of the format
> used to convert the moment object to a string.
> 
> - Explanation
> The format tokens are different between luxon and moment.
> 
> - After this commit
> An helper function has been introduced in order to transform a luxon format into a moment format.
> The DateRangeField component now properly converts a moment object to
> a luxon's DateTime object when applying the daterangepicker selection.
> 
> - Additional note
> Also, the DatePicker component was locally converting the luxon's
> datetime format and thus has been adapted to use the new helper.