### PR TITLE
[FIX] project_timesheet_holidays: fix AccessError with mrp

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -162,5 +162,5 @@ class ResourceCalendarLeaves(models.Model):
         result = super(ResourceCalendarLeaves, self).write(vals)
         if global_time_off_updated:
             global_time_offs_with_leave_timesheet = global_time_off_updated.filtered(lambda r: not r.resource_id and r.calendar_id.company_id.internal_project_id and r.calendar_id.company_id.leave_timesheet_task_id)
-            global_time_offs_with_leave_timesheet._timesheet_create_lines()
+            global_time_offs_with_leave_timesheet.sudo()._timesheet_create_lines()
         return result


### PR DESCRIPTION
Steps to reproduce
------------------

1) Install project_timesheet_holidays and mrp.
2) Go to Manufacturing > Settings and enable Work Orders.
3) Log in as a user with access rights to Manufacturing but no access rights to HR.
4) Create a Manufacturing Order with a Work Order.
5) Go to Operations > Work Order and start the Work Order.
5) Click on "Done", you should get an AccessRight error.

---

This commit fixes this error by calling sudo before creating the timesheet leaves for each employee.

Follow-up of https://github.com/odoo/odoo/pull/94414