### PR TITLE
[FIX] web: empty a many2one field

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -29,7 +29,7 @@ function m2oTupleFromData(data) {
     if ("display_name" in data) {
         name = data.display_name;
     } else {
-        let _name = data.name;
+        const _name = data.name;
         name = Array.isArray(_name) ? _name[1] : _name;
     }
     return [id, name];
@@ -78,9 +78,6 @@ export class Many2OneField extends Component {
         this.update = (value, params = {}) => {
             if (value) {
                 value = m2oTupleFromData(value[0]);
-            }
-            if (!value && !this.updateOnEmpty) {
-                return;
             }
             this.state.isFloating = false;
             return this.props.update(value);
@@ -132,10 +129,6 @@ export class Many2OneField extends Component {
     get resId() {
         return this.props.value && this.props.value[0];
     }
-    get updateOnEmpty() {
-        return true;
-    }
-
     getDomain() {
         return this.domain.toList(this.context);
     }
@@ -232,11 +225,4 @@ Many2OneField.extractProps = ({ attrs, field }) => {
 };
 
 registry.category("fields").add("many2one", Many2OneField);
-
-export class ListMany2OneField extends Many2OneField {
-    get updateOnEmpty() {
-        return false;
-    }
-}
-
-registry.category("fields").add("list.many2one", ListMany2OneField); // TODO WOWL: link isn't clickable in lists
+registry.category("fields").add("list.many2one", Many2OneField);


### PR DESCRIPTION
Before this commit, it was impossible to empty a many2one in a list view.

How to reproduce:
- go into a list view with a many2one
- empty a many2one containing a value
- click outside the line

Before this commit:
The record goes into readonly mode and its many2one returns to
its original value.

After this commit:
The record is saved and its many2one is empty.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
