### PR TITLE
[FIX] mail: fixes various issues introduced by recent changes

### DIFF
--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -19,7 +19,7 @@
                     'o-starred': messageView.message.isStarred,
                     'o-currentAuthor': messageView.message.isCurrentUserOrGuestAuthor,
                     'mt-1': !messageView.isSquashed,
-                    'mt-5': !messageView.isSquashed and messageView.messageListViewOwner,
+                    'mt-5': !messageView.isSquashed and messageView.messageListViewMessageViewItemOwner,
                     'px-3': !messageView.isInChatWindow,
                     'px-1': messageView.isInChatWindow,
                     'opacity-50': (messageView.messageListViewMessageViewItemOwner and messageView.messageListViewMessageViewItemOwner.messageListViewOwner.threadViewOwner.replyingToMessageView) and !messageView.isSelected,

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -873,7 +873,7 @@ export class ModelField {
             return;
         }
         // support for inherited models (eg. relation targeting `Record`)
-        for (const subModel of Object.values(this.models)) {
+        for (const subModel of Object.values(record.models)) {
             if (!(subModel.prototype instanceof otherModel)) {
                 continue;
             }

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -261,13 +261,8 @@ registerModel({
             return Boolean(
                 this.isHovered ||
                 this.messagingAsClickedMessageView ||
-                (
-                    this.messageActionList &&
-                    (
-                        this.messageActionList.reactionPopoverView ||
-                        this.messageActionList.deleteConfirmDialog
-                    )
-                )
+                (this.messageActionList && this.messageActionList.actionReaction && this.messageActionList.actionReaction.messageActionView && this.messageActionList.actionReaction.messageActionView.reactionPopoverView) ||
+                (this.messageActionList && this.messageActionList.actionDelete && this.messageActionList.actionDelete.messageActionView && this.messageActionList.actionDelete.messageActionView.deleteConfirmDialog)
             );
         },
         /**


### PR DESCRIPTION
- fix typo in model manager: "return" -> "continue" in loop
- fix typo in model field: "models" read from record not from field itself
- fix reading obsolete field in message view
- move listeners on records directly rather than storing a map on model manager
  (code a bit easier to read, and issues on deleted records easier to debug)
- remove obsolete trigger of listener in _created (not possible to observe a
  record before it exists)