### PR TITLE
[FIX] hr_contract: properly position first_contract_date

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -39,7 +39,7 @@
                             </div>
                         </button>
                     </div>
-                    <xpath expr="//field[@name='user_id']" position="before">
+                    <xpath expr="//page[@name='hr_settings']//field[@name='employee_type']" position="after">
                         <field name="first_contract_date"
                                attrs="{'invisible' : ['|', ('employee_type', 'not in', ['employee', 'student']), ('first_contract_date', '=', False)]}"
                                readonly="1"/>


### PR DESCRIPTION
Properly position the field first_contract_date by using a more explicit
xpath, as the previously used field was added as invisible in odoo/odoo#95729.
