### PR TITLE
[FIX] web: Many2One in list: keeps input after record create

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -146,7 +146,15 @@ export class Many2XAutocomplete extends Component {
             fieldString,
             onClose: () => {
                 const autoCompleteInput = autoCompleteContainer.el.querySelector("input");
-                autoCompleteInput.value = "";
+
+                // There are two cases:
+                // 1. Value is the same as the input: it means the autocomplete has re-rendered with the right value
+                //    This is in case we saved the record, triggering all the interface to update.
+                // 2. Value is different from the input: it means the input has a manually entered value and nothing
+                //    happened, that is, we discarded the changes
+                if (this.props.value !== autoCompleteInput.value) {
+                    autoCompleteInput.value = "";
+                }
                 autoCompleteInput.focus();
             },
         });


### PR DESCRIPTION
Have a many2one in an editable list view. Type something in the input and click
on "Create and edit".

Confirm the record creation in the modal.

Before this commit, the input of the field disappears.

After this commit, the input stays.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
