### PR TITLE
[FIX] web: restore old color of list view title

### DIFF
--- a/addons/web/static/src/legacy/scss/list_view.scss
+++ b/addons/web/static/src/legacy/scss/list_view.scss
@@ -14,7 +14,7 @@
         border-spacing: 0;
 
         thead {
-            color: color-contrast(opaque($body-bg, $light));
+            color: $o-main-headings-color;
             border-bottom: 1px solid #cacaca;
             > tr > th:not(.o_list_record_selector) {
                 border-left: 1px solid #dfdfdf;

--- a/addons/web/static/src/views/list/list_controller.scss
+++ b/addons/web/static/src/views/list/list_controller.scss
@@ -14,7 +14,7 @@
         border-spacing: 0;
 
         thead {
-            color: color-contrast(opaque($body-bg, $light));
+            color: $o-main-headings-color;
             border-bottom: 1px solid #cacaca;
             > tr > th:not(.o_list_record_selector) {
                 border-left: 1px solid #dfdfdf;


### PR DESCRIPTION
Before in BS4, the table used the `$table-head-color` SCSS variable to
color the header of table. This variable doesn't exist anymore on BS5.
In the commit of the BS5's merge, we have replaced the old value by
a value calculated with the color contrast in the case of the list view
it wasn't the right fix, so in this commit we restore the original value
like it was before the merge of BS5.

Note:
In BS4 branch the result is `#212529`:
```scss
$o-gray-900: #212529 !default;
$o-main-headings-color: $o-gray-900 !default;
$table-head-color: $o-main-headings-color !default;
.o_list_view .o_list_table thead {
  color: $table-head-color;
}
```
In BS5 branch the result is `#00000`:
```scss
.o_list_view .o_list_table thead {
  color: color-contrast(opaque($body-bg, $light));
}
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
