### PR TITLE
[IMP] account: early payment discount reboot

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -2,7 +2,7 @@
 
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import format_date, formatLang
+from odoo.tools import format_date, formatLang, frozendict
 
 from dateutil.relativedelta import relativedelta
 
@@ -39,8 +39,20 @@ class AccountPaymentTerm(models.Model):
             example_preview = ""
             if not record.example_invalid:
                 currency = self.env.company.currency_id
-                terms = record.compute(record.example_amount, record.example_amount, record.example_date, currency)
-                for i, (date, amount) in enumerate(record._get_amount_by_date(terms, currency).items()):
+                terms = record._compute_terms(
+                    date_ref=record.example_date,
+                    currency=currency,
+                    company=self.env.company,
+                    tax_amount=0,
+                    tax_amount_currency=0,
+                    untaxed_amount=record.example_amount,
+                    untaxed_amount_currency=record.example_amount,
+                    sign=1)
+                for i, info_by_dates in enumerate(record._get_amount_by_date(terms, currency).items()):
+                    date = info_by_dates[1]['date']
+                    discount_date = info_by_dates[1]['discount_date']
+                    amount = info_by_dates[1]['amount']
+                    discount_amount = info_by_dates[1]['discounted_amount'] or 0.0
                     example_preview += f"""
                         <div style='margin-left: 20px;'>
                             <b>{i+1}#</b>
@@ -48,21 +60,44 @@ class AccountPaymentTerm(models.Model):
                             <b>{formatLang(self.env, amount, monetary=True, currency_obj=currency)}</b>
                             on 
                             <b style='color: #704A66;'>{date}</b>
-                        </div>
                     """
+                    if discount_date:
+                        example_preview += f"""
+                         (<b>{formatLang(self.env, discount_amount, monetary=True, currency_obj=currency)}</b> if paid before <b>{format_date(self.env, terms[i].get('discount_date'))}</b>)
+                    """
+                    example_preview += "</div>"
+
             record.example_preview = example_preview
 
     @api.model
     def _get_amount_by_date(self, terms, currency):
         """
-        Returns a dictionary with the amount for each date of the payment term (grouped by date, sorted by date and ignoring null amounts).
+        Returns a dictionary with the amount for each date of the payment term
+        (grouped by date, discounted percentage and discount last date,
+        sorted by date and ignoring null amounts).
         """
-        terms = sorted(terms)
+        terms = sorted(terms, key=lambda t: t.get('date'))
         amount_by_date = {}
-        for date, amount in terms:
-            date = format_date(self.env, date)
-            if currency.compare_amounts(amount[0], 0) > 0:
-                amount_by_date[date] = amount_by_date.get(date, 0) + amount[0]
+        for term in terms:
+            key = frozendict({
+                'date': term['date'],
+                'discount_date': term['discount_date'],
+                'discount_percentage': term['discount_percentage'],
+            })
+            if not amount_by_date.get(key):
+                amount_by_date[key] = {
+                    'date': format_date(self.env, term['date']),
+                    'amount': 0.0,
+                    'discounted_amount': 0.0,
+                }
+            if not currency.round(term['company_amount']) > 0.0:
+                amount_by_date[key]['amount'] += term['company_amount']
+
+            amount_by_date[key]['discount_date'] = format_date(self.env, term['discount_date']) or False
+            if currency.round(term['discount_amount_currency']) > 0.0:
+                amount_by_date[key]['discounted_amount'] += term.get('discount_amount_currency')
+            else:
+                amount_by_date[key]['discounted_amount'] = 0.0
         return amount_by_date
 
     @api.constrains('line_ids')
@@ -70,44 +105,79 @@ class AccountPaymentTerm(models.Model):
         for terms in self:
             if len(terms.line_ids.filtered(lambda r: r.value == 'balance')) != 1:
                 raise ValidationError(_('The Payment Term must have one Balance line.'))
+            if terms.line_ids.filtered(lambda r: r.value == 'fixed' and r.discount_percentage):
+                raise ValidationError(_("You can't mix fixed amount with early payment percentage"))
 
-    def compute(self, company_value, foreign_value, date_ref, currency):
+    def _compute_terms(self, date_ref, currency, company, tax_amount, tax_amount_currency, sign, untaxed_amount, untaxed_amount_currency):
         """Get the distribution of this payment term.
-
-        :param company_value (float): the amount to pay in the company's currency
-        :param foreign_value (float): the amount to pay in the document's currency
-        :param date_ref (datetime.date): the reference date
-        :param currency (Model<res.currency>): the document's currency
+        :param date_ref: The move date to take into account
+        :param currency: the move's currency
+        :param company: the company issuing the move
+        :param tax_amount: the signed tax amount for the move
+        :param tax_amount_currency: the signed tax amount for the move in the move's currency
+        :param untaxed_amount: the signed untaxed amount for the move
+        :param untaxed_amount_currency: the signed untaxed amount for the move in the move's currency
+        :param sign: the sign of the move
         :return (list<tuple<datetime.date,tuple<float,float>>>): the amount in the company's currency and
             the document's currency, respectively for each required payment date
         """
         self.ensure_one()
