### PR TITLE
[IMP] payment_(alipay,ogone,payumoney,payulatam): deprecate the modules

### DIFF
--- a/addons/payment/data/payment_acquirer_data.xml
+++ b/addons/payment/data/payment_acquirer_data.xml
@@ -20,22 +20,6 @@
                ])]"/>
     </record>
 
-    <record id="payment_acquirer_alipay" model="payment.acquirer">
-        <field name="name">Alipay</field>
-        <field name="display_as">Credit Card (powered by Alipay)</field>
-        <field name="image_128" type="base64" file="payment_alipay/static/description/icon.png"/>
-        <field name="module_id" ref="base.module_payment_alipay"/>
-        <!-- https://intl.alipay.com/ihome/home/about/buy.htm?topic=paymentMethods -->
-        <field name="payment_icon_ids"
-               eval="[(6, 0, [
-                   ref('payment.payment_icon_cc_jcb'),
-                   ref('payment.payment_icon_cc_mastercard'),
-                   ref('payment.payment_icon_cc_western_union'),
-                   ref('payment.payment_icon_cc_webmoney'),
-                   ref('payment.payment_icon_cc_visa'),
-               ])]"/>
-    </record>
-
     <record id="payment_acquirer_aps" model="payment.acquirer">
         <field name="name">Amazon Payment Services</field>
         <field name="display_as">Amazon Payment Services</field>
@@ -164,23 +148,6 @@
 
     </record>
 
-    <record id="payment_acquirer_ogone" model="payment.acquirer">
-        <field name="name">Ogone</field>
-        <field name="display_as">Credit Card (powered by Ogone)</field>
-        <field name="image_128"
-               type="base64"
-               file="payment_ogone/static/description/icon.png"/>
-        <field name="module_id" ref="base.module_payment_ogone"/>
-        <field name="payment_icon_ids"
-               eval="[(6, 0, [
-                   ref('payment.payment_icon_cc_ideal'),
-                   ref('payment.payment_icon_cc_bancontact'),
-                   ref('payment.payment_icon_cc_maestro'),
-                   ref('payment.payment_icon_cc_mastercard'),
-                   ref('payment.payment_icon_cc_visa'),
-               ])]"/>
-    </record>
-
     <record id="payment_acquirer_paypal" model="payment.acquirer">
         <field name="name">PayPal</field>
         <field name="image_128" type="base64" file="payment_paypal/static/description/icon.png"/>
@@ -195,42 +162,6 @@
                    ref('payment.payment_icon_cc_jcb'),
                    ref('payment.payment_icon_cc_american_express'),
                    ref('payment.payment_icon_cc_unionpay'),
-                   ref('payment.payment_icon_cc_visa'),
-               ])]"/>
-    </record>
-
-    <record id="payment_acquirer_payulatam" model="payment.acquirer">
-        <field name="name">PayU Latam</field>
-        <field name="display_as">Credit Card (powered by PayU Latam)</field>
-        <field name="image_128"
-               type="base64"
-               file="payment_payulatam/static/description/icon.png"/>
-        <field name="module_id" ref="base.module_payment_payulatam"/>
-        <!-- https://www.payulatam.com/medios-de-pago/ -->
-        <field name="payment_icon_ids"
-               eval="[(6, 0, [
-                   ref('payment.payment_icon_cc_diners_club_intl'),
-                   ref('payment.payment_icon_cc_mastercard'),
-                   ref('payment.payment_icon_cc_american_express'),
-                   ref('payment.payment_icon_cc_visa'),
-                   ref('payment.payment_icon_cc_codensa_easy_credit'),
-               ])]"/>
-    </record>
-
-    <record id="payment_acquirer_payumoney" model="payment.acquirer">
-        <field name="name">PayUmoney</field>
-        <field name="display_as">Credit Card (powered by PayUmoney)</field>
-        <field name="image_128"
-               type="base64"
-               file="payment_payumoney/static/description/icon.png"/>
-        <field name="module_id" ref="base.module_payment_payumoney"/>
-        <!-- See https://www.payumoney.com/selfcare.html?userType=seller
-             > Banks & Cards > What options do you have in the Credit Card payment? -->
-        <field name="payment_icon_ids"
-               eval="[(6, 0, [
-                   ref('payment.payment_icon_cc_maestro'),
-                   ref('payment.payment_icon_cc_mastercard'),
-                   ref('payment.payment_icon_cc_american_express'),
                    ref('payment.payment_icon_cc_visa'),
                ])]"/>
     </record>

