### PR TITLE
Revert to Old method of Reconciliation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3906,7 +3906,7 @@ class AccountMoveLine(models.Model):
                 line.reconciled = (
                     line.company_currency_id.is_zero(line.amount_residual)
                     and (not line.currency_id or line.currency_id.is_zero(line.amount_residual_currency))
-                    and (line.matched_debit_ids or line.matched_credit_ids)
+                    and line.move_id.state not in ('draft', 'cancel')
                 )
             else:
                 # Must not have any reconciliation since the line is not eligible for that.


### PR DESCRIPTION
Reverting to allow the reconciliation of zero amount journal items and to allow write off to be cleared from the outstanding receipts/payments account when doing a write off on an invoice or bill

Description of the issue/feature this PR addresses:

Current behavior before PR:
outstanding receipts/payments account will always show on the dashboard even with 0 values since the line will not be reconciled

Desired behavior after PR is merged:

back to the old behaviour of correctly reconciling 0 values lines


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