-        date_ref = date_ref or fields.Date.context_today(self)
-        company_amount = company_value
-        foreign_amount = foreign_value
-        sign = company_value < 0 and -1 or 1
+        company_currency = company.currency_id
+        tax_amount_left = tax_amount
+        tax_amount_currency_left = tax_amount_currency
+        untaxed_amount_left = untaxed_amount
+        untaxed_amount_currency_left = untaxed_amount_currency
+        total_amount = tax_amount + untaxed_amount
+        total_amount_currency = tax_amount_currency + untaxed_amount_currency
         result = []
-        company_currency = self.env.company.currency_id
+
         for line in self.line_ids.sorted(lambda line: line.value == 'balance'):
+            term_vals = {
+                'date': line._get_due_date(date_ref),
+                'has_discount': line.discount_percentage,
+                'discount_date': None,
+                'discount_amount_currency': 0.0,
+                'discount_balance': 0.0,
+                'discount_percentage': line.discount_percentage,
+            }
+
             if line.value == 'fixed':
-                company_amt = sign * company_currency.round(line.value_amount)
-                foreign_amt = sign * currency.round(line.value_amount)
+                term_vals['company_amount'] = sign * company_currency.round(line.value_amount)
+                term_vals['foreign_amount'] = sign * currency.round(line.value_amount)
+                line_tax_amount = line_tax_amount_currency = line_untaxed_amount = line_untaxed_amount_currency = 0.0
             elif line.value == 'percent':
-                company_amt = company_currency.round(company_value * (line.value_amount / 100.0))
-                foreign_amt = currency.round(foreign_value * (line.value_amount / 100.0))
-            elif line.value == 'balance':
-                company_amt = company_currency.round(company_amount)
-                foreign_amt = currency.round(foreign_amount)
-            result.append((line._get_due_date(date_ref), (company_amt, foreign_amt)))
-            company_amount -= company_amt
-            foreign_amt -= foreign_amount
-        company_amount = sum(company_amt for _, (company_amt, _) in result)
-        company_dist = company_currency.round(company_value - company_amount)
-        foreign_amount = sum(foreign_amt for _, (_, foreign_amt) in result)
-        foreign_dist = currency.round(foreign_value - foreign_amount)
-        if company_dist or foreign_dist:
-            last_date = result and result[-1][0] or fields.Date.context_today(self)
-            result.append((last_date, (company_dist, foreign_dist)))
+                term_vals['company_amount'] = company_currency.round(total_amount * (line.value_amount / 100.0))
+                term_vals['foreign_amount'] = currency.round(total_amount_currency * (line.value_amount / 100.0))
+                line_tax_amount = company_currency.round(tax_amount * (line.value_amount / 100.0))
+                line_tax_amount_currency = currency.round(tax_amount_currency * (line.value_amount / 100.0))
+                line_untaxed_amount = term_vals['company_amount'] - line_tax_amount
+                line_untaxed_amount_currency = term_vals['foreign_amount'] - line_tax_amount_currency
+            else:
+                line_tax_amount = line_tax_amount_currency = line_untaxed_amount = line_untaxed_amount_currency = 0.0
+
+            tax_amount_left -= line_tax_amount
+            tax_amount_currency_left -= line_tax_amount_currency
+            untaxed_amount_left -= line_untaxed_amount
+            untaxed_amount_currency_left -= line_untaxed_amount_currency
+
+            if line.value == 'balance':
+                term_vals['company_amount'] = tax_amount_left + untaxed_amount_left
+                term_vals['foreign_amount'] = tax_amount_currency_left + untaxed_amount_currency_left
+                line_tax_amount = tax_amount_left
+                line_tax_amount_currency = tax_amount_currency_left
+                line_untaxed_amount = untaxed_amount_left
+                line_untaxed_amount_currency = untaxed_amount_currency_left
+
+            if line.discount_percentage:
+                if company.early_pay_discount_computation in ('excluded', 'mixed'):
+                    term_vals['discount_balance'] = company_currency.round(term_vals['company_amount'] - line_untaxed_amount * line.discount_percentage / 100.0)
+                    term_vals['discount_amount_currency'] = currency.round(term_vals['foreign_amount'] - line_untaxed_amount_currency * line.discount_percentage / 100.0)
+                else:
+                    term_vals['discount_balance'] = company_currency.round(term_vals['company_amount'] * (1 - (line.discount_percentage / 100.0)))
+                    term_vals['discount_amount_currency'] = currency.round(term_vals['foreign_amount'] * (1 - (line.discount_percentage / 100.0)))
+                term_vals['discount_date'] = date_ref + relativedelta(days=line.discount_days)
+
+            result.append(term_vals)
         return result
 
     @api.ondelete(at_uninstall=False)
@@ -139,6 +209,8 @@ class AccountPaymentTermLine(models.Model):
     days = fields.Integer(string='Days', required=True, default=0)
     end_month = fields.Boolean(string='End of month', help="Switch to end of the month after having added months or days")
     days_after = fields.Integer(string='Days after End of month', help="Days to add after the end of the month")
+    discount_percentage = fields.Float(string='Discount %', help='Early Payment Discount granted for this line')
+    discount_days = fields.Integer(string='Discount Days', help='Number of days before the early payment proposition expires')
     payment_id = fields.Many2one('account.payment.term', string='Payment Terms', required=True, index=True, ondelete='cascade')
 
     def _get_due_date(self, date_ref):
