### PR TITLE
[FIX] project: cannot remove stage in my tasks menu

### DIFF
--- a/addons/project/wizard/project_task_type_delete.py
+++ b/addons/project/wizard/project_task_type_delete.py
@@ -2,9 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
-
-import ast
+from ast import literal_eval
 
 
 class ProjectTaskTypeDelete(models.TransientModel):
@@ -66,7 +64,9 @@ class ProjectTaskTypeDelete(models.TransientModel):
         else:
             action = self.env["ir.actions.actions"]._for_xml_id("project.action_view_all_task")
 
-        context = dict(ast.literal_eval(action.get('context')), active_test=True)
+        context = action.get('context', '{}')
+        context = context.replace('uid', str(self.env.uid))
+        context = dict(literal_eval(context), active_test=True)
         action['context'] = context
         action['target'] = 'main'
         return action


### PR DESCRIPTION
Before this commit, when the user wants to delete a stage in the My
Tasks menu, he got a user error because the context in the action cannot
be converted from string to a dictionary with literal_eval function. The
reason is `uid` is not replaced by the current user id before using the
`literal_eval` function.

This commit replaces the uid by the current user id and then apply the
literal_eval function.

Steps to reproduce the issue:

1. Go to Project App
2. Click on `My Tasks` menu
3. Add a group by `Stage`
4. Try to remove a stage in which there is no recurrence task

Current Behavior:
A traceback is occurred because the literal_eval cannot convert the
context from the action.

Expected Behavior:
The stage should be archived and tasks contained in that stage.

Bug found task-2944742