### PR TITLE
[IMP] account,l10n_*: cleanup reports menu items.

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -36,7 +36,7 @@
             <menuitem id="account_reports_management_menu" name="Management" sequence="4">
                 <menuitem id="menu_action_account_invoice_report_all" name="Invoice Analysis" action="action_account_invoice_report_all" sequence="1"/>
             </menuitem>
-            <menuitem id="account_reports_legal_statements_menu" name="Financial Statements" sequence="1" groups="account.group_account_readonly"/>
+            <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly"/>
         </menuitem>
         <menuitem id="menu_finance_configuration" name="Configuration" sequence="35" groups="account.group_account_manager">
             <menuitem id="menu_account_config" name="Settings" action="action_account_config" groups="base.group_system" sequence="0"/>

--- a/addons/l10n_ae/data/l10n_ae_chart_data.xml
+++ b/addons/l10n_ae/data/l10n_ae_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_ae_statements_menu" name="UAE" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
      <record id="uae_chart_template_standard" model="account.chart.template">
          <field name="name">U.A.E Chart of Accounts - Standard</field>
          <field name="code_digits">6</field>

--- a/addons/l10n_ar/data/account_chart_template_data2.xml
+++ b/addons/l10n_ar/data/account_chart_template_data2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <menuitem id="account_reports_ar_statements_menu" name="Argentinean Statements" parent="account.menu_finance_reports" sequence="3" groups="account.group_account_readonly"/>
+    <menuitem id="account_reports_ar_statements_menu" name="Argentinean Statements" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
     <record id="l10nar_base_chart_template" model="account.chart.template">
         <field name="property_account_receivable_id" ref="base_deudores_por_ventas"/>

--- a/addons/l10n_at/data/account_chart_template.xml
+++ b/addons/l10n_at/data/account_chart_template.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <menuitem id="menu_finance_austria" name="Austria" parent="account.menu_finance_reports" sequence="-1" groups="account.group_account_readonly"/>
-
     <data>
         <!-- Vorlagen: Kontenplan -->
         <record id="l10n_at_chart_template" model="account.chart.template">

--- a/addons/l10n_au/views/menuitems.xml
+++ b/addons/l10n_au/views/menuitems.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <menuitem id="account_reports_au_statements_menu" name="Australia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+        <menuitem id="account_reports_au_statements_menu" name="Australia" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 </odoo>

--- a/addons/l10n_be/data/menuitem_data.xml
+++ b/addons/l10n_be/data/menuitem_data.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_be_statements_menu" name="Belgium" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+    <menuitem id="account_reports_be_statements_menu" name="Belgium" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 </odoo>

--- a/addons/l10n_bg/__manifest__.py
+++ b/addons/l10n_bg/__manifest__.py
@@ -22,7 +22,6 @@
         'data/account_tax_template_data.xml',
         "data/account_fiscal_position_template.xml",
         'data/account_chart_template_configure_data.xml',
-        'data/menuitem.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_bg/data/menuitem.xml
+++ b/addons/l10n_bg/data/menuitem.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="bg_reports_menu" name="Bulgaria" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_bo/data/l10n_bo_chart_data.xml
+++ b/addons/l10n_bo/data/l10n_bo_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_bo_statements_menu" name="Bolivia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <record id="bo_chart_template" model="account.chart.template">
         <field name="name">Bolivia - Plan de Cuentas</field>
         <field name="code_digits">6</field>

--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -54,7 +54,6 @@ come with any additional paid permission for online use of 'private modules'.
         'data/account_tax_template_data.xml',
         'data/fiscal_templates_data.xml',
         'data/account_fiscal_position_tax_template_data.xml',
-        'data/menuitem_data.xml',
         'views/account_view.xml',
         'views/account_fiscal_position_views.xml',
         'views/res_company_views.xml',

--- a/addons/l10n_br/data/l10n_br_chart_data.xml
+++ b/addons/l10n_br/data/l10n_br_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_br_statements_menu" name="Brazil" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
 	<record id="l10n_br_account_chart_template" model="account.chart.template">
 		<field name="name">Plano de Contas Brasileiro</field>
 		<field name="code_digits">6</field>

--- a/addons/l10n_br/data/menuitem_data.xml
+++ b/addons/l10n_br/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_br_statements_menu" name="Brazil" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_ch/data/l10n_ch_chart_data.xml
+++ b/addons/l10n_ch/data/l10n_ch_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_ch_statements_menu" name="Switzerland" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <data>
          <!-- Account Tags -->
         <record id="l10nch_chart_template" model="account.chart.template">

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -34,7 +34,6 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes.
         'data/account_tax_data.xml',
         'data/l10n_latam_identification_type_data.xml',
         'data/l10n_latam.document.type.csv',
