### PR TITLE
[FIX] mail: fix trace back with empty message body

### DIFF
--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -26,6 +26,8 @@ class LinkPreview(models.Model):
 
     @api.model
     def _create_link_previews(self, message):
+        if not message.body:
+            return
         tree = html.fromstring(message.body)
         urls = tree.xpath('//a/@href')
         link_previews = self.env['mail.link.preview']

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -573,7 +573,7 @@ registerModel({
                 const message = messaging.models['Message'].insert(
                     messaging.models['Message'].convertData(messageData)
                 );
-                if (this.messaging.hasLinkPreviewFeature) {
+                if (this.messaging.hasLinkPreviewFeature && !message.isBodyEmpty) {
                     this.messaging.rpc({
                         route: `/mail/link_preview`,
                         params: {


### PR DESCRIPTION
This PR fix a trace back that occur when the message body is empty (e.g. only
uploading an attachment).
