### PR TITLE
[FIX] web: innergroup separator should add a new line 

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -306,6 +306,10 @@ export class FormCompiler extends ViewCompiler {
                 forceNewline = false;
             }
 
+            if (getTag(child, true) === "separator") {
+                forceNewline = true;
+            }
+
             let slotContent;
             if (getTag(child, true) === "field") {
                 const addLabel = child.hasAttribute("nolabel")

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -8030,6 +8030,36 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+     QUnit.test("form rendering innergroup: separator should take one line", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <group>
+                                <separator string="sep"/>
+                                <td class="o_td_label">
+                                    <label for="display_name"/>
+                                </td>
+                                <field name="display_name" nolabel="1"/>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+
+         const rows = document.querySelectorAll('.o_inner_group tr');
+         assert.containsOnce(rows[0], '> td', 'Should only contain one cell');
+         assert.containsOnce(rows[0], '.o_horizontal_separator');
+         assert.containsN(rows[1], '> td', 2, 'Should contain 2 cells');
+         assert.containsOnce(rows[1], 'label[for=display_name]');
+         assert.containsOnce(rows[1], 'div[name=display_name]');
+    });
+
     QUnit.test("outer and inner groups string attribute", async function (assert) {
         await makeView({
             type: "form",


### PR DESCRIPTION
Steps to reproduce:

  - Go to Accounting > Configuration > Chart of account
  - Click on the setup button on the "Current Assets" line
  - items are not correctly aligned

Cause of the issue:

  `<separator/>` should take an entire row
  The separator was on the same row as the field label.