### PR TITLE
[FIX/IMP] improve website content list view

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -599,6 +599,10 @@ class Website(Home):
                 template = default_templ
 
         template = template and dict(template=template) or {}
+        website_id = kwargs.get('website_id')
+        if website_id:
+            website = request.env['website'].browse(website_id)
+            website._force()
         page = request.env['website'].new_page(path, add_menu=add_menu, **template)
         url = page['url']
 

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -46,7 +46,7 @@ class Page(models.Model):
     def _compute_is_homepage(self):
         website = self.env['website'].get_current_website()
         for page in self:
-            page.is_homepage = page.url == website.homepage_url
+            page.is_homepage = page.url == (website.homepage_url or page.website_id == website and '/')
 
     def _set_is_homepage(self):
         website = self.env['website'].get_current_website()

--- a/addons/website/static/src/components/views/page_kanban.js
+++ b/addons/website/static/src/components/views/page_kanban.js
@@ -1,0 +1,31 @@
+/** @odoo-module **/
+
+import {PageControllerMixin, PageRendererMixin} from "./page_views_mixin";
+import {registry} from '@web/core/registry';
+import {kanbanView} from "@web/views/kanban/kanban_view";
+
+
+export class PageKanbanController extends PageControllerMixin(kanbanView.Controller) {
+    /**
+     * @override
+     */
+    async createRecord() {
+        return this.createWebsiteContent();
+    }
+}
+PageKanbanController.template = 'website.PageKanbanView';
+
+export class PageKanbanRenderer extends PageRendererMixin(kanbanView.Renderer) {}
+PageKanbanRenderer.props = [
+    ...kanbanView.Renderer.props,
+    "activeWebsite",
+];
+PageKanbanRenderer.template = 'website.PageKanbanRenderer';
+
+export const PageKanbanView = {
+    ...kanbanView,
+    Renderer: PageKanbanRenderer,
+    Controller: PageKanbanController,
+};
+
+registry.category("views").add("website_pages_kanban", PageKanbanView);

--- a/addons/website/static/src/components/views/page_kanban.xml
+++ b/addons/website/static/src/components/views/page_kanban.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.PageKanbanRenderer" t-inherit="web.KanbanRenderer" owl="1">
+    <xpath expr="//t[@t-if='groupOrRecord.group']//KanbanRecord" position="attributes">
+        <attribute name="t-if">recordFilter(record, props.list.records)</attribute>
+    </xpath>
+    <xpath expr="//div/t/t[2]/KanbanRecord" position="attributes">
+        <attribute name="t-if">recordFilter(groupOrRecord.record, props.list.records)</attribute>
+    </xpath>
+</t>
+
+<t t-name="website.PageKanbanView" t-inherit="web.KanbanView" owl="1">
+    <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
+        <attribute name="activeWebsite">state.activeWebsite</attribute>
+    </xpath>
+    <xpath expr="//Layout" position="inside">
+        <t t-set-slot="control-panel-website-extra-actions">
+            <t t-call="website.RecordFilter"/>
+        </t>
+    </xpath>
+</t>
+
+</templates>

--- a/addons/website/static/src/components/views/page_list.js
+++ b/addons/website/static/src/components/views/page_list.js
@@ -4,7 +4,6 @@ import {AddPageDialog} from "../dialog/dialog";
 import {registry} from '@web/core/registry';
 import {listView} from '@web/views/list/list_view';
 import {useService} from "@web/core/utils/hooks";
-import { csrf_token } from 'web.core';
 
 const {onWillStart, useState} = owl;
 
