### PR TITLE
[FIX] bus: fix im status service listeners

### DIFF
--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -37,9 +37,9 @@ export const imStatusService = {
         if (multi_tab.isOnMainTab()) {
             startUpdatingBusPresence();
         }
-        env.bus.addEventListener('become_main_tab', startUpdatingBusPresence);
+        multi_tab.bus.addEventListener('become_main_tab', startUpdatingBusPresence);
         bus_service.addEventListener('reconnect', startUpdatingBusPresence);
-        env.bus.addEventListener('no_longer_main_tab', stopUpdatingBusPresence);
+        multi_tab.bus.addEventListener('no_longer_main_tab', stopUpdatingBusPresence);
         bus_service.addEventListener('disconnect', stopUpdatingBusPresence);
     },
 };


### PR DESCRIPTION
The im status service subscribes to the `become_main_tab`,
`no_longer_main_tab` events.

Since the PR improving the multi tab service, the multi tab
itself is not an event target anymore but exposes a bus instance
that should be used to subscribe to those events.

The im status service is still based on the first version which
means the event will never be received. This commit fixes this
issue.