--- a/addons/payment/views/payment_acquirer_views.xml
+++ b/addons/payment/views/payment_acquirer_views.xml
@@ -58,7 +58,7 @@
                             <button attrs="{'invisible': [('module_to_buy', '=', True)]}" type="object" class="btn btn-primary" name="button_immediate_install" string="Install"/>
                         </div>
                     </div>
-                    <div attrs="{'invisible': [('id', '!=', False)]}" class="alert alert-warning" role="alert">
+                    <div id="provider_creation_warning" attrs="{'invisible': [('id', '!=', False)]}" class="alert alert-warning" role="alert">
                         <strong>Warning</strong> Creating a payment acquirer from the <em>CREATE</em> button is not supported.
                         Please use the <em>Duplicate</em> action instead.
                     </div>

--- a/addons/payment_alipay/__init__.py
+++ b/addons/payment_alipay/__init__.py
@@ -3,8 +3,18 @@
 from . import controllers
 from . import models
 
+from odoo.exceptions import UserError
+from odoo.tools import config
+
 from odoo.addons.payment import reset_payment_acquirer
 
 
 def uninstall_hook(cr, registry):
     reset_payment_acquirer(cr, registry, 'alipay')
+
+
+def pre_init_hook(cr):
+    if not any(config.get(key) for key in ('init', 'update')):
+        raise UserError(
+            "This module is deprecated and cannot be installed. "
+            "Consider installing the Payment Acquirer: AsiaPay module instead.")

--- a/addons/payment_alipay/__manifest__.py
+++ b/addons/payment_alipay/__manifest__.py
@@ -5,15 +5,15 @@
     'category': 'Accounting/Payment Acquirers',
     'version': '2.0',
     'sequence': 345,
-    'summary': 'Payment Acquirer: Alipay Implementation',
-    'description': """Alipay Payment Acquirer""",
+    'summary': "This module is deprecated.",
     'depends': ['payment'],
     'data': [
         'views/payment_alipay_templates.xml',
         'views/payment_views.xml',
         'data/payment_acquirer_data.xml',
     ],
-    'application': True,
+    'application': False,
+    'pre_init_hook': 'pre_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/payment_alipay/data/payment_acquirer_data.xml
+++ b/addons/payment_alipay/data/payment_acquirer_data.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <record id="payment.payment_acquirer_alipay" model="payment.acquirer">
+    <record id="payment_acquirer_alipay" model="payment.acquirer">
+        <field name="name">Alipay</field>
+        <field name="display_as">Credit Card (powered by Alipay)</field>
+        <field name="image_128" type="base64" file="payment_alipay/static/description/icon.png"/>
+        <field name="module_id" ref="base.module_payment_alipay"/>
+        <!-- https://intl.alipay.com/ihome/home/about/buy.htm?topic=paymentMethods -->
+        <field name="payment_icon_ids"
+               eval="[(6, 0, [
+                   ref('payment.payment_icon_cc_jcb'),
+                   ref('payment.payment_icon_cc_mastercard'),
+                   ref('payment.payment_icon_cc_western_union'),
+                   ref('payment.payment_icon_cc_webmoney'),
+                   ref('payment.payment_icon_cc_visa'),
+               ])]"/>
         <field name="provider">alipay</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
     </record>

--- a/addons/payment_alipay/views/payment_views.xml
+++ b/addons/payment_alipay/views/payment_views.xml
@@ -6,7 +6,15 @@
         <field name="model">payment.acquirer</field>
         <field name="inherit_id" ref="payment.payment_acquirer_form"/>
         <field name="arch" type="xml">
-            <xpath expr='//group[@name="acquirer"]' position='inside'>
+            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+                <div class="alert alert-danger"
+                     role="alert"
+                     attrs="{'invisible': [('provider', '!=', 'alipay')]}">
+                    This provider is deprecated.
+                    Consider disabling it and moving to <strong>Asiapay</strong>.
+                </div>
+            </xpath>
+            <group name="acquirer" position="inside">
                 <group attrs="{'invisible': [('provider', '!=', 'alipay')]}">
                     <field name="alipay_payment_method" widget="radio"/>
                     <field name="alipay_seller_email"
