### PR TITLE
[FIX] payment: allow partner to see invoices preview for all it's companies

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -443,7 +443,7 @@ class PaymentPortal(portal.CustomerPortal):
         :return: None
         :raise UserError: If the companies don't match.
         """
-        if partner.company_id and partner.company_id != document_company:
+        if partner.company_id and document_company not in (partner.company_id | partner.user_ids.company_ids):
             raise UserError(
                 _("Please switch to company '%s' to make this payment.", document_company.name)
             )


### PR DESCRIPTION
In multi company, a user that has access to other companies can only preview invoices from it’s original company.
To reproduce :
Login as Admin
install account_payment
Create new company with demo data (by installing l10n_be for example)
Preview an invoice from second company

This fix also allows the preview if the document company is in partner.user_ids.company_ids.

Task: opw-2954181