### PR TITLE
[REF] web: DebugManager: remove usage of legacy FormViewDialog

### DIFF
--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
 import { Dialog } from "@web/core/dialog/dialog";
-import { FormViewDialog } from "web.view_dialogs";
+import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { formatMany2one } from "@web/views/fields/formatters";
 import { registry } from "@web/core/registry";
-import { standaloneAdapter } from "web.OwlCompatibility";
+import { useService } from "@web/core/utils/hooks";
 
 const { Component, onWillStart, useState } = owl;
 
@@ -13,6 +13,7 @@ const debugRegistry = registry.category("debug");
 
 class GetMetadataDialog extends Component {
     setup() {
+        this.dialogService = useService("dialog");
         this.title = this.env._t("View Metadata");
         this.state = useState({});
         onWillStart(this.onWillStart);
@@ -28,17 +29,11 @@ class GetMetadataDialog extends Component {
             default_res_id: this.state.id,
             default_model: this.props.res_model,
         });
-        const adapterParent = standaloneAdapter({ Component });
-        const dialog = new FormViewDialog(adapterParent, {
-            context: context,
-            on_saved: () => this.getMetadata(),
-            disable_multiple_selection: true,
-            res_model: "ir.model.data",
+        this.dialogService.add(FormViewDialog, {
+            context,
+            onRecordSaved: () => this.getMetadata(),
+            resModel: "ir.model.data",
         });
-        dialog.on("dialog_form_loaded", this, () => {
-            dialog.$el.find('[name="name"]').focus();
-        });
-        await dialog.open();
     }
 
     async toggleNoupdate() {


### PR DESCRIPTION
With this commit, we use the new (owl) FormViewDialog instead of
the legacy one in the "View Metadata" debug item.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
