### PR TITLE
[FIX] mail: get_mention_suggestions returns correct channel data

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1137,7 +1137,16 @@ class Channel(models.Model):
                             [('channel_partner_ids', 'in', [self.env.user.partner_id.id])]
                         ])
                     ])
-        return self.search_read(domain, ['id', 'name', 'public', 'channel_type'], limit=limit)
+        channels = self.search(domain, limit=limit)
+        return [{
+            'channel': {
+                'channel_type': channel.channel_type,
+                'id': channel.id,
+            },
+            'id': channel.id,
+            'name': channel.name,
+            'public': channel.public,
+        } for channel in channels]
 
     def channel_fetch_preview(self):
         """ Return the last message of the given channels """

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -214,10 +214,7 @@ registerModel({
                 { shadow: true },
             );
             this.messaging.models['Thread'].insert(channelsData.map(channelData =>
-                Object.assign(
-                    { model: 'mail.channel' },
-                    this.messaging.models['Thread'].convertData(channelData),
-                )
+                this.messaging.models['Thread'].convertData(channelData)
             ));
         },
         /**

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1224,6 +1224,10 @@ patch(MockServer.prototype, 'mail', {
                 }).map(channel => {
                     // expected format
                     return {
+                        channel: {
+                            channel_type: channel.channel_type,
+                            id: channel.id,
+                        },
                         id: channel.id,
                         name: channel.name,
                         public: channel.public,


### PR DESCRIPTION
ac08da0a834631b2a7c39c40b1f36f01a85e8617 moved channel_type from Thread to Channel, but data returned by get_mention_suggestions have not been updated accordingly. This commit adapts it.

Follow-up of task-2948676.