### PR TITLE
[IMP] website: allow controller as homepage

### DIFF
--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_image_upload_progress
 from . import test_is_multilang
 from . import test_media
 from . import test_multi_company
+from . import test_page
 from . import test_performance
 from . import test_redirect
 from . import test_reset_views

--- a/addons/test_website/tests/test_page.py
+++ b/addons/test_website/tests/test_page.py
@@ -1,0 +1,59 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+from odoo.tests.common import HOST
+from odoo.tools import config, mute_logger
+
+
+@tagged('-at_install', 'post_install')
+class WithContext(HttpCase):
+    def test_01_homepage_url(self):
+        # Setup
+        website = self.env['website'].browse([1])
+        website.write({
+            'name': 'Test Website',
+            'domain': f'http://{HOST}:{config["http_port"]}',
+            'homepage_url': '/unexisting',
+        })
+        home_url = '/'
+        contactus_url = '/contactus'
+        contactus_url_full = website.domain + contactus_url
+        contactus_content = b'content="Contact Us | Test Website"'
+        self.env['website.menu'].search([
+            ('website_id', '=', website.id),
+            ('url', '=', contactus_url),
+        ]).sequence = 1
+
+        # 404 shouldn't be served but fallback on first menu
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #    yes        | /contactus  |  /unexisting
+        # -------------------------------------------
+        r = self.url_open(website.homepage_url)
+        self.assertEqual(r.status_code, 404, "The website homepage_url should be a 404")
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.url, contactus_url_full)
+        self.assertIn(contactus_content, r.content)
+
+        # same with 403
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #    yes        | /contactus  |  /test_website/200/name-1
+        # -------------------------------------------
+        rec_unpublished = self.env['test.model'].create({
+            'name': 'name',
+            'is_published': False,
+        })
+        website.homepage_url = f"/test_website/200/name-{rec_unpublished.id}"
+        with mute_logger('odoo.http'):  # mute 403 warning
+            r = self.url_open(website.homepage_url)
+        self.assertEqual(r.status_code, 403, "The website homepage_url should be a 403")
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.url, contactus_url_full)
+        self.assertIn(contactus_content, r.content)

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -14,11 +14,13 @@ import werkzeug.wrappers
 from itertools import islice
 from lxml import etree
 from textwrap import shorten
+from werkzeug.exceptions import NotFound
 from xml.etree import ElementTree as ET
 
 import odoo
 
 from odoo import http, models, fields, _
+from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.osv import expression
 from odoo.tools import OrderedSet, escape_psql, html_escape as escape
@@ -70,21 +72,47 @@ class Website(Home):
 
     @http.route('/', type='http', auth="public", website=True, sitemap=True)
     def index(self, **kw):
+        """ The goal of this controller is to make sure we don't serve a 404 as
+        the website homepage. As this is the website entry point, serving a 404
+        is terrible.
+        There is multiple fallback mechanism to prevent that:
+        - If homepage URL is set (empty by default), serve the website.page
+        matching it
+        - If homepage URL is set (empty by default), serve the controller
+        matching it
+        - If homepage URL is not set, serve the `/` website.page
+        - Serve the first accessible menu as last resort. It should be relevant
+        content, at least better than a 404
+        - Serve 404
+        Most DBs will just have a website.page with '/' as URL and keep the
+        homepage_url setting empty.
+        """
         # prefetch all menus (it will prefetch website.page too)
         top_menu = request.website.menu_id
 
-        homepage_id = request.website._get_cached('homepage_id')
-        homepage = homepage_id and request.env['website.page'].browse(homepage_id)
-        if homepage and (homepage.sudo().is_visible or request.env.user._is_internal()) and homepage.url != '/':
-            request.env['ir.http'].reroute(homepage.url)
+        homepage_url = request.website._get_cached('homepage_url')
+        if homepage_url and homepage_url != '/':
+            request.env['ir.http'].reroute(homepage_url)
 
