### PR TITLE
[FIX] mrp: remove onchange in import hack

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -820,13 +820,7 @@ class MrpProduction(models.Model):
             if not vals.get('procurement_group_id'):
                 procurement_group_vals = self._prepare_procurement_group_vals(vals)
                 vals['procurement_group_id'] = self.env["procurement.group"].create(procurement_group_vals).id
-        productions = super().create(vals_list)
-        for production in productions:
-            # Trigger move_raw creation when importing a file
-            if 'import_file' in self.env.context:
-                production._onchange_move_raw()
-                production._onchange_move_finished()
-        return productions
+        return super().create(vals_list)
 
     def unlink(self):
         self.action_cancel()


### PR DESCRIPTION
Since d7716f071d5da, the onchanges to create the stock moves in mrp
production have been replaced by computes.
There was a hack in the create() method to trigger the onchanges in case
of import. As those onchanges do not exist anymore, this hack needs to
be remove too.
The compute methods are called naturally in imports.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
