### PR TITLE
[FIX] hr_skills: fix permissions on employee page

### DIFF
--- a/addons/hr_skills/models/hr_employee_skill_log.py
+++ b/addons/hr_skills/models/hr_employee_skill_log.py
@@ -19,5 +19,5 @@ class HrEmployeeSkillLog(models.Model):
     date = fields.Date(default=fields.Date.context_today)
 
     _sql_constraints = [
-        ('_unique_skill_log', 'unique (employee_id, skill_id, date)', "Two levels for the same skill on the same day is not allowed"),
+        ('_unique_skill_log', 'unique (employee_id, department_id, skill_id, date)', "Two levels for the same skill on the same day is not allowed"),
     ]

--- a/addons/hr_skills/security/ir.model.access.csv
+++ b/addons/hr_skills/security/ir.model.access.csv
@@ -12,4 +12,4 @@ access_hr_skill_employee,hr.skill.employee,model_hr_skill,base.group_user,1,0,1,
 access_hr_employee_skill,hr.employee.skill,model_hr_employee_skill,hr.group_hr_user,1,1,1,1
 access_hr_employee_skill_employee,hr.employee.skill,model_hr_employee_skill,base.group_user,1,1,1,1
 access_hr_employee_skill_report,hr.employee.skill.report,model_hr_employee_skill_report,hr.group_hr_user,1,0,0,0
-access_hr_employee_skill_log,hr.employee.skill.log,model_hr_employee_skill_log,hr.group_hr_user,1,0,1,0
+access_hr_employee_skill_log,hr.employee.skill.log,model_hr_employee_skill_log,hr.group_hr_user,1,1,1,0


### PR DESCRIPTION
Before this commit, a user wasn't able to modify
a skill from the employee page.