@@ -14,7 +22,7 @@
                     <field name="alipay_merchant_partner_id"/>
                     <field name="alipay_md5_signature_key" password="True"/>
                 </group>
-            </xpath>
+            </group>
         </field>
     </record>
 

--- a/addons/payment_ogone/__init__.py
+++ b/addons/payment_ogone/__init__.py
@@ -3,8 +3,18 @@
 from . import controllers
 from . import models
 
+from odoo.exceptions import UserError
+from odoo.tools import config
+
 from odoo.addons.payment import reset_payment_acquirer
 
 
 def uninstall_hook(cr, registry):
     reset_payment_acquirer(cr, registry, 'ogone')
+
+
+def pre_init_hook(cr):
+    if not any(config.get(key) for key in ('init', 'update')):
+        raise UserError(
+            "This module is deprecated and cannot be installed. "
+            "Consider installing the Payment Acquirer: Stripe module instead.")

--- a/addons/payment_ogone/__manifest__.py
+++ b/addons/payment_ogone/__manifest__.py
@@ -5,15 +5,15 @@
     'version': '2.0',
     'category': 'Accounting/Payment Acquirers',
     'sequence': 370,
-    'summary': 'Payment Acquirer: Ogone Implementation',
-    'description': """Ogone Payment Acquirer""",
+    'summary': "This module is deprecated.",
     'depends': ['payment'],
     'data': [
         'views/payment_views.xml',
         'views/payment_ogone_templates.xml',
         'data/payment_acquirer_data.xml',
     ],
-    'application': True,
+    'application': False,
+    'pre_init_hook': 'pre_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/payment_ogone/data/payment_acquirer_data.xml
+++ b/addons/payment_ogone/data/payment_acquirer_data.xml
@@ -1,7 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <record id="payment.payment_acquirer_ogone" model="payment.acquirer">
+    <record id="payment_acquirer_ogone" model="payment.acquirer">
+        <field name="name">Ogone</field>
+        <field name="display_as">Credit Card (powered by Ogone)</field>
+        <field name="image_128"
+               type="base64"
+               file="payment_ogone/static/description/icon.png"/>
+        <field name="module_id" ref="base.module_payment_ogone"/>
+        <field name="payment_icon_ids"
+               eval="[(6, 0, [
+                   ref('payment.payment_icon_cc_ideal'),
+                   ref('payment.payment_icon_cc_bancontact'),
+                   ref('payment.payment_icon_cc_maestro'),
+                   ref('payment.payment_icon_cc_mastercard'),
+                   ref('payment.payment_icon_cc_visa'),
+               ])]"/>
         <field name="provider">ogone</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="allow_tokenization">True</field>

--- a/addons/payment_ogone/views/payment_views.xml
+++ b/addons/payment_ogone/views/payment_views.xml
@@ -6,7 +6,15 @@
         <field name="model">payment.acquirer</field>
         <field name="inherit_id" ref="payment.payment_acquirer_form"/>
         <field name="arch" type="xml">
-            <xpath expr='//group[@name="acquirer"]' position='inside'>
+            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+                <div class="alert alert-danger"
+                     role="alert"
+                     attrs="{'invisible': [('provider', '!=', 'ogone')]}">
+                    This provider is deprecated.
+                    Consider disabling it and moving to <strong>Stripe</strong>.
+                </div>
+            </xpath>
+            <group name="acquirer" position="inside">
                 <group attrs="{'invisible': [('provider', '!=', 'ogone')]}">
                     <field name="ogone_pspid" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
                     <field name="ogone_userid" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}"/>
@@ -15,7 +23,7 @@
                     <field name="ogone_shakey_out" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}" password="True"/>
                     <field name="ogone_hash_function" attrs="{'required':[('provider', '=', 'ogone'), ('state', '!=', 'disabled')]}" groups="base.group_no_one"/>
                 </group>
-            </xpath>
+            </group>
         </field>
     </record>
 

