### PR TITLE
[FIX] web: Prevent tag from changing color on focus

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/tags_list.scss
+++ b/addons/web/static/src/views/fields/many2many_tags/tags_list.scss
@@ -38,9 +38,6 @@
                     background-color: nth($o-colors, $size);
                     color: color-contrast(nth($o-colors, $size));
                 }
-                &:focus-within {
-                    background-color: darken(nth($o-colors, $size), 20%);
-                }
             }
         }
     }


### PR DESCRIPTION
For now there was a darkening of the tag on focus, but we don't want it.