### PR TITLE
  [FIX] web: autocomplete should keep input value on search more 

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -117,17 +117,15 @@ export class AutoComplete extends Component {
         );
     }
     selectOption(indices, params = {}) {
-        this.inputRef.el.value = "";
-        this.forceValFromProp = true;
-
         const option = this.sources[indices[0]].options[indices[1]];
         if (option.unselectable) {
+            this.inputRef.el.value = "";
             return;
         }
 
+        this.forceValFromProp = true;
         this.props.onSelect(option, {
             ...params,
-            inputValue: this.inputRef.el.value.trim(),
             input: this.inputRef.el,
         });
         this.close();

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -167,7 +167,9 @@ export class Many2XAutocomplete extends owl.Component {
             },
             fieldString,
             onClose: () => {
-                autoCompleteContainer.el.querySelector("input").focus();
+                const autoCompleteInput = autoCompleteContainer.el.querySelector("input");
+                autoCompleteInput.value = "";
+                autoCompleteInput.focus();
             },
         });
 

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -612,8 +612,6 @@ QUnit.module("Fields", (hooks) => {
     );
 
     QUnit.test("many2ones in form views with search more", async function (assert) {
-        assert.expect(3);
-
         for (let i = 5; i < 11; i++) {
             serverData.models.partner.records.push({ id: i, display_name: `Partner ${i}` });
         }
@@ -654,6 +652,7 @@ QUnit.module("Fields", (hooks) => {
         await selectDropdownItem(target, "trululu", "Search More...");
 
         assert.strictEqual($("tr.o_data_row").length, 9, "should display 9 records");
+        assert.equal(target.querySelector(".o_field_widget[name=trululu] input").value, "aaa");
 
         const modal = target.querySelector(".modal");
 


### PR DESCRIPTION
# [FIX] web: autocomplete should keep input value on search more
- Before this commit
When searching more in an autocomplete component,
the input value is emptied before opening the Search More dialog.

- After this commit
The input value keeps its content when the Search More dialog opens.