### PR TITLE
[FIX] mail: `MessageInReplyToView`, space after author

### DIFF
--- a/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
+++ b/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
@@ -8,8 +8,8 @@
                     <span class="o_MessageInReplyToView_wrapOuter d-flex align-items-center text-muted opacity-75 opacity-100-hover cursor-pointer"  t-attf-class="{{ messageInReplyToView.messageView.isInChatWindowAndIsAlignedRight ? 'pe-3': 'ps-3' }}" t-on-click="messageInReplyToView.onClickReply">
                         <img class="o_MessageInReplyToView_avatar me-2 rounded-circle" t-att-src="messageInReplyToView.messageView.message.parentMessage.avatarUrl" t-att-title="messageInReplyToView.messageView.message.parentMessage.authorName" alt="Avatar"/>
                         <span class="o_MessageInReplyToView_wrapInner overflow-hidden">
-                            <b class="o_MessageInReplyToView_author">@<t t-out="messageInReplyToView.messageView.message.parentMessage.authorName"/></b>
-                            <span class="o_MessageInReplyToView_body text-break">
+                            <b class="o_MessageInReplyToView_author">@<t t-out="messageInReplyToView.messageView.message.parentMessage.authorName"/></b>:
+                            <span class="o_MessageInReplyToView_body ms-1 text-break">
                                 <t t-if="messageInReplyToView.hasBodyBackLink">
                                     <t t-out="messageInReplyToView.messageView.message.parentMessage.prettyBodyAsMarkup"/>
                                 </t>


### PR DESCRIPTION
Prior to this commit, there was no space between the author's name and
the message.

This commit fixes this issue.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
