### PR TITLE
[FIX][15.0] website_forum: remove the strip_style attribute of the fo…

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -311,7 +311,7 @@ class Post(models.Model):
 
     name = fields.Char('Title')
     forum_id = fields.Many2one('forum.forum', string='Forum', required=True)
-    content = fields.Html('Content', strip_style=True)
+    content = fields.Html('Content')
     plain_content = fields.Text('Plain Content', compute='_get_plain_content', store=True)
     tag_ids = fields.Many2many('forum.tag', 'forum_tag_rel', 'forum_id', 'forum_tag_id', string='Tags')
     state = fields.Selection([('active', 'Active'), ('pending', 'Waiting Validation'), ('close', 'Closed'), ('offensive', 'Offensive'), ('flagged', 'Flagged')], string='Status', default='active')


### PR DESCRIPTION
Remove the strip_style attribute of the website forum description

* Describe:
-adding the strip_style attribute will make the descriptions lose attributes such as bold, italic, underline ....
* Solution:
-remove the strip_style attribute of the content field

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
