### PR TITLE
[I18N] l10n_ch: missing translations

### DIFF
--- a/addons/l10n_ch/i18n_extra/de.po
+++ b/addons/l10n_ch/i18n_extra/de.po
@@ -334,37 +334,52 @@ msgstr "<span class=\"title\">Annahmestelle</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Account / Payable to</span><br/>"
-msgstr "<span class=\"title\">Konto / Zahlbar an</span><br/>"
+msgid "<span>Account / Payable to</span>"
+msgstr "<span>Konto / Zahlbar an</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Additional information</span><br/>"
-msgstr "<span class=\"title\">Zusätzliche Informationen</span><br/>"
+msgid "<span>Account / Payable to</span><br/>"
+msgstr "<span>Konto / Zahlbar an</span><br/>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Amount</span><br/>"
-msgstr "<span class=\"title\">Betrag</span><br/>"
+msgid "<span>Additional information</span>"
+msgstr "<span>Zusätzliche Informationen</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Currency</span><br/>"
-msgstr "<span class=\"title\">Währung</span><br/>"
+msgid "<span>Amount</span>"
+msgstr "<span>Betrag</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Payable by</span><br/>"
-msgstr "<span class=\"title\">Zahlbar durch</span><br/>"
+msgid "<span>Amount</span><br/>"
+msgstr "<span>Betrag</span><br/>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Reference</span><br/>"
-msgstr "<span class=\"title\">Referenz</span><br/>"
+msgid "<span>Currency</span>"
+msgstr "<span>Währung</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span>Payment Part</span>"
+msgid "<span>Payable by</span>"
+msgstr "<span>Zahlbar durch</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Reference</span>"
+msgstr "<span>Referenz</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span class=\"title\">Reference</span>"
+msgstr "<span class=\"title\">Referenz</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Payment part</span>"
 msgstr "<span>Zahlteil</span>"
 
 #. module: l10n_ch
@@ -1278,7 +1293,7 @@ msgstr ""
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.isr_invoice_form
 msgid "Print QR-bill"
-msgstr ""
+msgstr "Drucken QR-Rechnung"
 
 #. module: l10n_ch
 #: model:ir.model.fields,field_description:l10n_ch.field_res_company__l10n_ch_isr_print_bank_location
@@ -1366,7 +1381,7 @@ msgstr ""
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
 msgid "QR-bill for invoice"
-msgstr ""
+msgstr "QR-Rechnung"
 
 #. module: l10n_ch
 #: model:account.account.template,name:l10n_ch.ch_coa_3801

--- a/addons/l10n_ch/i18n_extra/fr.po
+++ b/addons/l10n_ch/i18n_extra/fr.po
@@ -39,37 +39,53 @@ msgstr "<span class=\"title\">Point de dépôt</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Account / Payable to</span><br/>"
-msgstr "<span class=\"title\">Compte / Payable à</span><br/>"
+msgid "<span>Account / Payable to</span>"
+msgstr "<span>Compte / Payable à</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Additional information</span><br/>"
-msgstr "<span class=\"title\">Information supplémentaires</span><br/>"
+msgid "<span>Account / Payable to</span><br/>"
+msgstr "<span>Compte / Payable à</span><br/>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Amount</span><br/>"
-msgstr "<span class=\"title\">Montant</span><br/>"
+msgid "<span>Additional information</span>"
+msgstr "<span>Informations supplémentaires</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Currency</span><br/>"
-msgstr "<span class=\"title\">Monnaie</span><br/>"
+msgid "<span>Amount</span>"
+msgstr "<span>Montant</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Payable by</span><br/>"
-msgstr "<span class=\"title\">Payable par</span><br/>"
+msgid "<span>Amount</span><br/>"
+msgstr "<span>Montant</span><br/>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Reference</span><br/>"
-msgstr "<span class=\"title\">Référence</span><br/>"
+msgid "<span>Currency</span>"
+msgstr "<span>Monnaie</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span>Payment Part</span>"
+msgid "<span>Payable by</span>"
+msgstr "<span>Payable par</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Reference</span>"
+msgstr "<span>Référence</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span class=\"title\">Reference</span>"
+msgstr "<span class=\"title\">Référence</span>"
+
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Payment part</span>"
 msgstr "<span>Section paiement</span>"
 
 #. module: l10n_ch

