### PR TITLE
[IMP] base, *: Monkeypatch refactoring

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -7,6 +7,7 @@ import itertools
 import json
 import logging
 import operator
+import xlsxwriter
 from collections import OrderedDict
 
 from werkzeug.exceptions import InternalServerError
@@ -17,7 +18,7 @@ from odoo import http
 from odoo.exceptions import UserError
 from odoo.http import content_disposition, request
 from odoo.tools import lazy_property, osutil, pycompat
-from odoo.tools.misc import xlsxwriter, get_lang
+from odoo.tools.misc import get_lang
 from odoo.tools.translate import _
 
 

--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -4,11 +4,11 @@
 from collections import deque
 import io
 import json
+import xlsxwriter
 
 from odoo import http, _
 from odoo.http import content_disposition, request
 from odoo.tools import ustr, osutil
-from odoo.tools.misc import xlsxwriter
 
 
 class TableExporter(http.Controller):

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -67,25 +67,6 @@ if hasattr(time, 'tzset'):
     time.tzset()
 
 #----------------------------------------------------------
-# PyPDF2 hack
-# ensure that zlib does not throw error -5 when decompressing
-# because some pdf won't fit into allocated memory
-# https://docs.python.org/3/library/zlib.html#zlib.decompressobj
-# ----------------------------------------------------------
-import PyPDF2
-
-try:
-    import zlib
-
-    def _decompress(data):
-        zobj = zlib.decompressobj()
-        return zobj.decompress(data)
-
-    PyPDF2.filters.decompress = _decompress
-except ImportError:
-    pass # no fix required
-
-#----------------------------------------------------------
 # Shortcuts
 #----------------------------------------------------------
 # The hard-coded super-user id (a.k.a. administrator, or root user).

--- a/odoo/addons/base/controllers/__init__.py
+++ b/odoo/addons/base/controllers/__init__.py
@@ -1,1 +1,2 @@
+from . import xmlrpc_client
 from . import rpc

--- a/odoo/addons/base/controllers/xmlrpc_client.py
+++ b/odoo/addons/base/controllers/xmlrpc_client.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+# pylint: disable=import-outside-toplevel
+
+import re
+from markupsafe import Markup
+from datetime import date, datetime
+from odoo.tools import lazy, ustr
+from odoo.tools.misc import frozendict
+from odoo.fields import Date, Datetime, Command
+from odoo.tools._monkeypatches import monkeypatch_register
+
+
+@monkeypatch_register('xmlrpc')
+def monkeypatch_xmlrpc():
+    """ XmlRPC fix: Dispatching has changed in xmlrpc.client versions
+        but we want it to have consistent behaviour with our datatypes.
+    """
+
+    import xmlrpc.client
+
+    # ustr decodes as utf-8 or latin1 so we can search for the ASCII bytes
+    #   Char ::= #x9 | #xA | #xD | [#x20-#xD7FF]
+    XML_INVALID = re.compile(b'[\x00-\x08\x0B\x0C\x0F-\x1F]')
+
+
+    class OdooMarshaller(xmlrpc.client.Marshaller):
+        dispatch = dict(xmlrpc.client.Marshaller.dispatch)
+
+        def dump_frozen_dict(self, value, write):
+            value = dict(value)
+            self.dump_struct(value, write)
+
+        # By default, in xmlrpc, bytes are converted to xmlrpc.client.Binary object.
+        # Historically, odoo is sending binary as base64 string.
+        # In python 3, base64.b64{de,en}code() methods now works on bytes.
+        # Convert them to str to have a consistent behavior between python 2 and python 3.
+        def dump_bytes(self, value, write):
+            # XML 1.0 disallows control characters, check for them immediately to
+            # see if this is a "real" binary (rather than base64 or somesuch) and
+            # blank it out, otherwise they get embedded in the output and break
+            # client-side parsers
+            if XML_INVALID.search(value):
+                self.dump_unicode('', write)
+            else:
+                self.dump_unicode(ustr(value), write)
+
+        def dump_datetime(self, value, write):
+            # override to marshall as a string for backwards compatibility
+            value = Datetime.to_string(value)
+            self.dump_unicode(value, write)
+
+        # convert date objects to strings in iso8061 format.
+        def dump_date(self, value, write):
+            value = Date.to_string(value)
+            self.dump_unicode(value, write)
+
+        def dump_lazy(self, value, write):
+            v = value._value
+            return self.dispatch[type(v)](self, v, write)
+
+        dispatch[frozendict] = dump_frozen_dict
+        dispatch[bytes] = dump_bytes
+        dispatch[datetime] = dump_datetime
+        dispatch[date] = dump_date
+        dispatch[lazy] = dump_lazy
+        dispatch[Command] = dispatch[int]
+        dispatch[Markup] = lambda self, value, write: self.dispatch[str](self, str(value), write)
+
+    # monkey-patch xmlrpc.client's marshaller
+    xmlrpc.client.Marshaller = OdooMarshaller

