### PR TITLE
[FIX] web: fix can create option m2m

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -257,6 +257,7 @@ Many2ManyTagsField.extractProps = ({ attrs, field }) => {
         colorField: attrs.options.color_field,
         nameCreateField: attrs.options.create_name_field,
         relation: field.relation,
+        canCreate,
         canQuickCreate: canCreate && !noQuickCreate,
         canCreateEdit: canCreate && !noCreateEdit,
         createDomain: attrs.options.create,

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -1674,6 +1674,7 @@ QUnit.module("Fields", (hooks) => {
 
         await editInput(target, ".o_field_many2many_tags .o-autocomplete--input", "new tag");
         assert.containsNone(target, ".o-autocomplete.dropdown li.o_m2o_dropdown_option");
+        assert.containsOnce(target, ".o-autocomplete.dropdown li.o_m2o_no_result");
     });
 
     QUnit.test("Many2ManyTagsField with attribute 'can_create' set to false", async (assert) => {


### PR DESCRIPTION
Since the "canCreate" option was not propagated this was leading to a traceback with the autocomplete.
Indeed the option "No records" was never added because it was always in a loading state.