### PR TITLE
[FIX] portal: allocate Renderer correctly on new x2many field

### DIFF
--- a/addons/portal/static/src/views/fields/portal_wizard_user_one2many.js
+++ b/addons/portal/static/src/views/fields/portal_wizard_user_one2many.js
@@ -4,11 +4,10 @@ import { PortalWizardUserListRenderer } from "../list/portal_wizard_user_list_re
 import { X2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { registry } from "@web/core/registry";
 
-export class PortalUserX2ManyField extends X2ManyField {
-    setup() {
-        super.setup();
-        this.Renderer = PortalWizardUserListRenderer;
-    }
-}
+export class PortalUserX2ManyField extends X2ManyField {}
+PortalUserX2ManyField.components = {
+    ...X2ManyField.components,
+    ListRenderer: PortalWizardUserListRenderer,
+};
 
 registry.category("fields").add("portal_wizard_user_one2many", PortalUserX2ManyField);


### PR DESCRIPTION
The new structure of X2manyField stores ListRenderer in its components.
PortalUserX2ManyField is not using that structure properly. Therefore,
PortalWizardUserListRenderer it is not found nor used correctly.
This commit correctly places that List Renderer in the components.

Commit changing the structure in odoo/odoo#97984

Task-2968411
