### PR TITLE
[FIX] web: Correct modals design

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -681,6 +681,7 @@ $o-form-label-margin-right: 0px;
 
         .o_form_sheet_bg {
             padding: 0;
+            width: 100%;
 
             > .o_form_statusbar, > .alert {
                 /**
@@ -781,7 +782,6 @@ $o-form-label-margin-right: 0px;
 }
 
 .o_form_view.o_xxl_form_view {
-    flex-flow: row nowrap;
 
     .o_form_sheet_bg {
         flex: 1 1 auto; // Side chatter is disabled if this has to shrink but this was added for safety


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/99503, o_xxl_form_view is
removed from the modal but there was still an useless overflow present.

Also we removed the `flex-flow: row nowrap;`,
as the flex direction is handle by the `form_compiler`

Note:
for a display: flex the default value for direction and wrap are:
```css
flex-direction: row;
flex-wrap: nowrap;
```

To reproduce:
- Add a bank account on accounting app
- Choose "create it" at the bottom of the modal
- The modal is broken