### PR TITLE
[FIX] web, barcodes: correctly handle chrome's autofill

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -59,6 +59,12 @@ export const barcodeService = {
         }
 
         function keydownHandler(ev) {
+            if (!ev.key) {
+                // Chrome may trigger incomplete keydown events under certain circumstances.
+                // E.g. when using browser built-in autocomplete on an input.
+                // See https://stackoverflow.com/questions/59534586/google-chrome-fires-keydown-event-when-form-autocomplete
+                return;
+            }
             // Ignore 'Shift', 'Escape', 'Backspace', 'Insert', 'Delete', 'Home', 'End', Arrow*, F*, Page*, ...
             // ctrl, meta and alt are often used for UX purpose (like shortcuts)
             // Note: shiftKey is not ignored because it can be used by some barcode scanner for digits.

--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -54,6 +54,12 @@ const AUTHORIZED_KEYS = [...ALPHANUM_KEYS, ...NAV_KEYS, "escape"];
  * @returns {string} the active hotkey, in lowercase
  */
 export function getActiveHotkey(ev) {
+    if (!ev.key) {
+        // Chrome may trigger incomplete keydown events under certain circumstances.
+        // E.g. when using browser built-in autocomplete on an input.
+        // See https://stackoverflow.com/questions/59534586/google-chrome-fires-keydown-event-when-form-autocomplete
+        return "";
+    }
     const hotkey = [];
 
     // ------- Modifiers -------
@@ -115,13 +121,6 @@ export const hotkeyService = {
          * @param {KeyboardEvent} event
          */
         function onKeydown(event) {
-            if (!event.key) {
-                // Chrome may trigger incomplete keydown events under certain circumstances.
-                // E.g. when using browser built-in autocomplete on an input.
-                // See https://stackoverflow.com/questions/59534586/google-chrome-fires-keydown-event-when-form-autocomplete
-                return;
-            }
-
             if (event.code && event.code.indexOf("Numpad") === 0 && /^\d$/.test(event.key)) {
                 // Ignore all number keys from the Keypad because of a certain input method
                 // of (advance-)ASCII characters on Windows OS: ALT+[numerical code from keypad]
@@ -130,6 +129,9 @@ export const hotkeyService = {
             }
 
             const hotkey = getActiveHotkey(event);
+            if (!hotkey) {
+                return;
+            }
             const { activeElement, isBlocked } = ui;
 
             // Do not dispatch if UI is blocked


### PR DESCRIPTION
On Chrome, have a field that supports autofill (you have to have set up an adress in Chrome first).
Click on that field, and apply the autofill proposition.

Before this commit, there was multiple crashes, roughly one for every handler of event `keydown`.
This was caused by the fact that the autofill feature triggers keydown events without the field `key`.
(https://bugs.chromium.org/p/chromium/issues/detail?id=581537, I could not find a better ticket).

This seems to be a bug on Chrome's side, since the spec doesn't mention that field may be unset (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).

After this commit, there is no crash.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
