### PR TITLE
[FIX] website: s_product_list: buttons are not at the right position

### DIFF
--- a/addons/website/static/src/snippets/s_product_list/000.scss
+++ b/addons/website/static/src/snippets/s_product_list/000.scss
@@ -3,6 +3,7 @@
     padding-top: 20px;
 
     > div > .row > div {
+        position: relative;
         margin-bottom: 20px; // without this style the columns go directly to the top of the bellow ones.
 
         height: 200px;


### PR DESCRIPTION
In Bootstrap 5 the `.col-X` classes don't have position relative anymore
and the button use position absolute (relative to its parent) to
position themselves.

> Columns no longer have position: relative applied, so you may have to
> add .position-relative to some elements to restore that behavior.

Ref:
https://getbootstrap.com/docs/5.1/migration/#grid-updates

Note: we have set the position relative in CSS to avoid doing a
migration script.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