--- a/addons/payment_payulatam/__init__.py
+++ b/addons/payment_payulatam/__init__.py
@@ -3,8 +3,18 @@
 from . import controllers
 from . import models
 
+from odoo.exceptions import UserError
+from odoo.tools import config
+
 from odoo.addons.payment import reset_payment_acquirer
 
 
 def uninstall_hook(cr, registry):
     reset_payment_acquirer(cr, registry, 'payulatam')
+
+
+def pre_init_hook(cr):
+    if not any(config.get(key) for key in ('init', 'update')):
+        raise UserError(
+            "This module is deprecated and cannot be installed. "
+            "Consider installing the Payment Acquirer: Mercado Pago module instead.")

--- a/addons/payment_payulatam/__manifest__.py
+++ b/addons/payment_payulatam/__manifest__.py
@@ -5,15 +5,15 @@
     'version': '2.0',
     'category': 'Accounting/Payment Acquirers',
     'sequence': 380,
-    'summary': 'Payment Acquirer: PayuLatam Implementation',
-    'description': """Payulatam payment acquirer""",
+    'summary': "This module is deprecated.",
     'depends': ['payment'],
     'data': [
         'views/payment_views.xml',
         'views/payment_payulatam_templates.xml',
         'data/payment_acquirer_data.xml',
     ],
-    'application': True,
+    'application': False,
+    'pre_init_hook': 'pre_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/payment_payulatam/data/payment_acquirer_data.xml
+++ b/addons/payment_payulatam/data/payment_acquirer_data.xml
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <record id="payment.payment_acquirer_payulatam" model="payment.acquirer">
+    <record id="payment_acquirer_payulatam" model="payment.acquirer">
+        <field name="name">PayU Latam</field>
+        <field name="display_as">Credit Card (powered by PayU Latam)</field>
+        <field name="image_128"
+               type="base64"
+               file="payment_payulatam/static/description/icon.png"/>
+        <field name="module_id" ref="base.module_payment_payulatam"/>
+        <!-- https://www.payulatam.com/medios-de-pago/ -->
+        <field name="payment_icon_ids"
+               eval="[(6, 0, [
+                   ref('payment.payment_icon_cc_diners_club_intl'),
+                   ref('payment.payment_icon_cc_mastercard'),
+                   ref('payment.payment_icon_cc_american_express'),
+                   ref('payment.payment_icon_cc_visa'),
+                   ref('payment.payment_icon_cc_codensa_easy_credit'),
+               ])]"/>
         <field name="provider">payulatam</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
     </record>

--- a/addons/payment_payulatam/views/payment_views.xml
+++ b/addons/payment_payulatam/views/payment_views.xml
@@ -6,7 +6,15 @@
         <field name="model">payment.acquirer</field>
         <field name="inherit_id" ref="payment.payment_acquirer_form"/>
         <field name="arch" type="xml">
-            <xpath expr='//group[@name="acquirer"]' position='inside'>
+            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+                <div class="alert alert-danger"
+                     role="alert"
+                     attrs="{'invisible': [('provider', '!=', 'payulatam')]}">
+                    This provider is deprecated.
+                    Consider disabling it and moving to <strong>Mercado Pago</strong>.
+                </div>
+            </xpath>
+            <group name="acquirer" position="inside">
                 <group attrs="{'invisible': [('provider', '!=', 'payulatam')]}">
                     <field name="payulatam_merchant_id"
                            attrs="{'required':[('provider', '=', 'payulatam'), ('state', '!=', 'disabled')]}"/>
@@ -16,7 +24,7 @@
                            attrs="{'required':[('provider', '=', 'payulatam'), ('state', '!=', 'disabled')]}"
                            password="True"/>
                 </group>
-            </xpath>
+            </group>
         </field>
     </record>
 

--- a/addons/payment_payumoney/__init__.py
+++ b/addons/payment_payumoney/__init__.py
@@ -3,8 +3,18 @@
 from . import controllers
 from . import models
 
+from odoo.exceptions import UserError
+from odoo.tools import config
+
 from odoo.addons.payment import reset_payment_acquirer
 
 
 def uninstall_hook(cr, registry):
     reset_payment_acquirer(cr, registry, 'payumoney')
