### PR TITLE
[FIX] stock: add tooltip for lot.label.layout quantity to print

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -3055,6 +3055,13 @@ msgid "If set, the operations are packed into this package"
 msgstr ""
 
 #. module: stock
+#: model:ir.model.fields,help:stock.field_lot_label_layout__label_quantity
+msgid ""
+"If the UoM of a lot is not 'units', the lot will be considered as a unit and"
+" only one label will be printed for this lot."
+msgstr ""
+
+#. module: stock
 #: model:ir.model.fields,help:stock.field_stock_warehouse_orderpoint__active
 msgid ""
 "If the active field is set to False, it will allow you to hide the "

--- a/addons/stock/wizard/stock_lot_label_layout.py
+++ b/addons/stock/wizard/stock_lot_label_layout.py
@@ -12,7 +12,7 @@ class ProductLabelLayout(models.TransientModel):
     picking_ids = fields.Many2many('stock.picking')
     label_quantity = fields.Selection([
         ('lots', 'One per lot/SN'),
-        ('units', 'One per unit')], string="Quantity to print", required=True, default='lots')
+        ('units', 'One per unit')], string="Quantity to print", required=True, default='lots', help="If the UoM of a lot is not 'units', the lot will be considered as a unit and only one label will be printed for this lot.")
     print_format = fields.Selection([
         ('4x12', '4 x 12'),
         ('zpl', 'ZPL Labels')], string="Format", default='4x12', required=True)


### PR DESCRIPTION
Current behavior:
If the UoM of a product is not 'units' (e.g 'kg') and tracked by lot.
When trying to print labels 'per unit', some users except one label printed
per 'kg'. But it will actually print one label per lot.

This is not a bug so we are just adding a tooltip to make it clear that only
one label will be printed for lots using UoM different from 'units'

Steps to reproduce:
- Create a product tracked by lots with 'kg' as UoM
- Create a purchase order for 5kg of this product
- Validate the PO and receive the products in 2 lots
- Print the labels "Lot/SN Labels" > "One per unit"
- Confirm, the PDF shows 2 labels

opw-2941942
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
