### PR TITLE
[FIX] web: legacy Many2ManyTags in list view: add/remove records

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -336,6 +336,19 @@ function registerField(name, LegacyFieldWidget) {
 
         update(fieldName, value) {
             if (fieldName === this.props.name) {
+                const record = this.props.record;
+                const fieldType = record.fields[fieldName].type;
+                if (["one2many", "many2many"].includes(fieldType) && !record.model.__bm__) {
+                    const staticList = this.props.value;
+                    switch (value.operation) {
+                        case "REPLACE_WITH": {
+                            return staticList.replaceWith(value.resIds);
+                        }
+                        case "FORGET": {
+                            return staticList.delete(value.ids);
+                        }
+                    }
+                }
                 return this.props.update(value);
             } else {
                 return this.props.record.update({ [fieldName]: value });


### PR DESCRIPTION
Have a list view (new RelationalModel inside a WOWL list view) that has
a legacy many2many tags field in its arch.

Try to add or remove some records from that many2many.

Before this commit, there was a crash, because the legacy field wrapper
doesn't use the model the right way for that case.

After this commit, there is no crash.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