@@ -16,7 +15,6 @@ export class PageListController extends listView.Controller {
     setup() {
         super.setup();
         this.website = useService('website');
-        this.http = useService('http');
 
         this.websiteSelection = [{id: 0, name: this.env._t("All Websites")}];
 
@@ -35,27 +33,7 @@ export class PageListController extends listView.Controller {
      */
     onClickCreate() {
         if (this.props.resModel === 'website.page') {
-            return this.dialogService.add(AddPageDialog, {
-                selectWebsite: true,
-                addPage: async (state) => {
-                    // TODO this is duplicated code from new_content.js, this
-                    // should be shared somehow.
-                    const websiteId = parseInt(state.websiteId);
-                    const url = `/website/add/${encodeURIComponent(state.name)}`;
-                    const data = await this.http.post(url, { 'add_menu': state.addMenu || '', 'website_id': websiteId, csrf_token });
-                    if (data.view_id) {
-                        this.actionService.doAction({
-                            'res_model': 'ir.ui.view',
-                            'res_id': data.view_id,
-                            'views': [[false, 'form']],
-                            'type': 'ir.actions.act_window',
-                            'view_mode': 'form',
-                        });
-                    } else {
-                        this.website.goToWebsite({ path: data.url, edition: true, websiteId });
-                    }
-                },
-            });
+            return this.dialogService.add(AddPageDialog, {selectWebsite: true});
         }
         const action = this.props.context.create_action;
         if (action) {

--- a/addons/website/static/src/components/views/page_list.js
+++ b/addons/website/static/src/components/views/page_list.js
@@ -3,14 +3,60 @@
 import {PageControllerMixin, PageRendererMixin} from "./page_views_mixin";
 import {registry} from '@web/core/registry';
 import {listView} from '@web/views/list/list_view';
+import {ConfirmationDialog} from "@web/core/confirmation_dialog/confirmation_dialog";
+import {useService} from "@web/core/utils/hooks";
+import {sprintf} from "@web/core/utils/strings";
 
 
 export class PageListController extends PageControllerMixin(listView.Controller) {
     /**
      * @override
      */
+    setup() {
+        super.setup();
+        this.orm = useService('orm');
+    }
+
+    /**
+     * @override
+     */
     onClickCreate() {
         return this.createWebsiteContent();
+    }
+
+    /**
+     * Adds a "Publish/Unpublish" button to the 'action' menu of the list view.
+     *
+     * @override
+     */
+    getActionMenuItems() {
+        const actionMenuItems = super.getActionMenuItems();
+        // 'Archive' / 'Unarchive' options are disabled only on 'website.page' list view.
+        if (this.props.resModel === 'website.page') {
+            actionMenuItems.other = actionMenuItems.other
+                .filter(item => !['archive', 'unarchive'].includes(item.key));
+        }
+        actionMenuItems.other.splice(-1, 0, {
+            description: this.env._t("Publish"),
+            callback: async () => {
+                this.dialogService.add(ConfirmationDialog, {
+                    title: this.env._t("Publish Website Content"),
+                    body: sprintf(this.env._t("%s record(s) selected, are you sure you want to publish them all?"), this.model.root.selection.length),
+                    confirm: () => this.togglePublished(true),
+                });
+            }
+        },
+        {
+            description: this.env._t("Unpublish"),
+            callback: async () => this.togglePublished(false),
+        });
+        return actionMenuItems;
+    }
+
+    async togglePublished(publish) {
+        const resIds = this.model.root.selection.map(record => record.resId);
+        await this.orm.write(this.props.resModel, resIds, {is_published: publish});
+        this.actionService.switchView('list');
     }
 }
 PageListController.template = `website.PageListView`;

--- a/addons/website/static/src/components/views/page_list.js
+++ b/addons/website/static/src/components/views/page_list.js
@@ -36,12 +36,13 @@ export class PageListController extends listView.Controller {
     onClickCreate() {
         if (this.props.resModel === 'website.page') {
             return this.dialogService.add(AddPageDialog, {
-                addPage: async (name, addMenu) => {
+                selectWebsite: true,
+                addPage: async (state) => {
                     // TODO this is duplicated code from new_content.js, this
                     // should be shared somehow.
-                    // FIXME this always create on website 1 whatever we do.
-                    const url = `/website/add/${encodeURIComponent(name)}`;
-                    const data = await this.http.post(url, { 'add_menu': addMenu || '', csrf_token });
+                    const websiteId = parseInt(state.websiteId);
+                    const url = `/website/add/${encodeURIComponent(state.name)}`;
+                    const data = await this.http.post(url, { 'add_menu': state.addMenu || '', 'website_id': websiteId, csrf_token });
                     if (data.view_id) {
                         this.actionService.doAction({
                             'res_model': 'ir.ui.view',
@@ -51,7 +52,7 @@ export class PageListController extends listView.Controller {
                             'view_mode': 'form',
                         });
                     } else {
-                        this.website.goToWebsite({ path: data.url, edition: true });
+                        this.website.goToWebsite({ path: data.url, edition: true, websiteId });
                     }
                 },
             });
@@ -80,18 +81,18 @@ PageListController.template = `website.PageListView`;
 
 export class PageListRenderer extends listView.Renderer {
     /**
-     * The goal here is to tweak the renderer to display pages following some
+     * The goal here is to tweak the renderer to display records following some
      * rules:
      * - All websites (props.activeWebsite.id === 0):
-     *     -> Show all generic/specific pages.
+     *     -> Show all generic/specific records.
      * - A website is selected:
-     *     -> Display website-specific pages & generic ones (only those without
+     *     -> Display website-specific records & generic ones (only those without
      *        specific clones).
      */
-    pageFilter(record, records) {
+    recordFilter(record, records) {
         return !this.props.activeWebsite.id
             || this.props.activeWebsite.id === record.data.website_id[0]
-            || !record.data.website_id[0] && records.filter(rec => rec.data.url === record.data.url).length === 1;
+            || !record.data.website_id[0] && records.filter(rec => rec.data.website_url === record.data.website_url).length === 1;
     }
 }
 PageListRenderer.props = [

--- a/addons/website/static/src/components/views/page_list.js
+++ b/addons/website/static/src/components/views/page_list.js
@@ -1,78 +1,21 @@
 /** @odoo-module **/
 
-import {AddPageDialog} from "../dialog/dialog";
+import {PageControllerMixin, PageRendererMixin} from "./page_views_mixin";
 import {registry} from '@web/core/registry';
 import {listView} from '@web/views/list/list_view';
-import {useService} from "@web/core/utils/hooks";
-
-const {onWillStart, useState} = owl;
 
 
-export class PageListController extends listView.Controller {
-    /**
-     * @override
-     */
-    setup() {
-        super.setup();
-        this.website = useService('website');
-
-        this.websiteSelection = [{id: 0, name: this.env._t("All Websites")}];
-
-        this.state = useState({
-            activeWebsite: this.websiteSelection[0],
-        });
-
-        onWillStart(async () => {
-            await this.website.fetchWebsites();
-            this.websiteSelection.push(...this.website.websites);
-        });
-    }
-
+export class PageListController extends PageControllerMixin(listView.Controller) {
     /**
      * @override
      */
     onClickCreate() {
-        if (this.props.resModel === 'website.page') {
-            return this.dialogService.add(AddPageDialog, {selectWebsite: true});
-        }
-        const action = this.props.context.create_action;
-        if (action) {
-            if (/^\//.test(action)) {
-                window.location.replace(action);
-                return;
-            }
-            this.actionService.doAction(action, {
-                onClose: (data) => {
-                    if (data) {
-                        this.website.goToWebsite({path: data.path});
-                    }
-                },
-            });
-        }
-    }
-
-    onSelectWebsite(website) {
-        this.state.activeWebsite = website;
+        return this.createWebsiteContent();
     }
 }
 PageListController.template = `website.PageListView`;
 
-export class PageListRenderer extends listView.Renderer {
-    /**
-     * The goal here is to tweak the renderer to display records following some
-     * rules:
-     * - All websites (props.activeWebsite.id === 0):
-     *     -> Show all generic/specific records.
-     * - A website is selected:
-     *     -> Display website-specific records & generic ones (only those without
-     *        specific clones).
-     */
-    recordFilter(record, records) {
-        return !this.props.activeWebsite.id
-            || this.props.activeWebsite.id === record.data.website_id[0]
-            || !record.data.website_id[0] && records.filter(rec => rec.data.website_url === record.data.website_url).length === 1;
-    }
-}
+export class PageListRenderer extends PageRendererMixin(listView.Renderer) {}
 PageListRenderer.props = [
     ...listView.Renderer.props,
     "activeWebsite",

--- a/addons/website/static/src/components/views/page_list.xml
+++ b/addons/website/static/src/components/views/page_list.xml
@@ -8,7 +8,7 @@
         </t>
     </xpath>
     <xpath expr="//tr[@class='o_data_row']" position="attributes">
-        <attribute name="t-if">pageFilter(record, list.records)</attribute>
+        <attribute name="t-if">recordFilter(record, list.records)</attribute>
     </xpath>
 </t>
 
@@ -17,7 +17,7 @@
         <attribute name="activeWebsite">state.activeWebsite</attribute>
     </xpath>
     <xpath expr="//Layout" position="inside">
-        <t t-set-slot="control-panel-website-extra-actions" t-if="props.resModel === 'website.page'">
+        <t t-set-slot="control-panel-website-extra-actions">
             <div class="btn-group" role="toolbar" aria-label="Main actions">
                 <button class="btn btn-light dropdown-toggle o-no-caret" data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="me-1 fa fa-globe"/><span t-esc="state.activeWebsite.name"/>

--- a/addons/website/static/src/components/views/page_list.xml
+++ b/addons/website/static/src/components/views/page_list.xml
@@ -18,17 +18,7 @@
     </xpath>
     <xpath expr="//Layout" position="inside">
         <t t-set-slot="control-panel-website-extra-actions">
-            <div class="btn-group" role="toolbar" aria-label="Main actions">
-                <button class="btn btn-light dropdown-toggle o-no-caret" data-bs-toggle="dropdown" aria-expanded="false">
-                    <i class="me-1 fa fa-globe"/><span t-esc="state.activeWebsite.name"/>
-                </button>
-                <div class="dropdown-menu">
-                    <t t-foreach="websiteSelection" t-as="website" t-key="website">
-                        <a role="menuitem" href="#" class="dropdown-item" t-on-click="() => this.onSelectWebsite(website)"><t t-esc="website.name"/></a>
-                        <div t-if="!website.id" class="dropdown-divider"/>
-                    </t>
-                </div>
-            </div>
+            <t t-call="website.RecordFilter"/>
         </t>
     </xpath>
 </t>
@@ -43,6 +33,20 @@
     <xpath expr="//t[@t-call='web.ControlPanel.Regular']" position="replace">
         <t t-call="website.ControlPanel.Regular"/>
     </xpath>
+</t>
+
+<t t-name="website.RecordFilter" owl="1">
+    <div class="btn-group" role="toolbar" aria-label="Main actions" t-if="'website_id' in props.archInfo.fieldNodes">
+        <button class="btn btn-light dropdown-toggle o-no-caret" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="me-1 fa fa-globe"/><span t-esc="state.activeWebsite.name"/>
+        </button>
+        <div class="dropdown-menu">
+            <t t-foreach="websiteSelection" t-as="website" t-key="website">
+                <a role="menuitem" href="#" class="dropdown-item" t-on-click="() => this.onSelectWebsite(website)"><t t-esc="website.name"/></a>
+                <div t-if="!website.id" class="dropdown-divider"/>
+            </t>
+        </div>
+    </div>
 </t>
 
 </templates>

--- a/addons/website/static/src/components/views/page_views_mixin.js
+++ b/addons/website/static/src/components/views/page_views_mixin.js
@@ -1,0 +1,80 @@
+/** @odoo-module **/
+
+import {AddPageDialog} from "../dialog/dialog";
+import {useService} from "@web/core/utils/hooks";
+
+const {onWillStart, useState} = owl;
+
+/**
+ * Used to share code and keep the same behaviour on different types of 'website
+ * content' views:
+ * - Trigger the 'new content' dialogs when 'CREATE' button is clicked.
+ * - Add a website selector on ControlPanel (that will be used by the renderer
+ * to filter content).
+ */
+export const PageControllerMixin = (component) => class extends component {
+    /**
+     * @override
+     */
+    setup() {
+        super.setup();
+        this.website = useService('website');
+        this.dialog = useService('dialog');
+
+        this.websiteSelection = [{id: 0, name: this.env._t("All Websites")}];
+
+        this.state = useState({
+            activeWebsite: this.websiteSelection[0],
+        });
+
+        onWillStart(async () => {
+            await this.website.fetchWebsites();
+            this.websiteSelection.push(...this.website.websites);
+        });
+    }
+
+    /**
+     * Adds the new 'website content' record depending on the targeted model and
+     * 'create_action' passed in context.
+     */
+    createWebsiteContent() {
+        if (this.props.resModel === 'website.page') {
+            return this.dialog.add(AddPageDialog, {selectWebsite: true});
+        }
+        const action = this.props.context.create_action;
+        if (action) {
+            if (/^\//.test(action)) {
+                window.location.replace(action);
+                return;
+            }
+            this.actionService.doAction(action, {
+                onClose: (data) => {
+                    if (data) {
+                        this.website.goToWebsite({path: data.path});
+                    }
+                },
+            });
+        }
+    }
+
+    onSelectWebsite(website) {
+        this.state.activeWebsite = website;
+    }
+};
+
+export const PageRendererMixin = (component) => class extends component {
+    /**
+     * The goal here is to tweak the renderer to display records following some
+     * rules:
+     * - All websites (props.activeWebsite.id === 0):
+     *     -> Show all generic/specific records.
+     * - A website is selected:
+     *     -> Display website-specific records & generic ones (only those without
+     *        specific clones).
+     */
+    recordFilter(record, records) {
+        return !this.props.activeWebsite.id
+            || this.props.activeWebsite.id === record.data.website_id[0]
+            || !record.data.website_id[0] && records.filter(rec => rec.data.website_url === record.data.website_url).length === 1;
+    }
+};

--- a/addons/website/static/src/systray_items/new_content.js
+++ b/addons/website/static/src/systray_items/new_content.js
@@ -4,7 +4,6 @@ import { registry } from '@web/core/registry';
 import { useService } from '@web/core/utils/hooks';
 import { WebsiteDialog, AddPageDialog } from "@website/components/dialog/dialog";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-import { csrf_token } from 'web.core';
 import { sprintf } from '@web/core/utils/strings';
 
 const { Component, xml, useState, onWillStart } = owl;
@@ -61,7 +60,6 @@ export class NewContentModal extends Component {
         this.dialogs = useService('dialog');
         this.website = useService('website');
         this.action = useService('action');
-        this.http = useService('http');
         this.isSystem = this.user.isSystem;
 
         this.newContentText = {
@@ -146,22 +144,7 @@ export class NewContentModal extends Component {
 
     createNewPage() {
         this.dialogs.add(AddPageDialog, {
-            addPage: async (state) => {
-                const url = `/website/add/${encodeURIComponent(state.name)}`;
-                const data = await this.http.post(url, { 'add_menu': state.addMenu || '', csrf_token });
-                if (data.view_id) {
-                    this.action.doAction({
-                        'res_model': 'ir.ui.view',
-                        'res_id': data.view_id,
-                        'views': [[false, 'form']],
-                        'type': 'ir.actions.act_window',
-                        'view_mode': 'form',
-                    });
-                } else {
-                    this.website.goToWebsite({ path: data.url, edition: true });
-                }
-                this.websiteContext.showNewContentModal = false;
-            },
+            onAddPage: () => this.websiteContext.showNewContentModal = false,
         });
     }
 

--- a/addons/website/static/src/systray_items/new_content.js
+++ b/addons/website/static/src/systray_items/new_content.js
@@ -146,9 +146,9 @@ export class NewContentModal extends Component {
 
     createNewPage() {
         this.dialogs.add(AddPageDialog, {
-            addPage: async (name, addMenu) => {
-                const url = `/website/add/${encodeURIComponent(name)}`;
-                const data = await this.http.post(url, { 'add_menu': addMenu || '', csrf_token });
+            addPage: async (state) => {
+                const url = `/website/add/${encodeURIComponent(state.name)}`;
+                const data = await this.http.post(url, { 'add_menu': state.addMenu || '', csrf_token });
                 if (data.view_id) {
                     this.action.doAction({
                         'res_model': 'ir.ui.view',

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -78,7 +78,7 @@
         <tree js_class="website_pages_list" type="object" action="open_website_url" default_order="url">
             <field name="is_homepage" invisible="1"/>
             <field name="name" string="Page Title"/>
-            <field name="url"/>
+            <field name="website_url" string="Page URL"/>
             <field name="view_id" invisible="1"/>
 
             <field name="website_indexed"/>

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -75,7 +75,7 @@
     <field name="model">website.page</field>
     <field name="priority">99</field>
     <field name="arch" type="xml">
-        <tree js_class="website_pages_list" type="object" action="open_website_url" default_order="url">
+        <tree js_class="website_pages_list" type="object" action="open_website_url" default_order="url asc, id asc">
             <field name="is_homepage" invisible="1"/>
             <field name="name" string="Page Title"/>
             <field name="website_url" string="Page URL"/>

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -75,7 +75,7 @@
     <field name="model">website.page</field>
     <field name="priority">99</field>
     <field name="arch" type="xml">
-        <tree js_class="website_pages_list" type="object" action="open_website_url" default_order="url asc, id asc">
+        <tree js_class="website_pages_list" type="object" action="open_website_url" multi_edit="1" default_order="url asc, id asc">
             <field name="is_homepage" invisible="1"/>
             <field name="name" string="Page Title"/>
             <field name="website_url" string="Page URL"/>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -49,31 +49,41 @@
     <field name="name">blog.post.kanban</field>
     <field name="model">blog.post</field>
     <field name="arch" type="xml">
-        <kanban class="o_kanban_mobile" sample="1">
+        <kanban js_class="website_pages_kanban" class="o_kanban_mobile" action="open_website_url" type="object" sample="1">
             <field name="name"/>
             <field name="blog_id"/>
             <field name="author_id"/>
             <field name="post_date"/>
+            <field name="website_url"/>
             <templates>
                 <t t-name="kanban-box">
-                    <div class="oe_kanban_global_click">
-                        <div class="row mb4">
+                    <div class="oe_kanban_global_click d-flex flex-column">
+                        <div class="row mb-auto">
                             <strong class="col-8">
-                                <span t-esc="record.name.value"/>
+                                <span class="o_text_overflow" t-esc="record.name.value"/>
+                                <div class="text-muted" t-if="record.website_id.value">
+                                    <i class="fa fa-globe me-1" title="Website"/>
+                                    <field name="website_id" groups="website.group_multi_website"/>
+                                </div>
                             </strong>
                             <strong class="col-4 text-end">
                                 <span t-esc="record.blog_id.value"/>
                             </strong>
                             <div class="col-8">
-                                <i class="fa fa-clock-o" role="img" aria-label="Post date" title="Post date"/><span t-esc="record.post_date.value"/>
+                                <i class="fa fa-clock-o me-1" role="img" aria-label="Post date" title="Post date"/><span t-esc="record.post_date.value"/>
                             </div>
                             <div class="col-4 text-end">
                                 <img t-if="record.author_id.raw_value"
                                      t-att-title="record.author_id.value"
                                      t-att-alt="record.author_id.value"
-                                     class="oe_kanban_avatar o_image_24_cover"
+                                     class="oe_kanban_avatar o_image_24_cover rounded-circle"
                                      t-att-src="kanban_image('res.partner', 'avatar_128', record.author_id.raw_value)"/>
                             </div>
+                        </div>
+                        <div class="border-top mt-2 pt-2">
+                            <field name="is_published" widget="boolean_toggle"/>
+                            <t t-if="record.is_published.raw_value">Published</t>
+                            <t t-else="">Not Published</t>
                         </div>
                     </div>
                 </t>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -115,7 +115,7 @@
     <field name="model">blog.post</field>
     <field name="priority">99</field>
     <field name="arch" type="xml">
-        <tree js_class="website_pages_list" type="object" action="open_website_url">
+        <tree js_class="website_pages_list" type="object" action="open_website_url" multi_edit="1">
             <field name="active" invisible="1"/>
             <field name="name"/>
             <field name="website_url"/>

--- a/addons/website_hr_recruitment/models/hr_recruitment.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment.py
@@ -72,8 +72,3 @@ class Job(models.Model):
 
     def get_backend_menu_id(self):
         return self.env.ref('hr_recruitment.menu_hr_recruitment_root').id
-
-    def open_website_url(self):
-        action = super().open_website_url()
-        action['target'] = 'new'
-        return action

--- a/addons/website_hr_recruitment/views/website_pages_views.xml
+++ b/addons/website_hr_recruitment/views/website_pages_views.xml
@@ -12,6 +12,9 @@
             <attribute name="js_class">website_pages_list</attribute>
             <attribute name="type">object</attribute>
             <attribute name="action">open_website_url</attribute>
+
+            <!-- TODO could be a nice addition but editing "Department" crashes... -->
+            <!-- <attribute name="multi_edit">1</attribute> -->
         </xpath>
 
         <field name="name" position="after">


### PR DESCRIPTION
After [1], The 'website_pages_list' view is used on website content records.

The goal of this PR is to:

- Tweak the website filter (added at [1]) to make it work for all website content
records (page,blog,...).

- Update the 'New Page' dialog to be able to select the website_id for the new
page.

[1]: https://github.com/odoo/odoo/pull/98937

task-2889981