### PR TITLE
[FIX] mail: fix chatter attachment drop test

### DIFF
--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -46,6 +46,7 @@ registerModel({
             if (this.chatterOwner && !this.chatterOwner.attachmentBoxView) {
                 this.chatterOwner.openAttachmentBoxView();
             }
+            this.messaging.messagingBus.trigger('o-file-uploader-upload', { files });
         },
         /**
          * Create an HTML element that will serve as file input.


### PR DESCRIPTION
The chatter drop attachment test fails in an indeterministic manner.
This is because we're assuming that the next render will be the one
corresponding to the file uploading. In order to be sure this render
is really the one we're expecting, the `o-file-uploader-upload` event
is added.
