### PR TITLE
[FIX] account, hr_timesheet, product, web: add missing oe_inline classes

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard_views.xml
+++ b/addons/account/wizard/account_automatic_entry_wizard_views.xml
@@ -30,14 +30,14 @@
                         <group>
                             <label for="total_amount" string="Adjusting Amount" attrs="{'invisible': [('action', '!=', 'change_period')]}"/>
                             <div attrs="{'invisible': [('action', '!=', 'change_period')]}">
-                                <field name="percentage" style="width:40% !important" class="oe_inline" attrs="{'readonly': [('action', '!=', 'change_period')]}"/>%<span class="px-3"></span>(<field name="total_amount" class="oe_inline"/>)
+                                <field name="percentage" style="width:40% !important" attrs="{'readonly': [('action', '!=', 'change_period')]}"/>%<span class="px-3"></span>(<field name="total_amount" class="oe_inline"/>)
                             </div>
                             <field name="total_amount" readonly="1" attrs="{'invisible': [('action', '=', 'change_period')]}"/>
                             <field name="journal_id"/>
                         </group>
                     </group>
                     <label for="preview_move_data" string="The following Journal Entries will be generated"/>
-                    <field name="preview_move_data" widget="grouped_view_widget"/>
+                    <field name="preview_move_data" widget="grouped_view_widget" class="d-block"/>
                     <footer>
                         <button string="Create Journal Entries" name="do_action" type="object" class="oe_highlight" data-hotkey="q"/>
                         <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="z"/>

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -134,7 +134,7 @@
                                     <label for="planned_hours" string="Allocated Days" attrs="{'invisible': [('encode_uom_in_days', '=', False)]}"/>
                                     <field name="planned_hours" class="oe_inline ms-2" widget="timesheet_uom_no_toggle"/>
                                     <span attrs="{'invisible': ['|', ('allow_subtasks', '=', False), ('subtask_count', '=', 0)]}">
-                                        (incl. <field name="subtask_planned_hours" nolabel="1" groups="project.group_subtask_project" widget="timesheet_uom_no_toggle"/> on
+                                        (incl. <field name="subtask_planned_hours" nolabel="1" groups="project.group_subtask_project" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                                         <span class="fw-bold text-dark"> Sub-tasks</span>)
                                     </span>
                                 </div>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -84,7 +84,7 @@
                                     <div name="standard_price_uom" groups="base.group_user" attrs="{'invisible': [('product_variant_count', '&gt;', 1), ('is_product_variant', '=', False)]}" class="o_row">
                                         <field name="standard_price" widget='monetary' options="{'currency_field': 'cost_currency_id', 'field_digits': True}"/>
                                         <span groups="uom.group_uom" class="oe_read_only">per
-                                            <field name="uom_name"/>
+                                            <field name="uom_name" class="oe_inline"/>
                                         </span>
                                     </div>
                                     <field name="categ_id" string="Product Category"/>

--- a/addons/web/static/src/views/fields/monetary/monetary_field.scss
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.scss
@@ -1,0 +1,3 @@
+.o_field_widget.o_field_monetary input {
+    width: 100px;
+}


### PR DESCRIPTION
Since the fields were rewritten in owl, they all have a width of 100% by
default, which is what we want when displaying a field on their own.
In some places, fields are used as part of a longer block of content (eg
unit of measure behind a number). In those cases, we want to display the
field inline, which requires the addition of the oe_inline class in the
arch.

There was also a missing piece of css for the monetary field, as the
previous rule no longer applied because of the slight changes to the DOM
structure.