### PR TITLE
[FIX] pos_loyalty: report action field on loyalty.program

### DIFF
--- a/addons/pos_loyalty/views/loyalty_program_views.xml
+++ b/addons/pos_loyalty/views/loyalty_program_views.xml
@@ -6,6 +6,9 @@
         <field name="model">loyalty.program</field>
         <field name="inherit_id" ref="loyalty.loyalty_program_view_form"/>
         <field name="arch" type="xml">
+            <field name="mail_template_id" position="after">
+                <field name="pos_report_print_id" attrs="{'invisible': [('program_type', 'not in', ('gift_card', 'ewallet'))]}" />
+            </field>
             <xpath expr="//label[@for='available_on']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>


### PR DESCRIPTION
Need to show the pos_report_print_id option on gift card and ewallet
programs like the mail_template_id. It's important on printing
newly generated gift card and ewallet from pos.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
