### PR TITLE
[FIX] website: break too long table of content generated entries

### DIFF
--- a/addons/website/static/src/snippets/s_table_of_content/000.scss
+++ b/addons/website/static/src/snippets/s_table_of_content/000.scss
@@ -11,6 +11,8 @@
             }
         }
         &.s_table_of_content_vertical_navbar .s_table_of_content_navbar {
+            overflow-wrap: break-word;
+
             > a.list-group-item-action {
                 background: none;
                 color: inherit;


### PR DESCRIPTION
Before this commit if a Table of Content entry was a too long word
without spaces, it span beyond the width of the menu part of the Table
of Content block.
Note that in Chrome, during Edit mode the words are already split
across several lines because the `contenteditable="true"` of the
`#wrap` node applies some built-in extra styles (not from user agent
stylesheet) among which `overflow-wrap: break-word;`.

After this commit long words are split across several lines.

task-2965279
