### PR TITLE
[FIX] mail: prevents traceback when downloading rtc call logs

### DIFF
--- a/addons/mail/static/src/models/call_option_menu.js
+++ b/addons/mail/static/src/models/call_option_menu.js
@@ -12,7 +12,7 @@ registerModel({
          * @param {MouseEvent} ev
          */
         async onClickDownloadLogs(ev) {
-            const channel = this.callActionListView.channel;
+            const channel = this.callActionListView.thread;
             if (!channel.rtc) {
                 return;
             }


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/96954 ,
the `CallActionListView` had its `channel` field renamed into `thread`.

A reference to this old field name was missed which caused the
traceback, this commit fixes this issue by using the right field name.

