### PR TITLE
[FIX] mail: adapt RTC code to not write on readonly fields

### DIFF
--- a/addons/mail/static/src/models/persona.js
+++ b/addons/mail/static/src/models/persona.js
@@ -34,6 +34,19 @@ registerModel({
             }
             return clear();
         },
+        /**
+         * @private
+         * @returns {res.users.settings.volumes|FieldCommand}
+         */
+        _computeVolumeSetting() {
+            if (this.guest) {
+                return this.guest.volumeSetting || clear();
+            }
+            if (this.partner) {
+                return this.partner.volumeSetting || clear();
+            }
+            return clear();
+        },
     },
     fields: {
         channelMembers: many('ChannelMember', {
@@ -53,6 +66,9 @@ registerModel({
         partner: one('Partner', {
             identifying: true,
             inverse: 'persona',
+        }),
+        volumeSetting: one('res.users.settings.volumes', {
+            compute: '_computeVolumeSetting',
         }),
     },
 });

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -67,26 +67,23 @@ registerModel({
              * Manually updating the volume field as it will not update based on
              * the change of the volume property of the audioElement alone.
              */
-            this.update({ volume });
+            this.update({ localVolume: volume });
             if (this.audioElement) {
-                this.audioElement.volume = volume;
+                this.audioElement.volume = this.volume;
             }
             if (this.isOwnSession) {
                 return;
             }
-            if (this.channelMember.persona.partner && this.channelMember.persona.partner.volumeSetting) {
-                this.channelMember.persona.partner.volumeSetting.update({ volume });
-            }
-            if (this.channelMember.persona.guest && this.channelMember.persona.guest.volumeSetting) {
-                this.channelMember.persona.guest.volumeSetting.update({ volume });
-            }
             if (this.messaging.isCurrentUserGuest) {
                 return;
+            }
+            if (this.channelMember.persona.volumeSetting) {
+                this.channelMember.persona.volumeSetting.update({ volume: this.volume });
             }
             this.messaging.userSetting.saveVolumeSetting({
                 partnerId: this.channelMember.persona.partner && this.channelMember.persona.partner.id,
                 guestId: this.channelMember.persona.guest && this.channelMember.persona.guest.id,
-                volume,
+                volume: this.volume,
             });
         },
         /**
@@ -259,12 +256,11 @@ registerModel({
          * @returns {number} float
          */
         _computeVolume() {
-            if (this.channelMember) {
-                if (this.channelMember.persona.partner && this.channelMember.persona.partner.volumeSetting) {
-                    return this.channelMember.persona.partner.volumeSetting.volume;
-                } else if (this.channelMember.persona.guest && this.channelMember.persona.guest.volumeSetting) {
-                    return this.channelMember.persona.guest.volumeSetting.volume;
-                }
+            if (this.localVolume !== undefined) {
+                return this.localVolume;
+            }
+            if (this.channelMember && this.channelMember.persona.volumeSetting) {
+                return this.channelMember.persona.volumeSetting.volume;
             }
             if (this.audioElement) {
                 return this.audioElement.volume;
@@ -469,6 +465,7 @@ registerModel({
          * RTCIceCandidate.type String
          */
         localCandidateType: attr(),
+        localVolume: attr(),
         /**
          * Token to identify the session, it is currently just the toString
          * id of the record.

--- a/addons/mail/static/src/models/user_setting.js
+++ b/addons/mail/static/src/models/user_setting.js
@@ -89,10 +89,10 @@ registerModel({
             await this.messaging.rtc.updateLocalAudioTrack(true);
         },
         /**
-         * @param {String} value
+         * @param {string} value
          */
         setDelayValue(value) {
-            this.update({ voiceActiveDuration: parseInt(value, 10) });
+            this.update({ localVoiceActiveDuration: parseInt(value, 10) });
             if (this.messaging.currentUser) {
                 this._saveSettings();
             }
@@ -102,7 +102,7 @@ registerModel({
          */
         async setPushToTalkKey(ev) {
             const pushToTalkKey = `${ev.shiftKey || ''}.${ev.ctrlKey || ev.metaKey || ''}.${ev.altKey || ''}.${ev.key}`;
-            this.update({ pushToTalkKey });
+            this.update({ localPushToTalkKey: pushToTalkKey });
             if (this.messaging.currentUser) {
                 this._saveSettings();
             }
@@ -136,7 +136,7 @@ registerModel({
             await this.messaging.rtc.updateVoiceActivation();
         },
         async togglePushToTalk() {
-            this.update({ usePushToTalk: !this.usePushToTalk });
+            this.update({ localUsePushToTalk: !this.usePushToTalk });
             await this.messaging.rtc.updateVoiceActivation();
             if (this.messaging.currentUser) {
                 this._saveSettings();
@@ -150,9 +150,12 @@ registerModel({
         },
         /**
          * @private
-         * @returns {boolean|FieldCommand}
+         * @returns {string|FieldCommand}
          */
         _computePushToTalkKey() {
+            if (this.localPushToTalkKey !== undefined) {
+                return this.localPushToTalkKey;
+            }
             if (!this.messaging.currentUser) {
                 return clear();
             }
@@ -166,6 +169,9 @@ registerModel({
          * @returns {boolean|FieldCommand}
          */
         _computeUsePushToTalk() {
+            if (this.localUsePushToTalk !== undefined) {
+                return this.localUsePushToTalk;
+            }
             if (!this.messaging.currentUser) {
                 return clear();
             }
@@ -179,6 +185,9 @@ registerModel({
          * @returns {boolean|FieldCommand}
          */
         _computeVoiceActiveDuration() {
+            if (this.localVoiceActiveDuration !== undefined) {
+                return this.localVoiceActiveDuration;
+            }
             if (!this.messaging.currentUser) {
                 return clear();
             }
@@ -289,6 +298,9 @@ registerModel({
         isRegisteringKey: attr({
             default: false,
         }),
+        localPushToTalkKey: attr(),
+        localUsePushToTalk: attr(),
+        localVoiceActiveDuration: attr(),
         /**
          * String that encodes the push-to-talk key with its modifiers.
          */


### PR DESCRIPTION
3c28be1b33ea18be7280d9372ebd53a54140da86 enforced readonly by default on computed and related fields, but some fields were not changed to be readonly, leading the application to crash when editing them.

This commit fixes that by introducing new fields to write on instead of the readonly ones.

Follow-up of task-2955927.
