### PR TITLE
[FIX] sale, purchase: fix inconsistent invoicing threshold tests

### DIFF
--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -506,6 +506,8 @@ class TestPurchaseToInvoice(AccountTestInvoicingCommon):
             'invoicing_switch_threshold': fields.Date.add(invoice.invoice_date, days=30),
         }).execute()
 
+        invoice.invalidate_cache(fnames=['payment_state'])
+
         self.assertEqual(line.qty_invoiced, 10)
         line.qty_received = 15
         self.assertEqual(line.qty_invoiced, 10)

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -492,6 +492,8 @@ class TestSaleToInvoice(TestSaleCommon):
             'invoicing_switch_threshold': fields.Date.add(invoice.invoice_date, days=30),
         }).execute()
 
+        invoice.invalidate_cache(fnames=['payment_state'])
+
         self.assertEqual(line.qty_invoiced, 10)
         line.qty_delivered = 15
         self.assertEqual(line.qty_invoiced, 10)


### PR DESCRIPTION
The tests introduced by https://github.com/odoo/odoo/commit/6605cc6673b8d46e1978c788fb48fc3828841112 were found to be inconsistent.

This commit fixes that.