### PR TITLE
[REV] web: do not use number format in exported group header for floats

### DIFF
--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -37,12 +37,7 @@ class XlsxCreatorCase(common.HttpCase):
         }
 
     def _mock_write(self, row, column, value, style=None):
-        if isinstance(value, float):
-            decimal_places = style.num_format[::-1].find('.')
-            style_format = "{:." + str(decimal_places) + "f}"
-            self.worksheet[row, column] = style_format.format(value)
-        else:
-            self.worksheet[row, column] = str(value)
+        self.worksheet[row, column] = str(value)
 
     def make(self, values, context=None):
         return self.model.with_context(**(context or {})).create(values)
@@ -77,7 +72,6 @@ class XlsxCreatorCase(common.HttpCase):
 
 class TestGroupedExport(XlsxCreatorCase):
     model_name = 'export.group_operator'
-    # pylint: disable=bad-whitespace
 
     def test_int_sum_max(self):
         values = [
@@ -124,12 +118,12 @@ class TestGroupedExport(XlsxCreatorCase):
             ['Int Sum'      ,'Float Min'],
             ['10 (2)'       ,'111.00'],
             ['    111.0 (1)','111.00'],
-            ['10'           ,'111.00'],
+            ['10'           ,'111.0'],
             ['    222.0 (1)','222.00'],
-            ['10'           ,'222.00'],
+            ['10'           ,'222.0'],
             ['20 (1)'       ,'333.00'],
             ['    333.0 (1)','333.00'],
-            ['20'           ,'333.00'],
+            ['20'           ,'333.0'],
         ])
 
     def test_float_avg(self):
@@ -144,12 +138,12 @@ class TestGroupedExport(XlsxCreatorCase):
             ['Int Sum'      ,'Float Avg'],
             ['10 (2)'       ,'150.00'],
             ['    100.0 (1)','100.00'],
-            ['10'           ,'100.00'],
+            ['10'           ,'100.0'],
             ['    200.0 (1)','200.00'],
-            ['10'           ,'200.00'],
+            ['10'           ,'200.0'],
             ['20 (1)'       ,'300.00'],
             ['    300.0 (1)','300.00'],
-            ['20'           ,'300.00'],
+            ['20'           ,'300.0'],
         ])
 
     def test_float_avg_nested(self):
@@ -166,12 +160,12 @@ class TestGroupedExport(XlsxCreatorCase):
             ['10 (3)'           ,'300.00'],
             ['    20 (1)'       ,'600.00'],
             ['        600.0 (1)','600.00'],
-            ['10'               ,'600.00'],
+            ['10'               ,'600.0'],
             ['    30 (2)'       ,'150.00'],
             ['        100.0 (1)','100.00'],
-            ['10'               ,'100.00'],
+            ['10'               ,'100.0'],
             ['        200.0 (1)','200.00'],
-            ['10'               ,'200.00'],
+            ['10'               ,'200.0'],
         ])
 
     def test_float_avg_nested_no_value(self):
@@ -188,11 +182,11 @@ class TestGroupedExport(XlsxCreatorCase):
             ['10 (3)'               ,'0.00'],
             ['    20 (1)'           ,'0.00'],
             ['        Undefined (1)','0.00'],
-            ['10'                   ,'0.00'],
+            ['10'                   ,'0.0'],
             ['    30 (2)'           ,'0.00'],
             ['        Undefined (2)','0.00'],
-            ['10'                   ,'0.00'],
-            ['10'                   ,'0.00'],
+            ['10'                   ,'0.0'],
+            ['10'                   ,'0.0'],
         ])
 
     def test_date_max(self):
@@ -366,11 +360,11 @@ class TestGroupedExport(XlsxCreatorCase):
             ['Int Sum', 'Float Monetary'],
             ['1 (1)','60739.200'],
             ['    60739.2 (1)','60739.200'],
-            ['1','60739.20'],
+            ['1','60739.2'],
             ['2 (1)','2.000'],
             ['    2.0 (1)','2.000'],
-            ['2','2.00'],
+            ['2','2.0'],
             ['3 (1)','1000.000'],
             ['    1000.0 (1)','1000.000'],
-            ['3','1000.00'],
+            ['3','1000.0'],
         ])


### PR DESCRIPTION
Reverts [this commit] because it modified the format of float numbers in
exported xlsx files and we want to avoid introducing an error or
unwanted behavior in version 13, for which support will soon come to an
end.

[this commit]:https://github.com/odoo/odoo/commit/27ab24214dabfafc652280f680f7a650e7d98d2b