### PR TITLE
[IMP] stock: Add translate=True attribute

### DIFF
--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -10,8 +10,8 @@ class RemovalStrategy(models.Model):
     _name = 'product.removal'
     _description = 'Removal Strategy'
 
-    name = fields.Char('Name', required=True)
-    method = fields.Char("Method", required=True, help="FIFO, LIFO...")
+    name = fields.Char('Name', required=True, translation=True)
+    method = fields.Char("Method", required=True, help="FIFO, LIFO...", translation=True)
 
 
 class StockPutawayRule(models.Model):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- When access to Inventory -> Configuration -> Settings -> choose
Storage Locations and Multi-Step Routes
- Switch to other languages, `First In First Out`, `Last In First Out`,
`Closest Locations`, `First Expiry First Out (FEFO)` are not translated.

Desired behavior after PR is merged:
- Add the `translate=True` attribute to the fields of
the model `product.removal` so that the words are translated in
different languages.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
