### PR TITLE
[FIX] web: kanban: fix kanban card drag&drop highlight

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -19,6 +19,9 @@
     --KanbanRecord__image--fill-width: #{$o-kanban-image-fill-width};
 
     --KanbanRecord__dropdown-gap: #{$border-width};
+
+    --KanbanColumn__highlight-background: #{rgba($o-info, .05)};
+    --KanbanColumn__highlight-border: #{$o-info};
     // ----------------------------------------------------------------------------
 
     .dropdown,
@@ -485,8 +488,8 @@
             }
         }
         &.o_kanban_hover {
-            background-color: #00a09d0d;
-            box-shadow: -1px 0px 0px 0px #00a09d inset, 1px 0px 0px 0px #00a09d inset;
+            background-color: var(--KanbanColumn__highlight-background);
+            box-shadow: -1px 0px 0px 0px var(--KanbanColumn__highlight-border) inset, 1px 0px 0px 0px var(--KanbanColumn__highlight-border) inset;
         }
     }
 

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -63,8 +63,14 @@ export class KanbanRenderer extends Component {
                     }
                     element.classList.add("o_dragged", "shadow");
                 },
-                onGroupEnter: (group) => group.classList.add("o_kanban_hover"),
-                onGroupLeave: (group) => group.classList.remove("o_kanban_hover"),
+                onGroupEnter: (group) => {
+                    group.classList.add("o_kanban_hover");
+                    group.classList.remove("bg-100");
+                },
+                onGroupLeave: (group) => {
+                    group.classList.remove("o_kanban_hover");
+                    group.classList.add("bg-100");
+                },
                 onStop: (group, element) => {
                     group && group.classList && group.classList.remove("o_kanban_hover");
                     element.classList.remove("o_dragged", "shadow");


### PR DESCRIPTION
Since odoo/odoo@209a97c, the drag&drop of a kanban card in a columnn
is highlighted.

This feature was tested visually on a build that was not up to date
 with master.
Resulting in a visual conflict with a recent changes [classes.push("bg-100");](https://github.com/odoo/odoo/commit/7cfe50749f89a2e2fdd5bfdcc943210f891e38c9#diff-4de8437424d1b687477e865e387b017fc5a6a86e9c50c9ea198da79d3a7a1a4cR266)
which overrides the highlight background-color.

This commit resolves this conflict to have the drag&drop highlight
 background.


Before this fix:
![image](https://user-images.githubusercontent.com/109217759/187980179-9e16a943-e1bb-44c3-85ce-a2d9c0e77f6b.png)
Now:
![image](https://user-images.githubusercontent.com/109217759/187980074-b9f527d3-d8f6-4f41-b963-9bc5144ddeae.png)
