### PR TITLE
[IMP] base: restrict fields_get attributes for web client

### DIFF
--- a/addons/web_editor/models/__init__.py
+++ b/addons/web_editor/models/__init__.py
@@ -7,6 +7,7 @@ from . import ir_ui_view
 from . import ir_http
 from . import ir_translation
 from . import ir_websocket
+from . import models
 
 from . import assets
 

--- a/addons/web_editor/models/models.py
+++ b/addons/web_editor/models/models.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+
+
+class Base(models.AbstractModel):
+    _inherit = 'base'
+
+    @api.model
+    def _get_view_field_attributes(self):
+        keys = super()._get_view_field_attributes()
+        keys.append('sanitize')
+        keys.append('sanitize_tags')
+        return keys

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1792,7 +1792,9 @@ class BaseModel(metaclass=MetaModel):
             # you just called `get_views` for that model, so obviously the web client already knows the model.
             'model': self._name,
             # sudo is important to get all fields, including fields restricted to groups, in the cache.
-            'models': {model: frozendict(self.env[model].sudo().fields_get()) for model in models},
+            'models': {model: frozendict(self.env[model].sudo().fields_get(
+                attributes=self._get_view_field_attributes(),
+            )) for model in models},
         }
 
         return frozendict(result)
@@ -1826,6 +1828,22 @@ class BaseModel(metaclass=MetaModel):
         result['arch'] = etree.tostring(node, encoding="unicode").replace('\t', '')
 
         return result
+
+    @api.model
+    def _get_view_field_attributes(self):
+        """ Returns the field attributes required by the web client to load the views.
+
+        The method is meant to be overridden by modules extending web client features and requiring additional
+        field attributes.
+
+        :return: string list of field attribute names
+        :rtype: list
+        """
+        return [
+            'context', 'currency_field', 'definition_record', 'digits', 'domain', 'group_operator', 'groups', 'help',
+            'name', 'readonly', 'related', 'relation', 'relation_field', 'required', 'searchable', 'selection', 'size',
+            'sortable', 'store', 'string', 'translate', 'trim', 'type',
+        ]
 
     @api.model
     def load_views(self, views, options=None):


### PR DESCRIPTION
Instead of fetching all field attributes sent with the field list
to the web client,
restrict the attributes to the ones actually required by the web client

This allows, for instance,
to gain 44,75KB on each call on `get_views` for `account.move`,
from 208.78KB to 164.03KB,
with only `account_accountant` installed.

![image](https://user-images.githubusercontent.com/5822488/188684235-e8b6b0ff-c8e7-45d9-8448-bcf7f7bd8ad6.png)

