### PR TITLE
[IMP] website_slides: allow course deletion when there are slides 

### DIFF
--- a/addons/website_slides/models/slide_question.py
+++ b/addons/website_slides/models/slide_question.py
@@ -13,7 +13,7 @@ class SlideQuestion(models.Model):
 
     sequence = fields.Integer("Sequence")
     question = fields.Char("Question Name", required=True, translate=True)
-    slide_id = fields.Many2one('slide.slide', string="Content", required=True)
+    slide_id = fields.Many2one('slide.slide', string="Content", required=True, ondelete='cascade')
     answer_ids = fields.One2many('slide.answer', 'question_id', string="Answer", copy=True)
     # statistics
     attempts_count = fields.Integer(compute='_compute_statistics', groups='website_slides.group_website_slides_officer')

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -119,7 +119,7 @@ class Slide(models.Model):
     sequence = fields.Integer('Sequence', default=0)
     user_id = fields.Many2one('res.users', string='Uploaded by', default=lambda self: self.env.uid)
     description = fields.Html('Description', translate=True)
-    channel_id = fields.Many2one('slide.channel', string="Course", required=True)
+    channel_id = fields.Many2one('slide.channel', string="Course", required=True, ondelete='cascade')
     tag_ids = fields.Many2many('slide.tag', 'rel_slide_tag', 'slide_id', 'tag_id', string='Tags')
     is_preview = fields.Boolean('Allow Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")
     is_new_slide = fields.Boolean('Is New Slide', compute='_compute_is_new_slide')
@@ -684,11 +684,6 @@ class Slide(models.Model):
         rec = super(Slide, self).copy(default)
         rec.sequence = 0
         return rec
-
-    @api.ondelete(at_uninstall=False)
-    def _unlink_except_already_taken(self):
-        if self.question_ids and self.channel_id.channel_partner_ids:
-            raise UserError(_("People already took this quiz. To keep course progression it should not be deleted."))
 
     def unlink(self):
         for category in self.filtered(lambda slide: slide.is_category):

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -134,6 +134,15 @@ class TestSlidesManagement(slides_common.SlidesCase):
             ['Congratulation! You completed %s' % self.channel.name, 'ATestSubject']
         )
 
+    def test_unlink_slide_channel(self):
+        self.assertTrue(self.channel.slide_content_ids.mapped('question_ids').exists(),
+            "Has question(s) linked to the slides")
+        self.assertTrue(self.channel.channel_partner_ids.exists(), "Has participant(s)")
+
+        self.channel.with_user(self.user_manager).unlink()
+        self.assertFalse(self.channel.exists(),
+            "Should have deleted channel along with the slides even if there are slides with quiz and participant(s)")
+
 
 class TestSequencing(slides_common.SlidesCase):
 


### PR DESCRIPTION
Currently, the validation error "slide_slide_channel_id_fkey" appears if we try
to delete a course(slide.channel) record with slides.The slide_ids field in the
"slide_channel" model has a one-to-many relationship with the channel_id field in
the "slide_slide" model, so deleting a course result in the foreign key error (fkey).

This commit solves the above problem by adding "ondelete=cascade" to
the channel_id field in the slide_slide model, which deletes the slide related
to the course.
 
Aside from that, this commit also made the below changes:
 
  - Adds "ondelete=cascade" to the slide_id field in the slide_question model,
    which deletes questions related to the slide.

  - Remove "_unlink_except_already_taken" method because it generates a user
    error when we try to delete a slide with a question and attendees. We
    should delete the slide instead.

task-2928164

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
