### PR TITLE
[IMP] stock: Auto-distribution of quantity_done among move lines in transfer

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -346,7 +346,7 @@ class StockMove(models.Model):
 
         self.env['stock.move'].browse(moves_ids_to_unlink).sudo().unlink()
         if phantom_moves_vals_list:
-            phantom_moves = self.env['stock.move'].create(phantom_moves_vals_list)
+            phantom_moves = self.env['stock.move'].with_context(from_mrp=True).create(phantom_moves_vals_list)
             phantom_moves._adjust_procure_method()
             moves_ids_to_return |= phantom_moves.action_explode().ids
         return self.env['stock.move'].browse(moves_ids_to_return)

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -306,21 +306,12 @@ class TestKitPicking(common.TestMrpCommon):
             'picking_type_id': self.env.ref('stock.picking_type_in').id,
             'immediate_transfer': True
         })
-        move_receipt_1 = self.env['stock.move'].create({
-            'name': self.kit_parent.name,
-            'product_id': self.kit_parent.id,
-            'quantity_done': 3,
-            'product_uom': self.kit_parent.uom_id.id,
-            'picking_id': picking.id,
-            'picking_type_id': self.env.ref('stock.picking_type_in').id,
-            'location_id':  self.test_supplier.id,
-            'location_dest_id': self.warehouse_1.wh_input_stock_loc_id.id,
-        })
-
-        self.env['stock.move.line'].create(dict(move_receipt_1._prepare_move_line_vals(), qty_done=3))
-
+        picking = Form(picking)
+        with picking.move_ids_without_package.new() as move:
+            move.product_id = self.kit_parent
+            move.quantity_done = 3
+        picking = picking.save()
         picking.button_validate()
-
         # We check that the picking has the correct quantities after its move were splitted.
         self.assertEqual(len(picking.move_ids), 7)
         for move_line in picking.move_ids:

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -316,6 +316,9 @@ class TestKitPicking(common.TestMrpCommon):
             'location_id':  self.test_supplier.id,
             'location_dest_id': self.warehouse_1.wh_input_stock_loc_id.id,
         })
+
+        self.env['stock.move.line'].create(dict(move_receipt_1._prepare_move_line_vals(), qty_done=3))
+
         picking.button_validate()
 
         # We check that the picking has the correct quantities after its move were splitted.

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -592,6 +592,8 @@ class TestUnbuild(TestMrpCommon):
         # Transfer it
         for ml in picking.move_ids_without_package:
             ml.quantity_done = 1
+            # NTR Remove this after merge auto-distribute done_qty
+            ml.move_line_ids.qty_done = 1
         picking._action_done()
 
         # Check the available quantity of components and final product in stock

--- a/addons/mrp_subcontracting/views/stock_picking_views.xml
+++ b/addons/mrp_subcontracting/views/stock_picking_views.xml
@@ -10,7 +10,7 @@
                 <button name="action_record_components" class="oe_highlight" attrs="{'invisible': [('display_action_record_components', '!=', 'mandatory')]}" string="Record components" type="object" data-hotkey="shift+x"/>
                 <button name="action_record_components" attrs="{'invisible': [('display_action_record_components', '!=', 'facultative')]}" string="Record components" type="object" data-hotkey="shift+x"/>
             </xpath>
-            <xpath expr="//field[@name='move_ids_without_package']//tree//button[@name='action_show_details']" position="after">
+            <xpath expr="//field[@name='move_ids_without_package']//tree//button[@name='action_assign_serial']" position="after">
                 <field name="show_subcontracting_details_visible" invisible="1"/>
                 <button name="action_show_subcontract_details" string="Register components for subcontracted product" type="object" icon="fa-sitemap"
                     width="0.1" attrs="{'invisible': [('show_subcontracting_details_visible', '=', False)]}"/>

--- a/addons/sale_stock/tests/test_sale_stock_report.py
+++ b/addons/sale_stock/tests/test_sale_stock_report.py
@@ -143,6 +143,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         picking = so.picking_ids
         picking.move_ids.quantity_done = 5
+        # NTR Remove this after merge auto-distribute done_qty
+        picking.move_ids.move_line_ids.qty_done = 5
         picking.button_validate()
 
         invoice = so._create_invoices()
@@ -182,6 +184,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         picking = so.picking_ids
         picking.move_ids.quantity_done = 4
+        # NTR Remove this after merge auto-distribute done_qty
+        picking.move_ids.move_line_ids.qty_done = 4
         picking.button_validate()
 
         html = self.env['ir.actions.report']._render_qweb_html(
@@ -292,6 +296,8 @@ class TestSaleStockInvoices(TestSaleCommon):
         # Deliver 10 x LOT0001
         delivery01 = so.picking_ids
         delivery01.move_ids.quantity_done = 10
+        # NTR Remove this after merge auto-distribute done_qty
+        delivery01.move_ids.move_line_ids.qty_done = 10
         delivery01.button_validate()
         self.assertEqual(delivery01.move_line_ids.lot_id.name, 'LOT0001')
 

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -112,6 +112,7 @@
             'stock/static/src/**/*.xml',
             'stock/static/src/scss/forecast_widget.scss',
             'stock/static/src/scss/stock_empty_screen.scss',
+            'stock/static/src/scss/stock_move_list_renderer.scss',
             'stock/static/src/views/**/*',
         ],
         'web.assets_frontend': [

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -156,7 +156,11 @@ class StockMove(models.Model):
         check_company=True)
     warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse', help="the warehouse to consider for the route selection on the next procurement (if any).")
     has_tracking = fields.Selection(related='product_id.tracking', string='Product with Tracking')
