### PR TITLE
[FIX] hr_timesheet: force active employee at timesheet creation

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from lxml import etree
 import re
 
-from odoo import api, fields, models, _
-from odoo.exceptions import UserError, AccessError
+from odoo import api, fields, models, _, _lt
+from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.osv import expression
 
 class AccountAnalyticLine(models.Model):
@@ -96,35 +96,73 @@ class AccountAnalyticLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        # Before creating a timesheet, we need to put a valid employee_id in the vals
         default_user_id = self._default_user()
-        user_ids = list(map(lambda x: x.get('user_id', default_user_id), filter(lambda x: not x.get('employee_id') and x.get('project_id'), vals_list)))
-
+        user_ids = []
+        employee_ids = []
+        # 1/ Collect the user_ids and employee_ids from each timesheet vals
         for vals in vals_list:
-            # when the name is not provide by the 'Add a line', we set a default one
-            if vals.get('project_id') and not vals.get('name'):
-                vals['name'] = '/'
             vals.update(self._timesheet_preprocess(vals))
+            if not vals.get('project_id'):
+                continue
+            if not vals.get('name'):
+                vals['name'] = '/'
+            employee_id = vals.get('employee_id')
+            user_id = vals.get('user_id', default_user_id)
+            if employee_id and employee_id not in employee_ids:
+                employee_ids.append(employee_id)
+            elif user_id not in user_ids:
+                user_ids.append(user_id)
 
-        # Although this make a second loop on the vals, we need to wait the preprocess as it could change the company_id in the vals
-        # TODO To be refactored in master
-        employees = self.env['hr.employee'].sudo().search([('user_id', 'in', user_ids)])
-        employee_for_user_company = defaultdict(dict)
+        # 2/ Search all employees related to user_ids and employee_ids, in the selected companies
+        employees = self.env['hr.employee'].sudo().search([
+            '&', '|', ('user_id', 'in', user_ids), ('id', 'in', employee_ids), ('company_id', 'in', self.env.companies.ids)
+        ])
+
+        #                 ┌───── in search results = active/in companies ────────> was found with... ─── employee_id ───> (A) There is nothing to do, we will use this employee_id
+        # 3/ Each employee                                                                          └──── user_id ──────> (B)** We'll need to select the right employee for this user
+        #                 └─ not in search results = archived/not in companies ──> (C) We raise an error as we can't create a timesheet for an archived employee
+        # ** We can rely on the user to get the employee_id if
+        #    he has an active employee in the company of the timesheet
+        #    or he has only one active employee for all selected companies
+        valid_employee_per_id = {}
+        employee_id_per_company_per_user = defaultdict(dict)
         for employee in employees:
-            employee_for_user_company[employee.user_id.id][employee.company_id.id] = employee.id
+            if employee.id in employee_ids:
+                valid_employee_per_id[employee.id] = employee
+            else:
+                employee_id_per_company_per_user[employee.user_id.id][employee.company_id.id] = employee.id
 
-        employee_ids = set()
+        # 4/ Put valid employee_id in each vals
+        error_msg = _lt('Timesheets must be created with an active employee in the selected companies.')
         for vals in vals_list:
-            # compute employee only for timesheet lines, makes no sense for other lines
-            if not vals.get('employee_id') and vals.get('project_id'):
-                employee_for_company = employee_for_user_company.get(vals.get('user_id', default_user_id), False)
-                if not employee_for_company:
+            if not vals.get('project_id'):
+                continue
+            employee_in_id = vals.get('employee_id')
+            if employee_in_id:
+                if employee_in_id in valid_employee_per_id:
+                    vals['user_id'] = valid_employee_per_id[employee_in_id].sudo().user_id.id   # (A) OK
                     continue
