### PR TITLE
[FIX] project: fix the tag groupby result

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2429,6 +2429,12 @@ class ProjectTags(models.Model):
         return AND([domain, [('id', 'in', tag_ids)]])
 
     @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        if 'project_id' in self.env.context:
+            domain = self._get_project_tags_domain(domain, self.env.context.get('project_id'))
+        return super().read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
+
+    @api.model
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
         if 'project_id' in self.env.context:
             domain = self._get_project_tags_domain(domain, self.env.context.get('project_id'))


### PR DESCRIPTION
Before this commit, when we go to a Task. Click on the Tags field > Search More. Group by Projects.
We get a list of project groups. Click on them and they go from (x) to (0) due to invalid group result from read_group without valid domain same as search_read.

So in this commit, override the read_group method to pass the valid domain same as search_read.

task-2959382
