### PR TITLE
[FIX] web: save a record with a required empty x2many

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -355,8 +355,8 @@ export class Record extends DataPoint {
         }
         for (const fieldName in this.activeFields) {
             const fieldType = this.fields[fieldName].type;
+            const activeField = this.activeFields[fieldName];
             if (fieldName in this._requiredFields) {
-                const activeField = this.activeFields[fieldName];
                 if (
                     !evalDomain(this._requiredFields[fieldName], this.evalContext) ||
                     (activeField && activeField.alwaysInvisible)
@@ -365,6 +365,15 @@ export class Record extends DataPoint {
                     continue;
                 }
             }
+
+            const isSet =
+                activeField && activeField.FieldComponent && activeField.FieldComponent.isSet;
+
+            if (this.isRequired(fieldName) && isSet && !isSet(this.data[fieldName])) {
+                this.setInvalidField(fieldName);
+                continue;
+            }
+
             switch (fieldType) {
                 case "boolean":
                 case "float":
@@ -383,7 +392,7 @@ export class Record extends DataPoint {
                     }
                     break;
                 default:
-                    if (this.isRequired(fieldName) && !this.data[fieldName]) {
+                    if (!isSet && this.isRequired(fieldName) && !this.data[fieldName]) {
                         this.setInvalidField(fieldName);
                     }
             }

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -304,6 +304,7 @@ Many2ManyTagsField.supportedTypes = ["many2many"];
 Many2ManyTagsField.fieldsToFetch = {
     display_name: { name: "display_name", type: "char" },
 };
+Many2ManyTagsField.isSet = (value) => value.count > 0;
 
 Many2ManyTagsField.extractProps = ({ attrs, field }) => {
     return {

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -579,6 +579,15 @@ export class Record extends DataPoint {
                 this._removeInvalidFields([fieldName]);
                 continue;
             }
+
+            const isSet =
+                activeField && activeField.FieldComponent && activeField.FieldComponent.isSet;
+
+            if (this.isRequired(fieldName) && isSet && !isSet(this.data[fieldName])) {
+                this.setInvalidField(fieldName);
+                continue;
+            }
+
             switch (fieldType) {
                 case "boolean":
                 case "float":
@@ -592,7 +601,7 @@ export class Record extends DataPoint {
                     }
                     break;
                 default:
-                    if (this.isRequired(fieldName) && !this.data[fieldName]) {
+                    if (!isSet && this.isRequired(fieldName) && !this.data[fieldName]) {
                         this.setInvalidField(fieldName);
                     }
             }

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -1559,4 +1559,25 @@ QUnit.module("Fields", (hooks) => {
             "goldsilver"
         );
     });
+
+    QUnit.test("save a record with an empty many2many_tags required", async function (assert) {
+        assert.expect(3);
+
+        const form = await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: '<form><field name="timmy" widget="many2many_tags" required="1"/></form>',
+        });
+
+        patchWithCleanup(form.env.services.notification, {
+            add: (message, params) => {
+                assert.strictEqual(message.toString(), "<ul><li>pokemon</li></ul>");
+                assert.deepEqual(params, { title: "Invalid fields: ", type: "danger" });
+            },
+        });
+
+        await clickSave(target);
+        assert.containsOnce(target, "[name='timmy'].o_field_invalid");
+    });
 });


### PR DESCRIPTION
Before this commit, it was possible to save a record containing a
required empty x2many field.

How to reproduce:
- Create a new record in a form view with a required x2many
- Leave the empty x2many field blank
- Click on the save button

Result before:
    The record is saved.

Result after:
    The record is not saved and a notification indicates the field x2many
    invalid.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
