### PR TITLE
[FIX] {mass_mailing_event}_track, website_event: fix the broken xpath

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -50,7 +50,7 @@
                             <field name="event_type_id" string="Template" options="{'no_create':True}"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
                         </group>
-                        <group>
+                        <group name="right_event_details">
                             <field name="organizer_id"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/mass_mailing_event/views/event_views.xml
+++ b/addons/mass_mailing_event/views/event_views.xml
@@ -8,7 +8,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='stage_id']" position="before">
                 <field name="event_registrations_open" invisible="1"/>
-                <field name="seats_expected" invisible="1"/>
                 <button name="action_invite_contacts" type="object" string="Invite"
                     class="btn btn-primary"
                     groups="mass_mailing.group_mass_mailing_user"

--- a/addons/mass_mailing_event_track/views/event_views.xml
+++ b/addons/mass_mailing_event_track/views/event_views.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="event.view_event_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='stage_id']" position="before">
-                <field name="track_count" invisible="1"/>
                 <button name="action_mass_mailing_track_speakers" string="Contact Track Speakers" type="object" attrs="{'invisible': [('track_count', '=', 0)]}" groups="mass_mailing.group_mass_mailing_user"/>
             </xpath>
         </field>

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -7,9 +7,9 @@
         <field name="priority" eval="5"/>
         <field name="inherit_id" ref="event.view_event_form"/>
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <xpath expr="//group[@name='right_event_details']/field[@name='company_id']" position="after">
                 <field name="website_id" options="{'no_create': True}" domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]" groups="website.group_multi_website"/>
-            </field>
+            </xpath>
             <div name="button_box" position="inside">
                 <field name="website_url" invisible="1"/>
                 <field name="is_published" widget="website_redirect_button"/>


### PR DESCRIPTION
Since a recent commit[1] (that added invisible fields to avoid their removal
from the view when there's group applied on it and logged in user does not
fall under this group), the view definition were changed and so there were
few xpath broken which dependent on such fields.

- In event (event.view_event_form form view), invisible 'company_id' field
  was added, which broke the the xpath in website_event since it was not
  not robust and considered first invisible 'company_id' field, which now
  should be the later one after commit[1].
- In mass_mailing_event_track, 'track_count' filed was added, that broke the
  xpath in website_event_track_gantt.

This commit addresses both of the issues by:

- putting group name "right_event_details" in the "event.event.form"
  form view and providing an xpath with group name in the
  "event.event.view.form.inherit.website" form view to adapt the changes.
- removing the 'track_count' invisible field from 'mass_mailing_event_track'
  module because that field in the original view does not have any group
  applied at view or model level so we don't need to add the same one as
  invisible field in the view

This commit also remove the invisible 'seats_expected' field from event
form view in 'mass_mailing_event' module for same reason as 'track_count'
field; it does not has any groups applied at view or model level so we
don't need to add the same one as invisible field once again.

commit[1] - https://github.com/odoo/odoo/commit/0501bbd62e517f6c215d9e7e36d61747c7f5816b

task-2964291

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
