### PR TITLE
[FIX] account: upload buttons on Accounting Dashboard are disabled

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -8,6 +8,7 @@ import { ListController } from "@web/views/list/list_controller";
 import { kanbanView } from "@web/views/kanban/kanban_view";
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { KanbanDropdownMenuWrapper } from "@web/views/kanban/kanban_dropdown_menu_wrapper";
 import { KanbanRecord } from "@web/views/kanban/kanban_record";
 import { FileUploader } from "@web/views/fields/file_handler";
 
@@ -126,6 +127,14 @@ export const AccountMoveUploadKanbanView = {
 };
 
 // Accounting Dashboard
+export class DashboardKanbanDropdownMenuWrapper extends KanbanDropdownMenuWrapper {
+    onClick(ev) {
+        // Keep the dropdown open as we need the fileuploader to remain in the dom
+        if (!ev.target.tagName === "INPUT" && !ev.target.closest('.file_upload_kanban_action_a')) {
+            super.onClick(ev);
+        }
+    }
+}
 export class DashboardKanbanRecord extends KanbanRecord {
     setup() {
         super.setup();
@@ -138,6 +147,7 @@ DashboardKanbanRecord.components = {
     ...DashboardKanbanRecord.components,
     AccountDropZone,
     AccountFileUploader,
+    KanbanDropdownMenuWrapper: DashboardKanbanDropdownMenuWrapper,
 };
 DashboardKanbanRecord.template = "account.DashboardKanbanRecord";
 

--- a/addons/account/static/src/components/bills_upload/bills_upload.scss
+++ b/addons/account/static/src/components/bills_upload/bills_upload.scss
@@ -13,3 +13,7 @@
       height: 100%;
     }
 }
+
+.file_upload_kanban_action_a {
+  @include o-kanban-dashboard-dropdown-link($link-padding-gap: $o-kanban-dashboard-dropdown-complex-gap);
+}

--- a/addons/account/static/src/components/bills_upload/bills_upload.xml
+++ b/addons/account/static/src/components/bills_upload/bills_upload.xml
@@ -20,7 +20,7 @@
                 onUploaded.bind="onFileUploaded"
                 onUploadComplete.bind="onUploadComplete">
                 <t t-set-slot="toggler">
-                    <t t-slot="toggleButton"/>
+                    <t t-slot="default"/>
                 </t>
             </FileUploader>
         </div>
@@ -50,26 +50,22 @@
 
     <t t-name="account.ListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary" owl="1">
         <xpath expr="//*[@class='btn btn-primary o_list_button_add']" position="after">
-            <AccountFileUploader extraContext="props.context">
-                <t t-set-slot="toggleButton">
-                    <button type="button" class="btn btn-secondary o_button_upload_bill">
-                        Upload
-                    </button>
-                </t>
-            </AccountFileUploader>
+            <t t-call="account.AccountViewUploadButton"/>
         </xpath>
     </t>
 
     <t t-name="account.KanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary" owl="1">
         <xpath expr="//*[@class='btn btn-primary o-kanban-button-new']" position="after">
-            <AccountFileUploader extraContext="props.context">
-                <t t-set-slot="toggleButton">
-                    <button type="button" class="btn btn-secondary o_button_upload_bill">
-                        Upload
-                    </button>
-                </t>
-            </AccountFileUploader>
+            <t t-call="account.AccountViewUploadButton"/>
         </xpath>
+    </t>
+
+    <t t-name="account.AccountViewUploadButton" owl="1">
+        <AccountFileUploader extraContext="props.context">
+            <button type="button" class="btn btn-secondary o_button_upload_bill">
+                Upload
+            </button>
+        </AccountFileUploader>
     </t>
 
     <t t-name="account.DashboardKanbanRecord" owl="1">

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -48,6 +48,16 @@
                             }"/>
                     </t>
 
+                    <t t-name="AccountKanbanUploaderButton" owl="1">
+                        <AccountFileUploader
+                            extraContext="{
+                                default_journal_id: record.id.raw_value,
+                                default_move_type: journal_type == 'sale' and 'out_invoice' or journal_type == 'purchase' and 'in_invoice' or 'entry'
+                            }">
+                                <t t-out="0"/>
+                        </AccountFileUploader>
+                    </t>
+
                     <t t-name="JournalTop">
                         <div t-attf-class="o_kanban_card_header">
                             <div class="o_kanban_card_header_title">
@@ -170,9 +180,13 @@
                                     </a>
                                 </div>
                                 <div t-if="journal_type == 'sale'">
-                                    <a class="o_button_upload_document" journal_type="sale" groups="account.group_account_invoice">
-                                        <span>Upload Invoices</span>
-                                    </a>
+                                    <t t-call="AccountKanbanUploaderButton">
+                                        <div class="file_upload_kanban_action_a">
+                                            <a href="#" groups="account.group_account_invoice">
+                                                <span>Upload Invoices</span>
+                                            </a>
+                                        </div>
+                                    </t>
                                 </div>
                             </div>
 
@@ -272,7 +286,7 @@
                                 </t>
                                 <div name="bank_journal_cta" class="mt-3 mt-sm-0">
                                     <div name="bank_statement_create_button" groups="account.group_account_invoice">
-                                        <a type="object" name="create_bank_statement" class="oe_inline">Create</a><span name="button_import_placeholder"/> Statements
+                                        <a type="object" name="create_bank_statement" class="oe_inline">Create</a><span class="d-inline-flex" name="button_import_placeholder"/> Statements
                                     </div>
                                 </div>
                             </t>
@@ -321,9 +335,11 @@
                             <t t-if="journal_type == 'purchase'">
                                 <field name="entries_count" invisible="1"/>
                                 <t t-if="record.entries_count.raw_value > 0">
-                                    <button class="btn btn-primary o_button_upload_document oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">
-                                        <span>Upload</span>
-                                    </button>
+                                    <t t-call="AccountKanbanUploaderButton">
+                                        <a role="button" class="btn btn-primary oe_kanban_action_button" groups="account.group_account_invoice">
+                                            <span>Upload</span>
+                                        </a>
+                                    </t>
                                 </t>
                                 <t t-else="">
                                     <button type="object" name="action_create_vendor_bill" class="btn btn-primary oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">


### PR DESCRIPTION
OWL disables view buttons that are missing attributes.
These buttons used legacy javascript, and were omitted from the accounting owl migration.

Activate those buttons.

