### PR TITLE
[FIX] im_livechat: properly display operator avatar in posted message

### DIFF
--- a/addons/im_livechat/static/src/legacy/models/public_livechat_message.js
+++ b/addons/im_livechat/static/src/legacy/models/public_livechat_message.js
@@ -41,7 +41,7 @@ const PublicLivechatMessage = Class.extend({
         this._type = data.message_type || undefined;
 
         this._defaultUsername = this.messaging.publicLivechatGlobal.options.default_username;
-        this._serverURL = this.messaging.publicLivechatGlobal.livechatButtonView.serverUrl;
+        this._serverURL = this.messaging.publicLivechatGlobal.serverUrl;
 
         if (parent.messaging.publicLivechatGlobal.livechatButtonView.isChatbot) {
             this._chatbotStepId = data.chatbot_script_step_id;


### PR DESCRIPTION
Before this commit, avatar of operator was not displayed properly.
This is due to src of avatar being wrongly computed: the serverUrl
data is in `PublicLivechatGlobal`, not in `LivechatButtonView`.

Because of this, the src was prefixed with `undefined/` instead
of the server url, hence no displaying the avatar of operator.

This commit fixes issue by getting actual `serverUrl` in correct
model `PublicLivechatGlobal`.
