### PR TITLE
[FIX] sale: fallback on the product uom

### DIFF
--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -185,7 +185,7 @@ class AccountMoveLine(models.Model):
             return order.pricelist_id._get_product_price(
                 self.product_id,
                 1.0,
-                self.product_uom_id,
+                uom=self.product_uom_id,
                 date=order.date_order,
             )
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -378,8 +378,8 @@ class SaleOrderLine(models.Model):
                 line.pricelist_item_id = line.order_id.pricelist_id._get_product_rule(
                     line.product_id,
                     line.product_uom_qty or 1.0,
-                    line.product_uom,
-                    line.order_id.date_order,
+                    uom=line.product_uom,
+                    date=line.order_id.date_order,
                 )
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
@@ -441,9 +441,10 @@ class SaleOrderLine(models.Model):
         order_date = self.order_id.date_order or fields.Date.today()
         product = self.product_id.with_context(**self._get_product_price_context())
         qty = self.product_uom_qty or 1.0
+        uom = self.product_uom or self.product_id.uom_id
 
         price = pricelist_rule._compute_price(
-            product, qty, self.product_uom, order_date, self.currency_id)
+            product, qty, uom, order_date, currency=self.currency_id)
 
         return price
 


### PR DESCRIPTION
`_compute_discount` from subscription add dependencies that triggered
the compute of the discount before the `product_uom` was set in a sale 
order line, once the uom is set, the `_compute_discount` will be 
triggered again.

Setting a fallback on the product uom will solve the bug before the
source of the problem can be fixed.

task-2960768

See also:
- https://github.com/odoo/enterprise/pull/30721