### PR TITLE
[IMP] core: allow inheriting test tags

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -9,7 +9,6 @@ import base64
 from lxml import etree
 
 
-@tagged('post_install', '-at_install')
 class AccountTestInvoicingCommon(TransactionCase):
 
     @classmethod
@@ -540,7 +539,6 @@ class AccountTestInvoicingCommon(TransactionCase):
         return etree.fromstring(xml_tree_str)
 
 
-@tagged('post_install', '-at_install')
 class AccountTestInvoicingHttpCommon(AccountTestInvoicingCommon, HttpCase):
     pass
 

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -3,7 +3,6 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
 
-@tagged('post_install', '-at_install')
 class TestTaxCommon(AccountTestInvoicingCommon):
 
     @classmethod

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -13,7 +13,6 @@ from odoo.tests.common import tagged
 from odoo.tools import mute_logger
 
 
-@tagged('lead_assign')
 class TestLeadAssignCommon(TestLeadConvertCommon):
 
     @classmethod

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -10,7 +10,6 @@ from odoo.tests.common import tagged, users
 from odoo.tools import mute_logger
 
 
-@tagged('lead_manage')
 class TestLeadMergeCommon(TestLeadConvertMassCommon):
     """ During a mixed merge (involving leads and opps), data should be handled a certain way following their type
     (m2o, m2m, text, ...). """

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -7,7 +7,6 @@ from odoo.exceptions import AccessError, UserError
 import time
 
 
-@tests.tagged('access_rights', 'post_install', '-at_install')
 class TestAllocationRights(TestHrHolidaysCommon):
 
     @classmethod

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/common.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/common.py
@@ -10,7 +10,6 @@ from odoo.tools.misc import file_open
 from odoo.tests import tagged
 
 
-@tagged('post_install_l10n', 'post_install', '-at_install')
 class TestUBLCommon(AccountEdiTestCommon):
 
     @classmethod

--- a/addons/l10n_eg_edi_eta/tests/common.py
+++ b/addons/l10n_eg_edi_eta/tests/common.py
@@ -6,7 +6,6 @@ from odoo.tests import tagged
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
 
 
-@tagged('post_install_l10n', 'post_install', '-at_install')
 class TestEGEdiCommon(AccountEdiTestCommon):
 
     @classmethod

--- a/addons/l10n_es_edi_sii/tests/common.py
+++ b/addons/l10n_es_edi_sii/tests/common.py
@@ -3,12 +3,10 @@ import base64
 from pytz import timezone
 from datetime import datetime
 
-from odoo.tests import tagged
 from odoo.tools import misc
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
 
 
-@tagged('post_install_l10n', 'post_install', '-at_install')
 class TestEsEdiCommon(AccountEdiTestCommon):
 
     @classmethod

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_xml.py
@@ -13,7 +13,6 @@ from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
-@tagged('post_install_l10n', 'post_install', '-at_install')
 class TestItEdiCommon(AccountEdiTestCommon):
 
     @classmethod

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -11,7 +11,6 @@ import logging
 
 _logger = logging.getLogger(__name__)
 
-@tagged('post_install', '-at_install')
 class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
 
     @classmethod
@@ -132,7 +131,6 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
         (invoice_rep_lines | refund_rep_lines).write({'account_id': cls.company_data['default_account_tax_sale'].id})
 
 
-@tagged('post_install', '-at_install')
 class TestPoSCommon(ValuationReconciliationTestCommon):
     """ Set common values for different special test cases.
 

--- a/addons/product_matrix/tests/common.py
+++ b/addons/product_matrix/tests/common.py
@@ -3,7 +3,6 @@
 from odoo.tests import tagged, common
 
 
-@tagged('post_install', '-at_install')
 class TestMatrixCommon(common.HttpCase):
 
     def setUp(self):

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -4,7 +4,6 @@ from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_c
 from odoo.tests import Form, tagged
 
 
-@tagged('post_install', '-at_install')
 class TestValuationReconciliationCommon(ValuationReconciliationTestCommon):
 
     @classmethod

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -6,7 +6,6 @@ from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounti
 from odoo.tests.common import tagged, Form
 
 
-@tagged("post_install", "-at_install")
 class TestAccountMoveStockCommon(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):

--- a/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
+++ b/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
@@ -5,7 +5,6 @@ from odoo.tests import tagged
 from odoo import fields
 
 
-@tagged('-at_install', 'post_install')
 class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
     """ Base class for tests checking interim accounts reconciliation works
     in anglosaxon accounting. It sets up everything we need in the tests, and is

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -11,7 +11,6 @@ from odoo.tests import tagged, users
 from odoo.tools import mute_logger
 
 
-@tagged('mail_template', 'multi_lang')
 class TestMailTemplateCommon(TestMailCommon, TestRecipients):
 
     @classmethod

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -21,7 +21,6 @@ from odoo.tools import mute_logger, formataddr
 from odoo.tests.common import users
 
 
-@tagged('mail_post')
 class TestMessagePostCommon(TestMailCommon, TestRecipients):
 
     @classmethod

--- a/addons/utm/tests/common.py
+++ b/addons/utm/tests/common.py
@@ -5,7 +5,6 @@ from odoo.tests import common
 from odoo.tests.common import tagged
 
 
