### PR TITLE
[IMP] purchase: change the billing status of PO

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -45,7 +45,7 @@ class PurchaseOrder(models.Model):
                 order.invoice_status = 'to invoice'
             elif (
                 all(
-                    float_is_zero(line.qty_to_invoice, precision_digits=precision)
+                    float_compare(line.product_qty, line.qty_invoiced, precision_digits=precision) != 1
                     for line in order.order_line.filtered(lambda l: not l.display_type)
                 )
                 and order.invoice_ids

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -98,10 +98,22 @@ class TestPurchaseToInvoice(AccountTestInvoicingCommon):
             self.assertEqual(line.qty_invoiced, 0.0)
 
         purchase_order.action_create_invoice()
-        self.assertEqual(purchase_order.invoice_status, "invoiced")
+        self.assertEqual(purchase_order.invoice_status, "no")
         for line in purchase_order.order_line:
             self.assertEqual(line.qty_to_invoice, 0.0)
             self.assertEqual(line.qty_invoiced, 5)
+
+        purchase_order.order_line.qty_received = 10
+        self.assertEqual(purchase_order.invoice_status, "to invoice")
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_to_invoice, 5)
+            self.assertEqual(line.qty_invoiced, 5)
+
+        purchase_order.action_create_invoice()
+        self.assertEqual(purchase_order.invoice_status, "invoiced")
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_to_invoice, 0.0)
+            self.assertEqual(line.qty_invoiced, 10)
 
     def test_vendor_bill_ordered(self):
         """Test if a order of product invoiced by ordered quantity can be
@@ -187,7 +199,7 @@ class TestPurchaseToInvoice(AccountTestInvoicingCommon):
             self.assertEqual(line.qty_to_invoice, -5)
             self.assertEqual(line.qty_invoiced, 10)
         purchase_order.action_create_invoice()
-        self.assertEqual(purchase_order.invoice_status, "invoiced")
+        self.assertEqual(purchase_order.invoice_status, "no")
         for line in purchase_order.order_line:
             self.assertEqual(line.qty_to_invoice, 0.0)
             self.assertEqual(line.qty_invoiced, 5)


### PR DESCRIPTION
Before this commit
===============
when product quantity partially received and also billed for received quantity
than the PO billing status is 'fully billed' instead of 'nothing to bill'

After this commit
===============
when product quantity partially received and also billed for received quantity
than the PO billing status is 'nothing to bill' and when product quantity fully
received and fully billed, than PO billing status is 'fully billed'.

TaskID: 2682551