### PR TITLE
[IMP] stock_move : make the code more elegant

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -740,8 +740,7 @@ class StockMove(models.Model):
             moves_to_unreserve.add(move.id)
         moves_to_unreserve = self.env['stock.move'].browse(moves_to_unreserve)
 
-        ml_to_update, ml_to_unlink = OrderedSet(), OrderedSet()
-        moves_not_to_recompute = OrderedSet()
+        ml_to_update, ml_to_unlink, moves_not_to_recompute = OrderedSet(), OrderedSet(), OrderedSet()
         for ml in moves_to_unreserve.move_line_ids:
             if ml.qty_done:
                 ml_to_update.add(ml.id)


### PR DESCRIPTION
In the _do_unreserve method ,we have put all the variables : ml_to_update, ml_to_unlink, moves_not_to_recompute in the same line as they are all OrderedSet at this stage so we have no reason to put the moves_not_to_recompute in new line,this will make the code more readable and elegant




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