-        'data/menuitem_data.xml',
         'data/product_data.xml',
         'data/uom_data.xml',
         'data/res.currency.csv',

--- a/addons/l10n_cl/data/menuitem_data.xml
+++ b/addons/l10n_cl/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_cl_statements_menu" name="Chile" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_co/data/account_chart_template_data.xml
+++ b/addons/l10n_co/data/account_chart_template_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_co_statements_menu" name="Colombia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+    <menuitem id="account_reports_co_statements_menu" name="Colombia" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
         <!-- Chart Template -->
         <record id="l10n_co_chart_template_generic" model="account.chart.template">

--- a/addons/l10n_de/__manifest__.py
+++ b/addons/l10n_de/__manifest__.py
@@ -20,7 +20,6 @@ German accounting chart and localization.
     ],
     'data': [
         'data/account_account_tags_data.xml',
-        'data/menuitem_data.xml',
         'views/account_view.xml',
         'views/res_company_views.xml',
     ],

--- a/addons/l10n_de/data/menuitem_data.xml
+++ b/addons/l10n_de/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_de_statements_menu" name="Germany" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -100,7 +100,6 @@ Produkt setup:
         'data/account_fiscal_position_tax_template.xml',
         'data/account_fiscal_position_account_template.xml',
         'data/account_chart_template_configuration_data.xml',
-        'data/menuitem_data.xml'
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_dk/data/menuitem_data.xml
+++ b/addons/l10n_dk/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_dk_statements_menu" name="Denmark" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_user"/>
-</odoo>

--- a/addons/l10n_do/data/l10n_do_chart_data.xml
+++ b/addons/l10n_do/data/l10n_do_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_do_statements_menu" name="Dominican Republic" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <!-- Chart of Accounts Template -->
     <record id="do_chart_template" model="account.chart.template">
         <field name="name">Catálogo de Cuentas Dominicano (NIIF)</field>

--- a/addons/l10n_et/data/l10n_et_chart_data.xml
+++ b/addons/l10n_et/data/l10n_et_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_et_statements_menu" name="Ethiopia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <record id="l10n_et" model="account.chart.template">
         <field name="name">Ethiopia Tax and Account Chart Template</field>
         <field name="code_digits">6</field>

--- a/addons/l10n_fi/data/account_chart_template_data.xml
+++ b/addons/l10n_fi/data/account_chart_template_data.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_fi_statements_menu" name="Finland" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_user"/>
     <!-- Account Chart Template -->
     <record id="fi_chart_template" model="account.chart.template">
         <field name="name">Finnish Chart of Accounts</field>

--- a/addons/l10n_fr/data/account_chart_template_data.xml
+++ b/addons/l10n_fr/data/account_chart_template_data.xml
@@ -10,7 +10,7 @@
         <field name="applicability">accounts</field>
     </record>
 
-    <menuitem id="account_reports_fr_statements_menu" name="France" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+    <menuitem id="account_reports_fr_statements_menu" name="France" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
     <record id="l10n_fr_pcg_chart_template" model="account.chart.template">
       <field name="property_account_receivable_id" ref="fr_pcg_recv"/>

--- a/addons/l10n_gr/data/l10n_gr_chart_data.xml
+++ b/addons/l10n_gr/data/l10n_gr_chart_data.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
-        <menuitem id="account_reports_gr_statements_menu" name="Greece" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
         <record id="l10n_gr_chart_template" model="account.chart.template">
             <field name="name">Πρότυπο Ελληνικού Λογιστικού Σχεδίου</field>
             <field name="bank_account_code_prefix">38</field>

--- a/addons/l10n_hr/data/l10n_hr_chart_data.xml
+++ b/addons/l10n_hr/data/l10n_hr_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_hr_statements_menu" name="Croatia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <data>
 
         <!-- Account Chart Template -->

--- a/addons/l10n_hu/__manifest__.py
+++ b/addons/l10n_hu/__manifest__.py
@@ -34,7 +34,6 @@ This module consists of:
         'data/res.bank.csv',
         'data/account_chart_template_data.xml',
         'data/account_chart_template_configure_data.xml',
-        'data/menuitem_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_hu/data/menuitem_data.xml
+++ b/addons/l10n_hu/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <menuitem id="hu_reports_menu" name="Hungary" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_ie/data/account_chart_template.xml
+++ b/addons/l10n_ie/data/account_chart_template.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <menuitem id="account_reports_ie_statements_menu" name="Irish Statements" parent="account.menu_finance_reports" sequence="3" groups="account.group_account_readonly"/>
-
     <!-- Chart template -->
     <record id="l10n_ie" model="account.chart.template">
         <field name="name">IE Tax and Account Chart Template</field>

