### PR TITLE
[FIX] web: changing the priority of a new record in kanban

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -120,10 +120,6 @@ export class Field extends Component {
 
         const modifiers = fieldInfo.modifiers || {};
         const readonlyFromModifiers = evalDomain(modifiers.readonly, evalContext);
-        const readonlyFromRecord = !record.isInEdition;
-        const readonlyFromViewMode = record.model.root
-            ? !record.model.root.isInEdition
-            : readonlyFromRecord;
 
         // Decoration props
         const decorationMap = {};
@@ -159,15 +155,18 @@ export class Field extends Component {
                 if (record.selected && record.model.multiEdit) {
                     return;
                 }
+                const rootRecord =
+                    record.model.root instanceof record.constructor && record.model.root;
+                const isInEdition = rootRecord ? rootRecord.isInEdition : record.isInEdition;
                 // We save only if we're on view mode readonly and no readonly field modifier
-                if (readonlyFromViewMode && !readonlyFromModifiers) {
+                if (!isInEdition && !readonlyFromModifiers) {
                     // TODO: maybe move this in the model
                     return record.save();
                 }
             },
             value: this.props.record.data[this.props.name],
             decorations: decorationMap,
-            readonly: readonlyFromRecord || readonlyFromModifiers || false,
+            readonly: !record.isInEdition || readonlyFromModifiers || false,
             ...propsFromAttrs,
             ...props,
             type: field.type,

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1392,10 +1392,6 @@ class DynamicList extends DataPoint {
     // Getters
     // -------------------------------------------------------------------------
 
-    get isInEdition() {
-        return !!this.editedRecord;
-    }
-
     get currentParams() {
         return JSON.stringify([this.domain, this.groupBy]);
     }
@@ -1790,7 +1786,8 @@ export class DynamicRecordList extends DynamicList {
         }
         await this.model.keepLast.add(this.model.mutex.exec(() => newRecord.load()));
         this.editedRecord = newRecord;
-        this.onCreateRecord(newRecord);
+        this.onRemoveNewRecord = await this.onCreateRecord(newRecord);
+
         return this.addRecord(newRecord, atFirstPosition ? 0 : this.count);
     }
 
@@ -1889,7 +1886,12 @@ export class DynamicRecordList extends DynamicList {
         this.count--;
         if (this.editedRecord === record) {
             this.editedRecord = null;
+            if (this.onRemoveNewRecord) {
+                this.onRemoveNewRecord(record);
+                this.onRemoveNewRecord = null;
+            }
         }
+
         this.model.notify();
         return record;
     }
@@ -2001,6 +2003,12 @@ export class DynamicGroupList extends DynamicList {
                     }
                 }
                 this.editedRecord = record;
+                const onRemoveRecord = (record) => {
+                    if (this.editedRecord === record) {
+                        this.editedRecord = null;
+                    }
+                };
+                return onRemoveRecord;
             });
     }
 


### PR DESCRIPTION
Have a grouped kanban which display a priority field widget.
Quick create a record.

Click on any priority widget to change the priority.

Before this commit, the model was still considered in edition, preventing any change
in other record. Hence, the priorities did not change (at least, there was no write operation)
when clicked on.

After this commit, this flow works as expected.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