--- a/odoo/tools/_monkeypatches.py
+++ b/odoo/tools/_monkeypatches.py
@@ -1,18 +1,170 @@
-try:
-    from xlrd import xlsx
-except ImportError:
-    pass
-else:
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+# pylint: disable=import-outside-toplevel
+
+"""Monkeypatching is not a good practice, it should be avoided in all cases.
+   Yet in some cases it's still necessary, mainly when relying on third party modules.
+   Reasons may vary:
+
+       - to adjust for compatibility between versions,
+       - to fix a small detail without reworking the external module.
+
+   In Odoo, there were several places in which monkeypatching is done.
+   This module aims to put the monkeypatching all together and to make clear
+   at a glance which external modules are subject to it, and how.
+
+   All the monkeypatching will be done so that import <module> will already load
+   the monkeypatched module. Modules will have a new <module>.__monkeypatched__
+   attribute set to True. This will remove the need to import from odoo.tools.misc.<module>
+   and also ensure that people not aware of the monkeypatching use the wrong version.
+
+   Until now, the modules present here are of broad interest, and may belong to the "base" module.
+   There are cases in which third-party monkeypatched module are of specific interest
+   of a single Odoo module. We can leave the monkeypatching in that module, but we suggest
+   using the `monkeypatch_register` function here to make it at least visible at runtime,
+   so that from the Odoo shell we can query them:
+
+   >>> from odoo.tools._monkeypatches import monkeypatched_modules
+   >>> from pprint import pprint
+   >>> pprint(monkeypatched_modules())
+   {'OpenSSL': <module 'OpenSSL' from '/path/to/OpenSSL/OpenSSL.py>,
+    'PyPDF2': <module 'PyPDF2' from '/path/to/PyPDF2/PyPDF2.py>,
+    'xlrd': <module 'xlrd.xlsx' from '/path/to/xlrd/xlrd.py>,
+    'xlsxwriter': <module 'xlsxwriter' from '/path/to/xlsxwriter/xlsxwriter.py>,
+    'xlwt': <module 'xlwt' from '/path/to/xlwt/xlwt.py>,
+    'xmlrpc': <module 'xmlrpc' from '/path/to/xmlrpc/xmlrpc.py>}
+"""
+
+import sys
+import importlib
+
+
+def monkeypatch_register(module_name):
+    """Creates a monkeypatching decorator and returns it.
+       The monkeypatching decorator will run and the module will be added
+       to the sys.modules registry of imported modules with the module.__monkeypatched__
+       flag set to True.
+    """
+    def monkeypatch_register_inner(monkeypatcher_func):
+        try:
+            monkeypatcher_func()
+        except Exception:
+            return
+        module = importlib.import_module(module_name)
+        module.__monkeypatched__ = True
+    return monkeypatch_register_inner
+
+def monkeypatched_modules():
+    """Returns a dict with monkeypatched modules.
+       The keys are the names, the values the modules themselves.
+    """
+    return {k: v for k, v in sys.modules.items() if getattr(v, '__monkeypatched__', False)}
+
+@monkeypatch_register('OpenSSL')
+def monkeypatch_OpenSSL():
+    """OpenSSL v0.x.x uses OpenSSL.X509_get_notBefore and OpenSSL.X509_get_notAfter
+       pyopenssl v19.0.0 uses those.
+       OpenSSL v1.1.0a+ renamed them to OpenSSL.X509_getm_notBefore and OpenSSL.X509_getm_notAfter
+       pyopenssl v20.0.0 adapted to those new ones.
+       This monkeypatch prevents misalignments between versions.
+    """
+    import OpenSSL
+    import ssl
+
+    pyopenssl_version = tuple(int(x) for x in OpenSSL.__version__.split('.'))
+    openssl_version = ssl.OPENSSL_VERSION_INFO[:3]
+
+    lib = OpenSSL._util.lib
+    if pyopenssl_version >= (20, 0, 0) and openssl_version < (1, 1, 0):
+        lib.X509_getm_notBefore = lib.X509_get_notBefore
+        lib.X509_getm_notAfter = lib.X509_get_notAfter
+    elif pyopenssl_version >= (19, 0, 0) and openssl_version >= (1, 1, 0):
+        lib.X509_get_notBefore = lib.X509_getm_notBefore
+        lib.X509_get_notAfter = lib.X509_getm_notAfter
+
+@monkeypatch_register('PyPDF2')
+def monkeypatch_PyPDF2():
+    """PyPDF2 fixes:
+       1) Fix invalid numbers like 0.000000000000-5684342
+          Because some PDF generators are building PDF streams with invalid numbers.
+          Ref: https://docs.python.org/3/library/zlib.html#zlib.decompressobj
+       2) Ensure that zlib does not throw error -5 when decompressing
+          because some pdf won't fit into allocated memory.
+    """
+    import zlib
+    import PyPDF2
+
+    orig_FloatObject___new__ = PyPDF2.generic.FloatObject.__new__
+
+    def FloatObject___new__(cls, value="0", context=None):
+        # Fix invalid numbers like 0.000000000000-5684342
+        # Because some PDF generators are building PDF streams with invalid numbers
+        if isinstance(value, bytes) and value[0] != b'-' and b'-' in value:
+            value = b'-' + b''.join(value.split(b'-', 1))
+        elif isinstance(value, str) and value[0] != '-' and '-' in value:
+            value = '-' + ''.join(value.split('-', 1))
+        return orig_FloatObject___new__(cls, value, context)
+
+    def _decompress(data):
+        zobj = zlib.decompressobj()
+        return zobj.decompress(data)
+
+    PyPDF2.generic.FloatObject.__new__ = FloatObject___new__
+    PyPDF2.filters.decompress = _decompress
+
+@monkeypatch_register('xlrd')
+def monkeypatch_xlrd():
+    """xlrd.xlsx supports defusedxml, defusedxml's etree interface is broken
+       (missing ElementTree and thus ElementTree.iter) which causes a fallback to
+       Element.getiterator(), triggering a warning before 3.9 and an error from 3.9.
+
+       We have defusedxml installed because zeep has a hard dep on defused and
+       doesn't want to drop it (mvantellingen/python-zeep#1014).
+
+       Ignore the check and set the relevant flags directly using lxml as we have a
+       hard dependency on it.
+    """
+    import xlrd
     from lxml import etree
