### PR TITLE
[FIX] im_livechat: do not willStart when livechat unavailable

### DIFF
--- a/addons/im_livechat/static/src/models/public_livechat_global.js
+++ b/addons/im_livechat/static/src/models/public_livechat_global.js
@@ -26,7 +26,9 @@ registerModel({
                 }
                 set_cookie(this.LIVECHAT_COOKIE_HISTORY, JSON.stringify(urlHistory), 60 * 60 * 24); // 1 day cookie
             }
-            this.willStart();
+            if (this.isAvailable) {
+                this.willStart();
+            }
         },
     },
     recordMethods: {


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/98160

PR above made single app im_livechat tests sometimes fail with
following error:

```
TypeError: LivechatController.livechat_init() missing 1 required positional argument: 'channel_id'
```

This comes from RPC `/im_livechat/init` in frontend, which must
provide `channel_id` but somehow doesn't sometimes.

This only happens with `test_im_livechat_support_page`, sometimes on runbot.

Task-2969488