### PR TITLE
[FIX][15.0] crm: don't assign leads to sales team members if that member is in active

### DIFF
--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -121,7 +121,7 @@ class Team(models.Model):
             )
 
         members_data, population, weights = dict(), list(), list()
-        members = self.filtered(lambda member: not member.assignment_optout and member.assignment_max > 0)
+        members = self.filtered(lambda member: not member.assignment_optout and member.assignment_max > 0 and member.user_id.active)
         if not members:
             return members_data
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

- currently Main processing method to assign leads to sales team members, including inactive members

Desired behavior after PR is merged:

- Only assign leads to active members of the sales team




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