-    # xlrd.xlsx supports defusedxml, defusedxml's etree interface is broken
-    # (missing ElementTree and thus ElementTree.iter) which causes a fallback to
-    # Element.getiterator(), triggering a warning before 3.9 and an error from 3.9.
-    #
-    # We have defusedxml installed because zeep has a hard dep on defused and
-    # doesn't want to drop it (mvantellingen/python-zeep#1014).
-    #
-    # Ignore the check and set the relevant flags directly using lxml as we have a
-    # hard dependency on it.
-    xlsx.ET = etree
-    xlsx.ET_has_iterparse = True
-    xlsx.Element_has_iter = True
+
+    xlrd.xlsx.ET = etree
+    xlrd.xlsx.ET_has_iterparse = True
+    xlrd.xlsx.Element_has_iter = True
+
+@monkeypatch_register('xlsxwriter')
+def monkeypatch_xlsxwriter():
+    """Xlsxwriter fix, add some sanitization to respect the excel sheet name restrictions
+       as the sheet name is often translatable, can not control the input.
+    """
+    import re
+    import xlsxwriter
+
+    class PatchedXlsxWorkbook(xlsxwriter.Workbook):
+        def add_worksheet(self, name=None, worksheet_class=None):
+            if name:
+                # invalid Excel character: []:*?/\
+                name = re.sub(r'[\[\]:*?/\\]', '', name)
+                # maximum size is 31 characters
+                name = name[:31]
+            return super(PatchedXlsxWorkbook, self).add_worksheet(name, worksheet_class)
+
+    xlsxwriter.Workbook = PatchedXlsxWorkbook
+
+@monkeypatch_register('xlwt')
+def monkeypatch_xlwt():
+    """Add some sanitization to respect the excel sheet name restrictions
+       as the sheet name is often translatable, can not control the input.
+    """
+    import re
+    import xlwt
+
+    class PatchedWorkbook(xlwt.Workbook):
+        def add_sheet(self, sheetname, cell_overwrite_ok=False):
+            # invalid Excel character: []:*?/\
+            sheetname = re.sub(r'[\[\]:*?/\\]', '', sheetname)
+            # maximum size is 31 characters
+            sheetname = sheetname[:31]
+            return super(PatchedWorkbook, self).add_sheet(sheetname, cell_overwrite_ok=cell_overwrite_ok)
+
+    xlwt.Workbook = PatchedWorkbook

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -332,49 +332,6 @@ def merge_sequences(*iterables):
             prev = item
     return topological_sort(deps)
 
