### PR TITLE
[FIX] service: fix attribute error on request handler

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -126,19 +126,16 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
         me = threading.current_thread()
         me.name = 'odoo.service.http.request.%s' % (me.ident,)
 
-    def send_response(self, code, message=None):
-        # Since the upgrade header is introduced in version 1.1, Firefox
-        # won't accept a websocket connection if the version is set to
-        # 1.0.
-        if self.environ.get('REQUEST_URI') == '/websocket':
-            self.protocol_version = "HTTP/1.1"
-        return super().send_response(code, message=message)
-
     def make_environ(self):
         environ = super().make_environ()
         # Add the TCP socket to environ in order for the websocket
         # connections to use it.
         environ['socket'] = self.connection
+        if self.headers.get('Upgrade') == 'websocket':
+            # Since the upgrade header is introduced in version 1.1, Firefox
+            # won't accept a websocket connection if the version is set to
+            # 1.0.
+            self.protocol_version = "HTTP/1.1"
         return environ
 
 


### PR DESCRIPTION
In order for websocket upgrade to work with firefox, the http version
must be set to `HTTP/1.1`.

Until now, this was done in the `send_response` method. The issue is
that this method is also used when sending an error. This is problematic
because we use environ to know whether or not the version should be changed
which means any error during `BaseHTTPRequestHandler.parse_request` (such as
wrong http version) would have led to an AttributeError being raised.

In order to solve this issue, this modification is done when making environ.
Moreover, we previously used the request uri to know whether or not the version
should be changed, this was not really reliable, we now use the upgrade header
for this purpose.