### PR TITLE
[FIX] purchase: currency_id is required for account-tax-totals-field

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -177,6 +177,7 @@
                             <field name="currency_id" groups="base.group_multi_currency" force_save="1"/>
                             <field name="id" invisible="1"/>
                             <field name="company_id" invisible="1"/>
+                            <field name="currency_id" invisible="1"/>
                         </group>
                         <group>
                             <field name="date_order" attrs="{'invisible': [('state','in',('purchase','done'))]}"/>


### PR DESCRIPTION
The widget `account-tax-totals-field` needs the value of the
`currency_id` field, even when not in multi-currency mode.

The widget is used in `sale.order`, `account.move` and
`purchase.order`. The only place where the field
was not included when not in multi-currency mode
was the purchase.order.

A traceback was raised when attempting
to open the purchase order form when
not in multi-currency.

This is an oversight of odoo/odoo#95729
