### PR TITLE
[FIX] web: apply decoration-bf/it styling

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -2,7 +2,12 @@
 
 import { evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
-import { archParseBoolean, evalDomain, X2M_TYPES } from "@web/views/utils";
+import {
+    archParseBoolean,
+    evalDomain,
+    getClassNameFromDecoration,
+    X2M_TYPES,
+} from "@web/views/utils";
 import { getTooltipInfo } from "./field_tooltip";
 
 const { Component, xml } = owl;
@@ -102,7 +107,7 @@ export class Field extends Component {
         const evalContext = record.evalContext;
         for (const decoName in decorations) {
             const value = evaluateExpr(decorations[decoName], evalContext);
-            classNames[`text-${decoName}`] = value;
+            classNames[getClassNameFromDecoration(decoName)] = value;
         }
 
         return classNames;

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -14,6 +14,7 @@ import { useSortable } from "@web/core/utils/sortable";
 import { getTabableElements } from "@web/core/utils/ui";
 import { Field } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
+import { getClassNameFromDecoration } from "@web/views/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useBounceButton } from "@web/views/view_hook";
 
@@ -656,7 +657,7 @@ export class ListRenderer extends Component {
                 const { decorations } = record.activeFields[column.name];
                 for (const decoName in decorations) {
                     if (evaluateExpr(decorations[decoName], record.evalContext)) {
-                        classNames.push(`text-${decoName}`);
+                        classNames.push(getClassNameFromDecoration(decoName));
                     }
                 }
             }

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -120,12 +120,21 @@ export function getActiveActions(rootNode) {
     };
 }
 
+export function getClassNameFromDecoration(decoration) {
+    if (decoration === "bf") {
+        return "fw-bold";
+    } else if (decoration === "it") {
+        return "fst-italic";
+    }
+    return `text-${decoration}`;
+}
+
 export function getDecoration(rootNode) {
     const decorations = [];
     for (const name of rootNode.getAttributeNames()) {
         if (name.startsWith("decoration-")) {
             decorations.push({
-                class: name.replace("decoration", "text"),
+                class: getClassNameFromDecoration(name.replace("decoration-", "")),
                 condition: rootNode.getAttribute(name),
             });
         }

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -635,6 +635,46 @@ QUnit.module("Views", (hooks) => {
         assert.hasClass(target.querySelector('.o_field_widget[name="foo"]'), "text-danger");
     });
 
+    QUnit.test("decoration-bf works on fields", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="int_field"/>
+                    <field name="display_name" decoration-bf="int_field &lt; 5"/>
+                    <field name="foo" decoration-bf="int_field &gt; 5"/>
+                </form>`,
+            resId: 2,
+        });
+        assert.doesNotHaveClass(
+            target.querySelector('.o_field_widget[name="display_name"]'),
+            "fw-bold"
+        );
+        assert.hasClass(target.querySelector('.o_field_widget[name="foo"]'), "fw-bold");
+    });
+
+    QUnit.test("decoration-it works on fields", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="int_field"/>
+                    <field name="display_name" decoration-it="int_field &lt; 5"/>
+                    <field name="foo" decoration-it="int_field &gt; 5"/>
+                </form>`,
+            resId: 2,
+        });
+        assert.doesNotHaveClass(
+            target.querySelector('.o_field_widget[name="display_name"]'),
+            "fst-italic"
+        );
+        assert.hasClass(target.querySelector('.o_field_widget[name="foo"]'), "fst-italic");
+    });
+
     QUnit.test("decoration on widgets are reevaluated if necessary", async function (assert) {
         await makeView({
             type: "form",

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -5179,6 +5179,45 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, "tbody tr", 4, "should have 4 rows");
     });
 
+    QUnit.test("support row decoration (decoration-bf)", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree decoration-bf="int_field > 5">
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        assert.containsN(target, "tbody tr.fw-bold", 3, "should have 3 columns with fw-bold class");
+
+        assert.containsN(target, "tbody tr", 4, "should have 4 rows");
+    });
+
+    QUnit.test("support row decoration (decoration-it)", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree decoration-it="int_field > 5">
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        assert.containsN(
+            target,
+            "tbody tr.fst-italic",
+            3,
+            "should have 3 columns with fst-italic class"
+        );
+
+        assert.containsN(target, "tbody tr", 4, "should have 4 rows");
+    });
+
     QUnit.test("support field decoration", async function (assert) {
         await makeView({
             type: "list",
@@ -5196,6 +5235,44 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, "tbody td.text-danger", 3);
         assert.containsN(target, "tbody td.o_list_number", 4);
         assert.containsNone(target, "tbody td.o_list_number.text-danger");
+    });
+
+    QUnit.test("support field decoration (decoration-bf)", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree>
+                    <field name="foo" decoration-bf="int_field > 5"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        assert.containsN(target, "tbody tr", 4);
+        assert.containsN(target, "tbody td.o_list_char", 4);
+        assert.containsN(target, "tbody td.fw-bold", 3);
+        assert.containsN(target, "tbody td.o_list_number", 4);
+        assert.containsNone(target, "tbody td.o_list_number.fw-bold");
+    });
+
+    QUnit.test("support field decoration (decoration-it)", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree>
+                    <field name="foo" decoration-it="int_field > 5"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        assert.containsN(target, "tbody tr", 4);
+        assert.containsN(target, "tbody td.o_list_char", 4);
+        assert.containsN(target, "tbody td.fst-italic", 3);
+        assert.containsN(target, "tbody td.o_list_number", 4);
+        assert.containsNone(target, "tbody td.o_list_number.fst-italic");
     });
 
     QUnit.test(


### PR DESCRIPTION
During the OWL refactoring, the "decoration-bf" and "decoration-it" were not included in the standard decoration handling to convert them into the default bootstrap classes. I.e. the previously applied commit:

https://github.com/odoo/odoo/pull/73210/commits/29390ccdc3447c3d1ef4da1d805e630d00402fbd

was not ported over to the updated OWL views/fields. Also added QUnit tests to handle these 2 decoration cases.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
