### PR TITLE
[FIX] hr_timesheet: fix issue for user

### DIFF
--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -54,11 +54,9 @@
             <field name="model_id" ref="analytic.model_account_analytic_line"/>
             <field name="domain_force">[
                 ('user_id', '=', user.id),
-                ('project_id', '!=', False),
-                '|', '|',
+                '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>


### PR DESCRIPTION
Before this commit, after giving Marc demo all timesheet access and login from
Marc demo and when we try to validate the timesheet of the project he doesn't
have access he can't be able to validate that timesheet

After this commit, after properly giving rights to the user all timesheet access
user can validate the timesheet

task-2954190

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
