### PR TITLE
[FIX] website_hr_recruitment: show job only when company has website

### DIFF
--- a/addons/website_hr_recruitment/models/hr_recruitment.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment.py
@@ -45,11 +45,12 @@ class Job(models.Model):
         return (default_description.render() if default_description else "")
 
     website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, default=_get_default_website_description, prefetch=False)
-
     def _compute_website_url(self):
         super(Job, self)._compute_website_url()
         for job in self:
-            job.website_url = "/jobs/detail/%s" % job.id
+            # can't publish a job of company without website
+            website = self.env['website'].search([('company_id', '=', job.company_id.id)], limit=1)
+            job.website_url = "/jobs/detail/%s" % job.id if website else False
 
     def set_open(self):
         self.write({'website_published': False})

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -13,7 +13,7 @@
             </xpath>
             <xpath expr="//div[@name='kanban_boxes']/div/div[1]" position="inside">
                 <field name="website_url" invisible="1"/>
-                <span>
+                <span t-if="record.website_url.raw_value">
                     <a t-attf-href="#{record.website_url.raw_value}">Job Description</a>
                 </span>
             </xpath>


### PR DESCRIPTION
To Reporduce
=============
- Create two companies A and B
- Create website for A
- Create job position in B

try to access the job description.

Problem
=======
When redirected to website we have an access error.
This is caused by the fact that the website belongs to Company A and we try to display job from Company B in it.

Solution
=========
Remove the possibility to access job description if the job's company doesn't have a website.

opw-2957744