### PR TITLE
[FIX] product: correctly compute price with pricelist rules

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -586,6 +586,10 @@ class PricelistItem(models.Model):
         convert_to_price_uom = (lambda price: product.uom_id._compute_price(price, price_uom))
         if self.compute_price == 'fixed':
             price = convert_to_price_uom(self.fixed_price)
+            if self._context.get('no_variant_attributes_price_extra'):
+                price_extra = sum(self._context.get('no_variant_attributes_price_extra'))
+                price_extra = product.currency_id._convert(price_extra, self.currency_id, self.env.company, date)
+                price += price_extra
         elif self.compute_price == 'percentage':
             price = (price - (price * (self.percent_price / 100))) or 0.0
         else:


### PR DESCRIPTION
The price of a product that has a fixed price rule doesn't change when
we select a variant (of creation mode 'Never') that adds an extra price

Steps to reproduce:
1. Install eCommerce
2. Go to Settings > Website > Pricing and enable Pricelists
3. Go to Website > Products > Products and create a product 'Test', add
   a variant with a creation mode of 'Never' and two values, one of
   which adds a price of 100$
4. Go to Website > Products > Pricelists and add a price rule in
   pricelist 'Public Pricelist' on product 'Test' with price 50$
5. Go to Website > Products > Products, open product 'Test' and open it
   on the website ('Go to Website' smart button)
6. Select the second variant, the price doesn't change even though this
   variant adds 100$ to the price

Solution:
Update the price with the 'no_variant_attributes_price_extra' when we
have a price rule with a fixed price

Problem:
`_compute_price` of pricelist doesn't take into account the extra price
of variants with creation mode of 'Never' like `price_compute` of
product does so if we completely overwrite the price (with a fixed price
rule), the extra price would be totally overlooked

opw-2957184