### PR TITLE
[IMP] hr_holidays: improve demo data and leave/allocation approvals

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -17,6 +17,16 @@
         <field name="responsible_id" ref="base.user_admin"/>
     </record>
 
+    <record id="holiday_status_training" model="hr.leave.type">
+        <field name="name">Training Time Off</field>
+        <field name="requires_allocation">yes</field>
+        <field name="employee_requests">no</field>
+        <field name="color_name">lightyellow</field>
+        <field name="leave_validation_type">both</field>
+        <field name="allocation_validation_type">officer</field>
+        <field name="responsible_id" ref="base.user_admin"/>
+    </record>
+
     <!-- Accrual Plan -->
     <record id="hr_accrual_plan_1" model="hr.leave.accrual.plan">
         <field name="name">Seniority Plan</field>
@@ -72,8 +82,8 @@
     </function>
 
     <record id="hr_holidays_vc" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Functional Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_admin"/>
@@ -162,8 +172,8 @@
     </record>
 
     <record id="hr_holidays_vc_al" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Soft Skills Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">12</field>
         <field name="employee_id" ref="hr.employee_al"/>
         <field name="employee_ids" eval="[(4, ref('hr.employee_al'))]"/>
@@ -216,8 +226,8 @@
     </record>
 
     <record id="hr_holidays_vc_mit" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Compliance Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_mit"/>
@@ -266,8 +276,8 @@
     </record>
 
     <record id="hr_holidays_vc_qdp" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Time Management Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_qdp"/>
         <field name="employee_ids" eval="[(4, ref('hr.employee_qdp'))]"/>
@@ -324,8 +334,8 @@
     </record>
 
     <record id="hr_holidays_vc_fpi" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Consulting Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_fpi"/>
         <field name="employee_ids" eval="[(4, ref('hr.employee_fpi'))]"/>
@@ -348,8 +358,8 @@
     </record>
 
     <record id="hr_holidays_vc_vad" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Software Development Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">5</field>
         <field name="employee_id" ref="hr.employee_niv"/>
         <field name="employee_ids" eval="[(4, ref('hr.employee_niv'))]"/>
@@ -403,8 +413,8 @@
     </record>
 
     <record id="hr_holidays_vc_kim" model="hr.leave.allocation">
-        <field name="name">Summer Vacation</field>
-        <field name="holiday_status_id" ref="holiday_status_unpaid"/>
+        <field name="name">Onboarding Training</field>
+        <field name="holiday_status_id" ref="holiday_status_training"/>
         <field name="number_of_days">5</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_jve"/>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -270,11 +270,11 @@
                 <button string="Validate" name="action_validate" type="object"
                     icon="fa-check"
                     states="confirm"
-                    groups="hr_holidays.group_hr_holidays_manager"/>
+                    groups="hr_holidays.group_hr_holidays_user"/>
                 <button string="Refuse" name="action_refuse" type="object"
                     icon="fa-times"
                     states="confirm"
-                    groups="hr_holidays.group_hr_holidays_manager"/>
+                    groups="hr_holidays.group_hr_holidays_user"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>
             </tree>
         </field>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -231,7 +231,7 @@
             <header>
                 <button string="Confirm" name="action_confirm" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('active', '=', False)]}"/>
                 <button string="Approve" name="action_approve" type="object" class="oe_highlight" attrs="{'invisible': ['|', '|', ('active', '=', False), ('can_approve', '=', False), ('state', '!=', 'confirm')]}"/>
-                <button string="Validate" name="action_validate" states="validate1" type="object" groups="hr_holidays.group_hr_holidays_manager" class="oe_highlight"/>
+                <button string="Validate" name="action_validate" states="validate1" type="object" groups="hr_holidays.group_hr_holidays_user" class="oe_highlight"/>
                 <button string="Refuse" name="action_refuse" type="object" attrs="{'invisible': ['|', '|', ('active', '=', False), ('can_approve', '=', False), ('state', 'not in', ('confirm','validate1','validate'))]}"/>
                 <button string="Cancel" name="action_cancel" type="object" attrs="{'invisible': ['|', ('active', '=', False), ('can_cancel', '=', False)]}" />
                 <button string="Mark as Draft" name="action_draft" type="object"
@@ -532,11 +532,11 @@
                 <button string="Validate" name="action_validate" type="object"
                     icon="fa-check"
                     states="validate1"
-                    groups="hr_holidays.group_hr_holidays_manager"/>
+                    groups="hr_holidays.group_hr_holidays_user"/>
                 <button string="Refuse" name="action_refuse" type="object"
                     icon="fa-times"
                     states="confirm,validate1"
-                    groups="hr_holidays.group_hr_holidays_manager"/>
+                    groups="hr_holidays.group_hr_holidays_user"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>
             </tree>
         </field>


### PR DESCRIPTION
In hr_holidays demo data, change the existing allocation from Unpaid to Training Time Off

When a user is logged as Time Off Officer (not administrator):
- In the Approvals > Time Off list view, display the refuse button
- In the Approvals > Allocations list view, display the approve/refuse button

task-2939201


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
