### PR TITLE
[FIX] sale_gift_card: unlink generated gift card

### DIFF
--- a/addons/sale_gift_card/models/sale_order.py
+++ b/addons/sale_gift_card/models/sale_order.py
@@ -19,6 +19,7 @@ class SaleOrder(models.Model):
         # release gift card amount when order state become canceled
         for record in self.filtered(lambda so: so.state == 'cancel'):
             record.order_line.filtered(lambda ol: ol.gift_card_id).unlink()
+            record.order_line.mapped('generated_gift_card_ids').unlink()
 
         # create and send gift card when order become confirmed
         for record in self.filtered(lambda so: so.state == 'sale'):


### PR DESCRIPTION
To reproduce:

* Setup gift card product
* Create SO with gift card product
* Confirm SO

This will generate gift card

* Cancel SO

Issue:
* Gift card is not deleted

Fix:
* Delete gift card when SO is canceled.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
