### PR TITLE
[FIX] web: daterange field: fix the input display

### DIFF
--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -39,6 +39,7 @@ export class DateRangeField extends Component {
                         },
                         startDate: start ? window.moment(start) : window.moment(),
                         endDate: end ? window.moment(end) : window.moment(),
+                        drops: "auto",
                     });
                     this.pickerContainer = window.$(el).data("daterangepicker").container[0];
 

--- a/addons/web/static/src/views/fields/daterange/daterange_field.xml
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.xml
@@ -6,7 +6,7 @@
             <t t-esc="formattedValue" />
         </t>
         <t t-else="">
-            <input t-ref="root" type="text" t-att-value="formattedValue" t-att-placeholder="props.placeholder" t-on-change="onChangeInput" />
+            <input class="o_input" style="width:100% !important"  t-ref="root" type="text" t-att-value="formattedValue" t-att-placeholder="props.placeholder" t-on-change="onChangeInput" />
         </t>
     </t>
 

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -84,7 +84,7 @@ $o-form-label-margin-right: 0px;
         margin: 0 (-$o-form-spacing-unit/2);
 
         > div, > span, > button, > label, > a, > input, > select { // > * did not add a level of priority to the rule
-            flex: 0 0 auto;
+            flex: 0 1 auto;
             width: auto!important;
             margin-right: $o-form-spacing-unit/2;
             margin-left: $o-form-spacing-unit/2;


### PR DESCRIPTION
[[FIX] web: daterange field: fix the input display](https://github.com/odoo/odoo/commit/582275458b4463a9ef033b94245bfa183ce83058)

Before, the input of the daterange field exceeded the size of its
parent, which caused an overflow and thus a visual bug in the form
and kanban view.
Now the daterange field is displayed as expected.

Step to reproduce the bug:
- Event > Quick create : the daterange is overflowing the parent
- Event > Create : the daterange is not displayed as expected

Before:
![image](https://user-images.githubusercontent.com/109217759/188156210-6fdd7c14-1ef8-493a-b49b-2eb986ca14e2.png)
![image](https://user-images.githubusercontent.com/109217759/188156430-95250a00-f549-44f5-bdfc-b5c6dec67bee.png)

Now:
![image](https://user-images.githubusercontent.com/109217759/188155658-0333dee0-d60a-4d16-adff-f936010dc38d.png)
![image](https://user-images.githubusercontent.com/109217759/188156727-cdd7d910-c83b-4424-9bea-35ebd3dbc80c.png)


task-2967165

[[IMP] web: daterange field: update daterangepicker library](https://github.com/odoo/odoo/commit/f8496da3309a54f159d2220d15fee7e08a05d910)

The `daterangepicker` was in version 3.0.5, since then the library is
now in version 3.1.

This version introduce a new feature that allows to automatically
(depending on the space left) position the picker above or below
the HTML element it's attached.

This commit updates the library but also take advantage of this update:

Before when clicking on a daterange field, even if there was no space
 left below, the picker was still displayed below the field.
Now, the picker is displayed above the field if there is less space
 below the field

Before:
![image](https://user-images.githubusercontent.com/109217759/188156120-3e833324-bff3-4eb1-853c-21e16fa50b66.png)
Now:
![image](https://user-images.githubusercontent.com/109217759/188155895-6af5fa3b-63a0-40ee-90b5-07337631f3cf.png)



