### PR TITLE
[FIX] web: restore checkbox/radio style

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -240,6 +240,8 @@ $kbd-box-shadow: 0px 1px 1px rgba($o-black, 0.2), inset 0px -1px 1px 1px rgba($o
 
 // Input
 $input-bg: $o-white !default;
+$form-check-input-checked-color: $o-brand-lightsecondary !default;
+$form-check-input-checked-border-color: $o-brand-primary !default;
 $form-check-input-checked-bg-color: $o-brand-primary !default;
 $form-switch-checked-color: $input-bg !default;
 $form-switch-circle-bg-color: $input-bg !default;


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/98770, the style of checkboxes
and radio buttons has also been simplified. This simplification makes
them less readable.

To fix that, this commit restores the previous style for checkboxes
and radio buttons.

Requires: 
- https://github.com/odoo/enterprise/pull/31092

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
