### PR TITLE
[IMP] account: improve Journal Items reconciliation view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1352,7 +1352,7 @@
         </record>
 
         <record id="action_account_moves_all_grouped_matching" model="ir.actions.act_window">
-            <field name="context">{'journal_type':'general', 'search_default_group_by_matching': 1, 'search_default_posted':1, 'expand':'1'}</field>
+            <field name="context">{'journal_type':'general', 'search_default_posted':1, 'expand':'1'}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
             <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>


### PR DESCRIPTION
Clean the action for reconciliation view for the correct handling of it.

Removes the group by Matching in the Journal Items reconciliation
list.

Moves a reconciliation scss file to enterprise.

task-2959808
