### PR TITLE
[FIX] base: fix batch report outlines traceback

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -732,8 +732,8 @@ class IrActionsReport(models.Model):
                     # the top level heading in /Outlines.
                     reader = PdfFileReader(pdf_content_stream)
                     root = reader.trailer['/Root']
+                    outlines_pages = []
                     if '/Outlines' in root and '/First' in root['/Outlines']:
-                        outlines_pages = []
                         node = root['/Outlines']['/First']
                         while True:
                             outlines_pages.append(root['/Dests'][node['/Dest']][0])
@@ -741,10 +741,9 @@ class IrActionsReport(models.Model):
                                 break
                             node = node['/Next']
                         outlines_pages = sorted(set(outlines_pages))
-                        # There should be only one top-level heading by document
-                        assert len(outlines_pages) == len(res_ids)
-                        # There should be a top-level heading on first page
-                        assert outlines_pages[0] == 0
+                    # There should be only one top-level heading by document
+                    # There should be a top-level heading on first page
+                    if len(outlines_pages) == len(res_ids) and outlines_pages[0] == 0:
                         for i, num in enumerate(outlines_pages):
                             to = outlines_pages[i + 1] if i + 1 < len(outlines_pages) else reader.numPages
                             attachment_writer = PdfFileWriter()
@@ -761,7 +760,9 @@ class IrActionsReport(models.Model):
                             streams.append(stream)
                         close_streams([pdf_content_stream])
                     else:
-                        # If no outlines available, do not save each record
+                        # We can not generate separate attachments because the outlines
+                        # do not reveal where the splitting points should be in the pdf.
+                        _logger.info('The PDF report can not be saved as attachment.')
                         streams.append(pdf_content_stream)
 
         # If attachment_use is checked, the records already having an existing attachment


### PR DESCRIPTION
Steps to reproduce:

Accounting app > Customers > Invoices
- Create invoice with customer and a couple of products
- In the terms & conditions tab at the bottom, add 20-30 empty lines
and then a heading (/h1-3) with some text. This insures that the printed
report will have more than 1 page.
- Go back to the Invoices list view
- Select the invoice + another random one > Print > Invoices

A traceback appears in _post_pdf: Assertion error
`assert len(outlines_pages) == len(res_ids)`

When printing a PDF file, `wkhtmltopdf` generates a number of `outlines`
equal to the number of headings (`<h1-6>`) in the printed document.
When printing multiple documents, the logic requires that each document
should have all of its headings on one page.

The traceback is raised because one document has headings on more
than one page.

The information about which `outlines` correspond to which document is
lost during the pdf creation process, so there is no easy way to reason
about the length of each document after the pdf is created.

Solution:

If there are more outlines then expected, then the matching fails and
each part of the PDF will not be saved as attachment, similarly to https://github.com/odoo/odoo/pull/25496

opw-2882507