### PR TITLE
[REF] account: allow pass multiple line taxes at once

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -384,7 +384,8 @@ class AccountTestInvoicingCommon(SavepointCase):
                 line_form.price_unit = amount
                 if taxes:
                     line_form.tax_ids.clear()
-                    line_form.tax_ids.add(taxes)
+                    for tax in taxes:
+                        line_form.tax_ids.add(tax)
 
         rslt = move_form.save()
 


### PR DESCRIPTION
Right now when extending **account** module AccountTestInvoicingCommon class to implement tests on custom modules you can only create invoices with one tax per line using `init_invoice()`.

Current behavior before PR:
You get an `Expected singleton` error when sending several taxes to `init_invoice()`.

```
  File "/Users/joselopez/Odoo/Odoo14/odoo/addons/account/tests/common.py", line 377, in init_invoice
    line_form.tax_ids.add(taxes)
  File "/Users/joselopez/Odoo/Odoo14/odoo/odoo/tests/common.py", line 2401, in add
    self._get_ids().append(record.id)
  File "/Users/joselopez/Odoo/Odoo14/odoo/odoo/fields.py", line 3818, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: account.tax(2931, 2950, 2953)
```

Desired behavior after PR is merged:
Be able to send multiple taxes at once without any error.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
