### PR TITLE
[I18N][15.0] base: Update vi.po translation file

### DIFF
--- a/odoo/addons/base/i18n/vi.po
+++ b/odoo/addons/base/i18n/vi.po
@@ -27357,7 +27357,7 @@ msgstr "Máy bán hàng nội bộ"
 #: model:ir.model.fields,field_description:base.field_res_users__user_id
 #: model_terms:ir.ui.view,arch_db:base.view_res_partner_filter
 msgid "Salesperson"
-msgstr "Nhân viên kinh doanh"
+msgstr "Nhân viên Kinh doanh"
 
 #. module: base
 #: model:res.country,name:base.ws


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- We wish translate `Salesperson` to `Nhân viên Kinh doanh` instead of
`Nhân viên bán hàng` to suit the context of our country.

Desired behavior after PR is merged:
- Change `Nhân viên bán hàng` into `Nhân viên Kinh doanh`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
