### PR TITLE
[FIX] web: Move context in kwargs

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -610,7 +610,9 @@ export class Record extends DataPoint {
     }
 
     async delete() {
-        const unlinked = await this.model.orm.unlink(this.resModel, [this.resId], this.context);
+        const unlinked = await this.model.orm.unlink(this.resModel, [this.resId], {
+            context: this.context,
+        });
         if (!unlinked) {
             return false;
         }
@@ -1136,7 +1138,7 @@ export class Record extends DataPoint {
             (!value[1] || activeField.options.always_reload)
         ) {
             const context = this.getFieldContext(fieldName);
-            const result = await this.model.orm.nameGet(relation, [value[0]], context);
+            const result = await this.model.orm.nameGet(relation, [value[0]], { context });
             return result[0];
         }
         return value;
@@ -1153,7 +1155,7 @@ export class Record extends DataPoint {
             }
             const { resModel, resId } = value;
             const context = this.getFieldContext(fieldName);
-            const nameGet = await this.model.orm.nameGet(resModel, [resId], context);
+            const nameGet = await this.model.orm.nameGet(resModel, [resId], { context });
             return {
                 resModel,
                 resId,
@@ -1813,7 +1815,9 @@ export class DynamicRecordList extends DynamicList {
             resIds = await this.getResIds(true);
             records = this.records.filter((r) => resIds.includes(r.resId));
             if (this.isDomainSelected) {
-                await this.model.orm.unlink(this.resModel, resIds, this.context);
+                await this.model.orm.unlink(this.resModel, resIds, {
+                    context: this.context,
+                });
                 deleted = true;
             }
         }
@@ -2453,7 +2457,9 @@ export class Group extends DataPoint {
         if (this.record) {
             return this.record.delete();
         } else {
-            return this.model.orm.unlink(this.resModel, [this.value], this.context);
+            return this.model.orm.unlink(this.resModel, [this.value], {
+                context: this.context,
+            });
         }
     }
 

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -4153,13 +4153,23 @@ QUnit.module("Views", (hooks) => {
         assert.ok(longText > emptyText, "Long word should change the height of the cell");
     });
 
-    QUnit.test("deleting one record", async function (assert) {
+    QUnit.test("deleting one record and verify context key", async function (assert) {
         await makeView({
             type: "list",
             resModel: "foo",
             serverData,
             actionMenus: {},
             arch: '<tree><field name="foo"/></tree>',
+            mockRPC(route, args) {
+                if (args.method === "unlink") {
+                    assert.step("unlink");
+                    const { context } = args.kwargs;
+                    assert.strictEqual(context.ctx_key, "ctx_val");
+                }
+            },
+            context: {
+                ctx_key: "ctx_val",
+            },
         });
 
         assert.containsNone(target, "div.o_control_panel .o_cp_action_menus");
@@ -4178,6 +4188,8 @@ QUnit.module("Views", (hooks) => {
         );
 
         await click(document, "body .modal footer button.btn-primary");
+
+        assert.verifySteps(["unlink"]);
 
         assert.containsN(target, "tbody td.o_list_record_selector", 3, "should have 3 records");
     });


### PR DESCRIPTION
The context should be a key inside the kwargs object.

since https://github.com/odoo/odoo/pull/99018/commits/97cf55fc1e510b1473670863fd44a0a38047ce9c