### PR TITLE
[FIX] purchase_stock: Fix receipt auto-batch

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -219,6 +219,7 @@ class PurchaseOrder(models.Model):
                 if not pickings:
                     res = order._prepare_picking()
                     picking = StockPicking.with_user(SUPERUSER_ID).create(res)
+                    pickings = picking
                 else:
                     picking = pickings[0]
                 moves = order.order_line._create_stock_moves(picking)
@@ -228,6 +229,7 @@ class PurchaseOrder(models.Model):
                     seq += 5
                     move.sequence = seq
                 moves._action_assign()
+                pickings.action_confirm()
                 picking.message_post_with_view('mail.message_origin_link',
                     values={'self': picking, 'origin': order},
                     subtype_id=self.env.ref('mail.mt_note').id)


### PR DESCRIPTION
When using the auto-batch feature for receipt, when creating a purchase,
it wouldn't batch pickings that matched the group-by conditions.

The issue is that the _create_picking() called when validating a
Purchase Order creates the picking, then creates its moves and then
validates them. Doing it this way avoids the trigger for the auto-batch
feature located in picking's action_confirm().

By calling action_confirm() on the created picking, we force the trigger
of the auto-batch, while not confirming the moves a second time since
their state isn't 'draft' anymore.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