-                company_id = list(employee_for_company)[0] if len(employee_for_company) == 1 else vals.get('company_id', self.env.company.id)
-                vals['employee_id'] = employee_for_company.get(company_id, False)
-            elif vals.get('employee_id'):
-                employee_ids.add(vals['employee_id'])
-        if any(not emp.active for emp in self.env['hr.employee'].browse(list(employee_ids))):
-            raise UserError(_('Timesheets must be created with an active employee.'))
+                else:
+                    raise ValidationError(error_msg)                                            # (C) KO
+            else:
+                user_id = vals.get('user_id', default_user_id)                                  # (B)...
+
+            # ...Look for an employee, with ** conditions
+            employee_per_company = employee_id_per_company_per_user.get(user_id)
+            employee_out_id = False
+            if employee_per_company:
+                company_id = list(employee_per_company)[0] if len(employee_per_company) == 1\
+                        else vals.get('company_id', self.env.company.id)
+                employee_out_id = employee_per_company.get(company_id, False)
+
+            if employee_out_id:
+                vals['employee_id'] = employee_out_id
+                vals['user_id'] = user_id
+            else:  # ...and raise an error if they fail
+                raise ValidationError(error_msg)
+
+        # 5/ Finally, create the timesheets
         lines = super(AccountAnalyticLine, self).create(vals_list)
         for line, values in zip(lines, vals_list):
             if line.project_id:  # applied only for timesheet
@@ -183,24 +221,22 @@ class AccountAnalyticLine(models.Model):
             Overrride this to compute on the fly some field that can not be computed fields.
             :param values: dict values for `create`or `write`.
         """
-        # project implies analytic account
-        if vals.get('project_id') and not vals.get('account_id'):
-            project = self.env['project.project'].browse(vals.get('project_id'))
+        project = self.env['project.project'].browse(vals.get('project_id', False))
+        task = self.env['project.task'].browse(vals.get('task_id', False))
+        # task implies project
+        if task and not project:
+            project = task.project_id
+            if not project:
+                raise ValidationError(_('You cannot create a timesheet on a task not linked to a project.'))
+            vals['project_id'] = project.id
+        if project and not vals.get('account_id'):
             vals['account_id'] = project.analytic_account_id.id
             vals['company_id'] = project.analytic_account_id.company_id.id or project.company_id.id
             if not project.analytic_account_id.active:
-                raise UserError(_('The project you are timesheeting on is not linked to an active analytic account. Set one on the project configuration.'))
-        # employee implies user
-        if vals.get('employee_id') and not vals.get('user_id'):
-            employee = self.env['hr.employee'].browse(vals['employee_id'])
-            vals['user_id'] = employee.user_id.id
+                raise UserError(_('You cannot add timesheets to a project linked to an inactive analytic account.'))
         # force customer partner, from the task or the project
-        if (vals.get('project_id') or vals.get('task_id')) and not vals.get('partner_id'):
-            partner_id = False
-            if vals.get('task_id'):
-                partner_id = self.env['project.task'].browse(vals['task_id']).partner_id.id
-            else:
-                partner_id = self.env['project.project'].browse(vals['project_id']).partner_id.id
+        if project and not vals.get('partner_id'):
+            partner_id = task.partner_id.id if task else project.partner_id.id
             if partner_id:
                 vals['partner_id'] = partner_id
         # set timesheet UoM from the AA company (AA implies uom)

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -48,7 +48,14 @@ class ResourceMixin(models.AbstractModel):
     def copy_data(self, default=None):
         if default is None:
             default = {}
-        resource = self.resource_id.copy()
+
+        resource_default = {}
+        if 'company_id' in default:
+            resource_default['company_id'] = default['company_id']
+        if 'resource_calendar_id' in default:
+            resource_default['calendar_id'] = default['resource_calendar_id']
+        resource = self.resource_id.copy(resource_default)
+
         default['resource_id'] = resource.id
         default['company_id'] = resource.company_id.id
         default['resource_calendar_id'] = resource.calendar_id.id

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -526,6 +526,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
     def test_transfert_project(self):
         """ Transfert task with timesheet to another project. """
+        self.env.user.employee_id = self.env['hr.employee'].create({'user_id': self.env.uid})
         Timesheet = self.env['account.analytic.line']
         Task = self.env['project.task']
         today = Date.context_today(self.env.user)


### PR DESCRIPTION
At creation of aal, check that timesheets have an active employee.

backport of https://github.com/odoo/odoo/pull/93823

opw-2884736
opw-2942444