### PR TITLE
[FIX] im_livechat: add w-auto on layout colors fields

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -128,8 +128,8 @@
                                         <field name="button_text"/>
                                         <label for="button_background_color" string="Livechat Button Color" />
                                         <div class="o_livechat_layout_colors d-flex align-items-center align-middle">
-                                            <field name="button_background_color" widget="color" class="mb-4 o_im_livechat_field_widget_color"/>
-                                            <field name="button_text_color" widget="color" class="mb-4 o_im_livechat_field_widget_color"/>
+                                            <field name="button_background_color" widget="color" class="mb-4 w-auto o_im_livechat_field_widget_color"/>
+                                            <field name="button_text_color" widget="color" class="mb-4 w-auto o_im_livechat_field_widget_color"/>
                                             <button class="btn btn-link oe_edit_only o_im_livechat_channel_form_button_colors_reset_button" aria-label="Reset to default colors" title="Reset to default colors">
                                                 <span class="fa fa-refresh mb-4"/>
                                             </button>


### PR DESCRIPTION
In commit 0194fa8236144596042a20f182ec3f48ea29b998, we fixed
the appearance of the color list in the livechat channel view.
But w-auto classnames were not added to some fields, which let
the positioning issues only partially fixed.

This commit concludes the fixed introduced in #98755.
