### PR TITLE
[FIX] web: missing styles on o_form_nosheet

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -174,7 +174,7 @@ $o-form-label-margin-right: 0px;
     }
 
     // No sheet
-    .o_form_nosheet {
+    &.o_form_nosheet, .o_form_nosheet {
         @include o-webclient-padding($top: $o-sheet-vpadding, $bottom: $o-sheet-vpadding);
 
         .o_form_statusbar {


### PR DESCRIPTION
Steps to reproduce:

 - Go to reconciliation models
 - Click on Line with Bank Fees
 - Click on a x2many line
 → The popup is missing some padding