### PR TITLE
[FIX] project_timesheet_holidays: holiday timesheet can't be deleted

### DIFF
--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -8,7 +8,7 @@ from odoo.exceptions import UserError
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
-    holiday_id = fields.Many2one("hr.leave", string='Leave Request')
+    holiday_id = fields.Many2one("hr.leave", string='Leave Request', copy=False)
     global_leave_id = fields.Many2one("resource.calendar.leaves", string="Global Time Off", ondelete='cascade')
 
     @api.ondelete(at_uninstall=False)


### PR DESCRIPTION
Issue:
When creating time off timesheet from the timesheet app,the newly
created timesheet is connected to a leave request while it shouldn't
be linked to any leave request and in consequence you can only delete
this new timesheet by deleting the leave request.
https://github.com/odoo/odoo/blob/b87f647010978762dd81c2aedc17c2e10764b83f/addons/project_timesheet_holidays/models/account_analytic.py#L17

Explanation:
To create the new timesheet timesheet_grid makes a copy of another
timesheet on the same line and that makes that the holiday_id (used
to link timesheet and leave request) is also copied.
https://github.com/odoo/enterprise/blob/8c3c14ce8ba172621355cc9a02d9b409950e7c0e/timesheet_grid/models/analytic.py#L470

Solution:
When copying a timesheet the holiday_id is not copied

opw-2951062
