### PR TITLE
[FIX] hr_recruitment: remove field from view

### DIFF
--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -73,7 +73,6 @@
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
           <form string="Jobs - Recruitment Form" class="o_applicant_form">
-            <field name="company_id" invisible="1"/>
             <field name="emp_id" invisible="1"/>
             <field name="meeting_ids" invisible="1"/>
             <field name="refuse_reason_id" invisible="1"/>


### PR DESCRIPTION
The company_id field was added in the form view in #95729 but it was
already present, this caused a wild `-1` to appear when
hr_applicant_extract was installed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
