### PR TITLE
[FIX] web: save a x2m with an invalid new record

### DIFF
--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -7,6 +7,7 @@ import { session } from "@web/session";
 import { Field } from "@web/views/fields/field";
 import { Record } from "@web/views/record";
 import {
+    addRow,
     click,
     clickDiscard,
     clickDropdown,
@@ -2120,24 +2121,7 @@ QUnit.module("Fields", (hooks) => {
             });
 
             // Click on "Add an item"
-            await click(target, ".o_field_x2many_list_row_add a");
-            target.querySelector(".o_field_widget.o_field_char[name=display_name] input").value =
-                "some text";
-            assert.containsOnce(
-                target,
-                ".o_field_widget.o_field_char[name=display_name]",
-                "should have a char field 'display_name' on this record"
-            );
-            assert.doesNotHaveClass(
-                target.querySelector(".o_field_widget.o_field_char[name=display_name]"),
-                "o_required_modifier",
-                "the char field should not be required on this record"
-            );
-            assert.strictEqual(
-                target.querySelector(".o_field_widget.o_field_char[name=display_name] input").value,
-                "some text",
-                "should have entered text in the char field on this record"
-            );
+            await addRow(target);
             assert.containsOnce(
                 target,
                 ".o_field_widget.o_required_modifier[name=trululu]",

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -12562,4 +12562,39 @@ QUnit.module("Fields", (hooks) => {
         await triggerEvents(target, ".o_data_row", ["touchstart", "touchend"]);
         assert.containsNone(target, ".o_data_row_selected");
     });
+
+    QUnit.test(
+        "save a record after creating and editing a new invalid record in a one2many",
+        async function (assert) {
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <form>
+                        <field name="p">
+                            <tree editable="bottom">
+                                <field name="display_name" required="1"/>
+                                <field name="int_field"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                resId: 1,
+            });
+
+            await clickEdit(target);
+            await addRow(target);
+            await editInput(target, ".o_field_widget[name=int_field] input", "3");
+            await clickSave(target);
+            assert.containsOnce(
+                target,
+                ".o_data_row.o_selected_row",
+                "line should not have been removed and should still be in edition"
+            );
+            assert.hasClass(
+                target.querySelector(".o_field_widget[name=display_name]"),
+                "o_field_invalid"
+            );
+        }
+    );
 });


### PR DESCRIPTION
The purpose of this commit is to prevent saving to a form view
if you have created and edited a new invalid record in an x2many.

How to reproduce
- go to a form view with an x2m
- create a new record with at least one required field empty in the x2m
- edit another field than the required one
- click on the save button

Before this commit:
- The view is switched to readonly mode and the new record is deleted.

After this commit:
- The view stays in edit mode, the new record is not deleted and
a notification indicating invalid fields is displayed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
