### PR TITLE
[IMP] mail, im_livechat: remove thread local id usage from tests

### DIFF
--- a/addons/im_livechat/static/src/legacy/widgets/public_livechat_window/public_livechat_window.xml
+++ b/addons/im_livechat/static/src/legacy/widgets/public_livechat_window/public_livechat_window.xml
@@ -4,7 +4,10 @@
         @param {im_livechat.legacy.PublicLivechatWindow} widget
     -->
     <t t-name="im_livechat.legacy.PublicLivechatWindow">
-        <div class="o_thread_window o_in_home_menu" t-att-data-thread-id="widget.messaging.publicLivechatGlobal.publicLivechat.id">
+        <div class="o_thread_window o_in_home_menu"
+            t-att-data-thread-id="widget.messaging.publicLivechatGlobal.publicLivechat.id"
+            t-att-data-thread-model='widget.messaging.publicLivechatGlobal.publicLivechat.model'
+        >
             <div class="o_thread_window_header">
                 <t t-call="im_livechat.legacy.PublicLivechatWindow.HeaderContent">
                     <t t-set="status" t-value="widget.messaging.publicLivechatGlobal.publicLivechat.status"/>

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -22,16 +22,11 @@ QUnit.test('livechat - avatar: should have a smiley face avatar for an anonymous
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     const livechatItem = document.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.containsOnce(
         livechatItem,
@@ -60,16 +55,11 @@ QUnit.test('livechat - avatar: should have a partner profile picture for a livec
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     const livechatItem = document.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.containsOnce(
         livechatItem,

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -136,12 +136,7 @@ QUnit.test('livechat - states: close manually by clicking the title', async func
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
     // fold the livechat category
@@ -153,12 +148,7 @@ QUnit.test('livechat - states: close manually by clicking the title', async func
     );
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category livechat should be closed and the content should be invisible"
     );
 });
@@ -185,12 +175,7 @@ QUnit.test('livechat - states: open manually by clicking the title', async funct
 
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
     // open the livechat category
@@ -202,12 +187,7 @@ QUnit.test('livechat - states: open manually by clicking the title', async funct
     );
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category livechat should be closed and the content should be invisible"
     );
 });
@@ -329,17 +309,12 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: true,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
     await afterNextRender(() => {
@@ -350,12 +325,7 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
     });
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category livechat should be closed and the content should be invisible"
     );
 });
@@ -377,17 +347,12 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
     await afterNextRender(() => {
@@ -398,12 +363,7 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
     });
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category livechat should be closed and the content should be invisible"
     );
 });
@@ -427,12 +387,7 @@ QUnit.test('livechat - states: category item should be invisible if the catgory 
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
     await afterNextRender(() =>
@@ -444,12 +399,7 @@ QUnit.test('livechat - states: category item should be invisible if the catgory 
 
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "inactive item should be invisible if the category is folded"
     );
 });
@@ -472,20 +422,12 @@ QUnit.test('livechat - states: the active category item should be visble even if
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
-    const livechat = document.querySelector(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId1,
-            model: 'mail.channel',
-        }).localId
-    }"]`);
+    const livechat = document.querySelector(`
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+    `);
     await afterNextRender(() => {
         livechat.click();
     });
@@ -500,12 +442,7 @@ QUnit.test('livechat - states: the active category item should be visble even if
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         'the active livechat item should remain even if the category is folded'
     );
 });

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -26,7 +26,7 @@ QUnit.test('livechat in the sidebar: basic rendering', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     assert.containsOnce(document.body, '.o_Discuss_sidebar',
@@ -43,12 +43,7 @@ QUnit.test('livechat in the sidebar: basic rendering', async function (assert) {
         "should have a channel group named 'Livechat'"
     );
     const livechat = groupLivechat.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.ok(
         livechat,
@@ -295,13 +290,13 @@ QUnit.test('livechats are sorted by last activity time in the sidebar: most rece
         "should have 2 livechat items"
     );
     assert.strictEqual(
-        initialLivechats[0].dataset.threadLocalId,
-        livechat12.localId,
+        parseInt(initialLivechats[0].dataset.threadId),
+        livechat12.id,
         "first livechat should be the one with the more recent last activity time"
     );
     assert.strictEqual(
-        initialLivechats[1].dataset.threadLocalId,
-        livechat11.localId,
+        parseInt(initialLivechats[1].dataset.threadId),
+        livechat11.id,
         "second livechat should be the one with the less recent last activity time"
     );
 
@@ -317,13 +312,13 @@ QUnit.test('livechats are sorted by last activity time in the sidebar: most rece
         "should have 2 livechat items"
     );
     assert.strictEqual(
-        newLivechats[0].dataset.threadLocalId,
-        livechat11.localId,
+        parseInt(newLivechats[0].dataset.threadId),
+        livechat11.id,
         "first livechat should be the one with the more recent last activity time"
     );
     assert.strictEqual(
-        newLivechats[1].dataset.threadLocalId,
-        livechat12.localId,
+        parseInt(newLivechats[1].dataset.threadId),
+        livechat12.id,
         "second livechat should be the one with the less recent last activity time"
     );
 });

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -23,7 +23,7 @@ QUnit.test('livechats should be in "chat" filter', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging } = await start();
+    await start();
     assert.containsOnce(
         document.body,
         '.o_MessagingMenu',
@@ -48,12 +48,7 @@ QUnit.test('livechats should be in "chat" filter', async function (assert) {
     );
     assert.containsOnce(
         document.body,
-        `.o_ThreadPreview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "livechat should be listed in 'all' tab/filter of messaging menu"
     );
 
@@ -67,12 +62,7 @@ QUnit.test('livechats should be in "chat" filter', async function (assert) {
     );
     assert.containsOnce(
         document.body,
-        `.o_ThreadPreview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "livechat should be listed in 'chat' tab/filter of messaging menu"
     );
 });

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -11,7 +11,8 @@
                     'o-isDeviceSmall position-fixed': messaging.device.isSmall,
                     'mw-100 mh-100': !messaging.device.isSmall,
                     'o-new-message': !chatWindow.thread,
-                }" t-att-style="chatWindow.componentStyle" t-on-keydown="chatWindow.onKeydown" t-on-focusout="chatWindow.onFocusout" t-att-data-chat-window-local-id="chatWindow.localId" t-att-data-thread-local-id="chatWindow.thread ? chatWindow.thread.localId : ''" t-ref="root"
+                }" t-att-style="chatWindow.componentStyle" t-on-keydown="chatWindow.onKeydown" t-on-focusout="chatWindow.onFocusout" t-att-data-chat-window-local-id="chatWindow.localId" t-att-data-thread-id="chatWindow.thread ? chatWindow.thread.id : ''" t-ref="root"
+                t-att-data-thread-model="chatWindow.thread ? chatWindow.thread.model : ''"
             >
                 <ChatWindowHeader
                     className="'o_ChatWindow_header flex-grow-0 flex-shrink-0'"

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
@@ -8,8 +8,8 @@
                     'bg-100': !categoryItem.isActive,
                     'o-active bg-200': categoryItem.isActive,
                     'o-unread': categoryItem.isUnread,
