### PR TITLE
[FIX] hr_expense: fix split wizard layout

### DIFF
--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -6,34 +6,32 @@
             <field name="model">hr.expense.split.wizard</field>
             <field name="arch" type="xml">
                 <form>
-                    <sheet>
-                        <field name="total_amount_original" invisible="1"/>
-                        <field name="expense_id" invisible="1"/>
-                        <field name="expense_split_line_ids" widget="one2many" context="{'default_expense_id': expense_id}">
-                            <tree editable="bottom">
-                                <field name="currency_id" invisible="1"/>
-                                <field name="expense_id" invisible="1"/>
-                                <field name="company_id" invisible="1"/>
-                                <field name="product_has_tax" invisible="1"/>
-                                <field name="product_has_cost" invisible="1"/>
-                                <field name="name"/>
-                                <field name="product_id"/>
-                                <field name="total_amount" force_save="1" attrs="{'readonly': [('product_has_cost', '=', True)]}"/>
-                                <field name="tax_ids" widget="many2many_tags" attrs="{'readonly': [('product_has_tax', '=', False)]}"/>
-                                <field name="amount_tax"/>
-                                <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" groups="analytic.group_analytic_accounting"/>
-                                <field name="employee_id" widget="many2one_avatar_employee"/>
-                            </tree>
-                        </field>
-                        <field name="currency_id" invisible="1"/>
-                        <group class="oe_subtotal_footer oe_right" colspan="2" name="expense_total">
-                            <label for="total_amount" attrs="{'invisible': [('split_possible', '=', True)]}"/>
-                            <field name="total_amount" nolabel="1" class="text-danger" attrs="{'invisible': [('split_possible', '=', True)]}"/>
-                            <field name="total_amount" attrs="{'invisible': [('split_possible', '=', False)]}"/>
-                            <field name="total_amount_original" widget='monetary' string="Original Amount"/>
-                            <field name="total_amount_taxes" widget='monetary' string="Taxes"/>
-                        </group>
-                    </sheet>
+                    <field name="total_amount_original" invisible="1"/>
+                    <field name="expense_id" invisible="1"/>
+                    <field name="expense_split_line_ids" widget="one2many" context="{'default_expense_id': expense_id}">
+                        <tree editable="bottom">
+                            <field name="currency_id" invisible="1"/>
+                            <field name="expense_id" invisible="1"/>
+                            <field name="company_id" invisible="1"/>
+                            <field name="product_has_tax" invisible="1"/>
+                            <field name="product_has_cost" invisible="1"/>
+                            <field name="name"/>
+                            <field name="product_id"/>
+                            <field name="total_amount" force_save="1" attrs="{'readonly': [('product_has_cost', '=', True)]}"/>
+                            <field name="tax_ids" widget="many2many_tags" attrs="{'readonly': [('product_has_tax', '=', False)]}"/>
+                            <field name="amount_tax"/>
+                            <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" groups="analytic.group_analytic_accounting"/>
+                            <field name="employee_id" widget="many2one_avatar_employee"/>
+                        </tree>
+                    </field>
+                    <field name="currency_id" invisible="1"/>
+                    <group class="oe_subtotal_footer oe_right" colspan="2" name="expense_total">
+                        <label for="total_amount" attrs="{'invisible': [('split_possible', '=', True)]}"/>
+                        <field name="total_amount" nolabel="1" class="text-danger" attrs="{'invisible': [('split_possible', '=', True)]}"/>
+                        <field name="total_amount" attrs="{'invisible': [('split_possible', '=', False)]}"/>
+                        <field name="total_amount_original" widget='monetary' string="Original Amount"/>
+                        <field name="total_amount_taxes" widget='monetary' string="Taxes"/>
+                    </group>
                     <field name="split_possible" invisible="1"/>
                     <footer>
                         <button name="action_split_expense" disabled="disabled" attrs="{'invisible': [ ('split_possible', '=', True)]}" string="Split Expense" type="object" class="oe_highlight"  data-hotkey="q"/>


### PR DESCRIPTION
Turns out having a <sheet> node is not well supported in layout
for dialogs, as it introduces unnecessary horizontall scrollbars.

Before:
![image](https://user-images.githubusercontent.com/9530767/188325897-f27c6b71-66a9-4115-ac7f-293f2849178d.png)

After:
![image](https://user-images.githubusercontent.com/9530767/188325887-ed206228-245c-474f-ad19-4002bb42dae6.png)
