### PR TITLE
[FIX] hr_attendance: take into account employee's leaves

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -163,8 +163,9 @@ class HrAttendance(models.Model):
             expected_attendances = emp.resource_calendar_id._attendance_intervals_batch(
                 start, stop, emp.resource_id
             )[emp.resource_id.id]
-            # Substract Global Leaves
-            expected_attendances -= emp.resource_calendar_id._leave_intervals_batch(start, stop, None)[False]
+            # Substract Global Leaves and Employee's Leaves
+            leave_intervals = emp.resource_calendar_id._leave_intervals_batch(start, stop, emp.resource_id)
+            expected_attendances -= leave_intervals[False] | leave_intervals[emp.resource_id.id]
 
             # working_times = {date: [(start, stop)]}
             working_times = defaultdict(lambda: [])


### PR DESCRIPTION
To Reporduce
=============
1.  Create  employee with Standard Working Schedule (100% presence / 40 hours / 08:00 - 12:00 & 13:00 - 17:00)
2. Create Time off type: Paid time off with following settings:
- Take time off in: Hours
- Deduct Extra Hours: No
3. Create a time off request for half a day for this employee (8/17/2022; morning)
4. Approve Time Off Request
5. Create an attendance record for this employee for the afternoon on this day (13:00 - 17:00)

Problem
=======
On the attendance report, this employee has -4:00 Extra Hours, which means that the leave wasn't taken into
account when computing Extra Hours

Solution
=========
to solve the issue we take into account the Employee's leaves when computing Extra Hours

opw-2956895
