### PR TITLE
[FIX] web: correct numpadDecimal issue for `number` type fields

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -237,6 +237,7 @@ class Location(models.Model):
         The quantity should be in the default UOM of the product, it is used when
         no package is specified.
         """
+        products = self.env.context.get('products', self.env['product.product'])
         # find package type on package or packaging
         package_type = self.env['stock.package.type']
         if package:
@@ -245,13 +246,12 @@ class Location(models.Model):
             package_type = packaging.package_type_id
 
         putaway_rules = self.env['stock.putaway.rule']
-        putaway_rules |= self.putaway_rule_ids.filtered(lambda x: x.product_id == product and (package_type in x.package_type_ids or package_type == x.package_type_ids))
+        putaway_rules |= self.putaway_rule_ids.filtered(lambda x: x.product_id in products or x.product_id == product)
         categ = product.categ_id
         while categ:
-            putaway_rules |= self.putaway_rule_ids.filtered(lambda x: x.category_id == categ and (package_type in x.package_type_ids or package_type == x.package_type_ids))
+            putaway_rules |= self.putaway_rule_ids.filtered(lambda x: x.category_id == categ)
             categ = categ.parent_id
         if package_type:
-            products = self.env.context.get('products')
             putaway_rules |= self.putaway_rule_ids.filtered(lambda pa: package_type in pa.package_type_ids or package_type == pa.package_type_ids)
             for dummy, putaways in groupby(putaway_rules, key=lambda pa: (pa.location_out_id.id, pa.storage_category_id)):
                 putaways = self.env['stock.putaway.rule'].concat(*putaways)
@@ -260,6 +260,9 @@ class Location(models.Model):
                 if set(products.ids).issubset(set(putaways.product_id.ids)):
                     continue
                 putaway_rules -= putaways
+
+            # Put the priority on putaway with the same package_type
+            putaway_rules = putaway_rules.sorted(lambda pa: package_type in pa.package_type_ids or package_type == pa.package_type_ids, reverse=True)
 
         putaway_location = None
         locations = self.child_internal_location_ids

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -542,6 +542,9 @@ var NumericField = InputField.extend({
         const kbdEvt = ev.originalEvent;
         if (kbdEvt && utils.isNumpadDecimalSeparatorKey(kbdEvt)) {
             const inputField = this.$input[0];
+            if (inputField.type === 'number'){
+                return this._super(...arguments);
+            }
             const curVal = inputField.value;
             const from = inputField.selectionStart;
             const to = inputField.selectionEnd;


### PR DESCRIPTION
Steps to reproduce:
- on barcode, go on inventory adjustment
- add a product
- add a quantity and press the numpad decimal

Issue:
- Traceback

Cause:
field of type number don't have function such as `selectionStart` or `selectionEnd`

Solution:
WIP

opw-2956481