### PR TITLE
[FIX] analytic: search accounts with 'not ilike'

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -165,7 +165,10 @@ class AccountAnalyticAccount(models.Model):
             # we have to cut the search in two searches ... https://github.com/odoo/odoo/issues/25175
             partner_ids = self.env['res.partner']._search([('name', operator, name)], limit=limit, access_rights_uid=name_get_uid)
             domain_operator = '&' if operator == 'not ilike' else '|'
-            domain = [domain_operator, domain_operator, ('code', operator, name), ('name', operator, name), ('partner_id', 'in', partner_ids)]
+            partner_domain = [('partner_id', 'in', partner_ids)]
+            if operator == 'not ilike':
+                partner_domain = expression.OR([partner_domain, [('partner_id', '=', False)]])
+            domain = [domain_operator, domain_operator, ('code', operator, name), ('name', operator, name)] + partner_domain
         return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
 


### PR DESCRIPTION
Before this commit:
Custom filter with the "doesn't contain" operator filters out the
results where no partner is set on the Analytic Account which is not
desirable.

After this commit:
Custom filter with the "doesn't contain" operator doesn't filter out the
results where no partner is set on the Analytic Account anymore.

OPW-2953118

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
