### PR TITLE
[FIX] account: constrain foreign currency in bank statements

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -771,6 +771,8 @@ class AccountBankStatementLine(models.Model):
                 raise ValidationError(_("The foreign currency must be different than the journal one: %s", st_line.currency_id.name))
             if not st_line.foreign_currency_id and st_line.amount_currency:
                 raise ValidationError(_("You can't provide an amount in foreign currency without specifying a foreign currency."))
+            if not st_line.amount_currency and st_line.foreign_currency_id:
+                raise ValidationError(_("You can't provide a foreign currency without specifying an amount in 'Amount in Currency' field."))
 
     # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -596,31 +596,6 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': -10.0,       'currency_id': self.currency_2.id},
         ])
 
-    def test_zero_amount_currency_journal_curr_1_statement_curr_2(self):
-        self.bank_journal_2.currency_id = self.currency_1
-
-        statement = self.env['account.bank.statement'].create({
-            'name': 'test_statement',
-            'date': '2019-01-01',
-            'journal_id': self.bank_journal_2.id,
-            'line_ids': [
-                (0, 0, {
-                    'date': '2019-01-01',
-                    'payment_ref': 'line_1',
-                    'partner_id': self.partner_a.id,
-                    'foreign_currency_id': self.currency_2.id,
-                    'amount': 10.0,
-                    'amount_currency': 0.0,
-                }),
-            ],
-        })
-
-        self.assertRecordValues(statement.line_ids.move_id.line_ids, [
-            # pylint: disable=C0326
-            {'debit': 10.0,     'credit': 0.0,      'amount_currency': 10.0,        'currency_id': self.currency_1.id},
-            {'debit': 0.0,      'credit': 10.0,     'amount_currency': 0.0,         'currency_id': self.currency_2.id},
-        ])
-
     def test_zero_amount_journal_curr_2_statement_curr_1(self):
         self.bank_journal_2.currency_id = self.currency_2
 
@@ -645,30 +620,6 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
             {'debit': 0.0,      'credit': 10.0,     'amount_currency': -10.0,       'currency_id': self.currency_1.id},
         ])
 
-    def test_zero_amount_currency_journal_curr_2_statement_curr_1(self):
-        self.bank_journal_2.currency_id = self.currency_2
-
-        statement = self.env['account.bank.statement'].create({
-            'name': 'test_statement',
-            'date': '2019-01-01',
-            'journal_id': self.bank_journal_2.id,
-            'line_ids': [
-                (0, 0, {
-                    'date': '2019-01-01',
-                    'payment_ref': 'line_1',
-                    'partner_id': self.partner_a.id,
-                    'foreign_currency_id': self.currency_1.id,
-                    'amount': 10.0,
-                    'amount_currency': 0.0,
-                }),
-            ],
-        })
-
-        self.assertRecordValues(statement.line_ids.move_id.line_ids, [
-            {'debit': 0.0,      'credit': 0.0,      'amount_currency': 10.0,        'currency_id': self.currency_2.id},
-            {'debit': 0.0,      'credit': 0.0,      'amount_currency': 0.0,         'currency_id': self.currency_1.id},
-        ])
-
     def test_zero_amount_journal_curr_2_statement_curr_3(self):
         self.bank_journal_2.currency_id = self.currency_2
 
@@ -691,30 +642,6 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self.assertRecordValues(statement.line_ids.move_id.line_ids, [
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': 0.0,         'currency_id': self.currency_2.id},
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': -10.0,       'currency_id': self.currency_3.id},
-        ])
-
-    def test_zero_amount_currency_journal_curr_2_statement_curr_3(self):
-        self.bank_journal_2.currency_id = self.currency_2
-
-        statement = self.env['account.bank.statement'].create({
-            'name': 'test_statement',
-            'date': '2019-01-01',
-            'journal_id': self.bank_journal_2.id,
-            'line_ids': [
-                (0, 0, {
-                    'date': '2019-01-01',
-                    'payment_ref': 'line_1',
-                    'partner_id': self.partner_a.id,
-                    'foreign_currency_id': self.currency_3.id,
-                    'amount': 10.0,
-                    'amount_currency': 0.0,
-                }),
-            ],
-        })
-
-        self.assertRecordValues(statement.line_ids.move_id.line_ids, [
-            {'debit': 5.0,      'credit': 0.0,      'amount_currency': 10.0,        'currency_id': self.currency_2.id},
-            {'debit': 0.0,      'credit': 5.0,      'amount_currency': 0.0,         'currency_id': self.currency_3.id},
         ])
 
     def test_constraints(self):
@@ -751,6 +678,12 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         assertStatementLineConstraint(statement_vals, {
             **statement_line_vals,
             'amount_currency': 10.0,
+        })
+
+        # Can't have a foreign currency set without amount in foreign currency.
+        assertStatementLineConstraint(statement_vals, {
+            **statement_line_vals,
+            'foreign_currency_id': self.currency_2.id,
         })
 
         # ==== Test constraints at edition ====


### PR DESCRIPTION
On a bank statement line:
If a foreign currency is set and the amount in currency is not set, the line is reconciled automatically (because the amount is 0) and this should not be the case.
Add a constraint on `account.bank.statement.line`: raise an error if the foreign currency is added, but the amount in currency is not.

This conflicts with the tests that allow this behaviour, so the related tests are deleted as this should not be allowed anymore.

task-2956422

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
