### PR TITLE
[IMP] website: add missing theme models fields 

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -437,6 +437,7 @@ class IrModuleModule(models.Model):
         def get_id(model_id):
             return self.env['ir.model.data']._xmlid_to_res_id(model_id)
         return [
+            ('state', '!=', 'uninstallable'),
             ('category_id', 'not in', [
                 get_id('base.module_category_hidden'),
                 get_id('base.module_category_theme_hidden'),

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -348,8 +348,10 @@ class Website(models.Model):
 
     @api.model
     def configurator_recommended_themes(self, industry_id, palette):
-        domain = [('name', '=like', 'theme%'), ('name', 'not in', ['theme_default', 'theme_common']), ('state', '!=', 'uninstallable')]
-        client_themes = request.env['ir.module.module'].search(domain).mapped('name')
+        Module = request.env['ir.module.module']
+        domain = Module.get_themes_domain()
+        domain = AND([[('name', '!=', 'theme_default')], domain])
+        client_themes = Module.search(domain).mapped('name')
         client_themes_img = {t: get_manifest(t).get('images_preview_theme', {}) for t in client_themes if get_manifest(t)}
         themes_suggested = self._website_api_rpc(
             '/api/website/2/configurator/recommended_themes/%s' % industry_id,


### PR DESCRIPTION
Before this commit, there were multiple issues related to the creation
of `theme.website.menu` records in a theme:

- Not possible to add a menu in the exististing website's navbar
- When one would try to create a `theme.website.menu` that menu would be
  created for every website when instaling the theme on a particular
  website, which is terribly wrong as it goes against the multi-website
  holy grail rule: when editing a website, do not impact other websites.
- Not possible to create a mega menu

Now, one can create a menu:
- as a navbar top menu
- as a child menu of another theme menu
- as a whole new menu hierarchy (top level container)

This is not possible to create a menu as a child of a website.menu, like
adding 2 submenu to the existing contact us menu.
First, this is technically impossible to do without introducing yet
another hack code in the `website.menu` write. Indeed, there is no way
to identify a generic menu's website copies. Neither through a direct
DB field, neither through a persistent info like we do with the `key`
attribute of views. So there is no reliable way to tell the system to
add a menu below the "Contact Us" menu of the website, as this is just a
menu copied when the website was created. We could obviously later add
a `key` field or something like that to identify an XML menu's copies.
Second, there is a workaround as one has to recreate the website.menu
and delete the original one (through a `<function/>` record).
Third, this should not be the main use case about menu creation in
themes.

----------

Some fields were also missing regarding the `website.page` model.

----------

A stable attempt is done at [1], this is where the current commit
originates from.
As the Odoo 17 release is quickly approaching, it was decided to first
write the proper IMP in master from which we will see what can be
backported and how, if needed.

[1]: https://github.com/odoo/odoo/pull/86669