### PR TITLE
[FIX] *: Adapt old custom-control class of Bootstrap

### DIFF
--- a/addons/hr_holidays/static/src/radio_image_field/radio_image_field.xml
+++ b/addons/hr_holidays/static/src/radio_image_field/radio_image_field.xml
@@ -12,7 +12,7 @@
             </t>
             <t t-else="">
                 <t t-foreach="items" t-as="item" t-key="item[0]">
-                    <div class="custom-control form-check o_radio_item" aria-atomic="true">
+                    <div class="form-check o_radio_item" aria-atomic="true">
                         <input
                             type="radio"
                             class="form-check-input o_radio_input"

--- a/addons/hr_holidays/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays/static/src/xml/time_off_calendar.xml
@@ -48,7 +48,7 @@
     </t>
 
     <t t-name="FieldRadioIcon.button">
-        <div t-if="mode === 'edit'" class="custom-control form-check o_radio_item" aria-atomic="true">
+        <div t-if="mode === 'edit'" class="form-check o_radio_item" aria-atomic="true">
             <input type="radio" class="form-check-input o_radio_input" t-att-checked="checked ? true : undefined" t-att-disabled="disabled ? true : undefined"
                 t-att-name="name" t-att-data-value="value[0]" t-att-data-index="index" t-att-id="id"/>
             <label class="form-check-label o_form_label" t-att-for="id"><img t-attf-src="/hr_holidays/static/src/img/icons/{{value[1]}}" width="48" height="48" /></label>

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.ComposerSuggestedRecipient" owl="1">
         <t t-if="composerSuggestedRecipientView">
             <div class="o_ComposerSuggestedRecipient" t-attf-class="{{ className }}" t-att-data-partner-id="composerSuggestedRecipientView.suggestedRecipientInfo.partner and composerSuggestedRecipientView.suggestedRecipientInfo.partner.id ? composerSuggestedRecipientView.suggestedRecipientInfo.partner.id : false" t-att-title="composerSuggestedRecipientView.suggestedRecipientInfo.titleText" t-ref="root">
-                <div class="custom-control form-check">
+                <div class="form-check">
                     <input t-attf-id="{{ id }}_checkbox" class="form-check-input" type="checkbox" t-att-checked="composerSuggestedRecipientView.suggestedRecipientInfo.isSelected ? 'checked' : undefined" t-on-change="_onChangeCheckbox" t-ref="checkbox" />
                     <label class="form-check-label" t-attf-for="{{ id }}_checkbox">
                         <t t-if="composerSuggestedRecipientView.suggestedRecipientInfo.name">

--- a/addons/sale/views/variant_templates.xml
+++ b/addons/sale/views/variant_templates.xml
@@ -41,7 +41,7 @@
                             <t t-foreach="ptal.product_template_value_ids._only_active()" t-as="ptav">
                                 <li class="list-inline-item form-group js_attribute_value" style="margin: 0;">
                                     <label class="col-form-label">
-                                        <div class="custom-control form-check">
+                                        <div class="form-check">
                                             <input type="radio"
                                                 t-attf-class="form-check-input js_variant_change #{ptal.attribute_id.create_variant}"
                                                 t-att-checked="ptav in combination"

--- a/addons/web/static/src/core/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.xml
@@ -7,18 +7,18 @@
                 <div class="align-self-center">
                     <div t-if="profiling.state.isEnabled" class="alert alert-info py-2 me-3">Recording...</div>
                     <span class="o_profiling_switch">
-                        <span class="custom-control form-switch" t-on-click.stop.prevent="() => this.profiling.toggleProfiling()">
+                        <span class="form-check form-switch" t-on-click.stop.prevent="() => this.profiling.toggleProfiling()">
                             <input type="checkbox" class="form-check-input" id="enable_profiling" t-att-checked="profiling.state.isEnabled"/>
                             <label class="form-check-label">Enable profiling</label>
                         </span>
                     </span>
                     <t t-if="profiling.state.isEnabled">
-                        <span class="o_profiling_switch custom-control form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('sql')">
+                        <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('sql')">
                             <input type="checkbox" class="form-check-input" id="profile_sql"
                                 t-att-checked="profiling.isCollectorEnabled('sql')"/>
                             <label class="form-check-label" for="profile_sql">Record sql</label>
                         </span>
