### PR TITLE
[IMP] web: kanban: add bottom quickCreate button

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -42,6 +42,7 @@
 
     .o_kanban_quick_create {
         margin-bottom: calc(var(--KanbanRecord-margin-h) * 2);
+        margin-top: calc(var(--KanbanRecord-margin-h) * 2);
         padding: 8px;
 
         .o_form_view .o_group.o_inner_group {
@@ -503,6 +504,12 @@
             background-color: var(--KanbanColumn__highlight-background);
             box-shadow: -1px 0px 0px 0px var(--KanbanColumn__highlight-border) inset,
                 1px 0px 0px 0px var(--KanbanColumn__highlight-border) inset;
+        }
+        .o_kanban_quick_add_bottom {
+            font-size: 0.94791667rem;
+            font-weight: $font-weight-bold;
+            @include o-hover-opacity(.7);
+            @include o-hover-text-color($text-muted, $body-color);
         }
     }
 

--- a/addons/web/static/src/views/kanban/kanban_model.js
+++ b/addons/web/static/src/views/kanban/kanban_model.js
@@ -163,13 +163,13 @@ class KanbanGroup extends Group {
     /**
      * @override
      */
-    quickCreate(activeFields, context) {
+    quickCreate(activeFields, context, atFirstPosition = false) {
         const ctx = { ...context };
         if (this.hasActiveProgressValue && this.progressValue.active !== FALSE) {
             const { fieldName } = this.model.progressAttributes;
             ctx[`default_${fieldName}`] = this.progressValue.active;
         }
-        return super.quickCreate(activeFields, ctx);
+        return super.quickCreate(activeFields, ctx, atFirstPosition);
     }
 
     async load() {
@@ -295,14 +295,14 @@ class KanbanGroup extends Group {
         await this.checkActiveValue();
     }
 
-    async validateQuickCreate() {
+    async validateQuickCreate(index) {
         const record = this.list.quickCreateRecord;
         if (!record) {
             return false;
         }
         const saved = await record.save();
         if (saved) {
-            this.addRecord(this.removeRecord(record), 0);
+            this.addRecord(this.removeRecord(record), index);
             this.count++;
             this.list.count++;
             return record;

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -83,6 +83,9 @@ export class KanbanRenderer extends Component {
                         parent.dataset.id === element.parentElement.dataset.id
                     ) {
                         parent && parent.classList && parent.classList.remove("o_kanban_hover");
+                        while (previous && !previous.dataset.id) {
+                            previous = previous.previousElementSibling;
+                        }
                         const refId = previous ? previous.dataset.id : null;
                         const targetGroupId = parent && parent.dataset.id;
                         await this.props.list.moveRecord(
@@ -379,15 +382,16 @@ export class KanbanRenderer extends Component {
     // Edition methods
     // ------------------------------------------------------------------------
 
-    quickCreate(group) {
-        return this.props.list.quickCreate(group);
+    quickCreate(group, atFirstPosition = true) {
+        return this.props.list.quickCreate(group, atFirstPosition);
     }
 
     async validateQuickCreate(mode, group) {
         const values = group.list.quickCreateRecord.data;
+        const quickCreateRecordIndex = group.list.quickCreateRecordIndex;
         let record;
         try {
-            record = await group.validateQuickCreate();
+            record = await group.validateQuickCreate(quickCreateRecordIndex);
         } catch (e) {
             // TODO: filter RPC errors more specifically (eg, for access denied, there is no point in opening a dialog)
             if (!(e instanceof RPCError)) {
@@ -420,7 +424,7 @@ export class KanbanRenderer extends Component {
             if (mode === "edit") {
                 await this.props.openRecord(record, "edit");
             } else {
-                await this.quickCreate(group);
+                await this.quickCreate(group, quickCreateRecordIndex === 0);
             }
         }
     }

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -47,7 +47,7 @@
                                             </DropdownItem>
                                         </t>
                                     </Dropdown>
-                                    <button t-if="canQuickCreate()" class="o_kanban_quick_add btn p-0 border-0 fs-6 shadow-none" t-on-click="() => this.quickCreate(group)">
+                                    <button t-if="canQuickCreate()" class="o_kanban_quick_add btn p-0 border-0 fs-6 shadow-none" t-on-click="() => this.quickCreate(group, true)">
                                         <i class="fa fa-plus fa-stack d-block small text-end text-700 opacity-50 opacity-100-hover cursor-pointer" role="img" aria-label="Quick add" title="Quick add" />
                                     </button>
                                 </t>
@@ -112,12 +112,18 @@
                             <div t-if="unloadedCount > 0" class="o_kanban_load_more">
                                 <button class="btn btn-outline-primary w-100 mt-4" t-on-click="() => this.loadMore(group)">Load more... (<t t-out="unloadedCount"/> remaining)</button>
                             </div>
+                            <span t-elif="canQuickCreate()" class="o_kanban_quick_add_bottom d-block m-2 cursor-pointer" t-on-click="() => this.quickCreate(group, false)">
+                                <i class="fa fa-plus" role="img" aria-label="Quick add" title="Quick add" /> New
+                            </span>
                         </t>
                         <t t-elif="env.isSmall">
                             <t t-set="unloadedCount" t-value="getGroupUnloadedCount(group)" />
                             <div t-if="unloadedCount > 0" class="o_kanban_load_more">
                                 <button class="btn btn-outline-primary w-100 mt-4" t-on-click="() => this.toggleGroup(group)">Load more... (<t t-out="unloadedCount"/> remaining)</button>
                             </div>
+                            <span t-elif="canQuickCreate()" class="o_kanban_quick_add_bottom d-block m-2 cursor-pointer" t-on-click="() => this.quickCreate(group, false)">
+                                <i class="fa fa-plus" role="img" aria-label="Quick add" title="Quick add" /> New
+                            </span>
                         </t>
                     </div>
                 </t>

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1750,6 +1750,9 @@ export class DynamicRecordList extends DynamicList {
         return this.records.find((r) => r.isInQuickCreation);
     }
 
+    get quickCreateRecordIndex() {
+        return this.records.findIndex((r) => r.isInQuickCreation);
+    }
     // -------------------------------------------------------------------------
     // Public
     // -------------------------------------------------------------------------
@@ -1901,7 +1904,7 @@ export class DynamicRecordList extends DynamicList {
         }
     }
 
-    async quickCreate(activeFields, context) {
+    async quickCreate(activeFields, context, atFirstPosition = true) {
         await this.model.mutex.getUnlockedDef();
         const record = this.quickCreateRecord;
         if (record) {
@@ -1911,7 +1914,10 @@ export class DynamicRecordList extends DynamicList {
             parent: this.rawContext,
             make: () => makeContext([context, {}]),
         };
-        return this.createRecord({ activeFields, rawContext, isInQuickCreation: true }, true);
+        return this.createRecord(
+            { activeFields, rawContext, isInQuickCreation: true },
+            atFirstPosition
+        );
     }
 
     /**
@@ -2201,7 +2207,7 @@ export class DynamicGroupList extends DynamicList {
         return this.groups.reduce((acc, group) => acc + group.count, 0);
     }
 
-    async quickCreate(group) {
+    async quickCreate(group, atFirstPosition = true) {
         group = group || this.groups[0];
         if (this.model.useSampleModel) {
             // Empty the groups because they contain sample data
@@ -2217,7 +2223,7 @@ export class DynamicGroupList extends DynamicList {
         if (isFolded) {
             await group.toggle();
         }
-        await group.quickCreate(this.quickCreateInfo.activeFields, this.context);
+        await group.quickCreate(this.quickCreateInfo.activeFields, this.context, atFirstPosition);
     }
 
     /**
@@ -2586,12 +2592,12 @@ export class Group extends DataPoint {
         });
     }
 
-    quickCreate(activeFields, context) {
+    quickCreate(activeFields, context, atFirstPosition = false) {
         const ctx = {
             ...context,
             [`default_${this.groupByField.name}`]: this.getServerValue(),
         };
-        return this.list.quickCreate(activeFields, ctx);
+        return this.list.quickCreate(activeFields, ctx, atFirstPosition);
     }
 
     /**


### PR DESCRIPTION
The purpose of this commit is to add a quick create button at the bottom
of each column in order to facilitate the user when he wants to quickly
create a record.

It was already possible to quick create a record in the kanban view.
To do so, the user needed to click on the quick create button placed
on top of the kanban view, forcing the user to scroll to the top of
the view if he consults records at the bottom.

task-2823605

![image](https://user-images.githubusercontent.com/109217759/186168778-e80b00bc-cad6-4fa5-a7ad-be7b70b575ef.png)

