### PR TITLE
[IMP] web, *: introduce `o-avatar-[size]` classes

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -111,7 +111,7 @@
                                         <field name="name"/>
                                     </em>
                                     <div class="col-2 text-end">
-                                        <img t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)" t-att-title="record.partner_id.value" t-att-alt="record.partner_id.value" class="oe_kanban_avatar o_image_24_cover"/>
+                                        <img t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)" t-att-title="record.partner_id.value" t-att-alt="record.partner_id.value" class="oe_kanban_avatar avatar-size"/>
                                     </div>
                                 </div>
                                 <div class="row">

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -118,7 +118,7 @@
                                 </strong></div>
                                 <div class="row">
                                     <div class="col flex-grow-0 pe-2">
-                                        <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(invoice.invoice_user_id.avatar_1024)" alt="Contact"/>
+                                        <img class="o_portal_contact_img avatar-size avatar-size-lg mt-1 rounded-circle" t-att-src="image_data_uri(invoice.invoice_user_id.avatar_1024)" alt="Contact"/>
                                     </div>
                                     <div class="col ps-0">
                                         <span t-field="invoice.invoice_user_id" t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True}'/>

--- a/addons/calendar/static/src/js/base_calendar.js
+++ b/addons/calendar/static/src/js/base_calendar.js
@@ -33,7 +33,7 @@ const Many2ManyAttendee = FieldMany2ManyTagsAvatar.extend({
     // context probably won't work
     // supportedFieldTypes: ['many2many'],
     specialData: "_fetchSpecialAttendeeStatus",
-    className: 'o_field_many2manytags avatar',
+    className: 'o_field_many2manytags avatar_wrap',
 
     init: function () {
         this._super.apply(this, arguments);

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -171,7 +171,7 @@
                 <field name="purchaser_id"/>
                 <templates>
                     <div t-name="activity-box">
-                        <img t-att-src="activity_image('res.partner', 'avatar_128', record.purchaser_id.raw_value)" t-att-title="record.purchaser_id.value" t-att-alt="record.purchaser_id.value"/>
+                        <img t-att-src="activity_image('res.partner', 'avatar_128', record.purchaser_id.raw_value)" t-att-title="record.purchaser_id.value" t-att-alt="record.purchaser_id.value" class="avatar-size avatar-size-lg"/>
                         <div>
                             <field name="vehicle_id" display="full"/>
                         </div>

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -149,7 +149,7 @@
                                     <em t-out="record.description.value"/>
                                     <div>
                                         <t t-foreach="record.unique_owner_ids.raw_value.slice(0,11)" t-as="owner" t-key="owner">
-                                            <img class="oe_kanban_avatar o_image_24_cover rounded-circle" t-att-src="kanban_image('res.users', 'avatar_128', owner)" t-att-data-member_id="owner" alt="Owner"/>
+                                            <img class="oe_kanban_avatar avatar-size rounded-circle" t-att-src="kanban_image('res.users', 'avatar_128', owner)" t-att-data-member_id="owner" alt="Owner"/>
                                         </t>
                                     </div>
                                 </div>

--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -169,7 +169,7 @@
                         <div t-attf-class="oe_kanban_card oe_kanban_global_click o_kanban_gamification #{record.end_date.raw_value &lt; record.last_update.raw_value and record.state.raw_value == 'failed' ? 'oe_kanban_color_2' : ''} #{record.end_date.raw_value &lt; record.last_update.raw_value and record.state.raw_value == 'reached' ? 'oe_kanban_color_5' : ''}">
                             <div class="o_kanban_content text-center">
                                 <p><strong><h4 class="oe_goal_name" tooltip="kanban-tooltip"><field name="definition_id" /></h4></strong></p>
-                                <img class="o_image_24_cover me-1 rounded-circle" t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
+                                <img class="avatar-size me-1 rounded-circle" t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
                                 <field name="user_id" class="fw-bold"/>
                                 <div class="o_goal_state_block pt-3 fs-1 fw-bolder">
                                     <t t-if="record.definition_display.raw_value == 'boolean'">

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -223,14 +223,14 @@ QUnit.module('hr', {}, function () {
             res_id: m2xAvatarEmployeeId1,
             views: [[false, 'form']],
         });
-        assert.containsN(document.body, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
+        assert.containsN(document.body, '.o_field_many2manytags.avatar_wrap.o_field_widget .badge', 2,
             "should have 2 records");
-        assert.strictEqual(document.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
+        assert.strictEqual(document.querySelector('.o_field_many2manytags.avatar_wrap.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`,
             "should have correct avatar image");
 
-        await dom.click(document.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
-        await dom.click(document.querySelectorAll('.o_field_many2manytags.avatar .badge .o_m2m_avatar')[1]);
+        await dom.click(document.querySelector('.o_field_many2manytags.avatar_wrap .badge .o_m2m_avatar'));
+        await dom.click(document.querySelectorAll('.o_field_many2manytags.avatar_wrap .badge .o_m2m_avatar')[1]);
 
         assert.verifySteps([
             `read m2x.avatar.employee ${m2xAvatarEmployeeId1}`,
@@ -428,14 +428,14 @@ QUnit.module('hr', {}, function () {
             views: [[false, 'form']],
         });
 
-        assert.containsN(document.body, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
+        assert.containsN(document.body, '.o_field_many2manytags.avatar_wrap.o_field_widget .badge', 2,
             "should have 2 records");
-        assert.strictEqual(document.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
+        assert.strictEqual(document.querySelector('.o_field_many2manytags.avatar_wrap.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`,
             "should have correct avatar image");
 
-        await dom.click(document.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
-        await dom.click(document.querySelectorAll('.o_field_many2manytags.avatar .badge .o_m2m_avatar')[1]);
+        await dom.click(document.querySelector('.o_field_many2manytags.avatar_wrap .badge .o_m2m_avatar'));
+        await dom.click(document.querySelectorAll('.o_field_many2manytags.avatar_wrap .badge .o_m2m_avatar')[1]);
 
         assert.verifySteps([
             `read m2x.avatar.employee ${hrEmployeePublicId1}`,

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -383,7 +383,7 @@
                     <field name="id"/>
                     <templates>
                         <div t-name="activity-box">
-                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.id.raw_value)" role="img" t-att-title="record.id.value" t-att-alt="record.id.value"/>
+                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.id.raw_value)" role="img" t-att-title="record.id.value" t-att-alt="record.id.value" class="avatar-size avatar-size-lg"/>
                             <div>
                                 <field name="name" display="full"/>
                                 <field name="job_id" muted="1" display="full"/>

--- a/addons/hr_attendance/static/src/scss/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/hr_attendance.scss
@@ -20,6 +20,10 @@
 
         .o_hr_attendance_user_badge {
             @include o-position-absolute(auto, $border-width * -1, 100%, $border-width * -1); // Compensate card's border
+
+            .avatar {
+                --avatar-size: 80px;
+            }
         }
     }
 

--- a/addons/hr_attendance/static/src/xml/attendance.xml
+++ b/addons/hr_attendance/static/src/xml/attendance.xml
@@ -19,7 +19,7 @@
 
     <t t-name="HrAttendanceUserBadge">
         <div class="o_hr_attendance_user_badge o_home_menu_background d-flex align-items-end justify-content-center flex-grow-1 pt-5 pt-md-4 bg-odoo">
-            <img class="img rounded-circle mb-n5" t-attf-src="/web/image?model=hr.employee.public&amp;field=avatar_128&amp;id=#{userId}" t-att-title="userName" height="80" t-att-alt="userName"/>
+            <img class="avatar-size img rounded-circle mb-n5" t-attf-src="/web/image?model=hr.employee.public&amp;field=avatar_128&amp;id=#{userId}" t-att-title="userName" t-att-alt="userName"/>
         </div>
     </t>
 

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -28,7 +28,7 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_global_click">
                             <div>
-                                <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="oe_kanban_avatar o_image_24_cover mr4"/>
+                                <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="oe_kanban_avatar avatar-size avatar-size-md mr4 rounded-circle"/>
                                 <span class="o_kanban_record_title">
                                     <strong><t t-esc="record.employee_id.value"/></strong>
                                 </span>

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -297,7 +297,7 @@
                     <field name="employee_id"/>
                     <templates>
                         <div t-name="activity-box">
-                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value"/>
+                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="avatar-size avatar-size-lg"/>
                             <div>
                                 <field name="name" display="full"/>
                                 <field name="job_id" muted="1" display="full"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -369,7 +369,7 @@
                     <field name="currency_id"/>
                     <templates>
                         <div t-name="activity-box">
-                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value"/>
+                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="avatar-size avatar-size-lg"/>
                             <div>
                                 <field name="name" display="full"/>
                                 <field name="total_amount" widget="monetary" muted="1" display="full"/>
@@ -939,7 +939,7 @@
                     <field name="currency_id"/>
                     <templates>
                         <div t-name="activity-box">
-                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value"/>
+                            <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="avatar-size avatar-size-lg"/>
                             <div>
                                 <field name="name" display="full"/>
                                 <field name="total_amount" widget="monetary" muted="1" display="full"/>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -409,7 +409,7 @@
                 <field name="employee_id"/>
                 <templates>
                     <div t-name="activity-box">
-                        <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value"/>
+                        <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="avatar-size avatar-size-lg"/>
                         <div>
                             <field name="employee_id"/>
                             <span class="ms-3 text-muted">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -198,7 +198,7 @@
                 <field name="number_of_days"/>
                 <templates>
                     <div t-name="activity-box">
-                        <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" width="50" height="50"/>
+                        <img t-att-src="activity_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="avatar-size avatar-size-lg"/>
                         <div>
                             <field name="name"/>
                             <span class="ms-3 text-muted">

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.scss
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.scss
@@ -6,15 +6,8 @@
 
     .o_org_chart_entry {
         .o_media_object {
-            width: $o-hr-org-chart-entry-pic-small-size;
-            height: $o-hr-org-chart-entry-pic-small-size;
             background-size: cover;
             background-position: center center;
-        }
-
-        &.o_org_chart_entry_self .o_media_object {
-            width: $o-hr-org-chart-entry-pic-size;
-            height: $o-hr-org-chart-entry-pic-size;
         }
 
         &:not(.o_org_chart_entry_self):hover .o_media_object {

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
@@ -24,7 +24,7 @@
         <!-- NOTE: Since by the default on not squared images odoo add white borders,
             use bg-images to get a clean and centred images -->
         <a t-if="! is_self"
-            class="o_media_object d-block rounded-circle o_employee_redirect"
+            class="o_media_object o_employee_redirect avatar-size avatar-size-xl d-block rounded-circle"
             t-att-style="'background-image:url(\'/web/image/hr.employee.public/' + employee.id + '/avatar_1024/\')'"
             t-att-alt="employee.name"
             t-att-data-employee-id="employee.id"
@@ -32,6 +32,7 @@
             t-on-click.prevent="() => this._onEmployeeRedirect(employee.id)"/>
         <div t-if="is_self"
             class="o_media_object d-block rounded-circle border border-info"
+            t-attf-class="{{ employee_type === 'self' ? 'avatar-size avatar-size-xxl' : 'avatar-size avatar-size-xl' }}"
             t-att-style="'background-image:url(\'/web/image/hr.employee.public/' + employee.id + '/avatar_1024/\')'"/>
     </div>
 

--- a/addons/mail/static/src/components/activity/activity.scss
+++ b/addons/mail/static/src/components/activity/activity.scss
@@ -4,8 +4,6 @@
 
 .o_Activity_detailsUserAvatar {
     object-fit: cover;
-    height: 18px;
-    width: 18px;
 }
 
 .o_Activity_iconContainer {
@@ -14,12 +12,6 @@
 
 .o_Activity_note p {
     margin-bottom: map-get($spacers, 0);
-}
-
-.o_Activity_sidebar {
-    width: $o-mail-thread-avatar-size;
-    min-width: $o-mail-thread-avatar-size;
-    height: $o-mail-thread-avatar-size;
 }
 
 // From python template

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -5,9 +5,9 @@
         <t t-if="activityView">
             <div class="o_Activity d-flex py-2 px-3" t-attf-class="{{ className }}" t-on-click="activityView.onClickActivity" t-ref="root">
                 <div class="o_Activity_sidebar me-3">
-                    <div class="o_Activity_user position-relative h-100 w-100">
+                    <div class="o_Activity_user position-relative">
                         <t t-if="activityView.activity.assignee">
-                            <img class="o_Activity_userAvatar rounded-circle h-100 w-100 o_object_fit_cover" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
+                            <img class="o_Activity_userAvatar avatar-size avatar-size-xl rounded-circle o_object_fit_cover" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
                         </t>
                         <div class="o_Activity_iconContainer d-flex align-items-center justify-content-center rounded-circle w-50 h-50 text-white"
                             t-att-class="{
@@ -71,7 +71,7 @@
                                     <div class="d-md-table-cell fw-bold text-md-end m-0 py-md-1 px-md-4">Created</div>
                                     <div class="o_Activity_detailsCreation d-md-table-cell py-md-1 pe-4">
                                         <t t-esc="activityView.formattedCreateDatetime"/>, <br t-if="messaging.device.isSmall"/>by
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar ms-1 me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView.activity.creator.id }}/avatar_128" t-att-title="activityView.activity.creator.nameOrDisplayName" t-att-alt="activityView.activity.creator.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar avatar-size ms-1 me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView.activity.creator.id }}/avatar_128" t-att-title="activityView.activity.creator.nameOrDisplayName" t-att-alt="activityView.activity.creator.nameOrDisplayName"/>
                                         <b class="o_Activity_detailsCreator">
                                             <t t-esc="activityView.activity.creator.nameOrDisplayName"/>
                                         </b>
@@ -80,7 +80,7 @@
                                 <div t-if="activityView.activity.assignee" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell fw-bold text-md-end m-0 py-md-1 px-md-4">Assigned to</div>
                                     <div class="o_Activity_detailsAssignation d-md-table-cell py-md-1 pe-4">
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-title="activityView.activity.assignee.nameOrDisplayName" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar avatar-size me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-title="activityView.activity.assignee.nameOrDisplayName" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
                                         <b t-esc="activityView.activity.assignee.nameOrDisplayName"/>
                                     </div>
                                 </div>

--- a/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.scss
+++ b/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.scss
@@ -7,8 +7,7 @@
 }
 
 .o_CallInviteRequestPopup_partnerInfoImage {
-    width: 70%;
-    height: 70%;
+    --avatar-size: 70%;
 }
 
 // ------------------------------------------------------------------

--- a/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.xml
+++ b/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.xml
@@ -6,7 +6,7 @@
             <div class="o_CallInviteRequestPopup d-flex flex-column m-2 p-5 border border-dark rounded-1 bg-900" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="callInviteRequestPopup.thread.rtcInvitingSession">
                     <div class="o_CallInviteRequestPopup_partnerInfo d-flex flex-column justify-content-around align-items-center text-nowrap">
-                        <img class="o_CallInviteRequestPopup_partnerInfoImage mb-2 rounded-circle cursor-pointer"
+                        <img class="o_CallInviteRequestPopup_partnerInfoImage avatar-size mb-2 rounded-circle cursor-pointer"
                             t-att-src="callInviteRequestPopup.thread.rtcInvitingSession.channelMember.avatarUrl"
                             t-on-click="callInviteRequestPopup.onClickAvatar"
                             alt="Avatar"/>

--- a/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.scss
+++ b/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.scss
@@ -3,11 +3,6 @@
     object-fit: cover;
 }
 
-.o_ChannelInvitationFormSelectablePartner_avatarContainer {
-    width: 32px;
-    height: 32px;
-}
-
 .o_ChannelInvitationForm_selectablePartnerName {
     min-width: 0;
 }

--- a/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.xml
+++ b/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.ChannelInvitationFormSelectablePartner" owl="1">
         <div class="o_ChannelInvitationFormSelectablePartner d-flex align-items-center px-3 py-1 btn-light" t-on-click="() => channelInvitationFormSelectablePartnerView.channelInvitationFormOwner.onClickSelectablePartner(channelInvitationFormSelectablePartnerView.partner)" t-att-data-partner-id="channelInvitationFormSelectablePartnerView.partner.id" t-attf-class="{{ className }}" t-ref="root">
             <div class="o_ChannelInvitationFormSelectablePartner_avatarContainer position-relative flex-shrink-0">
-                <img class="o_ChannelInvitationFormSelectablePartner_avatar w-100 h-100 rounded-circle" t-att-src="channelInvitationFormSelectablePartnerView.partner.avatarUrl" alt="Avatar"/>
+                <img class="o_ChannelInvitationFormSelectablePartner_avatar avatar-size avatar-size-xl rounded-circle" t-att-src="channelInvitationFormSelectablePartnerView.partner.avatarUrl" alt="Avatar"/>
                 <t t-if="channelInvitationFormSelectablePartnerView.personaImStatusIconView">
                     <PersonaImStatusIcon
                         className="'o_ChannelInvitationFormSelectablePartner_imStatusIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center text-white'"

--- a/addons/mail/static/src/components/channel_member/channel_member.scss
+++ b/addons/mail/static/src/components/channel_member/channel_member.scss
@@ -6,11 +6,6 @@
     object-fit: cover;
 }
 
-.o_ChannelMember_avatarContainer {
-    width: 32px;
-    height: 32px;
-}
-
 .o_ChannelMember_name {
     min-width: 0;
 }

--- a/addons/mail/static/src/components/channel_member/channel_member.xml
+++ b/addons/mail/static/src/components/channel_member/channel_member.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.ChannelMember" owl="1">
         <div class="o_ChannelMember d-flex align-items-center mx-2 p-2" t-att-class="{'cursor-pointer': channelMemberView.hasOpenChat}" t-attf-class="{{ className }}" t-att-data-partner-id="channelMemberView.channelMember.persona.partner and channelMemberView.channelMember.persona.partner.id" t-att-title="channelMemberView.memberTitleText" t-on-click="channelMemberView.onClickMember" t-ref="root">
             <div class="o_ChannelMember_avatarContainer position-relative flex-shrink-0">
-                <img class="o_ChannelMember_avatar rounded-circle w-100 h-100" t-att-src="channelMemberView.channelMember.avatarUrl" alt="Avatar"/>
+                <img class="o_ChannelMember_avatar avatar-size avatar-size-xl rounded-circle" t-att-src="channelMemberView.channelMember.avatarUrl" alt="Avatar"/>
 
                 <t t-if="channelMemberView.personaImStatusIconView">
                     <PersonaImStatusIcon

--- a/addons/mail/static/src/components/channel_preview_view/channel_preview_view.xml
+++ b/addons/mail/static/src/components/channel_preview_view/channel_preview_view.xml
@@ -16,7 +16,7 @@
             >
                 <div class="o_NotificationListItem_sidebar o_ChannelPreviewView_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_ChannelPreviewView_imageContainer o_ChannelPreviewView_sidebarItem position-relative">
-                        <img class="o_NotificationListItem_image o_ChannelPreviewView_image w-100 h-100 rounded-circle" t-att-src="channelPreviewView.imageUrl" alt="Thread Image"/>
+                        <img class="o_NotificationListItem_image o_ChannelPreviewView_image avatar-size avatar-size-xl rounded-circle" t-att-src="channelPreviewView.imageUrl" alt="Thread Image"/>
                         <t t-if="channelPreviewView.personaImStatusIconView">
                             <PersonaImStatusIcon
                                 className="'o_NotificationListItem_personaImStatusIcon o_ChannelPreviewView_personaImStatusIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center'"

--- a/addons/mail/static/src/components/composer/composer.scss
+++ b/addons/mail/static/src/components/composer/composer.scss
@@ -42,11 +42,6 @@
     min-width: 0;
 }
 
-.o_Composer_currentPartnerAvatar {
-    width: $o-mail-thread-avatar-size;
-    height: $o-mail-thread-avatar-size;
-}
-
 .o_Composer_sidebarMain {
     grid-area: sidebar-main;
     justify-self: center;

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -61,10 +61,10 @@
                 <t t-if="composerView.hasCurrentPartnerAvatar">
                     <div class="o_Composer_sidebarMain">
                         <t t-if="!messaging.currentGuest or composerView.composer.activeThread.model !== 'mail.channel'">
-                            <img class="o_Composer_currentPartnerAvatar mt-1 rounded-circle o_object_fit_cover" t-att-src="composerView.currentPartnerAvatar" alt="Avatar of user"/>
+                            <img class="o_Composer_currentPartnerAvatar avatar-size avatar-size-xl mt-1 rounded-circle" t-att-src="composerView.currentPartnerAvatar" alt="Avatar of user"/>
                         </t>
                         <t t-if="messaging.currentGuest and composerView.composer.activeThread.model === 'mail.channel'">
-                            <img class="o_Composer_currentPartnerAvatar mt-1 rounded-circle o_object_fit_cover" t-attf-src="/mail/channel/{{ composerView.composer.activeThread.id }}/guest/{{ messaging.currentGuest.id }}/avatar_128?unique={{ messaging.currentGuest.name }}" alt="Avatar of guest"/>
+                            <img class="o_Composer_currentPartnerAvatar avatar-size avatar-size-xl mt-1 rounded-circle" t-attf-src="/mail/channel/{{ composerView.composer.activeThread.id }}/guest/{{ messaging.currentGuest.id }}/avatar_128?unique={{ messaging.currentGuest.name }}" alt="Avatar of guest"/>
                         </t>
                     </div>
                 </t>

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.scss
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.scss
@@ -17,11 +17,6 @@
         display: none;
     }
 
-    .o_DiscussSidebarCategoryItem_imageContainer {
-        width: $o-mail-discuss-sidebar-category-item-avatar-size;
-        height: $o-mail-discuss-sidebar-category-item-avatar-size;
-    }
-
     .o_DiscussSidebarCategoryItem_threadIcon {
         width: 13px;
         height: 13px;

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
@@ -13,7 +13,7 @@
             >
                 <div class="o_DiscussSidebarCategoryItem_item o_DiscussSidebarCategoryItem_avatar ms-4">
                     <div class="o_DiscussSidebarCategoryItem_imageContainer position-relative d-flex">
-                        <img class="o_DiscussSidebarCategoryItem_image w-100 h-100 rounded-circle" t-att-src="categoryItem.avatarUrl" alt="Thread Image"/>
+                        <img class="o_DiscussSidebarCategoryItem_image avatar-size avatar-size-lg rounded-circle" t-att-src="categoryItem.avatarUrl" alt="Thread Image"/>
                         <t t-if="categoryItem.hasThreadIcon">
                             <ThreadIcon className="'o_DiscussSidebarCategoryItem_threadIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center rounded-circle bg-100'" thread="categoryItem.thread"/>
                         </t>

--- a/addons/mail/static/src/components/follower/follower.scss
+++ b/addons/mail/static/src/components/follower/follower.scss
@@ -2,11 +2,6 @@
 // Layout
 // ------------------------------------------------------------------
 
-.o_Follower_avatar {
-    width: $o-mail-partner-avatar-size;
-    height: $o-mail-partner-avatar-size;
-}
-
 .o_Follower_details {
     min-width: 0;
 }

--- a/addons/mail/static/src/components/follower/follower.xml
+++ b/addons/mail/static/src/components/follower/follower.xml
@@ -5,7 +5,7 @@
         <t t-if="followerView">
             <div class="o_Follower d-flex justify-content-between p-0" t-attf-class="{{ className }}" t-ref="root">
                 <a class="o_Follower_details d-flex align-items-center flex-grow-1 px-3 text-700" t-att-class="{ 'o-inactive fst-italic opacity-25': !followerView.follower.isActive }" href="#" role="menuitem" t-on-click="followerView.onClickDetails">
-                    <img class="o_Follower_avatar me-2 rounded-circle" t-att-src="followerView.follower.partner.avatarUrl" alt=""/>
+                    <img class="o_Follower_avatar avatar-size avatar-size-md me-2 rounded-circle" t-att-src="followerView.follower.partner.avatarUrl" alt=""/>
                     <span class="o_Follower_name flex-shrink text-truncate" t-esc="followerView.follower.partner.nameOrDisplayName"/>
                 </a>
                 <t t-if="followerView.follower.isEditable">

--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -6,11 +6,6 @@
     z-index: 10; // Place the element in front of the Composer when they overlap
 }
 
-.o_Message_authorAvatarContainer {
-    height: $o-mail-thread-avatar-size;
-    width: $o-mail-thread-avatar-size;
-}
-
 .o_Message_content {
     *:not(li):not(li div) {
         // Message content can contain arbitrary HTML that might overflow and break

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -31,8 +31,8 @@
                 <div class="position-relative d-flex flex-shrink-0" t-att-class="{ 'flex-row-reverse': messageView.isInChatWindowAndIsAlignedRight }">
                     <div class="o_Message_sidebar d-flex flex-shrink-0" t-att-class="{ 'o-message-squashed align-items-start': messageView.isSquashed, 'justify-content-center': messageView.isInChatWindow }">
                         <t t-if="!messageView.isSquashed">
-                            <div class="o_Message_authorAvatarContainer o_Message_sidebarItem position-relative">
-                                <img class="o_Message_authorAvatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-class="{ 'cursor-pointer': messageView.hasAuthorOpenChat, o_redirect: messageView.hasAuthorOpenChat }" t-att-src="messageView.message.avatarUrl" t-att-role="messageView.hasAuthorOpenChat ? 'button' : ''" t-att-tabindex="messageView.hasAuthorOpenChat ? '0' : ''" t-on-click="messageView.onClickAuthorAvatar" t-att-title="messageView.authorTitleText" t-att-alt="messageView.authorTitleText"/>
+                            <div class="o_Message_authorAvatarContainer o_Message_sidebarItem position-relative align-self-start">
+                                <img class="o_Message_authorAvatar avatar-size avatar-size-xl rounded-circle o_object_fit_cover" t-att-class="{ 'cursor-pointer': messageView.hasAuthorOpenChat, o_redirect: messageView.hasAuthorOpenChat }" t-att-src="messageView.message.avatarUrl" t-att-role="messageView.hasAuthorOpenChat ? 'button' : ''" t-att-tabindex="messageView.hasAuthorOpenChat ? '0' : ''" t-on-click="messageView.onClickAuthorAvatar" t-att-title="messageView.authorTitleText" t-att-alt="messageView.authorTitleText"/>
                                 <t t-if="messageView.personaImStatusIconView">
                                     <PersonaImStatusIcon
                                         className="'o_Message_personaImStatusIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center text-white'"

--- a/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.scss
+++ b/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.scss
@@ -10,11 +10,6 @@
     }
 }
 
-.o_MessageInReplyToView_avatar {
-    width: $o-mail-thread-avatar-size / 2;
-    height: $o-mail-thread-avatar-size / 2;
-}
-
 .o_MessageInReplyToView_wrapInner {
     display: -webkit-box;
     -webkit-box-orient: vertical;

--- a/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
+++ b/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
@@ -6,7 +6,7 @@
                 <span class="o_MessageInReplyToView_corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{  messageInReplyToView.messageView.isInChatWindowAndIsAlignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': messageInReplyToView.messageView.isInDiscuss }"/>
                 <t t-if="!messageInReplyToView.messageView.message.parentMessage.isEmpty">
                     <span class="o_MessageInReplyToView_wrapOuter d-flex align-items-center text-muted opacity-75 opacity-100-hover cursor-pointer"  t-attf-class="{{ messageInReplyToView.messageView.isInChatWindowAndIsAlignedRight ? 'pe-3': 'ps-3' }}" t-on-click="messageInReplyToView.onClickReply">
-                        <img class="o_MessageInReplyToView_avatar me-2 rounded-circle" t-att-src="messageInReplyToView.messageView.message.parentMessage.avatarUrl" t-att-title="messageInReplyToView.messageView.message.parentMessage.authorName" alt="Avatar"/>
+                        <img class="o_MessageInReplyToView_avatar avatar-size avatar-size-md me-2 rounded-circle" t-att-src="messageInReplyToView.messageView.message.parentMessage.avatarUrl" t-att-title="messageInReplyToView.messageView.message.parentMessage.authorName" alt="Avatar"/>
                         <span class="o_MessageInReplyToView_wrapInner overflow-hidden">
                             <b class="o_MessageInReplyToView_author">@<t t-out="messageInReplyToView.messageView.message.parentMessage.authorName"/></b>:
                             <span class="o_MessageInReplyToView_body ms-1 text-break">

--- a/addons/mail/static/src/components/notification_group/notification_group.xml
+++ b/addons/mail/static/src/components/notification_group/notification_group.xml
@@ -6,7 +6,7 @@
             <div class="o_NotificationListItem o_NotificationGroup d-flex flex-shrink-0 align-items-center p-1 cursor-pointer" t-attf-class="{{ className }}" t-on-click="notificationGroupView.onClick" t-ref="root">
                 <div class="o_NotificationListItem_sidebar o_NotificationGroup_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_NotificationGroup_imageContainer o_NotificationGroup_sidebarItem position-relative">
-                        <img class="o_NotificationListItem_image o_NotificationGroup_image w-100 h-100 rounded-circle" t-att-src="notificationGroupView.imageSrc" alt="Message delivery failure image"/>
+                        <img class="o_NotificationListItem_image o_NotificationGroup_image avatar-size avatar-size-xl rounded-circle" t-att-src="notificationGroupView.imageSrc" alt="Message delivery failure image"/>
                     </div>
                 </div>
                 <div class="o_NotificationListItem_content o_NotificationGroup_content d-flex flex-column flex-grow-1 align-self-start m-2">

--- a/addons/mail/static/src/components/notification_list/notification_list_item.scss
+++ b/addons/mail/static/src/components/notification_list/notification_list_item.scss
@@ -40,11 +40,6 @@ $o-mail-notification-list-item-muted-hover-background-color:
     object-fit: cover;
 }
 
-.o_NotificationListItem_imageContainer {
-    width: 40px;
-    height: 40px;
-}
-
 .o_NotificationListItem_inlineText {
     &.o-empty::before {
         content: '\00a0'; // keep line-height as if it had content

--- a/addons/mail/static/src/components/notification_request/notification_request.xml
+++ b/addons/mail/static/src/components/notification_request/notification_request.xml
@@ -6,7 +6,7 @@
             <div class="o_NotificationListItem o_NotificationRequest d-flex flex-shrink-0 align-items-center p-1 cursor-pointer" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
                 <div class="o_NotificationListItem_sidebar o_NotificationRequest_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_NotificationRequest_imageContainer o_NotificationRequest_sidebarItem position-relative">
-                        <img class="o_NotificationListItem_image o_NotificationRequest_image w-100 h-100 rounded-circle" t-att-src="messaging.partnerRoot.avatarUrl" alt="Avatar of OdooBot"/>
+                        <img class="o_NotificationListItem_image o_NotificationRequest_image avatar-size avatar-size-xl rounded-circle" t-att-src="messaging.partnerRoot.avatarUrl" alt="Avatar of OdooBot"/>
                         <PersonaImStatusIcon
                             t-if="notificationRequestView.personaImStatusIconView"
                             className="'o_NotificationListItem_personaImStatusIcon o_NotificationRequest_personaImStatusIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center'"

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
@@ -16,7 +16,7 @@
             >
                 <div class="o_NotificationListItem_sidebar o_ThreadNeedactionPreview_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_ThreadNeedactionPreview_imageContainer o_ThreadNeedactionPreview_sidebarItem position-relative">
-                        <img class="o_NotificationListItem_image o_ThreadNeedactionPreview_image w-100 h-100" t-att-src="image()" alt="Thread Image"/>
+                        <img class="o_NotificationListItem_image o_ThreadNeedactionPreview_image avatar-size avatar-size-xl" t-att-src="image()" alt="Thread Image"/>
                         <t t-if="threadNeedactionPreviewView.personaImStatusIconView">
                             <PersonaImStatusIcon
                                 className="'o_NotificationListItem_personaImStatusIcon o_ThreadNeedactionPreview_personaImStatusIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center'"

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.scss
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.scss
@@ -6,11 +6,6 @@
     height: $o-statusbar-height * 1.25;
 }
 
-.o_ThreadViewTopbar_avatar {
-    height: $o-mail-partner-avatar-size;
-    width: $o-mail-partner-avatar-size;
-}
-
 .o_ThreadViewTopbar_title {
     min-width: 0;
 }

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -87,7 +87,7 @@
                 <!-- FIXME: handle display on mobile -->
                 <t t-if="threadViewTopbar.threadView.threadViewer.discussPublicView and !messaging.device.isSmall">
                     <div class="o_ThreadViewTopbar_userInfo d-flex align-items-center">
-                        <img class="o_ThreadViewTopbar_avatar mx-1 rounded-circle o_object_fit_cover" t-att-src="threadViewTopbar.avatarUrl" alt="Avatar"/>
+                        <img class="o_ThreadViewTopbar_avatar avatar-size avatar-size-md mx-1 rounded-circle" t-att-src="threadViewTopbar.avatarUrl" alt="Avatar"/>
                         <t t-if="!threadViewTopbar.isEditingGuestName">
                             <span class="o_ThreadViewTopbar_userName o_ThreadViewTopbar_editableItem px-1 border fw-bold text-truncate" t-attf-class="{{ threadViewTopbar.isMouseOverUserName and messaging.isCurrentUserGuest ? 'o-userNameEditable bg-white' : 'border-light' }}" t-on-click="threadViewTopbar.onClickUserName" t-on-mouseenter="threadViewTopbar.onMouseEnterUserName" t-on-mouseleave="threadViewTopbar.onMouseLeaveUserName">
                                 <t t-esc="messaging.isCurrentUserGuest ? messaging.currentGuest.name : messaging.currentUser.nameOrDisplayName"/>

--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -70,9 +70,8 @@
         cursor: pointer;
 
         .o_m2o_avatar > img, > img {
-            width: 32px;
-            height: 32px;
-            max-height: 32px;
+            --avatar-size: #{map-get($utilities-avatar-sizes, 'lg')};
+            max-height: var(--avatar-size);
             margin-right: 16px;
         }
 

--- a/addons/mail/static/src/scss/m2x_avatar_user.scss
+++ b/addons/mail/static/src/scss/m2x_avatar_user.scss
@@ -9,7 +9,7 @@
     }
 }
 
-.o_field_many2manytags.avatar.o_clickable_m2x_avatar {
+.o_field_many2manytags.avatar_wrap.o_clickable_m2x_avatar {
     img.o_m2m_avatar {
         margin-right: 2px;
         &:hover {

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -11,7 +11,6 @@ $o-mail-chat-header-height: 46px !default;
 $o-mail-attachment-image-size: 100px !default;
 $o-mail-sidebar-icon-opacity: 0.7 !default;
 $o-mail-chat-sidebar-width: 250px !default;
-$o-mail-partner-avatar-size: 24px !default;
 $o-mail-partner-status-icon-size: 1.2em !default;
 // Needed because $border-radius variations are all set to 0 in enterprise.
 $o-mail-rounded-rectangle-border-radius-sm: .2rem !default;
@@ -25,7 +24,6 @@ $o-mail-discuss-sidebar-active-indicator-width: 3px !default;
 $o-mail-discuss-sidebar-category-title-icon-size: 15px !default;
 $o-mail-discuss-sidebar-category-item-margin: 3px !default;
 $o-mail-discuss-sidebar-category-item-avatar-left-margin: $o-mail-discuss-sidebar-category-title-icon-size + $o-mail-discuss-sidebar-category-item-margin !default;
-$o-mail-discuss-sidebar-category-item-avatar-size: 30px !default;
 $o-mail-discuss-sidebar-scrollbar-width: 15px !default;
 
 $o-mail-message-sidebar-width: 48px !default;

--- a/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
@@ -67,7 +67,7 @@ QUnit.module('mail', {}, function () {
             views: [[false, 'form']],
         });
 
-        await dom.click(document.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
+        await dom.click(document.querySelector('.o_field_many2manytags.avatar_wrap .badge .o_m2m_avatar'));
         assert.containsOnce(document.body, '.o_ChatWindow', 'Chat window should be opened');
         assert.strictEqual(
             document.querySelector('.o_ChatWindowHeader_name').textContent,
@@ -380,7 +380,7 @@ QUnit.module('mail', {}, function () {
             views: [[false, 'form']],
         });
         assert.strictEqual(
-            document.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
+            document.querySelector('.o_field_many2manytags.avatar_wrap.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -177,10 +177,6 @@ html, body {
                 color: red;
             }
         }
-        img {
-            width: 20px;
-            height: 20px;
-        }
     }
 }
 

--- a/addons/mass_mailing/static/src/xml/mass_mailing.xml
+++ b/addons/mass_mailing/static/src/xml/mass_mailing.xml
@@ -20,7 +20,7 @@
                     <span class="text-truncate" t-esc="template.subject"/>
                     <div class="ms-auto">
                         <i class="o_mail_template_remove_favorite fa fa-trash ps-2 me-1" t-att-data-id="template.id" title="Remove from Templates"/>
-                        <img t-if="template.userId" t-attf-src="/web/image/res.users/#{template.userId}/avatar_128" t-att-title="template.userName"/>
+                        <img t-if="template.userId" t-attf-src="/web/image/res.users/#{template.userId}/avatar_128" t-att-title="template.userName" class="avatar-size"/>
                     </div>
                 </div>
             </div>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -438,7 +438,7 @@
                                             <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length == 0 and record.last_working_user_id.raw_value"><i class="fa fa-pause" role="img" aria-label="Pause" title="Pause"/></span>
                                             <span t-if="record.working_state.raw_value == 'blocked' and (record.working_user_ids.raw_value.length == 0 or record.last_working_user_id.raw_value)"><i class="fa fa-stop" role="img" aria-label="Stop" title="Stop"/></span>
                                             <t name="user_avatar" t-if="record.last_working_user_id.raw_value">
-                                                <img t-att-src="kanban_image('res.users', 'avatar_128', record.last_working_user_id.raw_value)" class="oe_kanban_avatar" alt="Avatar"/>
+                                                <img t-att-src="kanban_image('res.users', 'avatar_128', record.last_working_user_id.raw_value)" class="oe_kanban_avatar avatar-size" alt="Avatar"/>
                                             </t>
                                         </div>
                                     </div>

--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -128,7 +128,7 @@
                         <img
                             t-if="follower_index &lt; 5"
                             t-att-src="kanban_image('res.partner', 'avatar_128', follower)"
-                            class="oe_kanban_avatar o_image_24_cover rounded-circle border border-white bg-white ml-n2"
+                            class="oe_kanban_avatar avatar-size avatar-size-md rounded-circle border border-white bg-white ml-n2"
                             t-att-data-member_id="follower"
                             alt="Follower"/>
                         <small

--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -405,8 +405,6 @@ form label {
 }
 
 .o_portal_contact_img {
-    width: 2.3em;
-    height: 2.3em;
     object-fit: cover;
 }
 
@@ -454,8 +452,6 @@ form label {
     padding: 10px;
 
     .o_portal_chatter_avatar {
-        width: 45px;
-        height: 45px;
         margin-right: 1rem;
     }
 

--- a/addons/portal/static/src/xml/portal_chatter.xml
+++ b/addons/portal/static/src/xml/portal_chatter.xml
@@ -32,7 +32,7 @@
                     Oops! Something went wrong. Try to reload the page and log in.
                 </div>
                 <div class="d-flex">
-                    <img alt="Avatar" class="o_portal_chatter_avatar o_object_fit_cover align-self-start" t-attf-src="/web/image/res.partner/#{widget.options['partner_id']}/avatar_128"
+                    <img alt="Avatar" class="o_portal_chatter_avatar avatar-size avatar-size-xl align-self-start" t-attf-src="/web/image/res.partner/#{widget.options['partner_id']}/avatar_128"
                          t-if="!widget.options['is_user_public'] or !widget.options['token']"/>
                     <div class="flex-grow-1">
                         <div class="o_portal_chatter_composer_input">
@@ -80,7 +80,7 @@
         <div class="o_portal_chatter_messages">
             <t t-foreach="widget.get('messages') || []" t-as="message">
                 <div class="d-flex o_portal_chatter_message" t-att-id="'message-' + message.id">
-                    <img class="o_portal_chatter_avatar" t-att-src="message.author_avatar_url" alt="avatar"/>
+                    <img class="o_portal_chatter_avatar avatar-size avatar-size-xl" t-att-src="message.author_avatar_url" alt="avatar"/>
                     <div class="flex-grow-1">
                         <t t-call="portal.chatter_internal_toggle" t-if="widget.options['is_user_employee']"/>
 

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -87,7 +87,7 @@
                 <a href="#" role="button" data-bs-toggle="dropdown" t-attf-class="dropdown-toggle #{_link_class}">
                     <t t-if="_avatar">
                         <t t-set="avatar_source" t-value="image_data_uri(user_id.avatar_256)"/>
-                        <img t-att-src="avatar_source" t-attf-class="rounded-circle o_object_fit_cover #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
+                        <img t-att-src="avatar_source" t-attf-class="avatar-size rounded-circle #{_avatar_class}" alt="" loading="eager"/>
                     </t>
                     <i t-if="_icon" t-attf-class="fa fa-1x fa-fw fa-user-circle-o #{_icon_class}"/>
                     <span t-if="_user_name" t-attf-class="#{_user_name_class}" t-esc="user_id.name[:23] + '...' if user_id.name and len(user_id.name) &gt; 25 else user_id.name"/>

--- a/addons/portal_rating/static/src/xml/portal_chatter.xml
+++ b/addons/portal_rating/static/src/xml/portal_chatter.xml
@@ -75,7 +75,7 @@
 
     <t t-name="portal_rating.chatter_rating_publisher_comment">
         <div class="d-flex o_portal_chatter_message">
-            <img class="o_portal_chatter_avatar" t-att-src="rating.publisher_avatar" alt="avatar"/>
+            <img class="o_portal_chatter_avatar avatar-size avatar-size-xl" t-att-src="rating.publisher_avatar" alt="avatar"/>
             <div class="flex-grow-1">
                 <div class="o_portal_chatter_message_title">
                     <div class="d-inline-block">
@@ -102,7 +102,7 @@
     </t>
     <t t-name="portal_rating.chatter_rating_publisher_form">
         <div t-if="is_publisher" class="d-flex o_portal_chatter_message shadow bg-white rounded px-3 py-3 my-1">
-            <img class="o_portal_chatter_avatar" t-att-src="rating.publisher_avatar" alt="avatar"/>
+            <img class="o_portal_chatter_avatar avatar-size avatar-size-xl" t-att-src="rating.publisher_avatar" alt="avatar"/>
             <div class="flex-grow-1">
                 <div class="o_portal_chatter_message_title">
                     <h5 class='mb-1'><t t-esc="rating.publisher_name"/></h5>

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -164,7 +164,7 @@
                                 <td>
                                     <t t-set="assignees" t-value="task.sudo().user_ids"/>
                                     <div t-if="assignees" class="row flex-nowrap ps-3">
-                                        <img class="rounded-circle o_portal_contact_img me-2" t-attf-src="#{image_data_uri(assignees[:1].avatar_1024)}" alt="User" style="width: 20px; height: 20px;"/>
+                                        <img class="avatar-size rounded-circle o_portal_contact_img me-2 p-0" t-attf-src="#{image_data_uri(assignees[:1].avatar_1024)}" alt="User"/>
                                         <span t-out="'%s%s' % (assignees[:1].name, ' + %s others' % len(assignees[1:]) if len(assignees.user_ids) > 1 else '')" t-att-title="'\n'.join(assignees[1:].mapped('name'))"/>
                                     </div>
                                 </td>
@@ -253,7 +253,7 @@
                                     <strong>Assignees</strong>
                                     <t t-foreach="task.user_ids" t-as="user">
                                         <div class="d-flex mb-3 flex-nowrap">
-                                            <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(user.avatar_1024)" alt="Contact"/>
+                                            <img class="avatar-size avatar-size-lg rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(user.avatar_1024)" alt="Contact"/>
                                             <div class="ms-2">
                                                 <div t-esc="user" t-options='{"widget": "contact", "fields": ["name"]}'/>
                                                 <a t-attf-href="tel:{{user.phone}}" t-if="user.phone"><div t-esc="user" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
@@ -267,7 +267,7 @@
                                 <div class="col-12 col-md-12 pb-2" t-if="task.partner_id">
                                     <strong>Customer</strong>
                                     <div class="d-flex flex-nowrap">
-                                        <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(task.partner_id.avatar_1024)" alt="Contact"/>
+                                        <img class="avatar-size avatar-size-lg rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(task.partner_id.avatar_1024)" alt="Contact"/>
                                         <div class="ms-2">
                                             <div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["name"]}'/>
                                             <a t-attf-href="tel:{{task.partner_id.phone}}" t-if="task.partner_id.phone"><div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -156,7 +156,7 @@
                               <div class="small mb-1"><strong class="text-muted">Purchase Representative</strong></div>
                               <div class="row flex-nowrap">
                                   <div class="col flex-grow-0 pe-2">
-                                      <img class="rounded-circle mr4 float-start o_portal_contact_img" t-att-src="image_data_uri(order.user_id.avatar_1024)" alt="Contact"/>
+                                      <img class="avatar-size avatar-size-lg rounded-circle mr4 float-start o_portal_contact_img" t-att-src="image_data_uri(order.user_id.avatar_1024)" alt="Contact"/>
                                   </div>
                                   <div class="col ps-0" style="min-width: 150px">
                                       <span t-field="order.user_id" t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True}'/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -179,7 +179,7 @@
                                 </div>
                                 <div class="row flex-nowrap">
                                     <div class="col flex-grow-0 pe-2">
-                                        <img class="rounded-circle mr4 float-start o_portal_contact_img"
+                                        <img class="avatar-size avatar-size-lg rounded-circle mr4 float-start o_portal_contact_img"
                                             t-att-src="image_data_uri(sale_order.user_id.avatar_1024)"
                                             alt="Contact"/>
                                     </div>

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -2802,7 +2802,7 @@ var FieldMany2ManyTags = AbstractField.extend({
 
 var FieldMany2ManyTagsAvatar = FieldMany2ManyTags.extend({
     tag_template: 'FieldMany2ManyTagAvatar',
-    className: 'o_field_many2manytags avatar',
+    className: 'o_field_many2manytags avatar_wrap',
 
     //--------------------------------------------------------------------------
     // Private

--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -281,7 +281,7 @@
             }
         }
         // Many2many tags avatar
-        &.avatar {
+        &.avatar_wrap {
             .badge {
                 align-items: center;
                 padding: 0;
@@ -317,7 +317,7 @@
                 background-color: #dee2e6;
                 vertical-align: bottom;
             }
-            &.avatar.o_clickable_m2x_avatar {
+            &.avatar_wrap.o_clickable_m2x_avatar {
                 img.o_m2m_avatar {
                     margin-right: 0px;
                     object-fit: cover;

--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -151,8 +151,6 @@
     &.o_field_many2one_avatar {
         .o_m2o_avatar > img, .o_m2o_avatar > .o_m2o_avatar_empty {
             border-radius: 50%;
-            width: 19px;
-            height: 19px;
             object-fit: cover;
             margin-right: 4px;
         }
@@ -309,8 +307,6 @@
                 display: inline-block;
             }
             .o_m2m_avatar, .o_m2m_avatar_empty {
-                width: 20px;
-                height: 20px;
                 margin-left: 0px;
             }
             .o_m2m_avatar_empty {

--- a/addons/web/static/src/legacy/scss/fields_extra.scss
+++ b/addons/web/static/src/legacy/scss/fields_extra.scss
@@ -21,7 +21,7 @@
             right: 0;
         }
 
-        &.avatar .o_dropdown_button {
+        &.avatar_wrap .o_dropdown_button {
             top: $o-input-padding-y;
         }
     }

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -522,8 +522,8 @@ $o-form-label-margin-right: 0px;
         margin-bottom: 10px;
 
         > img {
-            max-width: $o-avatar-size;
-            max-height: $o-avatar-size;
+            max-width: $o-image-field-size;
+            max-height: $o-image-field-size;
             vertical-align: top;
             border: 1px solid $o-gray-300;
         }

--- a/addons/web/static/src/legacy/scss/kanban_examples_dialog.scss
+++ b/addons/web/static/src/legacy/scss/kanban_examples_dialog.scss
@@ -70,10 +70,6 @@
             &.o_collapse {
                 margin-top: -1px;
             }
-            .o_ghost_avatar {
-                height: 20px;
-                width: 20px;
-            }
         }
     }
 }

--- a/addons/web/static/src/legacy/scss/kanban_view.scss
+++ b/addons/web/static/src/legacy/scss/kanban_view.scss
@@ -268,7 +268,7 @@
             line-height: 1.2;
             word-break: break-all;
 
-            &.avatar {
+            &.avatar_wrap {
                 margin: 0 0 0 6px;
                 .o_m2m_avatar_empty > span {
                     display: block;

--- a/addons/web/static/src/legacy/scss/kanban_view.scss
+++ b/addons/web/static/src/legacy/scss/kanban_view.scss
@@ -130,8 +130,8 @@
                     object-fit: cover;
                 }
                 .oe_kanban_avatar, .o_field_many2one_avatar > .o_m2o_avatar {
-                    width: 20px;
-                    height: 20px;
+                    width: map-get($utilities-avatar-sizes, 'sm');
+                    height: map-get($utilities-avatar-sizes, 'sm');
                     margin-left: 6px;
                 }
             }

--- a/addons/web/static/src/legacy/scss/primary_variables.scss
+++ b/addons/web/static/src/legacy/scss/primary_variables.scss
@@ -116,7 +116,7 @@ $o-modal-md: 650px !default;
 // Different required cancel paddings between web and web_enterprise
 $o-sheet-cancel-tpadding: 0px !default;
 
-$o-avatar-size: 90px !default;
+$o-image-field-size: 90px !default;
 
 $o-statusbar-height: 33px !default;
 

--- a/addons/web/static/src/legacy/scss/ui.scss
+++ b/addons/web/static/src/legacy/scss/ui.scss
@@ -206,3 +206,13 @@ span.o_force_ltr {
     // have an useless frontend rule.
     font-family: sans-serif;
 }
+
+// == Avatar
+//------------------------------------------------------------------------------
+// Size variations for avatars in bootstrap/utilities_custom.scss
+
+.avatar-size { 
+    width: var(--avatar-size, 1.5em);
+    height: var(--avatar-size, 1.5em);
+    object-fit: cover;
+}

--- a/addons/web/static/src/legacy/scss/web_calendar.scss
+++ b/addons/web/static/src/legacy/scss/web_calendar.scss
@@ -1,7 +1,5 @@
 // Variables
 $o-cw-color-today-accent: #FC3D39;
-$o-cw-popup-avatar-size: 16px;
-$o-cw-filter-avatar-size: 20px;
 
 // Animations
 @keyframes backgroundfade {
@@ -708,8 +706,6 @@ $o-cw-filter-avatar-size: 20px;
                 overflow: hidden;
 
                 &.o_beside_avatar {
-                    width: $o-cw-filter-avatar-size;
-                    height: $o-cw-filter-avatar-size;
                     border-radius: 2px;
                     object-fit: cover;
                 }
@@ -725,8 +721,6 @@ $o-cw-filter-avatar-size: 20px;
 
 
             .o_cw_filter_avatar {
-                width: $o-cw-filter-avatar-size;
-                height: $o-cw-filter-avatar-size;
                 border-radius: 2px;
 
                 &.fa {
@@ -788,8 +782,8 @@ $o-cw-filter-avatar-size: 20px;
 
     .o_calendar_avatars img {
         margin-right: 0.4rem;
-        width: $o-cw-popup-avatar-size;
-        height: $o-cw-popup-avatar-size;
+        width: map-get($utilities-avatar-sizes, 'xs');
+        height: map-get($utilities-avatar-sizes, 'xs');
         border-radius: 100%;
     }
 

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1032,8 +1032,8 @@
 
 <t t-name="web.Many2OneAvatar">
     <div class="o_m2o_avatar">
-        <img t-if="widget.value" t-att-src="url" t-att-alt="value"/>
-        <span t-elif="widget.mode === 'edit'" class="o_m2o_avatar_empty"></span>
+        <img t-if="widget.value" t-att-src="url" t-att-alt="value" class="avatar-size"/>
+        <span t-elif="widget.mode === 'edit'" class="o_m2o_avatar_empty avatar-size"></span>
         <span t-if="widget.mode === 'readonly'" t-esc="value"/>
     </div>
 </t>
@@ -1070,16 +1070,16 @@
 </t>
 <t t-name="FieldMany2ManyTagAvatar" t-extend="FieldMany2ManyTag">
     <t t-jquery="t[t-set='_badge_text']" t-operation="before">
-        <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
+        <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-data-id="el.id" class="avatar-size rounded-circle o_m2m_avatar"/></span>
     </t>
 </t>
 <t t-name="KanbanMany2ManyTagAvatar">
     <t t-set="visibleElements" t-value="elements.length === widget.visibleAvatarCount ? elements : elements.slice(0, widget.visibleAvatarCount - 1)"/>
     <t t-foreach="visibleElements" t-as="el" t-key="el_index">
-        <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-title="el.display_name" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
+        <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-title="el.display_name" t-att-data-id="el.id" class="avatar-size rounded-circle o_m2m_avatar"/></span>
     </t>
     <t t-if="elements.length > widget.visibleAvatarCount">
-        <span class="o_m2m_avatar_empty rounded-circle text-center fw-bold">
+        <span class="o_m2m_avatar_empty avatar-size rounded-circle text-center fw-bold">
             <span t-if="elements.length - widget.visibleAvatarCount + 1 > 9">9+</span>
             <span t-else="">+<t t-esc="elements.length - widget.visibleAvatarCount + 1"/></span>
         </span>
@@ -1092,17 +1092,17 @@
     <t t-else="">
         <t t-if="elements.length === 1">
             <div>
-                <img t-attf-src="/web/image/#{avatarModel}/#{elements[0].id}/#{avatarField}" t-att-data-id="elements[0].id" class="rounded-circle o_m2m_avatar"/>
+                <img t-attf-src="/web/image/#{avatarModel}/#{elements[0].id}/#{avatarField}" t-att-data-id="elements[0].id" class="rounded-circle o_m2m_avatar avatar-size"/>
                 <span t-esc="elements[0].display_name"/>
             </div>
         </t>
         <t t-else="">
             <t t-set="visibleElements" t-value="elements.length === widget.visibleAvatarCount ? elements : elements.slice(0, widget.visibleAvatarCount - 1)"/>
             <t t-foreach="visibleElements" t-as="el" t-key="el_index">
-                <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-title="el.display_name" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
+                <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-title="el.display_name" t-att-data-id="el.id" class="avatar-size rounded-circle o_m2m_avatar"/></span>
             </t>
             <t t-if="elements.length > widget.visibleAvatarCount">
-                <span class="o_m2m_avatar_empty rounded-circle text-center fw-bold">
+                <span class="o_m2m_avatar_empty avatar-size rounded-circle text-center fw-bold">
                     <span t-if="elements.length - widget.visibleAvatarCount + 1 > 9">9+</span>
                     <span t-else="">+<t t-esc="elements.length - widget.visibleAvatarCount + 1"/></span>
                 </span>

--- a/addons/web/static/src/legacy/xml/kanban.xml
+++ b/addons/web/static/src/legacy/xml/kanban.xml
@@ -179,7 +179,7 @@
             <t t-if="example.bullets and _.random(0, 5) > 3">
                 <t t-out="_.sample(example.bullets)"/>
             </t>
-        <img class="float-end o_ghost_avatar mt-2" src="/base/static/img/avatar.png" alt="Avatar"/>
+        <img class="avatar-size float-end o_ghost_avatar mt-2" src="/base/static/img/avatar.png" alt="Avatar"/>
     </div>
 </t>
 
@@ -204,7 +204,7 @@
     <div class="o_kanban_examples_ghost mb-3 p-2 border bg-white">
         <div class="o_ghost_content pb-3 bg-300"/>
         <div class="o_ghost_content o_ghost_tag d-inline-block w-50 mt-3 pb-3 bg-300"/>
-        <img class="float-end o_ghost_avatar mt-2" src="/base/static/img/avatar.png" alt="Avatar"/>
+        <img class="avatar-size float-end o_ghost_avatar mt-2" src="/base/static/img/avatar.png" alt="Avatar"/>
     </div>
 </t>
 

--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -88,12 +88,12 @@
                         <input type="checkbox" t-att-id="idForLabel" name="selection" class="position-absolute" t-att-checked="filter.active ? true : undefined"/>
 
                         <label t-att-for="idForLabel" class="d-flex align-items-start m-0">
-                            <span t-attf-class="o_cw_filter_input_bg align-items-start d-flex flex-shrink-0 justify-content-center position-relative me-1 #{widget.avatar_field ? 'o_beside_avatar' : ''}"
+                            <span t-attf-class="o_cw_filter_input_bg align-items-start d-flex flex-shrink-0 justify-content-center position-relative me-1 #{widget.avatar_field ? 'o_beside_avatar avatar-size' : ''}"
                                 t-att-style="color and !isColorNumber ? _.str.sprintf('border-color:%s;background-color:%s', color, color) : ''">
                                 <i class="fa fa-check position-relative"/>
                             </span>
-                            <i t-if="filter.value == 'all'" class="o_cw_filter_avatar fa fa-users fa-fw  flex-shrink-0 me-1" role="img" aria-label="Avatar" title="Avatar"/>
-                            <img t-elif="widget.avatar_field and filter.value" t-attf-src="/web/image/#{widget.avatar_model}/#{filter.value}/#{widget.avatar_field}" class="o_cw_filter_avatar flex-shrink-0 me-1" alt="Avatar"/>
+                            <i t-if="filter.value == 'all'" class="o_cw_filter_avatar avatar-size fa fa-users fa-fw  flex-shrink-0 me-1" role="img" aria-label="Avatar" title="Avatar"/>
+                            <img t-elif="widget.avatar_field and filter.value" t-attf-src="/web/image/#{widget.avatar_model}/#{filter.value}/#{widget.avatar_field}" class="o_cw_filter_avatar avatar-size flex-shrink-0 me-1" alt="Avatar"/>
                             <span class="o_cw_filter_title text-truncate flex-grow" t-esc="filter.label" t-attf-title="#{ ['all', false].includes(filter.value) or !widget.avatar_field ? filter.label : '' }"/>
                         </label>
 

--- a/addons/web/static/src/libs/bootstrap/utilities_custom.scss
+++ b/addons/web/static/src/libs/bootstrap/utilities_custom.scss
@@ -40,6 +40,21 @@ $utilities-sizes: map-merge(
     )
 );
 
+$utilities-avatar-sizes: () !default;
+$utilities-avatar-sizes-values: 1em, 1.25em, 2em, 2.35em, 2.75em, 3.75em;
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+    $utilities-avatar-sizes: map-merge(
+        $utilities-avatar-sizes,
+        (
+            $breakpoint : nth(
+                $utilities-avatar-sizes-values,
+                index(map-keys($grid-breakpoints), $breakpoint)
+            )
+        )
+    );
+}
+
 $order-array: (
     first: -1,
     last: $grid-columns + 1,
@@ -174,6 +189,11 @@ $utilities: map-merge(
             class: min-w,
             property: min-width,
             values: 0,
+        ),
+        "avatar": (
+            css-var: true,
+            class: avatar-size,
+            values: $utilities-avatar-sizes,
         ),
     )
 );

--- a/addons/web/static/src/views/fields/many2many_tags/tags_list.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/tags_list.xml
@@ -4,7 +4,7 @@
     <t t-name="web.TagsList" owl="1">
         <t t-foreach="visibleTags" t-as="tag" t-key="tag.id or tag_index">
             <span t-attf-class="{{`o_tag_color_${ tag.colorIndex or 0 } ${props.displayBadge ? 'badge rounded-pill' : ''}`}} o_tag d-inline-flex align-items-center h-100" tabindex="-1" t-att-data-color="tag.colorIndex" t-att-title="tag.text" t-on-click="(ev) => tag.onClick and tag.onClick(ev)" t-on-keydown="tag.onKeydown">
-                <img t-if="tag.img" t-att-src="tag.img" class="o_m2m_avatar rounded-circle" t-att-class="tag.className"/>
+                <img t-if="tag.img" t-att-src="tag.img" class="o_m2m_avatar avatar-size rounded-circle" t-att-class="tag.className"/>
                 <div t-if="props.displayBadge" class="o_tag_badge_text" t-esc="tag.text" />
                 <t t-else="">
                     <span />
@@ -13,7 +13,7 @@
                 <a tabIndex="-1" t-if="tag.onDelete" t-on-click.stop.prevent="(ev) => tag.onDelete and tag.onDelete(ev)" href="#" class="fa fa-times o_delete" title="Delete" aria-label="Delete"></a>
             </span>
         </t>
-        <span t-if="props.tags and otherTags.length" class="o_m2m_avatar_empty rounded-circle text-center fw-bold" t-att-data-tooltip="tooltip">
+        <span t-if="props.tags and otherTags.length" class="o_m2m_avatar_empty avatar-size rounded-circle text-center fw-bold" t-att-data-tooltip="tooltip">
             <span t-if="otherTags.length > 9" t-esc="'9+'" />
             <span t-else="" t-esc="'+' + otherTags.length" />
         </span>

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -4,8 +4,8 @@
     <t t-name="web.Many2OneAvatarField" owl="1">
         <div>
             <span class="o_m2o_avatar">
-                <span t-if="props.value === false and !props.readonly" class="o_m2o_avatar_empty"></span>
-                <img t-if="props.value !== false" t-attf-src="/web/image/{{props.relation}}/{{props.value[0]}}/avatar_128" />
+                <span t-if="props.value === false and !props.readonly" class="o_m2o_avatar_empty avatar-size"></span>
+                <img t-if="props.value !== false" t-attf-src="/web/image/{{props.relation}}/{{props.value[0]}}/avatar_128" class="avatar-size"/>
             </span>
             <Many2OneField t-props="props" />
         </div>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -271,8 +271,8 @@ $o-form-label-margin-right: 0px;
         margin-bottom: 10px;
 
         > div > img {
-            max-width: $o-avatar-size;
-            max-height: $o-avatar-size;
+            max-width: $o-image-field-size;
+            max-height: $o-image-field-size;
             vertical-align: top;
             border: 1px solid $o-gray-300;
         }

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -295,7 +295,7 @@
             line-height: 1.2;
             word-break: break-all;
 
-            &.avatar {
+            &.avatar_wrap {
                 margin: 0 0 0 6px;
                 .o_m2m_avatar_empty > span {
                     display: block;

--- a/addons/web/static/src/views/kanban/kanban_examples_dialog.scss
+++ b/addons/web/static/src/views/kanban/kanban_examples_dialog.scss
@@ -62,9 +62,4 @@
     &.o_collapse {
         margin-top: -1px;
     }
-
-    .o_ghost_avatar {
-        height: 20px;
-        width: 20px;
-    }
 }

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -159,7 +159,7 @@
                                         <div class="o_ghost_content w-100 pb-3 bg-300"/>
                                         <div class="o_ghost_content o_ghost_tag d-inline-block w-50 mt-3 pb-3 bg-300"/>
                                         <span class="mt-2 rounded-circle bg-300">
-                                            <img class="o_ghost_avatar" src="/base/static/img/avatar.png" alt="Avatar"/>
+                                            <img class="o_ghost_avatar avatar-size" src="/base/static/img/avatar.png" alt="Avatar"/>
                                         </span>
                                     </div>
                                 </div>

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -16,7 +16,7 @@
           <div class="o_burger_menu_topbar d-flex align-items-center justify-content-between flex-shrink-0 py-0 text-bg-odoo fs-4"
               t-on-click.stop='_toggleUserMenu'>
               <small class="o-no-caret dropdown-toggle d-flex align-items-center justify-content-between" t-att-class="{'active bg-white': isUserMenuUnfolded }">
-                  <img class="o_burger_menu_avatar o_image_24_cover rounded-circle" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
+                  <img class="o_burger_menu_avatar avatar-size rounded-circle" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
                   <span class="o_burger_menu_username px-2"><t t-esc="user.name"/></span>
                   <i t-if="isUserMenuTogglable" class="fa" t-att-class="state.isUserMenuOpened ? 'fa-caret-down' : 'fa-caret-left'"/>
               </small>

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -4,7 +4,7 @@
     <t t-name="web.UserMenu" owl="1">
         <Dropdown class="'o_user_menu d-none d-md-block pe-0'" togglerClass="'py-1 py-lg-0'">
             <t t-set-slot="toggler">
-                <img class="rounded-circle o_user_avatar h-75 py-1" t-att-src="source" alt="User"/>
+                <img class="avatar-size avatar-size-md rounded-circle o_user_avatar" t-att-src="source" alt="User"/>
                 <span class="oe_topbar_name d-none d-lg-block ms-1"><t t-esc="user.name"/><t t-if="env.debug" t-esc="' (' + user.db.name + ')'"/></span>
             </t>
             <t t-foreach="getElements()" t-as="element" t-key="element_index">

--- a/addons/web/static/tests/legacy/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields_tests.js
@@ -2062,8 +2062,8 @@ QUnit.module('Legacy relational_fields', {
             res_id: 2,
         });
 
-        assert.containsN(form, '.o_field_many2manytags.avatar.o_field_widget .badge', 2, "should have 2 records");
-        assert.strictEqual(form.$('.o_field_many2manytags.avatar.o_field_widget .badge:first img').data('src'), '/web/image/partner/2/avatar_128',
+        assert.containsN(form, '.o_field_many2manytags.avatar_wrap.o_field_widget .badge', 2, "should have 2 records");
+        assert.strictEqual(form.$('.o_field_many2manytags.avatar_wrap.o_field_widget .badge:first img').data('src'), '/web/image/partner/2/avatar_128',
             "should have correct avatar image");
 
         form.destroy();

--- a/addons/website/static/src/scss/website_visitor_views.scss
+++ b/addons/website/static/src/scss/website_visitor_views.scss
@@ -35,3 +35,7 @@
         margin-right: 0.25rem;
     }
 }
+
+.o_wvisitor_kanban_image .avatar {
+    --avatar-size: 54px;
+}

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -100,10 +100,10 @@
                                         <div class="o_wvisitor_kanban_image me-3">
                                             <img t-if="record.partner_image.raw_value"
                                                 t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)"
-                                                width="54px" height="54px" alt="Visitor"/>
+                                                alt="Visitor" class="avatar-size"/>
                                             <img t-else=""
                                                 t-attf-src="/base/static/img/avatar_grey.png"
-                                                width="54px" height="54px" alt="Visitor"/>
+                                                alt="Visitor" class="avatar-size"/>
                                         </div>
                                         <div class="o_wvisitor_name d-flex flex-grow-1 flex-column my-0 my-lg-2">
                                             <div class="d-flex align-items-start">

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -74,7 +74,7 @@
                                         <field name="kanban_state" widget="state_selection" groups="base.group_user"/>
                                         <img t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)"
                                             t-att-title="record.partner_id.value" t-att-alt="record.partner_id.value"
-                                            class="oe_kanban_avatar"/>
+                                            class="oe_kanban_avatar avatar-size"/>
                                     </div>
                                 </div>
                             </div>

--- a/addons/website_forum/static/src/scss/website_forum.scss
+++ b/addons/website_forum/static/src/scss/website_forum.scss
@@ -28,11 +28,6 @@ $bronze: #eea91e;
             background-color: rgba(map-get($theme-colors, 'info'), 0.1);
             color: darken(map-get($theme-colors, 'info'), 15%)!important;
         }
-
-        img.o_forum_avatar {
-            width: 30px;
-            height: 30px;
-        }
     }
 
     // Single Post
@@ -52,13 +47,6 @@ $bronze: #eea91e;
             padding-left: 1em;
             border-left: .25em solid map-get($grays, '500');
             color: map-get($grays, '600');
-        }
-
-        #post_reply {
-            img.o_forum_avatar {
-                width: 24px;
-                height: 24px;
-            }
         }
     }
 
@@ -223,23 +211,9 @@ $bronze: #eea91e;
     overflow: hidden;
 }
 
-img.o_forum_avatar {
-    width: 40px;
-    height: 40px;
-    object-fit: cover;
-}
-
 img.o_forum_avatar_big {
-    width: 75px;
-    height: 75px;
+    --avatar-size: 75px;
     object-fit: cover;
-}
-
-.o_wprofile_email_validation_container {
-    img.o_forum_avatar {
-        width: 16px;
-        height: 16px;
-    }
 }
 
 .o_wforum_bio_popover_wrap {

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -550,7 +550,7 @@
             data-bs-toggle="tooltip"
             data-trigger="hover"
             title="My profile">
-            <img class="o_forum_avatar rounded-circle me-1" t-att-src="website.image_url(user, 'avatar_128', '30x30')" alt="Avatar"/>
+            <img class="o_forum_avatar avatar-size avatar-size-md rounded-circle me-1" t-att-src="website.image_url(user, 'avatar_128', '30x30')" alt="Avatar"/>
             <div>
                 <h6 class="my-0" t-esc="user_id.name"/>
                 <small class="text-muted fw-bold"><t t-esc="user_id.karma"/>xp</small>
@@ -634,7 +634,7 @@
                     </span>
                     <span t-if="my" t-attf-class="w-100 w-md-auto mb-2 mb-md-0 border rounded ps-2 d-inline-flex align-items-center justify-content-between #{search and 'ms-md-2'}">
                         <div>
-                            <img t-if="uid" class="o_forum_avatar rounded-circle me-1" t-att-src="website.image_url(user, 'avatar_128', '16x16')" alt="Avatar"/>
+                            <img t-if="uid" class="o_forum_avatar avatar-size avatar-size-sm rounded-circle me-1" t-att-src="website.image_url(user, 'avatar_128', '16x16')" alt="Avatar"/>
                             <span t-if="my == 'favourites'"> My <b>Favourites</b></span>
                             <span t-elif="my == 'followed'"> I'm <b>Following</b></span>
                             <span t-elif="my == 'mine'"> My <b>Posts</b></span>
@@ -991,7 +991,7 @@
 <!-- Edition: post an answer -->
 <template id="post_answer">
     <div class="d-flex align-items-center mt-5 mb-2">
-        <img t-if="uid" t-attf-class="o_forum_avatar rounded-circle me-2" t-att-src="website.image_url(user, 'avatar_128', '24x24')" alt="Avatar"/>
+        <img t-if="uid" t-attf-class="o_forum_avatar avatar-size rounded-circle me-2" t-att-src="website.image_url(user, 'avatar_128', '24x24')" alt="Avatar"/>
         <h4 class="my-0">Your Answer</h4>
     </div>
     <t t-if="request.params.get('nocontent')">
@@ -1414,7 +1414,7 @@
     <t t-set="display_info" t-value="show_name or show_date or show_karma"/>
     <t t-if="allow_biography and object.can_display_biography" t-set="bio_popover_data">
         <div class="d-flex o_wforum_bio_popover_wrap">
-            <img class="o_forum_avatar_big flex-shrink-0 me-3" t-att-src="website.image_url(object.create_uid, 'avatar_128', '75x75')" alt="Avatar"/>
+            <img class="o_forum_avatar_big avatar-size flex-shrink-0 me-3" t-att-src="website.image_url(object.create_uid, 'avatar_128', '75x75')" alt="Avatar"/>
             <div>
                 <h5 class="o_wforum_bio_popover_name mb-0" t-field="object.create_uid" t-options='{"widget": "contact", "country_image": True, "fields": ["name", "country_id"]}'/>
 
@@ -1435,7 +1435,7 @@
             <span t-if="object_validable" class="o_wforum_author_box_check rounded-circle bg-success position-absolute">
                 <i class="fa fa-check fa-fw small text-white"/>
             </span>
-            <img t-attf-class="rounded-circle o_forum_avatar #{not display_info and 'shadow'}" t-att-src="website.image_url(object.create_uid, 'avatar_128', '40x40')" alt="Avatar"/>
+            <img t-attf-class="avatar-size avatar-size-md rounded-circle o_forum_avatar #{not display_info and 'shadow'}" t-att-src="website.image_url(object.create_uid, 'avatar_128', '40x40')" alt="Avatar"/>
         </a>
 
         <div t-if="show_name or show_date or show_karma" t-attf-class="d-flex #{compact and 'align-items-baseline ms-1' or 'flex-column justify-content-around ms-2'}">
@@ -1468,7 +1468,7 @@
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <input name="post_id" t-att-value="object.id" type="hidden" class="mt8"/>
                     <div class="d-flex w-100">
-                        <img class="d-none d-md-inline-block rounded-circle o_forum_avatar me-3" t-att-src="website.image_url(user, 'avatar_128', '40x40')" alt="Avatar"/>
+                        <img class="avatar-size avatar-size-md d-none d-md-inline-block rounded-circle o_forum_avatar me-3" t-att-src="website.image_url(user, 'avatar_128', '40x40')" alt="Avatar"/>
                         <div class="w-100">
                             <textarea name="comment" class="form-control mb-2" placeholder="Comment this post..."/>
                             <div>
@@ -1624,7 +1624,7 @@
                                                 <div class="form-check">
                                                     <input type="checkbox" t-att-value="user.id" class="form-check-input" t-attf-id="user_#{user.id}"/>
                                                     <label class="form-check-label" t-attf-for="user_#{user.id}">
-                                                        <img class="d-inline img o_forum_avatar" t-att-src="website.image_url(user, 'avatar_128', '40x40')" alt="Avatar"/>
+                                                        <img class="avatar-size avatar-size-sm d-inline img o_forum_avatar" t-att-src="website.image_url(user, 'avatar_128', '40x40')" alt="Avatar"/>
                                                         <span t-esc="user.name" class="d-inline"/>
                                                     </label>
                                                 </div>

--- a/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.scss
+++ b/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.scss
@@ -8,15 +8,7 @@
     padding: map-get($spacers, 4) map-get($spacers, 2);
 }
 
-.o_VisitorBanner_avatar {
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-}
-
 .o_VisitorBanner_avatarContainer {
-    height: $o-mail-thread-avatar-size;
-    width: $o-mail-thread-avatar-size;
     margin-left: map-get($spacers, 1);
     margin-right: map-get($spacers, 1);
     position: relative;

--- a/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.xml
+++ b/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.xml
@@ -5,8 +5,8 @@
         <t t-if="visitor">
             <div class="o_VisitorBanner" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_VisitorBanner_sidebar">
-                    <div class="o_VisitorBanner_avatarContainer">
-                        <img class="o_VisitorBanner_avatar rounded-circle" t-att-src="visitor.avatarUrl" alt="Avatar"/>
+                    <div class="o_VisitorBanner_avatarContainer align-self-start">
+                        <img class="o_VisitorBanner_avatar avatar-size avatar-size-lg rounded-circle" t-att-src="visitor.avatarUrl" alt="Avatar"/>
                         <t t-if="visitor.is_connected">
                             <i class="o_VisitorBanner_onlineStatusIcon fa fa-circle" title="Online" role="img" aria-label="Visitor is online"/>
                         </t>

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -42,7 +42,7 @@
                     Speaking With
                     <div name="livechat_operator_id"
                         class="fw-bold float-end d-inline-block">
-                        <img class="oe_avatar rounded-circle" width="19" height="19"
+                        <img class="oe_avatar avatar-size avatar-size-sm me-1 rounded-circle"
                             t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
                             alt="Operator Avatar"/>
                         <field name="livechat_operator_name"/>
@@ -62,7 +62,7 @@
                 <div t-if="record.livechat_operator_id.raw_value" class="col-lg col-sm-4 col-6 py-0 my-2">
                     <div>
                         <img name="livechat_operator_id"
-                            class="oe_avatar rounded-circle" width="19" height="19"
+                            class="oe_avatar avatar-size avatar-size-sm me-1 rounded-circle"
                             t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
                             alt="Operator Avatar"/>
                         <b><field name="livechat_operator_name"/></b>

--- a/addons/website_profile/static/src/scss/website_profile.scss
+++ b/addons/website_profile/static/src/scss/website_profile.scss
@@ -255,3 +255,7 @@ $owprofile-color-bg: mix($body-bg, #efeff4);
 .o_wprofile_border_focus {
     border-left: 4px solid map-get($theme-colors, 'secondary');
 }
+
+.avatar-podium {
+    --avatar-size: 128px;
+}

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -561,8 +561,7 @@
         <div class="card w-100 text-center mb-2 border-bottom-0 o_wprofile_pointer">
             <div class="card-body">
                 <div class="d-inline-block position-relative">
-                    <img class="rounded-circle img-fluid"
-                        style="width: 128px; height: 128px; object-fit: cover;"
+                    <img class="rounded-circle img-fluid avatar avatar-podium"
                          t-att-src="'/profile/avatar/%s?field=avatar_256%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
                     <img class="position-absolute" t-attf-src="/website_profile/static/src/img/rank_#{user_index + 1}.svg" alt="User rank" style="bottom: 0; right: -10px"/>
                 </div>
@@ -585,7 +584,7 @@
             <span t-esc="user['position']"/>
         </td>
         <td class="align-middle d-none d-sm-table-cell">
-            <img class="o_object_fit_cover rounded-circle o_wprofile_img_small" width="30" height="30" t-att-src="'/profile/avatar/%s?field=avatar_128%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
+            <img class="avatar-size avatar-size-md rounded-circle o_wprofile_img_small" t-att-src="'/profile/avatar/%s?field=avatar_128%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
         </td>
         <td class="align-middle w-md-75">
             <span class="fw-bold" t-esc="user['name']"/><br/>


### PR DESCRIPTION
In order to keep consistency between common avatar sizes, this commit
introduces new utility classes to handle them.

Requires: 
- https://github.com/odoo/enterprise/pull/31065

task-2973409

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
