### PR TITLE
[IMP] stock: Add missing translation part

### DIFF
--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -111,6 +111,10 @@
                 'xml_id': 'stock.picking_type_out',
                 'record': obj().env.ref('stock.warehouse0').out_type_id,
                 'noupdate': True,
+            },{
+                'xml_id': 'stock.picking_type_return',
+                'record': obj().env.ref('stock.warehouse0').return_type_id,
+                'noupdate': True,
             }]"/>
         </function>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- I want to translate `Returns` but it has not been initialized via xml
data so t added
![image](https://user-images.githubusercontent.com/96491226/186823408-624de0b7-7a1e-4e35-98bd-de37a6e6c790.png)



Desired behavior after PR is merged:
- To able to translate `Operation Type: Returns` default string



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
