### PR TITLE
[FIX] mrp: scss wrong after owl conversion

### DIFF
--- a/addons/mrp/static/src/scss/mrp_fields.scss
+++ b/addons/mrp/static/src/scss/mrp_fields.scss
@@ -2,6 +2,7 @@
     aspect-ratio: 3/2;
 }
 
-.o_manual_consumption.fw-bold {
+.o_manual_consumption.text-bf {
+    font-weight: bold;
     background-color: rgba($gray-200, .5);
 }


### PR DESCRIPTION
After owl conversion of views, css classes generated for "decoration-*" changed. In this fix, we match the new class for manual consumption function.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