-                }" t-attf-class="{{ className }}" t-on-click="categoryItem.onClick" t-att-data-thread-local-id="categoryItem.thread.localId" t-att-data-thread-name="categoryItem.thread.displayName"
-                t-ref="root"
+                }" t-attf-class="{{ className }}" t-on-click="categoryItem.onClick" t-att-data-thread-id="categoryItem.thread.id" t-att-data-thread-name="categoryItem.thread.displayName"
+                t-att-data-thread-model="categoryItem.thread.model" t-ref="root"
             >
                 <div class="o_DiscussSidebarCategoryItem_item o_DiscussSidebarCategoryItem_avatar ms-4">
                     <div class="o_DiscussSidebarCategoryItem_imageContainer position-relative d-flex">

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
@@ -7,7 +7,13 @@
                 The preview template is used by the discuss in mobile, and by the systray
                 menu in order to show preview of threads.
             -->
-            <div class="o_NotificationListItem o_ThreadNeedactionPreview d-flex flex-shrink-0 align-items-center p-1 cursor-pointer" t-attf-class="{{ className }}" t-on-click="threadNeedactionPreviewView.onClick" t-att-data-thread-local-id="threadNeedactionPreviewView.thread.localId" t-ref="root">
+            <div class="o_NotificationListItem o_ThreadNeedactionPreview d-flex flex-shrink-0 align-items-center p-1 cursor-pointer"
+                t-attf-class="{{ className }}"
+                t-on-click="threadNeedactionPreviewView.onClick"
+                t-att-data-thread-id="threadNeedactionPreviewView.thread.id"
+                t-att-data-thread-model="threadNeedactionPreviewView.thread.model"
+                t-ref="root"
+            >
                 <div class="o_NotificationListItem_sidebar o_ThreadNeedactionPreview_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_ThreadNeedactionPreview_imageContainer o_ThreadNeedactionPreview_sidebarItem position-relative">
                         <img class="o_NotificationListItem_image o_ThreadNeedactionPreview_image w-100 h-100" t-att-src="image()" alt="Thread Image"/>

--- a/addons/mail/static/src/components/thread_preview/thread_preview.xml
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.xml
@@ -7,7 +7,14 @@
                 The preview template is used by the discuss in mobile, and by the systray
                 menu in order to show preview of threads.
             -->
-            <div class="o_NotificationListItem o_ThreadPreview d-flex flex-shrink-0 align-items-center p-1 cursor-pointer" t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }" t-attf-class="{{ className }}" t-on-click="threadPreviewView.onClick" t-att-data-thread-local-id="threadPreviewView.thread.localId" t-ref="root">
+            <div class="o_NotificationListItem o_ThreadPreview d-flex flex-shrink-0 align-items-center p-1 cursor-pointer"
+                t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }"
+                t-attf-class="{{ className }}"
+                t-on-click="threadPreviewView.onClick"
+                t-att-data-thread-id="threadPreviewView.thread.id"
+                t-att-data-thread-model="threadPreviewView.thread.model"
+                t-ref="root"
+            >
                 <div class="o_NotificationListItem_sidebar o_ThreadPreview_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_ThreadPreview_imageContainer o_ThreadPreview_sidebarItem position-relative">
                         <img class="o_NotificationListItem_image o_ThreadPreview_image w-100 h-100 rounded-circle" t-att-src="image()" alt="Thread Image"/>

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -3,7 +3,15 @@
 
     <t t-name="mail.ThreadView" owl="1">
         <t t-if="threadView">
