### PR TITLE
[FIX] website: fix snippet social media values cache

### DIFF
--- a/addons/website/static/src/js/editor/wysiwyg.js
+++ b/addons/website/static/src/js/editor/wysiwyg.js
@@ -3,6 +3,7 @@ odoo.define('website.wysiwyg', function (require) {
 
 var Wysiwyg = require('web_editor.wysiwyg');
 var snippetsEditor = require('website.snippet.editor');
+let socialMediaOptions = require('@website/snippets/s_social_media/options')[Symbol.for("default")];
 
 /**
  * Show/hide the dropdowns associated to the given toggles and allows to wait
@@ -101,6 +102,15 @@ const WebsiteWysiwyg = Wysiwyg.extend({
      * @override
      */
     destroy: function () {
+        // We do not need the cache to live longer than the edition.
+        // Keeping it alive could end up in a corrupt state without the user
+        // even noticing. (If the values were changed in another tab or by
+        // someone else, when edit starts again here, without a clear cache at
+        // destroy, options will have wrong social media values).
+        // It would also survive (multi) website switch, not fetching the values
+        // from the accessed website.
+        socialMediaOptions.clearDbSocialValuesCache();
+
         this._restoreMegaMenus();
         this._super.apply(this, arguments);
     },

--- a/addons/website/static/src/snippets/s_social_media/options.js
+++ b/addons/website/static/src/snippets/s_social_media/options.js
@@ -7,6 +7,10 @@ import {_t} from 'web.core';
 
 let dbSocialValues;
 let dbSocialValuesProm;
+const clearDbSocialValuesCache = () => {
+    dbSocialValuesProm = undefined;
+    dbSocialValues = undefined;
+};
 
 options.registry.SocialMedia = options.Class.extend({
     /**
@@ -351,4 +355,5 @@ options.registry.SocialMedia = options.Class.extend({
 
 export default {
     SocialMedia: options.registry.SocialMedia,
+    clearDbSocialValuesCache,
 };


### PR DESCRIPTION
This `s_social_media` snippet option uses a variable defined in the
module's scope to store social media values. This
reduces the amount of RPCs needed to fetch the data as they will only be
done once per edition.

Prior to commit [1], this cache would only exist as long as the page
lived. Which means that switching website, switching page or going in
the backend would reset its value. Commit [1] moved the edition in the
backend which means that the cache would persist between pages but more
importantly, between websites, only resetting if the backend was
refreshed or left.

Steps to reproduce:
- Go on website 1
- Modify the URL for facebook in the footer
- Go on website 2
- The value is the same when it should still be facebook.com/Odoo

This commit fixes that by resetting the cache when the editor is
destroyed.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
