### PR TITLE
[FIX] account_facturx: add partner email to factur_x XML

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -83,6 +83,16 @@
                     <ram:ID t-esc="SpecifiedLegalOrganization"/>
                 </ram:SpecifiedLegalOrganization>
 
+                <ram:DefinedTradeContact>
+                    <ram:PersonName t-esc="partner.name"/>
+                    <ram:TelephoneUniversalCommunication t-if="partner.phone or partner.mobile">
+                        <ram:CompleteNumber t-esc="partner.phone or partner.mobile"/>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication t-if="partner.email">
+                        <ram:URIID schemeID='SMTP' t-esc="partner.email"/>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+
                 <!-- Address. -->
                 <ram:PostalTradeAddress>
                     <ram:PostcodeCode t-if="partner.zip" t-esc="partner.zip"/>
@@ -107,7 +117,7 @@
                 -->
                 <rsm:ExchangedDocumentContext>
                     <ram:GuidelineSpecifiedDocumentContextParameter>
-                        <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+                        <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
                     </ram:GuidelineSpecifiedDocumentContextParameter>
                 </rsm:ExchangedDocumentContext>
 

--- a/addons/account_facturx/tests/test_facturx.py
+++ b/addons/account_facturx/tests/test_facturx.py
@@ -65,7 +65,7 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
             <CrossIndustryInvoice>
                 <ExchangedDocumentContext>
                     <GuidelineSpecifiedDocumentContextParameter>
-                        <ID>urn:cen.eu:en16931:2017</ID>
+                        <ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ID>
                     </GuidelineSpecifiedDocumentContextParameter>
                 </ExchangedDocumentContext>
                 <ExchangedDocument>
@@ -114,10 +114,16 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                     <ApplicableHeaderTradeAgreement>
                         <SellerTradeParty>
                             <Name>company_1_data</Name>
+                            <DefinedTradeContact>
+                                <PersonName>company_1_data</PersonName>
+                            </DefinedTradeContact>
                             <PostalTradeAddress/>
                         </SellerTradeParty>
                         <BuyerTradeParty>
                             <Name>partner_b</Name>
+                            <DefinedTradeContact>
+                                <PersonName>partner_b</PersonName>
+                            </DefinedTradeContact>
                             <PostalTradeAddress/>
                         </BuyerTradeParty>
                         <BuyerOrderReferencedDocument>
@@ -127,6 +133,9 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                     <ApplicableHeaderTradeDelivery>
                         <ShipToTradeParty>
                             <Name>partner_b</Name>
+                            <DefinedTradeContact>
+                                <PersonName>partner_b</PersonName>
+                            </DefinedTradeContact>
                             <PostalTradeAddress/>
                         </ShipToTradeParty>
                     </ApplicableHeaderTradeDelivery>


### PR DESCRIPTION
Currently, when creating an invoice from factur_x XML, the vendor is identified by sequentially checking (in this order) the following information :
- VAT number
- name
- email

However, when we generate a factur_x XML, we do not include the partner's email address. This means that in some cases, two odoo databases are not able to communicate bills/invoices properly.

This commit brings back a behavior that was unintentionally removed in https://github.com/odoo/odoo/commit/d25fdafcd8eb4cfef14c2ef7ed8ad7785dd01b55

opw-2909408