### PR TITLE
 [FIX] hr_expense: fix upload button

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -5,6 +5,7 @@ import re
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import Form
 from odoo.tools import email_split, float_is_zero
 
 
@@ -238,11 +239,13 @@ class HrExpense(models.Model):
             raise UserError(_("You need to have at least one product that can be expensed in your database to proceed!"))
 
         for attachment in attachments:
-            expense = self.env['hr.expense'].create({
-                'name': attachment.name.split('.')[0],
-                'unit_amount': 0,
-                'product_id': product.id
-            })
+            with Form(self) as expense_form:
+                expense_form.name = attachment.name.split('.')[0]
+                expense_form.unit_amount = 1.0
+                expense_form.product_id = product
+
+            expense = expense_form.save()
+
             expense.message_post(body=_('Uploaded Attachment'))
             attachment.write({
                 'res_model': 'hr.expense',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 

expense upload button not working correctly

Current behavior before PR:

 Creating a new expense using the upload button sets a default product but does not trigger the computed fields related.


Desired behavior after PR is merged:

The creation of the expense triggers all the computed fields like uom and taxes accordingly


opw-2927930
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
