### PR TITLE
[FIX] hr_expense: precompute name, uom, taxes and account

### DIFF
--- a/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
+++ b/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
@@ -53,6 +53,7 @@ class TestExpenseMargin(TestExpenseCommon):
                     'product_id': product_with_no_cost.id,
                     'unit_amount': product_with_no_cost.standard_price,
                     'total_amount': 100,
+                    'tax_ids': False,
                     'employee_id': self.expense_employee.id,
                     'sale_order_id': sale_order.id
                 }),
@@ -74,6 +75,7 @@ class TestExpenseMargin(TestExpenseCommon):
                     'product_id': product_with_cost.id,
                     'quantity': 5,
                     'unit_amount': product_with_cost.standard_price,
+                    'tax_ids': False,
                     'employee_id': self.expense_employee.id,
                     'sale_order_id': sale_order.id
                 }),


### PR DESCRIPTION
This is an oversight of odoo/odoo#95729

In a database with multi-uom disabled,
when attempting to create an expense choosing a product
with a different unit of measure than the Unit(s)
a ValidationError was raised to the user
regarding  an UOM incompatibility

e.g.
- Create an expense
- Set the product "[MIL] Mileage", using the uom "km"
- Save
-> ValidationError about UOMs

This is because the above mentioned PR makes the
`product_uom_id` completely removed from the view,
and the onchange no longer set the uom correctly within the form.

Solve this by setting `precompute=True` on the UOM field,
and the other fields using the same compute method.

In addition to solve the issue, it also allows to create
more easily expenses from the XMLRPC API:
Before, when creating an expense for the product "Mileage",
it was required you set yourself the uom correctly
in your API call,
even if multi UOMs was disabled in your database.
After, it's no longer mandatory to pass the UOM to use,
it is correctly computed from the product directly,
by default.