### PR TITLE
[FIX] im_livechat: restore fold feature in public livechat

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.scss
+++ b/addons/im_livechat/static/src/legacy/public_livechat.scss
@@ -83,6 +83,7 @@ $o-mail-thread-window-zindex: $zindex-modal + 1 !default;
         .o_thread_window_title {
             cursor: pointer;
             flex: 1 1 auto;
+            height: 100%;
             @include o-text-overflow;
 
             .o_mail_thread_typing_icon {


### PR DESCRIPTION
Before this commit, folding chat window in public livechat
was not working.

This is because the title of chat window was 0px of height,
so it was impossible to click on it.

This commit fixes the issue by letting title take as much vertical
area as it is available in the header, so that the header
except buttons is clickable to fold the chat window.

Task-2964331
