### PR TITLE
[FIX] web: list selection banner takes the whole width on mobile

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -36,7 +36,11 @@
 
         > .o_cp_action_menus {
             margin-left: auto;
-            padding-right: 10px;
+            padding-right: 0;
+
+            @include media-breakpoint-up(md) {
+                padding-right: 10px;
+            }
 
             .o_hidden_input_file {
                 position: relative;
@@ -62,7 +66,11 @@
                 right: 10px;
             }
             .dropdown-toggle {
-                margin-right: 15px;
+                margin-right: 0;
+
+                @include media-breakpoint-up(md) {
+                    margin-right: 15px;
+                }
             }
         }
     }

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -20,31 +20,29 @@
                     <t t-slot="control-panel-bottom-left-buttons" t-if="display['bottom-left'] and display['bottom-left-buttons']" />
                     <t t-slot="control-panel-bottom-left" t-if="display['bottom-left']"/>
                 </div>
-                <div class="o_cp_bottom_right">
-                    <t t-if="display['bottom-right']">
-                        <t t-slot="control-panel-bottom-right">
-                            <div class="btn-group o_search_options position-static" role="search">
-                                <t t-foreach="searchMenus" t-as="menu" t-key="menu.key">
-                                    <t t-component="menu.Component"/>
-                                </t>
-                            </div>
-                        </t>
-
-                        <div class="o_cp_pager" role="search">
-                            <Pager t-if="pagerProps and pagerProps.total > 0" t-props="pagerProps"/>
+                <div t-if="display['bottom-right']" class="o_cp_bottom_right">
+                    <t t-slot="control-panel-bottom-right">
+                        <div class="btn-group o_search_options position-static" role="search">
+                            <t t-foreach="searchMenus" t-as="menu" t-key="menu.key">
+                                <t t-component="menu.Component"/>
+                            </t>
                         </div>
+                    </t>
 
-                        <t t-if="env.config.viewSwitcherEntries.length > 1">
-                            <nav class="btn-group o_cp_switch_buttons">
-                                <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
-                                    <button class="btn btn-light o_switch_view "
-                                        t-attf-class="o_{{view.type}} {{view.icon}} {{view.active ? 'active' : ''}}"
-                                        t-att-data-tooltip="view.name"
-                                        t-on-click="() => this.onViewClicked(view.type)"
-                                        />
-                                </t>
-                            </nav>
-                        </t>
+                    <div class="o_cp_pager" role="search">
+                        <Pager t-if="pagerProps and pagerProps.total > 0" t-props="pagerProps"/>
+                    </div>
+
+                    <t t-if="env.config.viewSwitcherEntries.length > 1">
+                        <nav class="btn-group o_cp_switch_buttons">
+                            <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
+                                <button class="btn btn-light o_switch_view "
+                                    t-attf-class="o_{{view.type}} {{view.icon}} {{view.active ? 'active' : ''}}"
+                                    t-att-data-tooltip="view.name"
+                                    t-on-click="() => this.onViewClicked(view.type)"
+                                    />
+                            </t>
+                        </nav>
                     </t>
                 </div>
             </div>

--- a/addons/web/static/src/search/layout.js
+++ b/addons/web/static/src/search/layout.js
@@ -15,14 +15,6 @@ export function extractLayoutComponents(params) {
 export class Layout extends Component {
     setup() {
         this.components = extractLayoutComponents(this.env.config);
-        const display = this.props.display;
-        if (display.controlPanel && this.env.inDialog) {
-            display.controlPanel = Object.assign({}, display.controlPanel, {
-                "top-left": false,
-                "bottom-left-buttons": false,
-            });
-        }
-        this.display = display;
     }
     get controlPanelSlots() {
         const slots = { ...this.props.slots };
@@ -30,6 +22,20 @@ export class Layout extends Component {
         delete slots["layout-buttons"];
         delete slots.default;
         return slots;
+    }
+    get display() {
+        const { controlPanel } = this.props.display;
+        if (!controlPanel || !this.env.inDialog) {
+            return this.props.display;
+        }
+        return {
+            ...this.props.display,
+            controlPanel: {
+                ...controlPanel,
+                "top-left": false,
+                "bottom-left-buttons": false,
+            },
+        };
     }
 }
 

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -301,6 +301,20 @@ export class ListController extends Component {
         return list.isGrouped ? list.nbTotalRecords : list.count;
     }
 
+    get display() {
+        if (!this.env.isSmall) {
+            return this.props.display;
+        }
+        const { controlPanel } = this.props.display;
+        return {
+            ...this.props.display,
+            controlPanel: {
+                ...controlPanel,
+                "bottom-right": !this.nbSelected,
+            },
+        };
+    }
+
     async downloadExport(fields, import_compat, format) {
         const resIds = await this.getSelectedResIds();
         const exportedFields = fields.map((field) => ({

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.ListView" owl="1">
         <div t-att-class="className" t-ref="root">
-            <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="props.display">
+            <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
                 <t t-set-slot="layout-buttons">
                     <t t-if="env.isSmall and nbSelected">
                         <t t-call="web.ListView.Selection" />
@@ -71,7 +71,7 @@
     </t>
 
     <t t-name="web.ListView.Selection" owl="1">
-        <div class="o_list_selection_box alert alert-info d-inline-flex align-items-center ps-0 px-lg-2 py-0 mb-0 ms-2" role="alert">
+        <div class="o_list_selection_box alert alert-info d-inline-flex align-items-center ps-0 px-lg-2 py-0 mb-0 ms-0 ms-md-2" role="alert">
             <t t-if="env.isSmall">
                 <button class="btn btn-link py-0 o_discard_selection" t-on-click="discardSelection">
                     <span class="fa-2x">&#215;</span>

--- a/addons/web/static/tests/mobile/mobile_list_view_tests.js
+++ b/addons/web/static/tests/mobile/mobile_list_view_tests.js
@@ -61,11 +61,13 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
 
         assert.containsN(fixture, ".o_data_row", 4);
         assert.containsNone(fixture, ".o_list_selection_box");
+        assert.containsOnce(fixture, ".o_control_panel .o_cp_bottom_right");
 
         // select a record
         await triggerEvents(fixture, ".o_data_row:nth-child(1)", ["touchstart", "touchend"]);
         assert.containsOnce(fixture, ".o_list_selection_box");
         assert.containsNone(fixture, ".o_list_selection_box .o_list_select_domain");
+        assert.containsNone(fixture, ".o_control_panel .o_cp_bottom_right");
         assert.ok(
             fixture.querySelector(".o_list_selection_box").textContent.includes("1 selected")
         );
@@ -92,6 +94,7 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
         // unselect all
         await click(fixture, ".o_discard_selection");
         assert.containsNone(fixture, ".o_list_selection_box");
+        assert.containsOnce(fixture, ".o_control_panel .o_cp_bottom_right");
     });
 
     QUnit.test("selection box is properly displayed (multi pages)", async function (assert) {


### PR DESCRIPTION
On mobile, in list view's selection mode, both the left & right bottom
parts of the ControlPanel are displayed but only the left one
(containing the selection banner and actions menu) should be displayed
(and take the full width).