### PR TITLE
[FIX] l10n_gcc_invoice: arabic invoice product name is displayed twice

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -255,17 +255,19 @@
                                 <t t-if="not line.display_type" name="account_invoice_line_accountable">
                                     <td name="account_invoice_line_name">
                                         <t t-set="translation_name" t-value="line.with_context(lang='ar_001').product_id.name"/>
-                                        <t t-if="line.product_id">
+                                        <t t-if="line.name and line.name != line.product_id.name and line.name != translation_name">
+                                            <span t-field="line.name" t-options="{'widget': 'text'}"/>
+                                        </t>
+
+                                        <t t-else="">
                                             <span t-field="line.product_id.name" t-options="{'widget': 'text'}"/>
+                                        </t>
+                                        <t t-if="line.product_id">
                                             <t t-if="line.product_id.name != translation_name">
                                                 <br/>
                                                 <span t-field="line.with_context(lang='ar_001').product_id.name"
                                                       t-options="{'widget': 'text'}"/>
                                             </t>
-                                        </t>
-                                        <t t-if="line.name and line.name != line.product_id.name and line.name != translation_name">
-                                            <t t-if="line.product_id"><br/></t>
-                                            <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </t>
                                     </td>
                                     <td class="text-right">


### PR DESCRIPTION
Steps to reproduce:
-install l10n_sa_invoice module
-switch to a company in Saudi Arabia (SA company)
-create and print an invoice with a product that has arabic translation

Bug:
When adding a product and the Arabic translation.
If we add an internal reference is added to the template,
Odoo directly concatenates this with the product name.
The result is the product name being duplicated.

Fix:
make eihter product name or line name be displayed not both

opw-2829934