### PR TITLE
[IMP] appointment: avoid useless queries

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1135,8 +1135,10 @@ class Meeting(models.Model):
 
     @api.model
     def _get_custom_fields(self):
-        all_fields = self.fields_get(attributes=['manual'])
-        return {fname for fname in all_fields if all_fields[fname]['manual']}
+        return {
+            fname
+            for fname, field in self._fields.items()
+            if field.get_description(self.env)['manual'] and (not field.groups or self.user_has_groups(field.groups))}
 
     @api.model
     def _get_public_fields(self):


### PR DESCRIPTION
Those queries where mainly visible in AppointmentTestPerformance
because has_group and check_access_rights were not in cache with
appointment only, leading to more queries than runbot.

Alternative to odoo/enterprise#31062

