### PR TITLE
[FIX] mail: add default empty string to mentionText field

### DIFF
--- a/addons/mail/static/src/models/composer_suggestion_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_view.js
@@ -127,6 +127,7 @@ registerModel({
          */
         mentionText: attr({
             compute: '_computeMentionText',
+            default: '',
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',


### PR DESCRIPTION
To avoid undefined value in the business logic.

task-2884212