-            <div class="o_ThreadView position-relative d-flex flex-column bg-100" t-att-class="threadView.extraClass" t-attf-class="{{ className }}" t-att-data-correspondent-id="threadView.thread and threadView.thread.correspondent and threadView.thread.correspondent.id" t-att-data-thread-local-id="threadView.thread and threadView.thread.localId" t-on-focusin="threadView.onFocusin" t-ref="root">
+            <div class="o_ThreadView position-relative d-flex flex-column bg-100"
+                t-att-class="threadView.extraClass"
+                t-attf-class="{{ className }}"
+                t-att-data-correspondent-id="threadView.thread and threadView.thread.correspondent and threadView.thread.correspondent.id"
+                t-att-data-thread-id="threadView.thread and threadView.thread.id"
+                t-att-data-thread-model="threadView.thread and threadView.thread.model"
+                t-on-focusin="threadView.onFocusin"
+                t-ref="root"
+            >
                 <t t-if="threadView.topbar">
                     <ThreadViewTopbar className="'border-bottom'" record="threadView.topbar"/>
                 </t>

--- a/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
+++ b/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
@@ -33,8 +33,8 @@ QUnit.test('select another mailbox', async function (assert) {
         "discuss should display a thread initially"
     );
     assert.strictEqual(
-        document.querySelector('.o_Discuss_thread').dataset.threadLocalId,
-        messaging.inbox.thread.localId,
+        document.querySelector('.o_Discuss_thread').dataset.threadId,
+        messaging.inbox.thread.id,
         "inbox mailbox should be opened initially"
     );
     assert.containsOnce(
@@ -54,8 +54,8 @@ QUnit.test('select another mailbox', async function (assert) {
         "discuss should still have a thread after clicking on starred mailbox"
     );
     assert.strictEqual(
-        document.querySelector('.o_Discuss_thread').dataset.threadLocalId,
-        messaging.starred.thread.localId,
+        document.querySelector('.o_Discuss_thread').dataset.threadId,
+        messaging.starred.thread.id,
         "starred mailbox should be opened after clicking on it"
     );
 });

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -228,7 +228,7 @@ QUnit.test('open chat from "new message" chat window should open chat in place o
     ]);
     const imSearchDef = makeDeferred();
     patchUiSize({ width: 1920 });
-    const { click, insertText, messaging } = await start({
+    const { click, insertText } = await start({
         mockRPC(route, args) {
             if (args.method === 'im_search') {
                 imSearchDef.resolve();
@@ -274,12 +274,7 @@ QUnit.test('open chat from "new message" chat window should open chat in place o
 
     // open channel-2
     await click(`.o_MessagingMenu_toggler`);
-    await click(`.o_NotificationListItem[data-thread-local-id="${
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId2,
-            model: 'mail.channel',
-        }).localId
-    }"]`);
+    await click(`.o_NotificationListItem[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]`);
     assert.containsN(
         document.body,
         '.o_ChatWindow',
@@ -418,7 +413,7 @@ QUnit.test('chat window: basic rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    const { click, messaging } = await start();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_NotificationList_preview`);
@@ -427,14 +422,10 @@ QUnit.test('chat window: basic rendering', async function (assert) {
         1,
         "should have open a chat window"
     );
-    const chatWindow = document.querySelector(`.o_ChatWindow`);
-    assert.strictEqual(
-        chatWindow.dataset.threadLocalId,
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId1,
-            model: 'mail.channel',
-        }).localId,
-        "should have open a chat window of channel"
+    const chatWindow = document.querySelector(`.o_ChatWindow[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`);
+    assert.ok(
+        chatWindow,
+        'should have open a chat window of channel'
     );
     assert.strictEqual(
         chatWindow.querySelectorAll(`:scope .o_ChatWindow_header`).length,
@@ -1014,16 +1005,11 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'mailChannel1' }, { name: 'mailChannel2' }]);
     patchUiSize({ width: 1920 }); // enough to fit at least 2 chat windows
-    const { click, messaging } = await start();
+    const { click } = await start();
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatWindow`).length,
@@ -1032,24 +1018,14 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "chat window of chat should be open"
     );
     assert.ok(
         document.querySelector(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).classList.contains('o-focused'),
         "chat window of chat should have focus"
     );
@@ -1057,12 +1033,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId2,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatWindow`).length,
@@ -1071,47 +1042,27 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "chat window of channel should be open"
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "chat window of chat should still be open"
     );
     assert.ok(
         document.querySelector(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).classList.contains('o-focused'),
         "chat window of channel should have focus"
     );
     assert.notOk(
         document.querySelector(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).classList.contains('o-focused'),
         "chat window of chat should no longer have focus"
     );
@@ -1143,18 +1094,13 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         { name: 'mailChannel3' },
     ]);
     patchUiSize({ width: 900 }); // enough to fit 2 chat windows but not 3
-    const { click, messaging } = await start();
+    const { click } = await start();
 
     // open, from systray menu, chat windows of channels with Id 1, 2, then 3
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatWindow`).length,
@@ -1175,12 +1121,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId2,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatWindow`).length,
@@ -1201,12 +1142,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId3,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatWindow`).length,
@@ -1225,36 +1161,21 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "chat window of channel 1 should be open"
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId3,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "chat window of channel 3 should be open"
     );
     assert.ok(
         document.querySelector(`
-            .o_ChatWindow[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId3,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ChatWindow[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]
         `).classList.contains('o-focused'),
         "chat window of channel 3 should have focus"
     );
@@ -1265,17 +1186,12 @@ QUnit.test('chat window: switch on TAB', async function (assert) {
 
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'channel1' }, { name: 'channel2' }]);
-    const { click, messaging } = await start();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        .o_NotificationList_preview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
     assert.containsOnce(document.body, '.o_ChatWindow', "Only 1 chatWindow must be opened");
@@ -1307,12 +1223,7 @@ QUnit.test('chat window: switch on TAB', async function (assert) {
     await click(`.o_MessagingMenu_toggler`);
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId2,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        .o_NotificationList_preview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]`
     );
 
     assert.containsN(document.body, '.o_ChatWindow', 2, "2 chatWindows must be opened");
@@ -1731,7 +1642,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
         },
     ]);
     patchUiSize({ width: 900 });
