### PR TITLE
[FIX][15.0] hr_contact: fix bug hr_contact

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -121,7 +121,7 @@ class Contract(models.Model):
                 end_domain = ['|', ('date_end', '>=', contract.date_start), ('date_end', '=', False)]
             else:
                 start_domain = [('date_start', '<=', contract.date_end)]
-                end_domain = ['|', ('date_end', '>', contract.date_start), ('date_end', '=', False)]
+                end_domain = ['|', ('date_end', '>=', contract.date_start), ('date_end', '=', False)]
 
             domain = expression.AND([domain, start_domain, end_domain])
             if self.search_count(domain):


### PR DESCRIPTION
- Create a contract for employee A as follows:
 + Contract 1 has a term: 15/4-18/5, 2022
 + Contract 2 has a term: 18/5-14/6/2022
 + Contract 3 has a term: 14/6-30/7, 2022

 With a setup like this, it is possible to set 2 activities running at
the same time => while blocking, only 1 activity can be in the running
state
Creating payslips for May or June will be charged up by 1 day because
there is a set of starting value of the following contract = the end
date of the previous contract

Resolve:
- add an equal sign into end_domain variable in _checl_current_contact
function so that 2 contract can not have the same start date and end
date





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
