### PR TITLE
[IMP]  web: improve cards and toggles design

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -239,21 +239,10 @@ $kbd-bg: $o-gray-100 !default;
 $kbd-box-shadow: 0px 1px 1px rgba($o-black, 0.2), inset 0px -1px 1px 1px rgba($o-gray-200, 0.8), inset 0px 2px 0px 0px rgba($o-white, 0.8) !default;
 
 // Input
-
 $input-bg: $o-white !default;
-$form-check-input-border-radius: 0 !default;
-$form-check-input-checked-color: $o-brand-lightsecondary !default;
-$form-check-input-checked-border-color: $o-brand-primary !default;
 $form-check-input-checked-bg-color: $o-brand-primary !default;
-
-$form-switch-color: rgba($black, .25) !default;
-$form-switch-checked-color: $o-brand-primary !default;
+$form-switch-checked-color: $input-bg !default;
 $form-switch-circle-bg-color: $input-bg !default;
-$form-switch-circle-checked-bg-color: $input-bg !default;
-$form-switch-icon-color: $form-switch-color !default;
-$form-switch-icon-checked-color: $form-switch-checked-color !default;
-$form-switch-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-circle-bg-color}'/><line x1='-1.5' y1='-1.5' x2='1.5' y2='1.5' stroke='#{$form-switch-icon-color}' stroke-width='0.75'/><line x1='1.5' y1='-1.5' x2='-1.5' y2='1.5' stroke='#{$form-switch-icon-color}' stroke-width='0.75'/></svg>") !default;
-$form-switch-checked-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-circle-checked-bg-color}'/><path d='m-2.125,-0.5l1.75,1.75l2.5,-2.5' fill='none' stroke='#{$form-switch-icon-checked-color}' stroke-width='0.75'/></svg>") !default;
 
 // Badge
 $badge-color: inherit !default;
@@ -262,3 +251,9 @@ $badge-padding-x: 0.4em !default;
 
 // Placeholder color 
 $input-placeholder-color: $gray-300 !default;
+
+// Card
+
+$card-spacer-y: $spacer !default; // BS Default
+$card-cap-padding-y: $card-spacer-y !default;
+$card-cap-bg: $o-white !default;

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -36,9 +36,6 @@ tfoot {
   outline: none;
 }
 
-div.o_boolean_toggle.form-switch.form-check > input.form-check-input:not(:checked) {
-  background-color: $form-switch-color;
-}
 
 // User input typically entered via keyboard
 kbd {


### PR DESCRIPTION
This PR improves cards and toggles designs.
The default values of the cards was not consistant with the rest of odoo (ex: screeshots -> default background color value was grey instead of the BS default which is white) and to avoid it, the card classes were not used, and if we wanted to use them, we had to add the 'bg-white' class everywhere which is not optimal.
It also simplifies toggle's visual rendering removing unnecessary graphical elements that were not readable in regular & small font-size, 
In some case the toggle design was even irrelevant with the content and was requiring unnecessary override css to hide it (ex: screenshots, it's ok on the recruitment module but not in the payroll module)

Enterprise PR: https://github.com/odoo/enterprise/pull/29829

![Screenshot 2022-08-25 at 14 40 45](https://user-images.githubusercontent.com/108661430/186667699-e7237d47-e3c2-4c06-ae3a-eca4c8a7bdb4.png)
![Screenshot 2022-08-25 at 14 41 33](https://user-images.githubusercontent.com/108661430/186667693-8e2b99aa-747c-40f7-96d1-1e6b2a4dfb3e.png)


![Screenshot 2022-08-25 at 14 34 47](https://user-images.githubusercontent.com/108661430/186667704-6778aac1-b0df-4ebb-911c-b180d4e4babe.png)
![Screenshot 2022-08-25 at 14 38 44](https://user-images.githubusercontent.com/108661430/186667702-66c6e0fc-a35b-427d-8a91-103ac7041d66.png)


task-2924487