-    const { click, messaging } = await start({
+    const { click } = await start({
         mockRPC(route, args) {
             if (route === '/mail/channel/messages') {
                 const { channel_id } = args;
@@ -1748,12 +1659,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
     );
     assert.containsNone(
         document.body,
-        `.o_ChatWindow[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId3,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_ChatWindow[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]`,
         "chat window for Channel #12 should be hidden"
     );
     assert.containsOnce(
@@ -1782,12 +1688,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
     );
     assert.containsOnce(
         document.body,
-        `.o_ChatWindow[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId3,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_ChatWindow[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]`,
         "chat window for Channel #12 should now be visible"
     );
     assert.verifySteps(
@@ -2048,22 +1949,12 @@ QUnit.test('should not have chat window hidden menu in mobile (transition from 2
     await click('.o_MessagingMenu_toggler');
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     await click('.o_ChatWindowHeader_commandBack');
     await click(`
         .o_MessagingMenu_dropdownMenu
-        .o_NotificationList_preview[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId2,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_NotificationList_preview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
     `);
     // simulate resize to go into mobile
     await afterNextRender(

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_tests.js
@@ -30,7 +30,7 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
             res_id: resPartnerId1,
         });
     }
-    const { messaging, openView } = await start();
+    const { openView } = await start();
     await openView({
         res_id: resPartnerId1,
         res_model: 'res.partner',
@@ -56,13 +56,10 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
         1,
         "should have a thread in the chatter"
     );
-    assert.strictEqual(
-        document.querySelector(`.o_Chatter_thread`).dataset.threadLocalId,
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: resPartnerId1,
-            model: 'res.partner',
-        }).localId,
-        "thread should have the right thread local id"
+    assert.containsOnce(
+        document.body,
+        `.o_Chatter_thread[data-thread-id="${resPartnerId1}"][data-thread-model="res.partner"]`,
+        "chatter should have the right thread."
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Message`).length,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
@@ -19,17 +19,12 @@ QUnit.test('sidebar: pinned channel 1: init with one pinned channel', async func
     await openDiscuss();
     assert.containsOnce(
         document.body,
-        `.o_Discuss_thread[data-thread-local-id="${messaging.inbox.thread.localId}"]`,
+        `.o_Discuss_thread[data-thread-id="${messaging.inbox.thread.id}"][data-thread-model="mail.box"]`,
         "The Inbox is opened in discuss"
     );
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "should have the only channel of which user is member in discuss sidebar"
     );
 });
@@ -39,19 +34,13 @@ QUnit.test('sidebar: pinned channel 2: open pinned channel', async function (ass
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
 
-    const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId1,
-        model: 'mail.channel',
-    });
-    await click(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        threadGeneral.localId
-    }"]`);
+    await click(`.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`);
     assert.containsOnce(
         document.body,
-        `.o_Discuss_thread[data-thread-local-id="${threadGeneral.localId}"]`,
+        `.o_Discuss_thread[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "The channel #General is displayed in discuss"
     );
 });
@@ -67,7 +56,7 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
             partner_id: pyEnv.currentPartnerId,
         }]],
     });
-    const { click, messaging, openDiscuss } = await start({
+    const { click, openDiscuss } = await start({
         async mockRPC(route, args) {
             if (args.method === 'action_unfollow') {
                 assert.step('action_unfollow');
@@ -79,13 +68,7 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
     });
     await openDiscuss();
 
-    const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId1,
-        model: 'mail.channel',
-    });
-    await click(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        threadGeneral.localId
-    }"]`);
+    await click(`.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`);
     assert.verifySteps([], "action_unfollow is not called yet");
 
     await click('.o_DiscussSidebarCategoryItem_commandLeave');
@@ -97,7 +80,7 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
     );
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${threadGeneral.localId}"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "The channel must have been removed from discuss sidebar"
     );
     assert.containsOnce(
@@ -114,28 +97,22 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
     const mailChannelId1 = pyEnv['mail.channel'].create({});
     const { click, messaging, openDiscuss } = await start();
     await openDiscuss();
-    const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId1,
-        model: 'mail.channel',
-    });
 
     assert.containsOnce(
         document.body,
-        `.o_Discuss_thread[data-thread-local-id="${messaging.inbox.thread.localId}"]`,
+        `.o_Discuss_thread[data-thread-id="${messaging.inbox.thread.id}"][data-thread-model="mail.box"]`,
         "The Inbox is opened in discuss"
     );
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${threadGeneral.localId}"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "1 channel is present in discuss sidebar and it is 'general'"
     );
 
-    await click(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        threadGeneral.localId
-    }"]`);
+    await click(`.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`);
     assert.containsOnce(
         document.body,
-        `.o_Discuss_thread[data-thread-local-id="${threadGeneral.localId}"]`,
+        `.o_Discuss_thread[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "The channel #General is opened in discuss"
     );
 
@@ -157,7 +134,7 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
     );
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${threadGeneral.localId}"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "The channel must have been removed from discuss sidebar"
     );
 });
@@ -178,15 +155,12 @@ QUnit.test('[technical] sidebar: channel group_based_subscription: mandatorily p
         }]],
         group_based_subscription: true,
     });
-    const { messaging, openDiscuss } = await start();
+    const {openDiscuss } = await start();
     await openDiscuss();
-    const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId1,
-        model: 'mail.channel',
-    });
+
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${threadGeneral.localId}"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "The channel #General is in discuss sidebar"
     );
     assert.containsNone(

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -18,16 +18,11 @@ QUnit.test('channel - avatar: should have correct avatar', async function (asser
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ avatarCacheKey: '100111' });
 
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     const channelItem = document.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         channelItem.querySelectorAll(`:scope .o_DiscussSidebarCategoryItem_image`).length,
@@ -51,16 +46,10 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
     const { messaging, openDiscuss } = await start();
     await openDiscuss();
 
-    const channelLocalId = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId1,
-        model: 'mail.channel',
-    }).localId;
-
     assert.strictEqual(
         document.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            channelLocalId
-        }"] .o_DiscussSidebarCategoryItem_image`).dataset.src,
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+        .o_DiscussSidebarCategoryItem_image`).dataset.src,
         `/web/image/mail.channel/${mailChannelId1}/avatar_128?unique=101010`,
     );
 
@@ -76,9 +65,8 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
 
     assert.strictEqual(
         document.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            channelLocalId
-        }"] .o_DiscussSidebarCategoryItem_image`).dataset.src,
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+        .o_DiscussSidebarCategoryItem_image`).dataset.src,
         `/web/image/mail.channel/${mailChannelId1}/avatar_128?unique=${newCacheKey}`,
     );
 });
@@ -96,16 +84,11 @@ QUnit.test('chat - avatar: should have correct avatar', async function (assert) 
         channel_type: 'chat',
         public: 'private',
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     const chatItem = document.querySelector(`
-        .o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         chatItem.querySelectorAll(`:scope .o_DiscussSidebarCategoryItem_image`).length,
@@ -142,17 +125,9 @@ QUnit.test('chat - sorting: should be sorted by last activity time', async funct
             public: 'private',
         },
     ]);
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
 
