### PR TITLE
[FIX] account{,edi_ubl_cii}: harmonize invoice upload

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -622,10 +622,10 @@ class AccountJournal(models.Model):
         # We simply call the setup bar function.
         return self.env['res.company'].setting_init_bank_account_action()
 
-    def create_invoice_from_attachment(self, attachment_ids=[]):
-        ''' Create the invoices from files.
-         :return: A action redirecting to account.move tree/form view.
-        '''
+    def _create_invoice_from_attachment(self, attachment_ids=None):
+        """
+        Create invoices from the attachments (for instance a Factur-X XML file)
+        """
         attachments = self.env['ir.attachment'].browse(attachment_ids)
         if not attachments:
             raise UserError(_("No attachment was provided"))
@@ -643,7 +643,16 @@ class AccountJournal(models.Model):
                 invoice = self.env['account.move'].create({})
             invoice.with_context(no_new_invoice=True).message_post(attachment_ids=[attachment.id])
             invoices += invoice
+        return invoices
 
+    def create_invoice_from_attachment(self, attachment_ids=None):
+        """
+        Create invoices from the attachments (for instance a Factur-X XML file)
+        and redirect the user to the newly created invoice(s).
+        :param attachment_ids: list of attachment ids
+        :return: action to open the created invoices
+        """
+        invoices = self._create_invoice_from_attachment(attachment_ids)
         action_vals = {
             'name': _('Generated Documents'),
             'domain': [('id', 'in', invoices.ids)],

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -247,8 +247,9 @@ class AccountEdiCommon(models.AbstractModel):
     # -------------------------------------------------------------------------
 
     def _import_invoice(self, journal, filename, tree, existing_invoice=None):
-        move_type, qty_factor = self._get_import_document_amount_sign(filename, tree)
-        if not move_type or (existing_invoice and existing_invoice.move_type != move_type):
+        move_types_allowed, qty_factor = self._get_import_document_amount_sign(filename, tree)
+        move_type = self._context.get('default_move_type', None)
+        if not move_type or move_type not in move_types_allowed or (existing_invoice and existing_invoice.move_type != move_type):
             return
 
         invoice = existing_invoice or self.env['account.move']

--- a/addons/account_edi_ubl_cii/models/account_edi_format.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_format.py
@@ -171,11 +171,7 @@ class AccountEdiFormat(models.Model):
         # EXTENDS account_edi
         self.ensure_one()
 
-        if not journal:
-            # infer the journal
-            journal = self.env['account.journal'].search([
-                ('company_id', '=', self.env.company.id), ('type', '=', 'purchase')
-            ], limit=1)
+        journal = journal or self.env['account.move']._get_default_journal()
 
         if not self._is_ubl_cii_available(journal.company_id):
             return super()._create_invoice_from_xml_tree(filename, tree, journal=journal)

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -375,9 +375,9 @@ class AccountEdiXmlCII(models.AbstractModel):
         if move_type_code is None:
             return None, None
         if move_type_code.text == '381':
-            return 'in_refund', 1
+            return ('in_refund', 'out_refund'), 1
         if move_type_code.text == '380':
             amount_node = tree.find('.//{*}SpecifiedTradeSettlementHeaderMonetarySummation/{*}TaxBasisTotalAmount')
             if amount_node is not None and float(amount_node.text) < 0:
-                return 'in_refund', -1
-            return 'in_invoice', 1
+                return ('in_refund', 'out_refund'), -1
+            return ('in_invoice', 'out_invoice'), 1

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -629,10 +629,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if tree.tag == '{urn:oasis:names:specification:ubl:schema:xsd:Invoice-2}Invoice':
             amount_node = tree.find('.//{*}LegalMonetaryTotal/{*}TaxExclusiveAmount')
             if amount_node is not None and float(amount_node.text) < 0:
-                return 'in_refund', -1
-            return 'in_invoice', 1
+                return ('in_refund', 'out_refund'), -1
+            return ('in_invoice', 'out_invoice'), 1
         if tree.tag == '{urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2}CreditNote':
-            return 'in_refund', 1
+            return ('in_refund', 'out_refund'), 1
         return None, None
 
     def _import_retrieve_partner_map(self, company):


### PR DESCRIPTION
# Aim of the PR
This PR aims at harmonizing the invoice upload in two cases:
- inside the Accounting app (Customer Invoice vs Vendor Bills)
- between the Accounting and the Documents apps

## Inside Accounting app
### Before this PR:
- Go to Accounting / Customer Invoices
- Upload a PDF with Factur-X XML embedded
- The document is uploaded as a Vendor Bill

### After this PR
This should not be the case anymore since we want to allow the import of customer invoices (that can be generated elsewhere)
This commit makes sure that we check from where we import the PDF (Upload button of Customer Invoices or Vendor Bills) to determine in which journal the generated invoice should go via the context.

## Between the Accounting and the Documents apps
To go even further, we also harmonize the invoice upload with the Documents app as such:

### Before this PR
We had two different behavior for the same functionality depending on the App used.
In the Documents App:
- Upload a PDF document with embedded Factur-X in the Documents app
- Click on Create Bill in the actions of the document
- The OCR is triggered.

In the Accounting App:
- Upload a PDF document with embedded Factur-X via the "Upload Bills" button in the Accounting Dashboard
- The invoice is created using the information contained in the Factur-X XML embedded in the PDF without using the OCR.

### After this PR
We should have the same behavior in both apps. Furthermore, if the invoice information can be retrieved from the XML, it is useless and more error-prone to use the OCR.
This commit fixes this by calling the Accounting importing function instead which also simplifies greatly the code

task-id 2961932

Enterprise PR: https://github.com/odoo/enterprise/pull/30879