### PR TITLE
[FIX] web: ReferenceField with model_field option

### DIFF
--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -16,13 +16,11 @@ export class ReferenceField extends Component {
             resModel: this.relation,
         });
 
-        let modelName = this.getModelName(this.props);
         onWillUpdateProps((nextProps) => {
             if (
                 valuesEqual(this.getValue(this.props) || {}, this.getValue(nextProps) || {}) &&
-                this.getModelName(nextProps) !== modelName
+                this.getRelation(nextProps) !== this.state.resModel
             ) {
-                modelName = this.getModelName(nextProps);
                 nextProps.update(false);
             }
         });
@@ -61,10 +59,18 @@ export class ReferenceField extends Component {
     }
 
     get relation() {
-        if (this.getModelName(this.props)) {
-            return this.getModelName(this.props);
-        } else if (this.getValue(this.props) && this.getValue(this.props).resModel) {
-            return this.getValue(this.props).resModel;
+        return this.getRelation(this.props);
+    }
+
+    getRelation(props) {
+        const modelName = this.getModelName(props);
+        if (modelName) {
+            return modelName;
+        }
+
+        const value = this.getValue(props);
+        if (value && value.resModel) {
+            return value.resModel;
         } else {
             return this.state && this.state.resModel;
         }

--- a/addons/web/static/tests/views/fields/reference_field_tests.js
+++ b/addons/web/static/tests/views/fields/reference_field_tests.js
@@ -875,4 +875,51 @@ QUnit.module("Fields", (hooks) => {
             );
         }
     );
+
+    QUnit.test(
+        "edit a record containing a ReferenceField with model_field option (list in form view)",
+        async function (assert) {
+            serverData.models.turtle.records[0].partner_ids = [1];
+            serverData.models.partner.records[0].reference = "product,41";
+            serverData.models.partner.records[0].model_id = 20;
+
+            await makeView({
+                type: "form",
+                resModel: "turtle",
+                resId: 1,
+                serverData,
+                arch: `
+                    <form>
+                        <field name="partner_ids">
+                            <tree editable="bottom">
+                                <field name="name" />
+                                <field name="model_id" />
+                                <field name="reference" options='{"model_field": "model_id"}'/>
+                            </tree>
+                        </field>
+                   </form>`,
+            });
+            assert.strictEqual(
+                target.querySelector(".o_list_table [name='name']").textContent,
+                "name"
+            );
+            assert.strictEqual(
+                target.querySelector(".o_list_table [name='reference']").textContent,
+                "xpad"
+            );
+
+            await clickEdit(target);
+            await click(target.querySelector(".o_list_table .o_data_cell"));
+            await editInput(target, ".o_list_table [name='name'] input", "plop");
+            await click(target, ".o_form_view");
+            assert.strictEqual(
+                target.querySelector(".o_list_table [name='name']").textContent,
+                "plop"
+            );
+            assert.strictEqual(
+                target.querySelector(".o_list_table [name='reference']").textContent,
+                "xpad"
+            );
+        }
+    );
 });


### PR DESCRIPTION
Before this commit, if we have a reference field with a "model_field" in
X2many in list mode and we modify this record, then the value of the
reference field is set to false.

Cause of the problem:
The reference field assumes that the preloadedData are always available.

How to reproduce :
- Go to an x2many in list mode containing a reference field with a
 "model_field" already containing a value
- edit another field than the reference
- click outside the record

Result before :
The record switches to readonly mode and its reference field contains
the value false

Result after:
The record switches to readonly mode and its reference field has not
changed value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