-
-try:
-    import xlwt
-
-    # add some sanitization to respect the excel sheet name restrictions
-    # as the sheet name is often translatable, can not control the input
-    class PatchedWorkbook(xlwt.Workbook):
-        def add_sheet(self, name, cell_overwrite_ok=False):
-            # invalid Excel character: []:*?/\
-            name = re.sub(r'[\[\]:*?/\\]', '', name)
-
-            # maximum size is 31 characters
-            name = name[:31]
-            return super(PatchedWorkbook, self).add_sheet(name, cell_overwrite_ok=cell_overwrite_ok)
-
-    xlwt.Workbook = PatchedWorkbook
-
-except ImportError:
-    xlwt = None
-
-try:
-    import xlsxwriter
-
-    # add some sanitization to respect the excel sheet name restrictions
-    # as the sheet name is often translatable, can not control the input
-    class PatchedXlsxWorkbook(xlsxwriter.Workbook):
-
-        # TODO when xlsxwriter bump to 0.9.8, add worksheet_class=None parameter instead of kw
-        def add_worksheet(self, name=None, **kw):
-            if name:
-                # invalid Excel character: []:*?/\
-                name = re.sub(r'[\[\]:*?/\\]', '', name)
-
-                # maximum size is 31 characters
-                name = name[:31]
-            return super(PatchedXlsxWorkbook, self).add_worksheet(name, **kw)
-
-    xlsxwriter.Workbook = PatchedXlsxWorkbook
-
-except ImportError:
-    xlsxwriter = None
-
-
 def to_xml(s):
     warnings.warn("Since 16.0, use proper escaping methods (e.g. `markupsafe.escape`).", DeprecationWarning, stacklevel=2)
     return s.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;')


### PR DESCRIPTION
Monkeypatching is not a good practice, but it's in some cases necessary.
This is especiallly true when relying on third party modules.
Reasons may vary:

- to adjust for compatibility between versions
- to fix a small detail without reworking the external module.

In Odoo, there are several places in which monkeypatching is done.
This PR aims to put most of the monkeypatching together and to make clear at a glance which external modules are subject to it, and how.

Until now, the modules present here are of broad interest, and may belong to the `base` module.
There are cases in which a single Odoo module will require a third-party monkeypatched module that will get installed as `external_dependencies` in the `__manifest__.py` file.
We can leave the monkeypatching in that module, but we suggest using the `register` function here to make it at least visible at runtime, so that from the Odoo shell we can query them for troubleshooting:

```py
>>> from odoo.tools.monkeypatch import monkeypatches
>>> from pprint import pprint
>>> pprint(monkeypatches)
{'OpenSSL': <function monkeypatch_OpenSSL at 0x7fd7d8db3b50>,
 'PyPDF2': <function monkeypatch_PyPDF2 at 0x7fd7d8db3be0>,
 'xlsx': <function monkeypatch_xlsx at 0x7fd7d8db3c70>,
 'xlsxwriter': <function monkeypatch_xlsxwriter at 0x7fd7d8db3d00>,
 'xlwt': <function monkeypatch_xlwt at 0x7fd7d8db3d90>,
 'xmlrpc': <function monkeypatch_xmlrpc at 0x7fd7d8db3e20>}
```

All the monkeypatching will be done so that import <module> will already load the monkeypatched module.
Modules will have a new `<module>.__is_monkeypatched__` attribute set to True.
This will remove the need to import from odoo.tools.misc.<module> and also ensure that people not aware of the monkeypatching use the wrong version.

Enterprise PR: https://github.com/odoo/enterprise/pull/30784