### PR TITLE
[FIX] point_of_sale: large canvas is sent to the printer

### DIFF
--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -105,6 +105,7 @@ var PrinterMixin = {
         return html2canvas(this.receipt[0], {
             height: Math.ceil(this.receipt.outerHeight() + this.receipt.offset().top),
             width: Math.ceil(this.receipt.outerWidth() + 2 * this.receipt.offset().left),
+            scale: 1,
         }).then(canvas => {
             $('.pos-receipt-print').empty();
             return this.process_canvas(canvas);


### PR DESCRIPTION
**Issue**

Printing a receipt when the app is displayed in high-dpi screen such as the macbook screen.

<img width="651" alt="Screenshot_2022-08-24_at_11 51 30" src="https://user-images.githubusercontent.com/3245568/186412185-2930e40b-43ad-4987-83d0-e1f121d7ef7b.png">

**Fix**

In screen with high dpi, scale of the canvas generated by html2canvas
is larger than normal (defaulting to scale 2). Apparently, receipt
printers don't recognize this so in this fix, we force the scale
to 1.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
