### PR TITLE
[FIX][15.0] base: Update vi.po translation file for Vietnamese

### DIFF
--- a/addons/base_import/i18n/vi.po
+++ b/addons/base_import/i18n/vi.po
@@ -485,7 +485,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Image size excessive, imported images must be smaller than 42 million pixel"
-msgstr "Kích cỡ ảnh quá lớn, ảnh được nhập phải nhỏ hơn 42 triệu pixel."
+msgstr "Kích cỡ hình ảnh quá lớn, ảnh được nhập phải nhỏ hơn 42 triệu pixel."
 
 #. module: base_import
 #. openerp-web

--- a/addons/event_booth/i18n/vi.po
+++ b/addons/event_booth/i18n/vi.po
@@ -422,22 +422,22 @@ msgstr "Hình ảnh"
 #. module: event_booth
 #: model:ir.model.fields,field_description:event_booth.field_event_booth_category__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: event_booth
 #: model:ir.model.fields,field_description:event_booth.field_event_booth_category__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: event_booth
 #: model:ir.model.fields,field_description:event_booth.field_event_booth_category__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: event_booth
 #: model:ir.model.fields,field_description:event_booth.field_event_booth_category__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: event_booth
 #: model:ir.model.fields,field_description:event_booth.field_event_booth__is_available

--- a/addons/gamification/i18n/vi.po
+++ b/addons/gamification/i18n/vi.po
@@ -1694,25 +1694,25 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:gamification.field_gamification_badge__image_1024
 #: model:ir.model.fields,field_description:gamification.field_gamification_karma_rank__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: gamification
 #: model:ir.model.fields,field_description:gamification.field_gamification_badge__image_128
 #: model:ir.model.fields,field_description:gamification.field_gamification_karma_rank__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: gamification
 #: model:ir.model.fields,field_description:gamification.field_gamification_badge__image_256
 #: model:ir.model.fields,field_description:gamification.field_gamification_karma_rank__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: gamification
 #: model:ir.model.fields,field_description:gamification.field_gamification_badge__image_512
 #: model:ir.model.fields,field_description:gamification.field_gamification_karma_rank__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: gamification
 #: model:ir.model.fields.selection,name:gamification.selection__gamification_challenge__state__inprogress

--- a/addons/hr/i18n/vi.po
+++ b/addons/hr/i18n/vi.po
@@ -1519,25 +1519,25 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:hr.field_hr_employee__image_1024
 #: model:ir.model.fields,field_description:hr.field_hr_employee_public__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__image_128
 #: model:ir.model.fields,field_description:hr.field_hr_employee_public__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__image_256
 #: model:ir.model.fields,field_description:hr.field_hr_employee_public__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__image_512
 #: model:ir.model.fields,field_description:hr.field_hr_employee_public__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: hr
 #: code:addons/hr/models/hr_employee.py:0

--- a/addons/lunch/i18n/vi.po
+++ b/addons/lunch/i18n/vi.po
@@ -1060,31 +1060,31 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:lunch.field_lunch_product__image_1024
 #: model:ir.model.fields,field_description:lunch.field_lunch_product_category__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: lunch
 #: model:ir.model.fields,field_description:lunch.field_lunch_order__image_128
 #: model:ir.model.fields,field_description:lunch.field_lunch_product__image_128
 #: model:ir.model.fields,field_description:lunch.field_lunch_product_category__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: lunch
 #: model:ir.model.fields,field_description:lunch.field_lunch_order__image_1920
 msgid "Image 1920"
-msgstr "Ảnh 1920"
+msgstr "Hình ảnh 1920px"
 
 #. module: lunch
 #: model:ir.model.fields,field_description:lunch.field_lunch_product__image_256
 #: model:ir.model.fields,field_description:lunch.field_lunch_product_category__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: lunch
 #: model:ir.model.fields,field_description:lunch.field_lunch_product__image_512
 #: model:ir.model.fields,field_description:lunch.field_lunch_product_category__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: lunch
 #: model_terms:ir.ui.view,arch_db:lunch.lunch_order_view_form

--- a/addons/mail/i18n/vi.po
+++ b/addons/mail/i18n/vi.po
@@ -3461,22 +3461,22 @@ msgstr "Hình ảnh"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_guest__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_guest__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_guest__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_guest__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_document_file_kanban

--- a/addons/mass_mailing/i18n/vi.po
+++ b/addons/mass_mailing/i18n/vi.po
@@ -2154,7 +2154,7 @@ msgstr "Bỏ qua"
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_masonry_block_options
 msgid "Image Text Image"
