### PR TITLE
[REM] website_event, *: remove new content controllers

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -334,40 +334,6 @@ class WebsiteEventController(http.Controller):
         }
 
     # ------------------------------------------------------------
-    # EDITOR (NEW EVENT)
-    # ------------------------------------------------------------
-
-    @http.route('/event/add_event', type='json', auth="user", methods=['POST'], website=True)
-    def add_event(self, name, event_start, event_end, address_values, **kwargs):
-        values = self._prepare_event_values(name, event_start, event_end, address_values)
-        event = request.env['event.event'].create(values)
-        return "/event/%s/register?enable_editor=1" % slug(event)
-
-    def _prepare_event_values(self, name, event_start, event_end, address_values=None):
-        """
-        Return the values to create a new event.
-        event_start,event_date are datetimes in the user tz.
-        address_values is used to either choose an existing location or create one as we allow it in the frontend.
-        """
-        date_begin = parse(event_start).astimezone(pytz.utc).replace(tzinfo=None)
-        date_end = parse(event_end).astimezone(pytz.utc).replace(tzinfo=None)
-        address_id = request.env['res.partner']
-        if address_values:
-            (address_pid, address_vals) = int(address_values[0]), address_values[1]
-            address_id = address_pid
-            if address_pid == 0:
-                address_id = request.env['res.partner'].create(address_vals).id
-        return {
-            'name': name,
-            'date_begin': date_begin,
-            'date_end': date_end,
-            'address_id': address_id,
-            'seats_available': 1000,
-            'website_id': request.website.id,
-            'event_ticket_ids': request.env['event.event.ticket'],
-        }
-
-    # ------------------------------------------------------------
     # TOOLS (HELPERS)
     # ------------------------------------------------------------
 

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -76,18 +76,3 @@ class WebsiteEventSaleController(WebsiteEventController):
                 request.website.sale_reset()
 
         return res
-
-    def _prepare_event_values(self, name, event_start, event_end, address_values=None):
-        values = super()._prepare_event_values(name, event_start, event_end, address_values)
-        product = request.env.ref('event_sale.product_product_event', raise_if_not_found=False)
-        if product:
-            values.update({
-                'event_ticket_ids': [[0, 0, {
-                    'name': _('Registration'),
-                    'product_id': product.id,
-                    'end_sale_datetime': False,
-                    'seats_max': 1000,
-                    'price': 0,
-                }]]
-            })
-        return values

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -67,27 +67,6 @@ class WebsiteForum(WebsiteProfile):
             'forums': forums
         })
 
-    @http.route('/forum/new', type='json', auth="user", methods=['POST'], website=True)
-    def forum_create(self, forum_name="New Forum", forum_mode="questions", forum_privacy="public", forum_privacy_group=False, add_menu=False):
-        forum = {
-            'name': forum_name,
-            'mode': forum_mode,
-            'privacy': forum_privacy,
-            'website_id': request.website.id,
-        }
-        if forum_privacy == 'private' and forum_privacy_group:
-            forum['authorized_group_id'] = forum_privacy_group
-        forum_id = request.env['forum.forum'].create(forum)
-        if add_menu:
-            menu_id = request.env['website.menu'].create({
-                'name': forum_name,
-                'url': "/forum/%s" % slug(forum_id),
-                'parent_id': request.website.menu_id.id,
-                'website_id': request.website.id,
-            })
-            forum_id.menu_id = menu_id
-        return "/forum/%s" % slug(forum_id)
-
     def sitemap_forum(env, rule, qs):
         Forum = env['forum.forum']
         dom = sitemap_qs2dom(qs, '/forum', Forum._rec_name)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1597,15 +1597,6 @@ class WebsiteSale(http.Controller):
     # Edit
     # ------------------------------------------------------
 
-    @http.route(['/shop/add_product'], type='json', auth="user", methods=['POST'], website=True)
-    def add_product(self, name=None, category=None, **post):
-        product = request.env['product.product'].create({
-            'name': name or _("New Product"),
-            'public_categ_ids': category,
-            'website_id': request.website.id,
-        })
-        return self.env["website"].get_client_action_url(product.product_tmpl_id.website_url, True)
-
     @http.route(['/shop/config/product'], type='json', auth='user')
     def change_product_config(self, product_id, **options):
         if not request.env.user.has_group('website.group_website_restricted_editor'):

--- a/addons/website_sale_slides/controllers/slides.py
+++ b/addons/website_sale_slides/controllers/slides.py
@@ -31,13 +31,3 @@ class WebsiteSaleSlides(WebsiteSlides):
             else:
                 values['product_info'] = False
         return values
-
-    def _slide_channel_prepare_values(self, **kwargs):
-        """Parse the values posted when we create a new course
-        from website to add the selected product.
-        """
-        channel = super(WebsiteSaleSlides, self)._slide_channel_prepare_values(**kwargs)
-        channel['enroll'] = kwargs.get('enroll')
-        if channel['enroll'] == 'payment' and 'product_id' in kwargs:
-            channel['product_id'] = int(kwargs['product_id'])
-        return channel

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -591,27 +591,6 @@ class WebsiteSlides(WebsiteProfile):
     # SLIDE.CHANNEL UTILS
     # --------------------------------------------------
 
-    @http.route('/slides/channel/add', type='http', auth='user', methods=['POST'], website=True)
-    def slide_channel_create(self, *args, **kw):
-        channel = request.env['slide.channel'].create(self._slide_channel_prepare_values(**kw))
-        return request.redirect("/slides/%s" % (slug(channel)))
-
-    def _slide_channel_prepare_values(self, **kw):
-        # `tag_ids` is a string representing a list of int with coma. i.e.: '2,5,7'
-        # We don't want to allow user to create tags and tag groups on the fly.
-        tag_ids = []
-        if kw.get('tag_ids'):
-            tag_ids = [int(item) for item in kw['tag_ids'].split(',')]
-
-        return {
-            'name': kw['name'],
-            'description': kw.get('description'),
-            'channel_type': kw.get('channel_type', 'documentation'),
-            'user_id': request.env.user.id,
-            'tag_ids': [(6, 0, tag_ids)],
-            'allow_comment': bool(kw.get('allow_comment')),
-        }
-
     def _slide_channel_prepare_review_values(self, channel):
         values = {
             'rating_avg': channel.rating_avg,

--- a/addons/website_slides_forum/controllers/main.py
+++ b/addons/website_slides_forum/controllers/main.py
@@ -7,15 +7,6 @@ from odoo.addons.website_slides.controllers.main import WebsiteSlides
 
 class WebsiteSlidesForum(WebsiteSlides):
 
-    def _slide_channel_prepare_values(self, **kwargs):
-        channel = super(WebsiteSlidesForum, self)._slide_channel_prepare_values(**kwargs)
-        if bool(kwargs.get('link_forum')):
-            forum = request.env['forum.forum'].create({
-                'name': kwargs.get('name')
-            })
-            channel['forum_id'] = forum.id
-        return channel
-
     # Profile
     # ---------------------------------------------------
 


### PR DESCRIPTION
*: website_event_sale, website_forum, website_sale, website_sale_slides,
website_slides, website_slides_forum

The goal of this PR is to remove remaining controllers no longer
used since the use of form view on website new content dialogs.

Remark: on some modules 'create_and_get_website_url()' is used
instead of controllers

task-2687506