### PR TITLE
[FIX] sale_management: `uom_id` not in the view without group_uom

### DIFF
--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -315,4 +315,5 @@ class TestSaleOrder(SaleManagementCommon):
         order_form = Form(self.sale_order)
         with order_form.sale_order_option_ids.new() as option:
             option.product_id = self.product_1
-            self.assertTrue(bool(option.uom_id))
+        order = order_form.save()
+        self.assertTrue(bool(order.sale_order_option_ids.uom_id))


### PR DESCRIPTION
The test `test_option_creation` makes sure the option uom is
well set once setting the product on the order.

But, the test doesn't add the group_uom to be able to see the uom
field within the view.
This is valid, the uom should nevertheless still be set correctly
automatically, but the assertion must be done on the saved record,
not in the form view itself, as the field is not displayed in
the form view in such a case.
