### PR TITLE
[FIX] bus: fix websocket errors on local tests

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+from werkzeug.exceptions import ServiceUnavailable
 
 from odoo.http import Controller, request, route
 from odoo.addons.base.models.assetsbundle import AssetsBundle
@@ -15,6 +16,10 @@ class WebsocketController(Controller):
         Handle the websocket handshake, upgrade the connection if
         successfull.
         """
+        is_headful_browser = request.httprequest.user_agent and 'Headless' not in request.httprequest.user_agent.string
+        if request.registry.in_test_mode() and is_headful_browser:
+            # Prevent browsers from interfering with the unittests
+            raise ServiceUnavailable()
         return WebsocketConnectionHandler.open_connection(request)
 
     @route('/websocket/health', type='http', auth='none', save_session=False)


### PR DESCRIPTION
When executing python tests with Odoo opened in the browser, the
websocket connection coming from the browser can lead to issues
with savepoints/rollbacks. Indeed, during test set up, a savepoint
is created. This savepoint is released at the end of each test.

The issue occurs when the websocket connection opens a cursor (and
thus creates a savepoint) after the one created by the test but releases
it after the one created by the test:
    - SAVEPOINT TEST
    - SAVEPOINT WS
    - ROLLBACK TO SAVEPOINT TEST
    - SAVEPOINT WS DOES NOT EXIST

In order to solve this issue, let's prevent browsers from opening a
websocket connection during python tests. This does not apply to chrome
headless since remaining threads are awaited before the end of every tour
(which means the websocket connection will be close before releasing the
test cursor).