### PR TITLE
[FIX] rating: check model is set before using it as key

### DIFF
--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -28,7 +28,11 @@ class MailMessage(models.Model):
 
     def message_format(self, format_reply=True):
         message_values = super().message_format(format_reply=format_reply)
-        rating_mixin_messages = self.filtered(lambda message: issubclass(self.pool[message.model], self.pool['rating.mixin']))
+        rating_mixin_messages = self.filtered(lambda message:
+            message.model
+            and message.res_id
+            and issubclass(self.pool[message.model], self.pool['rating.mixin'])
+        )
         if rating_mixin_messages:
             ratings = self.env['rating.rating'].sudo().search([('message_id', 'in', rating_mixin_messages.ids), ('consumed', '=', True)])
             rating_by_message_id = dict((r.message_id.id, r) for r in ratings)


### PR DESCRIPTION
As message_notify can be done on empty recordset, message.res_id and
message.model can be Falsy. During filtering on rating messages, we need to
prevent the code to crash when filtering on those two properties and filter out
messages that are not linked to any record.

Task-2850521