### PR TITLE
[FIX] im_livechat: display conversation name in title of chat window

### DIFF
--- a/addons/im_livechat/static/src/legacy/widgets/public_livechat_window/public_livechat_window.xml
+++ b/addons/im_livechat/static/src/legacy/widgets/public_livechat_window/public_livechat_window.xml
@@ -32,7 +32,7 @@
             <a href="#" class="o_thread_window_close fa fa-1x fa-arrow-left" aria-label="Close chat window" title="Close chat window"/>
         </span>
         <span class="o_thread_window_title">
-            <t t-esc="widget.messaging.publicLivechatGlobal.publicLivechat.title"/>
+            <t t-esc="widget.messaging.publicLivechatGlobal.publicLivechat.name"/>
             <span t-if="widget.messaging.publicLivechatGlobal.publicLivechat.unreadCounter"> (<t t-esc="widget.messaging.publicLivechatGlobal.publicLivechat.unreadCounter"/>)</span>
             <t t-if="widget.messaging.publicLivechatGlobal.publicLivechat.widget.isSomeoneTyping()" t-call="im_livechat.legacy.mail.ThreadTypingIcon"/>
         </span>


### PR DESCRIPTION
Before this commit, the title of public livechat window was blank.

This come from title relying on `PublicLivechat/title`, but it's
never defined as this field does not exist. There's actually
a `PublicLivechat/name`, which is most certainly the field
that contains the intended value to display.

This commit fixes the issue by replacing all `PublicLivechat/title`
usages to `PublicLivechat/name` instead.

Task-2964330
