### PR TITLE
[FIX] hw_escpos: convert iterator to list

### DIFF
--- a/addons/hw_escpos/controllers/main.py
+++ b/addons/hw_escpos/controllers/main.py
@@ -65,7 +65,7 @@ class EscposDriver(Thread):
 
                 return False
 
-        printers = usb.core.find(find_all=True, custom_match=FindUsbClass(7))
+        printers = list(usb.core.find(find_all=True, custom_match=FindUsbClass(7)))
 
         # if no printers are found after this step we will take the
         # first epson or star device we can find.


### PR DESCRIPTION
`usb.core.find()` with `find_all=True` argument will always return
an iterator according to documentation.

```python
>>> import usb.core
>>> usb.core.find(find_all=True, custom_match=lambda dev: False)
<generator object find.<locals>.device_iter at 0x7f5df6571eb0>
>>> list(usb.core.find(find_all=True, custom_match=lambda dev: False))
[]
```

In order to check it found list of printers is empty or not it has
to be converted to a list.

After this commit Epson TM-T88IV detects again by fallback mechanism.

Description of the issue/feature this PR addresses:  Epson TM-T88IV is not detected by IoT box



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
