### PR TITLE
[FIX] web: restore sizing for XXL Form View

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -790,7 +790,7 @@ $o-form-label-margin-right: 0px;
     }
 }
 
-.o_xxl_form_view {
+.o_form_view.o_xxl_form_view {
     flex-flow: row nowrap;
     height: 100%;
 


### PR DESCRIPTION
XXL Form View doesn't apply the right max-width (1320px instead of
1140px).

This is due to the precedence of the selector for `.o_xxl_form_view`
since https://github.com/odoo/odoo/pull/96627. Also this code block
applies to both legacy an new FormView instead of only the new one.

This commit fixes it by properly targetting the `.o_form_view` with the
`.o_xxl_form_view` and restores the previous behavior.