### PR TITLE
[FIX] base, l10n_*: set currency with existing lines

### DIFF
--- a/addons/product/tests/test_common.py
+++ b/addons/product/tests/test_common.py
@@ -7,7 +7,7 @@ from odoo.addons.product.tests.common import ProductCommon
 
 
 @tagged('post_install', '-at_install')
-class TestProductCommon(ProductCommon):
+class TestProduct(ProductCommon):
 
     def test_common(self):
         self.assertEqual(self.consumable_product.type, 'consu')

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -39,7 +39,11 @@ class BaseCommon(TransactionCase):
         # Enforce constant currency
         currency = cls._enable_currency(currency_code)
         if not cls.env.company.currency_id == currency:
-            cls.env.company.currency_id = currency
+            cls.env.transaction.cache.set(cls.env.company, type(cls.env.company).currency_id, currency.id, dirty=True)
+            # this is equivalent to cls.env.company.currency_id = currency but without triggering buisness code checks.
+            # The value is added in cache, and the cache value is set as dirty so that that
+            # the value will be written to the database on next flush.
+            # this was needed because some journal entries may exist when running tests, especially l10n demo data.
 
     @classmethod
     def _enable_currency(cls, currency_code):


### PR DESCRIPTION
Since #96791 the currency is reset to USD when starting a test to be
less dependant of demo data when starting tests.

Unfortunatelly, some l10n_modules will add account.move.line demo data
leading to an error:
```
        You cannot change the currency of the company since some journal
        items already exist
```

An initial solution would be to delete the existing account.move.line

```python
        cls.env['account.move.line'].search([('company_id', '=', company.id)]).unlink()
```

This is only possible passing some context flags in order to disable some checks

```python
        existing = cls.env['account.move.line'].search([('company_id', '=', company.id)])
        existing = existing.with_context(dynamic_unlink=True, force_delete=True)
        existing.unlink()
```

Actually, unlinking account.move.line also creates other ones.

```python
        existing = cls.env['account.move.line'].search([('company_id', '=', company.id)])
        existing = existing.with_context(dynamic_unlink=True, force_delete=True)
        existing.unlink()
        existing = cls.env['account.move.line'].search([('company_id', '=', company.id)])
        existing = existing.with_context(dynamic_unlink=True, force_delete=True)
        existing.unlink()
```

Finally, it looks easier to bypass all business logic leading to the proposed solution.