-    quantity_done = fields.Float('Quantity Done', compute='_quantity_done_compute', digits='Product Unit of Measure', inverse='_quantity_done_set')
+    quantity_done = fields.Float('Quantity Done', compute='_quantity_done_compute', digits='Product Unit of Measure', inverse='_quantity_done_set', store=True)
+    is_quantity_done_computed = fields.Boolean('Done Field Need Compute', store=True, default=True,
+        help="The quantity done field is semi-computable, when the quantity done is edited, the done field should keep the value hence set this field to False."
+            "When the fields that quantity_done depends on to compute changes (e.g. move_line_ids(.qty_done)), the quantity done should be computed"
+            "again to keep the consistency.")
     show_operations = fields.Boolean(related='picking_id.picking_type_id.show_operations')
     picking_code = fields.Selection(related='picking_id.picking_type_id.code', readonly=True)
     show_details_visible = fields.Boolean('Details Visible', compute='_compute_show_details_visible')
@@ -182,6 +186,10 @@ class StockMove(models.Model):
         help="Computes when a move should be reserved")
     product_packaging_id = fields.Many2one('product.packaging', 'Packaging', domain="[('product_id', '=', product_id)]", check_company=True)
     from_immediate_transfer = fields.Boolean(related="picking_id.immediate_transfer")
+    is_action_show_details_danger = fields.Boolean(compute='_compute_is_action_show_details_danger')
+
+    def is_multi_location(self):
+        return self.user_has_groups('stock.group_stock_multi_locations')
 
     @api.depends('product_id')
     def _compute_product_uom(self):
@@ -270,11 +278,7 @@ class StockMove(models.Model):
         for move in self:
             if not move.product_id:
                 move.is_quantity_done_editable = False
-            elif not move.picking_id.immediate_transfer and move.picking_id.state == 'draft':
-                move.is_quantity_done_editable = False
-            elif move.picking_id.is_locked and move.state in ('done', 'cancel'):
-                move.is_quantity_done_editable = False
-            elif move.show_details_visible:
+            elif move.state in ('done', 'cancel') and (move.picking_id.is_locked or move.show_details_visible or move.show_operations):
                 move.is_quantity_done_editable = False
             elif move.show_operations:
                 move.is_quantity_done_editable = False
@@ -318,7 +322,7 @@ class StockMove(models.Model):
             else:
                 move.delay_alert_date = False
 
