### PR TITLE
[FIX] point_of_sale: customer search domain

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -192,7 +192,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             var domain = [];
             if(this.state.query) {
                 domain = [
-                    '|','|',
+                    '|',
                     ["display_name", "ilike", this.state.query],
                     ["email", "ilike", this.state.query],
                     ];


### PR DESCRIPTION
Steps to reproduec:
1: Open a point of sale
2: Open the customer selection view (button "Customer" on odoo-numpad)
3: Enter the name of a customer in the searchbox
4: Click "Load partners" - (this is used if the limited partner load option is enabled)

Bug:
The created search domain is invalid because there are 2 "or"-operators but only 1 is needed.

Fix:
remove the extra OR

opw-2959501

