### PR TITLE
[REF] web_editor: merge insertion commands into one

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -108,9 +108,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(DynamicPlaceholderFieldMixin)
 
                 const t = document.createElement('T');
                 t.setAttribute('t-out', dynamicPlaceholder);
-                const fragment = new DocumentFragment();
-                fragment.appendChild(t);
-                this.wysiwyg.odooEditor.execCommand('insertFragment', fragment);
+                this.wysiwyg.odooEditor.execCommand('insert', t);
                 setSelection(...rightPos(t));
                 this.wysiwyg.odooEditor.editable.focus();
             }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -65,6 +65,7 @@ import {
     hasValidSelection,
     hasTableSelection,
     pxToFloat,
+    parseHTML,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -552,7 +553,7 @@ export class OdooEditor extends EventTarget {
                         let html = '\u200B<span contenteditable="false" class="o_stars o_three_stars">';
                         html += Array(3).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
                         html += '</span>';
-                        this.execCommand('insertHTML', html);
+                        this.execCommand('insert', parseHTML(html));
                     },
                 },
                 {
@@ -565,7 +566,7 @@ export class OdooEditor extends EventTarget {
                         let html = '\u200B<span contenteditable="false" class="o_stars o_five_stars">';
                         html += Array(5).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
                         html += '</span>';
-                        this.execCommand('insertHTML', html);
+                        this.execCommand('insert', parseHTML(html));
                     },
                 },
                 ...(this.options.commands || []),
