### PR TITLE
[FIX] tests: bump url_open timeout

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1679,7 +1679,7 @@ class HttpCase(TransactionCase):
             cls.browser.stop()
             cls.browser = None
 
-    def url_open(self, url, data=None, files=None, timeout=10, headers=None, allow_redirects=True, head=False):
+    def url_open(self, url, data=None, files=None, timeout=12, headers=None, allow_redirects=True, head=False):
         if url.startswith('/'):
             url = self.base_url() + url
         if head:


### PR DESCRIPTION
Some tests are randomly failling because /web takes more than 10 seconds
to load. A future pr will speedup /web but waiting for that a small
bump of the timeout should help.

Note that the url_open timeout also generate a strange behaviour breaking the retry mechanism, the remaining request may finish during the next test

example here http://runbot71.odoo.com/runbot/static/build/18809228-master/logs/test_only.txt
