### PR TITLE
[IMP] portal: remove 0 lines display

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -104,6 +104,7 @@ You could use this simplified accounting in case you work with an (external) acc
         ],
         'web.assets_frontend': [
             'account/static/src/js/account_portal_sidebar.js',
+            'account/static/src/js/account_portal.js',
         ],
         'web.assets_tests': [
             'account/static/tests/tours/**/*',

--- a/addons/account/static/src/js/account_portal.js
+++ b/addons/account/static/src/js/account_portal.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import publicWidget from 'web.public.widget';
+
+publicWidget.registry.PortalHomeCounters.include({
+    /**
+     * @override
+     */
+    _getCountersAlwaysDisplayed() {
+        return this._super(...arguments).concat(['invoice_count']);
+    },
+});

--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -71,26 +71,50 @@ publicWidget.registry.PortalHomeCounters = publicWidget.Widget.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Return a list of counters name linked to a line that we want to keep
+     * regardless of the number of documents present
+     * @private
+     * @returns {Array}
+     */
+    _getCountersAlwaysDisplayed() {
+        return [];
+    },
+
+    /**
      * @private
      */
     async _updateCounters(elem) {
         const numberRpc = 3;
-        const needed = this.$('[data-placeholder_count]')
-                                .map((i, o) => $(o).data('placeholder_count'))
-                                .toArray();
+        const needed = Object.values(this.el.querySelectorAll('[data-placeholder_count]'))
+                                .map(documentsCounterEl => documentsCounterEl.dataset['placeholder_count']);
         const counterByRpc = Math.ceil(needed.length / numberRpc);  // max counter, last can be less
+        const countersAlwaysDisplayed = this._getCountersAlwaysDisplayed();
 
         const proms = [...Array(Math.min(numberRpc, needed.length)).keys()].map(async i => {
-            await this._rpc({
+            const documentsCountersData = await this._rpc({
                 route: "/my/counters",
                 params: {
                     counters: needed.slice(i * counterByRpc, (i + 1) * counterByRpc)
                 },
-            }).then(data => {
-                Object.keys(data).map(k => this.$("[data-placeholder_count='" + k + "']").text(data[k]));
             });
+            Object.keys(documentsCountersData).forEach(counterName => {
+                const documentsCounterEl = this.el.querySelector(`[data-placeholder_count='${counterName}']`);
+                documentsCounterEl.textContent = documentsCountersData[counterName];
+                // The element is hidden by default, only show it if its counter is > 0 or if it's in the list of counters always shown
+                if (documentsCountersData[counterName] !== 0 || countersAlwaysDisplayed.includes(counterName)) {
+                    documentsCounterEl.parentElement.classList.remove('d-none');
+                }
+            });
+            return documentsCountersData;
         });
-        return Promise.all(proms);
+        return Promise.all(proms).then((results) => {
+            const counters = results.reduce((prev, current) => Object.assign({...prev, ...current}), {});
+            this.el.querySelector('.o_portal_doc_spinner').remove();
+            // Display a message when there are no documents available if there are no counters > 0 and no counters always shown
+            if (!countersAlwaysDisplayed.length && !Object.values(counters).filter((val) => val > 0).length) {
+                this.el.querySelector('.o_portal_no_doc_message').classList.remove('d-none');
+            }
+        });
     },
 });
 

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -187,6 +187,8 @@
                 <div class="oe_structure" id="oe_structure_portal_my_home_1"/>
                 <h3>Documents</h3>
                 <div class="o_portal_docs list-group">
+                    <div class="o_portal_doc_spinner spinner-border text-o-color-2 align-self-center mt-5"/>
+                    <p class="o_portal_no_doc_message d-none">No Documents to display</p>
                 </div>
             </div>
             <div class="oe_structure" id="oe_structure_portal_my_home_2"/>
@@ -194,7 +196,7 @@
     </template>
 
     <template id="portal_docs_entry" name="My Portal Docs Entry">
-        <a t-att-href="url" t-att-title="title" class="list-group-item list-group-item-action d-flex align-items-center justify-content-between">
+        <a t-att-href="url" t-att-title="title" class="list-group-item list-group-item-action d-flex align-items-center justify-content-between d-none">
             <t t-esc="title"/>
             <t t-if='count'>
                 <span class="badge text-bg-secondary rounded-pill" t-esc="count"/>

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -76,6 +76,7 @@ This module contains all the common features of Sales Management and eCommerce.
         'web.assets_frontend': [
             'sale/static/src/scss/sale_portal.scss',
             'sale/static/src/js/sale_portal_sidebar.js',
+            'sale/static/src/js/sale_portal.js',
             'sale/static/src/js/payment_form.js',
         ],
         'web.assets_tests': [

--- a/addons/sale/static/src/js/sale_portal.js
+++ b/addons/sale/static/src/js/sale_portal.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import publicWidget from 'web.public.widget';
+
+publicWidget.registry.PortalHomeCounters.include({
+    /**
+     * @override
+     */
+    _getCountersAlwaysDisplayed() {
+        return this._super(...arguments).concat(['quotation_count', 'order_count']);
+    },
+});


### PR DESCRIPTION
We now display only the lines that have documents linked to them.
In case, we want to display a line even if there are no doc, we
can do so by updating the list of counter to keep with
"getCountersToKeep()".

In case, there are no lines, we display a small message.
For now we always display the quotations, sale orders and invoices.

task-2947778
