### PR TITLE
[FIX] web: static template performance test

### DIFF
--- a/addons/web/tests/test_serving_base.py
+++ b/addons/web/tests/test_serving_base.py
@@ -999,4 +999,4 @@ class TestStaticInheritancePerformance(TestStaticInheritanceCommon):
         time_ratio = delta25000.total_seconds() / delta2500.total_seconds()
         _logger.runbot('Static Templates Inheritance: 25000 templates treated in %s seconds' % delta25000.total_seconds())
         _logger.runbot('Static Templates Inheritance: Computed linearity ratio: %s' % time_ratio)
-        self.assertLessEqual(time_ratio, 12)
+        self.assertLessEqual(time_ratio, 14)


### PR DESCRIPTION
Time comparison can always be slightly random (this is why this test
is a nightly one). The 20% margin left by the 12 ratio is not enough
in all cases. This test was sometime breaking with a
12.944994188420822 not less than or equal to 12

This is one of the max value found by quickly checking the builds.
A ratio of 14 should be hopefully enough.
