### PR TITLE
[FIX] base: fix t-field with empty value/default value 

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -1223,7 +1223,7 @@ class QWeb(object):
         else:
             content = (self._compile_tag_open(el, options, indent + 1, not without_attributes) +
                 self._compile_tag_close(el, options) +
-                self._flushText(options, indent + 2))
+                self._flushText(options, indent + 1))
             if content:
                 code.append(self._indent("elif force_display:", indent))
                 code.extend(content)

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -140,6 +140,24 @@ class TestQWebTField(TransactionCase):
         })
         self.assertEqual(str(rendered.strip()), result.strip())
 
+    def test_no_value_no_default_value(self):
+        # no value, no default value with attributes on t-field
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="out-field-default">
+                <div t-field="record.name"/>
+            </t>''',
+        })
+        result = """
+                <div data-oe-model="res.partner" data-oe-field="name" data-oe-type="char" data-oe-expression="record.name" data-oe-xpath="/t[1]/div[1]"></div>
+        """
+        # inherit_branding puts attribute on the field tag as well as force the display in case the field is empty
+        rendered = self.env['ir.qweb'].with_context(inherit_branding=True)._render(t.id, {
+            'record': self.env['res.partner'].new({}),
+        })
+        self.assertEqual(str(rendered.strip()), result.strip())
+
 
 class TestQWebNS(TransactionCase):
     def test_render_static_xml_with_namespace(self):


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/97347 we support default values for `t-field`
directives.
However this causes some issues in the case where we have: no value, no
default value AND force_display is true.
This is because the indentation for one of the lines in the compiled
code was not correct. (full explanation here: https://github.com/odoo/odoo/pull/97347#issuecomment-1222430659)