-msgstr "Ảnh chữ ảnh"
+msgstr "Hình ảnh chữ ảnh"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_masonry_block_options

--- a/addons/mrp/i18n/vi.po
+++ b/addons/mrp/i18n/vi.po
@@ -2121,22 +2121,22 @@ msgstr ""
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_document__image_height
 msgid "Image Height"
-msgstr "Chiều cao ảnh"
+msgstr "Chiều cao hình ảnh"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_document__image_src
 msgid "Image Src"
-msgstr "Nguồn ảnh"
+msgstr "Nguồn hình ảnh"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_document__image_width
 msgid "Image Width"
-msgstr "Chiều rộng ảnh"
+msgstr "Chiều rộng hình ảnh"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.view_document_file_kanban_mrp
 msgid "Image is a link"
-msgstr "Ảnh là một liên kết"
+msgstr "Hình ảnh là một liên kết"
 
 #. module: mrp
 #: model:ir.model,name:mrp.model_mrp_immediate_production

--- a/addons/product/i18n/vi.po
+++ b/addons/product/i18n/vi.po
@@ -1306,25 +1306,25 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:product.field_product_product__image_1024
 #: model:ir.model.fields,field_description:product.field_product_template__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: product
 #: model:ir.model.fields,field_description:product.field_product_product__image_128
 #: model:ir.model.fields,field_description:product.field_product_template__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: product
 #: model:ir.model.fields,field_description:product.field_product_product__image_256
 #: model:ir.model.fields,field_description:product.field_product_template__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: product
 #: model:ir.model.fields,field_description:product.field_product_product__image_512
 #: model:ir.model.fields,field_description:product.field_product_template__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: product
 #: code:addons/product/models/product_pricelist.py:0

--- a/addons/sales_team/i18n/vi.po
+++ b/addons/sales_team/i18n/vi.po
@@ -363,7 +363,7 @@ msgstr "Hình ảnh"
 #. module: sales_team
 #: model:ir.model.fields,field_description:sales_team.field_crm_team_member__image_128
 msgid "Image (128)"
-msgstr "Hình ảnh (128)"
+msgstr "Hình ảnh (128px)"
 
 #. module: sales_team
 #: model:crm.tag,name:sales_team.categ_oppor4

--- a/addons/web_editor/i18n/vi.po
+++ b/addons/web_editor/i18n/vi.po
@@ -1341,22 +1341,22 @@ msgstr "Hình ảnh"
 #: code:addons/web_editor/static/src/js/editor/snippets.editor.js:0
 #, python-format
 msgid "Image Formatting"
-msgstr ""
+msgstr "Định dạng Hình ảnh"
 
 #. module: web_editor
 #: model:ir.model.fields,field_description:web_editor.field_ir_attachment__image_height
 msgid "Image Height"
-msgstr "Chiều cao ảnh"
+msgstr "Chiều cao ảnh ảnh"
 
 #. module: web_editor
 #: model:ir.model.fields,field_description:web_editor.field_ir_attachment__image_src
 msgid "Image Src"
-msgstr "Nguồn ảnh"
+msgstr "Nguồn hình ảnh"
 
 #. module: web_editor
 #: model:ir.model.fields,field_description:web_editor.field_ir_attachment__image_width
 msgid "Image Width"
-msgstr "Chiều rộng ảnh"
+msgstr "Chiều rộng hình ảnh"
 
 #. module: web_editor
 #. openerp-web

--- a/addons/website/i18n/vi.po
+++ b/addons/website/i18n/vi.po
@@ -5525,12 +5525,12 @@ msgstr "Ảnh bìa"
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.snippet_options
 msgid "Image Menu"
-msgstr "Menu ảnh"
+msgstr "Menu hình ảnh"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_media_list_options
 msgid "Image Size"
-msgstr "Cỡ hình ảnh"
+msgstr "Kích cỡ hình ảnh"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_masonry_block_options

--- a/addons/website_event_exhibitor/i18n/vi.po
+++ b/addons/website_event_exhibitor/i18n/vi.po
@@ -472,12 +472,12 @@ msgstr "Nếu đánh dấu, một số tin nhắn bị lỗi khi gửi. "
 #. module: website_event_exhibitor
 #: model:ir.model.fields,field_description:website_event_exhibitor.field_event_sponsor__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: website_event_exhibitor
 #: model:ir.model.fields,field_description:website_event_exhibitor.field_event_sponsor__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: website_event_exhibitor
 #: model:ir.model.fields,field_description:website_event_exhibitor.field_event_sponsor__website_image_url

