### PR TITLE
[FIX] web: Many2ManyTags: don't edit color in list view

### DIFF
--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -342,8 +342,53 @@ QUnit.module("Fields", (hooks) => {
 
         // click on the tag: should do nothing and open the form view
         click(target.querySelector(".o_field_many2many_tags .badge :nth-child(1)"));
-
         assert.verifySteps(["selectRecord"]);
+        await nextTick();
+
+        assert.containsNone(target, ".o_colorlist");
+
+        await click(target.querySelectorAll(".o_list_record_selector")[1]);
+        click(target.querySelector(".o_field_many2many_tags .badge :nth-child(1)"));
+        assert.verifySteps(["selectRecord"]);
+        await nextTick();
+
+        assert.containsNone(target, ".o_colorlist");
+    });
+
+    QUnit.test("Many2ManyTagsField in tree view -- multi edit", async function (assert) {
+        serverData.models.partner.records[0].timmy = [12, 14];
+
+        await makeView({
+            type: "list",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <tree multi_edit="1">
+                    <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="foo"/>
+                </tree>`,
+            selectRecord: () => {
+                assert.step("selectRecord");
+            },
+        });
+
+        assert.containsN(target, ".o_field_many2many_tags .badge", 2, "there should be 2 tags");
+        assert.containsNone(target, ".badge.dropdown-toggle", "the tags should not be dropdowns");
+
+        // click on the tag: should do nothing and open the form view
+        click(target.querySelector(".o_field_many2many_tags .badge :nth-child(1)"));
+        assert.verifySteps(["selectRecord"]);
+        await nextTick();
+
+        assert.containsNone(target, ".o_colorlist");
+
+        await click(target.querySelectorAll(".o_list_record_selector")[1]);
+        click(target.querySelector(".o_field_many2many_tags .badge :nth-child(1)"));
+        assert.verifySteps([]);
+        await nextTick();
+
+        assert.containsOnce(target, ".o_selected_row");
+        assert.containsNone(target, ".o_colorlist");
     });
 
     QUnit.test("Many2ManyTagsField view a domain", async function (assert) {


### PR DESCRIPTION
Have a list view, displaying records of the model that has a many2many tags field
which supports colors.

Click on a badge.

Before this commit, the color picker opened.

After this commit, it doesn't.

The behavior in an editable list is that the color picker opens when
the record is selected or in edition.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