--- a/addons/l10n_ch/i18n_extra/it.po
+++ b/addons/l10n_ch/i18n_extra/it.po
@@ -317,37 +317,52 @@ msgstr "<span class=\"title\">Punto di accettazione</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Account / Payable to</span><br/>"
-msgstr "<span class=\"title\">Conto / Pagabile a</span><br/>"
+msgid "<span>Account / Payable to</span>"
+msgstr "<span>Conto / Pagabile a</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Additional information</span><br/>"
-msgstr "<span class=\"title\">Informationi supplementari</span><br/>"
+msgid "<span>Account / Payable to</span><br/>"
+msgstr "<span>Conto / Pagabile a</span><br/>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Amount</span><br/>"
-msgstr "<span class=\"title\">Importo</span><br/>"
+msgid "<span>Additional information</span>"
+msgstr "<span>Informationi supplementari</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Currency</span><br/>"
-msgstr "<span class=\"title\">Valuta</span><br/>"
+msgid "<span>Amount</span>"
+msgstr "<span>Importo</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Payable by</span><br/>"
-msgstr "<span class=\"title\">Pagabile da</span><br/>"
+msgid "<span>Amount</span><br/>"
+msgstr "<span>Importo</span><br/>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Reference</span><br/>"
-msgstr "<span class=\"title\">Riferimento</span><br/>"
+msgid "<span>Currency</span>"
+msgstr "<span>Valuta</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span>Payment Part</span>"
+msgid "<span>Payable by</span>"
+msgstr "<span>Pagabile da</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Reference</span>"
+msgstr "<span>Riferimento</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span class=\"title\">Reference</span>"
+msgstr "<span class=\"title\">Riferimento</span>"
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Payment part</span>"
 msgstr "<span>Sezione pagamento</span>"
 
 #. module: l10n_ch

--- a/addons/l10n_ch/i18n_extra/l10n_ch.pot
+++ b/addons/l10n_ch/i18n_extra/l10n_ch.pot
@@ -312,37 +312,52 @@ msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Account / Payable to</span><br/>"
+msgid "<span>Account / Payable to</span>"
 msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Additional information</span><br/>"
+msgid "<span>Account / Payable to</span><br/>"
 msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Amount</span><br/>"
+msgid "<span>Additional information</span>"
 msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Currency</span><br/>"
+msgid "<span>Amount</span>"
 msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Payable by</span><br/>"
+msgid "<span>Amount</span><br/>"
 msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span class=\"title\">Reference</span><br/>"
+msgid "<span>Currency</span>"
 msgstr ""
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
-msgid "<span>Payment Part</span>"
+msgid "<span>Payable by</span>"
+msgstr ""
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Reference</span>"
+msgstr ""
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span class=\"title\">Reference</span>"
+msgstr ""
+
+#. module: l10n_ch
+#: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
+msgid "<span>Payment part</span>"
 msgstr ""
 
 #. module: l10n_ch


### PR DESCRIPTION
Steps to reproduce:
  - change the location of the company in Switzerland;
  - create a customer located in Switzerland and whose language is French (CH);
  - create an invoice with a QR code for this customer.

Issue:
  Some words are not translated.

Cause:
  Some words are incorrectly filled (upper case, tags) in the ".pot" file.

Solution:
  Edit the ".pot" file.
  Edit the ".po" file (lack of time or not on Transifex)

Remark:
  The modification (addition of elements) in the ".pot" file was done by hand because the file is in the i18n_extra folder (not exported).

opw-2959226
[Steps_produce_switzerland_qr_invoice.pdf](https://github.com/odoo/odoo/files/9442927/Steps_produce_switzerland_qr_invoice.pdf)