### PR TITLE
[FIX] web: stop crashing on concurrent update of field wrapper

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -59,7 +59,7 @@ class FieldAdapter extends ComponentAdapter {
         return [name, record, options];
     }
 
-    updateWidget(nextProps) {
+    async updateWidget(nextProps) {
         const { name, record, options } = nextProps.fieldParams;
         if (this.widget.mode !== options.mode) {
             // the mode changed, we need to instantiate a new FieldWidget
@@ -69,9 +69,11 @@ class FieldAdapter extends ComponentAdapter {
                 this.oldWidget = this.widget;
             }
             this.widget = new this.props.Component(this, name, record, options);
-            return this.widget._widgetRenderAndInsert(() => {});
+            this.widgetProm = this.widget._widgetRenderAndInsert(() => {});
+            return this.widgetProm;
         } else {
             // the mode is the same, simply reset the FieldWidget with the new record
+            await this.widgetProm;
             return this.widget.reset(record, this.lastFieldChangedEvent, true);
         }
     }


### PR DESCRIPTION
Previously, if you updated a legacy field widget in a new view twice in
quick succession, it may be that the first update recrates the widget,
but the second update doesn't wait for that widget to be created by the
previous update, even though the second update may rely on the widget's
$el to be defined, which can result in a crash.

This commit fixes that by making sure the widget has finished starting
before attempting to recreate it with the new params.