-    const chat1 = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId1,
-        model: 'mail.channel',
-    });
-    const chat2 = messaging.models['Thread'].findFromIdentifyingData({
-        id: mailChannelId2,
-        model: 'mail.channel',
-    });
     const initialChats = document.querySelectorAll('.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategoryItem');
     assert.strictEqual(
         initialChats.length,
@@ -160,13 +135,13 @@ QUnit.test('chat - sorting: should be sorted by last activity time', async funct
         "should have 2 livechat items"
     );
     assert.strictEqual(
-        initialChats[0].dataset.threadLocalId,
-        chat2.localId,
+        parseInt(initialChats[0].dataset.threadId),
+        mailChannelId2,
         "first livechat should be the one with the more recent last activity time"
     );
     assert.strictEqual(
-        initialChats[1].dataset.threadLocalId,
-        chat1.localId,
+        parseInt(initialChats[1].dataset.threadId),
+        mailChannelId1,
         "second chat should be the one with the less recent last activity time"
     );
 
@@ -181,13 +156,13 @@ QUnit.test('chat - sorting: should be sorted by last activity time', async funct
         "should have 2 chat items"
     );
     assert.strictEqual(
-        newChats[0].dataset.threadLocalId,
-        chat1.localId,
+        parseInt(newChats[0].dataset.threadId),
+        mailChannelId1,
         "first chat should be the one with the more recent last activity time"
     );
     assert.strictEqual(
-        newChats[1].dataset.threadLocalId,
-        chat2.localId,
+        parseInt(newChats[1].dataset.threadId),
+        mailChannelId2,
         "second chat should be the one with the less recent last activity time"
     );
 });

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -198,18 +198,13 @@ QUnit.test('channel - states: close manually by clicking the title', async funct
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
     });
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category channel should be closed and the content should be invisible"
     );
 });
@@ -223,18 +218,13 @@ QUnit.test('channel - states: open manually by clicking the title', async functi
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category channel should be open and the content should be visible"
     );
 });
@@ -322,7 +312,7 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     await afterNextRender(() => {
@@ -333,12 +323,7 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
     });
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category channel should be closed and the content should be invisible"
     );
 });
@@ -352,7 +337,7 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     await afterNextRender(() => {
@@ -363,12 +348,7 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
     });
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category channel should be open and the content should be visible"
     );
 });
