### PR TITLE
[FIX] core: fixed fetching X2Many studio studio_fields

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3375,16 +3375,23 @@ Fields:
         # possibly raise exception for the records that could not be read
         missing = self - fetched
         if missing:
+            def match_ids(a, b):
+                for _id in a.ids:
+                    if not _id in b.ids:
+                        return False
+                return True
+            
             extras = fetched - self
-            if extras:
-                raise AccessError(
-                    _("Database fetch misses ids ({}) and has extra ids ({}), may be caused by a type incoherence in a previous request").format(
-                        missing._ids, extras._ids,
-                    ))
-            # mark non-existing records in missing
-            forbidden = missing.exists()
-            if forbidden:
-                raise self.env['ir.rule']._make_access_error('read', forbidden)
+            if not match_ids(missing, extras):
+                if extras:
+                    raise AccessError(
+                        _("Database fetch misses ids ({}) and has extra ids ({}), may be caused by a type incoherence in a previous request").format(
+                            missing._ids, extras._ids,
+                        ))
+                # mark non-existing records in missing
+                forbidden = missing.exists()
+                if forbidden:
+                    raise self.env['ir.rule']._make_access_error('read', forbidden)
 
     def get_metadata(self):
         """Return some metadata about the given records.


### PR DESCRIPTION
Steps to reproduce:
on a cotact form add a many2many field (to product template) using studio

Bug:
an error pops up when editing the email / phone number
"Database fetch misses ids ((<NewId origin= X >,)) and has extra ids ((X,)),
may be caused by a type incoherence in a previous request"
because fields created with studio have "NewId origin= " appended to them
X refers to the id of the product template

Fix:
perform the check on the ids

opw-2956616
opw-2966229
opw-2980948