### PR TITLE
[IMP/FIX/REF] web: orm service: rework API

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -27,7 +27,7 @@ export class AccountFileUploader extends Component {
             datas: file.data,
         };
         const att_id = await this.orm.create("ir.attachment", [att_data], {
-            ...this.props.extraContext, ...this.env.searchModel.context,
+            context: { ...this.props.extraContext, ...this.env.searchModel.context },
         });
         this.attachmentIdsToProcess.push(att_id);
     }

--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -26,7 +26,7 @@ export class AccountFileUploader extends Component {
             mimetype: file.type,
             datas: file.data,
         };
-        const att_id = await this.orm.create("ir.attachment", att_data, {
+        const att_id = await this.orm.create("ir.attachment", [att_data], {
             ...this.props.extraContext, ...this.env.searchModel.context,
         });
         this.attachmentIdsToProcess.push(att_id);

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -178,7 +178,7 @@ registerModel({
                     case 'create':
                         return ormService.create(model, args[0], context);
                     case 'read':
-                        return ormService.read(model, args[0], args.length > 1 ? args[1] : undefined, context);
+                        return ormService.read(model, args[0], args.length > 1 ? args[1] : undefined, {}, context);
                     case 'read_group':
                         return ormService.readGroup(model, domain, fields, groupBy, ormOptions, context);
                     case 'search':

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -171,24 +171,24 @@ registerModel({
                 return this.env.services.rpc(route, rpcParameters, { silent, ...rpcSettings });
             } else {
                 const { args, method, model, kwargs = {} } = params;
-                const { context, domain, fields, groupBy, ...ormOptions } = kwargs;
+                const { domain, fields, groupBy } = kwargs;
 
                 const ormService = 'shadow' in options ? this.env.services.orm.silent : this.env.services.orm;
                 switch (method) {
                     case 'create':
-                        return ormService.create(model, args[0], context);
+                        return ormService.create(model, args[0], kwargs);
                     case 'read':
-                        return ormService.read(model, args[0], args.length > 1 ? args[1] : undefined, {}, context);
+                        return ormService.read(model, args[0], args.length > 1 ? args[1] : undefined, kwargs);
                     case 'read_group':
-                        return ormService.readGroup(model, domain, fields, groupBy, ormOptions, context);
+                        return ormService.readGroup(model, domain, fields, groupBy, kwargs);
                     case 'search':
-                        return ormService.search(model, args[0], ormOptions, context);
+                        return ormService.search(model, args[0], kwargs);
                     case 'search_read':
-                        return ormService.searchRead(model, domain, fields, ormOptions, context);
+                        return ormService.searchRead(model, domain, fields, kwargs);
                     case 'unlink':
-                        return ormService.unlink(model, args[0], context);
+                        return ormService.unlink(model, args[0], kwargs);
                     case 'write':
-                        return ormService.write(model, args[0], args[1], context);
+                        return ormService.write(model, args[0], args[1], kwargs);
                     default:
                         return ormService.call(model, method, args, kwargs);
                 }

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -109,9 +109,12 @@ export class ORM {
         return this.rpc(url, params, { silent: this._silent });
     }
 
-    create(model, state, context) {
-        validateObject("state", state);
-        return this.call(model, "create", [state], { context });
+    create(model, records, context) {
+        validateArray("records", records);
+        for (const record of records) {
+            validateObject("record", record);
+        }
+        return this.call(model, "create", records, { context });
     }
 
     nameGet(model, ids, context) {

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -109,23 +109,23 @@ export class ORM {
         return this.rpc(url, params, { silent: this._silent });
     }
 
-    create(model, records, context) {
+    create(model, records, kwargs = {}) {
         validateArray("records", records);
         for (const record of records) {
             validateObject("record", record);
         }
-        return this.call(model, "create", records, { context });
+        return this.call(model, "create", records, kwargs);
     }
 
-    nameGet(model, ids, context) {
+    nameGet(model, ids, kwargs = {}) {
         validatePrimitiveList("ids", "number", ids);
         if (!ids.length) {
             return Promise.resolve([]);
         }
-        return this.call(model, "name_get", [ids], { context });
+        return this.call(model, "name_get", [ids], kwargs);
     }
 
-    read(model, ids, fields, kwargs = {}, context = {}) {
+    read(model, ids, fields, kwargs = {}) {
         validatePrimitiveList("ids", "number", ids);
         if (fields) {
             validatePrimitiveList("fields", "string", fields);
@@ -133,43 +133,43 @@ export class ORM {
         if (!ids.length) {
             return Promise.resolve([]);
         }
-        return this.call(model, "read", [ids, fields], { ...kwargs, context });
+        return this.call(model, "read", [ids, fields], kwargs);
     }
 
-    readGroup(model, domain, fields, groupby, kwargs = {}, context = {}) {
+    readGroup(model, domain, fields, groupby, kwargs = {}) {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
         validatePrimitiveList("groupby", "string", groupby);
-        return this.call(model, "read_group", [], { ...kwargs, domain, fields, groupby, context });
+        return this.call(model, "read_group", [], { ...kwargs, domain, fields, groupby });
     }
 
-    search(model, domain, kwargs = {}, context = {}) {
+    search(model, domain, kwargs = {}) {
         validateArray("domain", domain);
-        return this.call(model, "search", [domain], { ...kwargs, context });
+        return this.call(model, "search", [domain], kwargs);
     }
 
-    searchRead(model, domain, fields, kwargs = {}, context = {}) {
+    searchRead(model, domain, fields, kwargs = {}) {
         validateArray("domain", domain);
         if (fields) {
             validatePrimitiveList("fields", "string", fields);
         }
-        return this.call(model, "search_read", [], { ...kwargs, context, domain, fields });
+        return this.call(model, "search_read", [], { ...kwargs, domain, fields });
     }
 
-    searchCount(model, domain, context = {}) {
+    searchCount(model, domain, kwargs = {}) {
         validateArray("domain", domain);
-        return this.call(model, "search_count", [domain], { context });
+        return this.call(model, "search_count", [domain], kwargs);
     }
 
-    unlink(model, ids, context) {
+    unlink(model, ids, kwargs = {}) {
         validatePrimitiveList("ids", "number", ids);
         if (!ids.length) {
             return true;
         }
-        return this.call(model, "unlink", [ids], { context });
+        return this.call(model, "unlink", [ids], kwargs);
     }
 
-    webReadGroup(model, domain, fields, groupby, kwargs = {}, context = {}) {
+    webReadGroup(model, domain, fields, groupby, kwargs = {}) {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
         validatePrimitiveList("groupby", "string", groupby);
@@ -178,20 +178,19 @@ export class ORM {
             groupby,
             domain,
             fields,
-            context,
         });
     }
 
-    webSearchRead(model, domain, fields, kwargs = {}, context = {}) {
+    webSearchRead(model, domain, fields, kwargs = {}) {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
-        return this.call(model, "web_search_read", [], { ...kwargs, domain, fields, context });
+        return this.call(model, "web_search_read", [], { ...kwargs, domain, fields });
     }
 
-    write(model, ids, data, context) {
+    write(model, ids, data, kwargs = {}) {
         validatePrimitiveList("ids", "number", ids);
         validateObject("data", data);
-        return this.call(model, "write", [ids, data], { context });
+        return this.call(model, "write", [ids, data], kwargs);
     }
 }
 

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -122,7 +122,7 @@ export class ORM {
         return this.call(model, "name_get", [ids], { context });
     }
 
-    read(model, ids, fields, context = {}) {
+    read(model, ids, fields, kwargs = {}, context = {}) {
         validatePrimitiveList("ids", "number", ids);
         if (fields) {
             validatePrimitiveList("fields", "string", fields);
@@ -130,7 +130,7 @@ export class ORM {
         if (!ids.length) {
             return Promise.resolve([]);
         }
-        return this.call(model, "read", [ids, fields], { context });
+        return this.call(model, "read", [ids, fields], { ...kwargs, context });
     }
 
     readGroup(model, domain, fields, groupby, kwargs = {}, context = {}) {

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -8,17 +8,6 @@ import { registry } from "./registry";
  */
 
 // -----------------------------------------------------------------------------
-// Helper
-// -----------------------------------------------------------------------------
-function assignOptions(kwargs, options, whileList) {
-    for (let elem of whileList) {
-        if (elem in options) {
-            kwargs[elem] = options[elem];
-        }
-    }
-}
-
-// -----------------------------------------------------------------------------
 // ORM
 // -----------------------------------------------------------------------------
 
@@ -108,10 +97,10 @@ export class ORM {
 
     call(model, method, args = [], kwargs = {}) {
         validateModel(model);
-        let url = `/web/dataset/call_kw/${model}/${method}`;
+        const url = `/web/dataset/call_kw/${model}/${method}`;
         const fullContext = Object.assign({}, this.user.context, kwargs.context || {});
         const fullKwargs = Object.assign({}, kwargs, { context: fullContext });
-        let params = {
+        const params = {
             model,
             method,
             args,
@@ -120,20 +109,20 @@ export class ORM {
         return this.rpc(url, params, { silent: this._silent });
     }
 
-    create(model, state, ctx) {
+    create(model, state, context) {
         validateObject("state", state);
-        return this.call(model, "create", [state], { context: ctx });
+        return this.call(model, "create", [state], { context });
     }
 
-    nameGet(model, ids, ctx) {
+    nameGet(model, ids, context) {
         validatePrimitiveList("ids", "number", ids);
         if (!ids.length) {
             return Promise.resolve([]);
         }
-        return this.call(model, "name_get", [ids], { context: ctx });
+        return this.call(model, "name_get", [ids], { context });
     }
 
-    read(model, ids, fields, ctx) {
+    read(model, ids, fields, context = {}) {
         validatePrimitiveList("ids", "number", ids);
         if (fields) {
             validatePrimitiveList("fields", "string", fields);
@@ -141,84 +130,65 @@ export class ORM {
         if (!ids.length) {
             return Promise.resolve([]);
         }
-        return this.call(model, "read", [ids, fields], { context: ctx });
+        return this.call(model, "read", [ids, fields], { context });
     }
 
-    readGroup(model, domain, fields, groupby, options = {}, ctx = {}) {
+    readGroup(model, domain, fields, groupby, kwargs = {}, context = {}) {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
         validatePrimitiveList("groupby", "string", groupby);
-        const kwargs = {
-            domain,
-            groupby,
-            fields,
-            context: ctx,
-        };
-        assignOptions(kwargs, options, ["lazy", "offset", "orderby", "limit"]);
-        return this.call(model, "read_group", [], kwargs);
+        return this.call(model, "read_group", [], { ...kwargs, domain, fields, groupby, context });
     }
 
-    search(model, domain, options = {}, ctx = {}) {
+    search(model, domain, kwargs = {}, context = {}) {
         validateArray("domain", domain);
-        const kwargs = {
-            context: ctx,
-        };
-        assignOptions(kwargs, options, ["offset", "limit", "order"]);
-        return this.call(model, "search", [domain], kwargs);
+        return this.call(model, "search", [domain], { ...kwargs, context });
     }
 
-    searchRead(model, domain, fields, options = {}, ctx = {}) {
+    searchRead(model, domain, fields, kwargs = {}, context = {}) {
         validateArray("domain", domain);
         if (fields) {
             validatePrimitiveList("fields", "string", fields);
         }
-        const kwargs = { context: ctx, domain, fields };
-        assignOptions(kwargs, options, ["offset", "limit", "order"]);
-        return this.call(model, "search_read", [], kwargs);
+        return this.call(model, "search_read", [], { ...kwargs, context, domain, fields });
     }
 
-    searchCount(model, domain, ctx = {}) {
+    searchCount(model, domain, context = {}) {
         validateArray("domain", domain);
-        const kwargs = {
-            context: ctx,
-        };
-        return this.call(model, "search_count", [domain], kwargs);
+        return this.call(model, "search_count", [domain], { context });
     }
 
-    unlink(model, ids, ctx) {
+    unlink(model, ids, context) {
         validatePrimitiveList("ids", "number", ids);
         if (!ids.length) {
             return true;
         }
-        return this.call(model, "unlink", [ids], { context: ctx });
+        return this.call(model, "unlink", [ids], { context });
     }
 
-    webReadGroup(model, domain, fields, groupby, options = {}, ctx = {}) {
+    webReadGroup(model, domain, fields, groupby, kwargs = {}, context = {}) {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
         validatePrimitiveList("groupby", "string", groupby);
-        const kwargs = {
-            domain,
+        return this.call(model, "web_read_group", [], {
+            ...kwargs,
             groupby,
+            domain,
             fields,
-            context: ctx,
-        };
-        assignOptions(kwargs, options, ["lazy", "offset", "orderby", "limit", "expand"]);
-        return this.call(model, "web_read_group", [], kwargs);
+            context,
+        });
     }
 
-    webSearchRead(model, domain, fields, options = {}, ctx = {}) {
+    webSearchRead(model, domain, fields, kwargs = {}, context = {}) {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
-        const kwargs = { context: ctx, domain, fields };
-        assignOptions(kwargs, options, ["offset", "limit", "order", "count_limit"]);
-        return this.call(model, "web_search_read", [], kwargs);
+        return this.call(model, "web_search_read", [], { ...kwargs, domain, fields, context });
     }
 
-    write(model, ids, data, ctx) {
+    write(model, ids, data, context) {
         validatePrimitiveList("ids", "number", ids);
         validateObject("data", data);
-        return this.call(model, "write", [ids, data], { context: ctx });
+        return this.call(model, "write", [ids, data], { context });
     }
 }
 

--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -413,8 +413,10 @@ export class GraphModel extends Model {
                         domain.arrayRepr,
                         measures,
                         groupBy.map((gb) => gb.spec),
-                        { lazy: false }, // what is this thing???
-                        { fill_temporal: true, ...this.searchParams.context }
+                        {
+                            lazy: false, // what is this thing???
+                            context: { fill_temporal: true, ...this.searchParams.context },
+                        }
                     )
                     .then((data) => {
                         const dataPoints = [];

--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -752,7 +752,7 @@ export class PivotModel extends Model {
             this.metaData = metaData;
         } else {
             metaData.activeMeasures.push(fieldName);
-            let config = { metaData, data: this.data };
+            const config = { metaData, data: this.data };
             await this._loadData(config);
         }
         this.nextActiveMeasures = null;
@@ -955,14 +955,13 @@ export class PivotModel extends Model {
         const groupDomain = this._getGroupDomain(group, config);
         const measureSpecs = this._getMeasureSpecs(config);
         const groupBy = rowGroupBy.concat(colGroupBy);
-        const options = { lazy: false };
+        const kwargs = { lazy: false, context: this.searchParams.context };
         const subGroups = await this.orm.readGroup(
             config.metaData.resModel,
             groupDomain,
             measureSpecs,
             groupBy,
-            options,
-            this.searchParams.context
+            kwargs
         );
         return {
             group: group,

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -179,9 +179,9 @@ class RequestBatcherORM extends ORM {
      * @param {string[]} fields
      * @returns {Promise<Object[]>}
      */
-    async read(resModel, resIds, fields, context) {
+    async read(resModel, resIds, fields, kwargs, context) {
         const records = await this.batch(resIds, ["read", resModel, fields, context], (resIds) =>
-            super.read(resModel, resIds, fields, context)
+            super.read(resModel, resIds, fields, {}, context)
         );
         return records.filter((r) => resIds.includes(r.id));
     }
@@ -1202,10 +1202,16 @@ export class Record extends DataPoint {
         if (!fieldNames.length) {
             return {};
         }
-        const [serverValues] = await this.model.orm.read(this.resModel, [this.resId], fieldNames, {
-            bin_size: true,
-            ...this.context,
-        });
+        const [serverValues] = await this.model.orm.read(
+            this.resModel,
+            [this.resId],
+            fieldNames,
+            {},
+            {
+                bin_size: true,
+                ...this.context,
+            }
+        );
         return this._parseServerValues(serverValues);
     }
 
@@ -1700,7 +1706,7 @@ class DynamicList extends DataPoint {
 
         // Read the actual values set by the server and update the records
         const result = await this.model.keepLast.add(
-            this.model.orm.read(resModel, ids, [handleField], this.context)
+            this.model.orm.read(resModel, ids, [handleField], {}, this.context)
         );
         for (const recordData of result) {
             const record = records.find((r) => r.resId === recordData.id);

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1270,7 +1270,7 @@ export class Record extends DataPoint {
                 );
                 this.resId = resId;
             } else {
-                this.resId = await this.model.orm.create(this.resModel, changes, this.context);
+                this.resId = await this.model.orm.create(this.resModel, [changes], this.context);
             }
             delete this.virtualId;
             this.data.id = this.resId;

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -160,9 +160,9 @@ class RequestBatcherORM extends ORM {
      * @param {object} context
      * @returns {Promise<[number, string][]>}
      */
-    async nameGet(resModel, resIds, context) {
-        const pairs = await this.batch(resIds, ["name_get", resModel, context], (resIds) =>
-            super.nameGet(resModel, resIds, context)
+    async nameGet(resModel, resIds, kwargs) {
+        const pairs = await this.batch(resIds, ["name_get", resModel, kwargs], (resIds) =>
+            super.nameGet(resModel, resIds, kwargs)
         );
         return pairs.filter(([id]) => resIds.includes(id));
     }
@@ -179,9 +179,9 @@ class RequestBatcherORM extends ORM {
      * @param {string[]} fields
      * @returns {Promise<Object[]>}
      */
-    async read(resModel, resIds, fields, kwargs, context) {
-        const records = await this.batch(resIds, ["read", resModel, fields, context], (resIds) =>
-            super.read(resModel, resIds, fields, {}, context)
+    async read(resModel, resIds, fields, kwargs) {
+        const records = await this.batch(resIds, ["read", resModel, fields, kwargs], (resIds) =>
+            super.read(resModel, resIds, fields, kwargs)
         );
         return records.filter((r) => resIds.includes(r.id));
     }
@@ -195,9 +195,9 @@ class RequestBatcherORM extends ORM {
      * @param {number[]} resIds
      * @returns {Promise<boolean>}
      */
-    async unlink(resModel, resIds, context) {
-        return this.batch(resIds, ["unlink", resModel, context], (resIds) =>
-            super.unlink(resModel, resIds, context)
+    async unlink(resModel, resIds, kwargs) {
+        return this.batch(resIds, ["unlink", resModel, kwargs], (resIds) =>
+            super.unlink(resModel, resIds, kwargs)
         );
     }
 
@@ -1202,16 +1202,12 @@ export class Record extends DataPoint {
         if (!fieldNames.length) {
             return {};
         }
-        const [serverValues] = await this.model.orm.read(
-            this.resModel,
-            [this.resId],
-            fieldNames,
-            {},
-            {
+        const [serverValues] = await this.model.orm.read(this.resModel, [this.resId], fieldNames, {
+            context: {
                 bin_size: true,
                 ...this.context,
-            }
-        );
+            },
+        });
         return this._parseServerValues(serverValues);
     }
 
@@ -1259,6 +1255,7 @@ export class Record extends DataPoint {
         const keys = Object.keys(changes);
         const hasChanges = this.isVirtual || keys.length;
         const shouldReload = hasChanges ? !options.noReload : false;
+        const context = this.context;
 
         if (this.isVirtual) {
             if (keys.length === 1 && keys[0] === "display_name") {
@@ -1270,7 +1267,7 @@ export class Record extends DataPoint {
                 );
                 this.resId = resId;
             } else {
-                this.resId = await this.model.orm.create(this.resModel, [changes], this.context);
+                this.resId = await this.model.orm.create(this.resModel, [changes], { context });
             }
             delete this.virtualId;
             this.data.id = this.resId;
@@ -1278,7 +1275,7 @@ export class Record extends DataPoint {
             this.invalidateCache();
         } else if (keys.length > 0) {
             try {
-                await this.model.orm.write(this.resModel, [this.resId], changes, this.context);
+                await this.model.orm.write(this.resModel, [this.resId], changes, { context });
             } catch (e) {
                 if (!this.isInEdition) {
                     await Promise.all([this.model.reloadRecords(this.resId), this.load()]);
@@ -1481,14 +1478,10 @@ class DynamicList extends DataPoint {
         let resIds;
         if (isSelected) {
             if (this.isDomainSelected) {
-                resIds = await this.model.orm.search(
-                    this.resModel,
-                    this.domain,
-                    {
-                        limit: session.active_ids_limit,
-                    },
-                    this.context
-                );
+                resIds = await this.model.orm.search(this.resModel, this.domain, {
+                    limit: session.active_ids_limit,
+                    context: this.context,
+                });
             } else {
                 resIds = this.selection.map((r) => r.resId);
             }
@@ -1574,7 +1567,8 @@ class DynamicList extends DataPoint {
                 confirm: async () => {
                     const resIds = validSelection.map((r) => r.resId);
                     try {
-                        await this.model.orm.write(this.resModel, resIds, changes, this.context);
+                        const context = this.context;
+                        await this.model.orm.write(this.resModel, resIds, changes, { context });
                         this.invalidateCache();
                         validSelection.forEach((record) => {
                             record.selected = false;
@@ -1706,7 +1700,7 @@ class DynamicList extends DataPoint {
 
         // Read the actual values set by the server and update the records
         const result = await this.model.keepLast.add(
-            this.model.orm.read(resModel, ids, [handleField], {}, this.context)
+            this.model.orm.read(resModel, ids, [handleField], { context: this.context })
         );
         for (const recordData of result) {
             const record = records.find((r) => r.resId === recordData.id);
@@ -1924,18 +1918,22 @@ export class DynamicRecordList extends DynamicList {
      * @returns {Promise<Record[]>}
      */
     async _loadRecords() {
-        const options = {
+        const kwargs = {
             limit: this.limit,
             offset: this.offset,
             order: orderByToString(this.orderBy),
             count_limit: this.countLimit + 1,
+            context: {
+                bin_size: true,
+                ...this.context,
+            },
         };
         if (this.loadedCount > this.limit) {
             // This condition means that we are reloading a list of records
             // that has been manually extended: we need to load exactly the
             // same amount of records.
-            options.limit = this.loadedCount;
-            options.offset = 0;
+            kwargs.limit = this.loadedCount;
+            kwargs.offset = 0;
         }
         const { records: rawRecords, length } =
             this.data ||
@@ -1943,11 +1941,7 @@ export class DynamicRecordList extends DynamicList {
                 this.resModel,
                 this.domain,
                 this.fieldNames,
-                options,
-                {
-                    bin_size: true,
-                    ...this.context,
-                }
+                kwargs
             ));
 
         const records = await Promise.all(
@@ -2243,8 +2237,8 @@ export class DynamicGroupList extends DynamicList {
                 expand: this.expand,
                 offset: this.offset,
                 limit: this.limit,
-            },
-            this.context
+                context: this.context,
+            }
         );
         this.count = length;
 
@@ -2789,12 +2783,9 @@ export class StaticList extends DataPoint {
             }
             // 2) fetch values for non loaded records
             if (resIds.length) {
-                const result = await this.model.orm.read(
-                    this.resModel,
-                    resIds,
-                    orderFieldNames,
-                    this.context
-                );
+                const result = await this.model.orm.read(this.resModel, resIds, orderFieldNames, {
+                    context: this.context,
+                });
                 for (const values of result) {
                     const resId = values.id;
                     recordValues[resId] = {};

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -279,7 +279,7 @@ export class ExportDataDialog extends Component {
                     resource: this.props.root.resModel,
                 },
             ],
-            this.props.context
+            { context: this.props.context }
         );
         this.state.isEditingTemplate = false;
         this.state.templateId = id;
@@ -316,7 +316,7 @@ export class ExportDataDialog extends Component {
             text: this.env._t("Do you really want to delete this export template?"),
             delete: async () => {
                 const id = Number(this.state.templateId);
-                await this.orm.unlink("ir.exports", [id], this.props.context);
+                await this.orm.unlink("ir.exports", [id], { context: this.props.context });
                 this.templates.splice(
                     this.templates.findIndex((i) => i.id === id),
                     1

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -266,17 +266,19 @@ export class ExportDataDialog extends Component {
         }
         const id = await this.orm.create(
             "ir.exports",
-            {
-                name,
-                export_fields: this.state.exportList.map((field) => [
-                    0,
-                    0,
-                    {
-                        name: field.name,
-                    },
-                ]),
-                resource: this.props.root.resModel,
-            },
+            [
+                {
+                    name,
+                    export_fields: this.state.exportList.map((field) => [
+                        0,
+                        0,
+                        {
+                            name: field.name,
+                        },
+                    ]),
+                    resource: this.props.root.resModel,
+                },
+            ],
             this.props.context
         );
         this.state.isEditingTemplate = false;

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -94,7 +94,7 @@ QUnit.test("create method", async (assert) => {
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
     const env = await makeTestEnv();
-    await env.services.orm.create("partner", { color: "red" });
+    await env.services.orm.create("partner", [{ color: "red" }]);
     assert.strictEqual(query.route, "/web/dataset/call_kw/partner/create");
     assert.deepEqual(query.params, {
         args: [

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -52,7 +52,7 @@ QUnit.test("context is combined with user context in read request", async (asser
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
     const env = await makeTestEnv();
-    await env.services.orm.read("my.model", [3], ["id", "descr"], { earth: "isfucked" });
+    await env.services.orm.read("my.model", [3], ["id", "descr"], {}, { earth: "isfucked" });
     assert.strictEqual(query.route, "/web/dataset/call_kw/my.model/read");
     assert.deepEqual(query.params, {
         args: [[3], ["id", "descr"]],
@@ -131,6 +131,37 @@ QUnit.test("nameGet method", async (assert) => {
             },
         },
         method: "name_get",
+        model: "sale.order",
+    });
+});
+
+QUnit.test("read method", async (assert) => {
+    const [query, rpc] = makeFakeRPC();
+    serviceRegistry.add("rpc", rpc);
+    const env = await makeTestEnv();
+    await env.services.orm.read(
+        "sale.order",
+        [2, 5],
+        ["name", "amount"],
+        { load: "none" },
+        { abc: 3 }
+    );
+    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/read");
+    assert.deepEqual(query.params, {
+        args: [
+            [2, 5],
+            ["name", "amount"],
+        ],
+        kwargs: {
+            load: "none",
+            context: {
+                abc: 3,
+                lang: "en",
+                tz: "taht",
+                uid: 7,
+            },
+        },
+        method: "read",
         model: "sale.order",
     });
 });

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -52,7 +52,8 @@ QUnit.test("context is combined with user context in read request", async (asser
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
     const env = await makeTestEnv();
-    await env.services.orm.read("my.model", [3], ["id", "descr"], {}, { earth: "isfucked" });
+    const context = { earth: "isfucked" };
+    await env.services.orm.read("my.model", [3], ["id", "descr"], { context });
     assert.strictEqual(query.route, "/web/dataset/call_kw/my.model/read");
     assert.deepEqual(query.params, {
         args: [[3], ["id", "descr"]],
@@ -118,7 +119,8 @@ QUnit.test("nameGet method", async (assert) => {
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
     const env = await makeTestEnv();
-    await env.services.orm.nameGet("sale.order", [2, 5], { complete: true });
+    const context = { complete: true };
+    await env.services.orm.nameGet("sale.order", [2, 5], { context });
     assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/name_get");
     assert.deepEqual(query.params, {
         args: [[2, 5]],
@@ -139,13 +141,11 @@ QUnit.test("read method", async (assert) => {
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
     const env = await makeTestEnv();
-    await env.services.orm.read(
-        "sale.order",
-        [2, 5],
-        ["name", "amount"],
-        { load: "none" },
-        { abc: 3 }
-    );
+    const context = { abc: 3 };
+    await env.services.orm.read("sale.order", [2, 5], ["name", "amount"], {
+        load: "none",
+        context,
+    });
     assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/read");
     assert.deepEqual(query.params, {
         args: [

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -8278,7 +8278,7 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             `translate args ["partner",1,"foo"]`,
             `translate context {"lang":"en","uid":7,"tz":"taht"}`,
-            `search_read translations args: [] ; kwargs: {"context":{"lang":"en","uid":7,"tz":"taht"},"domain":[["res_id","=",1],["name","=","partner_type,foo"],["lang","in",["CUST","CUST2"]]],"fields":["lang","src","value"]}`,
+            `search_read translations args: [] ; kwargs: {"domain":[["res_id","=",1],["name","=","partner_type,foo"],["lang","in",["CUST","CUST2"]]],"fields":["lang","src","value"],"context":{"lang":"en","uid":7,"tz":"taht"}}`,
         ]);
 
         assert.containsOnce(target, ".modal");


### PR DESCRIPTION
This PR reworks the API of the orm service to better reflect the server-side API.
It basically does 3 things:
 1) the `create` function now takes an array of values, and thus allows to create a
     batch of records instead of a single record ;
 2) all functions now take a `kwargs` argument, and the `context` argument has
     been removed (it has to be given inside the `kwargs`) ;
 3) the `kwargs` propagated to the server are no longer whitelisted, which allows
     calls to overridden methods with extra kwargs.