### PR TITLE
[FIX] web: remove padding of StateSelection

### DIFF
--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
@@ -9,7 +9,7 @@
             </button>
         </t>
         <t t-else="">
-            <Dropdown title="currentValue" togglerClass="'btn btn-link d-flex px-0'">
+            <Dropdown title="currentValue" togglerClass="'btn btn-link d-flex p-0'">
                 <t t-set-slot="toggler">
                     <div class="d-flex align-items-center">
                         <span t-attf-class="o_status {{ statusColor(currentValue) }} "/>


### PR DESCRIPTION
This commit removes vertical padding of the dropdown
toggler used in the StateSelection field widget converted
to Owl recently. In a list, it was causing an unexpected
higher row.