### PR TITLE
[FIX] mail: fix activity Mark as Done panel

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -359,10 +359,12 @@ var BasicActivity = AbstractField.extend({
                     if ($(el).data('bs.collapse')) {
                         $(el).empty().collapse('dispose').removeClass('show');
                     }
+                    $(el).data('bs.collapse', false);
                 });
 
                 // Scroll  to selected activity
                 $markDoneBtn.parents('.o_activity_log_container').scrollTo($actLi.position().top, 100);
+                $panel.data('bs.collapse', true);
             }
 
             // Empty and reset panel on close
@@ -372,6 +374,7 @@ var BasicActivity = AbstractField.extend({
                     $panel.collapse('dispose');
                     $panel.empty();
                 }
+                $panel.data('bs.collapse', false);
             });
 
             this.$('.o_activity_selected').removeClass('o_activity_selected');

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -46,7 +46,7 @@
                     <t class="activities_list_group_item">
                         <t t-call="mail.activities-list-group-item"/>
                     </t>
-                    <li t-attf-id="o_activity_form_{{log.id}}" class="o_activity_form list-group-item border-top-0 py-0 mb-2 collapse"></li>
+                    <li t-attf-id="o_activity_form_{{log.id}}" class="o_activity_form list-group-item border-top-0 py-0 mb-2 collapse" data-bs-collapse="false"></li>
                 </t>
             </t>
         </ul>


### PR DESCRIPTION
Repeating a click on kanban activity Mark as Done button successfully resets the panel.

task-2961943