@@ -150,14 +222,18 @@ class AccountPaymentTermLine(models.Model):
             due_date += relativedelta(days=self.days_after)
         return due_date
 
-    @api.constrains('value', 'value_amount')
+    @api.constrains('value', 'value_amount', 'discount_percentage')
     def _check_percent(self):
         for term_line in self:
             if term_line.value == 'percent' and (term_line.value_amount < 0.0 or term_line.value_amount > 100.0):
                 raise ValidationError(_('Percentages on the Payment Terms lines must be between 0 and 100.'))
+            if term_line.discount_percentage and (term_line.discount_percentage < 0.0 or term_line.discount_percentage > 100.0):
+                raise ValidationError(_('Discount percentages on the Payment Terms lines must be between 0 and 100.'))
 
-    @api.constrains('months', 'days', 'days_after')
+    @api.constrains('months', 'days', 'days_after', 'discount_days')
     def _check_positive(self):
         for term_line in self:
             if term_line.months < 0 or term_line.days < 0:
                 raise ValidationError(_('The Months and Days of the Payment Terms lines must be positive.'))
+            if term_line.discount_days < 0:
+                raise ValidationError(_('The discount days of the Payment Terms lines must be positive.'))

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -810,12 +810,16 @@ class AccountTax(models.Model):
         }
 
     @api.model
-    def _compute_taxes_for_single_line(self, base_line, handle_price_include=True, include_caba_tags=False):
+    def _compute_taxes_for_single_line(self, base_line, handle_price_include=True, include_caba_tags=False, early_pay_discount_computation=None, early_pay_discount_percentage=None):
         orig_price_unit_after_discount = base_line['price_unit'] * (1 - (base_line['discount'] / 100.0))
         price_unit_after_discount = orig_price_unit_after_discount
         taxes = base_line['taxes']._origin
         currency = base_line['currency'] or self.env.company.currency_id
         rate = base_line['rate']
+
+        if early_pay_discount_computation in ('included', 'excluded'):
+            remaining_part_to_consider = (100 - early_pay_discount_percentage) / 100.0
+            price_unit_after_discount = remaining_part_to_consider * price_unit_after_discount
 
         if taxes:
 
@@ -840,6 +844,22 @@ class AccountTax(models.Model):
                 'price_subtotal': taxes_res['total_excluded'],
                 'price_total': taxes_res['total_included'],
             }
+
+            if early_pay_discount_computation == 'excluded':
+                new_taxes_res = taxes.with_context(**base_line['extra_context']).compute_all(
+                    orig_price_unit_after_discount,
+                    currency=currency,
+                    quantity=base_line['quantity'],
+                    product=base_line['product'],
+                    partner=base_line['partner'],
+                    is_refund=base_line['is_refund'],
+                    handle_price_include=manage_price_include,
+                    include_caba_tags=include_caba_tags,
+                )
+                for tax_res, new_taxes_res in zip(taxes_res['taxes'], new_taxes_res['taxes']):
+                    delta_tax = new_taxes_res['amount'] - tax_res['amount']
+                    tax_res['amount'] += delta_tax
+                    to_update_vals['price_total'] += delta_tax
 
             tax_values_list = []
             for tax_res in taxes_res['taxes']:
@@ -1180,6 +1200,8 @@ class AccountTax(models.Model):
 
         amount_total = amount_untaxed + amount_tax
 
+        display_tax_base = len(global_tax_details['tax_details']) == 1 and tax_group_vals['base_amount'] != amount_untaxed
+
         return {
             'amount_untaxed': amount_untaxed,
             'amount_total': amount_total,
@@ -1188,6 +1210,7 @@ class AccountTax(models.Model):
             'groups_by_subtotal': groups_by_subtotal,
             'subtotals': subtotals,
             'subtotals_order': sorted(subtotal_order.keys(), key=lambda k: subtotal_order[k]),
+            'display_tax_base': display_tax_base
         }
 
     @api.model

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -146,6 +146,9 @@ class AccountChartTemplate(models.Model):
     default_cash_difference_expense_account_id = fields.Many2one('account.account.template', string="Cash Difference Expense Account")
     default_pos_receivable_account_id = fields.Many2one('account.account.template', string="PoS receivable account")
 
+    account_journal_early_pay_discount_loss_account_id = fields.Many2one(comodel_name='account.account.template', string='Cash Discount Write-Off Loss Account', )
+    account_journal_early_pay_discount_gain_account_id = fields.Many2one(comodel_name='account.account.template', string='Cash Discount Write-Off Gain Account', )
+
     property_account_receivable_id = fields.Many2one('account.account.template', string='Receivable Account')
     property_account_payable_id = fields.Many2one('account.account.template', string='Payable Account')
     property_account_expense_categ_id = fields.Many2one('account.account.template', string='Category of Expense Account')
@@ -204,6 +207,24 @@ class AccountChartTemplate(models.Model):
             'name': _("Bank Suspense Account"),
             'code': self.env['account.account']._search_new_account_code(company, code_digits, company.bank_account_code_prefix or ''),
             'account_type': 'asset_current',
