### PR TITLE
 [IMP] mail: add support for inline definition of sort and compute

### DIFF
--- a/addons/im_livechat/static/src/models/channel.js
+++ b/addons/im_livechat/static/src/models/channel.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { addFields, patchRecordMethods } from '@mail/model/model_core';
+import { addFields, patchFields, patchRecordMethods } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
 import '@mail/models/channel'; // ensure that the model definition is loaded before the patch
 
@@ -9,16 +9,18 @@ addFields('Channel', {
     anonymous_name: attr(),
 });
 
-patchRecordMethods('Channel', {
-    /**
-     * @override
-     */
-    _computeDiscussSidebarCategory() {
-        if (this.channel_type === 'livechat') {
-            return this.messaging.discuss.categoryLivechat;
-        }
-        return this._super();
+patchFields('Channel', {
+    discussSidebarCategory: {
+        compute() {
+            if (this.channel_type === 'livechat') {
+                return this.messaging.discuss.categoryLivechat;
+            }
+            return this._super();
+        },
     },
+});
+
+patchRecordMethods('Channel', {
     /**
      * @override
      */

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -151,10 +151,26 @@ export class ModelField {
             }
         }
         /**
-         * Automatically make computes and relateds readonly.
+         * Automatically make relateds readonly.
          */
-        if (this.compute || this.related) {
+        if (this.related) {
             this.readonly = true;
+        }
+        if (this.compute) {
+            // Automatically make computes readonly.
+            this.readonly = true;
+            // If the compute function is not inlined, retrieve it from model
+            // methods.
+            if (typeof this.compute === 'string') {
+                this.compute = this.model.prototype[this.compute];
+            }
+        }
+        if (this.sort) {
+            // If the sort function is not inlined, retrieve it from model
+            // methods.
+            if (typeof this.sort === 'string') {
+                this.sort = this.model.prototype[this.sort];
+            }
         }
     }
 

--- a/addons/mail/static/src/model/model_field_relation_set.js
+++ b/addons/mail/static/src/model/model_field_relation_set.js
@@ -56,7 +56,7 @@ export class RelationSet {
                 onChange: info => {
                     // access all useful values of current record (and relations) to mark them as dependencies
                     this.record.modelManager.startListening(listener);
-                    const compareDefinition = this.record[this.field.sort]();
+                    const compareDefinition = this.field.sort.call(this.record);
                     const relatedPathSet = new Set(compareDefinition.map(operation => operation[1])); // only keep unique paths to avoid unnecessary listeners
                     for (const relatedPath of relatedPathSet) {
                         followRelations(value, relatedPath);

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -483,11 +483,12 @@ export class ModelManager {
                 }
                 // 4. Computed field.
                 if (field.compute) {
-                    if (!(typeof field.compute === 'string')) {
-                        throw new Error(`Property "compute" of field(${fieldName}) on ${model} must be a string (instance method name).`);
-                    }
-                    if (!model.prototype[field.compute]) {
-                        throw new Error(`Property "compute" of field(${fieldName}) on ${model} does not refer to an instance method of this model.`);
+                    if (typeof field.compute === 'string') {
+                        if (!model.prototype[field.compute]) {
+                            throw new Error(`Property "compute" of field(${fieldName}) on ${model} does not refer to an instance method of this model.`);
+                        }
+                    } else if (typeof field.compute !== 'function') {
+                        throw new Error(`Property "compute" of field(${fieldName}) on ${model} must be a string (instance method name) or a function (the actual compute).`);
                     }
                     if ('readonly' in field) {
                         throw new Error(`Computed field(${fieldName}) on ${model} has unnecessary "readonly" attribute (readonly is implicit for computed fields).`);
@@ -794,7 +795,7 @@ export class ModelManager {
                         name: `compute ${field} of ${record}`,
                         onChange: (info) => {
                             this.startListening(listener);
-                            const res = record[field.compute]();
+                            const res = field.compute.call(record);
                             this.stopListening(listener);
                             this._update(record, { [field.fieldName]: res }, { allowWriteReadonly: true });
                         },

--- a/addons/mail/static/src/models/activity_menu_view.js
+++ b/addons/mail/static/src/models/activity_menu_view.js
@@ -79,19 +79,12 @@ registerModel({
         _computeCounter() {
             return this.activityGroups.reduce((total, group) => total + group.total_count, this.extraCount);
         },
-        /**
-         * @private
-         * @returns {Array[]}
-         */
-        _sortActivityGroups() {
-            return [
-                ['smaller-first', 'irModel.id'],
-            ];
-        },
     },
     fields: {
         activityGroups: many('ActivityGroup', {
-            sort: '_sortActivityGroups',
+            sort() {
+                return [['smaller-first', 'irModel.id']];
+            }
         }),
         activityGroupViews: many('ActivityGroupView', {
             compute: '_computeActivityGroupViews',

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -112,21 +112,6 @@ registerModel({
         },
         /**
          * @private
-         * @returns {DiscussSidebarCategory|FieldCommand}
-         */
-        _computeDiscussSidebarCategory() {
-            switch (this.channel_type) {
-                case 'channel':
-                    return this.messaging.discuss.categoryChannel;
-                case 'chat':
-                case 'group':
-                    return this.messaging.discuss.categoryChat;
-                default:
-                    return clear();
-            }
-        },
-        /**
-         * @private
          * @returns {Object|FieldCommand}
          */
         _computeDiscussSidebarCategoryItem() {
@@ -196,16 +181,6 @@ registerModel({
         },
         /**
          * @private
-         * @returns {FieldCommand}
-         */
-        _computeThread() {
-            return {
-                id: this.id,
-                model: 'mail.channel',
-            };
-        },
-        /**
-         * @private
          * @returns {integer}
          */
         _computeUnknownMemberCount() {
@@ -262,7 +237,17 @@ registerModel({
          * Useful to compute `discussSidebarCategoryItem`.
          */
         discussSidebarCategory: one('DiscussSidebarCategory', {
-            compute: '_computeDiscussSidebarCategory',
+            compute() {
+                switch (this.channel_type) {
+                    case 'channel':
+                        return this.messaging.discuss.categoryChannel;
+                    case 'chat':
+                    case 'group':
+                        return this.messaging.discuss.categoryChat;
+                    default:
+                        return clear();
+                }
+            },
         }),
         /**
          * Determines the discuss sidebar category item that displays this
@@ -321,7 +306,12 @@ registerModel({
             default: false,
         }),
         thread: one('Thread', {
-            compute: '_computeThread',
+            compute() {
+                return {
+                    id: this.id,
+                    model: 'mail.channel',
+                };
+            },
             inverse: 'channel',
             isCausal: true,
             required: true,

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -117,15 +117,6 @@ registerModel({
                 active_id: this.discuss.activeId,
             });
         },
-        /**
-         * @private
-         * @returns {Array[]}
-         */
-        _sortMailboxes() {
-            return [
-                ['smaller-first', 'sequence'],
-            ];
-        },
     },
     fields: {
         /**
@@ -154,7 +145,9 @@ registerModel({
         }),
         orderedMailboxes: many('Mailbox', {
             related: 'messaging.allMailboxes',
-            sort: '_sortMailboxes',
+            sort() {
+                return [['smaller-first', 'sequence']];
+            },
         }),
         /**
          * Reference of the quick search input. Useful to filter channels and

--- a/addons/note/static/src/models/activity_menu_view.js
+++ b/addons/note/static/src/models/activity_menu_view.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { addFields, addRecordMethods, patchRecordMethods } from '@mail/model/model_core';
+import { addFields, addRecordMethods, patchFields, patchRecordMethods } from '@mail/model/model_core';
 import { attr } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 import '@mail/models/activity_menu_view'; // ensure the model definition is loaded before the patch
@@ -67,6 +67,17 @@ addRecordMethods('ActivityMenuView', {
     },
 });
 
+patchFields('ActivityMenuView', {
+    activityGroups: {
+        sort() {
+            return [
+                ['truthy-first', 'isNote'],
+                ...this._super(),
+            ];
+        },
+    },
+});
+
 patchRecordMethods('ActivityMenuView', {
     /**
      * @override
@@ -86,14 +97,6 @@ patchRecordMethods('ActivityMenuView', {
             return;
         }
         this._super(ev);
-    },
-    /**
-     * @override
-     */
-    _sortActivityGroups(ev) {
-        const res = this._super();
-        res.unshift(['truthy-first', 'isNote']);
-        return res;
     },
 });
 


### PR DESCRIPTION
This commit allows compute and sort functions to be declared within a
field definition instead of providing a string with the name of the
record method to be used to compute/sort the field value.

Example of code with compute inline:
```javascript
registerModel({
    fields: {
        thread: one('Thread', {
            compute() {
                return {
                    id: this.id,
                    model: 'mail.channel',
                };
            },
        }),
    },
});
```

Example of code WITHOUT:
```javascript
registerModel({
    recordMethods: {
        _computeThread() {
            return {
                id: this.id,
                model: 'mail.channel',
            };
        },
    },
    fields: {
        thread: one('Thread, {
            compute: '_computeThread',
        }),
    },
});
```

The aim of these changes is to empower a better separation of concerns,
by allowing to group together in one place the data related to a field.

Note that for technical reason (`Function.prototype.call` not working as
expected with arrow functions), compute/sort functions should not be
arrow functions.