-                        <span class="o_profiling_switch custom-control form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('traces_async')">
+                        <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('traces_async')">
                             <input type="checkbox" class="form-check-input" id="profile_traces_async"
                                 t-att-checked="profiling.isCollectorEnabled('traces_async')"/>
                             <label class="form-check-label" for="profile_traces_async">Record traces</label>
@@ -34,12 +34,12 @@
                                 <option value="1" t-att-selected="interval === '1'">1</option>
                             </select>
                         </div>
-                        <span t-if="profiling.isCollectorEnabled('sql') || profiling.isCollectorEnabled('traces_async')" class="o_profiling_switch custom-control form-switch mt-2" t-on-click.stop.prevent="(ev) => this.toggleParam('execution_context_qweb', ev)">
+                        <span t-if="profiling.isCollectorEnabled('sql') || profiling.isCollectorEnabled('traces_async')" class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="(ev) => this.toggleParam('execution_context_qweb', ev)">
                             <input type="checkbox" class="form-check-input" id="profile_execution_context_qweb"
                                 t-att-checked="!!profiling.state.params.execution_context_qweb"/>
                             <label class="form-check-label" for="profile_execution_context_qweb">Add qweb directive context</label>
                         </span>
-                        <span class="o_profiling_switch custom-control form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('qweb')">
+                        <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('qweb')">
                             <input type="checkbox" class="form-check-input" id="profile_qweb"
                                 t-att-checked="profiling.isCollectorEnabled('qweb')"/>
                             <label class="form-check-label" for="profile_qweb">Record qweb</label>

--- a/addons/web/static/src/legacy/js/widgets/data_export.js
+++ b/addons/web/static/src/legacy/js/widgets/data_export.js
@@ -105,7 +105,7 @@ var DataExport = Dialog.extend({
                     $label.html(_.str.sprintf("%s — %s", format.label, format.error));
                 }
 
-                $fmts.append($("<div class='radio form-check form-check-inline ps-4'></div>").append($radio, $label));
+                $fmts.append($("<div class='radio form-check-inline ps-4'></div>").append($radio, $label));
             });
 
             self.$exportFormatInputs = $fmts.find('input');

--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -167,17 +167,6 @@ $dropdown-item-padding-x: $o-dropdown-hpadding !default;
 $list-group-active-color: $o-list-group-active-color !default;
 $list-group-active-bg: $o-list-group-active-bg !default;
 
-// Forms
-$custom-control-indicator-border-color: $gray-500 !default;
-$custom-control-label-disabled-color: $o-main-color-muted !default;
-
-$custom-control-indicator-checked-color: $white !default;
-$custom-control-indicator-checked-bg: $primary !default;
-$custom-control-indicator-checked-border-color: $primary !default;
-
-$custom-control-indicator-disabled-bg: $gray-200 !default;
-$custom-control-indicator-checked-disabled-bg: $gray-200 !default;
-
 // Z-index master list
 
 // Change the z-index of the modal-backdrop elements to be equal to the

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1007,7 +1007,7 @@
         t-att-id="widget.idForLabel"/>
 </t>
 <t t-name="FieldRadio.button">
-    <div class="custom-control form-check o_radio_item" aria-atomic="true">
+    <div class="form-check o_radio_item" aria-atomic="true">
         <input type="radio" class="form-check-input o_radio_input" t-att-checked="checked ? true : undefined" t-att-disabled="disabled ? true : undefined"
             t-att-name="name" t-att-data-value="value[0]" t-att-data-index="index" t-att-id="id"/>
         <label class="form-check-label o_form_label" t-att-for="id"><t t-esc="value[1]"/></label>
@@ -1145,7 +1145,7 @@
                 <div role="menuitem" class="o_hide_in_kanban"
                      t-att-data-id="tag_id"
                      t-att-data-color="0">
-                    <div class="custom-control form-check">
+                    <div class="form-check">
                         <input type="checkbox" id="o_hide_in_kanban_checkbox" class="form-check-input"/>
                         <label for="o_hide_in_kanban_checkbox" class="form-check-label">Hide in Kanban</label>
                     </div>
