### PR TITLE
[FIX] purchase: remove price from RFQ mail

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -378,13 +378,15 @@ class PurchaseOrder(models.Model):
             message, msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
-        if self.date_order:
-            render_context['subtitle'] = _('%(amount)s due\N{NO-BREAK SPACE}%(date)s',
-                           amount=format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang')),
-                           date=format_date(self.env, self.date_order, date_format='short', lang_code=render_context.get('lang'))
-                          )
-        else:
-            render_context['subtitle'] = format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang'))
+        # don't show price on RFQ mail
+        if self.state not in ['draft', 'sent']:
+            if self.date_order:
+                render_context['subtitle'] = _('%(amount)s due\N{NO-BREAK SPACE}%(date)s',
+                            amount=format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang')),
+                            date=format_date(self.env, self.date_order, date_format='short', lang_code=render_context.get('lang'))
+                            )
+            else:
+                render_context['subtitle'] = format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang'))
         return render_context
 
     def _track_subtype(self, init_values):


### PR DESCRIPTION
To Reporduce
=============
- Create RFQ and send it by mail

Problem
=======
The received mail contains the amount which we don't want to show when it's just a RFQ

Solution
=========
to solve the issue a condition was added to show the amount only on Purchase Order

opw-2955758