### PR TITLE
[FIX] web: displays the right status on hover

### DIFF
--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
@@ -9,7 +9,7 @@
             </button>
         </t>
         <t t-else="">
-            <Dropdown title="currentValue" togglerClass="'btn btn-link d-flex p-0'">
+            <Dropdown tooltip="label" togglerClass="'btn btn-link d-flex p-0'">
                 <t t-set-slot="toggler">
                     <div class="d-flex align-items-center">
                         <span t-attf-class="o_status {{ statusColor(currentValue) }} "/>

--- a/addons/web/static/tests/views/fields/state_selection_field_tests.js
+++ b/addons/web/static/tests/views/fields/state_selection_field_tests.js
@@ -87,6 +87,11 @@ QUnit.module("Fields", (hooks) => {
             "should not have one green status since selection is the second, blocked state"
         );
         assert.containsNone(target, ".dropdown-menu", "there should not be a dropdown");
+        assert.strictEqual(
+            target.querySelector(".o_field_state_selection .dropdown-toggle").dataset.tooltip,
+            "Blocked",
+            "tooltip attribute has the right text"
+        );
 
         // Click on the status button to make the dropdown appear
         await click(target, ".o_field_widget.o_field_state_selection .o_status");


### PR DESCRIPTION
This commit fixes the StateSelection field, which
displayed the wrong value on hover. In legacy, the title
attribute was set to display that value. Now, it has been
replaced by a tooltip, since it can be used with touch
and is more convenient to use. A test has been modified
to assert the presence of the data-tooltip attribute.