### PR TITLE
[FIX] web: debug menu view metadata

### DIFF
--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -57,6 +57,7 @@ class GetMetadataDialog extends Component {
         )[0];
         this.state.id = metadata.id;
         this.state.xmlid = metadata.xmlid;
+        this.state.xmlids = metadata.xmlids;
         this.state.creator = formatMany2one(metadata.create_uid);
         this.state.lastModifiedBy = formatMany2one(metadata.write_uid);
         this.state.noupdate = metadata.noupdate;


### PR DESCRIPTION
Before this commit, in a legacy view, clicking on debug menu
"View Metadata" causes a crash.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
