### PR TITLE
[FIX] stock_account: correct return value for avco real_time valuation

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -34,10 +34,10 @@ class StockMove(models.Model):
         keys_sorted += [move.purchase_line_id.id, move.created_purchase_line_id.id]
         return keys_sorted
 
-    def _get_price_unit(self):
+    def _get_price_unit(self, return_price=False):
         """ Returns the unit price for the move"""
         self.ensure_one()
-        if self.purchase_line_id and self.product_id.id == self.purchase_line_id.product_id.id:
+        if self.purchase_line_id and self.product_id.id == self.purchase_line_id.product_id.id and not self.origin_returned_move_id:
             price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
             line = self.purchase_line_id
             order = line.order_id
@@ -56,7 +56,7 @@ class StockMove(models.Model):
                 price_unit = order.currency_id._convert(
                     price_unit, order.company_id.currency_id, order.company_id, fields.Date.context_today(self), round=False)
             return price_unit
-        return super(StockMove, self)._get_price_unit()
+        return super(StockMove, self)._get_price_unit(return_price)
 
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po

--- a/addons/purchase_stock/tests/test_fifo_returns.py
+++ b/addons/purchase_stock/tests/test_fifo_returns.py
@@ -84,6 +84,6 @@ class TestFifoReturns(ValuationReconciliationTestCommon):
         return_picking.move_lines[0].quantity_done = return_picking.move_lines[0].product_uom_qty
         return_picking._action_done()
 
-        #  After the return only 10 of the second purchase order should still be in stock as it applies fifo on the return too
+        #  The return will return the product from the second purchase order as a return always use the value of the move that he is returning
         self.assertEqual(product_fiforet_icecream.qty_available, 10.0, 'Qty available should be 10.0')
-        self.assertEqual(product_fiforet_icecream.value_svl, 800.0, 'Stock value should be 800')
+        self.assertEqual(product_fiforet_icecream.value_svl, 500.0, 'Stock value should be 800')

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -425,8 +425,8 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         return_pick.move_lines[0].move_line_ids[0].qty_done = 10
         return_pick.button_validate()
 
-        # valuation of product1 should be 200 as the first items will be sent out
-        self.assertEqual(self.product1.value_svl, 200)
+        # valuation of product1 should be 100 as a return will always use the value of the move he is returning
+        self.assertEqual(self.product1.value_svl, 100)
 
         # create a credit note for po2
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_refund'))
@@ -440,7 +440,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
 
         # check the anglo saxon entries
         price_diff_entry = self.env['account.move.line'].search([('account_id', '=', self.price_diff_account.id)])
-        self.assertEqual(price_diff_entry.credit, 100)
+        self.assertEqual(price_diff_entry.credit, 0)
 
     def test_anglosaxon_valuation(self):
         self.env.company.anglo_saxon_accounting = True

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -700,7 +700,7 @@ class TestStockValuationFIFO(TestStockValuationCommon):
         move4 = self._make_return(move3, 1)
         move5 = self._make_return(move4, 1)
 
-        self.assertEqual(self.product1.value_svl, 10)
+        self.assertEqual(self.product1.value_svl, 20)
         self.assertEqual(self.product1.quantity_svl, 1)
 
     def test_dropship_1(self):
@@ -1038,3 +1038,28 @@ class TestAngloSaxonAccounting(TestStockValuationCommon):
         self.assertEqual(len(anglo_lines), 2)
         self.assertEqual(abs(anglo_lines[0].balance), 10)
         self.assertEqual(abs(anglo_lines[1].balance), 10)
+
+    def test_avco_and_return(self):
+        """
+        When reversing an invoice that contains some anglo-saxo AML, the new anglo-saxo AML should have the same value
+        """
+        self.product1.categ_id.property_cost_method = 'average'
+        self.product1.categ_id.property_valuation = 'real_time'
+
+        self._make_in_move(self.product1, 2, unit_cost=10)
+        move_to_return = self._make_in_move(self.product1, 2, unit_cost=20)
+
+        return_move = self._make_return(move_to_return, 2)
+        self.assertEqual(return_move.stock_valuation_layer_ids.unit_cost, 20)
+        self.assertEqual(return_move.stock_valuation_layer_ids.value, -40)
+
+    def test_fifo_and_return(self):
+        self.product1.categ_id.property_cost_method = 'fifo'
+        self.product1.categ_id.property_valuation = 'real_time'
+
+        self._make_in_move(self.product1, 2, unit_cost=10)
+        move_to_return = self._make_in_move(self.product1, 2, unit_cost=20)
+
+        return_move = self._make_return(move_to_return, 2)
+        self.assertEqual(return_move.stock_valuation_layer_ids.unit_cost, 20)
+        self.assertEqual(return_move.stock_valuation_layer_ids.value, -40)


### PR DESCRIPTION
Current behavior:
If you use AVCO and Automatic stock valuation in anglo-saxon
accounting. When you make 2 purchase order for the same product with
different unit price and make a return for one of the 2 PO the return
value should be the same as the PO and not the average of the 2 PO.

Steps to reproduce:
- Make sure you are using anglo-saxon accounting
- Create a Product A with product category A that use AVCO and
  automatic valuation.
- Create a PO for product A with a unit price of 10€, validate
  the PO and receipt the product
- Create a PO for product A with a unit price of 20€, validate
  the PO and receipt the product
- Create a return for the second PO, validate it and click on
  the valuation smart button
- The value should be 20€ but it's 15€ (the average)

opw-2961395
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
