### PR TITLE
[FIX] sale, account: disable selection with a private address

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -796,6 +796,7 @@
                                        context="{
                                             'res_partner_search_mode': (context.get('default_move_type', 'entry') in ('out_invoice', 'out_refund', 'out_receipt') and 'customer') or (context.get('default_move_type', 'entry') in ('in_invoice', 'in_refund', 'in_receipt') and 'supplier') or False,
                                             'show_address': 1, 'default_is_company': True, 'show_vat': True}"
+                                       domain="[('type', '!=', 'private'), ('company_id', 'in', (False, company_id))]"
                                        options='{"always_reload": True, "no_quick_create": True}'
                                        attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}"/>
                                 <label for="ref" string="Bill Reference"

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -193,7 +193,7 @@ class SaleOrder(models.Model):
         'res.partner', string='Customer', readonly=True,
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
         required=True, change_default=True, index=True, tracking=1,
-        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",)
+        domain="[('type', '!=', 'private'), ('company_id', 'in', (False, company_id))]",)
     partner_invoice_id = fields.Many2one(
         'res.partner', string='Invoice Address',
         readonly=True, required=True,


### PR DESCRIPTION
Steps to repoduce:
	- create a customer with a private address (first select "individual" to show the selection field)
	- create a quotation (and/or invoice) and select this customer
	- this customer cannot receive an email and cannot be contacted afterwards (this behavior is intended)

Issue:
	- it's possible to choose this type of client

Cause:
	- there is no address type filter for this field

Solution:
	- add a condition in the domain of the field

opw-2909395