### PR TITLE
[FIX] pos_restaurant: synchronize orders in TicketScreen

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/TipScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/TipScreen.tour.js
@@ -55,7 +55,7 @@ odoo.define('pos_restaurant.tour.TipScreen', function (require) {
     Chrome.do.backToFloor();
     FloorScreen.check.orderCountSyncedInTableIs('T5', '1');
     Chrome.do.clickTicketButton();
-    TicketScreen.check.nthRowContains('4', 'Tipping');
+    TicketScreen.check.nthRowContains('3', 'Tipping');
 
     // Tip 20% on order1
     TicketScreen.do.selectOrder('-0001');


### PR DESCRIPTION
Before this commit: if more than one user work on a PoS restaurant, the
synced validated orders wouldn't remove from other user devices.

Steps to reproduce the issue:
	1. Create a PoS resturant
	2. Login to the PoS with two different browser
	3. Create some orders with some products in one of the browsers
	4. Complete the orders in another browser
	=> Orders will not remove from the first browser

The solution is to retrieve the latest orders of every table when going to
the TicketScreen

opw-2925193

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
