### PR TITLE
[FIX] bus: keep last notification id during refresh

### DIFF
--- a/addons/bus/models/__init__.py
+++ b/addons/bus/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from . import bus
 from . import bus_presence
+from . import ir_http
 from . import ir_model
 from . import ir_websocket
 from . import res_users

--- a/addons/bus/models/ir_http.py
+++ b/addons/bus/models/ir_http.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.http import request
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def session_info(self):
+        result = super().session_info()
+        result['dbuuid'] = request.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        return result
+
+    def get_frontend_session_info(self):
+        result = super().get_frontend_session_info()
+        result['dbuuid'] = request.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        return result

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -81,7 +81,6 @@ export class WebsocketWorker {
             this._onClientMessage(messagePort, ev.data);
         };
         this.channelsByClient.set(messagePort, []);
-        this._updateChannels();
     }
 
     /**
@@ -122,6 +121,9 @@ export class WebsocketWorker {
                 return this._deleteChannel(client, data);
             case 'force_update_channels':
                 return this._forceUpdateChannels();
+            case 'update_last_notification_id':
+                this.lastNotificationId = data;
+                this._updateChannels();
         }
     }
 
@@ -240,7 +242,7 @@ export class WebsocketWorker {
     _onWebsocketMessage(messageEv) {
         const notifications = JSON.parse(messageEv.data);
         this.lastNotificationId = notifications[notifications.length - 1].id;
-        this.broadcast('notification', notifications.map(notification => notification.message));
+        this.broadcast('notification', notifications);
     }
 
     /**

--- a/addons/bus/static/tests/helpers/mock_server.js
+++ b/addons/bus/static/tests/helpers/mock_server.js
@@ -15,6 +15,7 @@ patch(MockServer.prototype, 'bus', {
         this.websocketWorker = patchWebsocketWorkerWithCleanup();
         this.pendingLongpollingPromise = null;
         this.notificationsToBeResolved = [];
+        this.lastBusNotificationId = 0;
     },
 
     //--------------------------------------------------------------------------
@@ -56,10 +57,13 @@ patch(MockServer.prototype, 'bus', {
      * @param {Array} notifications
      */
     _mockBusBus__sendmany(notifications) {
+        if (!notifications.length) {
+            return;
+        }
         const values = [];
         for (const notification of notifications) {
             const [type, payload] = notification.slice(1, notification.length);
-            values.push({ payload, type });
+            values.push({ id: this.lastBusNotificationId++, message: { payload, type }});
             if (this.debug) {
                 console.log("%c[bus]", "color: #c6e; font-weight: bold;", type, payload);
             }

--- a/addons/bus/static/tests/websocket_worker_tests.js
+++ b/addons/bus/static/tests/websocket_worker_tests.js
@@ -81,7 +81,7 @@ QUnit.test('notification event is broadcasted', async function (assert) {
         broadcast(type, message) {
             if (type === 'notification') {
                 assert.step(`broadcast ${type}`);
-                assert.deepEqual(message, notifications.map(notif => notif.message));
+                assert.deepEqual(message, notifications);
             }
         },
     });


### PR DESCRIPTION
Before the websocket were introduced, the last notification id was
persisted in the local storage in order to use it even after a page
reload.

The last notification id is now stored on the `SharedWorker` which
means this information is lost if the last opened tab is reloaded.

This commit fixes this issue by storing this information by the mean of
the localStorage. Since the localStorage is not accessible from the
worker global scope, the bus service will store this information and
relay it to the worker when starting. The worker will now wait to
receive the last notification id before subscribing.

enterprise: https://github.com/odoo/enterprise/pull/31124