### PR TITLE
[FIX] web: fix field update

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -119,13 +119,11 @@ export class Field extends Component {
         const fieldInfo = this.props.fieldInfo;
 
         const modifiers = fieldInfo.modifiers || {};
-        const required = evalDomain(modifiers.required, evalContext);
         const readonlyFromModifiers = evalDomain(modifiers.readonly, evalContext);
         const readonlyFromRecord = !record.isInEdition;
         const readonlyFromViewMode = record.model.root
             ? !record.model.root.isInEdition
             : readonlyFromRecord;
-        const emptyRequiredValue = required && !this.props.value;
 
         // Decoration props
         const decorationMap = {};
@@ -162,7 +160,7 @@ export class Field extends Component {
                     return;
                 }
                 // We save only if we're on view mode readonly and no readonly field modifier
-                if (readonlyFromViewMode && !readonlyFromModifiers && !emptyRequiredValue) {
+                if (readonlyFromViewMode && !readonlyFromModifiers) {
                     // TODO: maybe move this in the model
                     return record.save();
                 }


### PR DESCRIPTION
When a field in readonly view can be modified, it should write to the
backend immediately. (No changes are stored to be comited later)

For some reason, a bit of code was preventing this if the field was
required and had a falsy value. Furthermore, the code seemed incorrect
or at least misplaced. Removing these lines didn't affect the test.

The fix simply remove this extra check.

There was a condition in the update code for required field in readonly
views that prevented the correct flow to be executed. Since no test are
broken removing this check but it fixes the problem, it is removed.