### PR TITLE
[FIX] mass_mailing: button uses sidebar instead of dialog.

### DIFF
--- a/addons/mass_mailing/static/src/js/wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/wysiwyg.js
@@ -1,3 +1,5 @@
+const { _t } = require('../../../../web/static/src/legacy/js/core/translation');
+
 odoo.define('mass_mailing.wysiwyg', function (require) {
 'use strict';
 
@@ -43,7 +45,9 @@ const MassMailingWysiwyg = Wysiwyg.extend({
         const linkCommands = commands.filter(command => command.name === 'Link' || command.name === 'Button');
         for (const linkCommand of linkCommands) {
             // Don't open the dialog: use the link tools.
-            linkCommand.callback = () => this.toggleLinkTools({forceDialog: false});
+            if (linkCommand.name === _t('Link')) {
+                linkCommand.callback = () => this.toggleLinkTools({forceDialog: false});
+            }
             // Remove the command if the selection is within a background-image.
             const superIsDisabled = linkCommand.isDisabled;
             linkCommand.isDisabled = () => {


### PR DESCRIPTION
**Current behavior before PR:**

Create a button with /button, it focuses the URL widget of the
sidebar instead of opening the button dialog.


**Desired behavior after PR is merged:**

Create a button with /button open the button dialog.

Task-2889670



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
