### PR TITLE
[FIX] base_address_extended: update street value in onchange

### DIFF
--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -33,6 +33,10 @@ class Partner(models.Model):
     street_number2 = fields.Char('Door', compute='_split_street', help="Door Number",
                                  inverse='_set_street', store=True)
 
+    @api.onchange("street_name", "street_number", "street_number2")
+    def _onchange_street(self):
+        self._set_street()
+
     def _formatting_address_fields(self):
         """Returns the list of address fields usable to format addresses."""
         return super(Partner, self)._formatting_address_fields() + self.get_street_fields()


### PR DESCRIPTION
This module splits street address into parts. It also inverse updates, but only
on creating/updating. This leads to wrong default values on the address form.

Fix it by adding onchange method.

STEPS: open partner, change any of the street fields (street_name,
street_number, street_number2), click "Add address"

Note. This solution has a side effect: while onchange updates `street` value,
the `_split_street` is also called which may change street values again. For
example, if user types `123 xxx` in the `House` field, the `xxx` part might be
moved to *Street Name* field.

opw-2954950

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
