### PR TITLE
[IMP] web: tests: helper to allow FormViewDialogs in legacy

### DIFF
--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -20,6 +20,9 @@ import { dialogService } from "@web/core/dialog/dialog_service";
 import { popoverService } from "@web/core/popover/popover_service";
 import { createDebugContext } from "@web/core/debug/debug_context";
 
+import { mapLegacyEnvToWowlEnv } from "@web/legacy/utils";
+import makeTestEnvironment from "web.test_env";
+
 const serviceRegistry = registry.category("services");
 
 /**
@@ -107,4 +110,23 @@ export function setupViewRegistries() {
     serviceRegistry.add("dialog", dialogService), { force: true };
     serviceRegistry.add("popover", popoverService), { force: true };
     serviceRegistry.add("company", fakeCompanyService);
+}
+
+/**
+ * This helper sets the legacy env and mounts a MainComponentsContainer
+ * to allow legacy code to use wowl FormViewDialogs.
+ *
+ * TODO: remove this when there's no legacy code using the wowl FormViewDialog.
+ *
+ * @param {Object} serverData
+ * @param {Function} [mockRPC]
+ * @returns {Promise}
+ */
+export async function prepareWowlFormViewDialogs(serverData, mockRPC) {
+    setupViewRegistries();
+    const wowlEnv = await makeTestEnv({ serverData, mockRPC });
+    const legacyEnv = makeTestEnvironment();
+    mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv);
+    owl.Component.env = legacyEnv;
+    await mount(MainComponentsContainer, getFixture(), { env: wowlEnv });
 }


### PR DESCRIPTION
This commit introduces an helper that can be used in legacy tests,
when the tested flow opens a FormViewDialog (wowl). The helper
properly sets up the legacy environment to make the (wowl) dialog
service available, and spawns a MainComponentsContainer s.t. the
(wowl) dialog can open. This helper is already used by several grid
and timesheet_grid tests, and it might be useful in other cases
soon as we are currently removing the use of legacy FormViewDialog.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
