### PR TITLE
[FIX] web: create="0" in a grouped kanban view

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -96,10 +96,12 @@ export class KanbanController extends Component {
     }
 
     get canCreate() {
-        if (!this.model.root.isGrouped) {
-            return this.props.archInfo.activeActions.create;
+        const { create, groupCreate } = this.props.archInfo.activeActions;
+        const list = this.model.root;
+        if (!create) {
+            return false;
         }
-        return !this.props.archInfo.activeActions.groupCreate || this.model.root.groups.length > 0;
+        return list.isGrouped ? list.groups.length > 0 || !groupCreate : true;
     }
 }
 

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -4608,6 +4608,25 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o-kanban-button-new");
     });
 
+    QUnit.test("kanban view with create=False and groupby", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban create="0">
+                    <templates>
+                        <t t-name="kanban-box">>
+                            <div><field name="foo"/></div>>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["product_id"],
+        });
+
+        assert.containsNone(target, ".o-kanban-button-new");
+    });
+
     QUnit.test("clicking on a link triggers correct event", async (assert) => {
         await makeView({
             type: "kanban",
@@ -10446,12 +10465,12 @@ QUnit.module("Views", (hooks) => {
     QUnit.test(
         "Color '200' (gray) can be used twice (for false value and another value) in progress bar",
         async (assert) => {
-        serverData.models.partner.records.push({ id: 5, bar: true }, { id: 6, bar: false });
-        await makeView({
-            type: "kanban",
-            resModel: "partner",
-            serverData,
-            arch: `
+            serverData.models.partner.records.push({ id: 5, bar: true }, { id: 6, bar: false });
+            await makeView({
+                type: "kanban",
+                resModel: "partner",
+                serverData,
+                arch: `
                 <kanban>
                     <field name="bar"/>
                     <field name="foo"/>
@@ -10465,56 +10484,57 @@ QUnit.module("Views", (hooks) => {
                     </templates>
                 </kanban>
             `,
-            groupBy: ["bar"],
-        });
+                groupBy: ["bar"],
+            });
 
-        assert.containsN(target, ".o_kanban_group:nth-child(1) .progress-bar", 2);
-        assert.deepEqual(
-            [...target.querySelectorAll(".o_kanban_group:nth-child(1) .progress-bar")].map(
-                (el) => el.dataset.tooltip
-            ),
-            ["1 blip", "1 Other"]
-        );
-        assert.containsN(target, ".o_kanban_group:nth-child(2) .progress-bar", 4);
-        assert.deepEqual(
-            [...target.querySelectorAll(".o_kanban_group:nth-child(2) .progress-bar")].map(
-                (el) => el.dataset.tooltip
-            ),
-            ["1 yop", "1 gnap", "1 blip", "1 Other"]
-        );
-        assert.deepEqual(getCounters(), ["2", "4"]);
+            assert.containsN(target, ".o_kanban_group:nth-child(1) .progress-bar", 2);
+            assert.deepEqual(
+                [...target.querySelectorAll(".o_kanban_group:nth-child(1) .progress-bar")].map(
+                    (el) => el.dataset.tooltip
+                ),
+                ["1 blip", "1 Other"]
+            );
+            assert.containsN(target, ".o_kanban_group:nth-child(2) .progress-bar", 4);
+            assert.deepEqual(
+                [...target.querySelectorAll(".o_kanban_group:nth-child(2) .progress-bar")].map(
+                    (el) => el.dataset.tooltip
+                ),
+                ["1 yop", "1 gnap", "1 blip", "1 Other"]
+            );
+            assert.deepEqual(getCounters(), ["2", "4"]);
 
-        await click(target.querySelector(".o_kanban_group:nth-child(2) .progress-bar"));
+            await click(target.querySelector(".o_kanban_group:nth-child(2) .progress-bar"));
 
-        assert.deepEqual(getCounters(), ["2", "1"]);
-        assert.strictEqual(
-            target.querySelector(".o_kanban_group:nth-child(2) .o_kanban_record").innerText,
-            "ABC"
-        );
-        assert.containsNone(target, ".o_kanban_group:nth-child(2) .o_kanban_load_more");
+            assert.deepEqual(getCounters(), ["2", "1"]);
+            assert.strictEqual(
+                target.querySelector(".o_kanban_group:nth-child(2) .o_kanban_record").innerText,
+                "ABC"
+            );
+            assert.containsNone(target, ".o_kanban_group:nth-child(2) .o_kanban_load_more");
 
-        await click(
-            target.querySelector(".o_kanban_group:nth-child(2) .progress-bar:nth-child(2)")
-        );
+            await click(
+                target.querySelector(".o_kanban_group:nth-child(2) .progress-bar:nth-child(2)")
+            );
 
-        assert.deepEqual(getCounters(), ["2", "1"]);
-        assert.strictEqual(
-            target.querySelector(".o_kanban_group:nth-child(2) .o_kanban_record").innerText,
-            "GHI"
-        );
-        assert.containsNone(target, ".o_kanban_group:nth-child(2) .o_kanban_load_more");
+            assert.deepEqual(getCounters(), ["2", "1"]);
+            assert.strictEqual(
+                target.querySelector(".o_kanban_group:nth-child(2) .o_kanban_record").innerText,
+                "GHI"
+            );
+            assert.containsNone(target, ".o_kanban_group:nth-child(2) .o_kanban_load_more");
 
-        await click(
-            target.querySelector(".o_kanban_group:nth-child(2) .progress-bar:nth-child(4)")
-        );
+            await click(
+                target.querySelector(".o_kanban_group:nth-child(2) .progress-bar:nth-child(4)")
+            );
 
-        assert.deepEqual(getCounters(), ["2", "1"]);
-        assert.strictEqual(
-            target.querySelector(".o_kanban_group:nth-child(2) .o_kanban_record").innerText,
-            ""
-        );
-        assert.containsNone(target, ".o_kanban_group:nth-child(2) .o_kanban_load_more");
-    });
+            assert.deepEqual(getCounters(), ["2", "1"]);
+            assert.strictEqual(
+                target.querySelector(".o_kanban_group:nth-child(2) .o_kanban_record").innerText,
+                ""
+            );
+            assert.containsNone(target, ".o_kanban_group:nth-child(2) .o_kanban_load_more");
+        }
+    );
 
     QUnit.test(
         "keep focus inside control panel when pressing arrowdown and no kanban card",


### PR DESCRIPTION
This commit is to remove the "Create" button in a grouped kanban view
with create="0".

Problem:
In a kanban view with create="0", the "Create" button should never be
displayed.

How to reproduce :
- go to a kanban view with create="0"
- group the view

Result before:
The "Create" button is displayed

Result after:
The "Create" button is not displayed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