-@tagged('post_install', '-at_install', 'utm_consistency')
 class TestUTMCommon(common.TransactionCase):
 
     @classmethod

--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -63,20 +63,18 @@ class TestSetTags(TransactionCase):
         class FakeClassA(TransactionCase):
             pass
 
-        @tagged('nightly')
-        class FakeClassB(FakeClassA):
-            pass
-
-        fc = FakeClassB()
-        self.assertEqual(fc.test_tags, {'at_install', 'standard', 'nightly'})
-        self.assertEqual(fc.test_module, 'base')
-
         class FakeClassC(FakeClassA):
             pass
 
         fc = FakeClassC()
-        self.assertEqual(fc.test_tags, {'at_install', 'standard'})
-        self.assertEqual(fc.test_module, 'base')
+        self.assertEqual(fc.test_tags, {'at_install', 'standard', 'slow'})
+
+        @tagged('-standard')
+        class FakeClassD(FakeClassA):
+            pass
+
+        fc = FakeClassD()
+        self.assertEqual(fc.test_tags, {'at_install', 'slow'})
 
     def test_untagging(self):
         """Test that one can remove the 'standard' tag"""
@@ -103,6 +101,17 @@ class TestSetTags(TransactionCase):
         fc = FakeClassC()
         self.assertEqual(fc.test_tags, {'fast', })
 
+    def test_parental_advisory(self):
+        """Explicit test tags on the class should override anything
+        """
+        @tagged('flow')
+        class FakeClassA(TransactionCase):
+            pass
+        class FakeClassB(FakeClassA):
+            test_tags = {'foo', 'bar'}
+
+        self.assertEqual(FakeClassA().test_tags, {'standard', 'at_install', 'flow'})
+        self.assertEqual(FakeClassB().test_tags, {'foo', 'bar'})
 
 @tagged('nodatabase')
 class TestSelector(TransactionCase):

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -11,7 +11,6 @@ from odoo.tools import config, file_open
 from .test_common import TestHttpBase
 
 
-@tagged('post_install', '-at_install')
 class TestHttpStaticCommon(TestHttpBase):
     @classmethod
     def setUpClass(cls):

--- a/odoo/addons/test_lint/tests/test_l10n.py
+++ b/odoo/addons/test_lint/tests/test_l10n.py
@@ -28,10 +28,14 @@ class L10nChecker(lint_case.NodeVisitor):
             (len({'post_install_l10n', 'external_l10n'} & tags) != 1)
             or ('post_install_l10n' in tags and 'post_install' not in tags)
             # or ('post_install_l10n' not in tags and 'post_install' in tags)
-            or ('external_l10n' in tags and 'external' not in tags)
-            or ('external_l10n' not in tags and 'external' in tags)
+            or (('external_l10n' in tags) ^ ('external' in tags))
         ):
-            return [node]
+            if any(
+                stmt.name.startswith('test_')
+                for stmt in node.body
+                if isinstance(stmt, ast.FunctionDef)
+            ):
+                return [node]
         return []
 
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -327,7 +327,8 @@ class MetaCase(type):
         super(MetaCase, cls).__init__(name, bases, attrs)
         # assign default test tags
         if cls.__module__.startswith('odoo.addons.'):
-            cls.test_tags = {'standard', 'at_install'}
+            if getattr(cls, 'test_tags', None) is None:
+                cls.test_tags = {'standard', 'at_install'}
             cls.test_module = cls.__module__.split('.')[2]
             cls.test_class = cls.__name__
             cls.test_sequence = 0
@@ -2896,18 +2897,21 @@ def _get_node(view, f, *arg):
     ), *arg)
 
 def tagged(*tags):
-    """
-    A decorator to tag BaseCase objects.
+    """A decorator to tag BaseCase objects.
+
     Tags are stored in a set that can be accessed from a 'test_tags' attribute.
+
     A tag prefixed by '-' will remove the tag e.g. to remove the 'standard' tag.
+
     By default, all Test classes from odoo.tests.common have a test_tags
     attribute that defaults to 'standard' and 'at_install'.
-    When using class inheritance, the tags are NOT inherited.
+
+    When using class inheritance, the tags ARE inherited.
     """
+    include = {t for t in tags if not t.startswith('-')}
+    exclude = {t[1:] for t in tags if t.startswith('-')}
     def tags_decorator(obj):
-        include = {t for t in tags if not t.startswith('-')}
-        exclude = {t[1:] for t in tags if t.startswith('-')}
-        obj.test_tags = (getattr(obj, 'test_tags', set()) | include) - exclude # todo remove getattr in master since we want to limmit tagged to BaseCase and always have +standard tag
+        obj.test_tags = (getattr(obj, 'test_tags', set()) | include) - exclude
         return obj
     return tags_decorator
 


### PR DESCRIPTION
The unconditional setting made a lot of sense before the new test tags (95b4f2ab4b5698ab3a28c9c35ac8da6fb6def983) when the test module was a test tag: filtering the module out of the existing tags would be difficult.

However since then the tags should only contain "actual" tags, therefore inheriting tags (and tagging mixins or Common cases) should not be an issue anymore.
