### PR TITLE
[FIX] sale_stock: apply sale order rules

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -181,7 +181,9 @@ class ProductionLot(models.Model):
         sale_orders = defaultdict(lambda: self.env['sale.order'])
         for move_line in self.env['stock.move.line'].search([('lot_id', 'in', self.ids), ('state', '=', 'done')]):
             move = move_line.move_id
-            if move.picking_id.location_dest_id.usage == 'customer' and move.sale_line_id.order_id:
+            if move.picking_id.location_dest_id.usage == "customer" and self.env["sale.order.line"].search(
+                [("id", "=", move.sale_line_id.id)]
+            ).mapped("order_id"):
                 sale_orders[move_line.lot_id.id] |= move.sale_line_id.order_id
         for lot in self:
             lot.sale_order_ids = sale_orders[lot.id]


### PR DESCRIPTION
The models `sale.order` and `sale.order.line` have rules limiting
the orders to [personal orders](https://github.com/odoo/odoo/blob/14.0/addons/sale/security/sale_security.xml#L124-L129) for group `group_sale_salesman`.

The rules were not applied when the performance improvement
https://github.com/odoo/odoo/pull/71949 took place.

Description of the issue/feature this PR addresses:
If a user in group `sales_team.group_sale_salesman` tries to view production
lots of products used in sale orders that were made by other users, an access
error shows up.

Current behavior before PR:

Desired behavior after PR is merged:
The sale orders would be limited to the user's sales.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
