### PR TITLE
[IMP] mail: remove follower subtype local id in tests

### DIFF
--- a/addons/mail/static/src/components/follower_subtype/follower_subtype.xml
+++ b/addons/mail/static/src/components/follower_subtype/follower_subtype.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.FollowerSubtype" owl="1">
         <t t-if="followerSubtypeView">
-            <div class="o_FollowerSubtype" t-attf-class="{{ className }}" t-att-data-local-id="followerSubtypeView.localId" t-ref="root">
+            <div class="o_FollowerSubtype" t-attf-class="{{ className }}" t-att-data-follower-subtype-id="followerSubtypeView.subtype.id" t-ref="root">
                 <label class="o_FollowerSubtype_label flex-grow-1 align-items-center d-flex mb-0 p-2 cursor-pointer">
                     <input class="o_FollowerSubtype_checkbox me-2" type="checkbox" t-att-checked="followerSubtypeView.follower.selectedSubtypes.includes(followerSubtypeView.subtype) ? 'checked': ''" t-on-change="followerSubtypeView.onChangeCheckbox"/>
                     <t t-esc="followerSubtypeView.subtype.name"/>

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
@@ -129,7 +129,7 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
     pyEnv['res.partner'].write([pyEnv.currentPartnerId], {
         message_follower_ids: [followerId],
     });
-    const { click, messaging, openView } = await start({
+    const { click, openView } = await start({
         // FIXME: should adapt mock server code to provide `hasWriteAccess`
         async mockRPC(route, args, performRPC) {
             if (route === '/mail/thread/data') {
@@ -147,22 +147,20 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
     });
     await click('.o_FollowerListMenu_buttonFollowers');
     await click('.o_Follower_editButton');
-    const followerSubtype = messaging.models['FollowerSubtype'].findFromIdentifyingData({ id: followerSubtypeId });
-    const followerSubtypeView = followerSubtype.followerSubtypeViews[0];
     assert.notOk(
-        document.querySelector(`.o_FollowerSubtype[data-local-id="${followerSubtypeView.localId}"] .o_FollowerSubtype_checkbox`).checked,
+        document.querySelector(`.o_FollowerSubtype[data-follower-subtype-id="${followerSubtypeId}"] .o_FollowerSubtype_checkbox`).checked,
         "checkbox should not be checked as follower subtype is not followed"
     );
 
-    await click(`.o_FollowerSubtype[data-local-id="${followerSubtypeView.localId}"] .o_FollowerSubtype_checkbox`);
+    await click(`.o_FollowerSubtype[data-follower-subtype-id="${followerSubtypeId}"] .o_FollowerSubtype_checkbox`);
     assert.ok(
-        document.querySelector(`.o_FollowerSubtype[data-local-id="${followerSubtypeView.localId}"] .o_FollowerSubtype_checkbox`).checked,
+        document.querySelector(`.o_FollowerSubtype[data-follower-subtype-id="${followerSubtypeId}"] .o_FollowerSubtype_checkbox`).checked,
         "checkbox should now be checked"
     );
 
-    await click(`.o_FollowerSubtype[data-local-id="${followerSubtypeView.localId}"] .o_FollowerSubtype_checkbox`);
+    await click(`.o_FollowerSubtype[data-follower-subtype-id="${followerSubtypeId}"] .o_FollowerSubtype_checkbox`);
     assert.notOk(
-        document.querySelector(`.o_FollowerSubtype[data-local-id="${followerSubtypeView.localId}"] .o_FollowerSubtype_checkbox`).checked,
+        document.querySelector(`.o_FollowerSubtype[data-follower-subtype-id="${followerSubtypeId}"] .o_FollowerSubtype_checkbox`).checked,
         "checkbox should be no more checked"
     );
 });


### PR DESCRIPTION
Using local ids in test is cumbersome: we need to retrieve the mail
record associated with the server record to get it while the message
id is more than enough and available. This PR replaces follower subtype
local id data attribute by its subtype id.

task-2959366