+        # Check for page
         website_page = request.env['ir.http']._serve_page()
         if website_page:
             return website_page
-        else:
-            first_menu = top_menu and top_menu.child_id and top_menu.child_id.filtered(lambda menu: menu.is_visible)
-            if first_menu and first_menu[0].url not in ('/', '', '#') and (not (first_menu[0].url.startswith(('/?', '/#', ' ')))):
-                return request.redirect(first_menu[0].url)
+
+        # Check for controller
+        if homepage_url and homepage_url != '/':
+            try:
+                return request._serve_ir_http()
+            except (AccessError, NotFound):
+                pass
+
+        # Fallback on first accessible menu
+        def is_reachable(menu):
+            return menu.is_visible and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
+
+        reachable_menus = top_menu.child_id.filtered(is_reachable)
+        if reachable_menus:
+            return request.redirect(reachable_menus[0].url)
 
         raise request.not_found()
 

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -552,7 +552,6 @@
             <field name="domain"></field>
             <field name="company_id" ref="base.main_company"/>
             <field name="user_id" ref="base.public_user"/>
-            <!-- Correct homepage will be set during bootstraping -->
         </record>
 
         <!-- Pre loaded images -->

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -27,6 +27,8 @@ class ResConfigSettings(models.TransientModel):
         'Website Domain',
         related='website_id.domain',
         readonly=False)
+    website_homepage_url = fields.Char(
+        related='website_id.homepage_url', readonly=False)
     website_country_group_ids = fields.Many2many(
         related='website_id.country_group_ids',
         readonly=False)

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -139,26 +139,28 @@ class Menu(models.Model):
     # would be better to take a menu_id as argument
     @api.model
     def get_tree(self, website_id, menu_id=None):
+        website = self.env['website'].browse(website_id)
+
         def make_tree(node):
-            is_homepage = bool(node.page_id and self.env['website'].browse(website_id).homepage_id.id == node.page_id.id)
+            menu_url = node.page_id.url if node.page_id else node.url
             menu_node = {
                 'fields': {
                     'id': node.id,
                     'name': node.name,
-                    'url': node.page_id.url if node.page_id else node.url,
+                    'url': menu_url,
                     'new_window': node.new_window,
                     'is_mega_menu': node.is_mega_menu,
                     'sequence': node.sequence,
                     'parent_id': node.parent_id.id,
                 },
                 'children': [],
-                'is_homepage': is_homepage,
+                'is_homepage': menu_url == (website.homepage_url or '/'),
             }
             for child in node.child_id:
                 menu_node['children'].append(make_tree(child))
             return menu_node
 
-        menu = menu_id and self.browse(menu_id) or self.env['website'].browse(website_id).menu_id
+        menu = menu_id and self.browse(menu_id) or website.menu_id
         return make_tree(menu)
 
     @api.model

--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -165,7 +165,6 @@ export class EditMenuDialog extends Component {
                         'parent_id': false,
                     },
                     'children': [],
-                    'is_homepage': false,
                 };
                 this.map.set(newMenu.fields['id'], newMenu);
                 this.state.rootMenu.children.push(newMenu);

--- a/addons/website/tests/test_http_endpoint.py
+++ b/addons/website/tests/test_http_endpoint.py
@@ -12,7 +12,7 @@ class TestHttpEndPoint(HttpCase):
         which causes a cache clearing.
         This test ensures that the rendering still works, even in this case.
         """
-        homepage_id = self.env['ir.ui.view'].search([
+        homepage_view = self.env['ir.ui.view'].search([
             ('website_id', '=', self.env.ref('website.default_website').id),
             ('key', '=', 'website.homepage'),
         ])
@@ -20,7 +20,7 @@ class TestHttpEndPoint(HttpCase):
             'name': 'Add cache clear to Home',
             'type': 'qweb',
             'mode': 'extension',
-            'inherit_id': homepage_id.id,
+            'inherit_id': homepage_view.id,
             'arch_db': """
                 <t t-call="website.layout" position="before">
                     <t t-esc="website.env['ir.http']._clear_routing_map()"/>

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -289,11 +289,11 @@ class WithContext(HttpCase):
             self.url_open(self.page.url).raise_for_status()
             session_save.assert_not_called()
 