--- a/addons/l10n_in/data/l10n_in_chart_data.xml
+++ b/addons/l10n_in/data/l10n_in_chart_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <menuitem id="account_reports_in_statements_menu" name="India" parent="account.menu_finance_reports" sequence="0"/>
+        <menuitem id="account_reports_in_statements_menu" name="India" parent="account.menu_finance_reports" sequence="5"/>
 
         <record id="indian_chart_template_standard" model="account.chart.template">
             <field name="name">Indian Chart of Accounts - Standard</field>

--- a/addons/l10n_ke/__manifest__.py
+++ b/addons/l10n_ke/__manifest__.py
@@ -20,7 +20,6 @@ This provides a base chart of accounts and taxes template for use in Odoo.
         'data/account_tax_template_data.xml',
         'data/account_fiscal_position_template.xml',
         'data/account_chart_template_configure_data.xml',
-        'data/menu_item_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml'

--- a/addons/l10n_ke/data/menu_item_data.xml
+++ b/addons/l10n_ke/data/menu_item_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_ke_statements_menu" name="Kenya" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_lt/__manifest__.py
+++ b/addons/l10n_lt/__manifest__.py
@@ -33,7 +33,6 @@
         'data/account_fiscal_position_template_data.xml',
         # Try Loading COA for Current Company
         'data/account_chart_template_load.xml',
-        'data/menuitem_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_lt/data/menuitem_data.xml
+++ b/addons/l10n_lt/data/menuitem_data.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <!-- LT BUSINESS ACCOUNTING STANDARD (BAS) REPORTS MENU ITEM -->
-    <menuitem id="account_reports_lt_statements_menu"
-        name="Lithuania"
-        parent="account.menu_finance_reports"
-        sequence="1"/>
-</odoo>

--- a/addons/l10n_lu/data/l10n_lu_chart_data.xml
+++ b/addons/l10n_lu/data/l10n_lu_chart_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <menuitem id="account_reports_lu_statements_menu" name="Luxembourg" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+        <menuitem id="account_reports_lu_statements_menu" name="Luxembourg" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
         <record id="lu_2011_chart_1" model="account.chart.template">
             <field name="name">PCMN Luxembourg</field>

--- a/addons/l10n_ma/data/l10n_ma_chart_data.xml
+++ b/addons/l10n_ma/data/l10n_ma_chart_data.xml
@@ -6,7 +6,6 @@
     Mis en place par la société Kazacube - partenaire OpenERP au Maroc
     Vérifié et validé par le cabinet SEDDIK d'expertise comptable, Casablanca.
       -->
-    <menuitem id="account_reports_ma_statements_menu" name="Morocco" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
 
     <record id="l10n_kzc_temp_chart" model="account.chart.template">
         <field name="name">Plan comptable marocain</field>

--- a/addons/l10n_mn/data/account_chart_template_data.xml
+++ b/addons/l10n_mn/data/account_chart_template_data.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <menuitem id="account_reports_mn_statements_menu" name="Mongolia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <record id="mn_chart_1" model="account.chart.template">
         <field name="name">Mongolia</field>
         <field name="bank_account_code_prefix">11</field>

--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -26,7 +26,6 @@
         'data/account_fiscal_position_tax_template.xml',
         'data/account_fiscal_position_account_template.xml',
         'data/account_chart_template_data.xml',
-        'data/menuitem.xml',
         'views/res_partner_views.xml',
         'views/res_company_views.xml',
     ],

--- a/addons/l10n_nl/data/menuitem.xml
+++ b/addons/l10n_nl/data/menuitem.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <menuitem id="account_reports_nl_statements_menu" name="Netherlands" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_no/data/l10n_no_chart_data.xml
+++ b/addons/l10n_no/data/l10n_no_chart_data.xml
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_no_statements_menu" name="Norway" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <data>
-
-	<menuitem id="account_reports_no_statements_menu" name="Norwegian Statements" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
 
     <!-- COA Templates -->
     <record id="no_chart_template" model="account.chart.template">

--- a/addons/l10n_pk/__manifest__.py
+++ b/addons/l10n_pk/__manifest__.py
@@ -15,7 +15,6 @@
         'data/account_tax_group.xml',
         'data/account_tax_template_data.xml',
         'data/account_chart_template_configure_data.xml',
