### PR TITLE
[FIX] account: add analytic_id for default rules selection 

### DIFF
--- a/addons/account/models/account_analytic_default.py
+++ b/addons/account/models/account_analytic_default.py
@@ -33,6 +33,7 @@ class AccountAnalyticDefault(models.Model):
     @api.model
     def account_get(self, product_id=None, partner_id=None, account_id=None, user_id=None, date=None, company_id=None):
         domain = []
+        analytic_id = self.env.context.get('analytic_id')
         if product_id:
             domain += ['|', ('product_id', '=', product_id)]
         domain += [('product_id', '=', False)]
@@ -48,6 +49,8 @@ class AccountAnalyticDefault(models.Model):
         if user_id:
             domain += ['|', ('user_id', '=', user_id)]
         domain += [('user_id', '=', False)]
+        if analytic_id:
+            domain += [('analytic_id', '=', analytic_id)]
         if date:
             domain += ['|', ('date_start', '<=', date), ('date_start', '=', False)]
             domain += ['|', ('date_stop', '>=', date), ('date_stop', '=', False)]
@@ -60,6 +63,8 @@ class AccountAnalyticDefault(models.Model):
             if rec.account_id: index += 1
             if rec.company_id: index += 1
             if rec.user_id: index += 1
+            if rec.analytic_id:
+                index += 1
             if rec.date_start: index += 1
             if rec.date_stop: index += 1
             if index > best_index:

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3931,11 +3931,11 @@ class AccountMoveLine(models.Model):
                 if rec:
                     record.analytic_account_id = rec.analytic_id
 
-    @api.depends('product_id', 'account_id', 'partner_id', 'date')
+    @api.depends('product_id', 'account_id', 'partner_id', 'date', 'analytic_account_id')
     def _compute_analytic_tag_ids(self):
         for record in self:
             if not record.exclude_from_invoice_tab or not record.move_id.is_invoice(include_receipts=True):
-                rec = self.env['account.analytic.default'].account_get(
+                rec = self.env['account.analytic.default'].with_context(analytic_id=record.analytic_account_id.id).account_get(
                     product_id=record.product_id.id,
                     partner_id=record.partner_id.commercial_partner_id.id or record.move_id.partner_id.commercial_partner_id.id,
                     account_id=record.account_id.id,


### PR DESCRIPTION
Steps to reproduce:
- Create two analytic default rules (account A1 -> tag T1 and account A2
  -> tag T2)
- In payrol create two payslips for two different employees in
the same batch, one employee has a contract with analytic account
A1 and the other has a contract with an analytic account A2
- generate draft entry

Current behavior:
The entries all have the T1 tags

Expected behavior:
Two entries with the T1 tag and two entries with the T2 tag

Explanation:
Odoo selected the same analytic default rules for the different
entries to be able to select the right rule we add the analytic
account in the search domain.

opw-2963149
