### PR TITLE
[FIX] hr_holidays: accross two years accrual plans period fail:

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -330,10 +330,14 @@ class HolidaysAllocation(models.Model):
         first_day_this_year = fields.Date.today() + relativedelta(month=1, day=1)
         for allocation in self:
             current_level = allocation._get_current_accrual_plan_level_id(first_day_this_year)[0]
+            lastcall = current_level._get_previous_date(first_day_this_year)
             nextcall = current_level._get_next_date(first_day_this_year)
+            if lastcall == first_day_this_year:
+                lastcall = current_level._get_previous_date(first_day_this_year - relativedelta(days=1))
+                nextcall = first_day_this_year
             if current_level and current_level.action_with_unused_accruals == 'lost':
                 # Allocations are lost but number_of_days should not be lower than leaves_taken
-                allocation.write({'number_of_days': allocation.leaves_taken, 'lastcall': first_day_this_year, 'nextcall': nextcall})
+                allocation.write({'number_of_days': allocation.leaves_taken, 'lastcall': lastcall, 'nextcall': nextcall})
 
     def _get_current_accrual_plan_level_id(self, date, level_ids=False):
         """
@@ -423,15 +427,6 @@ class HolidaysAllocation(models.Model):
                 # this is used to prorate the first number of days given to the employee
                 period_start = current_level._get_previous_date(allocation.lastcall)
                 period_end = current_level._get_next_date(allocation.lastcall)
-                # If accruals are lost at the beginning of year, skip accrual until beginning of this year
-                if current_level.action_with_unused_accruals == 'lost':
-                    this_year_first_day = today + relativedelta(day=1, month=1)
-                    if period_end < this_year_first_day:
-                        allocation.lastcall = allocation.nextcall
-                        allocation.nextcall = nextcall
-                        continue
-                    else:
-                        period_start = max(period_start, this_year_first_day)
                 # Also prorate this accrual in the event that we are passing from one level to another
                 if current_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
                     next_level = level_ids[current_level_idx + 1]

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -523,7 +523,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2022-01-01'):
             allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 0, 'There number of days should be reset')
+            self.assertEqual(allocation.number_of_days, 1, 'The number of days should be reset')
 
     def test_unused_accrual_postponed(self):
         # 1 accrual with 2 levels and level transition after
@@ -715,6 +715,36 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         allocation.action_confirm()
         allocation.action_validate()
         with freeze_time('2022-4-4'):
+            allocation._update_accrual()
+        self.assertEqual(allocation.number_of_days, 4, "Invalid number of days")
+
+    def test_accrual_lost_first_january(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan For Test',
+            'level_ids': [
+                (0, 0, {
+                    'start_count': 0,
+                    'start_type': 'day',
+                    'added_value': 3,
+                    'added_value_type': 'days',
+                    'frequency': 'yearly',
+                    'maximum_leave': 12,
+                    'action_with_unused_accruals': 'lost',
+                })
+            ],
+        })
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+            'name': 'Accrual Allocation - Test',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 0,
+            'allocation_type': 'accrual',
+            'date_from': datetime.date(2019, 1, 1),
+        })
+        allocation.action_confirm()
+        allocation.action_validate()
+        with freeze_time('2022-4-1'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 3, "Invalid number of days")
 


### PR DESCRIPTION
Steps to reproduce:
- Create Accrual plan to add 3 days with frequency Yearly on 1 of
January and days lost at the end of the year
- Submit an Allocation request for this accrual plan starting more than
2 years ago
- Run scheduled action "Accrual Time: Updates the number of time off"

Current behavior:
Allocation request calculation time off computes 0 hours

Expected behavior:
Allocation request calculation time off computes 3 hours for the
period between the first of last year and the first of this year

Explanation:
With this modification there are two changes:

1) When the attribution day is the first of january, the nextcall
set in the _end_of_the_year_accrual is the first day of next
year meaning that no days are going to be computed for the last
year period. We change that so that if the first of the year is
the attribution day then the first of the year is the nextcall and
the last call is computed accordingly.

2) If the period to compute the attributed days is acrros two years
the begining of the period is not the first of the year anymore but
the usual lastcall, this has an impact particularly on based on
worked time accrual plans.

opw-2948216

