### PR TITLE
[FIX] web: kanban: reload after creating a record

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -89,7 +89,14 @@ export class KanbanController extends Component {
         if (onCreate === "quick_create" && root.canQuickCreate()) {
             await root.quickCreate(group);
         } else if (onCreate && onCreate !== "quick_create") {
-            await this.actionService.doAction(onCreate, { additionalContext: root.context });
+            const options = {
+                additionalContext: root.context,
+                onClose: async () => {
+                    await this.model.root.load();
+                    this.render(true); // FIXME WOWL reactivity
+                },
+            };
+            await this.actionService.doAction(onCreate, options);
         } else {
             await this.props.createRecord();
         }


### PR DESCRIPTION
In kanban arch, one can set the attribute "on_create" on the root
node to an action xmlid. In this case, when the user clicks on
"Create", the action is executed. When this action is in target
new, it opens a dialog (typically to create a record...). Before
this commit, we didn't reload the kanban after closing the dialog.
As a consequence, the newly created record wasn't displayed. For
instance, it was the case in the Recruitement dashboard.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
