### PR TITLE
[FIX] website: fix scrollSpy crashes on TOC

### DIFF
--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -25,10 +25,6 @@ const TableOfContent = publicWidget.Widget.extend({
         if (indexCallback >= 0) {
             extraMenuUpdateCallbacks.splice(indexCallback, 1);
         }
-        const scrollSpyInstance = ScrollSpy.getInstance(this._scrollingElement);
-        if (scrollSpyInstance) {
-            scrollSpyInstance.dispose();
-        }
         this.$target.css('top', '');
         this.$target.find('.s_table_of_content_navbar').css('top', '');
         this._super(...arguments);
@@ -42,6 +38,10 @@ const TableOfContent = publicWidget.Widget.extend({
      * @private
      */
     _updateTableOfContentNavbarPosition() {
+        if (!this.$target[0].querySelector('a.table_of_content_link')) {
+            // Do not start the scrollspy if the TOC is empty.
+            return;
+        }
         let position = 0;
         const $fixedElements = $('.o_top_fixed_element');
         _.each($fixedElements, el => position += $(el).outerHeight());

--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -52,7 +52,12 @@ const TableOfContent = publicWidget.Widget.extend({
         position += $mainNavBar.length ? $mainNavBar.outerHeight() : 0;
         position += isHorizontalNavbar ? this.$target.outerHeight() : 0;
         this._scrollingElement = $().getScrollingElement();
-        this._scrollingElement.scrollspy({target: this.$target.find('.s_table_of_content_navbar'), method: 'offset', offset: position + 100, alwaysKeepFirstActive: true});
+        new ScrollSpy(this._scrollingElement, {
+            target: this.$target.find('.s_table_of_content_navbar'),
+            method: 'offset',
+            offset: position + 100,
+            alwaysKeepFirstActive: true
+        });
     },
 });
 

--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -25,7 +25,10 @@ const TableOfContent = publicWidget.Widget.extend({
         if (indexCallback >= 0) {
             extraMenuUpdateCallbacks.splice(indexCallback, 1);
         }
-        this._scrollingElement.scrollspy('dispose');
+        const scrollSpyInstance = ScrollSpy.getInstance(this._scrollingElement);
+        if (scrollSpyInstance) {
+            scrollSpyInstance.dispose();
+        }
         this.$target.css('top', '');
         this.$target.find('.s_table_of_content_navbar').css('top', '');
         this._super(...arguments);

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -2,6 +2,23 @@
 
 import wTourUtils from 'website.tour_utils';
 
+const scrollToHeading = function (position) {
+    return {
+        content: `Scroll to h1 number ${position}`,
+        trigger: `iframe h1:eq(${position})`,
+        run: function () {
+            this.$anchor[0].scrollIntoView(true);
+        },
+    };
+};
+const checkTOCNavBar = function (tocPosition, activeHeaderPosition) {
+    return {
+        content: `Check that the header ${activeHeaderPosition} is active for TOC ${tocPosition}`,
+        trigger: `iframe .s_table_of_content:eq(${tocPosition}) .table_of_content_link:eq(${activeHeaderPosition}).active `,
+        run: () => {}, // This is a check.
+    };
+};
+
 wTourUtils.registerWebsitePreviewTour('snippet_table_of_content', {
     test: true,
     url: '/',
@@ -12,4 +29,13 @@ wTourUtils.registerWebsitePreviewTour('snippet_table_of_content', {
     // To make sure that the public widgets of the two previous ones started.
     wTourUtils.dragNDrop({id: 's_banner', name: 'Banner'}),
     ...wTourUtils.clickOnSave(),
+    checkTOCNavBar(0, 0),
+    checkTOCNavBar(1, 0),
+    scrollToHeading(1),
+    checkTOCNavBar(0, 1),
+    checkTOCNavBar(1, 0),
+    scrollToHeading(2),
+    checkTOCNavBar(1, 0),
+    scrollToHeading(3),
+    checkTOCNavBar(1, 1),
 ]);

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -1,0 +1,15 @@
+/** @odoo-module */
+
+import wTourUtils from 'website.tour_utils';
+
+wTourUtils.registerWebsitePreviewTour('snippet_table_of_content', {
+    test: true,
+    url: '/',
+    edition: true,
+}, [
+    wTourUtils.dragNDrop({id: 's_table_of_content', name: 'Table of Content'}),
+    wTourUtils.dragNDrop({id: 's_table_of_content', name: 'Table of Content'}),
+    // To make sure that the public widgets of the two previous ones started.
+    wTourUtils.dragNDrop({id: 's_banner', name: 'Banner'}),
+    ...wTourUtils.clickOnSave(),
+]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -49,3 +49,6 @@ class TestSnippets(HttpCase):
 
     def test_07_image_gallery(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
+
+    def test_08_table_of_content(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_table_of_content', login='admin')

--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -5,7 +5,7 @@
     <section class="s_table_of_content pt24 pb24 o_cc o_cc1">
         <div class="container">
             <div class="row s_nb_column_fixed">
-                <div class="col-lg-3 s_table_of_content_navbar_wrap s_table_of_content_navbar_sticky                         s_table_of_content_vertical_navbar d-print-none d-none d-lg-block o_not_editable o_cc o_cc1" data-name="Navbar">
+                <div class="col-lg-3 s_table_of_content_navbar_wrap s_table_of_content_navbar_sticky s_table_of_content_vertical_navbar d-print-none d-none d-lg-block o_not_editable o_cc o_cc1" data-name="Navbar">
                     <div class="s_table_of_content_navbar list-group o_no_link_popover"/>
                 </div>
                 <div class="col-lg-9 s_table_of_content_main oe_structure oe_empty" data-name="Content">


### PR DESCRIPTION
The table of content (TOC) has two mechanisms that interest us here:

The first one is ScrollSpy (from Bootstrap) which allows (among other
things) to bold the menu items according to the scroll. The second one
is a mutation Observer which is implemented to regenerate the menu when
the content of the TOC changes.

This being said, when we edit the TOC and scroll at the same time, there
is a race condition that makes ScrollSpy want to add a class to a menu
item while this menu has just been regenerated by the observer. The
error is only visible since the migration from bootstrap 4 to bootstrap
5 because to add the class, bootstrap 4 did it with the JQuery
`addClass()` function which does not cause an error if the element on
which it is called does not exist. Now, bootstrap 5 does the same thing
in pure JS with `classList.add()` which causes an error if the element
on which it is called is not defined. This commit fixes this error by
disabling the ScrollSpy when you regenerate the menu.

Steps to reproduce the error:
- drop a table of content block
- drag a snippet around and go over the drop zones

=> traceback. It can appear directly or after some tries.

While this bug was being fixed, another one was discovered:

Since [this commit], when dropping several "table of content" blocks on
the same page, it was impossible to save. This commit solves this
problem.
Steps to reproduce the resolved bug:
- In edit mode, drop two TOC blocks
- Click on Save

=> the UI is blocked

[this commit]: https://github.com/odoo/odoo/commit/06b03ba5ef8375b1236f6ecb52ac468124e910ba

task-2948895
opw-3047375