### PR TITLE
[FIX] project_sms: cannot change task stage to stage with sms template

### DIFF
--- a/addons/project_sms/models/project_task.py
+++ b/addons/project_sms/models/project_task.py
@@ -20,6 +20,11 @@ class ProjectTask(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
+
         if 'stage_id' in vals:
-            self._send_sms()
+            if self.env.user.has_group('base.group_portal') and not self.env.su:
+                # sudo as sms template model is protected
+                self.sudo()._send_sms()
+            else:
+                self._send_sms()
         return res

--- a/addons/project_sms/tests/__init__.py
+++ b/addons/project_sms/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_project_sharing

--- a/addons/project_sms/tests/test_project_sharing.py
+++ b/addons/project_sms/tests/test_project_sharing.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.addons.project.tests.test_project_sharing import TestProjectSharingCommon
+
+
+class TestProjectSharingWithSms(TestProjectSharingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.sms_template = cls.env['sms.template'].sudo().create({
+            'body': '{{ object.name }}',
+            'model_id': cls.env['ir.model'].sudo().search([('model', '=', 'project.task')]).id,
+        })
+        cls.project_portal.type_ids[-1].write({'sms_template_id': cls.sms_template.id})
+        cls.project_portal.write({
+            'collaborator_ids': [
+                Command.create({'partner_id': cls.user_portal.partner_id.id}),
+            ],
+        })
+
+    def test_portal_user_can_change_stage_with_sms_template(self):
+        """ Test user portal can change the stage of a task to a stage with a sms template
+
+            The sms template should be sent and the stage should be changed on the task.
+        """
+        stage = self.project_portal.type_ids[-1]
+        self.task_portal.with_user(self.user_portal).write({'stage_id': stage.id})
+        self.assertEqual(self.task_portal.stage_id, stage)


### PR DESCRIPTION
Before this commit when the portal user changes the stage of a task
to a stage with sms template, he got a traceback saying he has no access
to the `sms.template` model.

This commit fixes by checking if the user is a portal one to send the
sms in sudo when the write on the task is correctly done.

Steps to reproduce:
==================
1) install `project_sms` module,
2) create a project,
3) in the kanban of tasks for this project create 2 stages,
4) edit the last one to set a sms template,
5) share the project in edit mode to a portal user,
6) create a task with the quick create,
7) log in as portal user and go the project shared
8) move the task into the last stage.

Actual Behavior:
---------------
A traceback is occurred saying the portal user has no access to
`sms.template` model.

Expected behavior:
-----------------
The task should be in the last stage and the sms should be sent.

