### PR TITLE
[FIX] account_payment: locked confirmed SO shows unpaid invoice as paid

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -25,7 +25,7 @@
                 <t t-if="invoice.state == 'posted' and last_tx.state == 'pending' and last_tx.acquirer_id.provider not in ('transfer', 'manual')">
                   <span class="badge badge-pill badge-warning"><span class="d-none d-md-inline"> Pending</span></span>
                 </t>
-                <t t-if="invoice.state == 'posted' and invoice.invoice_payment_state == 'paid' or last_tx.state == 'done'">
+                <t t-if="invoice.state == 'posted' and invoice.invoice_payment_state == 'paid'">
                     <span class="badge badge-pill badge-success"><i class="fa fa-fw fa-check"></i><span class="d-none d-md-inline"> Paid</span></span>
                 </t>
                 <t t-if="invoice.state == 'cancel'">


### PR DESCRIPTION
Steps to reproduce:
1. Ensure the Lock sales order setting is on.
2. Make a purchase on the website using wire transfer
3. Confirm the confirm the sales order on the backend and issue the
invoice
4. Do not register any payment
5. Go to the invoices in the customer portal

Issue:
With the option "lock confirmed sales", confirming the sale order
also confirms the transactions and hence the condition makes the
invoice shown as paid while no payment was registered.

opw-2920642
