### PR TITLE
[FIX] web: switch the record with keynav in FormView

### DIFF
--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -113,6 +113,9 @@ export function useInputField(params) {
     });
 
     useBus(env.bus, "RELATIONAL_MODEL:WILL_SAVE_URGENTLY", () => commitChanges(true));
+    useBus(env.bus, "RELATIONAL_MODEL:NEED_LOCAL_CHANGES", (ev) =>
+        ev.detail.proms.push(commitChanges())
+    );
 
     /**
      * Roughly the same as onChange, but called at more specific / critical times. (See bus events)

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -185,9 +185,7 @@ export class FormController extends Component {
                     limit: 1,
                     total: resIds.length,
                     onUpdate: async ({ offset }) => {
-                        if (this.model.root.isDirty) {
-                            await this.model.root.save({ stayInEdition: true });
-                        }
+                        await this.model.root.save({ stayInEdition: true });
                         this.model.load({ resId: resIds[offset] });
                     },
                 };

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1239,7 +1239,6 @@ export class Record extends DataPoint {
      * @returns {Promise<boolean>}
      */
     async _save(options = { stayInEdition: false, noReload: false }) {
-        this.model.env.bus.trigger("RELATIONAL_MODEL:NEED_LOCAL_CHANGES");
         if (!(await this._checkValidity())) {
             const invalidFields = [...this._invalidFields].map((fieldName) => {
                 return `<li>${escape(this.fields[fieldName].string || fieldName)}</li>`;


### PR DESCRIPTION
Before this commit, in a formView, if you modify an input and use
the keynav (alt+n or alt+p) to change the record, then the modification
is not saved.

How to reproduce?
- go to a form view with a pager containing more than one record
- edit an input
- press alt+n to move to the next record
- press alt+p to go back to the previous record

Result before:
    The record has not changed

Result after:
    The record has saved the change.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
