### PR TITLE
[FIX] web: restore default website navbar (BS5 order classes)

### DIFF
--- a/addons/web/static/src/libs/bootstrap/utilities_custom.scss
+++ b/addons/web/static/src/libs/bootstrap/utilities_custom.scss
@@ -44,7 +44,7 @@ $order-array: (
     first: -1,
     last: $grid-columns + 1,
 ) !default;
-@for $i from 1 through $grid-columns {
+@for $i from 0 through $grid-columns {
     $order-array: map-merge(
         $order-array,
         (#{$i}: $i)


### PR DESCRIPTION
Commit [1] broke the default website navbar by removing the generation
of order-XXX-0 classes.

[1]: https://github.com/odoo/odoo/commit/6ed6a512bfec8e2415da2d19304215fcd06273b2

---

Before this PR:
![image](https://user-images.githubusercontent.com/10338094/185963696-e19b807f-0df9-499e-a889-b649c9a1879c.png)

After this PR:
![image](https://user-images.githubusercontent.com/10338094/185963576-e8c96d58-87ad-4134-b057-17f6dd9f8ce3.png)
