### PR TITLE
[FIX] point_of_sale: show orders with correct tax from fiscal position

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1524,7 +1524,7 @@ exports.PosModel = Backbone.Model.extend({
         return taxes;
     },
 
-    get_taxes_after_fp: function(taxes_ids){
+    get_taxes_after_fp: function(taxes_ids, order = false){
         var self = this;
         var taxes =  this.taxes;
         var product_taxes = [];
@@ -1532,7 +1532,7 @@ exports.PosModel = Backbone.Model.extend({
             var tax = _.detect(taxes, function(t){
                 return t.id === el;
             });
-            product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax));
+            product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax, order));
         });
         product_taxes = _.uniq(product_taxes, function(tax) { return tax.id; });
         return product_taxes;
@@ -2245,7 +2245,7 @@ exports.Orderline = Backbone.Model.extend({
         return round_pr(this.get_unit_price() * this.get_quantity() * (1 - this.get_discount()/100), rounding);
     },
     get_taxes_after_fp: function(taxes_ids){
-        return this.pos.get_taxes_after_fp(taxes_ids);
+        return this.pos.get_taxes_after_fp(taxes_ids, this.order);
     },
     get_display_price_one: function(){
         var rounding = this.pos.currency.rounding;


### PR DESCRIPTION
Orders in POS all use the same fiscal position (the fiscal position
currently selected in the POS) so their tax might be wrong if the order
used another fiscal position that applies another tax mapping

Steps to reproduce:
1. Install Point of Sale
2. Go to Invoicing > Configuration > Accounting > Fiscal Positions and
   create a fiscal position 'Test' with a tax mapping from 'Tax 15.00%
   (Sales)' to 'Tax 10.00% (Sales)' (that you should create)
3. Go to Point of Sale and edit 'Shop' settings
4. Enable 'Manage Orders' and 'Fiscal Position per Order' and add fiscal
   position 'Test'
5. Go to Products and add 'Tax 15.00%' to the Customer Taxes of product
   'Acoustic Bloc Screens'
6. Open a new session in POS 'Shop'
7. Add 'Acoustic Bloc Screens' to the order with fiscal position 'Test'
   and validate it (total is $3,245.00)
8. Click on 'New Order' and then on the order management button
   (magnifying glass in the top right)
9. The order total is $3,392.50, if you go back and select the fiscal
   position 'Test', the order will have the correct total in the order
   management screen

Solution:
When we compute the taxes of an order, apply the tax mapping of the
fiscal position used on the order

Problem:
The taxes applied on the orders are all computed with the fiscal
position of the POS

opw-2956608