### PR TITLE
Master im status 404 error fix

### DIFF
--- a/addons/web/static/tests/core/network/rpc_service_tests.js
+++ b/addons/web/static/tests/core/network/rpc_service_tests.js
@@ -252,3 +252,24 @@ QUnit.test("check connection aborted", async (assert) => {
     connection.abort();
     assert.rejects(connection, ConnectionAbortedError);
 });
+
+QUnit.test(
+    "Response with status 404 and invalid JSON response result in a rerror with a readable message",
+    async (assert) => {
+        const env = await makeTestEnv({ serviceRegistry });
+
+        const MockXHR = makeMockXHR({}, () => {});
+        const request = new MockXHR();
+        request.response = "<h...";
+        request.status = "404";
+
+        try {
+            await env.services.rpc("/test/", null, { xhr: request });
+        } catch (_e) {
+            assert.strictEqual(
+                _e.message,
+                "server responded with invalid JSON response (HTTP404): <h..."
+            );
+        }
+    }
+);


### PR DESCRIPTION
[aju] not sure how to reproduce, but I get this traceback when I leave the helpdesk.ticket or project.task kanban views open for a long time: https://pastebin.com/rs91XEsx
--> [DAM] seems related to a bad response in const { error: responseError, result: responseResult } = JSON.parse(request.response); (rpc_service line 67)

nginx responds with an error 404 to the im_status request when the db is no longer available (sleeping) --> the request response
is not JSON parsable as expected by the rpc service...