### PR TITLE
[IMP] account: dedicated payments sequence

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -692,8 +692,7 @@ class AccountPayment(models.Model):
     # -------------------------------------------------------------------------
 
     def new(self, values=None, origin=None, ref=None):
-        self = self.with_context(is_payment=True)
-        payment = super().new(values, origin, ref)
+        payment = super(AccountPayment, self.with_context(is_payment=True)).new(values, origin, ref)
         if not payment.journal_id:  # might not be computed because declared by inheritance
             payment.move_id._compute_journal_id()
         return payment
@@ -701,7 +700,6 @@ class AccountPayment(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         # OVERRIDE
-        self = self.with_context(is_payment=True)
         write_off_line_vals_list = []
 
         for vals in vals_list:
@@ -712,7 +710,9 @@ class AccountPayment(models.Model):
             # Force the move_type to avoid inconsistency with residual 'default_move_type' inside the context.
             vals['move_type'] = 'entry'
 
-        payments = super().create(vals_list)
+        payments = super(AccountPayment, self.with_context(is_payment=True))\
+            .create(vals_list)\
+            .with_context(is_payment=False)
 
         for i, pay in enumerate(payments):
             write_off_line_vals = write_off_line_vals_list[i]

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -84,6 +84,7 @@
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <field name="refund_sequence" attrs="{'invisible': [('type', 'not in', ['sale', 'purchase'])]}"/>
+                                        <field name="payment_sequence" attrs="{'invisible': [('type', 'not in', ('bank', 'cash'))]}"/>
                                         <field name="code" placeholder="e.g. INV"/>
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                     </group>

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -39,6 +39,9 @@ class ReSequenceWizard(models.TransientModel):
             and len(move_types) > 1
         ):
             raise UserError(_('The sequences of this journal are different for Invoices and Refunds but you selected some of both types.'))
+        is_payment = set(active_move_ids.mapped(lambda x: bool(x.payment_id)))
+        if len(is_payment) > 1:
+            raise UserError(_('The sequences of this journal are different for Payments and non-Payments but you selected some of both types.'))
         values['move_ids'] = [(6, 0, active_move_ids.ids)]
         return values
 


### PR DESCRIPTION
Add setting on bank/cash journals to have dedicated payments sequences

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

Enterprise PR: odoo/enterprise#31059
[Task](https://www.odoo.com/web#id=2894299&model=project.task)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
