### PR TITLE
[IMP] mrp(_account): byproduct valuation fix for flexible consumption

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -366,7 +366,7 @@
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids" context="{'default_date': date_planned_finished, 'default_date_deadline': date_deadline, 'default_location_id': production_location_id, 'default_location_dest_id': location_dest_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" decoration-muted="is_done" editable="bottom">
-                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1" attrs="{'readonly': [('state', 'not in', ['draft', 'done']), ('is_locked', '=', False)]}"/>
                                     <field name="location_dest_id" string="To" readonly="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="company_id" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>

--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models
+from odoo import _, api, models
+from odoo.tools import float_is_zero
 
 
 class StockMove(models.Model):
@@ -42,3 +43,98 @@ class StockMove(models.Model):
         if self.unbuild_id:
             return True
         return super()._is_returned(valued_type)
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        def correction_svl_after_production(production, move):
+            """ For flexible consumption in AVCO and FIFO product category, Create valuation layer
+                from creating new line in Manufacturing order's components or byproducts """
+            if production.state == 'done' and production.product_id.cost_method in ('average', 'fifo'):
+                current_svl = move.stock_valuation_layer_ids.filtered(lambda l: l.quantity).sorted(
+                    lambda l: l.create_date and l.id, True)
+                if current_svl:
+                    production_diff = current_svl[0].value * -1
+                    # Add new By-product
+                    if move.production_id:
+                        self._create_correction_svl_done_mo(production, move, production_diff)
+                    # Add new line in Components of Manufacturing
+                    elif move.raw_material_production_id:
+                        production_diff, byproducts_diff = self._split_production_and_by_product_cost(production_diff,
+                                                                                                           production)
+                        # Create diff stock valuation for by product
+                        for byproduct_move, byproduct_diff in byproducts_diff.items():
+                            self._create_correction_svl_done_mo(production, byproduct_move, byproduct_diff)
+                        # Create diff stock valuation for finish product
+                        production_move = production.move_finished_ids.filtered(
+                            lambda l: l.product_id == production.product_id)
+                        self._create_correction_svl_done_mo(production, production_move, production_diff)
+        move_lines = super(StockMoveLine, self).create(vals_list)
+        for move_line in move_lines:
+            move = move_line.move_id
+            production = move.production_id or move.raw_material_production_id
+            float_qty_check = float_is_zero(move_line.qty_done, precision_digits=move_line.product_uom_id.rounding)
+            if production and not float_qty_check and not self._context.get('button_mark_done_production_ids'):
+                correction_svl_after_production(production, move)
+        return move_lines
+
+    def write(self, vals):
+        def correction_svl_after_production(production, move):
+            """ For flexible consumption in AVCO and FIFO product category, Create valuation layer from
+                change quantity in existing Manufacturing order's components, byproducts or production """
+            if production.product_id.cost_method in ('average', 'fifo') and production.state == 'done':
+                current_svl = move.stock_valuation_layer_ids.filtered(lambda l: l.quantity).sorted(
+                    lambda l: l.create_date and l.id, True)
+                if current_svl:
+                    production_diff = current_svl[0].value * -1
+                    # Change qty in Finished Product or By-proudct Manufacturing
+                    if move.production_id:
+                        self._create_correction_svl_done_mo(production, move, production_diff)
+                    # Change qty in Components of Manufacturing
+                    elif move.raw_material_production_id:
+                        production_diff, byproducts_diff = self._split_production_and_by_product_cost(production_diff,
+                                                                                                           production)
+                        # Create diff stock valuation for by product
+                        for byproduct_move, byproduct_diff in byproducts_diff.items():
+                            self._create_correction_svl_done_mo(production, byproduct_move, byproduct_diff)
+                        # Create diff stock valuation for finish product
+                        production_move = production.move_finished_ids.filtered(
+                            lambda l: l.product_id == production.product_id)
+                        self._create_correction_svl_done_mo(production, production_move, production_diff)
+        res = super(StockMoveLine, self).write(vals)
+        if 'qty_done' in vals:
+            for move_line in self:
+                move = move_line.move_id
+                production = move.production_id or move.raw_material_production_id
+                if production:
+                    correction_svl_after_production(production, move)
+        return res
+
+    def _split_production_and_by_product_cost(self, production_cost, production):
+        """ Return production cost diff and dictionary of byproduct move and byproduct cost
+            for create valuation layer in done manufacturing order """
+        byproduct_cost = {}
+        for move in production.move_byproduct_ids:
+            if move.cost_share:
+                cost = (production_cost * move.cost_share) / 100
+                byproduct_cost.update({move: cost})
+        return production_cost - sum(byproduct_cost.values()), byproduct_cost
+
+    @api.model
+    def _create_correction_svl_done_mo(self, production, move, cost):
+        """ Create valuation layer for done manufacturing order and production's product category is Done or Fifo """
+        StockValuationLayer = self.env['stock.valuation.layer']
+        svl_vals = move._prepare_common_svl_vals()
+        svl_vals.update({
+            'product_id': move.product_id.id,
+            'value': cost,
+            'unit_cost': cost,
+            'quantity': 0,
+            'description': 'Correction of Manufacturing Order %s' % production.name or move.name
+        })
+        svl_vals_list = [svl_vals]
+        svl = StockValuationLayer.sudo().create(svl_vals_list)
+        svl._validate_accounting_entries()

--- a/addons/mrp_account/tests/test_valuation_layers.py
+++ b/addons/mrp_account/tests/test_valuation_layers.py
@@ -316,3 +316,43 @@ class TestMrpValuationStandard(TestMrpValuationCommon):
         self.assertEqual(self.product1.quantity_svl, 2)
         self._make_out_move(self.product1, 1)
         self.assertEqual(self.product1.value_svl, 15)
+
+    def test_change_produced_qty_in_done_mo_fifo(self):
+        """Change in produced quantity then check done mo's valuation layers"""
+        self.component.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self._make_in_move(self.component, 1, 50)
+        mo = self._make_mo(self.bom, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        mo.action_toggle_is_locked()
+        mo.write({'qty_producing': 5.0})
+        valuation_domain = mo.action_view_stock_valuation_layers().get('domain')
+        layers = self.env['stock.valuation.layer'].search(valuation_domain)
+        main_product_cost = sum(layers.filtered(lambda l: l.product_id.id == self.product1.id).mapped('value'))
+        main_product_quantity = sum(layers.filtered(lambda l: l.product_id.id == self.product1.id).mapped('quantity'))
+        main_product_cost_per_unit = main_product_cost / main_product_quantity
+        component_cost = sum(layers.filtered(lambda l: l.product_id.id == self.component.id).mapped('value'))
+        self.assertEqual(main_product_cost, 50.0)
+        self.assertEqual(main_product_cost_per_unit, 10)
+        self.assertEqual(component_cost, -50.0)
+
+    def test_change_component_qty_in_done_mo_fifo(self):
+        """Change in component quantity then check done mo's valuation layers"""
+        self.component.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self._make_in_move(self.component, 1, 10)
+        mo = self._make_mo(self.bom, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        mo.action_toggle_is_locked()
+        mo.move_raw_ids.write({'quantity_done': 5.0})
+        valuation_domain = mo.action_view_stock_valuation_layers().get('domain')
+        layers = self.env['stock.valuation.layer'].search(valuation_domain)
+        main_product_cost = sum(layers.filtered(lambda l: l.product_id.id == self.product1.id).mapped('value'))
+        main_product_quantity = sum(layers.filtered(lambda l: l.product_id.id == self.product1.id).mapped('quantity'))
+        main_product_cost_per_unit = main_product_cost / main_product_quantity
+        component_cost = sum(layers.filtered(lambda l: l.product_id.id == self.component.id).mapped('value'))
+        self.assertEqual(main_product_cost, 50.0)
+        self.assertEqual(main_product_cost_per_unit, 50)
+        self.assertEqual(component_cost, -50.0)

--- a/addons/mrp_account/tests/test_valuation_layers.py
+++ b/addons/mrp_account/tests/test_valuation_layers.py
@@ -356,3 +356,39 @@ class TestMrpValuationStandard(TestMrpValuationCommon):
         self.assertEqual(main_product_cost, 50.0)
         self.assertEqual(main_product_cost_per_unit, 50)
         self.assertEqual(component_cost, -50.0)
+
+    def test_change_byproduct_qty_in_done_mo_avco(self):
+        """Change in byproduct quantity then check done mo's valuation layers"""
+        byproduct = self.env['product.product'].create({
+            'name': 'By Product',
+            'type': 'product',
+            'categ_id': self.component_category.id
+        })
+        self.bom.write({
+            'byproduct_ids': [(0, 0, {
+                'product_id': byproduct.id,
+                'product_qty': 1.0,
+                'cost_share': 10,
+            })]
+        })
+        byproduct.product_tmpl_id.categ_id.property_cost_method = 'average'
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+        self._make_in_move(self.component, 1, 10)
+        mo = self._make_mo(self.bom, 1)
+        self._produce(mo)
+        mo.button_mark_done()
+        mo.action_toggle_is_locked()
+        mo.move_raw_ids.write({'quantity_done': 5.0})
+        mo.move_byproduct_ids.write({'quantity_done': 5.0})
+        valuation_domain = mo.action_view_stock_valuation_layers().get('domain')
+        layers = self.env['stock.valuation.layer'].search(valuation_domain)
+        main_product_cost = sum(layers.filtered(lambda l: l.product_id.id == self.product1.id).mapped('value'))
+        byproduct_cost = sum(layers.filtered(lambda l: l.product_id.id == byproduct.id).mapped('value'))
+        by_product_quantity = sum(layers.filtered(lambda l: l.product_id.id == byproduct.id).mapped('quantity'))
+        by_product_cost_per_unit = byproduct_cost / by_product_quantity
+        component_cost = sum(layers.filtered(lambda l: l.product_id.id == self.component.id).mapped('value'))
+        self.assertEqual(main_product_cost, 45.0)
+        self.assertEqual(byproduct_cost, 5.0)
+        self.assertEqual(by_product_quantity, 5.0)
+        self.assertEqual(by_product_cost_per_unit, 1.0)
+        self.assertEqual(component_cost, -50.0)


### PR DESCRIPTION
PURPOSE:

1. For products that are manufactured with FIFO/AVCO product categories, once a
production is marked as done, users are given the possibility to unlock the MO
and update either
- the byproduct quantity : in the case the component consumption remains
unchanged

SPECIFICATION:

1. Modify By-Product Production

1. Use case 1 : Modify Byproduct

Example :
Produce 5 Litres worth $10.
Get 5 Litres (byproduct)
Modify byproduct to 6 Litres.

Current Behaviour : Post 1 new Layer, for 1 L worth $2

To do Instead :
    Post 0 quantity layer at - $2
    Post 1 quantity layer at + $2

And we make sure that the layers are linked so that the quantities are linked to
the original $10 Layer.

Task - 2574613