+            'company_id': company.id,
+        })
+
+    @api.model
+    def _create_cash_discount_loss_account(self, company, code_digits):
+        return self.env['account.account'].create({
+            'name': _("Cash Discount Write-Off Loss Account"),
+            'code': 999997,
+            'account_type': 'expense',
+            'company_id': company.id,
+        })
+
+    @api.model
+    def _create_cash_discount_gain_account(self, company, code_digits):
+        return self.env['account.account'].create({
+            'name': _("Cash Discount Write-Off Gain Account"),
+            'code': 999998,
+            'account_type': 'income_other',
             'company_id': company.id,
         })
 
@@ -316,6 +337,14 @@ class AccountChartTemplate(models.Model):
 
         # Install all the templates objects and generate the real objects
         acc_template_ref, taxes_ref = self._install_template(company, code_digits=self.code_digits)
+
+        # Set default cash discount write-off accounts
+        if not company.account_journal_early_pay_discount_loss_account_id:
+            company.account_journal_early_pay_discount_loss_account_id = self._create_cash_discount_loss_account(
+                company, self.code_digits)
+        if not company.account_journal_early_pay_discount_gain_account_id:
+            company.account_journal_early_pay_discount_gain_account_id = self._create_cash_discount_gain_account(
+                company, self.code_digits)
 
         # Set default cash difference account on company
         if not company.account_journal_suspense_account_id:

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -65,6 +65,13 @@ class ResCompany(models.Model):
     account_journal_suspense_account_id = fields.Many2one('account.account', string='Journal Suspense Account')
     account_journal_payment_debit_account_id = fields.Many2one('account.account', string='Journal Outstanding Receipts Account')
     account_journal_payment_credit_account_id = fields.Many2one('account.account', string='Journal Outstanding Payments Account')
+    account_journal_early_pay_discount_gain_account_id = fields.Many2one(comodel_name='account.account', string='Cash Discount Write-Off Gain Account')
+    account_journal_early_pay_discount_loss_account_id = fields.Many2one(comodel_name='account.account', string='Cash Discount Write-Off Loss Account')
+    early_pay_discount_computation = fields.Selection([
+        ('included', 'On early payment'),
+        ('excluded', 'Never'),
+        ('mixed', 'Always (upon invoice)')
+    ], string='Cash Discount Tax Reduction', default='included', readonly=False)
     transfer_account_code_prefix = fields.Char(string='Prefix of the transfer accounts')
     account_sale_tax_id = fields.Many2one('account.tax', string="Default Sale Tax")
     account_purchase_tax_id = fields.Many2one('account.tax', string="Default Purchase Tax")

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -159,6 +159,24 @@ class ResConfigSettings(models.TransientModel):
     # Quick encoding (fiduciary mode)
     quick_edit_mode = fields.Selection(string="Quick encoding", readonly=False, related='company_id.quick_edit_mode')
 
+    early_pay_discount_computation = fields.Selection(related='company_id.early_pay_discount_computation', string='Tax setting', readonly=False)
+    account_journal_early_pay_discount_loss_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Cash Discount Loss account',
+        help='Account for the difference amount after the expense discount has been granted',
+        readonly=False,
+        related='company_id.account_journal_early_pay_discount_loss_account_id',
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id), ('account_type', 'in', ('expense', 'income', 'income_other'))]",
+    )
+    account_journal_early_pay_discount_gain_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Cash Discount Gain account',
+        help='Account for the difference amount after the income discount has been granted',
+        readonly=False,
+        related='company_id.account_journal_early_pay_discount_gain_account_id',
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id), ('account_type', 'in', ('income', 'income_other', 'expense'))]",
+    )
+
     def set_values(self):
         super().set_values()
         # install a chart of accounts for the given company (if required)

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -36,3 +36,4 @@ from . import test_account_incoming_supplier_invoice
 from . import test_payment_term
 from . import test_account_payment_register
 from . import test_tour
+from . import test_early_payment_discount

--- a/addons/account/tests/test_account_move_line_tax_details.py
+++ b/addons/account/tests/test_account_move_line_tax_details.py
@@ -62,7 +62,7 @@ class TestAccountTaxDetailsReport(AccountTestInvoicingCommon):
             'amount': 5.0,
         })
 
-        invoice = self.env['account.move'].create({
+        invoice_create_values = {
             'move_type': 'out_invoice',
             'partner_id': self.partner_a.id,
             'invoice_date': '2019-01-01',
@@ -92,7 +92,9 @@ class TestAccountTaxDetailsReport(AccountTestInvoicingCommon):
                     'tax_ids': [Command.set((tax_20_affect + tax_10).ids)],
                 }),
             ]
-        })
+        }
+
+        invoice = self.env['account.move'].create(invoice_create_values)
         base_lines, tax_lines = self._dispatch_move_lines(invoice)
 
         tax_details = self._get_tax_details()
@@ -168,15 +170,12 @@ class TestAccountTaxDetailsReport(AccountTestInvoicingCommon):
             'children_tax_ids': [Command.set((tax_20_affect + tax_10 + tax_5).ids)],
         })
 
