### PR TITLE
[IMP] base: cache back-end views

### DIFF
--- a/addons/board/models/board.py
+++ b/addons/board/models/board.py
@@ -32,10 +32,14 @@ class Board(models.AbstractModel):
         if custom_view:
             res.update({'custom_view_id': custom_view.id,
                         'arch': custom_view.arch})
-        res.update({
-            'arch': self._arch_preprocessing(res['arch']),
-            'toolbar': {'print': [], 'action': [], 'relate': []}
-        })
+        res['arch'] = self._arch_preprocessing(res['arch'])
+        return res
+
+    @api.model
+    def get_views(self, views, options=None):
+        res = super().get_views(views, options)
+        for view in res['views'].values():
+            view['toolbar'] = {'print': [], 'action': [], 'relate': []}
         return res
 
     @api.model

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -179,18 +179,9 @@ class User(models.Model):
         # Note: limit the `sudo` to the only action of "editing own profile" action in order to
         # avoid breaking `groups` mecanism on res.users form view.
         profile_view = self.env.ref("hr.res_users_view_form_profile")
-        original_user = self.env.user
         if profile_view and view_id == profile_view.id:
             self = self.with_user(SUPERUSER_ID)
         result = super(User, self).get_view(view_id, view_type, **options)
-        # Due to using the SUPERUSER the result will contain action that the user may not have access too
-        # here we filter out actions that requires special implicit rights to avoid having unusable actions
-        # in the dropdown menu.
-        if options.get('toolbar') and self.env.user != original_user:
-            self = self.with_user(original_user.id)
-            if not self.user_has_groups("base.group_erp_manager"):
-                change_password_action = self.env.ref("base.change_password_wizard_action")
-                result['toolbar']['action'] = [act for act in result['toolbar']['action'] if act['id'] != change_password_action.id]
         return result
 
     @api.model_create_multi

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -86,7 +86,7 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': james.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        available_actions = james.get_view(view.id, toolbar=True)['toolbar']['action']
+        available_actions = james.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar']['action']
         change_password_action = self.env.ref("base.change_password_wizard_action")
 
         self.assertFalse(any(x['id'] == change_password_action.id for x in available_actions))
@@ -99,7 +99,7 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': john.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        available_actions = john.get_view(view.id, toolbar=True)['toolbar']['action']
+        available_actions = john.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar']['action']
         self.assertTrue(any(x['id'] == change_password_action.id for x in available_actions))
 
 

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1791,6 +1791,13 @@ class Task(models.Model):
         return public_fields
 
     @api.model
+    def _get_view_cache_key(self, view_id=None, view_type='form', **options):
+        """The override of fields_get making fields readonly for portal users
+        makes the view cache dependent on the fact the user has the group portal or not"""
+        key = super()._get_view_cache_key(view_id, view_type, **options)
+        return key + (self.env.user.has_group('base.group_portal'),)
+
+    @api.model
     def default_get(self, default_fields):
         vals = super(Task, self).default_get(default_fields)
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -4,6 +4,7 @@
 import odoo
 from odoo import api, fields, models, tools, _, Command
 from odoo.exceptions import MissingError, ValidationError, AccessError
+from odoo.tools import frozendict
 from odoo.tools.safe_eval import safe_eval, test_python_expr
 from odoo.tools.float_utils import float_compare
 from odoo.http import request
@@ -87,24 +88,40 @@ class IrActions(models.Model):
 
     @api.model
     def get_bindings(self, model_name):
-        return self._get_bindings(model_name, bool(request) and request.session.debug)
-
-    @tools.ormcache('frozenset(self.env.user.groups_id.ids)', 'model_name', 'debug')
-    def _get_bindings(self, model_name, debug=False):
         """ Retrieve the list of actions bound to the given model.
 
            :return: a dict mapping binding types to a list of dict describing
                     actions, where the latter is given by calling the method
                     ``read`` on the action record.
         """
