### PR TITLE
[REF] web: refactor `BooleanToggleField` to inherit to `BooleanField`

### DIFF
--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
@@ -1,27 +1,17 @@
 /** @odoo-module **/
 
-import { CheckBox } from "@web/core/checkbox/checkbox";
 import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
-import { standardFieldProps } from "../standard_field_props";
+import { BooleanField } from "../boolean/boolean_field";
 
-const { Component } = owl;
-
-export class BooleanToggleField extends Component {
+export class BooleanToggleField extends BooleanField {
     get isReadonly() {
         return this.props.record.isReadonly(this.props.name);
     }
 }
 
 BooleanToggleField.template = "web.BooleanToggleField";
-BooleanToggleField.components = { CheckBox };
-BooleanToggleField.props = {
-    ...standardFieldProps,
-};
 
 BooleanToggleField.displayName = _lt("Toggle");
-BooleanToggleField.supportedTypes = ["boolean"];
-
-BooleanToggleField.isEmpty = () => false;
 
 registry.category("fields").add("boolean_toggle", BooleanToggleField);

--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.xml
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.BooleanToggleField" owl="1">
-        <CheckBox
-            className="'o_field_boolean o_boolean_toggle form-switch'"
-            id="props.id"
-            value="props.value or false"
-            disabled="isReadonly"
-            onChange="props.update"
-        >
+    <t t-name="web.BooleanToggleField" t-inherit="web.BooleanField" t-inherit-mode="primary" owl="1">
+        <xpath expr="//CheckBox" position="attributes">
+            <attribute name="className">'o_field_boolean o_boolean_toggle form-switch'</attribute>
+        </xpath>
+        <xpath expr="//CheckBox" position="inside">
             &#8203; <!-- Zero width space needed to set height -->
-        </CheckBox>
+        </xpath>
     </t>
 
 </templates>


### PR DESCRIPTION
Before this commit, `BooleanToggleField` and `BooleanField` are 2
distincts components. However, they are some attributes in common.
Also, there is an inconsistency between the both components, in the
boolean field, a `onChange` method is defined but not in the other one.

This commit changes the `BooleanToggleField`, this one will inherit to
`BooleanField` to have the attributes in common and override the ones
which are different. Also, the `onChange` method will exist in the
both components.