### PR TITLE
[FIX] bus: websocket module import

### DIFF
--- a/addons/bus/tests/test_websocket_rate_limiting.py
+++ b/addons/bus/tests/test_websocket_rate_limiting.py
@@ -2,7 +2,11 @@
 
 import json
 import time
-from websocket._exceptions import WebSocketProtocolException
+
+try:
+    from websocket._exceptions import WebSocketProtocolException
+except ImportError:
+    pass
 
 from odoo.tests import common
 from .common import WebsocketCase


### PR DESCRIPTION
The websocket client library  is used during tests but is not in
requirements.txt.  Therefore, imports are usually wrap into a try/except.
An import present in `websocket_rate_limiting` is not wrapped leading to
errors for those who have not the library installed. This PR fixes this
issue by wrapping this import in a try/except block.
