### PR TITLE
[FIX] mail: fix indeterministic chat window manager test

### DIFF
--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -250,7 +250,17 @@ async function start(param0 = {}) {
     param0.serverData = param0.serverData || getActionManagerServerData();
     param0.serverData.models = { ...pyEnv.getData(), ...param0.serverData.models };
     param0.serverData.views = { ...pyEnv.getViews(), ...param0.serverData.views };
-    const webClient = await getWebClientReady({ ...param0, messagingBus, testSetupDoneDeferred });
+    let webClient;
+    await afterNextRender(async () => {
+        webClient = await getWebClientReady({ ...param0, messagingBus, testSetupDoneDeferred });
+        if (waitUntilMessagingCondition === 'created') {
+            await webClient.env.services.messaging.modelManager.messagingCreatedPromise;
+        }
+        if (waitUntilMessagingCondition === 'initialized') {
+            await webClient.env.services.messaging.modelManager.messagingCreatedPromise;
+            await webClient.env.services.messaging.modelManager.messagingInitializedPromise;
+        }
+    });
 
     registerCleanup(async () => {
         await webClient.env.services.messaging.modelManager.messagingInitializedPromise;
@@ -260,13 +270,6 @@ async function start(param0 = {}) {
         delete owl.Component.env[wowlServicesSymbol].messaging;
         delete owl.Component.env;
     });
-    if (waitUntilMessagingCondition === 'created') {
-        await webClient.env.services.messaging.modelManager.messagingCreatedPromise;
-    }
-    if (waitUntilMessagingCondition === 'initialized') {
-        await webClient.env.services.messaging.modelManager.messagingCreatedPromise;
-        await webClient.env.services.messaging.modelManager.messagingInitializedPromise;
-    }
     const openView = async (action, options) => {
         action['type'] = action['type'] || 'ir.actions.act_window';
         await afterNextRender(() => doAction(webClient, action, { props: options }));


### PR DESCRIPTION
Before this PR, some mail tests relying on DOM elements being present
but that are added after the messaging initialization could fail
unpredictability. This commit fixes this issue by waiting the next
render following the initialization of messaging.
