### PR TITLE
[FIX] mail: prevents shared rtcSession focus across callViews

### DIFF
--- a/addons/mail/static/src/models/call_participant_card.js
+++ b/addons/mail/static/src/models/call_participant_card.js
@@ -26,9 +26,9 @@ registerModel({
             }
             if (this.rtcSession) {
                 if (this.callView.activeRtcSession === this.rtcSession && this.mainViewTileOwner) {
-                    this.callView.update({ activeRtcSession: clear() });
+                    this.callView.channel.update({ activeRtcSession: clear() });
                 } else {
-                    this.callView.update({ activeRtcSession: this.rtcSession });
+                    this.callView.channel.update({ activeRtcSession: this.rtcSession });
                 }
                 return;
             }

--- a/addons/mail/static/src/models/call_settings_menu.js
+++ b/addons/mail/static/src/models/call_settings_menu.js
@@ -57,7 +57,7 @@ registerModel({
             }
             const activeRtcSession = this.callView.activeRtcSession;
             if (showOnlyVideo && activeRtcSession && !activeRtcSession.videoStream) {
-                this.callView.update({ activeRtcSession: clear() });
+                this.callView.channel.update({ activeRtcSession: clear() });
             }
         },
         onClickRegisterKeyButton() {

--- a/addons/mail/static/src/models/call_view.js
+++ b/addons/mail/static/src/models/call_view.js
@@ -158,7 +158,9 @@ registerModel({
         /**
          * The rtc session that is the main card of the view.
          */
-        activeRtcSession: one('RtcSession'),
+        activeRtcSession: one('RtcSession', {
+            related: 'channel.activeRtcSession',
+        }),
         /**
          * The aspect ratio of the tiles.
          */

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -192,6 +192,7 @@ registerModel({
         },
     },
     fields: {
+        activeRtcSession: one('RtcSession'),
         areAllMembersLoaded: attr({
             compute: '_computeAreAllMembersLoaded',
         }),


### PR DESCRIPTION
After https://github.com/odoo/odoo/pull/78439 and before this commit,
the `activeRtcSession` was a field of `callView` which is the same view
for all channels. Which means that setting an `activeRtcSession` would
display it for any channel instead of only the channel that hosted this
session.

This commit fixes this issue by moving the field to the `Channel` model.
