### PR TITLE
[FIX] mail: make Activity/note field readonly

### DIFF
--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -37,7 +37,7 @@ registerModel({
                 data2.id = data.id;
             }
             if ('note' in data) {
-                data2.note = data.note;
+                data2.rawNote = data.note;
             }
             if ('state' in data) {
                 data2.state = data.state;
@@ -246,10 +246,10 @@ registerModel({
          * @returns {string|undefined}
          */
         _computeNote() {
-            if (this.note === '<p><br></p>') {
+            if (this.rawNote === '<p><br></p>') {
                 return clear();
             }
-            return this.note;
+            return this.rawNote;
         },
         /**
          * @private
@@ -309,6 +309,7 @@ registerModel({
         noteAsMarkup: attr({
             compute: '_computeNoteAsMarkup',
         }),
+        rawNote: attr(),
         /**
          * Determines that an activity is linked to a requesting partner or not.
          * It will be used notably in website slides to know who triggered the


### PR DESCRIPTION
3c28be1b33ea18be7280d9372ebd53a54140da86 enforced readonly by default on computed and related fields, but Activity/note was not adapted to be readonly, leading the application to crash when editing a note.

This commit fixes it by introducing a new field to write on instead of the computed one.

Follow-up of task-2955927.