@@ -383,20 +363,12 @@ QUnit.test('channel - states: the active category item should be visble even if 
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
-    const channel = document.querySelector(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId1,
-            model: 'mail.channel',
-        }).localId
-    }"]`);
+    const channel = document.querySelector(
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
+    );
     await afterNextRender(() => {
         channel.click();
     });
@@ -405,12 +377,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         'the active channel item should remain even if the category is folded'
     );
 
@@ -419,12 +386,7 @@ QUnit.test('channel - states: the active category item should be visble even if 
     }"]`);
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "inactive item should be invisible if the category is folded"
     );
 });
@@ -578,17 +540,12 @@ QUnit.test('chat - states: close manually by clicking the title', async function
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
     });
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category chat should be closed and the content should be invisible"
     );
 });
@@ -605,17 +562,12 @@ QUnit.test('chat - states: open manually by clicking the title', async function 
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category chat should be closed and the content should be invisible"
     );
 });
@@ -705,7 +657,7 @@ QUnit.test('chat - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     await afterNextRender(() => {
@@ -716,12 +668,7 @@ QUnit.test('chat - states: close from the bus', async function (assert) {
     });
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category chat should be open and the content should be visible"
     );
 });
@@ -738,7 +685,7 @@ QUnit.test('chat - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
 
     await afterNextRender(() => {
@@ -749,12 +696,7 @@ QUnit.test('chat - states: open from the bus', async function (assert) {
     });
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "Category chat should be closed and the content should be invisible"
     );
 });
@@ -772,20 +714,12 @@ QUnit.test('chat - states: the active category item should be visble even if the
 
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`
     );
 
-    const chat = document.querySelector(`.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId1,
-            model: 'mail.channel',
-        }).localId
-    }"]`);
+    const chat = document.querySelector(`
+        .o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+    `);
     await afterNextRender(() => {
         chat.click();
     });
@@ -794,12 +728,7 @@ QUnit.test('chat - states: the active category item should be visble even if the
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         'the active chat item should remain even if the category is folded'
     );
 
@@ -808,12 +737,7 @@ QUnit.test('chat - states: the active category item should be visble even if the
     }"]`);
     assert.containsNone(
         document.body,
-        `.o_DiscussSidebarCategoryItem[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategoryItem[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "inactive item should be invisible if the category is folded"
     );
 });

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -422,7 +422,7 @@ QUnit.test('sidebar: basic channel rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    const { click, messaging, openDiscuss } = await start();
+    const { click, openDiscuss } = await start();
     await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`).length,
@@ -432,13 +432,13 @@ QUnit.test('sidebar: basic channel rendering', async function (assert) {
         .o_DiscussSidebar_categoryChannel
         .o_DiscussSidebarCategory_item
     `);
-    assert.strictEqual(
-        channel.dataset.threadLocalId,
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId1,
-            model: 'mail.channel',
-        }).localId,
-        "should have channel 1"
+    assert.containsOnce(
+        document.body,
+        `
+            .o_DiscussSidebar_categoryChannel
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+        `,
+        'channel 1 should be in sidebar'
     );
     assert.notOk(
         channel.classList.contains('o-active'),
@@ -547,7 +547,7 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
         { name: "channel1", public: 'public' },
         { name: "channel2", public: 'private' },
     ]);
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`).length,
@@ -557,12 +557,7 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChannel
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have channel 1"
@@ -570,33 +565,18 @@ QUnit.test('sidebar: public/private channel rendering', async function (assert) 
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChannel
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel'
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have channel 2"
     );
     const channel1 = document.querySelector(`
         .o_DiscussSidebar_categoryChannel
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel'
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     const channel2 = document.querySelector(`
         .o_DiscussSidebar_categoryChannel
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId2,
-                model: 'mail.channel'
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
     `);
     assert.ok(
         channel1.querySelectorAll(`:scope .o_ThreadIcon_channelPublic`).length,
@@ -622,22 +602,17 @@ QUnit.test('sidebar: basic chat rendering', async function (assert) {
         channel_type: 'chat', // testing a chat is the goal of the test
         public: 'private', // expected value for testing a chat
     });
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`).length,
         1,
         "should have one chat item"
     );
