### PR TITLE
[FIX] web: grouped list: support buttons in between aggregates

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -170,8 +170,8 @@
             <th t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group)" t-if="showGroupPager(group)">
                 <Pager t-props="getGroupPagerProps(group)"/>
             </th>
-            <td t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group)" t-foreach="getAggregateColumns(group)" t-as="column" t-key="column.id" class="o_list_number">
-                <t t-esc="formatAggregateValue(group, column)"/>
+            <td t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group)" t-foreach="getAggregateColumns(group)" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
+                <t t-if="column.type === 'field'" t-esc="formatAggregateValue(group, column)"/>
             </td>
             <t t-set="groupPagerColspan" t-value="getGroupPagerCellColspan(group)"/>
             <th t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group)" t-if="groupPagerColspan > 0" t-att-colspan="groupPagerColspan"/>

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -2740,6 +2740,25 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("aggregates in grouped lists with buttons", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            groupBy: ["m2o"],
+            arch: `
+                <tree>
+                    <field name="foo"/>
+                    <field name="int_field" sum="Sum"/>
+                    <button name="a" type="object"/>
+                    <field name="qux" sum="Sum"/>
+                </tree>`,
+        });
+
+        const cellVals = ["23", "6.4", "9", "13", "32", "19.40"];
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_list_number")), cellVals);
+    });
+
     QUnit.test(
         "hide aggregated value in grouped lists when no data provided by RPC call",
         async function (assert) {
@@ -13687,33 +13706,36 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(document.activeElement, intFieldInput);
     });
 
-    QUnit.test("continue creating new lines in editable=top on keyboard nav", async function (assert) {
-        await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: `
+    QUnit.test(
+        "continue creating new lines in editable=top on keyboard nav",
+        async function (assert) {
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: `
                 <tree editable="top">
                     <field name="int_field"/>
                 </tree>`,
-        });
+            });
 
-        let initialRowCount = $('.o_data_cell[name=int_field]').length
+            const initialRowCount = $(".o_data_cell[name=int_field]").length;
 
-        // click on int_field cell of first row
-        await click(target, ".o_list_button_add");
+            // click on int_field cell of first row
+            await click(target, ".o_list_button_add");
 
-        await editInput(target, ".o_data_cell[name=int_field] input", "1");
-        triggerHotkey("Tab");
-        await nextTick();
+            await editInput(target, ".o_data_cell[name=int_field] input", "1");
+            triggerHotkey("Tab");
+            await nextTick();
 
-        await editInput(target, ".o_data_cell[name=int_field] input", "2");
-        triggerHotkey("Enter");
-        await nextTick();
+            await editInput(target, ".o_data_cell[name=int_field] input", "2");
+            triggerHotkey("Enter");
+            await nextTick();
 
-        // 3 new rows: the two created ("1" and "2", and a new still in edit mode)
-        assert.strictEqual($('.o_data_cell[name=int_field]').length , initialRowCount + 3);
-    });
+            // 3 new rows: the two created ("1" and "2", and a new still in edit mode)
+            assert.strictEqual($(".o_data_cell[name=int_field]").length, initialRowCount + 3);
+        }
+    );
 
     QUnit.test("Date in evaluation context works with date field", async function (assert) {
         patchDate(1997, 0, 9, 12, 0, 0);


### PR DESCRIPTION
Before this commit, the list view crashed when it was grouped if
there was a button column in between two aggregatable fields
columns. The reason is that "formatAggragatableValue" makes sense
only on field columns, and it crashes when called on a column of
another type. It was for instance the case in the Stock > Locations
list view.