--- a/addons/website_forum/i18n/vi.po
+++ b/addons/website_forum/i18n/vi.po
@@ -2047,22 +2047,22 @@ msgstr "Hình ảnh"
 #. module: website_forum
 #: model:ir.model.fields,field_description:website_forum.field_forum_forum__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: website_forum
 #: model:ir.model.fields,field_description:website_forum.field_forum_forum__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: website_forum
 #: model:ir.model.fields,field_description:website_forum.field_forum_forum__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: website_forum
 #: model:ir.model.fields,field_description:website_forum.field_forum_forum__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: website_forum
 #: model:forum.post.reason,name:website_forum.reason_13

--- a/addons/website_sale/i18n/vi.po
+++ b/addons/website_sale/i18n/vi.po
@@ -1693,30 +1693,30 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:website_sale.field_product_image__image_1024
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_product_image__image_128
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_product_image__image_256
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: website_sale
 #: model:ir.model.fields,field_description:website_sale.field_product_image__image_512
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.view_product_image_form
 msgid "Image Name"
-msgstr "Tên hình"
+msgstr "Tên hình ảnh"
 
 #. module: website_sale
 #: code:addons/website_sale/controllers/main.py:0

--- a/addons/website_slides/i18n/vi.po
+++ b/addons/website_slides/i18n/vi.po
@@ -3051,25 +3051,25 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:website_slides.field_slide_channel__image_1024
 #: model:ir.model.fields,field_description:website_slides.field_slide_slide__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: website_slides
 #: model:ir.model.fields,field_description:website_slides.field_slide_channel__image_128
 #: model:ir.model.fields,field_description:website_slides.field_slide_slide__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: website_slides
 #: model:ir.model.fields,field_description:website_slides.field_slide_channel__image_256
 #: model:ir.model.fields,field_description:website_slides.field_slide_slide__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: website_slides
 #: model:ir.model.fields,field_description:website_slides.field_slide_channel__image_512
 #: model:ir.model.fields,field_description:website_slides.field_slide_slide__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: website_slides
 #: model:slide.answer,comment:website_slides.slide_slide_demo_1_4_question_0_1

--- a/odoo/addons/base/i18n/vi.po
+++ b/odoo/addons/base/i18n/vi.po
@@ -19180,7 +19180,7 @@ msgstr "Hình ảnh"
 #: model:ir.model.fields,field_description:base.field_res_partner__image_1024
 #: model:ir.model.fields,field_description:base.field_res_users__image_1024
 msgid "Image 1024"
-msgstr "Ảnh 1024"
+msgstr "Hình ảnh 1024px"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_avatar_mixin__image_128
@@ -19188,7 +19188,7 @@ msgstr "Ảnh 1024"
 #: model:ir.model.fields,field_description:base.field_res_partner__image_128
 #: model:ir.model.fields,field_description:base.field_res_users__image_128
 msgid "Image 128"
-msgstr "Ảnh 128"
+msgstr "Hình ảnh 128px"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_avatar_mixin__image_256
@@ -19196,7 +19196,7 @@ msgstr "Ảnh 128"
 #: model:ir.model.fields,field_description:base.field_res_partner__image_256
 #: model:ir.model.fields,field_description:base.field_res_users__image_256
 msgid "Image 256"
-msgstr "Ảnh 256"
+msgstr "Hình ảnh 256px"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_avatar_mixin__image_512
@@ -19204,12 +19204,12 @@ msgstr "Ảnh 256"
 #: model:ir.model.fields,field_description:base.field_res_partner__image_512
 #: model:ir.model.fields,field_description:base.field_res_users__image_512
 msgid "Image 512"
-msgstr "Ảnh 512"
+msgstr "Hình ảnh 512px"
 
 #. module: base
 #: model:ir.model,name:base.model_image_mixin
 msgid "Image Mixin"
-msgstr "Hình Mixin"
+msgstr "Hình ảnh Mixin"
 
 #. module: base
 #: code:addons/image.py:0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- Inhomogeneous translation of `Image` word between modules, in some places it is translated as `hình`, in other places it is translated as `ảnh`, so we want to unify the content of the word `Image` into 1 word `Hình ảnh` for vi.po translation file.
-  Also, wish there was a `px` character after the resolution number of the image

Desired behavior after PR is merged:
- Translate `Image` into `Hình ảnh` instead of `hình` or `ảnh`
- Adding `px`character after the resolution number of the image, example `Image 1024px` instead of `Image
1024`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
