### PR TITLE
[FIX] account_edi_ubl_cii: Confirm invoice without customer post code

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -75,7 +75,7 @@ class AccountEdiXmlCII(models.AbstractModel):
             # invoiced item VAT rate (BT-152) shall be greater than 0 (zero).
             'igic_tax_rate': self._check_non_0_rate_tax(vals)
                 if vals['record']['commercial_partner_id']['country_id']['code'] == 'ES'
-                   and vals['record']['commercial_partner_id']['zip'][:2] in ['35', '38'] else None,
+                   and (vals['record']['commercial_partner_id']['zip'] or '')[:2] in ['35', '38'] else None,
         })
         return constraints
 


### PR DESCRIPTION
Steps to reproduce the issue:

  - Install l10n_es module
  - Create a customer with Spain as country but NO post code
  - Create an invoice for the customer and try to confirm it

Issue:

  Traceback raised.

Cause:

  Trying to retrieve the last 2 digits of the customer post code while
  it's not set.

opw-2962250