### PR TITLE
[FIX] web: invalid kanban record quick_create stays open

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_model.js
+++ b/addons/web/static/src/views/kanban/kanban_model.js
@@ -295,6 +295,20 @@ class KanbanGroup extends Group {
         await this.checkActiveValue();
     }
 
+    async validateQuickCreate() {
+        const record = this.list.quickCreateRecord;
+        if (!record) {
+            return false;
+        }
+        const saved = await record.save();
+        if (saved) {
+            this.addRecord(this.removeRecord(record), 0);
+            this.count++;
+            this.list.count++;
+            return record;
+        }
+    }
+
     // ------------------------------------------------------------------------
     // Protected
     // ------------------------------------------------------------------------

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -2542,22 +2542,6 @@ export class Group extends DataPoint {
         this.model.notify();
     }
 
-    async validateQuickCreate() {
-        const record = this.list.quickCreateRecord;
-        if (!record) {
-            return false;
-        }
-        const saved = await record.save();
-        if (saved) {
-            this.addRecord(this.removeRecord(record), 0);
-            this.count++;
-            this.list.count++;
-            return record;
-        } else {
-            this.removeRecord(record);
-        }
-    }
-
     valueEquals(value) {
         return this.value instanceof DateTime ? this.value.equals(value) : this.value === value;
     }


### PR DESCRIPTION
- Before this commit
Validating an invalid kanban record on quick creation
would leave the quick creation mode.

- After this commit
Validating an invalid kanban record on quick creation
will stay in quick creation mode, indicating which fields are invalid.