@@ -1486,7 +1486,7 @@
     <div aria-atomic="true">
         <div t-foreach="widget.m2mValues" t-as="m2m_value" t-key="m2m_value_index">
             <t t-set="id_for_label" t-value="'o_many2many_checkbox_' + _.uniqueId()"/>
-            <div class="custom-control form-check">
+            <div class="form-check">
                 <input type="checkbox" t-att-id="id_for_label" class="form-check-input" t-att-data-record-id="JSON.stringify(m2m_value[0])"/>
                 <label t-att-for="id_for_label" class="form-check-label o_form_label"><t t-esc="m2m_value[1]"/></label>
             </div>

--- a/addons/web/static/src/legacy/xml/pivot.xml
+++ b/addons/web/static/src/legacy/xml/pivot.xml
@@ -40,7 +40,7 @@
                                          o_null: cell.value === 0,
                                     }" t-esc="_getFormattedVariation(cell)"/>
                                 <div t-elif="props.fields and props.fields[cell.measure].type === 'boolean'" class="o_value">
-                                    <div class="custom-control form-check">
+                                    <div class="form-check">
                                         <input type="checkbox" t-attf-id="checkbox_{{cell_index}}_{{row_index}}" disabled="disabled" t-att-checked="cell.value" class="form-check-input"/>
                                         <label t-attf-for="checkbox_{{cell_index}}_{{row_index}}" class="form-check-label"/>
                                     </div>

--- a/addons/web/static/src/legacy/xml/search_panel.xml
+++ b/addons/web/static/src/legacy/xml/search_panel.xml
@@ -132,7 +132,7 @@
         t-att-class="{ 'ps-2' : isChildList }"
         >
         <t t-set="value" t-value="values.get(valueId)"/>
-        <div class="custom-control form-check w-100">
+        <div class="form-check w-100">
             <input type="checkbox"
                 t-attf-id="{{ section.id }}_input_{{ valueId }}"
                 t-att-checked="state.active[section.id][valueId]"

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -131,7 +131,7 @@
         t-att-class="{ 'ps-2' : isChildList }"
         >
         <t t-set="value" t-value="values.get(valueId)"/>
-        <div class="custom-control form-check w-100">
+        <div class="form-check w-100">
             <input type="checkbox"
                 t-attf-id="{{ section.id }}_input_{{ valueId }}"
                 t-att-checked="state.active[section.id][valueId]"

--- a/addons/web/static/src/views/fields/radio/radio_field.xml
+++ b/addons/web/static/src/views/fields/radio/radio_field.xml
@@ -8,7 +8,7 @@
             t-att-aria-label="string"
         >
             <t t-foreach="items" t-as="item" t-key="item[0]">
-                <div class="custom-control form-check o_radio_item" aria-atomic="true">
+                <div class="form-check o_radio_item" aria-atomic="true">
                     <input
                         type="radio"
                         class="form-check-input o_radio_input"

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -65,7 +65,7 @@
                     <div class="o_export_format">
                         <strong>Export Format:</strong>
                         <t t-foreach="availableFormats" t-as="format" t-key="format.tag">
-                            <div class="radio form-check form-check-inline ps-5">
+                            <div class="radio form-check-inline ps-5">
                                 <input t-att-id="'o_radio' + format.tag" type="radio" t-att-checked="format.tag === availableFormats[state.selectedFormat].tag" name="o_export_format_name" t-att-value="format.tag" class="form-check-input" t-on-change="setFormat" />
                                 <label class="form-check-label" t-att-for="'o_radio' + format.tag" t-esc="format.label" />
                             </div>

