### PR TITLE
[FIX] web: Mock server required fields are actually required

### DIFF
--- a/addons/bus/static/tests/helpers/mock_python_environment.js
+++ b/addons/bus/static/tests/helpers/mock_python_environment.js
@@ -201,7 +201,7 @@ let pyEnv;
             },
          },
     );
-    pyEnv['mockServer'] = await makeMockServer({ actions, models, views });
+    pyEnv['mockServer'] = await makeMockServer({ actions, models, views }, null, { strict: false });
     pyEnv['mockServer'].pyEnv = pyEnv;
     registerCleanup(() => pyEnv = undefined);
     return pyEnv;

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -1121,6 +1121,36 @@ QUnit.module("MockServer", (hooks) => {
         }
     );
 
+    QUnit.test("performRPC: name_create", async (assert) => {
+        const server = new MockServer(data);
+        const result = await server.performRPC("", {
+            model: "bar",
+            method: "name_create",
+            args: ["abc"],
+            kwargs: {},
+        });
+
+        assert.ok(!isNaN(result[0]));
+        assert.strictEqual(result[1], "abc");
+    });
+
+    QUnit.test("performRPC: name_create with required field", async (assert) => {
+        data.models.bar.fields.foo.required = true;
+
+        const server = new MockServer(data);
+
+        try {
+            await server.performRPC("", {
+                model: "bar",
+                method: "name_create",
+                args: ["abc"],
+                kwargs: {},
+            });
+        } catch (err) {
+            assert.strictEqual(err.message, "Missing value for required fields: foo.");
+        }
+    });
+
     QUnit.test("many2one_ref should auto fill inverse field", async function (assert) {
         data.models.bar.records = [{ id: 1 }];
         data.models.foo.records = [


### PR DESCRIPTION
Before this commit, when the mock server created a record, the
"required" attribute on the model's fields was not taken into account.

Now, if the given values don't contain a required field, the request is
rejected with the name of the missing required fields.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
