### PR TITLE
[FIX] web: Many2ManyTagsField: honnor options

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -40,7 +40,8 @@ export class Many2ManyTagsField extends Component {
         this.activeActions = useActiveActions({
             fieldType: "many2many",
             crudOptions: {
-                create: this.props.canQuickCreate && this.props.createDomain,
+                create: this.props.canCreate && this.props.createDomain,
+                createEdit: this.props.canCreateEdit,
                 onDelete: removeRecord,
             },
             getEvalParams: (props) => {
@@ -286,7 +287,9 @@ Many2ManyTagsField.components = {
 Many2ManyTagsField.props = {
     ...standardFieldProps,
     canEditColor: { type: Boolean, optional: true },
+    canCreate: { type: Boolean, optional: true },
     canQuickCreate: { type: Boolean, optional: true },
+    canCreateEdit: { type: Boolean, optional: true },
     colorField: { type: String, optional: true },
     createDomain: { type: [Array, Boolean], optional: true },
     placeholder: { type: String, optional: true },
@@ -294,8 +297,10 @@ Many2ManyTagsField.props = {
     nameCreateField: { type: String, optional: true },
 };
 Many2ManyTagsField.defaultProps = {
+    canCreate: true,
     canEditColor: true,
     canQuickCreate: true,
+    canCreateEdit: true,
     nameCreateField: "name",
 };
 
@@ -307,12 +312,18 @@ Many2ManyTagsField.fieldsToFetch = {
 Many2ManyTagsField.isSet = (value) => value.count > 0;
 
 Many2ManyTagsField.extractProps = ({ attrs, field }) => {
+    const noCreate = Boolean(attrs.options.no_create);
+    const canCreate = attrs.can_create && Boolean(JSON.parse(attrs.can_create)) && !noCreate;
+    const noQuickCreate = Boolean(attrs.options.no_quick_create);
+    const noCreateEdit = Boolean(attrs.options.no_create_edit);
+
     return {
         colorField: attrs.options.color_field,
         nameCreateField: attrs.options.create_name_field,
         canEditColor: !attrs.options.no_edit_color,
         relation: field.relation,
-        canQuickCreate: !attrs.options.no_quick_create,
+        canQuickCreate: canCreate && !noQuickCreate,
+        canCreateEdit: canCreate && !noCreateEdit,
         createDomain: attrs.options.create,
         placeholder: attrs.placeholder,
     };

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -1580,4 +1580,69 @@ QUnit.module("Fields", (hooks) => {
         await clickSave(target);
         assert.containsOnce(target, "[name='timmy'].o_field_invalid");
     });
+
+    QUnit.test("Many2ManyTagsField with option 'no_quick_create' set to true", async (assert) => {
+        serverData.views = {
+            "partner_type,false,form": `<form><field name="name"/><field name="color"/></form>`,
+        };
+        patchWithCleanup(AutoComplete, {
+            timeout: 0,
+        });
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="timmy" widget="many2many_tags" options="{'no_quick_create': 1}"/>
+                </form>`,
+        });
+
+        assert.containsNone(target, ".o_tag");
+        await editInput(target, ".o_field_many2many_tags .o-autocomplete--input", "new tag");
+        assert.containsOnce(target, ".o-autocomplete.dropdown li.o_m2o_dropdown_option");
+        assert.hasClass(
+            target.querySelector(".o-autocomplete.dropdown li.o_m2o_dropdown_option"),
+            "o_m2o_dropdown_option_create_edit"
+        );
+        await clickOpenedDropdownItem(target, "timmy", "Create and edit...");
+        assert.containsOnce(target, ".modal");
+        assert.strictEqual(
+            target.querySelector(".modal .o_field_widget[name=name] input").value,
+            "new tag"
+        );
+        await click(target.querySelector(".modal .o_form_button_save"));
+        assert.containsOnce(target, ".o_tag");
+        assert.strictEqual(target.querySelector(".o_tag").innerText, "new tag");
+    });
+
+    QUnit.test("Many2ManyTagsField with option 'no_create' set to true", async (assert) => {
+        patchWithCleanup(AutoComplete, {
+            timeout: 0,
+        });
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><field name="timmy" widget="many2many_tags" options="{'no_create': 1}"/></form>`,
+        });
+
+        await editInput(target, ".o_field_many2many_tags .o-autocomplete--input", "new tag");
+        assert.containsNone(target, ".o-autocomplete.dropdown li.o_m2o_dropdown_option");
+    });
+
+    QUnit.test("Many2ManyTagsField with attribute 'can_create' set to false", async (assert) => {
+        patchWithCleanup(AutoComplete, {
+            timeout: 0,
+        });
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><field name="timmy" widget="many2many_tags" can_create="0"/></form>`,
+        });
+
+        await editInput(target, ".o_field_many2many_tags .o-autocomplete--input", "new tag");
+        assert.containsNone(target, ".o-autocomplete.dropdown li.o_m2o_dropdown_option");
+    });
 });


### PR DESCRIPTION
In the legacy implementation of FieldMany2ManyTags, we instantiated
a FieldMany2One with the attrs of the many2many field node. As a
consequence, the FieldMany2ManyTags honnored its own options and
all options supported by the FieldMany2One.

In the new implementation, before this commit, we lost the support
of the Many2ManyField's specific options, in particular "no_create"
and "no_create_edit". This commit fixes that issue.

With this commit, the FieldMany2ManyTags also takes into account
the "can_create" attribute that is automatically set to "0" by the
framework if the user hasn't the required access rights.

Note: Many2OneField options is a mess, it would be nice to
refactor and simplify them in the future.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