-    def test_homepage_not_slash_url(self):
+    def test_05_homepage_not_slash_url(self):
         website = self.env['website'].browse([1])
         # Set another page (/page_1) as homepage
         website.write({
-            'homepage_id': self.page.id,
+            'homepage_url': self.page.url,
             'domain': f"http://{HOST}:{config['http_port']}",
         })
         assert self.page.url != '/'
@@ -305,6 +305,108 @@ class WithContext(HttpCase):
         root_html = html.fromstring(r.content)
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
         self.assertIn(canonical_url, [f"{website.domain}/", f"{website.domain}/page_1"])
+
+    def test_06_homepage_url(self):
+        # Setup
+        website = self.env['website'].browse([1])
+        website.write({
+            'name': 'Test Website',
+            'domain': f'http://{HOST}:{config["http_port"]}',
+            'homepage_url': False,
+        })
+        contactus_url = '/contactus'
+        contactus_url_full = website.domain + contactus_url
+        contactus_content = b'content="Contact Us | Test Website"'
+        contactus_menu = self.env['website.menu'].search([
+            ('website_id', '=', website.id),
+            ('url', '=', contactus_url),
+        ], limit=1)
+        home_url = '/'
+        home_url_full = website.domain + home_url
+        home_content = b'content="Home | Test Website"'
+        home_menu = self.env['website.menu'].search([
+            ('website_id', '=', website.id),
+            ('url', '=', home_url),
+        ], limit=1)
+
+        # Case 1: Default case
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #    yes        |     /       |     None
+        # -------------------------------------------
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, home_url_full)
+        self.assertIn(home_content, r.content)
+
+        # Case 2: Another page as homepage
+        website.homepage_url = contactus_url
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #    yes        |     /       |  /contactus
+        # -------------------------------------------
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, home_url_full)
+        self.assertIn(contactus_content, r.content)
+
+        # Case 3: Check we don't fallback on first menu if there is a / page
+        contactus_menu.sequence = 2
+        website.homepage_url = False
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #    yes        | /contactus  |     None
+        # -------------------------------------------
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, home_url_full)
+        self.assertIn(home_content, r.content)
+
+        # Case 6: Wrong URL should fallback on first non "/" menu
+        website.homepage_url = '/unexisting'
+        home_menu.sequence = 1
+        self.assertEqual(website.menu_id.child_id[0], home_menu)
+        self.assertEqual(website.menu_id.child_id[1], contactus_menu)
+        # ----------------------------------------------------------
+        # / page exists | first menu  | second menu  |  homepage_url
+        # ----------------------------------------------------------
+        #     no        | /           |  /contactus  | /unexisting
+        # ----------------------------------------------------------
+        r = self.url_open(website.homepage_url)
+        self.assertEqual(r.status_code, 404, "The website homepage_url should be a 404")
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, contactus_url_full, "Menu fallback should be a redirect, not a reroute")
+        self.assertIn(contactus_content, r.content)
+
+        # Case 4: Check first menu fallback is a redirect (and not a reroute)
+        self.env['website.page'].search([('url', '=', home_url)]).unlink()  # this also deletes the / home menu
+        website.homepage_url = False
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #     no        | /contactus  |     None
+        # -------------------------------------------
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.history[0].status_code, 303)
+        self.assertEqual(r.url, contactus_url_full)
+        self.assertIn(contactus_content, r.content)
+
+        # Case 5: Check controller redirect and make sure it is a reroute
+        website.homepage_url = '/website/info'
+        # -------------------------------------------
+        # / page exists | first menu  |  homepage_url
+        # -------------------------------------------
+        #     no        | /contactus  | /website/info
+        # -------------------------------------------
+        r = self.url_open(home_url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, home_url_full)
+        self.assertIn(b'o_website_info', r.content)
 
     def test_07_alternatives(self):
         website = self.env.ref('website.default_website')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -178,7 +178,9 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_06_public_user_editor(self):
         website_default = self.env['website'].search([], limit=1)
