### PR TITLE
[FIX] website_sale: correct misspelling in website settings

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -241,7 +241,7 @@ msgstr ""
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
-msgid "<span class=\"o_form_label\">Remind Abandonned Carts</span>"
+msgid "<span class=\"o_form_label\">Remind Abandoned Carts</span>"
 msgstr ""
 
 #. module: website_sale
@@ -957,7 +957,7 @@ msgstr ""
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
-msgid "Configure mails at order confirmation, abandonned carts, etc"
+msgid "Configure mails at order confirmation, abandoned carts, etc"
 msgstr ""
 
 #. module: website_sale
@@ -1319,7 +1319,7 @@ msgstr ""
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.res_config_settings_view_form
-msgid "Email to authentified customers who did not complete the checkout"
+msgid "Email to authenticated customers who did not complete the checkout"
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -357,7 +357,7 @@
                     <div class="o_setting_right_pane">
                         <span class="o_form_label">Automated Emails</span>
                         <div class="text-muted">
-                            Configure mails at order confirmation, abandonned carts, etc
+                            Configure mails at order confirmation, abandoned carts, etc
                         </div>
                         <div class="mt8">
                             <button type="object" name="action_open_sale_mail_templates" string="Customize Email Templates" class="btn-link" icon="fa-arrow-right"/>
@@ -367,9 +367,9 @@
                 <div class="col-xs-12 col-lg-6 o_setting_box" id="abandoned_carts_setting" title="Abandoned carts are all carts left unconfirmed by website visitors. You can find them in *Website > Orders > Abandoned Carts*. From there you can send recovery emails to visitors who entered their contact details.">
                     <div class="o_setting_left_pane"/>
                     <div class="o_setting_right_pane">
-                        <span class="o_form_label">Remind Abandonned Carts</span>
+                        <span class="o_form_label">Remind Abandoned Carts</span>
                         <div class="text-muted">
-                            Email to authentified customers who did not complete the checkout
+                            Email to authenticated customers who did not complete the checkout
                         </div>
                         <div class="content-group" title="Carts are flagged as abandoned after this delay.">
                             <div class="row mt16">


### PR DESCRIPTION
Corrects misspelling of "abandonned" -> "abandoned" and incorrect word "authentified" -> "authenticated" in website+e-commerce settings.

Steps:
- Install E-commerce module
- Navigate to Website -> Configuration -> Settings
- Search for "Abandoned Cart" section

Problem was introduced in commit: 73483c8e5ab53a2ea3fb678f40e04e2cfc2e7ef0

opw-2949403

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
