### PR TITLE
[FIX] web: fix domain widget record counter update + wording

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -66,6 +66,9 @@ export class DomainField extends Component {
             resModel: this.getResModel(this.props),
             domain: this.getDomain(this.props.value).toList(this.getContext(this.props)) || [],
             context: this.getContext(this.props) || {},
+        }, {
+            // The counter is reloaded "on close" because some modal allows to modify data that can impact the counter
+            onClose: () => this.loadCount(this.props)
         });
     }
     get isValidDomain() {

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.xml
@@ -17,7 +17,7 @@
                 <t t-if="!props.noCreate">
                     <button class="btn btn-primary" data-hotkey="c" t-on-click="createEditRecord">Create</button>
                 </t>
-                <button class="btn o_form_button_cancel" t-att-class="(props.disableMultipleSelection &amp;&amp; props.noCreate) ? 'btn-primary' : 'btn-secondary'" data-hotkey="z" t-on-click="() => this.props.close()">Cancel</button>
+                <button class="btn o_form_button_cancel" t-att-class="(props.disableMultipleSelection &amp;&amp; props.noCreate) ? 'btn-primary' : 'btn-secondary'" data-hotkey="z" t-on-click="() => this.props.close()">Close</button>
             </t>
         </Dialog>
     </t>

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -3103,8 +3103,8 @@ QUnit.module("Fields", (hooks) => {
 
         assert.deepEqual(
             getNodesTextContent(target.querySelectorAll(".modal-footer button")),
-            ["Cancel"],
-            "Only the cancel button is present in modal"
+            ["Close"],
+            "Only the close button is present in modal"
         );
     });
 


### PR DESCRIPTION
In mass mailing, a button allows you to see selected records. In some case the
displayed view of selected records allows to alter records (ex.: cancel
attendee in event) which then affects the number of selected records. This fix
forces the recompute of the number of selected record when closing the view so
that it takes into account the potential modification done in the selected
record view.

In mass mailing, in the selected records view, the button is called "cancel"
but any action performed in the modal will still be applied. This fix renames
that button to "close".

Technical note: select_create_dialog is used by the domain widget to see the
records and not to select or create them. So as mentioned above the wording
"cancel" for the button is not appropriate. To identify the case where the
dialog is used only to see the record, the code relies on the absence of the
methods onSelect and onCreateEdit in the props.

Task-2921762

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
