### PR TITLE
[FIX] hr_holidays: correct "current year" filter

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -68,8 +68,8 @@ class LeaveReport(models.Model):
                     allocation.holiday_status_id as holiday_status_id,
                     allocation.state as state,
                     allocation.holiday_type,
-                    null as date_from,
-                    null as date_to,
+                    allocation.date_from as date_from,
+                    allocation.date_to as date_to,
                     'allocation' as leave_type,
                     allocation.employee_company_id as company_id
                 from hr_leave_allocation as allocation

--- a/addons/hr_holidays/report/hr_leave_reports.xml
+++ b/addons/hr_holidays/report/hr_leave_reports.xml
@@ -17,8 +17,7 @@
                 <separator/>
                 <filter string="Active Employee" name="active_employee" domain="[('active_employee','=',True)]"/>
                 <separator/>
-                <filter name="year" string="Current Year"
-                    domain="[('holiday_status_id.active', '=', True)]" help="Active Time Off"/>
+                <filter name="year" date="date_from" default_period="this_year" string="Current Year"/>
                 <separator/>
                 <filter string="My Requests" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>


### PR DESCRIPTION
Before this commit, the "Current Year" filter on the
time off analysis report showed records according to the
activeness of their status. This commit fixes that filter.

taskID 2951192