### PR TITLE
[FIX] stock_move :Fix the _recompute_state method

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1782,7 +1782,7 @@ class StockMove(models.Model):
                 continue
             elif float_compare(move.reserved_availability, move.product_uom_qty, precision_rounding=rounding) == 0:
                 moves_state_to_write['assigned'].add(move.id)
-            elif move.reserved_availability and float_compare(move.reserved_availability, move.product_uom_qty, precision_rounding=rounding) <= 0:
+            elif move.reserved_availability and float_compare(move.reserved_availability, move.product_uom_qty, precision_rounding=rounding) < 0:
                 moves_state_to_write['partially_available'].add(move.id)
             elif move.procure_method == 'make_to_order' and not move.move_orig_ids:
                 moves_state_to_write['waiting'].add(move.id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This Fix will fix one of the cases of the recomputing of the stock_move state

Current behavior before PR:

The _recompute_state method recompute the state of the stock_move basing on the modification of some fields,
In the first case : the state of the stock_move will become assigned if the reserved_availability = product_uom_qty with is correct and logical
But in the second case : the state of the stock_move will become partially_available if reserved_availability <= product_uom_qty which is not correct

Desired behavior after PR is merged:

The state of the stock_move will become partially_available only if the reserved_availability < product_uom_qty




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
