### PR TITLE
[FIX] website_sale: add to cart (image too large)

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -58,6 +58,7 @@ function animateClone($cart, $elem, offsetTop, offsetLeft) {
                     top: $imgtodrag.offset().top,
                     left: $imgtodrag.offset().left
                 })
+                .removeClass()
                 .addClass('o_website_sale_animate')
                 .appendTo(document.body)
                 .css({


### PR DESCRIPTION
Steps to reproduce:
1- enable "add to cart" feature on the website shop page
2- add any product to the cart
3- the image is way too large

Bug:
the animation creates a clone of the original image on which new css
classes has been added (h-100 w-100) that sets the image to full size

Fix:
since the CSS atribute of the new image are set in the function removing
all the classes of the original image solves the issue

Note:
the bug only started on 15.2 where the new classes have been added
merging on 15.0 just to prevent future issues

opw-2952608
