### PR TITLE
[FIX] point_of_sale: correct the type of the default journal

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -663,7 +663,7 @@ class PosConfig(models.Model):
             pos_journal = self.env['account.journal'].search([('company_id', '=', company.id), ('code', '=', 'POSS')])
             if not pos_journal:
                 pos_journal = self.env['account.journal'].create({
-                    'type': 'general',
+                    'type': 'sale',
                     'name': 'Point of Sale',
                     'code': 'POSS',
                     'company_id': company.id,

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -80,7 +80,7 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
 
         # Create POS journal
         cls.pos_config.journal_id = cls.env['account.journal'].create({
-            'type': 'general',
+            'type': 'sale',
             'name': 'Point of Sale - Test',
             'code': 'POSS - Test',
             'company_id': cls.env.company.id,
@@ -156,7 +156,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         # Set basic defaults
         cls.company = cls.company_data['company']
         cls.pos_sale_journal = cls.env['account.journal'].create({
-            'type': 'general',
+            'type': 'sale',
             'name': 'Point of Sale Test',
             'code': 'POSS',
             'company_id': cls.company.id,


### PR DESCRIPTION
Before this commit, Default PoS journal is created together with the
installation of PoS, named "Point of Sale" with the default type Miscellaneous
instead of type Sales.

After this commit, this journal will be created with default type Sales.

task-2958110