### PR TITLE
[IMP] profiler and tests fixes and improvemetns

### DIFF
--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -203,6 +203,8 @@ class TestMailMailRace(common.TransactionCase):
             'state': 'outgoing',
             'recipient_ids': [(4, self.partner.id)]
         })
+        mail_message = mail.mail_message_id
+
         message = self.env['mail.message'].create({
             'subject': 'S',
             'body': 'B',
@@ -249,8 +251,8 @@ class TestMailMailRace(common.TransactionCase):
         self.env['ir.mail_server']._revert_method('send_email')
 
         notif.unlink()
-        message.unlink()
         mail.unlink()
+        (mail_message | message).unlink()
         self.partner.unlink()
         self.env.cr.commit()
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -682,7 +682,7 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
         if not hasattr(self, 'profile_session'):
             self.profile_session = profiler.make_session(test_method)
         return profiler.Profiler(
-            description='%s %s %s' % (test_method, self.env.user.name, 'warm' if self.warm else 'cold'),
+            description='%s uid:%s %s' % (test_method, self.env.user.id, 'warm' if self.warm else 'cold'),
             db=self.env.cr.dbname,
             profile_session=self.profile_session,
             **kwargs)


### PR DESCRIPTION
**Backport of speedscope constant_time option**

This is mainly sefull to spot indeterministic queries.

**Imporve test_mail_bounce_during_send cleanup**

A message is commit and not unlinked during this test. This was spot using the rollback sequence option/

**Display id instead of name in test profiler**
 The naive `user.name` was prefetching the user and this can have an impact on what is profiled, removing one query to read the user. 

This was initially part of #92134 but was moved in a separte pr.