### PR TITLE
[FIX] base: do not leave <t groups=""></t> blocks

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -970,7 +970,20 @@ actual arch.
         be removed from the view to people who are not members.
         """
         if node.get('groups'):
-            if not self.user_has_groups(groups=node.get('groups')):
+            if not self.user_has_groups(groups=node.attrib.pop('groups')):
+                node.getparent().remove(node)
+            elif node.tag == 't' and not node.attrib:
+                # Move content of <t> blocks with no other instructions than just "groups=" to the parent
+                # and remove the <t> node.
+                # This is to keep the structure
+                # <group>
+                #   <field name="foo"/>
+                #   <field name="bar"/>
+                # <group>
+                # so the web client adds the label as expected.
+                node_info['children'] = list(node)
+                for child in reversed(node):
+                    node.addnext(child)
                 node.getparent().remove(node)
 
     def _get_view_refs(self, node):


### PR DESCRIPTION
In form views, when wrapping <field/> nodes
within a <t/> node to set a group,
the web client no longer set the field labels before the field.

Therefore, remove these <t/> node before sending them to the
web client.

e.g.
```xml
<group>
    <field name="origin"/>
    <field name="date_deadline"/>
    <t groups="stock.group_stock_manager">
        <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
    </t>
</group>
```
