### PR TITLE
[FIX] website: handle search keyboard navigation manually

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1523,6 +1523,11 @@ $ribbon-padding: 100px;
 }
 
 // Search results
+.o_searchbar_form {
+    .dropdown-item.o_focus {
+        @extend .dropdown-item:hover;
+    }
+}
 .o_search_result_item_detail {
     flex: 1;
 }

--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -234,20 +234,36 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
      * @private
      */
     _onKeydown: function (ev) {
+        const focusedEl = this.$menu && this.$menu[0].querySelector('.o_focus');
         switch (ev.which) {
             case $.ui.keyCode.ESCAPE:
                 this._render();
                 break;
             case $.ui.keyCode.UP:
             case $.ui.keyCode.DOWN:
-                ev.preventDefault();
                 if (this.$menu) {
-                    let $element = ev.which === $.ui.keyCode.UP ? this.$menu.children().last() : this.$menu.children().first();
-                    $element.focus();
+                    const suggestionEls = [null, ...this.$menu[0].querySelectorAll('.dropdown-item')];
+                    const currentIndex = suggestionEls.indexOf(focusedEl);
+                    const delta = ev.which === $.ui.keyCode.UP ? suggestionEls.length - 1 : 1;
+                    const nextIndex = (currentIndex + delta) % suggestionEls.length;
+                    const nextFocusedEl = suggestionEls[nextIndex];
+                    if (focusedEl) {
+                        focusedEl.classList.remove('o_focus');
+                    }
+                    if (nextFocusedEl) {
+                        nextFocusedEl.classList.add('o_focus');
+                        nextFocusedEl.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+                    } else {
+                        this.$input[0].scrollIntoView({behavior: 'smooth', block: 'nearest'});
+                    }
                 }
                 break;
             case $.ui.keyCode.ENTER:
                 this.limit = 0; // prevent autocomplete
+                if (focusedEl) {
+                    focusedEl.click();
+                    ev.preventDefault();
+                }
                 break;
         }
     },


### PR DESCRIPTION
Since [1] when BS5 was introduced, the keyboard navigation of search
autocomplete suggestions did not work anymore.

This commit avoids relying on bootstrap and JQuery to navigate the
suggestions.
It also autoscrolls to the highlighted option if needed, when using the
keyboard navigation.

[1]: https://github.com/odoo/odoo/commit/971e5a91aab96d36129a823e03f1f9f1b1293968

task-3148871