### PR TITLE
[FIX] sale_coupon: Better performance

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -317,8 +317,8 @@ class SaleCouponProgram(models.Model):
 
     def _is_valid_partner(self, partner):
         if self.rule_partners_domain and self.rule_partners_domain != '[]':
-            domain = safe_eval(self.rule_partners_domain) + [('id', '=', partner.id)]
-            return bool(self.env['res.partner'].search_count(domain))
+            domain = safe_eval(self.rule_partners_domain)
+            return bool(partner.filtered_domain(domain))
         else:
             return True
 


### PR DESCRIPTION
This commit fixes the same issue as #56324 but for partner this time.

Description of the issue/feature this PR addresses:
Performance issue when you add a product to the cart in the ecommerce if you have a lot of coupon programs

Current behavior before PR:
One search_count per coupon program is performed

Desired behavior after PR is merged:
Use filtered_domain allows to use the cache instead


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
