### PR TITLE
[FIX] point_of_sale: remove redundant or sign in the domain

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -192,7 +192,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             var domain = [];
             if(this.state.query) {
                 domain = [
-                    '|','|',
+                    '|',
                     ["display_name", "ilike", this.state.query],
                     ["email", "ilike", this.state.query],
                     ];


### PR DESCRIPTION
One of the "or" signs is redundant and should be removed.
Related commit: 7065a6e8440f401cdb6c96ddfd4dd06fe7f61657

opw-2952814

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
