### PR TITLE
[IMP] hr_attendance: add camera choice for barcode scanner

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -162,6 +162,7 @@ class HrEmployee(models.Model):
         action_message['barcode'] = employee.barcode
         action_message['next_action'] = next_action
         action_message['hours_today'] = employee.hours_today
+        action_message['kiosk_delay'] = employee.company_id.attendance_kiosk_delay * 1000
 
         if employee.user_id:
             modified_attendance = employee.with_user(employee.user_id).sudo()._attendance_action_change()

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -13,6 +13,18 @@ class ResCompany(models.Model):
     overtime_company_threshold = fields.Integer(string="Tolerance Time In Favor Of Company", default=0)
     overtime_employee_threshold = fields.Integer(string="Tolerance Time In Favor Of Employee", default=0)
 
+    attendance_kiosk_mode = fields.Selection([
+        ('barcode', 'Barcode / RFID'),
+        ('barcode_manual', 'Barcode / RFID and Manual Selection'),
+        ('manual', 'Manual Selection'),
+    ], string='Attendance Mode', default='barcode_manual')
+    attendance_barcode_source = fields.Selection([
+        ('scanner', 'Scanner'),
+        ('front', 'Front Camera'),
+        ('back', 'Back Camera'),
+    ], string='Barcode Source', default='front')
+    attendance_kiosk_delay = fields.Integer(default=10)
+
     def write(self, vals):
         search_domain = False  # Overtime to generate
         delete_domain = False  # Overtime to delete

--- a/addons/hr_attendance/models/res_config_settings.py
+++ b/addons/hr_attendance/models/res_config_settings.py
@@ -17,6 +17,9 @@ class ResConfigSettings(models.TransientModel):
         string="Tolerance Time In Favor Of Company", readonly=False)
     overtime_employee_threshold = fields.Integer(
         string="Tolerance Time In Favor Of Employee", readonly=False)
+    attendance_kiosk_mode = fields.Selection(related='company_id.attendance_kiosk_mode', readonly=False)
+    attendance_barcode_source = fields.Selection(related='company_id.attendance_barcode_source', readonly=False)
+    attendance_kiosk_delay = fields.Integer(related='company_id.attendance_kiosk_delay', readonly=False)
 
     @api.model
     def get_values(self):

