### PR TITLE
[FIX] web: kanban: no quick create icon when quick_create="0"

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -43,11 +43,9 @@ export class KanbanArchParser extends XMLParser {
             groupCreate: archParseBoolean(xmlDoc.getAttribute("group_create"), true),
             groupDelete: archParseBoolean(xmlDoc.getAttribute("group_delete"), true),
             groupEdit: archParseBoolean(xmlDoc.getAttribute("group_edit"), true),
+            quickCreate: archParseBoolean(xmlDoc.getAttribute("quick_create"), true),
         };
-        const onCreate =
-            activeActions.create &&
-            archParseBoolean(xmlDoc.getAttribute("quick_create"), true) &&
-            xmlDoc.getAttribute("on_create");
+        const onCreate = xmlDoc.getAttribute("on_create");
         const quickCreateView = xmlDoc.getAttribute("quick_create_view");
         const tooltipInfo = {};
         let handleField = null;

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -84,9 +84,9 @@ export class KanbanController extends Component {
     }
 
     async createRecord(group) {
-        const { onCreate } = this.props.archInfo;
+        const { activeActions, onCreate } = this.props.archInfo;
         const { root } = this.model;
-        if (onCreate === "quick_create" && root.canQuickCreate()) {
+        if (activeActions.quickCreate && onCreate === "quick_create" && root.canQuickCreate()) {
             await root.quickCreate(group);
         } else if (onCreate && onCreate !== "quick_create") {
             const options = {

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -365,6 +365,10 @@ export class KanbanRenderer extends Component {
         return this.props.archInfo.activeActions.edit;
     }
 
+    canQuickCreate() {
+        return this.props.archInfo.activeActions.quickCreate && this.props.list.canQuickCreate();
+    }
+
     // ------------------------------------------------------------------------
     // Edition methods
     // ------------------------------------------------------------------------

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -47,7 +47,7 @@
                                             </DropdownItem>
                                         </t>
                                     </Dropdown>
-                                    <button t-if="props.list.canQuickCreate()" class="o_kanban_quick_add btn p-0 border-0 fs-6 shadow-none" t-on-click="() => this.quickCreate(group)">
+                                    <button t-if="canQuickCreate()" class="o_kanban_quick_add btn p-0 border-0 fs-6 shadow-none" t-on-click="() => this.quickCreate(group)">
                                         <i class="fa fa-plus fa-stack d-block small text-end text-700 opacity-50 opacity-100-hover cursor-pointer" role="img" aria-label="Quick add" title="Quick add" />
                                     </button>
                                 </t>

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -1194,6 +1194,33 @@ QUnit.module("Views", (hooks) => {
         ]);
     });
 
+    QUnit.test("grouped kanban with quick_create attrs set to false", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban quick_create="false" on_create="quick_create">
+                    <field name="product_id"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="foo"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["product_id"],
+            createRecord: () => assert.step("create record"),
+        });
+
+        assert.containsN(target, ".o_kanban_group", 2);
+        assert.containsNone(target, ".o_kanban_quick_add");
+
+        await click(target.querySelector(".o-kanban-button-new"));
+
+        assert.containsNone(target, ".o_kanban_quick_create");
+        assert.verifySteps(["create record"]);
+    });
+
     QUnit.test("create in grouped on m2o", async (assert) => {
         await makeView({
             type: "kanban",


### PR DESCRIPTION
Before this commit, the "+" icon was displayed in kanban columns
even if the attribute "quick_create" was set to false in the arch.
With this commit, we correctly takes that attribute into account.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
