### PR TITLE
[FIX] website: put the name of the "edit in backend" button in the state

### DIFF
--- a/addons/website/static/src/systray_items/edit_in_backend.js
+++ b/addons/website/static/src/systray_items/edit_in_backend.js
@@ -3,7 +3,7 @@
 import { registry } from "@web/core/registry";
 import { useService, useBus } from "@web/core/utils/hooks";
 
-const { Component, onWillStart, onMounted } = owl;
+const { Component, onWillStart, onMounted, useState } = owl;
 
 const websiteSystrayRegistry = registry.category('website_systray');
 
@@ -11,6 +11,7 @@ export class EditInBackendSystray extends Component {
     setup() {
         this.websiteService = useService('website');
         this.actionService = useService('action');
+        this.state = useState({mainObjectName: ''});
 
         onWillStart(this._updateMainObjectName);
         useBus(websiteSystrayRegistry, 'CONTENT-UPDATED', this._updateMainObjectName);
@@ -33,7 +34,7 @@ export class EditInBackendSystray extends Component {
     }
 
     async _updateMainObjectName() {
-        this.mainObjectName = await this.websiteService.getUserModelName();
+        this.state.mainObjectName = await this.websiteService.getUserModelName();
     }
 }
 EditInBackendSystray.template = "website.EditInBackendSystray";

--- a/addons/website/static/src/systray_items/edit_in_backend.xml
+++ b/addons/website/static/src/systray_items/edit_in_backend.xml
@@ -4,7 +4,7 @@
     <div class="o_website_edit_in_backend">
         <a href="#" accesskey="e" t-on-click="editInBackend">
             <span class="fa fa-cog me-2"/>
-            <t t-esc="mainObjectName"/>
+            <t t-esc="state.mainObjectName"/>
         </a>
     </div>
 </t>


### PR DESCRIPTION
Since the button must be rendered when its text changes, the variable
that holds its text must be stored in the component state. The button
already had the right text before a bit by chance because the new name
was computed before the component was rendered. Now we make sure that
the component will be rendered when the name is recomputed. The problem
is visible if we slow down the getUserModelName function and go to a
forum.post from a forum.forum.

task-2889929
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
