### PR TITLE
[FIX] hr_holidays: no date_from creates error

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -694,6 +694,9 @@ class HolidaysRequest(models.Model):
     def name_get(self):
         res = []
         for leave in self:
+            user_tz = timezone(leave.tz)
+            date_from_utc = leave.date_from and leave.date_from.astimezone(user_tz).date()
+            date_to_utc = leave.date_to and leave.date_to.astimezone(user_tz).date()
             if self.env.context.get('short_name'):
                 if leave.leave_type_request_unit == 'hour':
                     res.append((leave.id, _("%s : %.2f hours") % (leave.name or leave.holiday_status_id.name, leave.number_of_hours_display)))
@@ -718,25 +721,23 @@ class HolidaysRequest(models.Model):
                                 person=target,
                                 leave_type=leave.holiday_status_id.name,
                                 duration=leave.number_of_hours_display,
-                                date=fields.Date.to_string(leave.date_from),
+                                date=fields.Date.to_string(date_from_utc) or "",
                             )
                         ))
                     else:
-                        user_tz = timezone(leave.tz)
-                        date_from_utc = leave.date_from.astimezone(user_tz).date()
                         res.append((
                             leave.id,
                             _("%(person)s on %(leave_type)s: %(duration).2f hours on %(date)s",
                                 person=target,
                                 leave_type=leave.holiday_status_id.name,
                                 duration=leave.number_of_hours_display,
-                                date=fields.Date.to_string(date_from_utc),
+                                date=fields.Date.to_string(date_from_utc) or "",
                             )
                         ))
                 else:
-                    display_date = fields.Date.to_string(leave.date_from)
-                    if leave.number_of_days > 1:
-                        display_date += ' / %s' % fields.Date.to_string(leave.date_to)
+                    display_date = fields.Date.to_string(date_from_utc) or ""
+                    if leave.number_of_days > 1 and date_from_utc and date_to_utc:
+                        display_date += ' / %s' % fields.Date.to_string(date_to_utc) or ""
                     if self.env.context.get('hide_employee_name') and 'employee_id' in self.env.context.get('group_by', []):
                         res.append((
                             leave.id,

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -56,7 +56,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_confirm(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_draft()
-        with self.assertQueryCount(__system__=22, admin=23):
+        with self.assertQueryCount(__system__=23, admin=24):
             leave.action_confirm()
         leave.state = 'refuse'
 


### PR DESCRIPTION
Probem:
With some time off type as default type in an allocation request
you get a traceback as soon as you try to open the allocation
request form.

Cause:
FIX commit [1] introduced the issue as it didn't consider the
possibility of a false date_from

Improvement 1:
Having a date_from False sets a False in the leave request name
displayed on the form, we change that to have an empty string
instead

Improvement 2:
The timezone bug fix in commit [1] is only applied on a specific
configuration, we applie it to all configuration of leave request
name

[1] 5a50dea2652cff014d9198f59265cf36a3ec1865

opw-2961344


