### PR TITLE
[IMP] web: list: select range of records with shift

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -76,6 +76,12 @@ export function getActiveHotkey(ev) {
 
     // ------- Key -------
     let key = ev.key.toLowerCase();
+
+    // The browser space is natively " ", we want "space" for esthetic reasons
+    if (key === " ") {
+        key = "space";
+    }
+
     // Identify if the user has tapped on the number keys above the text keys.
     if (ev.code && ev.code.indexOf("Digit") === 0) {
         key = ev.code.slice(-1);
@@ -88,6 +94,7 @@ export function getActiveHotkey(ev) {
     if (!MODIFIERS.includes(key)) {
         hotkey.push(key);
     }
+
     return hotkey.join("+");
 }
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -405,7 +405,7 @@ export class ListRenderer extends Component {
 
     focus(el) {
         el.focus();
-        if (["INPUT", "TEXTAREA"].includes(el.tagName)) {
+        if (["text", "search", "URL", "tel", "password", "textarea"].includes(el.type)) {
             if (el.selectionStart === null) {
                 return;
             }

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -217,7 +217,7 @@
             t-on-touchend="() => this.onRowTouchEnd(record)"
             t-on-touchmove="() => this.onRowTouchMove(record)"
         >
-            <td t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group, record)" t-if="hasSelectors" class="o_list_record_selector" t-on-click.stop="() => this.toggleRecordSelection(record)" tabindex="-1">
+            <td t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group, record)" t-if="hasSelectors" class="o_list_record_selector user-select-none" t-on-click.stop="() => this.toggleRecordSelection(record)" tabindex="-1">
                 <CheckBox disabled="!!props.list.editedRecord or props.list.model.useSampleModel" value="record.selected" onChange.bind="() => this.toggleRecordSelection(record)" />
             </td>
             <t t-foreach="getColumns(record)" t-as="column" t-key="column.id">

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -4,7 +4,7 @@ import { browser } from "@web/core/browser/browser";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { registry } from "@web/core/registry";
 import { uiService, useActiveElement } from "@web/core/ui/ui_service";
-import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
+import { getActiveHotkey, hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import { makeTestEnv } from "../../helpers/mock_env";
 import {
     destroy,
@@ -1167,4 +1167,19 @@ QUnit.test("mixing hotkeys with and without operation area", async (assert) => {
     triggerHotkey("Space");
     await nextTick();
     assert.verifySteps(["withArea"]);
+});
+
+QUnit.test("native browser space key ' ' is correctly translated to 'space' ", async (assert) => {
+    class A extends Component {
+        setup() {
+            useHotkey("space", () => assert.step("space"));
+        }
+    }
+    A.template = xml``;
+
+    assert.strictEqual(getActiveHotkey({ key: " " }), "space");
+
+    await mount(A, target, { env });
+    await triggerHotkey(" "); // event key triggered by the browser
+    assert.verifySteps(["space"]);
 });


### PR DESCRIPTION
Before, in the list view, the user could not select a record range easily. He had to
check/uncheck manually each checkbox in the range.

Now, the user can select a range of records in list view by hitting its first record
and and its last record while holding SHIFT for the second.

It's also possible to do it with the keyboard:
- pressing < SPACE > to select a record and <SHIFT+SPACE> to select a range of records.
- pressing <SHIFT+ARROW> to extend to current checkbox

![shiftList](https://user-images.githubusercontent.com/109217759/202680390-05708718-30a6-4d34-9229-5569269ea093.gif)

task-2039894