-    const chat = document.querySelector(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`);
-    assert.strictEqual(
-        chat.dataset.threadLocalId,
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: mailChannelId1,
-            model: 'mail.channel'
-        }).localId,
-        "should have channel 1"
-    );
+    const chat = document.querySelector(`
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+    `);
+    assert.ok(chat, "should have channel 1 in the sidebar");
     assert.strictEqual(
         chat.querySelectorAll(`:scope .o_ThreadIcon`).length,
         1,
@@ -749,7 +724,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
             public: 'private',
         }
     ]);
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_item`).length,
@@ -759,12 +734,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChat
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have Partner 1"
@@ -772,12 +742,7 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChat
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have Partner 2"
@@ -785,42 +750,22 @@ QUnit.test('sidebar: chat im_status rendering', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_DiscussSidebar_categoryChat
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId3,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have Partner 3"
     );
     const chat1 = document.querySelector(`
         .o_DiscussSidebar_categoryChat
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     const chat2 = document.querySelector(`
         .o_DiscussSidebar_categoryChat
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId2,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
     `);
     const chat3 = document.querySelector(`
         .o_DiscussSidebar_categoryChat
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId3,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId3}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         chat1.querySelectorAll(`:scope .o_ThreadIcon_offline`).length,
@@ -901,12 +846,7 @@ QUnit.test('default thread rendering', async function (assert) {
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have channel 1 in the sidebar"
@@ -986,21 +926,11 @@ QUnit.test('default thread rendering', async function (assert) {
     );
 
     await click(`
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.ok(
         document.querySelector(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).classList.contains('o-active'),
         "channel 20 should be active thread"
     );
@@ -1145,7 +1075,7 @@ QUnit.test('open channel from active_id as channel id', async function (assert) 
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { messaging, openDiscuss } = await start({
+    const { openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: mailChannelId1,
@@ -1156,9 +1086,7 @@ QUnit.test('open channel from active_id as channel id', async function (assert) 
     assert.containsOnce(
         document.body,
         `
-            .o_Discuss_thread[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({ id: mailChannelId1, model: 'mail.channel' }).localId
-            }"]
+            .o_Discuss_thread[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `,
         "should have channel 1 open in Discuss when providing its active_id"
     );
@@ -1892,7 +1820,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             res_id: mailChannelId2,
         });
     }
-    const { afterEvent, messaging, openDiscuss } = await start({
+    const { afterEvent, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1947,12 +1875,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             // select channel 2
             document.querySelector(`
                 .o_DiscussSidebar_categoryChannel
-                .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    messaging.models['Thread'].findFromIdentifyingData({
-                        id: mailChannelId2,
-                        model: 'mail.channel',
-                    }).localId
-                }"]
+                .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
             `).click();
         },
         message: "should wait until channel 2 scrolled to its last message",
@@ -1980,12 +1903,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             // select channel 1
             document.querySelector(`
                 .o_DiscussSidebar_categoryChannel
-                .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    messaging.models['Thread'].findFromIdentifyingData({
-                        id: mailChannelId1,
-                        model: 'mail.channel',
-                    }).localId
-                }"]
+                .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
             `).click();
         },
         message: "should wait until channel 1 restored its scroll position",
@@ -2010,12 +1928,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
             // select channel 2
             document.querySelector(`
                 .o_DiscussSidebar_categoryChannel
-                .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    messaging.models['Thread'].findFromIdentifyingData({
-                        id: mailChannelId2,
-                        model: 'mail.channel',
-                    }).localId
-                }"]
+                .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
             `).click();
         },
         message: "should wait until channel 2 recovered its scroll position (to bottom)",
@@ -2072,24 +1985,14 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebar_categoryChannel
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).classList.contains('o-active'),
         "channel 'General' should be active"
     );
     assert.notOk(
         document.querySelector(`
             .o_DiscussSidebar_categoryChat
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).classList.contains('o-active'),
         "Chat 'Demo' should not be active"
     );
