### PR TITLE
[FIX] website, *: define specific dynamic snippet name

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -65,7 +65,7 @@ class QWeb(models.AbstractModel):
                 sub_call = el.get('t-call')
                 if sub_call:
                     el.set('t-call-options', f"{{'snippet-key': '{snippet_key}', 'snippet-sub-call-key': '{sub_call}'}}")
-                # If it already has a data-snippet it is a saved snippet.
+                # If it already has a data-snippet it is a saved or an inherited snippet.
                 # Do not override it.
                 elif 'data-snippet' not in el.attrib:
                     el.attrib['data-snippet'] = snippet_key.split('.', 1)[-1]

--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -19,6 +19,8 @@ const dynamicSnippetOptions = options.Class.extend({
      * @override
      */
     onBuilt: function () {
+        // TODO Remove in master.
+        this.$target[0].dataset['snippet'] = 's_dynamic_snippet';
         this._setOptionsDefaultValues();
     },
 

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/options.js
@@ -5,6 +5,14 @@ const options = require('web_editor.snippets.options');
 const s_dynamic_snippet_options = require('website.s_dynamic_snippet_options');
 
 const dynamicSnippetCarouselOptions = s_dynamic_snippet_options.extend({
+    /**
+     * @override
+     */
+    onBuilt() {
+        this._super(...arguments);
+        // TODO Remove in master.
+        this.$target[0].dataset['snippet'] = 's_dynamic_snippet_carousel';
+    },
 
     //--------------------------------------------------------------------------
     // Options

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="website.s_dynamic_snippet_template">
-        <section t-attf-class="#{snippet_name} s_dynamic d-none pt24 pb24">
+        <section t-attf-class="#{snippet_name} s_dynamic d-none pt24 pb24" t-att-data-snippet="snippet_name">
             <div class="container o_not_editable">
                 <div class="css_non_editable_mode_hidden">
                     <div class="missing_option_warning alert alert-info rounded-0 fade show d-print-none">

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
@@ -20,6 +20,8 @@ const dynamicSnippetProductsOptions = s_dynamic_snippet_carousel_options.extend(
      */
     onBuilt: function () {
         this._super.apply(this, arguments);
+        // TODO Remove in master.
+        this.$target[0].dataset['snippet'] = 's_dynamic_snippet_products';
         this._rpc({
             route: '/website_sale/snippet/options_filters'
         }).then((data) => {


### PR DESCRIPTION
*: web_editor, website_sale

Since [1] when the Dynamic Snippet was first introduced, it also
introduced a concept of "inherited" snippets. Specific snippets would
all `t-call` the same template for their rendering.
A mechanism was introduced to deduce the `data-snippet` from the caller
template, but it stored the obtained value in the `t-called` template
itself. Because of this if several "specific snippets" that used that
template had to be rendered, they would all have the `data-snippet`
value of the first one that got compiled.

We could compile the snippet template into something having a
dynamically obtained `data-snippet` value, but then that would be
equivalent to just using a `t-att-data-snippet`.
All specific snippets already do set a `snippet_name` in the context
because it needs to be added in the classes.

This commit therefore adds a `t-att-data-snippet` attribute on the
base template, and populates with that same value in `onBuilt` for
stable versions.

During forward ports across stable versions, each new caller must be
patched as well - and all patches must be removed in master.

[1]: https://github.com/odoo/odoo/pull/53175

task-2922635
