### PR TITLE
[FIX] website_slides: join & submit button when user already joined

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -58,6 +58,7 @@
         */
         init: function (parent, slide_data, channel_data, quiz_data) {
             this._super.apply(this, arguments);
+            this.parent = parent;
             this.slide = _.defaults(slide_data, {
                 id: 0,
                 name: '',
@@ -488,6 +489,7 @@
             this._renderValidationInfo();
             this._applySessionAnswers();
             this._submitQuiz();
+            this.parent.slides.forEach((slide) => slide.isMember = true);
        },
 
         /**


### PR DESCRIPTION
Steps to reproduce:
- Create a course with two successive video with quizz
- Try the course without clicking on the "join course" of the website
- On the first video quizz you can "join and submitt"

Current behavior:
- On the second video quizz you again have the "join and submit"
button and if you try to click on it you have an error message:
"You have already joined this channel"

Expected behavior:
- There is no "join and submit" button on the second video but
rather a button "check you answers"

Explanation:
The first time the join & submit button is clicked the user join
the course in the backend thanks to the rpc call but the frontend
and the other slides don't have this information. To solve the
issue we add on every slides the information so that when they are
changed to they don't act like if the user had not joined the course

opw-2971158