+        result = {}
+        for action_type, all_actions in self._get_bindings(model_name).items():
+            actions = []
+            for action in all_actions:
+                action = dict(action)
+                groups = action.pop('groups_id', None)
+                if groups and not self.user_has_groups(groups):
+                    # the user may not perform this action
+                    continue
+                res_model = action.pop('res_model', None)
+                if res_model and not self.env['ir.model.access'].check(
+                    res_model,
+                    mode='read',
+                    raise_exception=False
+                ):
+                    # the user won't be able to read records
+                    continue
+                actions.append(action)
+            if actions:
+                result[action_type] = actions
+        return result
+
+    @tools.ormcache('model_name', 'self.env.lang')
+    def _get_bindings(self, model_name):
         cr = self.env.cr
-        IrModelAccess = self.env['ir.model.access']
 
         # discard unauthorized actions, and read action definitions
         result = defaultdict(list)
-        user_groups = self.env.user.groups_id
-        if not debug:
-            user_groups -= self.env.ref('base.group_no_one')
 
         self.env.flush_all()
         cr.execute("""
@@ -117,25 +134,22 @@ class IrActions(models.Model):
         for action_id, action_model, binding_type in cr.fetchall():
             try:
                 action = self.env[action_model].sudo().browse(action_id)
-                action_groups = getattr(action, 'groups_id', ())
-                action_model = getattr(action, 'res_model', False)
-                if action_groups and not action_groups & user_groups:
-                    # the user may not perform this action
-                    continue
-                if action_model and not IrModelAccess.check(action_model, mode='read', raise_exception=False):
-                    # the user won't be able to read records
-                    continue
                 fields = ['name', 'binding_view_types']
-                if 'sequence' in action._fields:
-                    fields.append('sequence')
-                result[binding_type].append(action.read(fields)[0])
-            except (AccessError, MissingError):
+                for field in ('groups_id', 'res_model', 'sequence'):
+                    if field in action._fields:
+                        fields.append(field)
+                action = action.read(fields)[0]
+                if action.get('groups_id'):
+                    groups = self.env['res.groups'].browse(action['groups_id'])
+                    action['groups_id'] = ','.join(ext_id for ext_id in groups._ensure_xml_id().values())
+                result[binding_type].append(frozendict(action))
+            except (MissingError):
                 continue
 
         # sort actions by their sequence if sequence available
         if result.get('action'):
-            result['action'] = sorted(result['action'], key=lambda vals: vals.get('sequence', 0))
-        return result
+            result['action'] = tuple(sorted(result['action'], key=lambda vals: vals.get('sequence', 0)))
+        return frozendict(result)
 
     @api.model
     def _for_xml_id(self, full_xml_id):

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -159,12 +159,12 @@ class Module(models.Model):
     _order = 'application desc,sequence,name'
 
     @api.model
-    def get_view(self, view_id=None, view_type='form', **options):
-        res = super().get_view(view_id, view_type, **options)
-        if view_type == 'form' and res.get('toolbar',False):
+    def get_views(self, views, options=None):
+        res = super().get_views(views, options)
+        if res['views'].get('form', {}).get('toolbar'):
             install_id = self.env.ref('base.action_server_module_immediate_install').id
-            action = [rec for rec in res['toolbar']['action'] if rec.get('id', False) != install_id]
-            res['toolbar'] = {'action': action}
+            action = [rec for rec in res['views']['form']['toolbar']['action'] if rec.get('id', False) != install_id]
+            res['views']['form']['toolbar'] = {'action': action}
         return res
 
     @classmethod

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -965,27 +965,6 @@ actual arch.
         arch = root.with_prefetch(tree_views._prefetch_ids)._combine(hierarchy)
         return arch
 
-    def _apply_groups(self, node, name_manager, node_info):
-        """ Apply group restrictions: elements with a 'groups' attribute should
-        be removed from the view to people who are not members.
-        """
-        if node.get('groups'):
-            if not self.user_has_groups(groups=node.attrib.pop('groups')):
-                node.getparent().remove(node)
-            elif node.tag == 't' and not node.attrib:
-                # Move content of <t> blocks with no other instructions than just "groups=" to the parent
-                # and remove the <t> node.
-                # This is to keep the structure
-                # <group>
-                #   <field name="foo"/>
-                #   <field name="bar"/>
-                # <group>
-                # so the web client adds the label as expected.
-                node_info['children'] = list(node)
-                for child in reversed(node):
-                    node.addnext(child)
-                node.getparent().remove(node)
-
     def _get_view_refs(self, node):
         """ Extract the `[view_type]_view_ref` keys and values from the node context attribute,
         giving the views to use for a field node.
@@ -1031,6 +1010,68 @@ actual arch.
             name_managers.extend(name_manager.children)
         return arch, models
 
+    def _postprocess_access_rights(self, tree, models):
+        """
+        Apply group restrictions: elements with a 'groups' attribute should
+        be removed from the view to people who are not members.
+
+        Compute and set on node access rights based on view type. Specific
+        views can add additional specific rights like creating columns for
+        many2one-based grouping views.
+        """
+        models = {
+            model: {
+                fname: field
+                for fname, field in fields.items()
+                if not field.get('groups') or self.user_has_groups(field['groups'])
+            }
+            for model, fields in models.items()
+        }
+
+        for node in tree.xpath('//*[@groups]'):
+            if not self.user_has_groups(node.attrib.pop('groups')):
+                node.getparent().remove(node)
+            elif node.tag == 't' and not node.attrib:
+                # Move content of <t> blocks with no other instructions than just "groups=" to the parent
+                # and remove the <t> node.
+                # This is to keep the structure
+                # <group>
+                #   <field name="foo"/>
+                #   <field name="bar"/>
+                # <group>
+                # so the web client adds the label as expected.
+                for child in reversed(node):
+                    node.addnext(child)
+                node.getparent().remove(node)
+
+        base_model = tree.get('model_access_rights')
+        for node in tree.xpath('//*[@model_access_rights]'):
+            model = self.env[node.attrib.pop('model_access_rights')]
+            if node.tag == 'field':
+                can_create = model.check_access_rights('create', raise_exception=False)
+                can_write = model.check_access_rights('write', raise_exception=False)
+                node.set('can_create', 'true' if can_create else 'false')
+                node.set('can_write', 'true' if can_write else 'false')
+            else:
+                is_base_model = base_model == model._name
+                for action, operation in (('create', 'create'), ('delete', 'unlink'), ('edit', 'write')):
+                    if (not node.get(action) and
+                            not model.check_access_rights(operation, raise_exception=False) or
+                            not self._context.get(action, True) and is_base_model):
+                        node.set(action, 'false')
+                if node.tag == 'kanban':
+                    group_by_name = node.get('default_group_by')
+                    group_by_field = model._fields.get(group_by_name)
+                    if group_by_field and group_by_field.type == 'many2one':
+                        group_by_model = model.env[group_by_field.comodel_name]
+                        for action, operation in (('group_create', 'create'), ('group_delete', 'unlink'), ('group_edit', 'write')):
+                            if (not node.get(action) and
+                                    not group_by_model.check_access_rights(operation, raise_exception=False) or
+                                    not self._context.get(action, True) and is_base_model):
+                                node.set(action, 'false')
+
+        return tree, models
+
     def _postprocess_view(self, node, model_name, editable=True, parent_name_manager=None, **options):
         """ Process the given architecture, modifying it in-place to add and
         remove stuff.
@@ -1074,7 +1115,6 @@ actual arch.
                     # the node has been removed, stop processing here
                     continue
 
-            self._apply_groups(node, name_manager, node_info)
             transfer_node_to_modifiers(node, node_info['modifiers'], self._context)
             transfer_modifiers_to_node(node_info['modifiers'], node)
 
@@ -1083,7 +1123,7 @@ actual arch.
                 stack.append((child, node_info['editable']))
 
         name_manager.update_available_fields()
-        self._postprocess_access_rights(root, model.sudo(False))
+        root.set('model_access_rights', model._name)
 
         return name_manager
 
@@ -1115,30 +1155,6 @@ actual arch.
                     if not node.get('on_change'):
                         node.set('on_change', '1')
 
-    def _postprocess_access_rights(self, node, model):
-        """ Compute and set on node access rights based on view type. Specific
-        views can add additional specific rights like creating columns for
-        many2one-based grouping views. """
-        # testing ACL as real user
-        is_base_model = self.env.context.get('base_model_name', model._name) == model._name
-
-        if node.tag in ('kanban', 'tree', 'form', 'activity', 'calendar'):
-            for action, operation in (('create', 'create'), ('delete', 'unlink'), ('edit', 'write')):
-                if (not node.get(action) and
-                        not model.check_access_rights(operation, raise_exception=False) or
-                        not self._context.get(action, True) and is_base_model):
-                    node.set(action, 'false')
-
-        if node.tag == 'kanban':
-            group_by_name = node.get('default_group_by')
-            group_by_field = model._fields.get(group_by_name)
-            if group_by_field and group_by_field.type == 'many2one':
-                group_by_model = model.env[group_by_field.comodel_name]
-                for action, operation in (('group_create', 'create'), ('group_delete', 'unlink'), ('group_edit', 'write')):
-                    if (not node.get(action) and
-                            not group_by_model.check_access_rights(operation, raise_exception=False) or
-                            not self._context.get(action, True) and is_base_model):
-                        node.set(action, 'false')
 
     #------------------------------------------------------
     # Specific node postprocessors
@@ -1156,11 +1172,22 @@ actual arch.
             attrs = {'id': node.get('id'), 'select': node.get('select')}
             field = name_manager.model._fields.get(node.get('name'))
             if field:
-                # apply groups (no tested)
-                if field.groups and not self.user_has_groups(groups=field.groups):
-                    node.getparent().remove(node)
-                    # no point processing view-level ``groups`` anymore, return
-                    return
+                if field.groups:
+                    if node.get('groups'):
+                        # if the node has a group (e.g. "base.group_no_one")
+                        # and the field in the Python model has a group as well (e.g. "base.group_system")
+                        # the user must have both group to see the field.
+                        # groups="base.group_no_one,base.group_system" directly on the node
+                        # would be one of the two groups, not both (OR instead of AND).
+                        # To make mandatory to have both groups, wrap the field node in a <t> node with the group
+                        # set on the field in the Python model
+                        # e.g. <t groups="base.group_system"><field name="foo" groups="base.group_no_one"/></t>
+                        # The <t> node will be removed later, in _postprocess_access_rights.
+                        node_t = E.t(groups=field.groups)
+                        node.getparent().replace(node, node_t)
+                        node_t.append(node)
+                    else:
+                        node.set('groups', field.groups)
                 if (
                     node_info.get('view_type') == 'form'
                     and field.type in ('one2many', 'many2many')
@@ -1192,17 +1219,11 @@ actual arch.
                 for child in node:
                     if child.tag in ('form', 'tree', 'graph', 'kanban', 'calendar'):
                         node_info['children'] = []
-                        self.with_context(
-                            base_model_name=name_manager.model._name,
-                        )._postprocess_view(
+                        self._postprocess_view(
                             child, field.comodel_name, editable=node_info['editable'], parent_name_manager=name_manager,
                         )
                 if field.type in ('many2one', 'many2many'):
-                    comodel = self.env[field.comodel_name].sudo(False)
-                    can_create = comodel.check_access_rights('create', raise_exception=False)
-                    can_write = comodel.check_access_rights('write', raise_exception=False)
-                    node.set('can_create', 'true' if can_create else 'false')
-                    node.set('can_write', 'true' if can_write else 'false')
+                    node.set('model_access_rights', field.comodel_name)
 
             name_manager.has_field(node, node.get('name'), attrs)
 
@@ -1223,23 +1244,25 @@ actual arch.
         if not field or not field.comodel_name:
             return
         # post-process the node as a nested view, and associate it to the field
-        self.with_context(
-            base_model_name=name_manager.model._name,
-        )._postprocess_view(node, field.comodel_name, editable=False, parent_name_manager=name_manager)
+        self._postprocess_view(node, field.comodel_name, editable=False, parent_name_manager=name_manager)
         name_manager.has_field(node, name)
 
     def _postprocess_tag_label(self, node, name_manager, node_info):
         if node.get('for'):
             field = name_manager.model._fields.get(node.get('for'))
-            if field and field.groups and not self.user_has_groups(groups=field.groups):
-                node.getparent().remove(node)
+            if field and field.groups:
+                if node.get('groups'):
+                    # See the comment for this in `_postprocess_tag_field`
+                    node_t = E.t(groups=field.groups)
+                    node.getparent().replace(node, node_t)
+                    node_t.append(node)
+                else:
+                    node.set('groups', field.groups)
 
     def _postprocess_tag_search(self, node, name_manager, node_info):
         searchpanel = [child for child in node if child.tag == 'searchpanel']
         if searchpanel:
-            self.with_context(
-                base_model_name=name_manager.model._name,
-            )._postprocess_view(
+            self._postprocess_view(
                 searchpanel[0], name_manager.model._name, editable=False, parent_name_manager=name_manager
             )
             node_info['children'] = [child for child in node if child.tag != 'searchpanel']

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -115,6 +115,10 @@ class Country(models.Model):
         if ('code' in vals or 'phone_code' in vals):
             # Intentionally simplified by not clearing the cache in create and unlink.
             self.clear_caches()
+        if 'address_view_id' in vals:
+            # Changing the address view of the company must invalidate the view cached for res.partner
+            # because of _view_get_address
+            self.env['res.partner'].clear_caches()
         return res
 
     def get_address_fields(self):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -384,6 +384,15 @@ class Partner(models.Model):
             arch = self._view_get_address(arch)
         return arch, view
 
+    @api.model
+    def _get_view_cache_key(self, view_id=None, view_type='form', **options):
+        """The override of _get_view, using _view_get_address,
+        changing the architecture according to the address view of the company,
+        makes the view cache dependent on the company.
+        Different companies could use each a different address view"""
+        key = super()._get_view_cache_key(view_id, view_type, **options)
+        return key + (self.env.company,)
+
     @api.constrains('parent_id')
     def _check_parent_id(self):
         if not self._check_recursion():

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -215,6 +215,26 @@ class Groups(models.Model):
             self.env['ir.model.access'].call_cache_clearing_methods()
         return super(Groups, self).write(vals)
 
+    def _ensure_xml_id(self):
+        """Return the groups external identifiers, creating the external identifier for groups missing one"""
+        result = self.get_external_id()
+        missings = {group_id: f'__custom__.group_{group_id}' for group_id, ext_id in result.items() if not ext_id}
+        if missings:
+            self.env['ir.model.data'].create(
+                [
+                    {
+                        'name': name.split('.')[1],
+                        'model': 'res.groups',
+                        'res_id': group_id,
+                        'module': name.split('.')[0],
+                    }
+                    for group_id, name in missings.items()
+                ]
+            )
+            result.update(missings)
+
+        return result
+
 
 class ResUsersLog(models.Model):
     _name = 'res.users.log'

--- a/odoo/addons/test_action_bindings/tests/test_bindings.py
+++ b/odoo/addons/test_action_bindings/tests/test_bindings.py
@@ -9,8 +9,8 @@ class TestActionBindings(common.TransactionCase):
         # first make sure there is no bound action
         self.env.ref('base.action_partner_merge').unlink()
         bindings = Actions.get_bindings('res.partner')
-        self.assertFalse(bindings['action'])
-        self.assertFalse(bindings['report'])
+        self.assertFalse(bindings.get('action'))
+        self.assertFalse(bindings.get('report'))
 
         # create action bindings, and check the returned bindings
         action1 = self.env.ref('base.action_attachment')
@@ -53,19 +53,19 @@ class TestBindingViewFilters(common.TransactionCase):
     def test_act_window(self):
         A = self.env['tab.a']
 
-        form_act = A.get_view(toolbar=True)['toolbar']['action']
+        form_act = A.get_views([(False, 'form')], {'toolbar': True})['views']['form']['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in form_act],
             ['Action 1', 'Action 2', 'Action 3'],
             "forms should have all actions")
 
-        list_act = A.get_view(view_type='tree', toolbar=True)['toolbar']['action']
+        list_act = A.get_views([(False, 'list')], {'toolbar': True})['views']['list']['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in list_act],
             ['Action 1', 'Action 3'],
             "lists should not have the form-only action")
 
-        kanban_act = A.get_view(view_type='kanban', toolbar=True)['toolbar']['action']
+        kanban_act = A.get_views([(False, 'kanban')], {'toolbar': True})['views']['kanban']['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in kanban_act],
             ['Action 1'],
@@ -74,19 +74,19 @@ class TestBindingViewFilters(common.TransactionCase):
     def test_act_record(self):
         B = self.env['tab.b']
 
-        form_act = B.get_view(toolbar=True)['toolbar']['action']
+        form_act = B.get_views([(False, 'form')], {'toolbar': True})['views']['form']['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in form_act],
             ['Record 1', 'Record 2', 'Record 3'],
             "forms should have all actions")
 
-        list_act = B.get_view(view_type='tree', toolbar=True)['toolbar']['action']
+        list_act = B.get_views([(False, 'list')], {'toolbar': True})['views']['list']['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in list_act],
             ['Record 1', 'Record 3'],
             "lists should not have the form-only action")
 
-        kanban_act = B.get_view(view_type='kanban', toolbar=True)['toolbar']['action']
+        kanban_act = B.get_views([(False, 'kanban')], {'toolbar': True})['views']['kanban']['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in kanban_act],
             ['Record 1'],

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1660,6 +1660,11 @@ class BaseModel(metaclass=MetaModel):
                         if view_type in result['views']:
                             result['views'][view_type]['toolbar'].setdefault(key, []).append(action)
 
+        if options.get('load_filters') and 'search' in result['views']:
+            result['views']['search']['filters'] = self.env['ir.filters'].get_filters(
+                self._name, options.get('action_id')
+            )
+
         return result
 
     @api.model
@@ -1671,7 +1676,6 @@ class BaseModel(metaclass=MetaModel):
         :param int view_id: id of the view or None
         :param str view_type: type of the view to return if view_id is None ('form', 'tree', ...)
         :param dict options: bool options to return additional features:
-            - bool load_filters: returns the model's filters (for search views)
             - bool mobile: true if the web client is currently using the responsive mobile view
               (to use kanban views instead of list views for x2many fields)
         :return: architecture of the view as an etree node, and the browse record of the view used
@@ -1784,10 +1788,8 @@ class BaseModel(metaclass=MetaModel):
         :param int view_id: id of the view or None
         :param str view_type: type of the view to return if view_id is None ('form', 'tree', ...)
         :param dict options: boolean options to return additional features:
-
-            - load_filters: returns the model's filters (for search views)
-            - mobile: true if the web client is currently using the responsive mobile view
-              (to use kanban views instead of list views for x2many fields)
+            - bool mobile: true if the web client is currently using the responsive mobile view
+            (to use kanban views instead of list views for x2many fields)
         :return: composition of the requested view (including inherited views and extensions)
         :rtype: dict
         :raise AttributeError:
@@ -1804,9 +1806,6 @@ class BaseModel(metaclass=MetaModel):
         node = etree.fromstring(result['arch'])
         node, result['models'] = self.env['ir.ui.view']._postprocess_access_rights(node, result['models'])
         result['arch'] = etree.tostring(node, encoding="unicode").replace('\t', '')
-
-        if options.get('load_filters') and view_type == 'search':
-            result['filters'] = self.env['ir.filters'].get_filters(self._name, options.get('action_id'))
 
         return result
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1635,9 +1635,12 @@ class BaseModel(metaclass=MetaModel):
             )
             for [v_id, v_type] in views
         }
-        models = set(model for info in result['views'].values() for model in info.pop('models'))
 
-        result['models'] = {model: self.env[model].fields_get() for model in models}
+        result['models'] = {
+            model: fields
+            for info in result['views'].values()
+            for model, fields in info.pop('models').items()
+        }
 
         # Add related action information if asked
         if options.get('toolbar'):
@@ -1716,6 +1719,63 @@ class BaseModel(metaclass=MetaModel):
         return arch, view
 
     @api.model
+    def _get_view_cache_key(self, view_id=None, view_type='form', **options):
+        """ Get the key to use for caching `_get_view_cache`.
+
+        This method is meant to be overriden by models needing additional keys.
+
+        :param int view_id: id of the view or None
+        :param str view_type: type of the view to return if view_id is None ('form', 'tree', ...)
+        :param dict options: bool options to return additional features:
+            - bool mobile: true if the web client is currently using the responsive mobile view
+              (to use kanban views instead of list views for x2many fields)
+        :return: a cache key
+        :rtype: tuple
+        """
+        return (view_id, view_type, options.get('mobile'), self.env.lang) + tuple(
+            (key, value) for key, value in self.env.context.items() if key.endswith('_view_ref')
+        )
+
+    @api.model
+    @ormcache('self._get_view_cache_key(view_id, view_type, **options)')
+    def _get_view_cache(self, view_id=None, view_type='form', **options):
+        """ Get the view information ready to be cached
+
+        The cached view includes the postprocessed view, including inherited views, for all groups.
+        The blocks restricted to groups must therefore be removed after calling this method
+        for users not part of the given groups.
+
+        :param int view_id: id of the view or None
+        :param str view_type: type of the view to return if view_id is None ('form', 'tree', ...)
+        :param dict options: boolean options to return additional features:
+            - bool mobile: true if the web client is currently using the responsive mobile view
+              (to use kanban views instead of list views for x2many fields)
+        :return: a dictionnary including
+            - string arch: the architecture of the view (including inherited views, postprocessed, for all groups)
+            - int id: the view id
+            - string model: the view model
+            - dict models: the fields of the models used in the view (including sub-views)
+        :rtype: dict
+        """
+        # Get the view arch and all other attributes describing the composition of the view
+        arch, view = self._get_view(view_id, view_type, **options)
+
+        # Apply post processing, groups and modifiers etc...
+        arch, models = view.postprocess_and_fields(arch, model=self._name, **options)
+        result = {
+            'arch': arch,
+            # TODO: only `web_studio` seems to require this. I guess this is acceptable to keep it.
+            'id': view.id,
+            # TODO: only `web_studio` seems to require this. But this one on the other hand should be eliminated:
+            # you just called `get_views` for that model, so obviously the web client already knows the model.
+            'model': self._name,
+            # sudo is important to get all fields, including fields restricted to groups, in the cache.
+            'models': {model: frozendict(self.env[model].sudo().fields_get()) for model in models},
+        }
+
+        return frozendict(result)
+
+    @api.model
     def get_view(self, view_id=None, view_type='form', **options):
         """ get_view([view_id | view_type='form'])
 
@@ -1739,24 +1799,11 @@ class BaseModel(metaclass=MetaModel):
         """
         self.check_access_rights('read')
 
-        # Get the view arch and all other attributes describing the composition of the view
-        arch, view = self._get_view(view_id, view_type, **options)
+        result = dict(self._get_view_cache(view_id, view_type, **options))
 
-        # Override context for postprocessing
-        if view and (view.model or self._name) != self._name:
-            view = view.with_context(base_model_name=view.model)
-
-        # Apply post processing, groups and modifiers etc...
-        arch, models = view.postprocess_and_fields(arch, model=self._name, **options)
-        result = {
-            'arch': arch,
-            # TODO: only `web_studio` seems to require this. I guess this is acceptable to keep it.
-            'id': view.id,
-            # TODO: only `web_studio` seems to require this. But this one on the other hand should be eliminated:
-            # you just called `get_views` for that model, so obviously the web client already knows the model.
-            'model': self._name,
-            'models': models,
-        }
+        node = etree.fromstring(result['arch'])
+        node, result['models'] = self.env['ir.ui.view']._postprocess_access_rights(node, result['models'])
+        result['arch'] = etree.tostring(node, encoding="unicode").replace('\t', '')
 
         if options.get('load_filters') and view_type == 'search':
             result['filters'] = self.env['ir.filters'].get_filters(self._name, options.get('action_id'))


### PR DESCRIPTION
The master plan finally comes to an end.

Thanks to:
- odoo/odoo#87522 refactoring `load_views`,
- odoo/odoo#94337 refactoring `common.Form` to prevent changing
    invisible fields in unit tests using `Form` instances,
- odoo/odoo#95729 refactoring the behavior of `groups=` in views,
- odoo/odoo#98551 removing the need of the `groups_id` many2many field
    on back-end views.

The result returned by `get_view`/`get_views` can now finally be easily
and efficiently cached, in order to cache back-end views.

The goal of this revision is to cache the model views and fields
already post-processed for the web client
(with the modifiers, etc., already computed)
without group restriction.
Then, from this cached version, post-process group related features,
such as removing nodes restricted with a `groups=` attribute,
set the create/write button according to the user access rights to models, ...

Not including the groups in the cache key allows:
- to have less cached versions,
  (otherwise it would be one cached version per different group combination)
- to not have to fetch the user groups to compute the key
  (with the current cache key,
  there is nothing to fetch from the database to compute the key)

Besides, post-processing the groups features
after taking the view from the cache of the view doesn't take a tremendous time:
 - parsing arch from/to string with etree is fast,
 - removing the `groups=` nodes using etree is fast,
 - adding the `create="False"`, `write="False"`, `delete="False"` on the view
   root node according to the access right of the user on the model is fast.

This allows way faster calls to `get_views` by the web client,
as the server no longer need, for each call, to fetch the views in database,
combine the inherited views, post-process the modifiers attributes, etc.

Enterprise PR: odoo/enterprise#30974

From easiest case to worst case:

### res.company (small view)

#### only base installed, with list and form, no toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 8.96 s, sys: 415 ms, total: 9.37 s
Wall time: 12.8 s
```
After
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 443 ms, sys: 0 ns, total: 443 ms
Wall time: 474 ms
```

#### only base installed, with list and form, with toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 9.1 s, sys: 462 ms, total: 9.56 s
Wall time: 13.5 s
```
After
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 480 ms, sys: 117 µs, total: 480 ms
Wall time: 480 ms
```

#### only base installed, with list, form and search, with toolbar, with filters

Before
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 10.8 s, sys: 686 ms, total: 11.5 s
Wall time: 16.3 s
```
After
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 1.4 s, sys: 83.9 ms, total: 1.49 s
Wall time: 2.02 s
```

#### all modules installed, with list and form, no toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 26.2 s, sys: 930 ms, total: 27.2 s
Wall time: 33.8 s
```
After
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 1.49 s, sys: 38.1 ms, total: 1.53 s
Wall time: 1.58 s
```

#### all modules installed, with list and form, with toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 25.5 s, sys: 1.13 s, total: 26.7 s
Wall time: 34.4 s
```
After
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 1.55 s, sys: 30.9 ms, total: 1.58 s
Wall time: 1.64 s
```

#### all modules installed, with list, form and search, with toolbar with filters

Before
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 29.6 s, sys: 1.29 s, total: 30.9 s
Wall time: 39.5 s
```
After
```py
%time for i in range(1000): self.env['res.company'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 2.65 s, sys: 48.8 ms, total: 2.69 s
Wall time: 3.22 s
```

### res.partner (big view, with get_view override)

#### only base installed, with list and form, no toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 24.9 s, sys: 787 ms, total: 25.7 s
Wall time: 31.3 s
```
After
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 1.48 s, sys: 973 µs, total: 1.48 s
Wall time: 1.5 s
```

#### only base installed, with list and form, with toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 25.8 s, sys: 729 ms, total: 26.5 s
Wall time: 32.2 s
```
After
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 1.5 s, sys: 0 ns, total: 1.5 s
Wall time: 1.5 s
```

#### only base installed, with list, form and search, with toolbar, with filters

Before
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 30.2 s, sys: 1.13 s, total: 31.4 s
Wall time: 40.1 s
```
After
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 2.8 s, sys: 61.2 ms, total: 2.86 s
Wall time: 3.53 s
```

#### all modules installed, with list and form, no toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 1min 10s, sys: 1.15 s, total: 1min 11s
Wall time: 1min 21s
```
After
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')]); self.env.invalidate_all();
CPU times: user 5.51 s, sys: 953 µs, total: 5.51 s
Wall time: 5.57 s
```

#### all modules installed, with list and form, with toolbar, no filter

Before
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 1min 12s, sys: 995 ms, total: 1min 13s
Wall time: 1min 24s
```
After
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form')], options={'toolbar': True}); self.env.invalidate_all();
CPU times: user 5.1 s, sys: 540 µs, total: 5.1 s
Wall time: 5.17 s
```

### all modules installed, with list, form and search, with toolbar, with filters

Before
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 1min 22s, sys: 1.8 s, total: 1min 23s
Wall time: 1min 38s
```
After
```py
%time for i in range(1000): self.env['res.partner'].get_views([(False, 'list'), (False, 'form'), (False, 'search')], options={'toolbar': True, 'load_filters': True}); self.env.invalidate_all();
CPU times: user 5.6 s, sys: 99 ms, total: 5.7 s
Wall time: 6.36 s
```