--- a/addons/hr_attendance/static/src/js/greeting_message.js
+++ b/addons/hr_attendance/static/src/js/greeting_message.js
@@ -20,6 +20,7 @@ var GreetingMessage = AbstractAction.extend({
         var self = this;
         this._super.apply(this, arguments);
         this.activeBarcode = true;
+        this.kioskDelay = action.kiosk_delay;
 
         // if no correct action given (due to an erroneous back or refresh from the browser), we set the dismiss button to return
         // to the (likely) appropriate menu, according to the user access rights
@@ -81,7 +82,9 @@ var GreetingMessage = AbstractAction.extend({
     welcome_message: function() {
         var self = this;
         var now = this.attendance.check_in.clone();
-        this.return_to_main_menu = setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, 5000);
+        if (this.kioskDelay > 0) {
+            this.return_to_main_menu = setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, this.kioskDelay);
+        }
 
         if (now.hours() < 5) {
             this.$('.o_hr_attendance_message_message').append(_t("Good night"));
@@ -117,13 +120,17 @@ var GreetingMessage = AbstractAction.extend({
     farewell_message: function() {
         var self = this;
         var now = this.attendance.check_out.clone();
-        this.return_to_main_menu = setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, 5000);
+        if (this.kioskDelay > 0) {
+            this.return_to_main_menu = setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, this.kioskDelay);
+        }
 
         if(this.previous_attendance_change_date){
             var last_check_in_date = this.previous_attendance_change_date.clone();
             if(now - last_check_in_date > 1000*60*60*12){
                 this.$('.o_hr_attendance_warning_message').show().append(_t("<b>Warning! Last check in was over 12 hours ago.</b><br/>If this isn't right, please contact Human Resource staff"));
-                clearTimeout(this.return_to_main_menu);
+                if (this.return_to_main_menu) {
+                    clearTimeout(this.return_to_main_menu);
+                }
                 this.activeBarcode = false;
             } else if(now - last_check_in_date > 1000*60*60*8){
                 this.$('.o_hr_attendance_random_message').html(_t("Another good day's work! See you soon!"));
@@ -167,10 +174,14 @@ var GreetingMessage = AbstractAction.extend({
                         self.do_action(result.action);
                     } else if (result.warning) {
                         self.displayNotification({ title: result.warning, type: 'danger' });
-                        setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, 5000);
+                        if (this.kioskDelay > 0) {
+                            setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, this.kioskDelay);
+                        }
                     }
                 }, function () {
-                    setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, 5000);
+                    if (this.kioskDelay > 0) {
+                        setTimeout( function() { self.do_action(self.next_action, {clear_breadcrumbs: true}); }, this.kioskDelay);
+                    }
                 });
         }
     },

--- a/addons/hr_attendance/static/src/js/kiosk_mode.js
+++ b/addons/hr_attendance/static/src/js/kiosk_mode.js
@@ -26,11 +26,13 @@ var KioskMode = AbstractAction.extend({
         var def = this._rpc({
                 model: 'res.company',
                 method: 'search_read',
-                args: [[['id', '=', company_id]], ['name']],
+                args: [[['id', '=', company_id]], ['name', 'attendance_kiosk_mode', 'attendance_barcode_source']],
             })
             .then(function (companies){
                 self.company_name = companies[0].name;
                 self.company_image_url = self.session.url('/web/image', {model: 'res.company', id: company_id, field: 'logo',});
+                self.kiosk_mode = companies[0].attendance_kiosk_mode;
+                self.barcode_source = companies[0].attendance_barcode_source;
                 self.$el.html(QWeb.render("HrAttendanceKioskMode", {widget: self}));
                 self.start_clock();
             });

--- a/addons/hr_attendance/static/src/xml/attendance.xml
+++ b/addons/hr_attendance/static/src/xml/attendance.xml
@@ -39,17 +39,19 @@
             <t t-set="bodyContent">
                 <h2 class="mb-2"><small>Welcome to</small> <t t-esc="widget.company_name"/></h2>
                 <img t-attf-src="{{widget.company_image_url}}" alt="Company Logo" class="o_hr_attendance_kiosk_company_image align-self-center img img-fluid mb-3" width="200"/>
-                <div class="o_hr_attendance_kiosk_welcome_row row align-items-stretch pb-5">
-                    <div class="col-md-5 position-relative mt-5 mb-5 mb-md-0">
-                        <img class="img img-fluid d-block mx-auto" src="/barcodes/static/img/barcode.png"/>
-                        <h6 class="position-absolute top-100 start-0 end-0 mt-2 text-muted">Scan your badge</h6>
+                <div class="o_hr_attendance_kiosk_welcome_row d-flex flex-column pb-5">
+                    <div class="col-md-5 mt-5 mb-5 mb-md-0 align-self-center" t-if="widget.kiosk_mode != 'manual'">
+                        <img src="/barcodes/static/img/barcode.png" alt="Barcode"/>
+                        <h6 class="mt-2 text-muted">Scan your badge</h6>
                     </div>
-                    <div class="col-md-2 align-self-center mt-5">
-                        <h4 class="mt0 mb8"><i>or</i></h4>
-                    </div>
-                    <div class="col-md-5 mt-5">
-                        <button class="o_hr_attendance_button_employees btn btn-primary py-5 py-md-2 h-100">
+                    <div class="mt-5 align-self-end" t-if="widget.kiosk_mode == 'barcode_manual'">
+                        <button class="o_hr_attendance_button_employees btn btn-link">
                             Identify Manually
+                        </button>
+                    </div>
+                    <div class="mt-5 align-self-center" t-if="widget.kiosk_mode == 'manual'">
+                        <button class="o_hr_attendance_button_employees btn btn-primary px-5 py-3 mt-4 mb-2">
+                            <span class="fs-2">Identify Manually</span>
                         </button>
                     </div>
                 </div>

--- a/addons/hr_attendance/static/tests/hr_attendance_tests.js
+++ b/addons/hr_attendance/static/tests/hr_attendance_tests.js
@@ -44,10 +44,14 @@ QUnit.module('HR Attendance', {
             'res.company': {
                 fields: {
                     name: {string: 'Name', type: 'char'},
+                    attendance_kiosk_mode: {type: 'char'},
+                    attendance_barcode_source: {type: 'char'},
                 },
                 records: [{
                     id: 1,
                     name: "Company A",
+                    attendance_kiosk_mode: 'barcode_manual',
+                    attendance_barcode_source: 'front',
                 }],
             },
         };

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -8,16 +8,66 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Attendances" string="Attendances" data-key="hr_attendance" groups="hr_attendance.group_hr_attendance_manager">
-                    <h2>Check-In/Out</h2>
+                    <h2>Check-In/Out in Kiosk Mode</h2>
+                    <div class="row mt16 o_settings_container" name="kiosk_mode_setting_container">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_right_pane">
+                                <label for="attendance_kiosk_mode"/>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                <div class="row">
+                                    <div class="text-muted col-lg-10">
+                                        Define the way the user will be identified by the application.
+                                    </div>
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="attendance_kiosk_mode" required="1" class="w-75"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_right_pane">
+                                <label for="attendance_kiosk_delay" string="Display Time"/>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                <div class="row">
+                                    <div class="text-muted col-lg-10">
+                                        Choose how long the greeting message will be displayed.
+                                    </div>
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="attendance_kiosk_delay" required="1" class="text-center oe_inline"/> seconds
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <div class="row mt16 o_settings_container" name="pincode_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" title="Set PIN codes in the employee detail form (in HR Settings tab).">
+                        <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('attendance_kiosk_mode', '=', 'manual')]}">
+                            <div class="o_setting_right_pane">
+                                <label for="attendance_barcode_source"/>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                <div class="row">
+                                    <div class="text-muted col-lg-10">
+                                        Define the camera used for the barcode scan.
+                                    </div>
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="attendance_barcode_source" required="1"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box" title="Set PIN codes in the employee detail form (in HR Settings tab)." attrs="{'invisible': [('attendance_kiosk_mode', '=', 'barcode')]}">
                             <div class="o_setting_left_pane">
                                 <field name="group_attendance_use_pin"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <span class="o_form_label">Employee PIN</span>
-                                <div class="text-muted">
-                                    Use PIN codes to check in in Kiosk Mode
+                                <label for="group_attendance_use_pin"/>
+                                <div class="text-muted col-lg-10">
+                                    Use PIN codes (defined on the Employee's profile) to check-in.
                                 </div>
                             </div>
                         </div>
@@ -29,8 +79,8 @@
                                 <field name="hr_attendance_overtime"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <label for="hr_attendance_overtime" class="o_form_label">Count of Extra Hours</label>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
                                     Compare attendance with working hours set on employee.
                                 </div>


### PR DESCRIPTION
Add new settings to allow the user to select which camera to use for the
barcode scanner and to allow/disallow the manual identification of
employees.

task-2973809

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
