### PR TITLE
[I18N][15.0] im_livechat: Add missing translation part

### DIFF
--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-24 08:19+0000\n"
-"PO-Revision-Date: 2022-01-24 08:19+0000\n"
+"POT-Creation-Date: 2022-08-24 01:53+0000\n"
+"PO-Revision-Date: 2022-08-24 01:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -613,8 +613,20 @@ msgid "Group By..."
 msgstr ""
 
 #. module: im_livechat
+#: code:addons/im_livechat/models/im_livechat_channel.py:0
+#: model:im_livechat.channel,button_text:im_livechat.im_livechat_channel_data
+#, python-format
+msgid "Have a Question? Chat with us."
+msgstr ""
+
+#. module: im_livechat
 #: model:ir.model.fields,field_description:im_livechat.field_im_livechat_channel__header_background_color
 msgid "Header Background Color"
+msgstr ""
+
+#. module: im_livechat
+#: model:im_livechat.channel,default_message:im_livechat.im_livechat_channel_data
+msgid "Hello, how may I help you?"
 msgstr ""
 
 #. module: im_livechat

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -28,7 +28,7 @@ class ImLivechatChannel(models.Model):
 
     # attribute fields
     name = fields.Char('Name', required=True, help="The name of the channel")
-    button_text = fields.Char('Text of the Button', default='Have a Question? Chat with us.',
+    button_text = fields.Char('Text of the Button', default=_('Have a Question? Chat with us.'),
         help="Default text displayed on the Livechat Support Button")
     default_message = fields.Char('Welcome Message', default='How may I help you?',
         help="This is an automated 'welcome' message that your visitor will see when they initiate a new conversation.")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

The live-chat box is currently not able to translate
![Screenshot from 2022-08-24 08-56-39](https://user-images.githubusercontent.com/101797346/186304296-400ca970-4ebe-4183-ad8a-c32693374313.png)

Desired behavior after PR is merged:

To be able to translate button_text default string




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
