### PR TITLE
[IMP] account_reports,l10n_*: create abstract model for custom reports

### DIFF
--- a/addons/account/data/account_reports_data.xml
+++ b/addons/account/data/account_reports_data.xml
@@ -9,9 +9,6 @@
             <field name="filter_fiscal_position" eval="1"/>
             <field name="default_opening_date_filter">last_month</field>
             <field name="only_tax_exigible" eval="True"/>
-            <field name="dynamic_lines_generator">_dynamic_lines_generator_generic_tax_report</field>
-            <field name="custom_options_initializer">_custom_options_initializer_tax_report</field>
-            <field name="caret_options_initializer">_caret_options_initializer_generic_tax_report</field>
             <field name="column_ids">
                 <record id="generic_tax_report_column_net" model="account.report.column">
                     <field name="name">NET</field>
@@ -27,8 +24,6 @@
         <record id="generic_tax_report_account_tax" model="account.report">
             <field name="name">Group by: Account &gt; Tax </field>
             <field name="root_report_id" ref="generic_tax_report"/>
-            <field name="dynamic_lines_generator">_dynamic_lines_generator_generic_tax_report_account_tax_grouping</field>
-            <field name="caret_options_initializer">_caret_options_initializer_generic_tax_report</field>
             <field name="column_ids">
                 <record id="generic_tax_report_account_tax_column_net" model="account.report.column">
                     <field name="name">NET</field>
@@ -44,8 +39,6 @@
         <record id="generic_tax_report_tax_account" model="account.report">
             <field name="name">Group by: Tax &gt; Account </field>
             <field name="root_report_id" ref="generic_tax_report"/>
-            <field name="dynamic_lines_generator">_dynamic_lines_generator_generic_tax_report_tax_account_grouping</field>
-            <field name="caret_options_initializer">_caret_options_initializer_generic_tax_report</field>
             <field name="column_ids">
                 <record id="generic_tax_report_tax_account_column_net" model="account.report.column">
                     <field name="name">NET</field>

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -33,7 +33,6 @@ class AccountReport(models.Model):
     chart_template_id = fields.Many2one(string="Chart of Accounts", comodel_name='account.chart.template')
     country_id = fields.Many2one(string="Country", comodel_name='res.country')
     only_tax_exigible = fields.Boolean(string="Only Tax Exigible Lines")
-    caret_options_initializer = fields.Char(string="Caret Options Initializer", required=True, default='_caret_options_initializer_default')
     availability_condition = fields.Selection(
         string="Availability",
         selection=[('country', "Country Matches"), ('coa', "Chart of Accounts Matches"), ('always', "Always")],
@@ -114,18 +113,6 @@ class AccountReport(models.Model):
         string="Filter Multivat",
         compute=lambda x: x._compute_report_option_filter('filter_fiscal_position'), readonly=False, store=True, depends=['root_report_id'],
     )
-
-    #  CUSTOM REPORTS ================================================================================================================================
-    # Those fields allow case-by-case fine-tuning or the engine, for custom reports
-
-    dynamic_lines_generator = fields.Char(string="Dynamic Lines Generator")
-    custom_options_initializer = fields.Char(
-        string="Custom Options Initializer",
-        compute=lambda x: x._compute_report_option_filter('custom_options_initializer'), readonly=False, store=True, depends=['root_report_id'],
-    )
-    custom_line_postprocessor = fields.Char(string="Custom Line Postprocessor")
-    custom_groupby_line_completer = fields.Char(string="Custom Groupby Line Completer")
-    custom_unfold_all_batch_data_generator = fields.Char(string="Custom Unfold All Batch Data Generator")
 
     def _compute_report_option_filter(self, field_name, default_value=False):
         # We don't depend on the different filter fields on the root report, as we don't want a manual change on it to be reflected on all the reports


### PR DESCRIPTION
In Reportalypse, custom reports use fields to refer to functions
allowing customizing different behaviors of the engine.

With this, all account.report models contain all the functions
of all the custom reports, leading to possible name clashes
if the functions aren't properly prefixed.

We can improve that a little: instead of having multiple fields,
we use but one, referring to an AbstractModel inheriting
from a new AbstractModel called account.report.custom.handler.

This AbstractModel simply contains the different functions
that can be overridden, and its subclasses are responsible to do so.

In the code, instead of calling _get_custom_report_function,
we check whether there is a custom handler for the report,
and call the right function on it.

task-2954761

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