-    @api.depends('move_line_ids.qty_done', 'move_line_ids.product_uom_id', 'move_line_nosuggest_ids.qty_done', 'picking_type_id.show_reserved')
+    @api.depends('move_line_ids.qty_done', 'move_line_ids.product_uom_id', 'move_line_nosuggest_ids.qty_done', 'picking_type_id.show_reserved', 'is_quantity_done_computed')
     def _quantity_done_compute(self):
         """ This field represents the sum of the move lines `qty_done`. It allows the user to know
         if there is still work to do.
@@ -336,10 +340,16 @@ class StockMove(models.Model):
                     quantity_done += move_line.product_uom_id._compute_quantity(
                         move_line.qty_done, move.product_uom, round=False)
                 move.quantity_done = quantity_done
+                move.is_quantity_done_computed = True
+
+            moves = self.env['stock.move'].browse([m._origin.id for m in self])
+            for move in moves:
+                move.is_quantity_done_computed = True
         else:
             # compute
             move_lines_ids = set()
-            for move in self:
+            moves = self.filtered(lambda m: m.is_quantity_done_computed)
+            for move in moves:
                 move_lines_ids |= set(move._get_move_lines().ids)
 
             data = self.env['stock.move.line']._read_group(
@@ -352,27 +362,34 @@ class StockMove(models.Model):
             for d in data:
                 rec[d['move_id'][0]] += [(d['product_uom_id'][0], d['qty_done'])]
 
-            for move in self:
+            for move in moves:
                 uom = move.product_uom
                 move.quantity_done = sum(
                     self.env['uom.uom'].browse(line_uom_id)._compute_quantity(qty, uom, round=False)
                      for line_uom_id, qty in rec.get(move.ids[0] if move.ids else move.id, [])
                 )
 
+    def _get_qty_done_mls(self):
+        return sum([ml.product_uom_id._compute_quantity(ml.qty_done, self.product_uom, round=False) for ml in self._get_move_lines()])
+
     def _quantity_done_set(self):
         quantity_done = self[0].quantity_done  # any call to create will invalidate `move.quantity_done`
         for move in self:
-            move_lines = move._get_move_lines()
-            if not move_lines:
-                if quantity_done:
-                    # do not impact reservation here
-                    move_line = self.env['stock.move.line'].create(dict(move._prepare_move_line_vals(), qty_done=quantity_done))
-                    move.write({'move_line_ids': [(4, move_line.id)]})
-                    move_line._apply_putaway_strategy()
-            elif len(move_lines) == 1:
-                move_lines[0].qty_done = quantity_done
-            else:
-                move._multi_line_quantity_done_set(quantity_done)
+            quantity_done = move.quantity_done
+            from_mrp = self.env.context.get('from_mrp')
+            if not move.picking_id or from_mrp or not ((move.has_tracking != 'none' or move.is_multi_location()) and not move.scrapped):
+                move_lines = move._get_move_lines()
+                if not move_lines:
+                    if quantity_done:
+                        # do not impact reservation here
+                        move_line = self.env['stock.move.line'].create(dict(move._prepare_move_line_vals(), qty_done=quantity_done))
+                        move.write({'move_line_ids': [(4, move_line.id)]})
+                        move_line._apply_putaway_strategy()
+                elif len(move_lines) == 1:
+                    move_lines[0].qty_done = quantity_done
+                else:
+                    move._multi_line_quantity_done_set(quantity_done)
+            move.is_quantity_done_computed = move._get_qty_done_mls() == move.quantity_done
 
     def _multi_line_quantity_done_set(self, quantity_done):
         move_lines = self._get_move_lines()
@@ -500,6 +517,13 @@ class StockMove(models.Model):
                     move_update.date_deadline -= delta
                 else:
                     move_update.date_deadline = new_deadline
+
+    @api.depends('move_line_ids.qty_done', 'move_line_ids.product_uom_id', 'move_line_nosuggest_ids.qty_done', 'picking_type_id.show_reserved', 'quantity_done', 'product_uom')
+    def _compute_is_action_show_details_danger(self):
+        self.is_action_show_details_danger = False
+        for move in self:
+            if move.product_uom:
+                move.is_action_show_details_danger = float_compare(move.quantity_done, move._get_qty_done_mls(), precision_rounding=move.product_uom.rounding) != 0
 
     @api.depends('move_line_ids', 'move_line_ids.lot_id', 'move_line_ids.qty_done')
     def _compute_lot_ids(self):
@@ -715,6 +739,8 @@ class StockMove(models.Model):
         else:
             move_lines = self.move_line_nosuggest_ids
         move_lines.unlink()
+        self.is_quantity_done_computed = True
+        self._quantity_done_compute()
         return self.action_show_details()
 
     def action_assign_serial(self):
@@ -782,7 +808,7 @@ class StockMove(models.Model):
         self.ensure_one()
         lot_names = self.env['stock.lot'].generate_lot_names(self.next_serial, next_serial_count or self.next_serial_count)
         move_lines_commands = self._generate_serial_move_line_commands(lot_names)
-        self.write({'move_line_ids': move_lines_commands})
+        self.write({'move_line_ids': move_lines_commands, 'is_quantity_done_computed': True})
         return True
 
     def _push_apply(self):
@@ -1660,8 +1686,13 @@ class StockMove(models.Model):
 
     def _action_done(self, cancel_backorder=False):
         self.filtered(lambda move: move.state == 'draft')._action_confirm()  # MRP allows scrapping draft moves
+
         moves = self.exists().filtered(lambda x: x.state not in ('done', 'cancel'))
         moves_ids_todo = OrderedSet()
+
+        for move in self.exists():
+            if move.is_action_show_details_danger:
+                raise UserError(f'Move of product {move.product_id.name} with demand of {move.product_qty} has inconsistent done value {move._get_qty_done_mls()} vs {move.quantity_done}')
 
         # Cancel moves where necessary ; we should do it before creating the extra moves because
         # this operation could trigger a merge of moves.

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -610,8 +610,12 @@ class StockMove(models.Model):
         for move in self:
             if move.product_uom:
                 move.is_action_show_details_danger = float_compare(move.quantity_done, move._get_qty_done_mls(), precision_rounding=move.product_uom.rounding) != 0
-                if move.is_action_show_details_danger and (move.has_tracking == 'none' or float_compare(move.quantity_done, move._get_reserve_qty_mls(), precision_rounding=move.product_uom.rounding) <= 0):
-                    move.is_action_show_details_danger = False
+                # if move.is_action_show_details_danger:
+                #     if move.has_tracking == 'none' or float_compare(move.quantity_done, move._get_reserve_qty_mls(), precision_rounding=move.product_uom.rounding) <= 0:
+                #         move.is_action_show_details_danger = False
+                #     if move.has_tracking != 'none':
+                #         available_quantity = move._get_available_quantity(self.location_id, strict=True)
+                #         move.is_action_show_details_danger = float_compare(move.quantity_done, available_quantity, precision_rounding=move.product_uom.rounding) <= 0
 
     @api.depends('move_line_ids', 'move_line_ids.lot_id', 'move_line_ids.qty_done')
     def _compute_lot_ids(self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -334,6 +334,8 @@ class StockMoveLine(models.Model):
                 next_moves = ml.move_id.move_dest_ids.filtered(lambda move: move.state not in ('done', 'cancel'))
                 next_moves._do_unreserve()
                 next_moves._action_assign()
+        if mls.move_id:
+            mls.move_id.is_quantity_done_computed = True
         return mls
 
     def write(self, vals):
@@ -473,6 +475,10 @@ class StockMoveLine(models.Model):
                 move.product_uom_qty = move.quantity_done
             next_moves._do_unreserve()
             next_moves._action_assign()
+
+        # There is update to qty_done -> re-enable compute done
+        if 'qty_done' in vals:
+            self.move_id.is_quantity_done_computed = True
 
         if moves_to_recompute_state:
             moves_to_recompute_state._recompute_state()

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -838,6 +838,9 @@ class StockMoveLine(models.Model):
         # To Override
         pass
 
+    def action_clear_lines_show_details(self):
+        return self.env['stock.move'].browse(self.env.context['move_id']).action_clear_lines_show_details()
+
     @api.model
     def _prepare_stock_move_vals(self):
         self.ensure_one()

--- a/addons/stock/static/src/js/stock_move_list_renderer.js
+++ b/addons/stock/static/src/js/stock_move_list_renderer.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { X2ManyField } from "@web/views/fields/x2many/x2many_field";
+import { ViewButton } from "@web/views/view_button/view_button";
+
+class MovesViewButton extends ViewButton {
+    async onClick(ev) {
+        if (this.props.clickParams.name != 'action_show_details') {
+            super.onClick(ev)
+        } else {
+            await this.props.record.saveAndOpenActionShowDetails()
+        }
+    }
+}
+MovesViewButton.props = [...ViewButton.props]
+export class MovesListRenderer extends ListRenderer {}
+
+MovesListRenderer.recordRowTemplate = "stock.ListRenderer.RecordRow";
+MovesListRenderer.components = { ...ListRenderer.components, ViewButton: MovesViewButton }
+
+export class StockMoveX2ManyField extends X2ManyField {}
+StockMoveX2ManyField.components = { ...X2ManyField.components, ListRenderer: MovesListRenderer };
+
+registry.category("fields").add("stock_move_one2many", StockMoveX2ManyField);

--- a/addons/stock/static/src/scss/stock_move_list_renderer.scss
+++ b/addons/stock/static/src/scss/stock_move_list_renderer.scss
@@ -1,0 +1,11 @@
+.o_form_view {
+    // One2Many outside of group
+    .o_field_widget {
+        &.o_field_stock_move_one2many {
+            width: 100%;
+            > div {
+                width: 100%;
+            }
+        }
+    }
+}

--- a/addons/stock/static/src/views/picking_form/picking_form_controller.js
+++ b/addons/stock/static/src/views/picking_form/picking_form_controller.js
@@ -1,0 +1,42 @@
+/** @odoo-module **/
+
+import { sortBy } from "@web/core/utils/arrays";
+import { FormController } from "@web/views/form/form_controller";
+import { useBus, useService } from "@web/core/utils/hooks";
+
+export class StockPickingFormController extends FormController {
+    setup() {
+        super.setup();
+        this.action = useService("action");
+        useBus(this.env.bus, "STOCK_MOVE:UPDATED", (ev) => this._qtyUpdated(ev));
+        useBus(this.env.bus, "STOCK_MOVE:SAVED", (ev) => this._actionOpenShowDetails(ev));
+    }
+
+    // TRIGGER
+    async _actionOpenShowDetails(ev) {
+        let id = ev.detail.id;
+        if (!id) {
+            const moveByIdsDesc = sortBy(
+                this.model.root.data.move_ids_without_package.records,
+                "id",
+                "desc"
+            );
+            const newRecord = moveByIdsDesc.find(
+                (e) => e.data.product_id[0] == ev.detail.product_id[0]
+            );
+            id = newRecord.data.id;
+        }
+        const action = await this.model.orm.call("stock.move", "action_show_details", [id]);
+        this.action.doAction(action, { onClose: () => this._load_and_render()});
+    }
+
+    async _load_and_render() {
+        await this.model.root.load();
+        this.render(true);
+    }
+
+    async _qtyUpdated(ev) {
+        await this.model.root.save();
+        ev.detail.resolve();
+    }
+}

--- a/addons/stock/static/src/views/picking_form/picking_form_controller.xml
+++ b/addons/stock/static/src/views/picking_form/picking_form_controller.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="stock.PickingFormView.Buttons" t-inherit="web.FormView.Buttons" t-inherit-mode="primary" owl="1">
+        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="replace"></xpath>
+    </t>
+</templates>

--- a/addons/stock/static/src/views/picking_form/picking_form_model.js
+++ b/addons/stock/static/src/views/picking_form/picking_form_model.js
@@ -1,0 +1,41 @@
+/** @odoo-module **/
+
+import { Record, RelationalModel } from "@web/views/basic_relational_model";
+
+export class StockPickingAutoSaveRecord extends Record {
+    async saveAndOpenActionShowDetails() {
+        this._lock = true;
+        await new Promise((resolve) => {
+            this.model.env.bus.trigger("STOCK_MOVE:UPDATED", { resolve });
+        });
+        this.model.env.bus.trigger("STOCK_MOVE:SAVED", {
+            id: this.data.id,
+            product_id: this.data.product_id,
+        });
+        this._lock = false;
+    }
+
+    async update(changes) {
+        const record_prom = super.update(changes);
+        if (this._lock || this.resModel !== "stock.move" || !("quantity_done" in changes)) {
+            return record_prom;
+        }
+        this._lock = true;
+        await record_prom;
+        console.log(this)
+        console.log(this.data.picking_id)
+        if (this.data.picking_id) {
+            await this.save()
+        } else {
+            await new Promise((resolve) => {
+                this.model.env.bus.trigger("STOCK_MOVE:UPDATED", { resolve });
+            });
+        }
+        console.log(this)
+        this._lock = false;
+        return record_prom;
+     }
+}
+
+export class StockPickingModel extends RelationalModel {}
+StockPickingModel.Record = StockPickingAutoSaveRecord;

--- a/addons/stock/static/src/views/picking_form/picking_form_view.js
+++ b/addons/stock/static/src/views/picking_form/picking_form_view.js
@@ -1,0 +1,15 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { formView } from "@web/views/form/form_view";
+import { StockPickingModel } from "@stock/views/picking_form/picking_form_model";
+import { StockPickingFormController } from "@stock/views/picking_form/picking_form_controller";
+
+export const StockPickingFormView = {
+    ...formView,
+    Controller: StockPickingFormController,
+    Model: StockPickingModel,
+    buttonTemplate: "stock.PickingFormView.Buttons",
+};
+
+registry.category("views").add("picking_form", StockPickingFormView);

--- a/addons/stock/static/src/xml/picking_list_renderer.xml
+++ b/addons/stock/static/src/xml/picking_list_renderer.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="stock.ListRenderer.RecordRow" t-inherit="web.ListRenderer.RecordRow" t-inherit-mode="primary" owl="1">
+        <xpath expr="//td[hasclass('o_data_cell')]//ViewButton" position="replace">
+            <ViewButton t-if="!evalModifier(button.modifiers.invisible, record)"
+                className="button.className"
+                clickParams="button.clickParams"
+                defaultRank="button.defaultRank"
+                disabled="record.isVirtual and button.clickParams.name != 'action_show_details'"
+                icon="button.icon"
+                record="record"
+                string="button.string"
+                title="button.title"
+                tabindex="props.list.editedRecord ? '-1' : '0'"
+            />
+        </xpath>
+    </t>
+</templates>

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5185,20 +5185,12 @@ class StockMove(TransactionCase):
 
         move1.quantity_done = 10
         self.assertEqual(picking.move_ids.quantity_done, 10)
-        self.assertEqual(picking.move_ids._get_qty_done_mls(), 0)
+        self.assertEqual(picking.move_ids._get_qty_done_mls(), 10)
 
-        self.env['stock.move.line'].create({
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-            'product_id': self.product.id,
-            'product_uom_id': self.uom_unit.id,
-            'qty_done': 10.0,
-            'picking_id': picking.id,
-        })
         picking._action_done()
 
         self.assertEqual(len(picking.move_ids), 1, 'One move should exist for the picking.')
-        self.assertEqual(len(picking.move_line_ids), 1, 'One move line should exist for the picking.')
+        self.assertEqual(len(picking.move_line_ids), 1, 'One move line should exist for the picking')
         self.assertEqual(picking.move_ids.quantity_done, 10)
         self.assertEqual(picking.move_ids._get_qty_done_mls(), 10)
 
@@ -5623,10 +5615,9 @@ class StockMove(TransactionCase):
             'picking_id': picking.id,
             'picking_type_id': self.env.ref('stock.picking_type_out').id,
         })
+        picking.action_confirm()
+
         move1.quantity_done = 5
-        self.env['stock.move.line'].create(dict(
-            move1._prepare_move_line_vals(),
-            qty_done=5))
         picking.action_put_in_pack()  # Create a package
 
         delivery_form = Form(picking)

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5140,7 +5140,6 @@ class StockMove(TransactionCase):
         move_out._action_confirm()
         move_out._action_assign()
         move_out.quantity_done = self.product.qty_available
-        self.env['stock.move.line'].create(dict(move_out._prepare_move_line_vals(), qty_done=move_out.quantity_done))
         move_out._action_done()
         self.product.detailed_type = 'consu'
 

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -1520,6 +1520,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         # do not set a lot_id or lot_name, it should work
         delivery_order._action_done()
 
@@ -1553,6 +1556,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         move_line = delivery_order.move_ids.move_line_ids
 
         # not lot_name set, should raise
@@ -1593,6 +1599,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         move_line = delivery_order.move_ids.move_line_ids
 
         # not lot_name set, should raise
@@ -1633,6 +1642,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         move_line = delivery_order.move_ids.move_line_ids
 
         # not lot_name set, should raise

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -117,6 +117,9 @@ class TestWarehouse(TestStockCommon):
         self.assertEqual(product.virtual_available, -5.0)
 
         customer_move.quantity_done = 5
+        self.env['stock.move.line'].create(dict(
+            customer_move._prepare_move_line_vals(),
+            qty_done=5))
         customer_move._action_done()
         self.assertEqual(product.qty_available, -5.0)
 
@@ -157,7 +160,7 @@ class TestWarehouse(TestStockCommon):
             'location_id': stock_location.id,
             'location_dest_id': customer_location.id,
         })
-        self.env['stock.move'].create({
+        move = self.env['stock.move'].create({
             'name': productA.name,
             'product_id': productA.id,
             'product_uom_qty': 1,
@@ -168,6 +171,9 @@ class TestWarehouse(TestStockCommon):
         })
         picking_out.action_confirm()
         picking_out.move_ids.quantity_done = 1
+        self.env['stock.move.line'].create(dict(
+            move._prepare_move_line_vals(),
+            qty_done=1))
         picking_out._action_done()
 
         quant = self.env['stock.quant'].search([('product_id', '=', productA.id), ('location_id', '=', stock_location.id)])
@@ -181,6 +187,9 @@ class TestWarehouse(TestStockCommon):
         return_pick = self.env['stock.picking'].browse(stock_return_picking_action['res_id'])
         return_pick.action_assign()
         return_pick.move_ids.quantity_done = 1
+        self.env['stock.move.line'].create(dict(
+            return_pick.move_ids._prepare_move_line_vals(),
+            qty_done=1))
         return_pick._action_done()
 
         quant = self.env['stock.quant'].search([('product_id', '=', productA.id), ('location_id', '=', stock_location.id)])
@@ -200,7 +209,7 @@ class TestWarehouse(TestStockCommon):
             'location_id': stock_location.id,
             'location_dest_id': customer_location.id,
         })
-        self.env['stock.move'].create({
+        move = self.env['stock.move'].create({
             'name': productA.name,
             'product_id': productA.id,
             'product_uom_qty': 1,
@@ -211,6 +220,9 @@ class TestWarehouse(TestStockCommon):
         })
         picking_out.action_confirm()
         picking_out.move_ids.quantity_done = 1
+        self.env['stock.move.line'].create(dict(
+            move._prepare_move_line_vals(),
+            qty_done=1))
         picking_out._action_done()
 
         # Make an inventory adjustment to set the quantity to 0
@@ -385,16 +397,24 @@ class TestWarehouse(TestStockCommon):
         self.assertTrue(picking_stock_transit)
         picking_stock_transit.action_assign()
         picking_stock_transit.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_stock_transit.move_ids[0].move_line_ids.qty_done = 1.0
         picking_stock_transit._action_done()
 
         picking_transit_shop_namur = self.env['stock.picking'].search([('location_dest_id', '=', warehouse_shop_namur.lot_stock_id.id)])
         self.assertTrue(picking_transit_shop_namur)
         picking_transit_shop_namur.action_assign()
         picking_transit_shop_namur.move_ids[0].quantity_done = 1.0
+        self.env['stock.move.line'].create(dict(
+            picking_transit_shop_namur.move_ids[0]._prepare_move_line_vals(),
+            qty_done=1))
         picking_transit_shop_namur._action_done()
 
         picking_out_namur.action_assign()
         picking_out_namur.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_out_namur.move_ids[0].move_line_ids.qty_done = 1.0
+
         picking_out_namur._action_done()
 
         # Check that the correct quantity has been provided to customer
@@ -429,16 +449,23 @@ class TestWarehouse(TestStockCommon):
         self.assertTrue(picking_stock_transit)
         picking_stock_transit.action_assign()
         picking_stock_transit.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_stock_transit.move_ids[0].move_line_ids.qty_done = 1.0
         picking_stock_transit._action_done()
 
         picking_transit_shop_wavre = self.env['stock.picking'].search([('location_dest_id', '=', warehouse_shop_wavre.lot_stock_id.id)])
         self.assertTrue(picking_transit_shop_wavre)
         picking_transit_shop_wavre.action_assign()
         picking_transit_shop_wavre.move_ids[0].quantity_done = 1.0
+        self.env['stock.move.line'].create(dict(
+            picking_transit_shop_wavre.move_ids[0]._prepare_move_line_vals(),
+            qty_done=1))
         picking_transit_shop_wavre._action_done()
 
         picking_out_wavre.action_assign()
         picking_out_wavre.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_out_wavre.move_ids[0].move_line_ids.qty_done = 1.0
         picking_out_wavre._action_done()
 
         # Check that the correct quantity has been provided to customer

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -117,9 +117,6 @@ class TestWarehouse(TestStockCommon):
         self.assertEqual(product.virtual_available, -5.0)
 
         customer_move.quantity_done = 5
-        self.env['stock.move.line'].create(dict(
-            customer_move._prepare_move_line_vals(),
-            qty_done=5))
         customer_move._action_done()
         self.assertEqual(product.qty_available, -5.0)
 
@@ -160,7 +157,7 @@ class TestWarehouse(TestStockCommon):
             'location_id': stock_location.id,
             'location_dest_id': customer_location.id,
         })
-        move = self.env['stock.move'].create({
+        self.env['stock.move'].create({
             'name': productA.name,
             'product_id': productA.id,
             'product_uom_qty': 1,
@@ -171,9 +168,6 @@ class TestWarehouse(TestStockCommon):
         })
         picking_out.action_confirm()
         picking_out.move_ids.quantity_done = 1
-        self.env['stock.move.line'].create(dict(
-            move._prepare_move_line_vals(),
-            qty_done=1))
         picking_out._action_done()
 
         quant = self.env['stock.quant'].search([('product_id', '=', productA.id), ('location_id', '=', stock_location.id)])
@@ -217,9 +211,6 @@ class TestWarehouse(TestStockCommon):
         })
         picking_out.action_confirm()
         picking_out.move_ids.quantity_done = 1
-        self.env['stock.move.line'].create(dict(
-            move._prepare_move_line_vals(),
-            qty_done=1))
         picking_out._action_done()
 
         # Make an inventory adjustment to set the quantity to 0

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -187,9 +187,6 @@ class TestWarehouse(TestStockCommon):
         return_pick = self.env['stock.picking'].browse(stock_return_picking_action['res_id'])
         return_pick.action_assign()
         return_pick.move_ids.quantity_done = 1
-        self.env['stock.move.line'].create(dict(
-            return_pick.move_ids._prepare_move_line_vals(),
-            qty_done=1))
         return_pick._action_done()
 
         quant = self.env['stock.quant'].search([('product_id', '=', productA.id), ('location_id', '=', stock_location.id)])

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -156,40 +156,45 @@
                     <field name="product_uom_category_id" invisible="1"/>
                     <field name="display_clear_serial" invisible="1"/>
                     <group>
-                        <group>
+                        <h2>
                             <field name="product_id" readonly="1"/>
-                            <label for="product_uom_qty" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}"/>
-                            <div class="o_row" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}">
-                                <span><field name="product_uom_qty" readonly="1" nolabel="1"/></span>
-                                <span><field name="product_uom" readonly="1" nolabel="1"/></span>
-                            </div>
-                            <label for="quantity_done"/>
-                            <div class="o_row">
-                                <span><field name="quantity_done" readonly="1" nolabel="1"/></span>
-                                <span attrs="{'invisible': ['|', ('state', '=', 'done'), ('from_immediate_transfer', '=', True)]}"> / </span>
-                                <span><field name="reserved_availability" nolabel="1" attrs="{'invisible': ['|', ('state', '=', 'done'), ('from_immediate_transfer', '=', True)]}" /></span>
-                                <span><field name="product_uom" readonly="1" nolabel="1" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}"/></span>
-                            </div>
-                            <field name="next_serial"
-                                attrs="{'invisible': [('display_assign_serial', '=', False)]}"/>
-                            <label for="next_serial_count" attrs="{'invisible': [('display_assign_serial', '=', False)]}"/>
-                            <div class="o_row" attrs="{'invisible': [('display_assign_serial', '=', False)]}">
-                                <span><field name="next_serial_count"/></span>
-                                <button name="action_assign_serial_show_details" type="object"
-                                        class="btn-link" data-hotkey="k"
-                                        title="Assign Serial Numbers">
-                                    <span>Assign Serial Numbers</span>
-                                </button>
-                                <button name="action_clear_lines_show_details" type="object"
-                                        class="btn-link" data-hotkey="y"
-                                        title="Clear Lines"
-                                        attrs="{'invisible': [('display_clear_serial', '=', False)]}">
-                                    <span>Clear All</span>
-                                </button>
-                            </div>
-                        </group>
+                        </h2>
                     </group>
-                    <field name="move_line_ids" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'tree_view_ref': 'stock.view_stock_move_line_operation_tree', 'default_product_uom_id': product_uom, 'default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_company_id': company_id}"/>
+                    <group>
+                        <label for="product_uom_qty" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}"/>
+                        <div class="o_row" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}">
+                            <span><field name="product_uom_qty" readonly="1" nolabel="1"/></span>
+                            <span><field name="product_uom" readonly="1" nolabel="1"/></span>
+                        </div>
+                        <label for="quantity_done"/>
+                        <div class="o_row">
+                            <span><field name="quantity_done" readonly="1" nolabel="1"/></span>
+                            <span attrs="{'invisible': ['|', ('state', '=', 'done'), ('from_immediate_transfer', '=', True)]}"> / </span>
+                            <span><field name="reserved_availability" nolabel="1" attrs="{'invisible': ['|', ('state', '=', 'done'), ('from_immediate_transfer', '=', True)]}" /></span>
+                            <span><field name="product_uom" readonly="1" nolabel="1" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}"/></span>
+                        </div>
+                    </group>
+                    <notebook>
+                        <page string="Product">    
+                            <field name="move_line_ids" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'tree_view_ref': 'stock.view_stock_move_line_operation_tree', 'default_product_uom_id': product_uom, 'default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_company_id': company_id}"/>
+                        </page>
+                        <page string="Generate Series" attrs="{'invisible': [('display_assign_serial', '=', False)]}">
+                            <group>
+                                <field name="next_serial"/>
+                                <field name="next_serial_count"/>
+                            </group>
+                            <group>
+                                <div class="d-flex justify-content-center">
+                                    <button name="action_assign_serial_show_details" type="object"
+                                                class="btn-primary" data-hotkey="k"
+                                                title="Assign Serial Numbers">
+                                            Generate
+                                    </button>
+                                </div>
+                            </group>
+                        </page>
+                    </notebook>
+                    
                     <footer class="oe_edit_only" attrs="{'invisible': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}">
                         <button string="Confirm" special="save" data-hotkey="v" class="oe_highlight"/>
                         <button string="Discard" special="cancel" data-hotkey="z"/>
@@ -220,6 +225,10 @@
             <field name="priority">1000</field>
             <field name="arch" type="xml">
                 <tree editable="bottom" decoration-muted="state == 'done' and is_locked == True" decoration-success="reserved_uom_qty==qty_done" decoration-danger="qty_done &gt; reserved_uom_qty and state != 'done' and picking_code != 'incoming'">
+                    <control>
+                        <create string="Add a line"/>
+                        <button name="action_clear_lines_show_details" type="object" class="btn-link" string="Clear" context="{'move_id': parent.id}"/>
+                    </control>
                     <field name="company_id" invisible="1" force_save="1"/>
                     <field name="picking_id" invisible="1" force_save="1"/>
                     <field name="move_id" invisible="1" force_save="1" />
@@ -252,8 +261,9 @@
                     <field name="state" invisible="1"/>
                     <field name="is_locked" invisible="1"/>
                     <field name="picking_code" invisible="1"/>
-                    <field name="qty_done" attrs="{'readonly': ['|', '&amp;', ('state', '=', 'done'), ('is_locked', '=', True), '&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"/>
-                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"
+                    <field name="qty_done" string="Quantity" invisible="context.get('show_reserved_quantity')" attrs="{'readonly': ['|', '&amp;', ('state', '=', 'done'), ('is_locked', '=', True), '&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"/>
+                    <field name="qty_done" string="Done" invisible="not context.get('show_reserved_quantity')" attrs="{'readonly': ['|', '&amp;', ('state', '=', 'done'), ('is_locked', '=', True), '&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"/>
+                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" string="Unit" groups="uom.group_uom"
                         attrs="{'readonly': ['|', '|', ('reserved_uom_qty', '!=', 0.0),
                                                 '&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True),
                                                 '&amp;', ('state', '=', 'done'), ('id', '!=', False)]}"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -104,7 +104,7 @@
             <field name="model">stock.picking</field>
             <field eval="12" name="priority"/>
             <field name="arch" type="xml">
-                <form string="Transfer">
+                <form string="Transfer" js_class="picking_form">
 
                 <field name="is_locked" invisible="1"/>
                 <field name="show_mark_as_todo" invisible="1"/>
@@ -245,10 +245,10 @@
                         </page>
 
                         <page string="Operations" name="operations">
-                            <field name="move_ids_without_package" mode="tree,kanban"
+                            <field name="move_ids_without_package" widget="stock_move_one2many" mode="tree,kanban"
                                 attrs="{'readonly': ['&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}"
                                 context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref':'stock.view_move_form', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_partner_id': partner_id}"
-                                add-label="Add a Product">
+                                add-label="Add a Product" widget="stock_move_one2many">
                                 <tree decoration-danger="not parent.immediate_transfer and state != 'done' and quantity_done > reserved_availability and show_reserved_availability" decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <field name="company_id" invisible="1"/>
                                     <field name="name" invisible="1"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -275,6 +275,7 @@
                                     <field name="date_deadline" optional="hide"/>
                                     <field name="is_initial_demand_editable" invisible="1"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
+                                    <field name="is_action_show_details_danger" invisible="1"/>
                                     <field name="product_packaging_id" groups="product.group_stock_packaging"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" 
@@ -288,7 +289,9 @@
                                         attrs="{'column_invisible': ['|', '|', ('parent.state', 'in', ['draft', 'done']), ('parent.picking_type_code', 'in', ['incoming', 'outgoing']), ('parent.immediate_transfer', '=', True)]}"/>
                                     <field name="product_qty" invisible="1" readonly="1"/>
                                     <field name="quantity_done" string="Done" attrs="{'readonly': [('is_quantity_done_editable', '=', False)], 'column_invisible':[('parent.state', '=', 'draft'), ('parent.immediate_transfer', '=', False)]}"/>
-                                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
+                                    <button name="action_show_details" type="object" icon="fa-list" title="Details" attrs="{'invisible': ['|', ('is_action_show_details_danger', '=', True), ('show_details_visible', '=', False)]}" options='{"warn": true}'/>
+                                    <button name="action_show_details" type="object" icon="fa-list text-danger" title="Details" attrs="{'invisible': ['|', ('is_action_show_details_danger', '=', False), ('show_details_visible', '=', False)]}" options='{"warn": true}'/>
+                                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit" groups="uom.group_uom"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         groups="stock.group_production_lot"
                                         attrs="{'invisible': ['|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial')]}"
@@ -297,8 +300,6 @@
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"
                                         domain="[('product_id','=',product_id)]"
                                     />
-                                    <button name="action_show_details" type="object" icon="fa-list" width="0.1" title="Details"
-                                            attrs="{'invisible': [('show_details_visible', '=', False)]}" options='{"warn": true}'/>
                                     <button name="action_assign_serial" type="object"
                                             icon="fa-plus-square"
                                             width="0.1"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -254,6 +254,7 @@
                                     <field name="name" invisible="1"/>
                                     <field name="state" invisible="1" readonly="0"/>
                                     <field name="picking_type_id" invisible="1"/>
+                                    <field name="picking_id" invisible="1"/>
                                     <field name="location_id" invisible="1"/>
                                     <field name="location_dest_id" invisible="1"/>
                                     <field name="partner_id" invisible="1"/>
@@ -275,6 +276,7 @@
                                     <field name="date_deadline" optional="hide"/>
                                     <field name="is_initial_demand_editable" invisible="1"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
+                                    <field name="can_open_action_details" invisible="1"/>
                                     <field name="is_action_show_details_danger" invisible="1"/>
                                     <field name="product_packaging_id" groups="product.group_stock_packaging"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -248,7 +248,7 @@
                             <field name="move_ids_without_package" widget="stock_move_one2many" mode="tree,kanban"
                                 attrs="{'readonly': ['&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}"
                                 context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref':'stock.view_move_form', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_partner_id': partner_id}"
-                                add-label="Add a Product" widget="stock_move_one2many">
+                                add-label="Add a Product">
                                 <tree decoration-danger="not parent.immediate_transfer and state != 'done' and quantity_done > reserved_availability and show_reserved_availability" decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <field name="company_id" invisible="1"/>
                                     <field name="name" invisible="1"/>


### PR DESCRIPTION
This commit will allow user to quickly Edit the done_qty for the moves in the picking. Right now this field is read-only most of the time. In this commit, we implement auto-distribute the entered qty_done by the user to the move lines (if possible). More details of the behavior of the implementation in the task page.
task-id: 2960983

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
