### PR TITLE
[FIX] project: cannot change stage if stage contains rating email

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1824,7 +1824,7 @@ class Task(models.Model):
 
         # rating on stage
         if 'stage_id' in vals and vals.get('stage_id'):
-            self.filtered(lambda x: x.project_id.rating_active and x.project_id.rating_status == 'stage')._send_task_rating_mail(force_send=True)
+            tasks.filtered(lambda x: x.project_id.rating_active and x.project_id.rating_status == 'stage')._send_task_rating_mail(force_send=True)
         for task in self:
             if task.display_project_id != task.project_id and not task.parent_id:
                 # We must make the display_project_id follow the project_id if no parent_id set

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -17,7 +17,7 @@ class TestProjectSharingCommon(TestProjectCommon):
 
         project_sharing_stages_vals_list = [
             (0, 0, {'name': 'To Do', 'sequence': 1}),
-            (0, 0, {'name': 'Done', 'sequence': 10}),
+            (0, 0, {'name': 'Done', 'sequence': 10, 'fold': True, 'rating_template_id': cls.env.ref('project.rating_project_request_email_template').id}),
         ]
 
         cls.partner_portal = cls.env['res.partner'].create({
@@ -226,3 +226,18 @@ class TestProjectSharing(TestProjectSharingCommon):
         self.assertFalse(self.task_cow.with_user(self.user_portal).user_ids, 'the portal user should see no assigness in the task.')
         task_portal_read = self.task_cow.with_user(self.user_portal).read(['portal_user_names'])
         self.assertEqual(self.task_cow.portal_user_names, task_portal_read[0]['portal_user_names'], 'the portal user should see assignees name in the task via the `portal_user_names` field.')
+
+    def test_portal_user_can_change_stage_with_rating(self):
+        """ Test portal user can change the stage of task to a stage with rating template email
+
+            The user should be able to change the stage and the email should be sent as expected
+            if a email template is set in `rating_template_id` field in the new stage.
+        """
+        self.project_portal.write({
+            'rating_active': True,
+            'rating_status': 'stage',
+            'collaborator_ids': [
+                Command.create({'partner_id': self.user_portal.partner_id.id}),
+            ],
+        })
+        self.task_portal.with_user(self.user_portal).write({'stage_id': self.project_portal.type_ids[-1].id})


### PR DESCRIPTION
Before this commit, when the portal user changes the stage of a task and
the new stage contains a rating template email, he got a traceback
saying he has no access to `mail.template` model.

This commit fixes the issue by sending the email in superuser when we
are sure the user can write on that task.

Steps to reproduce:
==================

1) Enable the rating feature in the settings of Project App
2) Create a Project A and edit it to enable the rating feature on that
project and select "Rating when changing stage" (if it is not already
the case)
3) share the project to a portal user
4) Set a rating email template on a stage of the project
5) Create a new task and save
6) log in as portal user and go the project shared
7) Change the stage of that task to the stage contained the rating email
template

Actual Behavior:
---------------
A traceback is occurred saying the user has no access to `mail.template`
model.

Expected Behavior:
-----------------
The stage of the task should be changed and the rating email should be
sent.
