### PR TITLE
[FIX] l10n_latam_invoice_document: add document type and number below…

### DIFF
--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -40,7 +40,7 @@
                 <field name="l10n_latam_manual_document_number" invisible="1"/>
             </form>
 
-            <xpath expr="//field[@name='journal_id']/.." position="after">
+            <xpath expr="//div[@name='journal_div']" position="after">
                 <field name="l10n_latam_document_type_id"
                     attrs="{'invisible': [('l10n_latam_use_documents', '=', False)], 'required': [('partner_id', '!=', False), ('l10n_latam_use_documents', '=', True)], 'readonly': [('posted_before', '=', True)]}"
                     domain="[('id', 'in', l10n_latam_available_document_type_ids)]" options="{'no_open': True, 'no_create': True}"/>


### PR DESCRIPTION
… the journal

The account_move view was changed in master and that way
the document type and number were not visible anymore or in
a weird way.  If we just put it after the journal_div, everything
seems fine.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
