### PR TITLE
[FIX] web: list & form: reload view after executing action

### DIFF
--- a/addons/web/static/src/search/action_menus/action_menus.js
+++ b/addons/web/static/src/search/action_menus/action_menus.js
@@ -98,7 +98,7 @@ export class ActionMenus extends Component {
         const context = makeContext([this.props.context, activeIdsContext]);
         return this.actionService.doAction(action.id, {
             additionalContext: context,
-            on_close: () => this.trigger("reload"),
+            onClose: this.props.onActionExecuted,
         });
     }
 
@@ -141,5 +141,9 @@ ActionMenus.props = {
             other: { type: Array, optional: true },
         },
     },
+    onActionExecuted: { type: Function, optional: true },
+};
+ActionMenus.defaultProps = {
+    onActionExecuted: () => {},
 };
 ActionMenus.template = "web.ActionMenus";

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -21,6 +21,7 @@
                             isDomainSelected="model.root.isDomainSelected"
                             resModel="model.root.resModel"
                             domain="props.domain"
+                            onActionExecuted="() => model.load()"
                         />
                     </t>
                 </t>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -22,7 +22,8 @@
                             domain="props.domain"
                             items="getActionMenuItems()"
                             isDomainSelected="model.root.isDomainSelected"
-                            resModel="model.root.resModel"/>
+                            resModel="model.root.resModel"
+                            onActionExecuted="() => model.load()"/>
                     </t>
                 </t>
                 <t t-component="props.Renderer" list="model.root" activeActions="activeActions" archInfo="archInfo" allowSelectors="props.allowSelectors" editable="editable" openRecord.bind="openRecord" noContentHelp="props.info.noContentHelp" onAdd.bind="createRecord"/>


### PR DESCRIPTION
Before this commit, the form and list views didn't reload when an action from the ActionMenu (formerly known as "toolbar") was executed. For instance, go to Contacts (list) > select records > Actions > Merge: the contacts are correctly merged, but the view still shows the merged contacts.

Note: it worked well for "static" actions like Archive, Delete, this fix only concerns "contextual" actions.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
