### PR TITLE
[FIX] im_livechat: do not cut header content in external lib livechat

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.scss
+++ b/addons/im_livechat/static/src/legacy/public_livechat.scss
@@ -42,6 +42,7 @@ $o-mail-thread-window-zindex: $zindex-modal + 1 !default;
         border-bottom: 1px solid map-get($grays, '300');
         background-color: $o-brand-odoo;
         padding: 8px;
+        cursor: pointer;
 
         @include media-breakpoint-down(md) {
             align-items: center;
@@ -81,9 +82,7 @@ $o-mail-thread-window-zindex: $zindex-modal + 1 !default;
         }
 
         .o_thread_window_title {
-            cursor: pointer;
             flex: 1 1 auto;
-            height: 100%;
             @include o-text-overflow;
 
             .o_mail_thread_typing_icon {

--- a/addons/im_livechat/static/src/legacy/widgets/public_livechat_window/public_livechat_window.js
+++ b/addons/im_livechat/static/src/legacy/widgets/public_livechat_window/public_livechat_window.js
@@ -18,7 +18,7 @@ const PublicLivechatWindow = Widget.extend({
     template: 'im_livechat.legacy.PublicLivechatWindow',
     events: {
         'click .o_thread_window_close': '_onClickClose',
-        'click .o_thread_window_title': '_onClickFold',
+        'click .o_thread_window_header': '_onClickFold',
         'click .o_composer_text_field': '_onComposerClick',
         'click .o_mail_thread': '_onThreadWindowClicked',
         'keydown .o_composer_text_field': '_onKeydown',

--- a/addons/im_livechat/static/src/models/public_livechat_window.js
+++ b/addons/im_livechat/static/src/models/public_livechat_window.js
@@ -59,9 +59,10 @@ registerModel({
                 $(this).on('click', self.messaging.publicLivechatGlobal.livechatButtonView.widget._onChatbotOptionClicked.bind(self.messaging.publicLivechatGlobal.livechatButtonView.widget));
             });
 
-            this.widget.$('.o_livechat_chatbot_main_restart').on('click',
-                this.messaging.publicLivechatGlobal.livechatButtonView.onChatbotRestartScript
-            );
+            this.widget.$('.o_livechat_chatbot_main_restart').on('click', (ev) => {
+                ev.stopPropagation(); // prevent fold behaviour
+                this.messaging.publicLivechatGlobal.livechatButtonView.onChatbotRestartScript(ev);
+            });
 
             if (this.messaging.publicLivechatGlobal.messages.length !== 0) {
                 const lastMessage = this.messaging.publicLivechatGlobal.lastMessage;

--- a/addons/im_livechat/static/src/scss/im_livechat_bootstrap.scss
+++ b/addons/im_livechat/static/src/scss/im_livechat_bootstrap.scss
@@ -15,7 +15,7 @@
     box-sizing: border-box;
   }
   .o_thread_window_header {
-    height: 28px;
+    height: 35px;
     .fa-close {
       text-decoration: none;
       font-weight: bold;


### PR DESCRIPTION
Before this commit, chat window header in external lib had text
and button, due to chat window header being too narrow.

This commit fixes the issue by increasing the chat window header
height to match the visual in website livechat, which by itself
also fixes the text and button being properly visible.

Task-2973046
