### PR TITLE
[FIX] account: take sequence_override_regex int account when resequencing

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -100,7 +100,7 @@ class ReSequenceWizard(models.TransientModel):
             for move in record.move_ids._origin:  # Sort the moves by period depending on the sequence number reset
                 moves_by_period[_get_move_key(move)] += move
 
-            format, format_values = self.env['account.move']._get_sequence_format_param(record.first_name)
+            seq_format, format_values = record.move_ids[0]._get_sequence_format_param(record.first_name)
 
             new_values = {}
             for j, period_recs in enumerate(moves_by_period.values()):
@@ -114,7 +114,7 @@ class ReSequenceWizard(models.TransientModel):
                         'server-date': str(move.date),
                     }
 
-                new_name_list = [format.format(**{
+                new_name_list = [seq_format.format(**{
                     **format_values,
                     'year': period_recs[0].date.year % (10 ** format_values['year_length']),
                     'month': period_recs[0].date.month,


### PR DESCRIPTION

Before this fix, resequencing would use values from _get_sequence_format_() run from an empty model.
This method result is influenced by the sequence_override_regex param of the move journal.
This means that if the journal of the moves that are resequenced has a sequence_override_regex param, it will be ignored in the wizard.
This fix run the _get_sequence_format_() method on the first move to take the journal into account.
Note that the wizard only allows resequencing moves from one same journal.

Task: opw-2825699