### PR TITLE
[FIX] web[_editor]: Apply RTL position to translate button

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -170,7 +170,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         if (_t.database.multi_lang && this.record.fields[fieldName].translate && this.res_id) {
             return $('<button>', {
                     type: 'button',
-                    'class': 'o_field_translate fa fa-globe btn btn-link',
+                    'class': 'o_field_translate fa fa-globe btn btn-primary',
                 })
                 .on('click', this._onTranslate.bind(this));
         }

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -715,10 +715,6 @@ $o-form-label-margin-right: 0px;
             padding-right: 25px;
         }
     }
-    iframe.wysiwyg_iframe + .o_field_translate {
-        right: 30px !important;
-        top: 7px !important;
-    }
 
     // Text field with oe_inline class
     .o_field_text.oe_inline {

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -11,6 +11,7 @@ const {QWebPlugin} = require('@web_editor/js/backend/QWebPlugin');
 require('web._field_registry');
 
 var _lt = core._lt;
+var _t = core._t;
 var TranslatableFieldMixin = basic_fields.TranslatableFieldMixin;
 var QWeb = core.qweb;
 
@@ -538,13 +539,19 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      */
     _onLoadWysiwyg: function () {
         var $button = this._renderTranslateButton();
-        $button.css({
-            'font-size': '15px',
-            position: 'absolute',
-            right: odoo.debug && this.nodeOptions.codeview ? '40px' : '5px',
-            top: '5px',
-        });
-        this.$el.append($button);
+        var $container;
+        if (this.nodeOptions.cssEdit && this.wysiwyg) {
+            $container = this.wysiwyg.$iframeBody.find('.email_designer_top_actions');
+        } else {
+            $container = this.$el;
+            $button.css({
+                'font-size': '15px',
+                position: 'absolute',
+                top: '5px',
+                [_t.database.parameters.direction === 'rtl' ? 'left' : 'right']: odoo.debug && this.nodeOptions.codeview ? '40px' : '5px',
+            });
+        }
+        $container.append($button);
         if (odoo.debug && this.nodeOptions.codeview) {
             const $codeviewButtonToolbar = $(`
                 <div id="codeview-btn-group" class="btn-group">


### PR DESCRIPTION
Steps to reproduce:

  - Install Inventory
  - Open any product
  - Switch to RTL language
  - Edit the product
  - Try to translate field "Internal Note"

Issue:

  Button is not displayed correctly (nearly hidden).
  Issue (related) also present with wysiwyg or codeview editors.

Cause:

  Applying style `right: 5px` to the button without taking into account
  if layout direction.

Solution:

  On translate button:
  - Apply direction left for side-space if RTL, else right.
  - If wysiwyg is enabled, don't apply custo css (except color) and 
    add it after the buttons that are in the sidebar.

opw-2962790