-        website_default.homepage_id.arch = """
+        self.env['website.page'].search([
+            ('url', '=', '/'), ('website_id', '=', website_default.id)
+        ], limit=1).arch = """
             <t name="Homepage" t-name="website.homepage">
                 <t t-call="website.layout">
                     <textarea class="o_public_user_editor_test_textarea o_wysiwyg_loader"/>

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -43,6 +43,10 @@
                                         <label class="col-lg-3" string="Domain" for="website_domain"/>
                                         <field name="website_domain" placeholder="https://www.odoo.com" title="Display this website when users visit this domain"/>
                                     </div>
+                                    <div class="row mt8">
+                                        <label class="col-lg-3" string="Homepage URL" for="website_homepage_url"/>
+                                        <field name="website_homepage_url" placeholder="/" title="Main page of your website served to visitors"/>
+                                    </div>
                                     <div class="row mt8" groups="base.group_no_one">
                                         <label class="col-lg-3" string="Country Groups" for="website_country_group_ids"/>
                                         <field name="website_country_group_ids" widget="many2many_tags" title="Once the selection of available websites by domain is done, you can filter by country group. You can have 2 websites with same domain AND a condition on country group to select which website to use."/>


### PR DESCRIPTION
Before this commit, only a website.page could be used as a custom
homepage ('custom' meaning other than '/').

But it is a real use case and requirement for our users to be able to
select a controller as homepage.
For instance, an ecommerce would want its homepage to be the shop and
not a regular page from where you then have to navigate to the shop.

Right now, this can (almost) be achieved by doing some technical
advanced operations:
- Move the 'Shop' menu first in the menu navbar of the website
- Delete the specific '/' website.page for the website
- Delete the generic '/' website.page (no website_id)

That way, the system will redirect `/` to `/shop`, which is not ideal as
it should remain `/` in the URL.

That's because, until now, the homepage (`/` controller) serve order
was:
- Serve the website.page set as homepage (`website.homepage_id`),
  happens when one did select another page as homepage through the page
  properties dialog
- Serve the website.page having `/` as URL (default)
- Serve the first accessible menu if there no `/` page or other page set
  as homepage, it acts as a last resort attempt to not serve a 404 and
  to try serving relevant content (the first menu of a website is most
  likely always better than a 404)
- Serve 404

This commit allows to introduce an URL as homepage, instead of only a
website.page. It can be done through the website settings in the
backend.

There is 2 main points to keep in mind about serving the homepage:
- make sure we don't serve a 404 as the website homepage. This is the
  website entry point, serving a 404 is terrible. That's why we have
  some fallback mechanism like serving the first menu.
- We need to serve / before fallbacking to the first menu, as a lot of
  site just remove the 'Home' first menu since it is a duplicate of the
  logo, which also redirect to the homepage. In such cases, it doesn't
  mean that the user want his first menu to be the homepage. We
  shouldn't rely on such a behavior, it should just be used as a last
  resort.

With this commit, the homepage serve order is now:
- If homepage URL is set (empty by default), serve the website.page
  matching it
- If homepage URL is set (empty by default), serve the controller
  matching it
- If homepage URL is not set, serve the `/` website.page
- Serve the first accessible menu as last resort. It should be relevant
  content, at least better than a 404
- Serve 404

Most DBs will just have a website.page with '/' as URL and keep the
homepage_url setting empty.

task-2969683