### PR TITLE
[FIX] [15.0] stock: name in report signed delivery slip isn't displayed correctly

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1514,7 +1514,7 @@ class Picking(models.Model):
         report = self.env.ref('stock.action_report_delivery')._render_qweb_pdf(self.id)
         filename = "%s_signed_delivery_slip" % self.name
         if self.partner_id:
-            message = _('Order signed by %s') % (self.partner_id.name)
+            message = _('Order signed by %s') % (self.env.user.name)
         else:
             message = _('Order signed')
         self.message_post(

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -200,7 +200,7 @@
                             <img t-att-src="image_data_uri(o.signature)" style="max-height: 4cm; max-width: 8cm;"/>
                         </div>
                         <div class="offset-8 text-center">
-                            <p t-field="o.partner_id.name"/>
+                            <p t-field="o.env.user.name"/>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- name in report signed delivery slip isn't displayed correctly( always showing partner name)
- I expect the name of the signature in the report to be the name of the signer
- bug:
[Untitled_ Aug 24, 2022 11_33 AM.webm](https://user-images.githubusercontent.com/71593331/186329563-64887c38-52fb-4b4a-bb6d-409fdd83fe25.webm)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
