### PR TITLE
[FIX] sale: timezone of online payment invoice

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -110,6 +110,8 @@ class PaymentTransaction(models.Model):
         if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
             # Invoice the sale orders in self instead of in confirmed_orders to create the invoice
             # even if only a partial payment was made.
+            if not self.create_uid.tz:
+                self.create_uid.tz = confirmed_orders.user_id.tz
             self._invoice_sale_orders()
             self._send_invoice()
         return super()._reconcile_after_done()


### PR DESCRIPTION
Steps to reproduce:
-run odoo using faketime
(TZ=UTC faketime -m '2021-06-19 01:33:00' python3 ./odoo/odoo-bin --addons-path=./custom,./odoo/addons,./enterprise/ -d bug_fix_mst_pcfic --dev xml --smtp=localhost --smtp-port=1025 --max-cron-threads=0)
(equivalent to 2021-06-18 18:33 PST)
-enable test payment provider and automatic invoice in settings
-set user timezone in preference to America/Los_Angeles
-create a subscription and send quotation by mail
-open customer preview
-copy link to a private window in the browser (user not loged in)
-sign and pay
-invoice date is 19/06/2021 (instead of 18/06/2021 when user is logged in)

Bug:
when the user is not logged in the timezone defaults to UTC

Fix:
create invoice using sales person timezone when user isn't logged in

opw-2356448
