### PR TITLE
[FIX] test_website: avoid random test failure related to image links

### DIFF
--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -5,6 +5,18 @@ import tour from 'web_tour.tour';
 /**
  * The purpose of this tour is to check the link on image flow.
  */
+ 
+const selectImageSteps = [{
+    content: "select block",
+    trigger: "#wrapwrap .s_text_image",
+}, {
+    content: "check link popover disappeared",
+    trigger: "body:not(:has(.o_edit_menu_popover))",
+    run: () => {}, // check
+}, {
+    content: "select image",
+    trigger: "#wrapwrap .s_text_image img",
+}];
 
 tour.register('test_image_link', {
     url: '/',
@@ -19,20 +31,18 @@ tour.register('test_image_link', {
         extra_trigger: "body.editor_enable.editor_has_snippets",
         moveTrigger: ".oe_drop_zone",
         run: "drag_and_drop #wrap",
-    }, {
-        content: "select image",
-        trigger: "#wrapwrap .s_text_image img",
-    }, {
+    },
+    ...selectImageSteps,
+    {
         content: "enable link",
         trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-customizeblock-option:has(we-title:contains(Media)) we-button.fa-link",
     }, {
         content: "enter site URL",
         trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
         run: "text odoo.com",
-    }, {
-        content: "select image",
-        trigger: "#wrapwrap .s_text_image img",
-    }, {
+    },
+    ...selectImageSteps,
+    {
         content: "check popover content has site URL",
         trigger: ".o_edit_menu_popover a.o_we_url_link[href='http://odoo.com/']:contains(http://odoo.com/)",
         run: () => {}, // check
@@ -40,10 +50,9 @@ tour.register('test_image_link', {
         content: "remove URL",
         trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
         run: "remove_text",
-    }, {
-        content: "select image",
-        trigger: "#wrapwrap .s_text_image img",
-    }, {
+    },
+    ...selectImageSteps,
+    {
         content: "check popover content has no URL",
         trigger: ".o_edit_menu_popover a.o_we_url_link:not([href]):contains(No URL specified)",
         run: () => {}, // check
@@ -51,10 +60,9 @@ tour.register('test_image_link', {
         content: "enter email URL",
         trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
         run: "text mailto:test@test.com",
-    }, {
-        content: "select image",
-        trigger: "#wrapwrap .s_text_image img",
-    }, {
+    },
+    ...selectImageSteps,
+    {
         content: "check popover content has mail URL",
         trigger: ".o_edit_menu_popover:has(.fa-envelope-o) a.o_we_url_link[href='mailto:test@test.com']:contains(mailto:test@test.com)",
         run: () => {}, // check
@@ -62,10 +70,9 @@ tour.register('test_image_link', {
         content: "enter phone URL",
         trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
         run: "text tel:555-2368",
-    }, {
-        content: "select image",
-        trigger: "#wrapwrap .s_text_image img",
-    }, {
+    },
+    ...selectImageSteps,
+    {
         content: "check popover content has phone URL",
         trigger: ".o_edit_menu_popover:has(.fa-phone) a.o_we_url_link[href='tel:555-2368']:contains(tel:555-2368)",
         run: () => {}, // check
@@ -73,10 +80,9 @@ tour.register('test_image_link', {
         content: "remove URL",
         trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
         run: "remove_text",
-    }, {
-        content: "select image",
-        trigger: "#wrapwrap .s_text_image img",
-    }, {
+    },
+    ...selectImageSteps,
+    {
         content: "check popover content has no URL",
         trigger: ".o_edit_menu_popover a.o_we_url_link:not([href]):contains(No URL specified)",
         run: () => {}, // check


### PR DESCRIPTION
A random test failure happens during the test of image links. Sometimes
the image link tools popover does not appear anymore.

This commit adds additional steps to make sure the popover is fully
removed before a new one is created.

runbot-4615
runbot-4617
runbot-4618
runbot-4620

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
