### PR TITLE
[IMP] profiler: profile requests in httpCase

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -677,12 +677,12 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
     def assertHTMLEqual(self, original, expected):
         return self._assertXMLEqual(original, expected, 'html')
 
-    def profile(self, **kwargs):
+    def profile(self, description='', **kwargs):
         test_method = getattr(self, '_testMethodName', 'Unknown test method')
         if not hasattr(self, 'profile_session'):
             self.profile_session = profiler.make_session(test_method)
         return profiler.Profiler(
-            description='%s uid:%s %s' % (test_method, self.env.user.id, 'warm' if self.warm else 'cold'),
+            description='%s uid:%s %s %s' % (test_method, self.env.user.id, 'warm' if self.warm else 'cold', description),
             db=self.env.cr.dbname,
             profile_session=self.profile_session,
             **kwargs)
@@ -1626,6 +1626,16 @@ class HttpCase(TransactionCase):
         code = kwargs.pop('code', "odoo.startTour('%s'%s)" % (tour_name, step_delay))
         ready = kwargs.pop('ready', "odoo.__DEBUG__.services['web_tour.tour'].tours['%s'].ready" % tour_name)
         return self.browser_js(url_path=url_path, code=code, ready=ready, **kwargs)
+
+    def profile(self, **kwargs):
+        """
+        for http_case, also patch _get_profiler_context_manager in order to profile all requests
+        """
+        sup = super()
+        _profiler = sup.profile(**kwargs)
+        def route_profiler(request):
+            return sup.profile(description=request.httprequest.full_path)
+        return profiler.Nested(_profiler, patch('odoo.http.Request._get_profiler_context_manager', route_profiler))
 
 
 # kept for backward compatibility


### PR DESCRIPTION
When profiling an HTTPCase the only result will be the starting of the
browser and the ready/ok code. All requests are in other thread
and are not profiled.

HTTPCase profiler will now patch the _get_profiler_context_manager
in order to enable profiler on all requests during this time