### PR TITLE
[IMP] iap: add automatic deletion of accounts without token

### DIFF
--- a/addons/iap/models/iap.py
+++ b/addons/iap/models/iap.py
@@ -171,6 +171,17 @@ class IapAccount(models.Model):
                 ('company_ids', '=', False)
         ]
         accounts = self.search(domain, order='id desc')
+        accounts_without_token = accounts.filtered(lambda acc: not acc.account_token)
+        if accounts_without_token:
+            with self.pool.cursor() as cr:
+                # In case of a further error that will rollback the database, we should
+                # use a different SQL cursor to avoid undo the accounts deletion.
+
+                # Flush the pending operations to avoid a deadlock.
+                self.flush()
+                IapAccount = self.with_env(self.env(cr=cr))
+                IapAccount.search(domain + [('account_token', '=', False)]).unlink()
+                accounts = accounts - accounts_without_token
         if not accounts:
             with self.pool.cursor() as cr:
                 # Since the account did not exist yet, we will encounter a NoCreditError,


### PR DESCRIPTION
Since the accounts without token are useless and could create errors
afterwards, we should delete them and automatically create a new one
with a new token in case force_create is set to True.

Description of the issue/feature this PR addresses:
opw-2948766

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
