### PR TITLE
[FIX] mail: remove fallback currency in mail track

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -54,7 +54,7 @@ class BaseModel(models.AbstractModel):
                 tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, new_value, col_name, col_info, tracking_sequence, self._name)
                 if tracking:
                     if tracking['field_type'] == 'monetary':
-                        tracking['currency_id'] = getattr(self, col_info.get('currency_field', ''), self.company_id.currency_id).id
+                        tracking['currency_id'] = self[col_info['currency_field']].id
                     tracking_value_ids.append([0, 0, tracking])
                 changes.add(col_name)
 


### PR DESCRIPTION
### Steps to reproduce
- go to Apps, switch to studio and create and create a new app.
- on the form view, add a Many2one field related to 'Sales Order'.
- add a Ralated Field, related to 'Sales Order > Total'. You will be  presented with a prompt informing you that you need a currency field on the model. Click 'OK' to add the currency field.
- again, add a Ralated Field, related to 'Sales Order > Total'.
- close Studio, fill the form you just created and save.
- switch back to studio and, again, add a Ralated Field, related to 'Sales Order > Total'.

You will be met with the following traceback:
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/data/build/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/data/build/odoo/odoo/http.py", line 687, in dispatch
    result = self._call_function(**self.params)
  File "/data/build/odoo/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/data/build/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/data/build/odoo/odoo/http.py", line 355, in checked_call
    self._cr.flush()
  File "/data/build/odoo/odoo/sql_db.py", line 110, in flush
    self.precommit.run()
  File "/data/build/odoo/odoo/tools/misc.py", line 1145, in run
    func()
  File "/data/build/odoo/addons/mail/models/mail_thread.py", line 544, in _finalize_tracking
    tracking = records.with_context(context).message_track(fnames, initial_values)
  File "/data/build/odoo/addons/mail/models/mail_thread.py", line 605, in message_track
    tracking[record.id] = record._mail_track(tracked_fields, initial_values[record.id])
  File "/data/build/odoo/addons/mail/models/models.py", line 57, in _mail_track
    tracking['currency_id'] = getattr(self, col_info.get('currency_field', ''), self.company_id.currency_id).id
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/build/odoo/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/data/build/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'x_aaa' object has no attribute 'company_id'
```
opw-2951697