### PR TITLE
[FIX] website_sale: fix cart popover

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -75,7 +75,9 @@ publicWidget.registry.websiteSaleCartLink = publicWidget.Widget.extend({
             self._popoverRPC = $.get("/shop/cart", {
                 type: 'popover',
             }).then(function (data) {
-                self.$el.data("bs.popover").config.content = data;
+                const popover = Popover.getInstance(self.$el[0]);
+                popover._config.content = data;
+                popover.setContent(popover.getTipElement());
                 self.$el.popover("show");
                 $('.popover').on('mouseleave', function () {
                     self.$el.trigger('mouseleave');


### PR DESCRIPTION
The cart popover was broken since the bootstrap changes as data that was
previously set on the jquery element upon creating the popover was not
set anymore.
