### PR TITLE
[FIX] im_livechat: make bubble background behind message content

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.scss
+++ b/addons/im_livechat/static/src/legacy/public_livechat.scss
@@ -687,6 +687,7 @@ $o-mail-thread-window-zindex: $zindex-modal + 1 !default;
 
 .o_PublicLivechatMessage_background {
     position: absolute;
+    z-index: -1;
     left: 0;
     top: 0;
     width: 100%;


### PR DESCRIPTION
Before this commit, bubble background was on top of message content.
This prevent user interaction on the message.
This commit fixes the issue by properly putting background behind text.
