### PR TITLE
[IMP] base: back-end views, remove attributes unused by the web client

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -95,19 +95,21 @@ def transfer_node_to_modifiers(node, modifiers, context=None):
     # Don't deal with groups, it is done by check_group().
     # Need the context to evaluate the invisible attribute on tree views.
     # For non-tree views, the context shouldn't be given.
-    if node.get('attrs'):
-        attrs = node.get('attrs').strip()
-        modifiers.update(ast.literal_eval(attrs))
+    attrs = node.attrib.pop('attrs', None)
+    if attrs:
+        modifiers.update(ast.literal_eval(attrs.strip()))
 
-    if node.get('states'):
+    states = node.attrib.pop('states', None)
+    if states:
+        states = states.split(',')
         if 'invisible' in modifiers and isinstance(modifiers['invisible'], list):
             # TODO combine with AND or OR, use implicit AND for now.
-            modifiers['invisible'].append(('state', 'not in', node.get('states').split(',')))
+            modifiers['invisible'].append(('state', 'not in', states))
         else:
-            modifiers['invisible'] = [('state', 'not in', node.get('states').split(','))]
+            modifiers['invisible'] = [('state', 'not in', states)]
 
     for attr in ('invisible', 'readonly', 'required'):
-        value_str = node.get(attr)
+        value_str = node.attrib.pop(attr, None)
         if value_str:
             value = bool(quick_eval(value_str, {'context': context or {}}))
             if (attr == 'invisible'
@@ -131,7 +133,8 @@ def simplify_modifiers(modifiers):
 def transfer_modifiers_to_node(modifiers, node):
     if modifiers:
         simplify_modifiers(modifiers)
-        node.set('modifiers', json.dumps(modifiers))
+        if modifiers:
+            node.set('modifiers', json.dumps(modifiers))
 
 
 @lazy


### PR DESCRIPTION
In back-end views, the attributes
- attrs
- states
- invisible
- readonly
- required

are transfered to the `modifiers` attribute.
The web client only uses this `modifiers` attribute.
Hence, the above attributes which gets transfered
to the `modifiers` attribute can be safely removed
from the architecture sent to the web client.

In addition, in case the modifiers were all falsy
e.g. `{'invisible': False, 'readonly': False, 'required': False}`
`simplify_modifiers` was simplifying these modifiers to
`{}` and `modifiers="{}"` was set on the node,
which is a bit useless and waste transferred bytes.

This allows to gain some KB for all `get_views` calls.

For instance, with only `account_accountant` installed,
`get_views` of `account.move` goes
from 228.01 KB to 208.78,
therefore sparing 10% of KB for each calls.

![image](https://user-images.githubusercontent.com/5822488/188598561-d8ecd4cc-a854-4e4e-b646-c8e8181bdaba.png)

An example using the `res.partner` form:
Before
```xml
<field name="is_company" invisible="1" on_change="1" modifiers="{&quot;invisible&quot;: true}"/>
<field name="commercial_partner_id" invisible="1" on_change="1" modifiers="{&quot;invisible&quot;: true, &quot;readonly&quot;: true}" can_create="true" can_write="true"/>
<field name="active" invisible="1" on_change="1" modifiers="{&quot;invisible&quot;: true}"/>
<field name="company_id" invisible="1" on_change="1" modifiers="{&quot;invisible&quot;: true}" can_create="true" can_write="true"/>
<field name="country_code" invisible="1" modifiers="{&quot;invisible&quot;: true, &quot;readonly&quot;: true}"/>
<field name="company_type" widget="radio" options="{'horizontal': true}" on_change="1" modifiers="{}"/>
```

After:
```xml
<field name="is_company" on_change="1" modifiers="{&quot;invisible&quot;: true}"/>
<field name="commercial_partner_id" on_change="1" modifiers="{&quot;invisible&quot;: true, &quot;readonly&quot;: true}" can_create="true" can_write="true"/>
<field name="active" on_change="1" modifiers="{&quot;invisible&quot;: true}"/>
<field name="company_id" on_change="1" modifiers="{&quot;invisible&quot;: true}" can_create="true" can_write="true"/>
<field name="country_code" modifiers="{&quot;invisible&quot;: true, &quot;readonly&quot;: true}"/>
<field name="company_type" widget="radio" options="{'horizontal': true}" on_change="1"/>
```
