### PR TITLE
[FIX] web: time picker should always be LTR

### DIFF
--- a/addons/web/static/src/scss/daterangepicker.scss
+++ b/addons/web/static/src/scss/daterangepicker.scss
@@ -51,6 +51,8 @@
             }
         }
         .calendar-time {
+            /*rtl:ignore*/
+            direction:ltr;
             select {
                 &.hourselect, &.minuteselect, &.secondselect, &.ampmselect {
                     display: initial;


### PR DESCRIPTION
Steps to reproduce:
1-set language to an LTR language (arabic / hebrew...)
2-select any field with the date-time range widget (eg: planning>add)
3-the hour and the minute selection is reversed.

Bug:
the hours and minutes order depends on the language orientation where
they should always follow this format HH:MM

Fix:
force the time to be displayed Left To Right regardless of language

opw-2953221