### PR TITLE
[FIX] pos_sale: display weight for product product in sales report

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -53,8 +53,8 @@ class SaleReport(models.Model):
             partner.country_id AS country_id,
             partner.industry_id AS industry_id,
             partner.commercial_partner_id AS commercial_partner_id,
-            (sum(t.weight) * l.qty / u.factor) AS weight,
-            (sum(t.volume) * l.qty / u.factor) AS volume,
+            (sum(p.weight) * l.qty / u.factor) AS weight,
+            (sum(p.volume) * l.qty / u.factor) AS volume,
             l.discount as discount,
             sum((l.price_unit * l.discount * l.qty / 100.0 / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)) as discount_amount,
             NULL as order_id

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -37,3 +37,46 @@ class TestPoSSaleReport(TestPoSCommon):
         self.assertEqual(reports[0].volume, 4)
         self.assertEqual(reports[1].weight, 18)
         self.assertEqual(reports[1].volume, 24)
+
+    def test_weight_and_volume_product_variant(self):
+        colors = ['red', 'blue']
+        prod_attr = self.env['product.attribute'].create({'name': 'Color', 'create_variant': 'dynamic'})
+        prod_attr_values = self.env['product.attribute.value'].create([{'name': color, 'attribute_id': prod_attr.id, 'sequence': 1} for color in colors])
+
+        uom_unit = self.env.ref('uom.product_uom_unit')
+        product_template = self.env['product.template'].create({
+            'name': 'Sofa',
+            'uom_id': uom_unit.id,
+            'uom_po_id': uom_unit.id,
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': prod_attr.id,
+                'value_ids': [(6, 0, prod_attr_values.ids)]
+            })]
+        })
+        prod_tmpl_attrs = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids.id),
+            ('product_attribute_value_id', 'in', prod_attr_values.ids)
+        ])
+
+        product_1 = product_template._create_product_variant(prod_tmpl_attrs[0])
+        product_1.weight = 1
+        product_1.volume = 1
+
+        product_2 = product_template._create_product_variant(prod_tmpl_attrs[1])
+        product_2.weight = 2
+        product_2.volume = 2
+
+        self.open_new_session()
+        session = self.pos_session
+
+        order = self.create_ui_order_data([(product_1, 3), (product_2, 3)])
+        self.env['pos.order'].create_from_ui([order])
+
+        session.action_pos_session_closing_control()
+
+        report = self.env['sale.report'].sudo().search([('product_id', '=', product_1.id)], order='id', limit=1)
+        self.assertEqual(report.weight, 3)
+        self.assertEqual(report.weight, 3)
+        report = self.env['sale.report'].sudo().search([('product_id', '=', product_2.id)], order='id', limit=1)
+        self.assertEqual(report.weight, 6)
+        self.assertEqual(report.weight, 6)


### PR DESCRIPTION
Steps to reproduce:

  - Install pos_sale module
  - Create a product and set it as available in POS
  - Create 2 variants and set a weight for each variant
  - Open a POS session and make an order with one of the variants
  - Go to the Sales -> Reporting -> Sales and select view pivot
  - Set Gross Weight as measure

Issue:

  Weight for ordered variant is set to 0.

Cause:

  Sales Analysis is an SQL view and it use product template in instead
  of product product to get the weight value.

opw-2956457