### PR TITLE
[FIX] bus: bus message dispatching

### DIFF
--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -6,7 +6,11 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from '@web/core/registry';
 
 const { EventBus } = owl;
-const NO_POPUP_CLOSE_CODES = [WEBSOCKET_CLOSE_CODES.SESSION_EXPIRED, WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT];
+const NO_POPUP_CLOSE_CODES = [
+    WEBSOCKET_CLOSE_CODES.SESSION_EXPIRED,
+    WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT,
+    WEBSOCKET_CLOSE_CODES.TRY_LATER,
+];
 
 /**
  * Communicate with a SharedWorker in order to provide a single websocket

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -43,7 +43,7 @@ export class WebsocketWorker {
     constructor(websocketURL) {
         this.websocketURL = websocketURL;
         this.channelsByClient = new Map();
-        this.connectRetryDelay = 0;
+        this.connectRetryDelay = 1000;
         this.connectTimeout = null;
         this.isReconnecting = false;
         this.lastChannelSubscription = null;
@@ -216,6 +216,10 @@ export class WebsocketWorker {
         // WebSocket was not closed cleanly, let's try to reconnect.
         this.broadcast('reconnecting', { closeCode: code });
         this.isReconnecting = true;
+        if (code === WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT) {
+            // Don't wait to reconnect on keep alive timeout.
+            this.connectRetryDelay = 0;
+        }
         this._onWebsocketError();
     }
 


### PR DESCRIPTION
Before the websockets were introduced, longpolling coroutines were
sleeping until postgres notify. Each coroutine was then wake up and
notifications were fetched.

Since the websocket introduction, the main loop, responsible for listening
to postgres sends the notifications itself. This means, the postgres loop
is blocked during message fetch/dispatching and notifications are dispatched
in a sequential fashion resulting in a slow message dispatching.

In order to solve this issue, websocket coroutines are now responsible to
fetch/dispatch notifications, letting the main loop free to relay notifications
as they come and allowing notifications to be sent simultaneously.

When instructed to dispatch available notifications, the websocket coroutines
will try to acquire a cursor. Each coroutine will try up to `MAX_TRY_ON_POOL_ERROR`
times, sleeping between each try. If no cursor can be acquired, the connection is
closed with the TRY_LATER` close code.