### PR TITLE
[FIX] web: Dropping record in folded column loads it

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -2423,7 +2423,6 @@ export class Group extends DataPoint {
      */
     addRecord(record, index) {
         this.count++;
-        this.isFolded = false;
         return this.list.addRecord(record, index);
     }
 


### PR DESCRIPTION
Before this PR, when dropping a record on a folded column in a
kanban view, the column would not load its records and display a "load
more" button instead.

Now, dropping a record on a folded column loads it entirely before
unfolding it, displaying its records normally (including the newly
dropped one).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
