### PR TITLE
[FIX] account: fix alignment of fields

### DIFF
--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -15,9 +15,8 @@
 
                                 <label for="fiscalyear_last_month" string="Fiscal Year End"/>
                                 <div>
-                                    <field name="fiscalyear_last_day" class="oe_inline text-center" style="width: 20% !important;"/>
-                                    <span style="width: 5%; display: inline-block"/>
-                                    <field name="fiscalyear_last_month" class="oe_inline" style="width: 75% !important;"/>
+                                    <field name="fiscalyear_last_day" class="text-center me-2" style="width: 20% !important;"/>
+                                    <field name="fiscalyear_last_month" class="w-75"/>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
This commit fixes the alignment of fields in the
setup wizard template. Since the conversion of those fields, some parts of the DOM have been altered, and the oe_inline class makes the inputs and selects
elements larger than it should.

After this commit, and its enterprise counterpart, the UI is correctly aligned.

Before this PR: 
<img width="480" alt="image" src="https://user-images.githubusercontent.com/35101914/188806264-1bec6e45-e111-4fc8-aa5a-d45fe6da4ba3.png">


After this PR: 
<img width="478" alt="image" src="https://user-images.githubusercontent.com/35101914/188806012-9a221966-7944-4b82-8bea-ddf20cd500ff.png">