@@ -2120,24 +2023,14 @@ QUnit.test('redirect to author (open chat)', async function (assert) {
     assert.notOk(
         document.querySelector(`
             .o_DiscussSidebar_categoryChannel
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).classList.contains('o-active'),
         "channel 'General' should become inactive after author redirection"
     );
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebar_categoryChat
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).classList.contains('o-active'),
         "chat 'Demo' should become active after author redirection"
     );
@@ -2151,7 +2044,7 @@ QUnit.test('sidebar quick search', async function (assert) {
     for (let id = 1; id <= 20; id++) {
         pyEnv['mail.channel'].create({ name: `channel${id}` });
     }
-    const { messaging, openDiscuss } = await start();
+    const { openDiscuss } = await start();
     await openDiscuss();
     assert.strictEqual(
         document.querySelectorAll(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item`).length,
@@ -2189,13 +2082,10 @@ QUnit.test('sidebar quick search', async function (assert) {
         "should have filtered to a single channel item"
     );
     assert.strictEqual(
-        document.querySelector(`
+        parseInt(document.querySelector(`
             .o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_item
-        `).dataset.threadLocalId,
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: pyEnv['mail.channel'].search([['name', '=', 'channel12']])[0],
-            model: 'mail.channel',
-        }).localId,
+        `).dataset.threadId),
+        pyEnv['mail.channel'].search([['name', '=', 'channel12']])[0],
         "should have filtered to a single channel (channel12)"
     );
 
@@ -2258,12 +2148,7 @@ QUnit.test('basic top bar rendering', async function (assert) {
     );
 
     await click(`
-        .o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]
+        .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
     `);
     assert.strictEqual(
         document.querySelector(`
@@ -2324,12 +2209,7 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
     );
     assert.strictEqual(
         document.querySelector(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
             .o_DiscussSidebarCategoryItem_counter
         `).textContent,
         "2",
@@ -2359,12 +2239,7 @@ QUnit.test('inbox: mark all messages as read', async function (assert) {
     );
     assert.strictEqual(
         document.querySelectorAll(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
             .o_DiscussSidebarCategoryItem_counter
         `).length,
         0,
@@ -2931,26 +2806,16 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { afterEvent, messaging, openDiscuss } = await start();
+    const { afterEvent, openDiscuss } = await start();
     await openDiscuss();
     assert.containsOnce(
         document.body,
-        `.o_DiscussSidebarCategory_item[data-thread-local-id="${
-            messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-            }).localId
-        }"]`,
+        `.o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]`,
         "should have discuss sidebar item with the channel"
     );
     assert.hasClass(
         document.querySelector(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `),
         'o-unread',
         "sidebar item of channel 1 should be unread"
@@ -2960,12 +2825,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
         eventName: 'o-thread-last-seen-by-current-partner-message-id-changed',
         func: () => {
             document.querySelector(`
-                .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    messaging.models['Thread'].findFromIdentifyingData({
-                        id: mailChannelId1,
-                        model: 'mail.channel',
-                    }).localId
-                }"]
+                .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
             `).click();
         },
         message: "should wait until last seen by current partner message id changed",
@@ -2979,12 +2839,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
     }));
     assert.doesNotHaveClass(
         document.querySelector(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `),
         'o-unread',
         "sidebar item of channel 1 should not longer be unread"
@@ -3827,7 +3682,7 @@ QUnit.test('mark channel as seen if last message is visible when switching chann
         model: "mail.channel",
         res_id: mailChannelId2,
     }]);
-    const { afterEvent, messaging, openDiscuss } = await start({
+    const { afterEvent, openDiscuss } = await start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId2}`,
@@ -3850,12 +3705,7 @@ QUnit.test('mark channel as seen if last message is visible when switching chann
         eventName: 'o-thread-last-seen-by-current-partner-message-id-changed',
         func: () => {
             document.querySelector(`
-                .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                    messaging.models['Thread'].findFromIdentifyingData({
-                        id: mailChannelId1,
-                        model: 'mail.channel',
-                    }).localId
-                }"]
+                .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
             `).click();
         },
         message: "should wait until last seen by current partner message id changed",
@@ -3869,12 +3719,7 @@ QUnit.test('mark channel as seen if last message is visible when switching chann
     }));
     assert.doesNotHaveClass(
         document.querySelector(`
-            .o_DiscussSidebarCategory_item[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_DiscussSidebarCategory_item[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `),
         'o-unread',
         "sidebar item of channel 1 should no longer be unread"

--- a/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -532,7 +532,7 @@ QUnit.test('filtered previews', async function (assert) {
             res_id: mailChannelId2, // id of related channel
         },
     ]);
-    const { click, messaging } = await start();
+    const { click } = await start();
 
     await click(`.o_MessagingMenu_toggler`);
     assert.strictEqual(
@@ -543,12 +543,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have preview of chat"
@@ -556,12 +551,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have preview of channel"
@@ -576,12 +566,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have preview of chat"
@@ -589,12 +574,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         0,
         "should not have preview of channel"
@@ -612,12 +592,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         0,
         "should not have preview of chat"
@@ -625,12 +600,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have preview of channel"
@@ -645,12 +615,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId1,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have preview of chat"
@@ -658,12 +623,7 @@ QUnit.test('filtered previews', async function (assert) {
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${
-                messaging.models['Thread'].findFromIdentifyingData({
-                    id: mailChannelId2,
-                    model: 'mail.channel',
-                }).localId
-            }"]
+            .o_ThreadPreview[data-thread-id="${mailChannelId2}"][data-thread-model="mail.channel"]
         `).length,
         1,
         "should have preview of channel"
@@ -934,7 +894,7 @@ QUnit.test('Group chat should be displayed inside the chat section of the messag
     const mailChannelId1 = pyEnv['mail.channel'].create({
         channel_type: 'group',
     });
-    const { click, messaging } = await start();
+    const { click } = await start();
 
     await click('.o_MessagingMenu_toggler');
     await click(`.o_MessagingMenuTab[data-tab-id="chat"]`);
@@ -942,10 +902,8 @@ QUnit.test('Group chat should be displayed inside the chat section of the messag
     assert.strictEqual(
         document.querySelectorAll(`
             .o_MessagingMenu_dropdownMenu
-            .o_ThreadPreview[data-thread-local-id="${messaging.models['Thread'].findFromIdentifyingData({
-                id: mailChannelId1,
-                model: 'mail.channel',
-             }).localId}"]`).length,
+            .o_ThreadPreview[data-thread-id="${mailChannelId1}"][data-thread-model="mail.channel"]
+        `).length,
         1,
         "should have one preview of group"
     );

--- a/addons/mail/static/tests/qunit_suite_tests/models/file_uploader_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/file_uploader_tests.js
@@ -42,12 +42,7 @@ QUnit.test('no conflicts between file uploaders', async function (assert) {
 
     // Uploading file in the second thread: mail.channel in chatWindow.
     await click(`.o_MessagingMenu_toggler`);
-    await click(`.o_NotificationListItem[data-thread-local-id="${
-        messaging.models['Thread'].findFromIdentifyingData({
-            id: channelId,
-            model: 'mail.channel',
-        }).localId
-    }"]`);
+    await click(`.o_NotificationListItem[data-thread-id="${channelId}"][data-thread-model="mail.channel"]`);
     const file2 = await createFile({
         name: 'text2.txt',
         content: 'hello, world',


### PR DESCRIPTION
Using local ids in test is cumbersome: we need to retrieve the mail
record associated with the server record to get it while the record
id is more than enough. Let's remove those local ids and use the record
id instead.

task-2959366