### PR TITLE
[FIX] product: give correct dimension parameter to delivery

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -264,9 +264,9 @@ class ProductTemplate(models.Model):
         """
         product_length_in_feet_param = self.env['ir.config_parameter'].sudo().get_param('product.volume_in_cubic_feet')
         if product_length_in_feet_param == '1':
-            return self.env.ref('uom.product_uom_foot')
+            return self.env.ref('uom.product_uom_inch')
         else:
-            return self.env.ref('uom.product_uom_millimeter')
+            return self.env.ref('uom.product_uom_cm')
 
     @api.model
     def _get_volume_uom_id_from_ir_config_parameter(self):


### PR DESCRIPTION
currently product packages have either foot or millimeter in length
dimensions depending on the imperial or metric systems chosen. It should be
either centimeters or inches, as these are the dimensions that all delivery
methods accept.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
