### PR TITLE
[FIX] web: Adapt .o_form_view css selectors

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -174,7 +174,7 @@ $o-form-label-margin-right: 0px;
     }
 
     // No sheet
-    &.o_form_nosheet, .o_form_nosheet {
+    .o_form_nosheet {
         @include o-webclient-padding($top: $o-sheet-vpadding, $bottom: $o-sheet-vpadding);
 
         .o_form_statusbar {
@@ -638,7 +638,7 @@ $o-form-label-margin-right: 0px;
         display: none;  // Hide the handler on readonly fields
     }
 
-    &.oe_form_configuration {
+    .oe_form_configuration {
         .o_group .o_form_label {
             white-space: nowrap;
         }
@@ -646,7 +646,7 @@ $o-form-label-margin-right: 0px;
             margin-top: 32px !important;
         }
     }
-    &.o_company_document_layout {
+    .o_company_document_layout {
         .report_layout_container {
             display: inline-block;
             div {


### PR DESCRIPTION
Before the form merge we had
```xml
<o_action>
    <o_content>
        <o_form_view oe_form_configuration>
        </o_form_view oe_form_configuration>
    </o_content>
</o_action>
```

now we have

```xml
<o_action o_form_view>
    <o_content>
        <oe_form_configuration>
        </oe_form_configuration>
    </o_content o_form_view>
</o_action>
```

So we have to adapt form_controllers.scss to match this new structure.