-        invoice.write({
-            'invoice_line_ids': [Command.update(base_lines[0].id, {
-                'tax_ids': [Command.set(tax_group.ids)],
-            })],
-        })
+        invoice_create_values['invoice_line_ids'][0][2]['tax_ids'] = [Command.set(tax_group.ids)]
+        invoice = self.env['account.move'].create(invoice_create_values)
 
         base_lines, tax_lines = self._dispatch_move_lines(invoice)
 
-        tax_details = self._get_tax_details()
+        tax_details = self._get_tax_details(extra_domain=[('move_id', '=', invoice.id)])
         self.assertTaxDetailsValues(tax_details, [
             {
                 'base_line_id': base_lines[0].id,

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import fields, Command
+
+
+@tagged('post_install', '-at_install')
+class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        # Payment Terms
+        cls.early_pay_10_percents_10_days = cls.env['account.payment.term'].create({
+            'name': '10% discount if paid within 10 days',
+            'company_id': cls.company_data['company'].id,
+            'line_ids': [Command.create({
+                'value': 'balance',
+                'days': 0,
+                'discount_percentage': 10,
+                'discount_days': 10
+            })]
+        })
+
+        cls.early_pay_mixed_5_10 = cls.env['account.payment.term'].create({
+            'name': '5 percent discount on 50% of the amount, 10% on the balance, if payed within 10 days',
+            'company_id': cls.company_data['company'].id,
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50,
+                    'days': 30,
+                    'discount_percentage': 5,
+                    'discount_days': 10
+                }),
+                Command.create({
+                    'value': 'balance',
+                    'days': 30,
+                    'discount_percentage': 10,
+                    'discount_days': 10
+                })],
+        })
+
+    # ========================== Tests Payment Terms ==========================
+    def test_early_payment_end_date(self):
+        inv_1200_10_percents_discount_no_tax = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [Command.create({
+                'name': 'line', 'price_unit': 1200.0, 'tax_ids': []
+            })],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        for line in inv_1200_10_percents_discount_no_tax.line_ids:
+            if line.display_type == 'payment_term':
+                self.assertEqual(
+                    line.discount_date,
+                    fields.Date.from_string('2019-01-11') or False
+                )
+
+    # ========================== Tests Payment Register ==========================
+    def test_register_discounted_payment_on_single_invoice(self):
+        self.company_data['company'].early_pay_discount_computation = 'included'
+        out_invoice_1 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        out_invoice_1.action_post()
+        active_ids = out_invoice_1.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2017-01-01',
+        })._create_payments()
+
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -1000.0},
+            {
+                'account_id': self.env.company['account_journal_early_pay_discount_loss_account_id'].id,
+                'amount_currency': 100.0,
+            },
+            {'amount_currency': 900.0},
+        ])
+
+    def test_register_discounted_payment_on_single_invoice_with_tax(self):
+        self.company_data['company'].early_pay_discount_computation = 'included'
+        inv_1500_10_percents_discount_tax_incl_15_percents_tax = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [Command.create({'name': 'line', 'price_unit': 1500.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        inv_1500_10_percents_discount_tax_incl_15_percents_tax.action_post()
+        active_ids = inv_1500_10_percents_discount_tax_incl_15_percents_tax.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2017-01-01',
+        })._create_payments()
+
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -1552.5},
+            {'amount_currency': -150.0},
+            {'amount_currency': -22.5},
+            {'amount_currency': 1725.0},
+        ])
+
+    def test_register_discounted_payment_multi_line_discount(self):
+        self.company_data['company'].early_pay_discount_computation = 'included'
+        inv_mixed_lines_discount_and_no_discount = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({'name': 'line', 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]}),
+                Command.create({'name': 'line', 'price_unit': 2000.0, 'tax_ids': None})
+            ],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        inv_mixed_lines_discount_and_no_discount.action_post()
+        active_ids = inv_mixed_lines_discount_and_no_discount.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2017-01-01',
+            'group_payment': True
+        })._create_payments()
+
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -2835.0},
+            {'amount_currency': -200.0},
+            {'amount_currency': -100.0},
+            {'amount_currency': -15.0},
+            {'amount_currency': 3150.0},
+        ])
+
+    def test_register_discounted_payment_multi_line_multi_discount(self):
+        self.company_data['company'].early_pay_discount_computation = 'included'
+        inv_mixed_lines_multi_discount = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({'name': 'line', 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]}),
+                Command.create({'name': 'line', 'price_unit': 2000.0, 'tax_ids': None})
+            ],
+            'invoice_payment_term_id': self.early_pay_mixed_5_10.id,
+        })
+        inv_mixed_lines_multi_discount.action_post()
+        active_ids = inv_mixed_lines_multi_discount.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move',
+                                                                     active_ids=active_ids).create({
+            'payment_date': '2019-01-01',
+            'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -2913.75},
+            {'amount_currency': -150.0},
+            {'amount_currency': -75},
+            {'amount_currency': -11.25},
+            {'amount_currency': 3150.0},
+        ])
+
+    def test_register_discounted_payment_multi_line_multi_discount_tax_excluded(self):
+        self.company_data['company'].early_pay_discount_computation = 'excluded'
+        inv_mixed_lines_multi_discount = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({'name': 'line', 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]}),
+                Command.create({'name': 'line', 'price_unit': 2000.0, 'tax_ids': None})
+            ],
+            'invoice_payment_term_id': self.early_pay_mixed_5_10.id,
+        })
+        inv_mixed_lines_multi_discount.action_post()
+        active_ids = inv_mixed_lines_multi_discount.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move',
+                                                                     active_ids=active_ids).create({
+            'payment_date': '2019-01-01',
+            'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -2925.00},
+            {'amount_currency': -225},
+            {'amount_currency': 3150.0},
+        ])
+
+    def test_register_discounted_payment_multi_line_multi_discount_tax_mixed(self):
+        self.env.company.early_pay_discount_computation = 'mixed'
+        inv_mixed_lines_multi_discount = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({'name': 'line', 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]}),
+                Command.create({'name': 'line', 'price_unit': 2000.0, 'tax_ids': None})
+            ],
+            'invoice_payment_term_id': self.early_pay_mixed_5_10.id,
+        })
+        inv_mixed_lines_multi_discount.action_post()
+        active_ids = inv_mixed_lines_multi_discount.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-01', 'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -2902.50},
+            {'amount_currency': -225.0},
+            {'amount_currency': 3127.50},
+        ])
+
+    def test_register_discounted_payment_multi_line_multi_discount_tax_mixed_too_late(self):
+        self.env.company.early_pay_discount_computation = 'mixed'
+        inv_mixed_lines_multi_discount = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({'name': 'line', 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]}),
+                Command.create({'name': 'line', 'price_unit': 2000.0, 'tax_ids': None})
+            ],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        inv_mixed_lines_multi_discount.action_post()
+        active_ids = inv_mixed_lines_multi_discount.ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-31', 'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -3135.00},
+            {'amount_currency': 3135.00},
+        ])
+
+    def test_register_payment_batch_included(self):
+        self.env.company.early_pay_discount_computation = 'included'
+        out_invoice_1 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        out_invoice_2 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+
+        (out_invoice_1 + out_invoice_2).action_post()
+        active_ids = (out_invoice_1 + out_invoice_2).ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-01', 'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -3000.0},
+            {'amount_currency': 300.0},
+            {'amount_currency': 2700},
+        ])
+
+    def test_register_payment_batch_excluded(self):
+        self.env.company.early_pay_discount_computation = 'excluded'
+        out_invoice_1 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        out_invoice_2 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+
+        (out_invoice_1 + out_invoice_2).action_post()
+        active_ids = (out_invoice_1 + out_invoice_2).ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-01', 'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -3150.0},
+            {'amount_currency': 300.0},
+            {'amount_currency': 2850},
+        ])
+
+    def test_register_payment_batch_mixed(self):
+        self.env.company.early_pay_discount_computation = 'mixed'
+        out_invoice_1 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        out_invoice_2 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+
+        (out_invoice_1 + out_invoice_2).action_post()
+        active_ids = (out_invoice_1 + out_invoice_2).ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-01', 'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -3135.0},
+            {'amount_currency': 300.0},
+            {'amount_currency': 2835.0},
+        ])
+
+    def test_register_payment_batch_mixed_one_too_late(self):
+        self.env.company.early_pay_discount_computation = 'mixed'
+        out_invoice_1 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        out_invoice_2 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+
+        (out_invoice_1 + out_invoice_2).action_post()
+        active_ids = (out_invoice_1 + out_invoice_2).ids
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-01', 'group_payment': True
+        })._create_payments()
+        self.assertTrue(payments.is_reconciled)
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -3135.0},
+            {'amount_currency': 200.0},
+            {'amount_currency': 2935.0},
+
+        ])

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -110,6 +110,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 3600,
             'amount_untaxed': 3000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -144,6 +145,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 3600,
             'amount_untaxed': 3000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -177,6 +179,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 1000,
             'amount_untaxed': 1000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -222,6 +225,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 3620,
             'amount_untaxed': 3000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -256,6 +260,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 3620,
             'amount_untaxed': 3000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -307,6 +312,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 2750,
             'amount_untaxed': 2000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -341,6 +347,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 2750,
             'amount_untaxed': 2000,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -392,6 +399,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 2846,
             'amount_untaxed': 2300,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {
@@ -477,6 +485,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         self.assertTaxTotals(document, {
             'amount_total': 1867,
             'amount_untaxed': 1500,
+            'display_tax_base': False,
             'groups_by_subtotal': {
                 'Untaxed Amount': [
                     {

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -181,6 +181,8 @@
                     <field name="debit" sum="Total Debit" readonly="1"/>
                     <field name="credit" sum="Total Credit" readonly="1"/>
                     <field name="tax_tag_ids" string="Tax Grids" widget="many2many_tags" width="0.5" optional="hide"/>
+                    <field name="discount_date" string="Discount Date"/>
+                    <field name="discount_amount_currency" string="Discount Amount"/>
                     <field name="tax_line_id" string="Originator Tax" optional="hide" readonly="1"/>
                     <field name="date_maturity" optional="hide"/>
                     <field name="balance" sum="Total Balance" optional="hide" readonly="1"/>
@@ -1096,6 +1098,14 @@
                                                sum="Total Credit"
                                                attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))], 'readonly': [('parent.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')), ('display_type', 'in', ('line_section', 'line_note', 'product'))]}"/>
                                         <field name="balance" invisible="1"/>
+                                        <field name="discount_date"
+                                               string="Discount Date"
+                                               optional="hide"
+                                        />
+                                        <field name="discount_amount_currency"
+                                               string="Discount Amount"
+                                               optional="hide"
+                                        />
 
                                         <field name="tax_tag_ids"
                                                widget="many2many_tags"

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -38,13 +38,16 @@
                         <group>
                             <group>
                                 <field name="name"/>
-                                <field name="display_on_invoice"/>
                             </group>
                             <group>
                                 <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             </group>
                         </group>
-                        <field name="note" placeholder="Payment term explanation for the customer..."/>
+                        <group>
+                            <field name="note" placeholder="Payment term explanation for the customer..."/>
+                        </group>
+                        <label for="display_on_invoice"/>
+                        <field name="display_on_invoice"/>
                         <separator string="Terms"/>
                         <p class="text-muted">
                             The last line's computation type should be "Balance" to ensure that the whole amount will be allocated.
@@ -57,6 +60,8 @@
                                 <field name="days"/>
                                 <field name="end_month" widget="boolean_toggle"/>
                                 <field name="days_after" attrs="{'invisible': [('end_month','=', False)]}"/>
+                                <field name="discount_percentage"/>
+                                <field name="discount_days"/>
                             </tree>
                         </field>
 

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -197,18 +197,39 @@
                             </div>
                         </div>
                     </div>
-                    <p t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference" name="payment_communication">
+                    <p t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference" name="payment_communication" class="mt-4">
                         Please use the following communication for your payment : <b><span t-field="o.payment_reference"/></b>
                     </p>
-                    <div t-if="o.invoice_payment_term_id" name="payment_term">
-                        <div t-field="o.invoice_payment_term_id.note"/>
-                        <t t-set="terms" t-value="o.invoice_payment_term_id.compute(o.amount_total, o.amount_total_in_currency_signed, o.invoice_date, o.currency_id)"/>
-                        <t t-if="o.invoice_payment_term_id.display_on_invoice" t-foreach="o.invoice_payment_term_id._get_amount_by_date(terms, o.currency_id).items()" t-as="pay_term_line">
-                            <div>
-                                <span t-esc="pay_term_line[1]" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/> are due on <span t-esc="pay_term_line[0]"/>
+                    <t t-set="payment_term_details" t-value="o.payment_term_details"/>
+                    <div t-field="o.invoice_payment_term_id.note" name="payment_term"/>
+                    <t t-if="o.invoice_payment_term_id.display_on_invoice and payment_term_details">
+                        <div t-if='o.show_payment_term_details' id="total_payment_term_details_table" class="row">
+                            <div t-attf-class="#{'col-7' if report_type != 'html' else 'col-sm-7 col-md-6'} mt-2 mb-2">
+                                <table class="table table-sm" style="page-break-inside: avoid;">
+                                    <th class="border-black text-start">
+                                        Due Date
+                                    </th>
+                                    <th class="border-black text-end">
+                                        Amount Due
+                                    </th>
+                                    <th t-if="o.show_discount_details" class="border-black text-end">
+                                        Discount
+                                    </th>
+                                    <t t-foreach="payment_term_details" t-as="term">
+                                        <tr>
+                                            <td t-esc="term.get('date')" class="text-start"/>
+                                            <td t-options='{"widget": "monetary", "display_currency": o.currency_id}' t-esc="term.get('amount')" class="text-end"/>
+                                            <td t-if="term.get('discount_date')" class="text-end">
+                                                <span t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                                      t-esc="term.get('discount_amount_currency')"/> if paid before
+                                                <span t-esc="term.get('discount_date')"/>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                </table>
                             </div>
-                        </t>
-                    </div>
+                        </div>
+                    </t>
                     <div t-if="not is_html_empty(o.narration)" name="comment">
                         <span t-field="o.narration"/>
                     </div>
@@ -289,7 +310,7 @@
             -->
             <t t-foreach="tax_totals['groups_by_subtotal'][subtotal_to_show]" t-as="amount_by_group">
                 <tr>
-                    <t t-if="len(tax_totals['groups_by_subtotal'][subtotal_to_show]) > 1 or (tax_totals['amount_untaxed'] != amount_by_group['tax_group_base_amount'])">
+                    <t t-if="tax_totals['display_tax_base']">
                         <td>
                             <span t-esc="amount_by_group['tax_group_name']"/>
                             <span class="text-nowrap"> on

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -82,6 +82,19 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane"/>
+                                <div class="o_setting_right_pane">
+                                    <span class="o_form_label">Cash Discount Tax computation</span>
+                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                    <div class="text-muted">
+                                        When will the tax be reduced when offering a cash discount
+                                    </div>
+                                    <div class="content-group">
+                                        <field name="early_pay_discount_computation"/>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="taxcloud_settings">
                                 <div class="o_setting_left_pane">
                                     <field name="module_account_taxcloud" widget="upgrade_boolean"/>
@@ -523,8 +536,12 @@
                                                 <field name="account_journal_payment_credit_account_id"/>
                                             </div>
                                             <div class="row mt8">
-                                                <label for="transfer_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="transfer_account_id"/>
+                                                <label for="account_journal_early_pay_discount_gain_account_id" class="col-lg-5 o_light_label"/>
+                                                <field name="account_journal_early_pay_discount_gain_account_id"/>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="account_journal_early_pay_discount_loss_account_id" class="col-lg-5 o_light_label"/>
+                                                <field name="account_journal_early_pay_discount_loss_account_id"/>
                                             </div>
                                         </div>
                                     </div>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -11,6 +11,7 @@
                     <field name="line_ids" invisible="1"/>
                     <field name="can_edit_wizard" invisible="1" force_save="1"/>
                     <field name="can_group_payments" invisible="1" force_save="1"/>
+                    <field name="early_payment_discount_mode" invisible="1" force_save="1"/>
                     <field name="payment_type" invisible="1" force_save="1"/>
                     <field name="partner_type" invisible="1" force_save="1"/>
                     <field name="source_amount" invisible="1" force_save="1"/>
@@ -26,7 +27,11 @@
                     <field name="available_payment_method_line_ids" invisible="1"/>
                     <field name="available_partner_bank_ids" invisible="1"/>
                     <field name="company_currency_id" invisible="1"/>
+                    <field name="hide_writeoff_section" invisible="1"/>
 
+                    <div role="alert" class="alert alert-info" attrs="{'invisible': [('hide_writeoff_section', '=', False)]}">
+                        <p><b>Early Payment Discount applied.</b></p>
+                    </div>
                     <group>
                         <group name="group1">
                             <field name="journal_id" options="{'no_open': True, 'no_create': True}" required="1"/>
@@ -60,12 +65,12 @@
                             <div>
                                 <field name="payment_difference"/>
                                 <field name="payment_difference_handling" widget="radio" nolabel="1"/>
-                                <div attrs="{'invisible': [('payment_difference_handling','=','open')]}">
+                                <div attrs="{'invisible': ['|', ('hide_writeoff_section', '=', True), ('payment_difference_handling','=','open')]}">
                                     <label for="writeoff_account_id" string="Post Difference In" class="oe_edit_only"/>
                                     <field name="writeoff_account_id"
                                            string="Post Difference In"
                                            options="{'no_create': True}"
-                                           attrs="{'required': [('payment_difference_handling', '=', 'reconcile')]}"/>
+                                           attrs="{'required': [('payment_difference_handling', '=', 'reconcile'), ('early_payment_discount_mode', '=', False)]}"/>
                                     <label for="writeoff_label" class="oe_edit_only" string="Label"/>
                                     <field name="writeoff_label" attrs="{'required': [('payment_difference_handling', '=', 'reconcile')]}"/>
                                 </div>

--- a/addons/account_payment/wizards/account_payment_register.py
+++ b/addons/account_payment/wizards/account_payment_register.py
@@ -86,8 +86,8 @@ class AccountPaymentRegister(models.TransientModel):
     # BUSINESS METHODS
     # -------------------------------------------------------------------------
 
-    def _create_payment_vals_from_wizard(self):
+    def _create_payment_vals_from_wizard(self, batch_result):
         # OVERRIDE
-        payment_vals = super()._create_payment_vals_from_wizard()
+        payment_vals = super()._create_payment_vals_from_wizard(batch_result)
         payment_vals['payment_token_id'] = self.payment_token_id.id
         return payment_vals

--- a/addons/sale/wizard/account_payment_register.py
+++ b/addons/sale/wizard/account_payment_register.py
@@ -6,8 +6,8 @@ from odoo import models
 class AccountPaymentRegister(models.TransientModel):
     _inherit = 'account.payment.register'
 
-    def _create_payment_vals_from_wizard(self):
-        vals = super()._create_payment_vals_from_wizard()
+    def _create_payment_vals_from_wizard(self, batch_result):
+        vals = super()._create_payment_vals_from_wizard(batch_result)
         # Make sure the account move linked to generated payment
         # belongs to the expected sales team
         # team_id field on account.payment comes from the `_inherits` on account.move model


### PR DESCRIPTION
Purpose :
Improve multiple use cases while handling the Accounting part of Cash Discounts in Odoo.

When creating a Payment Term, the user can now specifically design an early payment discount for each payment term lines.
The user can choose between three different kind of tax computation for the discount. If the conditions for the cash discount are fulfilled, the tax will either be:
- included : the tax and base amounts will be discounted.
- excluded : the tax will be left untouched, the base amount will be discounted.
- mixed : the tax is durably discounted, the base is discounted if the early payment occurs.

The discounted amount and the conditions to fulfill are printed below the invoice PDF if the option to do so is checked.

Took the opportunity to improve the display of the payment terms on the invoice in general.

Registering a payment while filling the condition for an early payment discount will prefill the fields accordingly.

The Journal Items in the account.move, the payment and the reconciliation are modified as needed to take the discount into account.

Reconciliation --> In the reconciliation widget, the logic of Early Payments Discounts is also applied to allow as often as possible for an automatic reconciliation.

Related : https://github.com/odoo/enterprise/pull/28607
Task-2968644

