### PR TITLE
[FIX] l10n_nz: GST tax on tax report

### DIFF
--- a/addons/l10n_nz/data/account_tax_template_data.xml
+++ b/addons/l10n_nz/data/account_tax_template_data.xml
@@ -286,6 +286,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('nz_21330'),
+                'plus_report_line_ids': [ref('tax_report_box11')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -298,6 +299,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('nz_21330'),
+                'minus_report_line_ids': [ref('tax_report_box11')],
             }),
         ]"/>
     </record>


### PR DESCRIPTION
Items with tax "GST Only - Import" does not
appear on tax report

Add "BOX 11" tag to "GST Only" tax.

opw-2919731
