### PR TITLE
[FIX] website: switch theme when using Firefox

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -125,7 +125,9 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         };
         if (!this.wysiwyg.isDirty()) {
             destroy();
-            window.location.reload();
+            if (reload) {
+                window.location.reload();
+            }
             return;
         }
         this.wysiwyg.__edition_will_stopped_already_done = true; // TODO adapt in master, see above


### PR DESCRIPTION
When using Firefox, the "Switch Theme" option in the "Theme" tab does
not redirect to the theme selection page if there is no modification to
save on the page.

This happens because when there is no change in the page that needs to
be saved, the page is reloaded.
In Firefox, this reload happens right away and prevents the further
steps of the Promise chain to redirect the URL to the theme selection.
In Chrome, it seems the reload gets scheduled as an operation that will
only occur once all micro-tasks are completed.

This commit avoids calling reload if the `reload` flag was set to
`false` by the caller of the save operation.

task-2920252

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
