### PR TITLE
[FIX] web: kanban quick create with legacy many2one

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -34,8 +34,12 @@ export class KanbanRecordQuickCreate extends Component {
                     return;
                 }
                 const target = this.mousedownTarget || ev.target;
-                const gotClickedOutside = !this.rootRef.el.contains(target);
-                if (gotClickedOutside) {
+                // accounts for clicking on legacy daterangepicker and legacy autocomplete
+                const gotClickedInside =
+                    target.closest(".daterangepicker") ||
+                    target.closest(".ui-autocomplete") ||
+                    this.rootRef.el.contains(target);
+                if (!gotClickedInside) {
                     let force = false;
                     for (const selector of ACTION_SELECTORS) {
                         const closestEl = target.closest(selector);


### PR DESCRIPTION
Have a quick create view in kanban that has a legacy many2one
field (not yet converted to the WOWL framework for some reason).
Click on that many2one to see the dropdown of propositions.
Click on one proposition.

Before this commit, the quick create got closed, because we clicked
somewhere outside of it (the legacy dropdown).
This is a known, quite common issue in some other part of the codebase
(see d3662d370c97ccc31a11a3378f93e0be0a79b66a).

After this commit, the quick create works as expected.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
