### PR TITLE
[FIX] web: many2one close "No records"

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -120,6 +120,7 @@ export class AutoComplete extends Component {
         const option = this.sources[indices[0]].options[indices[1]];
         if (option.unselectable) {
             this.inputRef.el.value = "";
+            this.close();
             return;
         }
 

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -3073,6 +3073,13 @@ QUnit.module("Fields", (hooks) => {
                 ".o_field_many2one[name=product_id] .o_m2o_no_result",
                 "there should be option for 'No records'"
             );
+
+            await triggerEvent(target, ".o_field_many2one[name=product_id] input", "blur");
+            assert.containsNone(
+                target,
+                ".o_field_many2one[name=product_id] .o_m2o_no_result",
+                "there should be option for 'No records'"
+            );
         }
     );
 


### PR DESCRIPTION
Before this commit, when a many2one's input shows the choice
"No records", the dropdown does not close.

Cause:
When blurring, the many2one will select its first item. In our case,
"No records" is not selectable and it will not close the dropdown.

How to reproduce:
- go to a form view with a many2one field
- insert a non-existent value in the many2one ("No records" is displayed)
- leave the many2one input ("blur" event)

Result before:
The dropdown containing "No records" is still open.

Result after:
The dropdown containing "No records" is closed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
