### PR TITLE
[FIX] point_of_sale : wrong api

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -32,7 +32,6 @@ class PosPayment(models.Model):
     ticket = fields.Char('Payment Receipt Info')
     is_change = fields.Boolean(string='Is this payment change?', default=False)
 
-    @api.model
     def name_get(self):
         res = []
         for payment in self:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this PR when you select a pos.payment in custom, it raise.
It doesn't make sens to use api.model here

@pimodoo @rco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
