### PR TITLE
[FIX] base_address_extended: auto complete issues address

### DIFF
--- a/addons/base_address_extended/models/res_country.py
+++ b/addons/base_address_extended/models/res_country.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResCountry(models.Model):
@@ -16,3 +16,8 @@ class ResCountry(models.Model):
              "\n%(street_number)s: the house number"
              "\n%(street_number2)s: the door number",
         default='%(street_number)s/%(street_number2)s %(street_name)s', required=True)
+
+    @api.onchange("street_format")
+    def onchange_street_format(self):
+        # Prevent unexpected truncation with whitespaces in front of the street format
+        self.street_format = self.street_format.strip()


### PR DESCRIPTION
Steps to reproduce:
- install the "Extended Adresses" module;
- in the configuration menu --> countries, edit the street format for Belgium to "  %(street_name)s" (with whitespaces)
- create a new contact;
- select a contact suggested by the auto complete feature (for example Odoo)

Issue:
   Some letters are removed if we add whitespaces in the street format (street_name field has the value "e du Laid Burniat 5" instead of "Rue du Laid Burniat 5").

Cause:
   The function which splits the raw address taking into account heading characters.
   Therefore the function truncates whatever is in front of the first field of the street format which is normally the image of the address (street_raw).

   **Example 1: (correct use)**
   street_raw = "header Rue du Laid Burniat 5"
   street_format = "header %(street_name)s"

   street_name = "Rue du Laid Burniat 5" --> OK (format address is properly configured to match with street_raw)

   **Example 2: (incorrect use but desired behavior)**
   street_raw = "Rue du Laid Burniat 5"
   street_format = "header %(street_name)s"

   street_name = "Laid Burniat 5" --> truncation is expected (7 leading characters are removed) (format address is not properly configured to match with street_raw)

   **Example 3: (incorrect use and unwanted behavior)**
   street_raw = "Rue du Laid Burniat 5"
   street_format = " %(street_name)s"

   street_name = "ue du Laid Burniat 5" --> truncation is not expected (1 leading character is removed) (format address is "properly" configured but with whitespace)

Solution:
   Remove whitespaces before street format when editing this field to prevent truncation of the field value.

opw-2964457