### PR TITLE
[FIX] project: display partner_id dropdown

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1494,6 +1494,7 @@
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <tree string="Tasks" multi_edit="1" sample="1" js_class="project_list">
+                    <field name="company_id" invisible="1"/>
                     <field name="message_needaction" invisible="1" readonly="1"/>
                     <field name="is_closed" invisible="1" />
                     <field name="sequence" invisible="1" readonly="1"/>


### PR DESCRIPTION
Steps :

In a ONE company environment,
\- Go to Project Task list view.
\- Display 'Customer' column.
\- Select multiple records (multi-edit).
\- Click on a 'Customer' cell to display the dropdown list.

Issue :
Traceback : company not found.

Cause :
partner_id's domain refers to company_id,
which is not present in the vue if not in multicompany.

Fix :
Add it in ivisible.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
