### PR TITLE
[FIX] calendar: correct attendee_id

### DIFF
--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -72,8 +72,8 @@ class Partner(models.Model):
             for attendee in attendees_by_partner[partner.id]:
                 attendee_is_organizer = self.env.user == attendee.event_id.user_id and attendee.partner_id == self.env.user.partner_id
                 attendees_details.append({
-                    'id': partner_info[0],
-                    'name': partner_info[1],
+                    'id': partner.id,
+                    'name': partner_info,
                     'status': attendee.state,
                     'event_id': attendee.event_id.id,
                     'attendee_id': attendee.id,


### PR DESCRIPTION
Steps to reproduce:
- Create an event
- Change organiser to Joel
- Try to delete

Issue:
- js traceback error

Cause:
- the id returned is the first letter of the chain character `partner_info` and breaks the `declineEvent` function.

opw-2951894