### PR TITLE
[FIX] sale_stock: display delivery orders for DS in portal view

### DIFF
--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -14,7 +14,7 @@
                     <strong>Delivery Orders</strong>
                 </div>
                 <div>
-                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code == 'outgoing')" t-as="i">
+                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code == 'outgoing' or picking.picking_type_id.sequence_code == 'DS')" t-as="i">
                         <t t-set="delivery_report_url" t-value="'/my/picking/pdf/%s?%s' % (i.id, keep_query())"/>
                         <div class="d-flex flex-wrap align-items-center justify-content-between o_sale_stock_picking">
                             <div>


### PR DESCRIPTION
Steps to reproduce:
- Activate Dropship and multi routes
- Create a SO and select the route Dropship
- Confirm the SO
- Click on Customer Preview

Issue:
The delivery orders is empty

opw-2961884