-        'data/menuitem_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml'

--- a/addons/l10n_pk/data/menuitem_data.xml
+++ b/addons/l10n_pk/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_pk_statements_menu" name="Pakistan" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_user"/>
-</odoo>

--- a/addons/l10n_pl/data/l10n_pl_chart_data.xml
+++ b/addons/l10n_pl/data/l10n_pl_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<menuitem id="account_reports_pl_statements_menu" name="Poland" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
 <data>
     <!-- Chart template -->
 

--- a/addons/l10n_pt/data/l10n_pt_chart_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_pt_statements_menu" name="Portugal" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly" />
-
     <data>
 
     <record id="pt_chart_template" model="account.chart.template">

--- a/addons/l10n_ro/data/l10n_ro_chart_data.xml
+++ b/addons/l10n_ro/data/l10n_ro_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_ro_statements_menu" name="Romania" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <!-- Chart template -->
     <record id="ro_chart_template" model="account.chart.template">
         <field name="name">Romania - Chart of Accounts</field>

--- a/addons/l10n_se/__manifest__.py
+++ b/addons/l10n_se/__manifest__.py
@@ -29,7 +29,6 @@ It also includes the invoice OCR payment reference handling.
         "data/account_chart_template_configuration.xml",
         "views/partner_view.xml",
         "views/account_journal_view.xml",
-        'data/menuitem_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_se/data/menuitem_data.xml
+++ b/addons/l10n_se/data/menuitem_data.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_se_statements_menu" name="Sweden" parent="account.menu_finance_reports" sequence="0"
-              groups="account.group_account_readonly"/>
-</odoo>

--- a/addons/l10n_sg/data/l10n_sg_chart_data.xml
+++ b/addons/l10n_sg/data/l10n_sg_chart_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_sg_statements_menu" name="Singapore" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+    <menuitem id="account_reports_sg_statements_menu" name="Singapore" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
         <record id="sg_chart_template" model="account.chart.template">
             <field name="name">Singapore Chart of Accounts - Standard</field>

--- a/addons/l10n_si/data/l10n_si_chart_data.xml
+++ b/addons/l10n_si/data/l10n_si_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_si_statements_menu" name="Slovenia" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <record id="gd_chart" model="account.chart.template">
         <field name="name">Slovenian Chart of Accounts</field>
         <field name="bank_account_code_prefix">110</field>

--- a/addons/l10n_th/data/l10n_th_chart_data.xml
+++ b/addons/l10n_th/data/l10n_th_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_th_statements_menu" name="Thailand" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
 <!-- CHART OF Template -->
 
 <record id="chart" model="account.chart.template">

--- a/addons/l10n_uk/data/l10n_uk_chart_data.xml
+++ b/addons/l10n_uk/data/l10n_uk_chart_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_uk_statements_menu" name="United Kingdom" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
+    <menuitem id="account_reports_uk_statements_menu" name="United Kingdom" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
 
         <!-- Chart template -->
         <record id="l10n_uk" model="account.chart.template">

--- a/addons/l10n_uy/data/l10n_uy_chart_data.xml
+++ b/addons/l10n_uy/data/l10n_uy_chart_data.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="account_reports_uy_statements_menu" name="Uruguay" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <data>
         <record id="uy_chart_template" model="account.chart.template">
             <field name="name">Plan de Cuentas Uruguay - Template</field>
@@ -12,6 +10,5 @@
             <field name="currency_id" ref="base.UYU"/>
             <field name="country_id" ref="base.uy"/>
         </record>
-
     </data>
 </odoo>

--- a/addons/l10n_vn/data/l10n_vn_chart_data.xml
+++ b/addons/l10n_vn/data/l10n_vn_chart_data.xml
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<menuitem id="account_reports_vn_statements_menu" name="Vietnam" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
 <data>
     <!-- Account Chart Templates -->
     <record id="vn_template" model="account.chart.template">

--- a/addons/l10n_za/data/account_chart_template_data.xml
+++ b/addons/l10n_za/data/account_chart_template_data.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <menuitem id="account_reports_za_statements_menu" name="South Africa" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_readonly"/>
-
     <record id="default_chart_template" model="account.chart.template">
         <field name="name">South African Tax and Account Chart Template (by Paradigm Digital)</field>
         <field name="bank_account_code_prefix">1200</field>


### PR DESCRIPTION
Following reportalypse, reorder the menu items in order to bring
some consistency to the report menu.
Also clean the menu items by removing all the menu items no longer
used since most reports are now selectable by going  on the generic
reports and then switching to localized ones.

Task id #2965755
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
