### PR TITLE
[FIX] purchase: Update price unit on new line even if confirmed RFQ

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1082,7 +1082,7 @@ class PurchaseOrderLine(models.Model):
 
     @api.onchange('product_qty', 'product_uom')
     def _onchange_quantity(self):
-        if not self.product_id or self.state in ('purchase', 'done'):
+        if not self.product_id or (self._origin and self.state in ('purchase', 'done')):
             return
         params = {'order_id': self.order_id}
         seller = self.product_id._select_seller(


### PR DESCRIPTION
Steps to reproduce:

  - Install purchase
  - Go to Settings and activate `Variant Grid Entry`
  - Create a new Request for Quotation
  - Add a customer and add a product that has a variant min 2 variant
  - Wizard should ask for the variant
  - Select 1 variant by increasing quantity in the grid and confirm
  - Confirm order
  - Add again a product variant with the wizard

Issue:

  Price unit is not set on the new line.

Cause:

  In `_onchange_quantity` (triggered by the purchase_product_matrix
  module), we do not update price unit if order line
  is in state `purchase` or `done`.

Solution:

  Update the line anyway if it's a new line (no `self_origin`).

opw-2956755