### PR TITLE
[FIX][15.0] account: Adjust label string

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -262,8 +262,8 @@
             <field name="inherit_id" ref="base.view_res_partner_filter"/>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='inactive']" position="before">
-                   <filter string="Customer Invoices" name="customer" domain="[('customer_rank','>', 0)]"/>
-                   <filter string="Vendor Bills" name="supplier" domain="[('supplier_rank','>', 0)]"/>
+                   <filter string="Customer" name="customer" domain="[('customer_rank','>', 0)]"/>
+                   <filter string="Vendor" name="supplier" domain="[('supplier_rank','>', 0)]"/>
                    <separator/>
                 </xpath>
             </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- When in Purchase/Orders/Vendor the filter show `Vendor Bills` and `Customer Invoices` which is not correct for its purpose

Desired behavior after PR is merged:
- We wish to change `Customer Invoices` into `Customer`
- Also change `Vendor Bills` into `Vendor`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
