### PR TITLE
[IMP] mail: allow readonly: false on computes and relateds

### DIFF
--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -153,7 +153,7 @@ export class ModelField {
         /**
          * Automatically make computes and relateds readonly.
          */
-        if (this.compute || this.related) {
+        if ((this.compute || this.related) && this.readonly !== false) {
             this.readonly = true;
         }
     }

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -498,8 +498,8 @@ export class ModelManager {
                     if (!model.prototype[field.compute]) {
                         throw new Error(`Property "compute" of field(${fieldName}) on ${model} does not refer to an instance method of this model.`);
                     }
-                    if ('readonly' in field) {
-                        throw new Error(`Computed field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicit for computed fields).`);
+                    if (field.readonly) {
+                        throw new Error(`Computed field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicitly set to true for computed fields).`);
                     }
                 }
                 // 5. Related field.
@@ -548,8 +548,8 @@ export class ModelManager {
                     ) {
                         throw new Error(`Related field(${fieldName}) on ${model} has mismatched target model name with its related model field.`);
                     }
-                    if ('readonly' in field) {
-                        throw new Error(`Related field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicit for related fields).`);
+                    if (field.readonly) {
+                        throw new Error(`Related field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicitly set to true for related fields).`);
                     }
                 }
             }


### PR DESCRIPTION
3c28be1b33ea18be7280d9372ebd53a54140da86 enforced computes and relateds to be readonly. But there still are some fields that are not trivial to redesign in a readonly fashion.

This commit allows to disable readonly on fields with until the remaining problematic fields are converted.