### PR TITLE
[FIX] web: sequenceable list in readonly context

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -117,7 +117,6 @@ KanbanController.components = { Layout, KanbanRenderer };
 KanbanController.props = {
     ...standardViewProps,
     defaultGroupBy: { validate: (dgb) => !dgb || typeof dgb === "string", optional: true },
-    editable: { type: Boolean, optional: true },
     forceGlobalClick: { type: Boolean, optional: true },
     onSelectionChanged: { type: Function, optional: true },
     showButtons: { type: Boolean, optional: true },

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -54,7 +54,6 @@ export class ListController extends Component {
         this.rootRef = useRef("root");
 
         this.archInfo = this.props.archInfo;
-        this.editable = this.props.editable ? this.archInfo.editable : false;
         this.multiEdit = this.archInfo.multiEdit;
         this.activeActions = this.archInfo.activeActions;
         const fields = this.props.fields;
@@ -146,6 +145,16 @@ export class ListController extends Component {
             },
             () => [this.model.root.selection.length]
         );
+    }
+
+    get editable() {
+        if (this.props.readonly) {
+            return false;
+        }
+        if ("editable" in this.props) {
+            return this.props.editable;
+        }
+        return this.archInfo.editable || false;
     }
 
     async createRecord({ group } = {}) {
@@ -443,8 +452,9 @@ ListController.template = `web.ListView`;
 ListController.components = { ActionMenus, ListViewHeaderButton, Layout, ViewButton };
 ListController.props = {
     ...standardViewProps,
+    editable: { type: Boolean, optional: true }, // no default, it's retrieved from the arch.
+    readonly: { type: Boolean, optional: true },
     allowSelectors: { type: Boolean, optional: true },
-    editable: { type: Boolean, optional: true },
     onSelectionChanged: { type: Function, optional: true },
     showButtons: { type: Boolean, optional: true },
     Model: Function,
@@ -455,7 +465,7 @@ ListController.props = {
 ListController.defaultProps = {
     allowSelectors: true,
     createRecord: () => {},
-    editable: true,
+    readonly: false,
     selectRecord: () => {},
     showButtons: true,
 };

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -26,7 +26,7 @@
                             onActionExecuted="() => model.load()"/>
                     </t>
                 </t>
-                <t t-component="props.Renderer" list="model.root" activeActions="activeActions" archInfo="archInfo" allowSelectors="props.allowSelectors" editable="editable" openRecord.bind="openRecord" noContentHelp="props.info.noContentHelp" onAdd.bind="createRecord"/>
+                <t t-component="props.Renderer" list="model.root" activeActions="activeActions" archInfo="archInfo" allowSelectors="props.allowSelectors" editable="editable" readonly="props.readonly" openRecord.bind="openRecord" noContentHelp="props.info.noContentHelp" onAdd.bind="createRecord"/>
             </Layout>
         </div>
     </t>

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -321,6 +321,9 @@ export class ListRenderer extends Component {
         if (!this.props.list.canResequence()) {
             return false;
         }
+        if (this.props.readonly) {
+            return false;
+        }
         const orderBy = this.props.list.orderBy;
         const handleField = this.props.archInfo.handleField;
         return !orderBy.length || (orderBy.length && orderBy[0].name === handleField);
@@ -1073,7 +1076,6 @@ export class ListRenderer extends Component {
     }
 
     applyCellKeydownEditModeGroup(hotkey, cell, group, record) {
-        const { activeActions, editable } = this.props;
         const groupIndex = group.list.records.indexOf(record);
         const isLastOfGroup = groupIndex === group.list.records.length - 1;
         const isDirty = record.isDirty || this.lastIsDirty;
@@ -1084,8 +1086,8 @@ export class ListRenderer extends Component {
         }
         if (
             isLastOfGroup &&
-            activeActions.create &&
-            editable === "bottom" &&
+            this.props.activeActions.create &&
+            this.props.editable === "bottom" &&
             record.checkValidity() &&
             (isEnterBehavior || isTabBehavior)
         ) {
@@ -1722,10 +1724,16 @@ ListRenderer.props = [
     "onAdd?",
     "cycleOnTab?",
     "allowSelectors?",
+    "readonly?",
     "editable?",
     "noContentHelp?",
     "nestedKeyOptionalFieldsData?",
 ];
-ListRenderer.defaultProps = { hasSelectors: false, cycleOnTab: true };
+ListRenderer.defaultProps = {
+    hasSelectors: false,
+    cycleOnTab: true,
+    readonly: false,
+    editable: true,
+};
 
 ListRenderer.LONG_TOUCH_THRESHOLD = 400;

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.js
@@ -13,8 +13,8 @@ export class SelectCreateDialog extends Component {
         this.state = useState({ resIds: [] });
         this.baseViewProps = {
             display: { searchPanel: false },
-            editable: false, // readonly
             noBreadcrumbs: true,
+            readonly: true,
             noContentHelp: markup(`<p>${escape(this.env._t("No records found!"))}</p>`),
             showButtons: false,
             selectRecord: (resId) => this.select([resId]),

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -14855,4 +14855,81 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row:first-child td.o_list_button", 1);
         await click(target, ".o_data_row:first-child td.o_list_button");
     });
+
+    QUnit.test("resequenceable list view, readonly parent view", async function (assert) {
+        serverData.models.bar = {
+            fields: {
+                titi: { string: "Char", type: "char" },
+                int_field: { string: "Integer", type: "integer" },
+            },
+            records: [
+                { id: 1, titi: "one", int_field: 1 },
+                { id: 2, titi: "two", int_field: 2 },
+            ],
+        };
+        serverData.models.foo.records[0].o2m = [1, 2];
+
+        await makeView({
+            type: "form",
+            resModel: "foo",
+            serverData,
+            resId: 1,
+            arch: `
+                <form>
+                    <sheet>
+                        <field name="o2m">
+                            <tree>
+                                <field name="int_field" widget="handle"/>
+                                <field name="titi" readonly="1"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                </form>`,
+        });
+        assert.doesNotHaveClass(target.querySelector(".o_data_row"), "o_row_draggable");
+        await clickEdit(target);
+        assert.hasClass(target.querySelector(".o_data_row"), "o_row_draggable");
+        await clickSave(target);
+        assert.doesNotHaveClass(target.querySelector(".o_data_row"), "o_row_draggable");
+    });
+
+    QUnit.test(
+        "resequenceable list view, readonly parent view, readonly field x2m",
+        async function (assert) {
+            serverData.models.bar = {
+                fields: {
+                    titi: { string: "Char", type: "char" },
+                    int_field: { string: "Integer", type: "integer" },
+                },
+                records: [
+                    { id: 1, titi: "one", int_field: 1 },
+                    { id: 2, titi: "two", int_field: 2 },
+                ],
+            };
+            serverData.models.foo.records[0].o2m = [1, 2];
+
+            await makeView({
+                type: "form",
+                resModel: "foo",
+                serverData,
+                resId: 1,
+                arch: `
+                <form>
+                    <sheet>
+                        <field name="o2m" readonly="1">
+                            <tree>
+                                <field name="int_field" widget="handle"/>
+                                <field name="titi" readonly="1"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                </form>`,
+            });
+            assert.doesNotHaveClass(target.querySelector(".o_data_row"), "o_row_draggable");
+            await clickEdit(target);
+            assert.doesNotHaveClass(target.querySelector(".o_data_row"), "o_row_draggable");
+            await clickSave(target);
+            assert.doesNotHaveClass(target.querySelector(".o_data_row"), "o_row_draggable");
+        }
+    );
 });


### PR DESCRIPTION
Currently, a list renderer allow row sequencing while being in a
readonly context, such as a x2m inside a view form.

This commit fix this by providing to the renderer the prop "readonly".
The list controller or the field instantiating the renderer had all the
information required.

There was confusion around the differences between "editable" (top,
bottom) and "readonly", so it was cleaned a bit.