### PR TITLE
[FIX] web: make a parse smart date test pass

### DIFF
--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -80,12 +80,12 @@ export function areDateEquals(d1, d2) {
  *   "-4y" will return now + 4 years
  *
  * @param {string} value
- * @returns {DateTime|false} Luxon datetime object (in the UTC timezone)
+ * @returns {DateTime|false} Luxon datetime object (in the user's local timezone)
  */
 function parseSmartDateInput(value) {
     const match = smartDateRegex.exec(value);
     if (match) {
-        let date = DateTime.utc();
+        let date = DateTime.local();
         const offset = parseInt(match[2], 10);
         const unit = smartDateUnits[match[3] || "d"];
         if (match[1] === "+") {

--- a/addons/web/static/tests/core/l10n/dates_tests.js
+++ b/addons/web/static/tests/core/l10n/dates_tests.js
@@ -311,47 +311,35 @@ QUnit.module(
         });
 
         QUnit.test("parse smart date input", async (assert) => {
-            const format = "dd MM yyyy";
-            assert.strictEqual(
-                parseDate("+1d").toFormat(format),
-                DateTime.utc().plus({ days: 1 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDateTime("+2w").toFormat(format),
-                DateTime.utc().plus({ weeks: 2 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDate("+3m").toFormat(format),
-                DateTime.utc().plus({ months: 3 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDateTime("+4y").toFormat(format),
-                DateTime.utc().plus({ years: 4 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDate("+5").toFormat(format),
-                DateTime.utc().plus({ days: 5 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDateTime("-5").toFormat(format),
-                DateTime.utc().minus({ days: 5 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDate("-4y").toFormat(format),
-                DateTime.utc().minus({ years: 4 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDateTime("-3m").toFormat(format),
-                DateTime.utc().minus({ months: 3 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDate("-2w").toFormat(format),
-                DateTime.utc().minus({ weeks: 2 }).toFormat(format)
-            );
-            assert.strictEqual(
-                parseDateTime("-1d").toFormat(format),
-                DateTime.utc().minus({ days: 1 }).toFormat(format)
-            );
+            patchDate(2020, 0, 1, 0, 0, 0); // 2020-01-01 00:00:00
+
+            const format = "yyyy-MM-dd HH:mm";
+            // with parseDate
+            assert.strictEqual(parseDate("+0").toFormat(format), "2020-01-01 00:00");
+            assert.strictEqual(parseDate("-0").toFormat(format), "2020-01-01 00:00");
+            assert.strictEqual(parseDate("+1d").toFormat(format), "2020-01-02 00:00");
+            assert.strictEqual(parseDate("+2w").toFormat(format), "2020-01-15 00:00");
+            assert.strictEqual(parseDate("+3m").toFormat(format), "2020-04-01 00:00");
+            assert.strictEqual(parseDate("+4y").toFormat(format), "2024-01-01 00:00");
+            assert.strictEqual(parseDate("+5").toFormat(format), "2020-01-06 00:00");
+            assert.strictEqual(parseDate("-5").toFormat(format), "2019-12-27 00:00");
+            assert.strictEqual(parseDate("-4y").toFormat(format), "2016-01-01 00:00");
+            assert.strictEqual(parseDate("-3m").toFormat(format), "2019-10-01 00:00");
+            assert.strictEqual(parseDate("-2w").toFormat(format), "2019-12-18 00:00");
+            assert.strictEqual(parseDate("-1d").toFormat(format), "2019-12-31 00:00");
+            // with parseDateTime
+            assert.strictEqual(parseDateTime("+0").toFormat(format), "2020-01-01 00:00");
+            assert.strictEqual(parseDateTime("-0").toFormat(format), "2020-01-01 00:00");
+            assert.strictEqual(parseDateTime("+1d").toFormat(format), "2020-01-02 00:00");
+            assert.strictEqual(parseDateTime("+2w").toFormat(format), "2020-01-15 00:00");
+            assert.strictEqual(parseDateTime("+3m").toFormat(format), "2020-04-01 00:00");
+            assert.strictEqual(parseDateTime("+4y").toFormat(format), "2024-01-01 00:00");
+            assert.strictEqual(parseDateTime("+5").toFormat(format), "2020-01-06 00:00");
+            assert.strictEqual(parseDateTime("-5").toFormat(format), "2019-12-27 00:00");
+            assert.strictEqual(parseDateTime("-4y").toFormat(format), "2016-01-01 00:00");
+            assert.strictEqual(parseDateTime("-3m").toFormat(format), "2019-10-01 00:00");
+            assert.strictEqual(parseDateTime("-2w").toFormat(format), "2019-12-18 00:00");
+            assert.strictEqual(parseDateTime("-1d").toFormat(format), "2019-12-31 00:00");
         });
 
         QUnit.test("parseDateTime ISO8601 Format", async (assert) => {


### PR DESCRIPTION
> **[FIX] web: make a parse smart date test pass**
> - Name of the test
> "utils > dates > parse smart date input"
> 
> - Before this commit
> The test makes a comparison between the result of parse utils,
> which yields luxon's DateTime objects in the user's local TZ
> (patched by default to UTC+1 in the testing env), and locally
> created DateTime objects in UTC.
> This has no sense to compare a date in UTC with another in UTC+1.
> The test was thus failing when ran between 11pm and 0am.
> 
> - After this commit
> The test has been refactored.
> Also, even if it has no impact on the parsing result, the local function
> parseSmartDateInput now use a DateTime object in local TZ.
> This has been done in order to avoid future confusion.
> If you're wondering why it has no impact, it is because this function is
> used in parseDate(Time), which always sets the local TZ at the end:
> ```
> const a = {
>   foo: luxon.DateTime.local(),
>   bar: luxon.DateTime.utc(),
> };
> a.foo.equals(a.bar.setZone("default")); // true
> ```