### PR TITLE
[FIX] mrp: scraps have wrong destination location

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -254,7 +254,8 @@ class StockMove(models.Model):
         product_id_to_product = defaultdict(lambda: self.env['product.product'])
         for values in vals_list:
             mo_id = values.get('raw_material_production_id', False) or values.get('production_id', False)
-            if mo_id:
+            location_dest = self.env['stock.location'].browse(values.get('location_dest_id'))
+            if mo_id and not values.get('scrapped') and not location_dest.scrap_location:
                 mo = mo_id_to_mo[mo_id]
                 if not mo:
                     mo = mo.browse(mo_id)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1239,15 +1239,23 @@ class TestMrpOrder(TestMrpCommon):
         mo_form.product_id = product
         mo = mo_form.save()
         move = self.env['stock.move'].create({
-            'name': 'mrp_move',
             'product_id': self.product_2.id,
             'product_uom': self.ref('uom.product_uom_unit'),
             'production_id': mo.id,
-            'location_id': self.ref('stock.stock_location_stock'),
             'location_dest_id': self.ref('stock.stock_location_output'),
             'product_uom_qty': 0,
             'quantity_done': 0,
         })
+
+        self.assertEqual(move.name, mo.name)
+        self.assertEqual(move.origin, mo._get_origin())
+        self.assertEqual(move.group_id, mo.procurement_group_id)
+        self.assertEqual(move.propagate_cancel, mo.propagate_cancel)
+        self.assertFalse(move.raw_material_production_id)
+        self.assertEqual(move.location_id, mo.production_location_id)
+        self.assertEqual(move.date, mo._get_date_planned_finished())
+        self.assertEqual(move.date_deadline, mo.date_deadline)
+
         mo.move_raw_ids |= move
         mo.action_confirm()
 

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -144,7 +144,14 @@ class TestWarehouseMrp(common.TestMrpCommon):
             scrap_id.do_scrap()
 
         # Scrap Product Wood with lot.
-        self.env['stock.scrap'].with_context(active_model='mrp.production', active_id=production_3.id).create({'product_id': self.product_2.id, 'scrap_qty': 1.0, 'product_uom_id': self.product_2.uom_id.id, 'location_id': location_id, 'lot_id': lot_product_2.id, 'production_id': production_3.id})
+        scrap_id = self.env['stock.scrap'].with_context(active_model='mrp.production', active_id=production_3.id).create({'product_id': self.product_2.id, 'scrap_qty': 1.0, 'product_uom_id': self.product_2.uom_id.id, 'location_id': location_id, 'lot_id': lot_product_2.id, 'production_id': production_3.id})
+        scrap_id.do_scrap()
+        scrap_move = scrap_id.move_id
+
+        self.assertTrue(scrap_move.raw_material_production_id)
+        self.assertTrue(scrap_move.scrapped)
+        self.assertEqual(scrap_move.location_dest_id, scrap_id.scrap_location_id)
+        self.assertEqual(scrap_move.price_unit, scrap_move.product_id.standard_price)
 
         #Check scrap move is created for this production order.
         #TODO: should check with scrap objects link in between


### PR DESCRIPTION
Steps to reproduce:

- Manufacturing app > Operations > Manufacturing orders > Create
- Set product to [FURN_7800] Desk Combination > Save > Confirm
- Click on scrap, choose any product > Done
- Edit the manufacturing order > set the quantity to 1/1 > Save

An error pops up: You cannot change the UoM for a stock move that has
been set to 'Done'.

This happens because the scrapped product has its destination location
wrongly set to the production location of the manufacturing order.
Because of this, it is considered as a component of the manufacturing
order. The scrap is also confirmed right after creation, so its state
is set to 'done'. Finally, when confirming a manufacturing order, all
of its component moves are also confirmed, hence the error.

This commit prevents the override of the scrap's destination location,
so that it is not wrongly considered a component anymore.

The commit also adds tests for the override method, added in
commit 0b247ab17ccc5be0c2058ef92ccf3502c97e0bb3

opw-2945182
