### PR TITLE
[IMP] web: kanban: highlight destination column on drag&drop

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -484,6 +484,10 @@
                 }
             }
         }
+        &.o_kanban_hover {
+            background-color: #00a09d0d;
+            box-shadow: -1px 0px 0px 0px #00a09d inset, 1px 0px 0px 0px #00a09d inset;
+        }
     }
 
     .o_group_draggable .o_column_title {

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -65,9 +65,13 @@ export class KanbanRenderer extends Component {
                 },
                 onGroupEnter: (group) => group.classList.add("o_kanban_hover"),
                 onGroupLeave: (group) => group.classList.remove("o_kanban_hover"),
-                onStop: (_group, element) => element.classList.remove("o_dragged", "shadow"),
+                onStop: (group, element) => {
+                    group && group.classList && group.classList.remove("o_kanban_hover");
+                    element.classList.remove("o_dragged", "shadow");
+                },
                 onDrop: async ({ element, previous, parent }) => {
                     element.classList.remove("o_record_draggable");
+                    parent && parent.classList && parent.classList.remove("o_kanban_hover");
                     const refId = previous ? previous.dataset.id : null;
                     const targetGroupId = parent && parent.dataset.id;
                     await this.props.list.moveRecord(
@@ -262,7 +266,12 @@ export class KanbanRenderer extends Component {
         if (!this.env.isSmall && group.isFolded) {
             classes.push("o_column_folded");
         }
-        if (this.canResequenceGroups && group.value && !group.isFolded && !group.hasActiveProgressValue) {
+        if (
+            this.canResequenceGroups &&
+            group.value &&
+            !group.isFolded &&
+            !group.hasActiveProgressValue
+        ) {
             classes.push("bg-100");
         }
         if (group.progressBars.length) {

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -71,15 +71,21 @@ export class KanbanRenderer extends Component {
                 },
                 onDrop: async ({ element, previous, parent }) => {
                     element.classList.remove("o_record_draggable");
-                    parent && parent.classList && parent.classList.remove("o_kanban_hover");
-                    const refId = previous ? previous.dataset.id : null;
-                    const targetGroupId = parent && parent.dataset.id;
-                    await this.props.list.moveRecord(
-                        dataRecordId,
-                        dataGroupId,
-                        refId,
-                        targetGroupId
-                    );
+                    if (
+                        !this.props.list.isGrouped ||
+                        parent.classList.contains("o_kanban_hover") ||
+                        parent.dataset.id === element.parentElement.dataset.id
+                    ) {
+                        parent && parent.classList && parent.classList.remove("o_kanban_hover");
+                        const refId = previous ? previous.dataset.id : null;
+                        const targetGroupId = parent && parent.dataset.id;
+                        await this.props.list.moveRecord(
+                            dataRecordId,
+                            dataGroupId,
+                            refId,
+                            targetGroupId
+                        );
+                    }
                     element.classList.add("o_record_draggable");
                 },
             });

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -3,6 +3,7 @@
 import { makeFakeDialogService } from "@web/../tests/helpers/mock_services";
 import {
     click,
+    drag,
     dragAndDrop,
     editInput,
     getFixture,
@@ -4039,6 +4040,34 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".thisiseditable", 4);
 
         assert.verifySteps(["resequence"]);
+    });
+
+    QUnit.test("drag and drop highlight on hover", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban on_create="quick_create">
+                <field name="product_id"/>
+                <templates><t t-name="kanban-box">
+                <div class="oe_kanban_global_click"><field name="foo"/>
+                </div>
+                </t></templates>
+                </kanban>`,
+            groupBy: ["product_id"],
+        });
+        assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 2);
+        assert.containsN(target, ".o_kanban_group:nth-child(2) .o_kanban_record", 2);
+
+        // first record of first column moved to the bottom of second column
+        const drop = drag(
+            ".o_kanban_group:first-child .o_kanban_record",
+            ".o_kanban_group:nth-child(2)"
+        );
+        assert.hasClass(target.querySelector(".o_kanban_group:nth-child(2)"), "o_kanban_hover");
+        await drop();
+        assert.containsNone(target, ".o_kanban_group:nth-child(2).o_kanban_hover");
     });
 
     QUnit.test("drag and drop a record, grouped by selection", async (assert) => {

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -4070,6 +4070,29 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_kanban_group:nth-child(2).o_kanban_hover");
     });
 
+    QUnit.test("drag and drop outside of a column", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban on_create="quick_create">
+                <field name="product_id"/>
+                <templates><t t-name="kanban-box">
+                <div class="oe_kanban_global_click"><field name="foo"/>
+                </div>
+                </t></templates>
+                </kanban>`,
+            groupBy: ["product_id"],
+        });
+        assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 2);
+        assert.containsN(target, ".o_kanban_group:nth-child(2) .o_kanban_record", 2);
+
+        // first record of first column moved to the right of a column
+        await dragAndDrop(".o_kanban_group:first-child .o_kanban_record", ".o_column_quick_create");
+        assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 2);
+    });
+
     QUnit.test("drag and drop a record, grouped by selection", async (assert) => {
         assert.expect(7);
 


### PR DESCRIPTION
[[IMP] web: kanban: highlight destination column on drag&drop](https://github.com/odoo/odoo/pull/98897/commits/a17b5a6cbb885947edb84c2684e8e2217171f875)
Before, the destination column while drag&drop was not highlighted.
Therefore it was not obvious for the user in which column the card
would be dropped. e.g. when the column header is not visible because
the user scrolled

Now, the destination column is highlighted when drag&dropping a card.

![image](https://user-images.githubusercontent.com/109217759/186656313-38e8d4a4-7c6f-4044-a4a2-685fe1c905f1.png)

[[IMP] web: kanban: drop card only when a column is highlighted](https://github.com/odoo/odoo/pull/98897/commits/8479b0dad40d5c22c7de26b31330c12ef4594fcf)

Before, when the user dragged a card outside of a column
(e.g. whitespace to the right), the card was moved to the last stage
for which the event handler for the target was registered.

Now, we move the card only when the card drop is done inside a column.

[[IMP] web: utils: add drag and drop helper functions](https://github.com/odoo/odoo/pull/98897/commits/d9a97920e29b0742efa8c0b451229005628a21dc)

Before, it was possible to drag&drop an element from a point to another.
However it can be useful for tests to drag, make actions/tests
and then drop.

Now, the developer can use the `drag` function and drop after with the
returned function.

task-2459381