### PR TITLE
[IMP] mail: model_field: use this.model instead of record.constructor

### DIFF
--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -142,7 +142,7 @@ export class ModelField {
         this.to = to;
         if (this.identifying) {
             this.readonly = true;
-            if (model.identifyingMode === 'and') {
+            if (this.model.identifyingMode === 'and') {
                 this.required = true;
             }
         }
@@ -215,8 +215,7 @@ export class ModelField {
      */
     computeRelated(record) {
         const [relationName, relatedFieldName] = this.related.split('.');
-        const model = record.constructor;
-        const relationField = model.__fieldMap.get(relationName);
+        const relationField = this.model.__fieldMap.get(relationName);
         if (relationField.relationType === 'many') {
             const newVal = [];
             for (const otherRecord of record[relationName]) {
@@ -368,7 +367,7 @@ export class ModelField {
                         }
                         break;
                     default:
-                        throw new Error(`Field "${record.constructor.name}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
+                        throw new Error(`Field "${this.model.name}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
                 }
             } else if (this.fieldType === 'relation') {
                 switch (commandName) {
@@ -413,7 +412,7 @@ export class ModelField {
                         }
                         break;
                     default:
-                        throw new Error(`Field "${record.constructor.name}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
+                        throw new Error(`Field "${this.model.name}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
                 }
             }
         }


### PR DESCRIPTION
Since be0fc43bbd0664340d555f2156630870e3548466, a reference to the model is passed to ModelField constructor. This commit replaces all occurrences of record.constructor with this.model (shorter and more straightforward).