### PR TITLE
[FIX] web: do not save settings on discard

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
@@ -13,10 +13,13 @@ export class SettingsFormController extends formView.Controller {
     setup() {
         super.setup();
         const beforeExecuteAction = async (clickParams) => {
+            if (clickParams.name === "cancel") {
+                return true;
+            }
             let _continue = true;
             if (
                 this.model.root.isDirty &&
-                !["cancel", "execute"].includes(clickParams.name) &&
+                !["execute"].includes(clickParams.name) &&
                 !clickParams.noSaveDialog
             ) {
                 const message = this.env._t("Would you like to save your changes?");


### PR DESCRIPTION
The "beforeExecuteAction" of view buttons in the form view is set to
automatically save, so that when the user clicks a button which wil
change their current view, we ask them if they want to save their
changes.

In the case of the discard button, we  don't want to ask the user if
they want to save their changes, but we don't want to save either. This
commit fixes that.