@@ -2639,11 +2640,11 @@ export class OdooEditor extends EventTarget {
      *
      * @private
      * @param {string} clipboardData
-     * @returns {string}
+     * @returns {Element}
      */
     _prepareClipboardData(clipboardData) {
         const container = document.createElement('fake-container');
-        container.innerHTML = clipboardData;
+        container.append(parseHTML(clipboardData));
 
         for (const tableElement of container.querySelectorAll('table')) {
             tableElement.classList.add('table', 'table-bordered', 'o_table');
@@ -2659,24 +2660,24 @@ export class OdooEditor extends EventTarget {
         // particular case in all of those functions. In fact, this case cannot
         // happen on a new document created using this editor, but will happen
         // instantly when editing a document that was created from Etherpad.
-        const temporaryContainer = document.createElement('template');
-        let temporaryP = document.createElement('p');
+        const fragment = document.createDocumentFragment();
+        let p = document.createElement('p');
         for (const child of [...container.childNodes]) {
             if (isBlock(child)) {
-                if (temporaryP.childNodes.length > 0) {
-                    temporaryContainer.content.appendChild(temporaryP);
-                    temporaryP = document.createElement('p');
+                if (p.childNodes.length > 0) {
+                    fragment.appendChild(p);
+                    p = document.createElement('p');
                 }
-                temporaryContainer.content.appendChild(child);
+                fragment.appendChild(child);
             } else {
-                temporaryP.appendChild(child);
+                p.appendChild(child);
             }
 
-            if (temporaryP.childNodes.length > 0) {
-                temporaryContainer.content.appendChild(temporaryP);
+            if (p.childNodes.length > 0) {
+                fragment.appendChild(p);
             }
         }
-        return temporaryContainer.innerHTML;
+        return fragment;
     }
     /**
      * Clean a node for safely pasting. Cleaning an element involves unwrapping
@@ -3030,7 +3031,7 @@ export class OdooEditor extends EventTarget {
             } else if (closestTag === 'TABLE') {
                 this._onTabulationInTable(ev);
             } else if (!ev.shiftKey) {
-                this.execCommand('insertText', '\u00A0 \u00A0\u00A0');
+                this.execCommand('insert', '\u00A0 \u00A0\u00A0');
             }
             ev.preventDefault();
             ev.stopPropagation();
@@ -3687,7 +3688,7 @@ export class OdooEditor extends EventTarget {
             imageNode.dataset.fileName = imageFile.name;
             getImageUrl(imageFile).then((url)=> {
                 imageNode.src = url;
-                this.execCommand('insertHTML', imageNode.outerHTML);
+                this.execCommand('insert', imageNode);
             });
         }
     }
@@ -3700,7 +3701,7 @@ export class OdooEditor extends EventTarget {
         const files = getImageFiles(ev.clipboardData);
         const clipboardHtml = ev.clipboardData.getData('text/html');
         if (clipboardHtml) {
-            this.execCommand('insertHTML', this._prepareClipboardData(clipboardHtml));
+            this.execCommand('insert', this._prepareClipboardData(clipboardHtml));
         } else if (files.length) {
             this.addImagesFiles(files);
         } else {
@@ -3769,7 +3770,7 @@ export class OdooEditor extends EventTarget {
 
                     if (isImageUrl) {
                         const stepIndexBeforeInsert = this._historySteps.length - 1;
-                        this.execCommand('insertText', splitAroundUrl[i]);
+                        this.execCommand('insert', splitAroundUrl[i]);
                         this.powerbox.open([
                             {
                                 category: this.options._t('Embed'),
@@ -3795,7 +3796,7 @@ export class OdooEditor extends EventTarget {
                         ]);
                     } else if (this.options.allowCommandVideo && youtubeUrl) {
                         const stepIndexBeforeInsert = this._historySteps.length - 1;
-                        this.execCommand('insertText', splitAroundUrl[i]);
+                        this.execCommand('insert', splitAroundUrl[i]);
                         this.powerbox.open([
                             {
                                 category: this.options._t('Embed'),
@@ -3858,7 +3859,7 @@ export class OdooEditor extends EventTarget {
                     const textFragments = splitAroundUrl[i].split(/\r?\n/);
                     let textIndex = 1;
                     for (const textFragment of textFragments) {
-                        this.execCommand('insertText', textFragment);
+                        this.execCommand('insert', textFragment);
                         if (textIndex < textFragments.length) {
                             this._applyCommand('oShiftEnter');
                         }
@@ -3906,7 +3907,7 @@ export class OdooEditor extends EventTarget {
                     const range = this.document.caretRangeFromPoint(ev.clientX, ev.clientY);
                     setSelection(range.startContainer, range.startOffset);
                 }
-                this.execCommand('insertHTML', this._prepareClipboardData(pastedText));
+                this.execCommand('insert', this._prepareClipboardData(pastedText));
             });
         }
         this.historyStep();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -2180,6 +2180,14 @@ export function rgbToHex(rgb = '') {
     }
 }
 
+export function parseHTML(html) {
+    const fragment = document.createDocumentFragment();
+    const parser = new DOMParser();
+    const parsedDocument = parser.parseFromString(html, 'text/html');
+    fragment.replaceChildren(...parsedDocument.body.childNodes);
+    return fragment;
+}
+
 /**
  * Take a string containing a size in pixels, return that size as a float.
  *

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/collab.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/collab.test.js
@@ -237,19 +237,19 @@ describe('Collaboration', () => {
                 afterCreate: clientInfos => {
                     applyConcurentActions(clientInfos, {
                         c1: editor => {
-                            editor.execCommand('insertText', 'b');
-                            editor.execCommand('insertText', 'c');
-                            editor.execCommand('insertText', 'd');
+                            editor.execCommand('insert', 'b');
+                            editor.execCommand('insert', 'c');
+                            editor.execCommand('insert', 'd');
                         },
                         c2: editor => {
-                            editor.execCommand('insertText', 'f');
-                            editor.execCommand('insertText', 'g');
-                            editor.execCommand('insertText', 'h');
+                            editor.execCommand('insert', 'f');
+                            editor.execCommand('insert', 'g');
+                            editor.execCommand('insert', 'h');
                         },
                         c3: editor => {
-                            editor.execCommand('insertText', 'j');
-                            editor.execCommand('insertText', 'k');
-                            editor.execCommand('insertText', 'l');
+                            editor.execCommand('insert', 'j');
+                            editor.execCommand('insert', 'k');
+                            editor.execCommand('insert', 'l');
                         },
                     });
                     mergeClientsSteps(clientInfos);
@@ -265,10 +265,10 @@ describe('Collaboration', () => {
                 afterCreate: clientInfos => {
                     applyConcurentActions(clientInfos, {
                         c1: editor => {
-                            editor.execCommand('insertText', 'e');
+                            editor.execCommand('insert', 'e');
                         },
                         c2: editor => {
-                            editor.execCommand('insertText', 'f');
+                            editor.execCommand('insert', 'f');
                         },
                     });
                     mergeClientsSteps(clientInfos);
@@ -284,12 +284,12 @@ describe('Collaboration', () => {
                 afterCreate: clientInfos => {
                     applyConcurentActions(clientInfos, {
                         c1: editor => {
-                            editor.execCommand('insertText', 'e');
-                            editor.execCommand('insertText', 'f');
+                            editor.execCommand('insert', 'e');
+                            editor.execCommand('insert', 'f');
                         },
                         c2: editor => {
-                            editor.execCommand('insertText', 'g');
-                            editor.execCommand('insertText', 'h');
+                            editor.execCommand('insert', 'g');
+                            editor.execCommand('insert', 'h');
                         },
                     });
                     mergeClientsSteps(clientInfos);
@@ -305,7 +305,7 @@ describe('Collaboration', () => {
                 afterCreate: clientInfos => {
                     applyConcurentActions(clientInfos, {
                         c1: editor => {
-                            editor.execCommand('insertText', 'd');
+                            editor.execCommand('insert', 'd');
                         },
                         c2: editor => {
                             editor.execCommand('oDeleteBackward');
@@ -324,8 +324,8 @@ describe('Collaboration', () => {
                 afterCreate: clientInfos => {
                     applyConcurentActions(clientInfos, {
                         c1: editor => {
-                            editor.execCommand('insertText', 'd');
-                            editor.execCommand('insertText', 'e');
+                            editor.execCommand('insert', 'd');
+                            editor.execCommand('insert', 'e');
                         },
                         c2: editor => {
                             editor.execCommand('oDeleteBackward');
@@ -344,7 +344,7 @@ describe('Collaboration', () => {
             clientIds: ['c1', 'c2'],
             contentBefore: '<p>a[c1}{c1]</p>',
             afterCreate: clientInfos => {
-                clientInfos.c1.editor.execCommand('insertText', 'b');
+                clientInfos.c1.editor.execCommand('insert', 'b');
                 clientInfos.c1.editor._historyMakeSnapshot();
                 // Insure the snapshot is considered to be older than 30 seconds.
                 clientInfos.c1.editor._historySnapshots[0].time = 1;
@@ -367,11 +367,11 @@ describe('Collaboration', () => {
                 clientIds: ['c1', 'c2', 'c3'],
                 contentBefore: '<p><x>a[c1}{c1]</x><y>b[c2}{c2]</y><z>c[c3}{c3]</z></p>',
                 afterCreate: clientInfos => {
-                    clientInfos.c1.editor.execCommand('insertText', 'd');
+                    clientInfos.c1.editor.execCommand('insert', 'd');
                     clientInfos.c2.editor.onExternalHistorySteps([
                         clientInfos.c1.editor._historySteps[1],
                     ]);
-                    clientInfos.c2.editor.execCommand('insertText', 'e');
+                    clientInfos.c2.editor.execCommand('insert', 'e');
                     clientInfos.c1.editor.onExternalHistorySteps([
                         clientInfos.c2.editor._historySteps[2],
                     ]);
@@ -392,7 +392,7 @@ describe('Collaboration', () => {
                 clientIds: ['c1', 'c2', 'c3'],
                 contentBefore: '<p><i>a[c1}{c1]</i><b>b[c2}{c2]</b></p>',
                 afterCreate: clientInfos => {
-                    clientInfos.c1.editor.execCommand('insertText', 'c');
+                    clientInfos.c1.editor.execCommand('insert', 'c');
                     clientInfos.c2.editor.onExternalHistorySteps([
                         clientInfos.c1.editor._historySteps[1],
                     ]);
@@ -407,8 +407,8 @@ describe('Collaboration', () => {
                     clientInfos.c3.editor.historyResetFromSteps(steps);
 
                     // In the meantime client 2 send the step to client 1
-                    clientInfos.c2.editor.execCommand('insertText', 'd');
-                    clientInfos.c2.editor.execCommand('insertText', 'e');
+                    clientInfos.c2.editor.execCommand('insert', 'd');
+                    clientInfos.c2.editor.execCommand('insert', 'e');
                     clientInfos.c1.editor.onExternalHistorySteps([
                         clientInfos.c2.editor._historySteps[2],
                     ]);
@@ -417,7 +417,7 @@ describe('Collaboration', () => {
                     ]);
 
                     // Now client 2 is connected to client 3 and client 2 make a new step.
-                    clientInfos.c2.editor.execCommand('insertText', 'f');
+                    clientInfos.c2.editor.execCommand('insert', 'f');
                     clientInfos.c1.editor.onExternalHistorySteps([
                         clientInfos.c2.editor._historySteps[4],
                     ]);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -443,11 +443,11 @@ describe('Format', () => {
                 contentBefore: `<p>ab${u(s(`cd[]ef`))}</p>`,
                 stepFunction: async editor => {
                     await editor.execCommand('underline');
-                    await editor.execCommand('insertText', 'A');
+                    await editor.execCommand('insert', 'A');
                     await editor.execCommand('underline');
-                    await editor.execCommand('insertText', 'B');
+                    await editor.execCommand('insert', 'B');
                     await editor.execCommand('underline');
-                    await editor.execCommand('insertText', 'C');
+                    await editor.execCommand('insert', 'C');
                 },
                 contentAfterEdit: `<p>ab${u(s(`cd`))}${s(`A${u(`B`)}${uselessSpan(`C[]`)}${uselessU}`)}${u(s(`ef`))}</p>`,
             });
@@ -537,11 +537,11 @@ describe('Format', () => {
                 contentBefore: `<p>ab${u(i(`cd[]ef`))}</p>`,
                 stepFunction: async editor => {
                     await editor.execCommand('underline');
-                    await editor.execCommand('insertText', 'A');
+                    await editor.execCommand('insert', 'A');
                     await editor.execCommand('underline');
-                    await editor.execCommand('insertText', 'B');
+                    await editor.execCommand('insert', 'B');
                     await editor.execCommand('underline');
-                    await editor.execCommand('insertText', 'C');
+                    await editor.execCommand('insert', 'C');
                 },
                 contentAfter: `<p>ab${u(i(`cd`))}${i(`A${u(`B`)}${uselessSpan(`C[]`)}${uselessU}`)}${u(i(`ef`))}</p>`,
             });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
@@ -1,3 +1,4 @@
+import { parseHTML } from '../../src/utils/utils.js';
 import { BasicEditor, testEditor } from '../utils.js';
 
 describe('insert HTML', () => {
@@ -6,7 +7,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>[]<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
@@ -17,7 +18,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p><br></p>[]',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
@@ -28,7 +29,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[]b<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b<br></p>',
@@ -39,7 +40,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>[]<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit: '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
                 contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]<br></p>',
@@ -49,7 +50,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[]b<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b<br></p>',
@@ -60,7 +61,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[]e<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<p>b</p><p>c</p><p>d</p>');
+                    await editor.execCommand('insert', parseHTML('<p>b</p><p>c</p><p>d</p>'));
                 },
                 contentAfter: '<p>ab</p><p>c</p><p>d[]e<br></p>',
             });
@@ -71,7 +72,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>[a]<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit: '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
                 contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]<br></p>',
@@ -81,7 +82,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[b]c<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insertHTML', '<i class="fa fa-pastafarianism"></i>');
+                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]c<br></p>',

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
@@ -512,7 +512,7 @@ describe('Link', () => {
         //                     direction: Direction.FORWARD,
         //                 },
         //             });
-        //             await editor.execCommand('insertText', { text: 'd' });
+        //             await editor.execCommand('insert', 'd');
         //         },
         //         contentAfter: '<div><p>123</p><p><a href="#">d[]</a></p></div>',
         //     });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -37,6 +37,7 @@ const closestElement = OdooEditorLib.closestElement;
 const setSelection = OdooEditorLib.setSelection;
 const endPos = OdooEditorLib.endPos;
 const hasValidSelection = OdooEditorLib.hasValidSelection;
+const parseHTML = OdooEditorLib.parseHTML;
 
 var id = 0;
 const basicMediaSelector = 'img, .fa, .o_image, .media_iframe_video';
@@ -1324,9 +1325,7 @@ const Wysiwyg = Widget.extend({
             this.odooEditor.unbreakableStepUnactive();
             this.odooEditor.historyStep();
         } else {
-            const fragment = new DocumentFragment();
-            fragment.append(element);
-            return this.odooEditor.execCommand('insertFragment', fragment);
+            return this.odooEditor.execCommand('insert', element);
         }
 
         if (this.snippetsMenu) {
@@ -1970,7 +1969,7 @@ const Wysiwyg = Widget.extend({
                         args: [this.getSession().uid, ['signature']],
                     });
                     if (res && res[0] && res[0].signature) {
-                        this.odooEditor.execCommand('insertHTML', res[0].signature);
+                        this.odooEditor.execCommand('insert', parseHTML(res[0].signature));
                     }
                 },
             },


### PR DESCRIPTION
Prior to this commit, we had three insertion commands:
* insertText: takes a string to insert a text node with the provided string as text
* insertHtml: takes a string, convert it to elements then insert these elements in the dom
* insertFragment: takes a fragment element then insert it in the dom

With this commit, we now have a single one polymorphic command `insert` that accept two types of arguments:
* string: inserts a text node with the provided string as text
* node:  insert the provided not in the dom

The new `insert` command does **not** support the previous case of `insertHtml` which used to convert string into html on the fly. No more magically hidden conversions ! No more need to construct a fragment yourself like with `insertFragent` either. If you need to convert string into html, notably for hardcoded fixed html, you can use the `parseHTML` util which returns a frament containing the parsed nodes which can be given to `insert` directly..