### PR TITLE
[IMP] l10n_pe: Welcome ISC tax

### DIFF
--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -132,6 +132,43 @@
             }),
         ]"/>
     </record>
+    <record id="sale_tax_ics_0" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">0% ISC</field>
+        <field name="description">ISC</field>
+        <field name="l10n_pe_edi_tax_code">1000</field>
+        <field name="l10n_pe_edi_unece_category">S</field>
+        <field name="amount">0.0</field>
+        <field name="type_tax_use">sale</field>
+        <field name="sequence">1</field>
+        <field name="include_base_amount">1</field>
+        <field name="tax_group_id" ref="tax_group_isc"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart4012'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('chart4012'),
+            }),
+        ]"/>
+    </record>
     <!--    VAT for purchase-->
     <record id="purchase_tax_igv_18" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>

--- a/addons/l10n_pe/models/account_tax.py
+++ b/addons/l10n_pe/models/account_tax.py
@@ -26,6 +26,12 @@ class AccountTax(models.Model):
         help="Follow the UN/ECE 5305 standard from the United Nations Economic Commission for Europe for more "
              "information http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
     )
+    l10n_pe_edi_isc_type = fields.Selection([
+        ('01', 'System to value'),
+        ('02', 'Application of the Fixed Amount'),
+        ('03', 'Retail Price System'),
+    ], 'ISC Type',
+        help='Used in Selective Consumption Tax to indicate the type of calculation for the ISC.')
 
 
 class AccountTaxTemplate(models.Model):
@@ -52,6 +58,12 @@ class AccountTaxTemplate(models.Model):
         help="Follow the UN/ECE 5305 standard from the United Nations Economic Commission for Europe for more "
              "information  http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
     )
+    l10n_pe_edi_isc_type = fields.Selection([
+        ('01', 'System to value'),
+        ('02', 'Application of the Fixed Amount'),
+        ('03', 'Retail Price System'),
+    ], 'ISC Type',
+        help='Used in Selective Consumption Tax to indicate the type of calculation for the ISC.')
 
     def _get_tax_vals(self, company, tax_template_to_tax):
         val = super()._get_tax_vals(company, tax_template_to_tax)

--- a/addons/l10n_pe/views/account_tax_view.xml
+++ b/addons/l10n_pe/views/account_tax_view.xml
@@ -11,6 +11,8 @@
                        attrs="{'invisible': [('country_code', '!=', 'PE')]}"/>
                 <field name="l10n_pe_edi_unece_category"
                        attrs="{'invisible': [('country_code', '!=', 'PE')]}"/>
+                <field name="l10n_pe_edi_isc_type"
+                       attrs="{'invisible': [('country_code', '!=', 'PE')]}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The SUNAT requires that when an ISC tax is used on an invoice, on the
cbc:TierRange attribute be specified the ISC type.

Now, the 3 options could be:
- 01: System to value
- 02: Application of the Fixed Amount
- 03: Retail Price System

To this, now was added a new field on the tax, with these options.

Extra, the ISC could have many amount options, for now, only is
generated a tax of 0%, that allows to the customer only change the
a percentage that will use.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
