### PR TITLE
[FIX] website: Cannot create account

### DIFF
--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -81,7 +81,8 @@ class ResUsers(models.Model):
                 if visitor_current_user_sudo:
                     # A visitor exists for the logged in user, link public
                     # visitor records to it.
-                    visitor_pre_authenticate_sudo._merge_visitor(visitor_current_user_sudo)
+                    if visitor_pre_authenticate_sudo != visitor_current_user_sudo:
+                        visitor_pre_authenticate_sudo._merge_visitor(visitor_current_user_sudo)
                     visitor_current_user_sudo._update_visitor_last_visit()
                 else:
                     visitor_pre_authenticate_sudo.access_token = user_partner.id


### PR DESCRIPTION
When creating an account from the website (through the link "Don't have an account?") while having been previously identified, the creation lasts a very long time and ends-up with a http 502 error (actually a timeout).

Technical note: The problem was due to a database deadlock: a record was deleted in one transaction while being written in another (_merge_visitor deletes it and _update_visitor_last_visit writes it but with in a different transaction).

Task-2950241

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
