### PR TITLE
[FIX] project,survey: Fix gutters in kanban_grouped

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -253,7 +253,7 @@
                                     At each stage, employees can block tasks or mark them as ready for the next step.
                                     You can customize here the labels for each state.
                                 </p>
-                                <div class="row ms-1" colspan="2">
+                                <div class="row g-0 ms-1" colspan="2">
                                     <label for="legend_normal" string=" " class="o_status mt4"
                                         title="Task in progress. Click to block or set as done."
                                         aria-label="Task in progress. Click to block or set as done." role="img"/>
@@ -261,7 +261,7 @@
                                         <field name="legend_normal"/>
                                     </div>
                                 </div>
-                                <div class="row ms-1" colspan="2">
+                                <div class="row g-0 ms-1" colspan="2">
                                     <label for="legend_blocked" string=" " class="o_status o_status_red mt4"
                                         title="Task is blocked. Click to unblock or set as done."
                                         aria-label="Task is blocked. Click to unblock or set as done." role="img"/>
@@ -269,7 +269,7 @@
                                         <field name="legend_blocked"/>
                                     </div>
                                 </div>
-                                <div class="row ms-1" colspan="2">
+                                <div class="row g-0 ms-1" colspan="2">
                                     <label for="legend_done" string=" " class="o_status o_status_green mt4"
                                         title="This step is done. Click to block or set in progress."
                                         aria-label="This step is done. Click to block or set in progress." role="img"/>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -331,7 +331,7 @@
                             <div class="o_kanban_record_top">
                                 <h4 class="o_kanban_record_title p-0 mb4"><field name="title" /></h4>
                             </div>
-                            <div class="row">
+                            <div class="row g-0">
                                 <div class="col-10 p-0 pb-1">
                                     <div class="container o_kanban_card_content" t-if="record.answer_count.raw_value != 0">
                                         <div class="row mt-4 ms-5">


### PR DESCRIPTION
https://getbootstrap.com/docs/5.1/migration/
add g-0 to rows to remove gutters in the project and in the elearning kanban view

Steps (survey):
- Go to eLearning/Certifications
- Set kanban mode
- Use a groupby

Steps on project are the same as survey
