### PR TITLE
[FIX] web: fix database manager test

### DIFF
--- a/addons/web/tests/test_db_manager.py
+++ b/addons/web/tests/test_db_manager.py
@@ -15,6 +15,8 @@ from odoo.tools import config
 
 class TestDatabaseManager(HttpCase):
     def test_database_manager(self):
+        if not config['list_db']:
+            return
         res = self.url_open('/web/database/manager')
         self.assertEqual(res.status_code, 200)
 


### PR DESCRIPTION
Skip test on database manager rendered page when option
--no-database-list is used



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
