### PR TITLE
[FIX] pos_sale: add margin for pos sales in sales report

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -61,8 +61,8 @@ class SaleReport(models.Model):
             NULL as order_id
         '''
 
-        for field in fields.keys():
-            select_ += ', NULL AS %s' % (field)
+        for value in fields.values():
+            select_ += value
         return select_
 
     def _from_pos(self):
@@ -112,6 +112,8 @@ class SaleReport(models.Model):
         if not fields:
             fields = {}
         res = super()._query(with_clause, fields, groupby, from_clause)
+        for key in fields:
+            fields[key] = ', NULL as %s' % (key)
         current = '(SELECT %s FROM %s WHERE %s GROUP BY %s)' % \
                   (self._select_pos(fields), self._from_pos(), self._where_pos(), self._group_by_pos())
 

--- a/addons/pos_sale_margin/__init__.py
+++ b/addons/pos_sale_margin/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import report

--- a/addons/pos_sale_margin/__manifest__.py
+++ b/addons/pos_sale_margin/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': 'pos_sale_margin',
+    'version': '1.1',
+    'category': 'Hidden',
+    'summary': 'Link module between Point of Sale and Sales Margin',
+    'description': """
+
+This module adds enable you to view the margin of your Point of Sale orders in the Sales Margin report.
+""",
+    'depends': ['pos_sale', 'sale_margin'],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/pos_sale_margin/report/__init__.py
+++ b/addons/pos_sale_margin/report/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_report

--- a/addons/pos_sale_margin/report/sale_report.py
+++ b/addons/pos_sale_margin/report/sale_report.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class SaleReport(models.Model):
+    _inherit = "sale.report"
+
+    def _select_pos(self, fields=None):
+        fields['margin'] = ', SUM(l.price_subtotal - l.total_cost / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END) AS margin'
+        return super()._select_pos(fields)

--- a/addons/pos_sale_margin/tests/__init__.py
+++ b/addons/pos_sale_margin/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_pos_sale_margin_report

--- a/addons/pos_sale_margin/tests/test_pos_sale_margin_report.py
+++ b/addons/pos_sale_margin/tests/test_pos_sale_margin_report.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import odoo
+
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPoSSaleMarginReport(TestPoSCommon):
+
+    def setUp(self):
+        super(TestPoSSaleMarginReport, self).setUp()
+        self.config = self.basic_config
+
+    def test_pos_sale_margin_report(self):
+
+        product1 = self.create_product('Product 1', self.categ_basic, 150, standard_price=50)
+
+        self.open_new_session()
+        session = self.pos_session
+
+        self.env['pos.order'].create({
+            'session_id': session.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': product1.id,
+                'price_unit': 450,
+                'discount': 5.0,
+                'qty': 1.0,
+                'price_subtotal': 150,
+                'price_subtotal_incl': 150,
+                'total_cost': 50,
+            }),],
+            'amount_total': 150.0,
+            'amount_tax': 0.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+
+        # PoS Orders have negative IDs to avoid conflict, so reports[0] will correspond to the newest order
+        reports = self.env['sale.report'].sudo().search([('product_id', '=', product1.id)], order='id')
+
+        self.assertEqual(reports[0].margin, 100)


### PR DESCRIPTION
Current behavior:
In the sales report of a product, the margin was not appearing
for product that were sold in the PoS.

Steps to reproduce:
- Activate the margin option in the settings
- Create a product available in PoS, the product should have a price
  and cost set
- Start a PoS session and sell the product, then close the PoS
- Go on the product page, click the "Sold" smart button
- Add the "Margin" measure to the pivot
- There is no value in the margin column

opw-2937616
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
