### PR TITLE
[IMP] speedup /web (and other page) loading

### DIFF
--- a/addons/mrp_subcontracting/views/subcontracting_portal_templates.xml
+++ b/addons/mrp_subcontracting/views/subcontracting_portal_templates.xml
@@ -74,7 +74,7 @@
                 </script>
                 <base target="_parent"/>
                 <t t-call-assets="web.assets_common" t-js="false"/>
-                <t t-call-assets="mrp_subcontracting.webclient" t-js="false"/>
+                <t t-call-assets="web.assets_backend" t-js="false"/>
                 <t t-call-assets="web.assets_common" t-css="false"/>
                 <t t-call-assets="mrp_subcontracting.webclient" t-css="false"/>
                 <t t-call="web.conditional_assets_tests"/>

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -99,7 +99,6 @@
         # We can reduce the size of loaded assets in POS UI by selectively
         # loading the `web` assets. We should only include what POS needs.
         'point_of_sale.pos_assets_backend': [
-            ('include', 'web.assets_common'),
             ('include', 'web.assets_backend'),
             ('remove', 'web/static/src/core/errors/error_handlers.js'),
             ('remove', 'web/static/src/legacy/legacy_rpc_error_handler.js'),

--- a/addons/point_of_sale/views/pos_assets_common.xml
+++ b/addons/point_of_sale/views/pos_assets_common.xml
@@ -4,6 +4,7 @@
 <template id="point_of_sale.assets_common" name="POS Assets Common">
     <t t-call-assets="point_of_sale.pos_assets_backend_style" t-js="false"/>
     <t t-call-assets="point_of_sale.assets" t-js="false" />
+    <t t-call-assets="web.assets_common" t-css="false" />
     <t t-call-assets="point_of_sale.pos_assets_backend" t-css="false" />
     <t t-call-assets="point_of_sale.assets" t-css="false" />
 </template>

--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -84,4 +84,4 @@ class TestLoad(HttpCase):
 
         with patch('odoo.addons.base.models.assetsbundle.AssetsBundle.save_attachment', save_attachment):
             self.url_open('/web').raise_for_status()
-            #self.url_open('/').raise_for_status() #currently breaking because of the website_id
+            self.url_open('/').raise_for_status()

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tools import mute_logger
-from odoo.tests.common import HttpCase
+from odoo.tests.common import HttpCase, tagged
 
 EXTRA_REQUEST = 2 - 1
 """ During tests, the query on 'base_registry_signaling, base_cache_signaling'
@@ -140,10 +140,13 @@ class TestWebsitePerformance(UtilPerf):
         self.assertEqual(self._get_url_hot_query(self.page.url), 6)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
 
+
+@tagged('-at_install', 'post_install')
+class TestWebsitePerformancePost(UtilPerf):
     @mute_logger('odoo.http')
     def test_50_perf_sql_web_assets(self):
         # assets route /web/assets/..
-        self.url_open('/')  # create assets attachments
+        self.env['ir.qweb']._generate_asset_nodes('web.assets_common', css=False, js=True)
         assets_url = self.env['ir.attachment'].search([('url', '=like', '/web/assets/%/web.assets_common%.js')], limit=1).url
         self.assertEqual(self._get_url_hot_query(assets_url), 4)
         self.assertEqual(self._get_url_hot_query(assets_url, cache=False), 4)

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -382,7 +382,7 @@ from odoo import api, models, tools
 from odoo.tools import config, safe_eval, pycompat, SUPPORTED_DEBUGGER
 from odoo.tools.safe_eval import assert_valid_codeobj, _BUILTINS, to_opcodes, _EXPR_OPCODES, _BLACKLIST
 from odoo.tools.json import scriptsafe
-from odoo.tools.misc import get_lang, str2bool
+from odoo.tools.misc import str2bool
 from odoo.tools.image import image_data_uri
 from odoo.http import request
 from odoo.modules.module import get_resource_path

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2533,15 +2533,17 @@ class IrQWeb(models.AbstractModel):
                     js_bundles.add(asset)
                 if css:
                     css_bundles.add(asset)
-
+        nodes = []
         start = time.time()
         for bundle in sorted(js_bundles):
-            self._generate_asset_nodes(bundle, css=False, js=True)
+            nodes += self._generate_asset_nodes(bundle, css=False, js=True)
         _logger.info('JS Assets bundles generated in %s seconds', time.time()-start)
         start = time.time()
         for bundle in sorted(css_bundles):
-            self._generate_asset_nodes(bundle, css=True, js=False)
+            nodes += self._generate_asset_nodes(bundle, css=True, js=False)
         _logger.info('CSS Assets bundles generated in %s seconds', time.time()-start)
+        return nodes
+
 
 def render(template_name, values, load, **options):
     """ Rendering of a qweb template without database and outside the registry.

--- a/odoo/addons/test_assetsbundle/__init__.py
+++ b/odoo/addons/test_assetsbundle/__init__.py
@@ -1,1 +1,2 @@
 from . import controllers
+from . import models

--- a/odoo/addons/test_assetsbundle/models/__init__.py
+++ b/odoo/addons/test_assetsbundle/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_qweb

--- a/odoo/addons/test_assetsbundle/models/ir_qweb.py
+++ b/odoo/addons/test_assetsbundle/models/ir_qweb.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+class IrQweb(models.AbstractModel):
+    _inherit = 'ir.qweb'
+
+    def _register_hook(self):
+        super()._register_hook()
+        # if this module is installed, we are in a test environement.
+        # pregenerate assets at the end of the loading to speedup tests
+        if self.env.registry.updated_modules:
+            self._pregenerate_assets_bundles()

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -579,7 +579,11 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
         else:
             _logger.error('At least one test failed when loading the modules.')
 
-        # STEP 8: call _register_hook on every model
+
+        # STEP 8: save installed/updated modules for post-install tests and _register_hook
+        registry.updated_modules += processed_modules
+
+        # STEP 9: call _register_hook on every model
         # This is done *exactly once* when the registry is being loaded. See the
         # management of those hooks in `Registry.setup_models`: all the calls to
         # setup_models() done here do not mess up with hooks, as registry.ready
@@ -589,8 +593,6 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
             model._register_hook()
         env.flush_all()
 
-        # STEP 9: save installed/updated modules for post-install tests
-        registry.updated_modules += processed_modules
 
 def reset_modules_state(db_name):
     """

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1307,7 +1307,12 @@ def preload_registries(dbnames):
                                 sorted(registry._init_modules))
                 _logger.info("Starting post tests")
                 tests_before = registry._assertion_report.testsRun
-                result = loader.run_suite(loader.make_suite(module_names, 'post_install'))
+                post_install_suite = loader.make_suite(module_names, 'post_install')
+                if post_install_suite.countTestCases():
+                    with registry.cursor() as cr:
+                        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+                        env['ir.qweb']._pregenerate_assets_bundles()
+                result = loader.run_suite(post_install_suite)
                 registry._assertion_report.update(result)
                 _logger.info("%d post-tests in %.2fs, %s queries",
                              registry._assertion_report.testsRun - tests_before,


### PR DESCRIPTION
This is a part of #97879

When loading /web for the first time (cold)
- assets are generated 
- visible menu are computed (for each user)

This pr proposes to pregenerate assets after install. Generation would be even speed up with #97879
This may have a noticable impact on post install tests since every browser_js or url_open test starts cold.

Also, batch access rules to compute visible menu ids.

This pr should be more mature that that but this extracted part may help avoiding errors on runbot and speed up tests. 

