### PR TITLE
[FIX] web: form_compiler, avoid using technical IDs to link the field

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -184,7 +184,7 @@ export class FormCompiler extends ViewCompiler {
         const fieldName = el.getAttribute("name");
         const fieldString = el.getAttribute("string");
         const fieldId = el.getAttribute("field_id") || fieldName;
-        const labelsForAttr = el.getAttribute("id") || fieldId;
+        const labelsForAttr = el.getAttribute("id") || fieldName;
         const labels = this.getLabels(labelsForAttr);
         const dynamicLabel = (label) => {
             const formLabel = this.createLabelFromField(

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -924,6 +924,25 @@ QUnit.module("Views", (hooks) => {
         assert.hasClass(target.querySelectorAll(".o_form_label")[1], "c");
     });
 
+    QUnit.test("invisible fields are not used for the label generation", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <field name="qux" invisible="1"/>
+                        <label for="qux"/>
+                        <field name="qux"/>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+
+        assert.containsOnce(target, "label:contains(Qux)");
+    });
+
     QUnit.test("invisible elements are properly hidden", async function (assert) {
         await makeView({
             type: "form",


### PR DESCRIPTION
with its label

Before this commit, when compiling the field to link the field with a
previously found label, to search, we used in order : the 'id' (encoded
on the arch), the 'field_id' (an internal technical ID), the 'name'
(also in the arch).

The issue with this is that the "field_id" is a technical id and
shouldn't be used, to search the label.

Now, we only search for the 'id' and the 'name'.