+
+
+def pre_init_hook(cr):
+    if not any(config.get(key) for key in ('init', 'update')):
+        raise UserError(
+            "This module is deprecated and cannot be installed. "
+            "Consider installing the Payment Acquirer: Razorpay module instead.")

--- a/addons/payment_payumoney/__manifest__.py
+++ b/addons/payment_payumoney/__manifest__.py
@@ -5,19 +5,15 @@
     'version': '2.0',
     'category': 'Accounting/Payment Acquirers',
     'sequence': 385,
-    'summary': 'Payment Acquirer: PayuMoney Implementation',
-    'description': """
-PayuMoney Payment Acquirer for India.
-
-PayUmoney payment gateway supports only INR currency.
-""",
+    'summary': "This module is deprecated.",
     'depends': ['payment'],
     'data': [
         'views/payment_views.xml',
         'views/payment_payumoney_templates.xml',
         'data/payment_acquirer_data.xml',
     ],
-    'application': True,
+    'application': False,
+    'pre_init_hook': 'pre_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/payment_payumoney/data/payment_acquirer_data.xml
+++ b/addons/payment_payumoney/data/payment_acquirer_data.xml
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <record id="payment.payment_acquirer_payumoney" model="payment.acquirer">
+    <record id="payment_acquirer_payumoney" model="payment.acquirer">
+        <field name="name">PayUmoney</field>
+        <field name="display_as">Credit Card (powered by PayUmoney)</field>
+        <field name="image_128"
+               type="base64"
+               file="payment_payumoney/static/description/icon.png"/>
+        <field name="module_id" ref="base.module_payment_payumoney"/>
+        <!-- See https://www.payumoney.com/selfcare.html?userType=seller
+             > Banks & Cards > What options do you have in the Credit Card payment? -->
+        <field name="payment_icon_ids"
+               eval="[(6, 0, [
+                   ref('payment.payment_icon_cc_maestro'),
+                   ref('payment.payment_icon_cc_mastercard'),
+                   ref('payment.payment_icon_cc_american_express'),
+                   ref('payment.payment_icon_cc_visa'),
+               ])]"/>
         <field name="provider">payumoney</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
     </record>

--- a/addons/payment_payumoney/views/payment_views.xml
+++ b/addons/payment_payumoney/views/payment_views.xml
@@ -6,12 +6,20 @@
         <field name="model">payment.acquirer</field>
         <field name="inherit_id" ref="payment.payment_acquirer_form"/>
         <field name="arch" type="xml">
-            <xpath expr='//group[@name="acquirer"]' position='inside'>
+            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+                <div class="alert alert-danger"
+                     role="alert"
+                     attrs="{'invisible': [('provider', '!=', 'payumoney')]}">
+                    This provider is deprecated.
+                    Consider disabling it and moving to <strong>Razorpay</strong>.
+                </div>
+            </xpath>
+            <group name="acquirer" position="inside">
                 <group attrs="{'invisible': [('provider', '!=', 'payumoney')]}">
                     <field name="payumoney_merchant_key" attrs="{'required':[ ('provider', '=', 'payumoney'), ('state', '!=', 'disabled')]}"/>
                     <field name="payumoney_merchant_salt" attrs="{'required':[ ('provider', '=', 'payumoney'), ('state', '!=', 'disabled')]}" password="True"/>
                 </group>
-            </xpath>
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
The four payment acquirers implemented with these modules all present
a subset of the following issues:
- The user experience for the payment step is really bad: All of them.
- The API is poorly documented, breaks often, or is badly designed and
  hard to work with: All of them.
- It is no longer possible to open a new account: PayULatam, PayU money.
- The countries/payment methods/currencies coverage is limited: Alipay,
  PayU money.
- It is not possible to implement additional features such as
  tokenization, manual capture, or refunds: Alipay, PayULatam,
  PayU money.
- They have a better replacement already available in Odoo: All of them.

This commit thus deprecates the above-mentioned payment acquirers. This
means that their module can no longer be installed on new databases and
alternatives are suggested. Existing databases in which the modules were
already installed will keep working.

task-2806832

See also:
- https://github.com/odoo/documentation/pull/2686
- https://github.com/odoo/upgrade/pull/3848