--- a/addons/web/static/tests/views/widgets/week_days_tests.js
+++ b/addons/web/static/tests/views/widgets/week_days_tests.js
@@ -98,7 +98,7 @@ QUnit.module("Widgets", ({ beforeEach }) => {
         await clickEdit(fixture);
         assert.containsNone(
             fixture,
-            ".custom-control input:disabled",
+            ".form-check input:disabled",
             "all inputs should be enabled in readonly mode"
         );
 

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -399,7 +399,7 @@ a.o_underline {
                 align-items: center;
                 font-size: 11px;
 
-                >.custom-control {
+                >.form-check {
                     margin-right: $grid-gutter-width/4;
                 }
             }

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -370,7 +370,7 @@
                                 <a href="#" class="dropdown-item active" data-website_name="*">All Websites</a>
                             </div>
                         </div>
-                        <div class="ms-2 custom-control form-switch">
+                        <div class="ms-2 form-check form-switch">
                             <input id="o_show_inactive" class="form-check-input" type="checkbox"/>
                             <label class="form-check-label" for="o_show_inactive">Show inactive views</label>
                         </div>

--- a/addons/website_forum/static/src/xml/public_templates.xml
+++ b/addons/website_forum/static/src/xml/public_templates.xml
@@ -28,7 +28,7 @@
         <t t-foreach="posts" t-as="post">
             <div class="card mb-1 o_spam_character">
                 <div class="card-body py-2">
-                    <div class="custom-control form-check">
+                    <div class="form-check">
                         <input type="checkbox" class="form-check-input" t-attf-id="post_#{post.id}" t-att-value='post.id' checked='checked'/>
                         <label class="form-check-label" t-attf-for="post_#{post.id}">
                             <b><t t-esc="post.name" /></b>

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -1621,7 +1621,7 @@
                                     <div t-foreach="posts_ids.mapped('create_uid')" t-as="user" class="col-6">
                                         <div class="card mb-2">
                                             <div class="card-body py-2">
-                                                <div class="custom-control form-check">
+                                                <div class="form-check">
                                                     <input type="checkbox" t-att-value="user.id" class="form-check-input" t-attf-id="user_#{user.id}"/>
                                                     <label class="form-check-label" t-attf-for="user_#{user.id}">
                                                         <img class="d-inline img o_forum_avatar" t-att-src="website.image_url(user, 'avatar_128', '40x40')" alt="Avatar"/>
@@ -1638,7 +1638,7 @@
                                     <div t-foreach="posts_ids.mapped('create_uid.country_id')" t-as="country" class="col-6">
                                         <div class="card mb-2">
                                             <div class="card-body py-2">
-                                                <div class="custom-control form-check">
+                                                <div class="form-check">
                                                     <input type="checkbox" class="form-check-input" t-attf-id="country_#{country.id}" t-att-value="country.id"/>
                                                     <label class="form-check-label" t-attf-for="country_#{country.id}">
                                                         <span t-field="country.image_url" t-options='{"widget": "image_url", "class": "country_flag"}' class="me-2"/>

--- a/addons/website_payment/views/donation_templates.xml
+++ b/addons/website_payment/views/donation_templates.xml
@@ -44,7 +44,7 @@
                             <t t-set="prefilled_options" t-value="donation_options.get('prefilledOptions')"/>
                             <t t-if="prefilled_options">
                                 <t t-foreach="donation_amounts" t-as="donation_amount">
-                                    <div class="custom-control form-check my-2">
+                                    <div class="form-check my-2">
                                         <t t-set="is_checked" t-value="float(amount) == float(donation_amount)"/>
                                         <t t-set="has_checked" t-value="has_checked or is_checked"/>
                                         <input class="o_wpayment_fee_impact form-check-input" type="radio" name="amount"
@@ -58,7 +58,7 @@
                                         </label>
                                     </div>
                                 </t>
-                                <div t-attf-class="custom-control form-check my-2 #{not donation_layout and 'd-none' or ''}">
+                                <div t-attf-class="form-check my-2 #{not donation_layout and 'd-none' or ''}">
                                     <input class="o_wpayment_fee_impact form-check-input" type="radio" id="other_amount" name="amount"
                                         t-att-value="amount" t-att-checked="not has_checked or None"/>
                                     <label class="form-check-label mt-0 d-block" for="other_amount">
@@ -73,7 +73,7 @@
                             </t>
                         </div>
                         <div class="col-lg-12 px-0">
-                            <div class="custom-control form-check mt-3">
+                            <div class="form-check mt-3">
                                 <input class="form-check-input" type="checkbox" value="" id="donation_comment_checkbox"/>
                                 <label class="form-check-label" for="donation_comment_checkbox">Write us a comment</label>
                             </div>

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -144,7 +144,7 @@ $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale
         .o_categories_collapse_title, .o_products_attributes_title {
             font-size: 0.9rem;
         }
-        .custom-control.form-check {
+        .form-check {
             .form-check-input {
                 ~ .form-check-label:before {
                     outline: none;

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -438,7 +438,7 @@
     </template>
 
     <template id="categorie_link" name="Category Link">
-        <div t-att-data-link-href="keep('/shop/category/' + slug(c), category=0)" class="custom-control form-check mb-1 d-inline-block">
+        <div t-att-data-link-href="keep('/shop/category/' + slug(c), category=0)" class="form-check mb-1 d-inline-block">
             <input type="radio" style="pointer-events:none;" class="form-check-input" t-att-id="c.id" t-att-value="c.id" t-att-checked="'true' if c.id == category.id else None"/>
             <label class="form-check-label fw-normal" t-att-for="c.id" t-field="c.name"/>
         </div>
@@ -461,7 +461,7 @@
                 <ul class="nav flex-column my-2">
                     <form>
                         <li class="nav-item">
-                            <div t-att-data-link-href="keep('/shop', category=0)" class="custom-control form-check mb-1 d-inline-block">
+                            <div t-att-data-link-href="keep('/shop', category=0)" class="form-check mb-1 d-inline-block">
                                 <input type="radio" style="pointer-events:none;" class="form-check-input o_not_editable" t-att-id="all_products" t-att-value="all_products" t-att-checked="'true' if not category else None"/>
                                 <label class="form-check-label fw-normal" t-att-for="all_products">All Products</label>
                             </div>
@@ -535,7 +535,7 @@
                                 <t t-if="a.display_type == 'radio' or a.display_type == 'pills'">
                                     <div class="flex-column">
                                         <t t-foreach="a.value_ids" t-as="v">
-                                            <div class="custom-control form-check mb-1">
+                                            <div class="form-check mb-1">
                                                 <input type="checkbox" name="attrib" class="form-check-input" t-att-id="'%s-%s' % (a.id,v.id)" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None"/>
                                                 <label class="form-check-label fw-normal" t-att-for="'%s-%s' % (a.id,v.id)" t-field="v.name"/>
                                             </div>
@@ -896,7 +896,7 @@
                 <input type="hidden" t-if="len(filtered_sorted_variants) == 1" class="product_id" name="product_id" t-att-value="filtered_sorted_variants[0].id"/>
                 <t t-if="len(filtered_sorted_variants) &gt; 1">
                     <div class="mb-4">
-                        <div t-foreach="filtered_sorted_variants" t-as="variant_id" class="custom-control form-check mb-1">
+                        <div t-foreach="filtered_sorted_variants" t-as="variant_id" class="form-check mb-1">
                             <t t-set="template_combination_info" t-value="product._get_combination_info(only_template=True, add_qty=add_qty, pricelist=pricelist)"/>
                             <t t-set="combination_info" t-value="variant_id._get_combination_info_variant(add_qty=add_qty, pricelist=pricelist)"/>
                             <input type="radio" name="product_id" class="form-check-input product_id js_product_change" t-att-checked="'checked' if variant_id_index == 0 else None" t-attf-id="radio_variant_#{variant_id.id}" t-att-value="variant_id.id" t-att-data-price="combination_info['price']" t-att-data-combination="variant_id.product_template_attribute_value_ids.ids"/>
@@ -1688,7 +1688,7 @@
 
     <template id="payment_footer" name="Payment">
         <div name="o_checkbox_container"
-             class="custom-control form-check mt-2 o_accept_tc_button"/>
+             class="form-check mt-2 o_accept_tc_button"/>
         <div class="float-start mt-2">
             <a role="button" href="/shop/cart" class="btn btn-secondary">
                 <i class="fa fa-chevron-left"/> Return to Cart


### PR DESCRIPTION
* = hr_holidays, mail, sale, web, web_editor, website, website_forum,
website_payment, website_sale

https://getbootstrap.com/docs/5.1/migration/

replacing `custom-control` by `form-check` because in bs4 this class had
a use which is not the case in bs5.