### PR TITLE
[FIX] sale_project: Allow user to cancel SO linked to project

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -107,7 +107,7 @@ class SaleOrder(models.Model):
 
     def write(self, values):
         if 'state' in values and values['state'] == 'cancel':
-            self.project_id.sale_line_id = False
+            self.project_id.sudo().sale_line_id = False
         return super(SaleOrder, self).write(values)
 
 


### PR DESCRIPTION
Steps to reproduce:

- Go to Projects and find one having field "sale_line_id" set
  (example "AGR - S00048" with
  "S00048 - Senior Architect (Invoice on Timesheets)")
- Go to Sales -> Quotations and :
  1/ cancel
  2/ set in draft
  3/ edit Project to "AGR - SO00048"
  4/ confirm again (see attached)
- Alter Marc Demo access right to have:
  Sales -> Administrator
  Project -> User
- With Marc Demo, go to Sales -> Quotations and open S00048
- Try to cancel it

Issue:

  Access right error.

Cause:

  When canceling a SO, we remove the related SO line on the project
  however, the current user have access to edit SO but not the project.

Solution:

  Use sudo().

opw-2959627