### PR TITLE
[IMP] base, web: misc improvements for the properties field 

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -114,7 +114,7 @@ class Lead(models.Model):
     team_id = fields.Many2one(
         'crm.team', string='Sales Team', check_company=True, index=True, tracking=True,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        compute='_compute_team_id', ondelete="set null", readonly=False, store=True)
+        compute='_compute_team_id', ondelete="set null", readonly=False, store=True, precompute=True)
     company_id = fields.Many2one(
         'res.company', string='Company', index=True,
         compute='_compute_company_id', readonly=False, store=True)
@@ -124,6 +124,9 @@ class Lead(models.Model):
     type = fields.Selection([
         ('lead', 'Lead'), ('opportunity', 'Opportunity')], required=True, tracking=15, index=True,
         default=lambda self: 'lead' if self.env['res.users'].has_group('crm.group_use_lead') else 'opportunity')
+    properties = fields.Properties(
+        'Properties', definition='team_id.lead_properties',
+        copy=True)
     # Pipeline management
     priority = fields.Selection(
         crm_stage.AVAILABLE_PRIORITIES, string='Priority', index=True,

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -54,6 +54,8 @@ class Team(models.Model):
     alias_user_id = fields.Many2one(
         'res.users', related='alias_id.alias_user_id', readonly=False, inherited=True,
         domain=lambda self: [('groups_id', 'in', self.env.ref('sales_team.group_sale_salesman_all_leads').id)])
+    # properties
+    lead_properties = fields.PropertiesDefinition('Lead Properties')
 
     @api.depends('crm_team_member_ids.assignment_max')
     def _compute_assignment_max(self):

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -258,7 +258,8 @@
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             </group>
                         </group>
-
+                        <field attrs="{'invisible': [('team_id', '=', False)]}"
+                            name="properties" nolabel="1" columns="2"/>
                         <notebook>
                             <page string="Internal Notes" name="internal_notes">
                                 <field name="description" placeholder="Add a description..." options="{'collaborative': true}" />

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -361,6 +361,7 @@ class Project(models.Model):
     allow_task_dependencies = fields.Boolean('Task Dependencies', default=lambda self: self.env.user.has_group('project.group_project_task_dependencies'))
     allow_milestones = fields.Boolean('Milestones', default=lambda self: self.env.user.has_group('project.group_project_milestone'))
     tag_ids = fields.Many2many('project.tags', relation='project_project_project_tags_rel', string='Tags')
+    task_properties = fields.PropertiesDefinition('Task Properties')
 
     # Project Sharing fields
     collaborator_ids = fields.One2many('project.collaborator', 'project_id', string='Collaborators', copy=False)
@@ -1122,7 +1123,7 @@ class Task(models.Model):
         help="Date on which the stage of your task has last been modified.\n"
             "Based on this information you can identify tasks that are stalling and get statistics on the time it usually takes to move tasks from one stage to another.")
     project_id = fields.Many2one('project.project', string='Project', recursive=True,
-        compute='_compute_project_id', store=True, readonly=False,
+        compute='_compute_project_id', store=True, readonly=False, precompute=True,
         index=True, tracking=True, check_company=True, change_default=True)
     # Defines in which project the task will be displayed / taken into account in statistics.
     # Example: 1 task A with 1 subtask B in project P
@@ -1319,6 +1320,9 @@ class Task(models.Model):
             "By default, the analytic account of the project is set. However, it can be changed on each task individually if necessary.")
     is_analytic_account_id_changed = fields.Boolean('Is Analytic Account Manually Changed', compute='_compute_is_analytic_account_id_changed', store=True)
     project_analytic_account_id = fields.Many2one('account.analytic.account', string='Project Analytic Account', related='project_id.analytic_account_id')
+
+    # Properties
+    properties = fields.Properties('Properties', definition='project_id.task_properties', copy=True)
 
     @property
     def SELF_READABLE_FIELDS(self):

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1179,6 +1179,8 @@
                             <field name="legend_done" invisible="1"/>
                         </group>
                     </group>
+                    <field attrs="{'invisible': [('project_id', '=', False)]}"
+                        name="properties" nolabel="1" columns="2"/>
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" type="html" options="{'collaborative': true, 'resizable': false}"/>

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -124,6 +124,10 @@ export class AutoComplete extends Component {
             return;
         }
 
+        if (this.props.resetOnSelect) {
+            this.inputRef.el.value = "";
+        }
+
         this.forceValFromProp = true;
         this.props.onSelect(option, {
             ...params,
@@ -295,6 +299,7 @@ Object.assign(AutoComplete, {
         },
         placeholder: { type: String, optional: true },
         autoSelect: { type: Boolean, optional: true },
+        resetOnSelect: { type: Boolean, optional: true },
         onInput: { type: Function, optional: true },
         onChange: { type: Function, optional: true },
         onBlur: { type: Function, optional: true },

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -59,6 +59,10 @@ Popover.defaultProps = {
     position: "bottom",
 };
 Popover.props = {
+    id: {
+        optional: true,
+        type: Number,
+    },
     popoverClass: {
         optional: true,
         type: String,

--- a/addons/web/static/src/core/popover/popover.xml
+++ b/addons/web/static/src/core/popover/popover.xml
@@ -5,6 +5,7 @@
         <div role="tooltip" class="o_popover popover mw-100 shadow-sm"
             t-att-class="props.popoverClass"
             t-ref="popper"
+            t-att-popover-id="props.id"
         >
             <div class="popover-arrow"/>
             <t t-slot="default" />

--- a/addons/web/static/src/core/popover/popover_container.js
+++ b/addons/web/static/src/core/popover/popover_container.js
@@ -21,6 +21,7 @@ class PopoverController extends Component {
 
     get popoverProps() {
         return {
+            id: this.props.id,
             target: this.target,
             position: this.props.position,
             popoverClass: this.props.popoverClass,
@@ -42,7 +43,8 @@ class PopoverController extends Component {
         }
     }
     onClickAway(ev) {
-        if (this.target.contains(ev.target) || ev.target.closest(".o_popover")) {
+        if (this.target.contains(ev.target)
+            || ev.target.closest(`.o_popover[popover-id="${this.props.id}"]`)) {
             return;
         }
         if (this.props.preventClose && this.props.preventClose(ev)) {

--- a/addons/web/static/src/core/position_hook.js
+++ b/addons/web/static/src/core/position_hook.js
@@ -193,7 +193,7 @@ function getBestPosition(reference, popper, { container, margin, position }) {
  * @param {HTMLElement} popper
  * @param {Options} options
  */
-function reposition(reference, popper, options) {
+export function reposition(reference, popper, options) {
     options = {
         container: document.documentElement,
         ...options,

--- a/addons/web/static/src/legacy/js/fields/field_utils.js
+++ b/addons/web/static/src/legacy/js/fields/field_utils.js
@@ -416,20 +416,6 @@ function formatSelection(value, field, options) {
     return value;
 }
 
-/**
- * Returns a string representing the value of the python properties field.
- *
- * @param {string|false} value
- * @param {Object} [field]
- *        a description of the field (note: this parameter is ignored)
- */
-function formatProperties(value, field) {
-    if (!value || !value.length) {
-        return '';
-    }
-    return value.map(property => property['string']).join(', ');
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Parse
 ////////////////////////////////////////////////////////////////////////////////
@@ -763,8 +749,6 @@ return {
         monetary: formatMonetary,
         one2many: formatX2Many,
         percentage: formatPercentage,
-        properties: formatProperties,
-        properties_definition: formatProperties,
         reference: formatMany2one,
         selection: formatSelection,
         text: formatChar,

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -354,6 +354,20 @@ export function formatPercentage(value, options = {}) {
 }
 
 /**
+ * Returns a string representing the value of the python properties field.
+ *
+ * @param {string|false} value
+ * @param {Object} [field]
+ *        a description of the field (note: this parameter is ignored)
+ */
+function formatProperties(value, field) {
+    if (!value || !value.length) {
+        return '';
+    }
+    return value.map(property => property['string']).join(', ');
+}
+
+/**
  * Returns a string representing the value of the reference field.
  *
  * @param {Object|false} value Object with keys "resId" and "displayName"
@@ -404,6 +418,8 @@ registry
     .add("many2many", formatX2many)
     .add("monetary", formatMonetary)
     .add("percentage", formatPercentage)
+    .add("properties", formatProperties)
+    .add("properties_definition", formatProperties)
     .add("reference", formatReference)
     .add("selection", formatSelection)
     .add("text", formatText);

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -223,24 +223,7 @@ export class PropertiesField extends Component {
             (property) => property.name === propertyDefinition.name
         );
 
-        // if the type / model are the same, restore the original name to not reset the children
-        // otherwise, generate a new value so all value of the record are reset
-        const initialValues = this.initialValues[propertyDefinition.name];
-        if (
-            initialValues &&
-            propertyDefinition.type === initialValues.type &&
-            propertyDefinition.comodel === initialValues.comodel
-        ) {
-            // restore the original name
-            propertyDefinition.name = initialValues.name;
-        } else if (initialValues && initialValues.name === propertyDefinition.name) {
-            // generate a new new to reset all values on other records
-            // store the new generated name to be able to restore it
-            // if needed
-            const newName = uuid();
-            this.initialValues[newName] = initialValues;
-            propertyDefinition.name = newName;
-        }
+        this._setPropertyName(propertyDefinition);
 
         propertiesValues[propertyIndex] = propertyDefinition;
         this.props.update(propertiesValues);
@@ -375,7 +358,7 @@ export class PropertiesField extends Component {
         this.state.canChangeDefinition = await this.orm.call(
             definitionRecordModel,
             "check_access_rights",
-            ["write", false]
+            ["write", false],
         );
     }
 
@@ -398,6 +381,33 @@ export class PropertiesField extends Component {
                 type: propertiesValues.type,
                 comodel: propertiesValues.comodel,
             };
+        }
+    }
+
+    /**
+     * Regenerate a new name if needed or restore the original one.
+     * (see @_saveInitialPropertiesValues).
+     *
+     * @param {object} propertyDefinition
+     */
+    _setPropertyName(propertyDefinition) {
+        // if the type / model are the same, restore the original name to not reset the children
+        // otherwise, generate a new value so all value of the record are reset
+        const initialValues = this.initialValues[propertyDefinition.name];
+        if (
+            initialValues &&
+            propertyDefinition.type === initialValues.type &&
+            propertyDefinition.comodel === initialValues.comodel
+        ) {
+            // restore the original name
+            propertyDefinition.name = initialValues.name;
+        } else if (initialValues && initialValues.name === propertyDefinition.name) {
+            // generate a new new to reset all values on other records
+            // store the new generated name to be able to restore it
+            // if needed
+            const newName = uuid();
+            this.initialValues[newName] = initialValues;
+            propertyDefinition.name = newName;
         }
     }
 }

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -116,6 +116,16 @@ export class PropertiesField extends Component {
             return true;
         }
 
+        if (event.target.closest(".o_tag_popover")) {
+            // tag color popover
+            return true;
+        }
+
+        if (event.target.closest(".o_field_selector_popover")) {
+            // domain selector
+            return true;
+        }
+
         return false;
     }
 

--- a/addons/web/static/src/views/fields/properties/properties_field.scss
+++ b/addons/web/static/src/views/fields/properties/properties_field.scss
@@ -13,9 +13,6 @@
     .o_datepicker_button {
         @include print-variable(o-input-border-color, $o-form-lightsecondary);
         color: initial !important;
-        * {
-            color: initial !important;
-        }
     }
 
     & {
@@ -37,10 +34,6 @@
 }
 
 .o_property_field {
-    .o_td_label,
-    .o_property_field_value {
-        padding: 0 45px 0 0;
-    }
     .o_property_field_value {
         height: fit-content;
     }
@@ -63,6 +56,8 @@
     .o_field_property_label {
         max-width: 150px;
         width: fit-content;
+        margin-right: -25px !important;
+
         b {
             word-break: break-word;
             max-height: 100px;
@@ -122,6 +117,7 @@
 .o_xxs_form_view .o_field_properties {
     // mobile view
     .o_property_field {
+        margin-bottom: 20px;
         min-width: 100%;
         flex-wrap: wrap;
         padding: 0;
@@ -129,7 +125,7 @@
         .o_td_label,
         .o_property_field_value {
             min-width: 100%;
-            padding: 0;
+            padding: 0 !important;
             &>* {
                 max-width: 100%;
             }

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="web.PropertiesField" owl="1">
         <div t-ref="properties" class="w-100">
-            <div class="o_group w-100 d-flex flex-row flex-wrap mt-0">
+            <div class="o_group w-100 d-flex flex-row flex-wrap my-0">
                 <div
                     t-foreach="propertiesList"
                     t-as="propertyConfiguration"
                     t-key="propertyConfiguration.name"
-                    class="o_property_field d-flex flex-row justify-content-start"
+                    class="o_property_field d-flex flex-row align-items-center justify-content-start"
                     t-att-property-name="propertyConfiguration.name"
                     t-attf-class="col-md-{{12 / props.columns}} col-sm-12">
                     <div class="o_td_label">
@@ -20,23 +20,23 @@
                                 New Property
                             </i>
                             <i
-                                t-if="state.canChangeDefinition"
+                                t-if="state.canChangeDefinition &amp;&amp; !props.readonly"
                                 class="o_field_property_open_popover fa fa-pencil ms-2"
                                 t-on-click="(event) => this.onPropertyEdit(event, propertyConfiguration.name)"/>
                         </label>
                     </div>
-                    <div class="o_property_field_value align-top w-100">
+                    <div class="o_property_field_value align-top w-100 o_td_value">
                         <PropertyValue
-                            readonly="props.readonly"
                             canChangeDefinition="state.canChangeDefinition"
-                            type="propertyConfiguration.type"
-                            string="propertyConfiguration.string"
-                            value="propertyConfiguration.value"
-                            selection="propertyConfiguration.selection"
-                            tags="propertyConfiguration.tags"
                             comodel="propertyConfiguration.comodel || ''"
-                            domain="propertyConfiguration.domain || '[]'"
                             context="context"
+                            domain="propertyConfiguration.domain || '[]'"
+                            readonly="props.readonly"
+                            selection="propertyConfiguration.selection"
+                            string="propertyConfiguration.string"
+                            tags="propertyConfiguration.tags"
+                            type="propertyConfiguration.type"
+                            value="propertyConfiguration.value"
                             onChange.bind="(value) => this.onPropertyValueChange(propertyConfiguration.name, value)"
                             onTagsChange.bind="(newTags, newValue) => this.onTagsChange(propertyConfiguration.name, newTags, newValue)"
                         />

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -2,6 +2,7 @@
 
 import { _lt } from "@web/core/l10n/translation";
 import { PropertyValue } from "./property_value";
+import { CheckBox } from "@web/core/checkbox/checkbox";
 import { DomainSelector } from "@web/core/domain_selector/domain_selector";
 import { Domain } from "@web/core/domain";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -40,6 +41,7 @@ export class PropertyDefinition extends Component {
             resModel: "",
             resModelDescription: "",
             matchingRecordsCount: undefined,
+            propertyIndex: this.props.propertyIndex,
         });
 
         this._syncStateWithProps(propertyDefinition);
@@ -56,7 +58,11 @@ export class PropertyDefinition extends Component {
             this.labelFocused = true;
             const labelInput = this.propertyDefinitionRef.el.querySelectorAll("input")[0];
             if (labelInput) {
-                labelInput.focus();
+                if (this.props.isNewlyCreated) {
+                    labelInput.select();
+                } else {
+                    labelInput.focus();
+                }
             }
         });
     }
@@ -86,6 +92,20 @@ export class PropertyDefinition extends Component {
     }
 
     /**
+     * Return True if the current properties is the first one in the list.
+     */
+    get isFirst() {
+        return this.state.propertyIndex === 0;
+    }
+
+    /**
+     * Return True if the current properties is the last one in the list.
+     */
+    get isLast() {
+        return this.state.propertyIndex === this.props.propertiesSize - 1;
+    }
+
+    /**
      * Return the list of tag values, that will be selected by the PropertyTags
      * component (all existing tags because we are editing the definition).
      *
@@ -112,6 +132,18 @@ export class PropertyDefinition extends Component {
         };
         this.props.onChange(propertyDefinition);
         this.state.propertyDefinition = propertyDefinition;
+    }
+
+    /**
+     * Pressed enter on the property label close the definition.
+     *
+     * @param {event} event
+     */
+    onPropertyLabelKeypress(event) {
+        if (event.key !== 'Enter') {
+            return;
+        }
+        this.props.close();
     }
 
     /**
@@ -204,6 +236,20 @@ export class PropertyDefinition extends Component {
             domain: new Domain(this.state.propertyDefinition.domain || "[]").toList(),
             context: this.props.context || {},
         });
+    }
+
+    /**
+     * Move the current property up or down.
+     *
+     * @param {string} direction, either 'up' or 'down'
+     */
+    onPropertyMove(direction) {
+        if (direction === 'up') {
+            this.state.propertyIndex--;
+        } else {
+            this.state.propertyIndex++;
+        }
+        this.props.onPropertyMove(direction);
     }
 
     /**
@@ -309,6 +355,7 @@ export class PropertyDefinition extends Component {
 
 PropertyDefinition.template = "web.PropertyDefinition";
 PropertyDefinition.components = {
+    CheckBox,
     DomainSelector,
     Dropdown,
     DropdownItem,
@@ -323,10 +370,14 @@ PropertyDefinition.props = {
     canChangeDefinition: { type: Boolean, optional: true },
     propertyDefinition: { optional: true },
     context: { type: Object },
+    isNewlyCreated: { type: Boolean, optional: true },
+    // index and number of properties, to hide the move arrows when needed
+    propertyIndex: { type: Number },
+    propertiesSize: { type: Number },
+    // events
     onChange: { type: Function, optional: true },
     onDelete: { type: Function, optional: true },
     onPropertyMove: { type: Function, optional: true },
-
     // prop needed by the popover service
     close: { type: Function, optional: true },
 };

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -141,8 +141,12 @@ export class PropertyDefinition extends Component {
             value: false,
         };
 
+        delete propertyDefinition.comodel;
+
         this.props.onChange(propertyDefinition);
         this.state.propertyDefinition = propertyDefinition;
+        this.state.resModel = '';
+        this.state.resModelDescription = '';
         this.state.typeLabel = this._typeLabel(newType);
     }
 

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -12,16 +12,17 @@
                     placeholder="Property Name"
                     t-model="state.propertyDefinition.string"
                     t-on-change="onPropertyLabelChange"
+                    t-on-keypress="onPropertyLabelKeypress"
                 />
                 <div class="d-flex flex-row me-3">
                     <button
-                        class="btn btn-link p-0 m-0 me-2"
-                        t-on-click="() => props.onPropertyMove('up')">
+                        t-attf-class="btn btn-link p-0 m-0 me-2 {{this.isFirst ? 'disabled' : ''}}"
+                        t-on-click="() => this.onPropertyMove('up')">
                         <i class="fa fa-chevron-up"/>
                     </button>
                     <button
-                        class="btn btn-link p-0 m-0"
-                        t-on-click="() => props.onPropertyMove('down')">
+                        t-attf-class="btn btn-link p-0 m-0 {{this.isLast ? 'disabled' : ''}}"
+                        t-on-click="() => this.onPropertyMove('down')">
                         <i class="fa fa-chevron-down"/>
                     </button>
                     <button

--- a/addons/web/static/src/views/fields/properties/property_tags.scss
+++ b/addons/web/static/src/views/fields/properties/property_tags.scss
@@ -1,8 +1,3 @@
-.o_field_property_dropdown_add {
-    * {
-        color: $primary !important;
-    }
-}
 .o_field_property_tag_readonly {
     // deactivate all click interactions with tags
     // if we can't change their definition
@@ -10,16 +5,35 @@
 }
 
 .o_field_property_tag {
+    border: 1px solid var(--o-input-border-color);
+
     .o_tag {
         margin: 1px 2px 1px 0;
-        .o_delete {
-            padding-left: 4px;
-        }
     }
     .o_delete {
-        margin-top: 2px;
+        margin-left: 3px;
+        line-height: 1;
+        &::before {
+            line-height: 1.1;
+        }
     }
     .o_badge_text {
         line-height: 1.1;
     }
+    .o_input_dropdown {
+        width: 100px !important;
+        min-width: 100px !important;
+        input {
+            border: 0px !important;
+        }
+    }
+    .o_field_property_dropdown_add {
+        * {
+            color: $primary !important;
+        }
+    }
+}
+
+.o_form_readonly .o_field_property_tag {
+    border: 0px;
 }

--- a/addons/web/static/src/views/fields/properties/property_tags.xml
+++ b/addons/web/static/src/views/fields/properties/property_tags.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.PropertyTags" owl="1">
-        <div class="o_field_property_tag">
+        <!-- Copy many2many tags style without duplicating all the CSS -->
+        <div class="o_field_property_tag o_field_widget o_field_many2manytags o_input py-1 d-flex flex-row align-items-center pt-2 w-100">
             <TagsList
                 tags="tagListItems"
                 className="props.canChangeTags ? '' : 'o_field_property_tag_readonly' "/>

--- a/addons/web/static/src/views/fields/properties/property_tags.xml
+++ b/addons/web/static/src/views/fields/properties/property_tags.xml
@@ -12,7 +12,8 @@
                 <AutoComplete
                     value="''"
                     sources="autocompleteSources"
-                    onSelect.bind="(event) => this.onOptionSelected(event.value)"/>
+                    onSelect.bind="({value}) => this.onOptionSelected(value)"
+                    resetOnSelect="true"/>
                 <a role="button" class="o_dropdown_button" draggable="false" />
             </div>
         </div>

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { _lt } from "@web/core/l10n/translation";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { CheckBox } from "@web/core/checkbox/checkbox";
@@ -40,6 +41,8 @@ export class PropertyValue extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
+
+        this.noAccessMessage = _lt('No Access');
 
         this.openMany2X = useOpenMany2XRecord({
             resModel: this.props.model,
@@ -97,18 +100,20 @@ export class PropertyValue extends Component {
                 return [];
             }
 
-            // Convert to TagList component format
+            // Convert to TagsList component format
             return value.map((many2manyValue) => {
+                const hasAccess = many2manyValue[1] !== null;
                 return {
                     id: many2manyValue[0],
-                    text: many2manyValue[1],
-                    onClick: async () =>
-                        await this._openRecord(this.props.comodel, many2manyValue[0]),
+                    text: hasAccess ? many2manyValue[1] : this.noAccessMessage,
+                    onClick: hasAccess
+                        && (async () => await this._openRecord(this.props.comodel, many2manyValue[0])),
                     onDelete:
-                        !this.props.readonly && (() => this.onMany2manyDelete(many2manyValue[0])),
+                        !this.props.readonly && hasAccess
+                        && (() => this.onMany2manyDelete(many2manyValue[0])),
                     colorIndex: 0,
                     img: this.showAvatar
-                        ? `/web/image/${this.props.comodel}/${many2manyValue[0]}/avatar_128`
+                        ? `/web/image/${this.props.comodel}/${hasAccess ? many2manyValue[0] : 0}/avatar_128`
                         : null,
                 };
             });

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -79,9 +79,11 @@ export class PropertyValue extends Component {
             // force to show at least 1 digit, even for integers
             return value;
         } else if (this.props.type === "datetime") {
-            return typeof value === "string" ? deserializeDateTime(value) : value;
+            const ret = typeof value === "string" ? deserializeDateTime(value) : value;
+            return ret && !ret.invalid ? ret : false;
         } else if (this.props.type === "date") {
-            return typeof value === "string" ? deserializeDate(value) : value;
+            const ret = typeof value === "string" ? deserializeDate(value) : value;
+            return ret && !ret.invalid ? ret : false;
         } else if (this.props.type === "boolean") {
             return !!value;
         } else if (this.props.type === "selection") {
@@ -105,6 +107,9 @@ export class PropertyValue extends Component {
                     onDelete:
                         !this.props.readonly && (() => this.onMany2manyDelete(many2manyValue[0])),
                     colorIndex: 0,
+                    img: this.showAvatar
+                        ? `/web/image/${this.props.comodel}/${many2manyValue[0]}/avatar_128`
+                        : null,
                 };
             });
         } else if (this.props.type === "tags") {
@@ -123,7 +128,11 @@ export class PropertyValue extends Component {
         if (!this.props.domain || !this.props.domain.length) {
             return [];
         }
-        return new Domain(this.props.domain).toList();
+        let domain = new Domain(this.props.domain);
+        if (this.props.type === "many2many" && this.props.value) {
+            domain = Domain.and([domain, [['id', 'not in', this.props.value.map(rec => rec[0])]]])
+        }
+        return domain.toList();
     }
 
     /**
@@ -152,6 +161,14 @@ export class PropertyValue extends Component {
         return value.toString();
     }
 
+    /**
+     * Return True if we need to display a avatar for the current property.
+     */
+    get showAvatar() {
+        return ["many2one", "many2many"].includes(this.props.type)
+            && ["res.users", "res.partner"].includes(this.props.comodel);
+    }
+
     /* --------------------------------------------------------
      * Event handlers
      * -------------------------------------------------------- */
@@ -163,9 +180,9 @@ export class PropertyValue extends Component {
      */
     async onValueChange(newValue) {
         if (this.props.type === "datetime") {
-            newValue = serializeDateTime(newValue);
+            newValue = newValue && serializeDateTime(newValue);
         } else if (this.props.type === "date") {
-            newValue = serializeDate(newValue);
+            newValue = newValue && serializeDate(newValue);
         } else if (this.props.type === "integer") {
             newValue = parseInt(newValue) || 0;
         } else if (this.props.type === "float") {

--- a/addons/web/static/src/views/fields/properties/property_value.scss
+++ b/addons/web/static/src/views/fields/properties/property_value.scss
@@ -30,6 +30,12 @@ input.o_field_property_input[type=number] {
         margin-left: -1.6em;
         padding-left: 1.6em;
     }
+
+    a.disabled {
+        pointer-events: none;
+        color: gray;
+        font-style: italic;
+    }
 }
 
 .o_field_property_many2many_value {

--- a/addons/web/static/src/views/fields/properties/property_value.scss
+++ b/addons/web/static/src/views/fields/properties/property_value.scss
@@ -18,17 +18,38 @@ input.o_field_property_input[type=number] {
     height: 25px;
 }
 
+.o_field_property_many2one_value {
+    img {
+        height: 1.4em;
+        width: 1.4em;
+        object-fit: cover;
+    }
+
+    &.avatar .o_input_dropdown{
+        // counter the avatar size to keep things aligned
+        margin-left: -1.6em;
+        padding-left: 1.6em;
+    }
+}
+
 .o_field_property_many2many_value {
-    .o_tag {
-        margin: 1px 2px 1px 0;
-        .o_delete {
-            padding-left: 4px;
-        }
+    .o_tag,
+    .o_tag_badge_text,
+    .o_delete {
+        color: gray !important;
     }
     .o_delete {
-        margin-top: 2px;
+        line-height: 1;
     }
-    .o_badge_text {
-        line-height: 1.1;
+    .o_input_dropdown {
+        width: 100px !important;
+        min-width: 100px !important;
+        input {
+            border: 0px !important;
+        }
     }
+}
+
+.o_form_readonly .o_field_property_many2many_value {
+    border: 0px;
 }

--- a/addons/web/static/src/views/fields/properties/property_value.xml
+++ b/addons/web/static/src/views/fields/properties/property_value.xml
@@ -64,8 +64,11 @@
             </t>
             <div
                 t-elif="props.type === 'many2one'"
-                class="d-flex flex-row">
+                t-attf-class="d-flex flex-row align-items-center o_field_property_many2one_value {{showAvatar ? 'avatar' : ''}}">
                 <t t-if="props.comodel">
+                    <img t-if="showAvatar &amp;&amp; propertyValue[0]"
+                        t-attf-src="/web/image/{{props.comodel}}/{{propertyValue[0]}}/avatar_128"
+                        class="rounded-circle me-1"/>
                     <a
                         t-if="props.readonly"
                         class="o_form_uri"
@@ -99,7 +102,9 @@
                 </t>
             </div>
             <t t-elif="props.type === 'many2many'">
-                <div t-if="props.comodel" class="o_field_property_many2many_value">
+                <div t-if="props.comodel" class="o_field_property_many2many_value py-1 d-flex flex-row pt-2 w-100"
+                    t-attf-class="o_field_widget o_field_many2manytags o_input {{showAvatar ? 'avatar' : ''}}">
+                    <!-- Copy many2many tags style without duplicating all CSS -->
                     <TagsList tags="propertyValue"/>
                     <Many2XAutocomplete
                         t-if="!props.readonly"

--- a/addons/web/static/src/views/fields/properties/property_value.xml
+++ b/addons/web/static/src/views/fields/properties/property_value.xml
@@ -66,19 +66,20 @@
                 t-elif="props.type === 'many2one'"
                 t-attf-class="d-flex flex-row align-items-center o_field_property_many2one_value {{showAvatar ? 'avatar' : ''}}">
                 <t t-if="props.comodel">
+                    <t t-set="hasAccess" t-value="!propertyValue || propertyValue[1]"/>
                     <img t-if="showAvatar &amp;&amp; propertyValue[0]"
-                        t-attf-src="/web/image/{{props.comodel}}/{{propertyValue[0]}}/avatar_128"
+                        t-attf-src="/web/image/{{props.comodel}}/{{hasAccess ? propertyValue[0] : 0}}/avatar_128"
                         class="rounded-circle me-1"/>
                     <a
-                        t-if="props.readonly"
-                        class="o_form_uri"
+                        t-if="props.readonly || !hasAccess"
+                        t-attf-class="o_form_uri {{propertyValue &amp;&amp; propertyValue[1] ? '' : 'disabled'}}"
                         t-att-href="propertyValue[0] ? `#id=${propertyValue[0]}&amp;model=${props.comodel}` : '#'"
                         t-on-click.prevent="onMany2oneClick">
-                        <span t-out="propertyValue &amp;&amp; propertyValue[1] || ''" />
+                        <t t-out="hasAccess ? propertyValue[1] : noAccessMessage" />
                     </a>
                     <Many2XAutocomplete
                         t-else=""
-                        value="propertyValue &amp;&amp; propertyValue[1] || ''"
+                        value="propertyValue[1] || ''"
                         id="propertyValue[0] ? propertyValue[0].toString() : ''"
                         resModel="props.comodel"
                         autoSelect="true"
@@ -90,7 +91,7 @@
                         activeActions="{canCreate: true, canCreateEdit: true, canWrite: true}"
                     />
                     <button
-                        t-if="!props.readonly &amp;&amp; propertyValue &amp;&amp; propertyValue[0]"
+                        t-if="!props.readonly &amp;&amp; propertyValue &amp;&amp; propertyValue[0] &amp;&amp; hasAccess"
                         type="button"
                         class="btn btn-secondary fa fa-external-link o_external_button o_properties_external_button py-0"
                         tabindex="-1"

--- a/addons/web/static/src/views/form/form_view_extra.scss
+++ b/addons/web/static/src/views/form/form_view_extra.scss
@@ -81,7 +81,8 @@ $o-td-label-padding-right: 8px;
         .o_td_label, .o_checkbox_optional_field > .o_form_label {
             border-right: 1px solid #ddd;
         }
-        .o_td_label + td {
+        .o_td_label + td,
+        .o_td_label + .o_td_value {
             padding: 0px 36px 0px $o-td-label-padding-right;
         }
         .o_checkbox_optional_field > .o_form_label {

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -266,12 +266,12 @@ export function toStringExpression(str) {
 }
 
 /**
- * Generate a unique identifier.
+ * Generate a unique identifier (64 bits) in hexadecimal.
  *
  * @returns {string}
  */
 export function uuid() {
-    const array = new Uint8Array(16);
+    const array = new Uint8Array(8);
     window.crypto.getRandomValues(array);
     // Uint8Array to hex
     return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -110,6 +110,26 @@ QUnit.module("Fields", (hooks) => {
                         },
                     ],
                 },
+                'res.users': {
+                    fields: {
+                        name: {
+                            string: "Name",
+                            type: "char",
+                        },
+                    },
+                    records: [
+                        {
+                            id: 1,
+                            display_name: "Alice",
+                        }, {
+                            id: 2,
+                            display_name: "Bob",
+                        }, {
+                            id: 3,
+                            display_name: "Eve",
+                        },
+                    ],
+                },
             },
         };
 
@@ -763,9 +783,8 @@ QUnit.module("Fields", (hooks) => {
 
     /**
      * Test the properties many2many
-     * FIXME: broken by mighty TDE
      */
-    QUnit.skip("properties: many2many", async function (assert) {
+    QUnit.test("properties: many2many", async function (assert) {
         async function mockRPC(route, { method, model, args, kwargs }) {
             if (method === "check_access_rights") {
                 return true;
@@ -774,6 +793,8 @@ QUnit.module("Fields", (hooks) => {
                     { model: "res.partner", display_name: "Partner" },
                     { model: "res.users", display_name: "User" },
                 ];
+            } else if (method === "display_name_for" && model === "ir.model" && args[0][0] === "res.users") {
+                return [{"display_name": "User", "model": "res.users"}]
             } else if (method === "name_create" && model === "res.users") {
                 // Add a prefix to check that "name_create"
                 // has been called with the right parameters

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -12,6 +12,12 @@ async function closePopover(target) {
     await click(document, "html");
 }
 
+async function changeType(target, propertyTypeIndex) {
+    await click(target, ".o_field_property_definition_type input");
+    await nextTick();
+    await click(target, `.o_field_property_definition_type .dropdown-item:nth-child(${propertyTypeIndex})`);
+}
+
 QUnit.module("Fields", (hooks) => {
     hooks.beforeEach(() => {
         target = getFixture();
@@ -238,11 +244,7 @@ QUnit.module("Fields", (hooks) => {
 
         // Change the property type to "Date & Time"
         await editInput(target, ".o_field_property_definition_header input", "My Datetime");
-        await click(target, ".o_field_property_definition_type button");
-        await click(
-            target,
-            ".o_field_property_definition_type .dropdown-menu .dropdown-item:nth-child(6)"
-        );
+        await changeType(target, 6);
         assert.strictEqual(type.value, "Date & Time", "Should have changed the property type");
 
         // Choosing a date in the date picker should not close the definition popover
@@ -609,9 +611,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
         let popover = target.querySelector(".o_property_field_popover");
         // Select the tags type
-        await click(popover, ".o_field_property_definition_type input");
-        await nextTick();
-        await click(popover, ".o_field_property_definition_type .dropdown-item:nth-child(8)");
+        await changeType(target, 8);
 
         // Create 3 tags
         const tagsInputSelector = ".o_property_field_popover .o_field_property_dropdown_menu input";
@@ -742,9 +742,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
         const popover = target.querySelector(".o_property_field_popover");
         // Select the many2one type
-        await click(popover, ".o_field_property_definition_type input");
-        await nextTick();
-        await click(popover, ".o_field_property_definition_type .dropdown-item:nth-child(9)");
+        await changeType(target, 9);
 
         // Choose the "User" model
         await click(popover, ".o_field_property_definition_model input");
@@ -794,7 +792,10 @@ QUnit.module("Fields", (hooks) => {
                     { model: "res.users", display_name: "User" },
                 ];
             } else if (method === "display_name_for" && model === "ir.model" && args[0][0] === "res.users") {
-                return [{"display_name": "User", "model": "res.users"}]
+                return [
+                    {"display_name": "User", "model": "res.users"},
+                    {"display_name": "Partner", "model": "res.partner"},
+                ];
             } else if (method === "name_create" && model === "res.users") {
                 // Add a prefix to check that "name_create"
                 // has been called with the right parameters
@@ -832,9 +833,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
         const popover = target.querySelector(".o_property_field_popover");
         // Select the many2many type
-        await click(popover, ".o_field_property_definition_type input");
-        await nextTick();
-        await click(popover, ".o_field_property_definition_type .dropdown-item:nth-child(10)");
+        await changeType(target, 10);
 
         // Choose the "User" model
         await click(popover, ".o_field_property_definition_model input");
@@ -968,5 +967,111 @@ QUnit.module("Fields", (hooks) => {
         assert.verifySteps([]);
         await click(target, ".o_form_button_save");
         assert.verifySteps(["write", "read"]);
+    });
+
+    /**
+     * Changing the type or the model of a property must regenerate it's name.
+     * (so if we change the type / model, all other property values on other records
+     * are set to False).
+     * Resetting the old model / type should reset the original name.
+     */
+    QUnit.test("properties: name reset", async function (assert) {
+        async function mockRPC(route, { method, model, kwargs }) {
+            if (method === "check_access_rights") {
+                return true;
+            } else if (method === "get_available_models" && model === "ir.model") {
+                return [
+                    { model: "res.partner", display_name: "Partner" },
+                    { model: "res.users", display_name: "User" },
+                ];
+            } else if (method === "display_name_for" && model === "ir.model") {
+                return [
+                    {"display_name": "User", "model": "res.users"},
+                    {"display_name": "Partner", "model": "res.partner"},
+                ];
+            } else if (method === "search_count") {
+                return 5;
+            }
+        }
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="company_id"/>
+                            <field name="properties"/>
+                        </group>
+                    </sheet>
+                </form>`,
+            mockRPC,
+        });
+
+        await click(target, ".o_form_button_edit");
+
+        assert.ok(target.querySelector('.o_property_field[property-name="property_2"]'));
+
+        // open the definition popover
+        await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
+
+        // change the type to "many2one"
+        await changeType(target, 9);
+
+        // select the "User" model
+        await click(target, ".o_field_property_definition_model input");
+        await click(target, ".o_field_property_definition_model .ui-menu-item:nth-child(2)");
+
+        await closePopover(target);
+
+        // check that the name has been regenerated
+        let property = target.querySelector(".o_property_field:nth-child(2)");
+        const propertyName2 = property.getAttribute("property-name");
+        assert.ok(propertyName2.length === 16 && propertyName2 !== "property_2", "Name must have been regenerated");
+
+        // change back to "Selection" and verify that the original name is restored
+        await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
+        await changeType(target, 7);
+        await closePopover(target);
+        property = target.querySelector(".o_property_field:nth-child(2)");
+        const propertyName3 = property.getAttribute("property-name");
+        assert.strictEqual(propertyName3, "property_2", "Name must have been restored");
+
+        // re-select many2one user
+        await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
+        await changeType(target, 9);
+        await click(target, ".o_field_property_definition_model input");
+        await click(target, ".o_field_property_definition_model .ui-menu-item:nth-child(2)");
+        property = target.querySelector(".o_property_field:nth-child(2)");
+        const propertyName4 = property.getAttribute("property-name");
+
+        // save and edit (if we do not save, the name will be the same even if
+        // we change the model, because it would be useless to regenerate it again)
+        await click(target, ".o_form_button_save");
+        await click(target, ".o_form_button_edit");
+
+        // change the model to "Partner"
+        await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
+        await click(target, ".o_field_property_definition_model input");
+        await click(target, ".o_field_property_definition_model .ui-menu-item:nth-child(1)");
+        await closePopover(target);
+
+        // check that a new name has been regenerated
+        property = target.querySelector(".o_property_field:nth-child(2)");
+        const propertyName5 = property.getAttribute("property-name");
+        assert.ok(propertyName5.length === 16);
+        assert.notOk(["property_2", propertyName2, propertyName3, propertyName4].includes(propertyName5));
+
+        // restore the model "User", and check that the name has been restored
+        await click(target, ".o_property_field:nth-child(2) .o_field_property_open_popover");
+        await click(target, ".o_field_property_definition_model input");
+        await click(target, ".o_field_property_definition_model .ui-menu-item:nth-child(2)");
+        await closePopover(target);
+        property = target.querySelector(".o_property_field:nth-child(2)");
+        const propertyName6 = property.getAttribute("property-name");
+        assert.strictEqual(propertyName4, propertyName6);
     });
 });

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -169,7 +169,7 @@ class PropertiesCase(TransactionCase):
             'SELECT "test_new_api_message"."id" AS "id", "test_new_api_message"."attributes" AS "attributes" FROM "test_new_api_message" WHERE "test_new_api_message".id IN %s',
             'SELECT "test_new_api_message"."id" AS "id", "test_new_api_message"."discussion" AS "discussion", "test_new_api_message"."body" AS "body", "test_new_api_message"."author" AS "author", "test_new_api_message"."name" AS "name", "test_new_api_message"."important" AS "important", "test_new_api_message"."label"->>\'en_US\' AS "label", "test_new_api_message"."priority" AS "priority", "test_new_api_message"."create_uid" AS "create_uid", "test_new_api_message"."create_date" AS "create_date", "test_new_api_message"."write_uid" AS "write_uid", "test_new_api_message"."write_date" AS "write_date" FROM "test_new_api_message" WHERE "test_new_api_message".id IN %s',
             # read the definition on the definition record
-            'SELECT "test_new_api_discussion"."id" AS "id", "test_new_api_discussion"."attributes_definition" AS "attributes_definition" FROM "test_new_api_discussion" WHERE "test_new_api_discussion".id IN %s',
+            'SELECT "test_new_api_discussion"."id" AS "id", "test_new_api_discussion"."name" AS "name", "test_new_api_discussion"."moderator" AS "moderator", "test_new_api_discussion"."message_concat" AS "message_concat", "test_new_api_discussion"."attributes_definition" AS "attributes_definition", "test_new_api_discussion"."create_uid" AS "create_uid", "test_new_api_discussion"."create_date" AS "create_date", "test_new_api_discussion"."write_uid" AS "write_uid", "test_new_api_discussion"."write_date" AS "write_date" FROM "test_new_api_discussion" WHERE "test_new_api_discussion".id IN %s',
             # check the many2one existence
             'SELECT "test_new_api_partner".id FROM "test_new_api_partner" WHERE "test_new_api_partner".id IN %s',
             'SELECT "test_new_api_partner"."id" AS "id", "test_new_api_partner"."name" AS "name", "test_new_api_partner"."create_uid" AS "create_uid", "test_new_api_partner"."create_date" AS "create_date", "test_new_api_partner"."write_uid" AS "write_uid", "test_new_api_partner"."write_date" AS "write_date" FROM "test_new_api_partner" WHERE "test_new_api_partner".id IN %s',
@@ -230,7 +230,7 @@ class PropertiesCase(TransactionCase):
             }])
             self.env.invalidate_all()
 
-        with self.assertQueryCount(9):
+        with self.assertQueryCount(7):
             messages = self.env['test_new_api.message'].create([{
                 'name': 'Test Message',
                 'discussion': self.discussion_1.id,
@@ -807,7 +807,7 @@ class PropertiesCase(TransactionCase):
             'comodel': 'test_new_api.partner',
         }]
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(4):
             self.message_1.attributes = [
                 {
                     "name": "moderator_partner_ids",
@@ -985,7 +985,7 @@ class PropertiesCase(TransactionCase):
         """If we change the definition record, the onchange of the properties field must be triggered."""
         message_form = Form(self.env['test_new_api.message'])
 
-        with self.assertQueryCount(11):
+        with self.assertQueryCount(8):
             message_form.discussion = self.discussion_1
             message_form.author = self.user
 
@@ -1019,7 +1019,7 @@ class PropertiesCase(TransactionCase):
                 msg='Should take the values of the new definition record',
             )
 
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(6):
             message = message_form.save()
 
         self.assertEqual(
@@ -1034,7 +1034,7 @@ class PropertiesCase(TransactionCase):
 
         # change the definition record, change the definition and add default values
         self.assertEqual(message.discussion, self.discussion_2)
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(4):
             message.discussion = self.discussion_1
         self.assertEqual(
             self.discussion_1.attributes_definition,

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -128,6 +128,7 @@ class PropertiesCase(TransactionCase):
         self.assertEqual(self.message_3.read(['attributes'])[0]['attributes'], expected)
         self.assertEqual(self.message_3.attributes, expected)
 
+    @mute_logger('odoo.fields')
     def test_properties_field_write_batch(self):
         """Test the behavior of the write called in batch.
 
@@ -186,6 +187,7 @@ class PropertiesCase(TransactionCase):
             # 2 more queries for message 2 to verify his partner existence / name_get
             (self.message_1 | self.message_2).read(['attributes'])
 
+    @mute_logger('odoo.fields')
     def test_properties_field_delete(self):
         """Test to delete a property using the flag "definition_deleted"."""
         self.message_1.attributes = [{
@@ -215,6 +217,7 @@ class PropertiesCase(TransactionCase):
         self.assertEqual(len(self.message_1.attributes), 1)
         self.assertEqual(self.message_1.attributes[0]['value'], 'purple')
 
+    @mute_logger('odoo.fields')
     def test_properties_field_create_batch(self):
         # first create to cache the access rights
         self.env['test_new_api.message'].create({'name': 'test'})
@@ -507,7 +510,7 @@ class PropertiesCase(TransactionCase):
         self.assertEqual(properties[1]['value'], (self.partner_2.id, self.partner_2.display_name))
         self.assertEqual(properties[1]['comodel'], 'test_new_api.partner')
 
-    @mute_logger('odoo.models.unlink')
+    @mute_logger('odoo.models.unlink', 'odoo.fields')
     def test_properties_field_many2one_unlink(self):
         """Test the case where we unlink the many2one record."""
         self.message_2.attributes = [{
@@ -800,7 +803,7 @@ class PropertiesCase(TransactionCase):
                 },
             ]
 
-    @mute_logger('odoo.models.unlink')
+    @mute_logger('odoo.models.unlink', 'odoo.fields')
     def test_properties_field_many2many_basic(self):
         """Test the basic operation on a many2many properties (read, write...).
 
@@ -1016,6 +1019,7 @@ class PropertiesCase(TransactionCase):
                 {'name': 'state', 'type': 'datetime'},
             ]
 
+    @mute_logger('odoo.fields')
     def test_properties_field_onchange(self):
         """If we change the definition record, the onchange of the properties field must be triggered."""
         message_form = Form(self.env['test_new_api.message'])
@@ -1169,6 +1173,7 @@ class PropertiesCase(TransactionCase):
             message.attributes,
             [{'name': 'new_property', 'type': 'char', 'value': 'test value'}])
 
+    @mute_logger('odoo.fields')
     def test_properties_field_definition_update(self):
         """Test the definition update from the child."""
         self.discussion_1.attributes_definition = []
@@ -1220,6 +1225,7 @@ class PropertiesCase(TransactionCase):
         }
         self.assertEqual(expected_properties, sql_properties)
 
+    @mute_logger('odoo.fields')
     def test_properties_field_security(self):
         """Check the access right related to the Properties fields."""
         MultiTag = type(self.env['test_new_api.multi.tag'])

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3355,6 +3355,8 @@ class Properties(Field):
                     property_definition.pop('value', None)
                 container[self.definition_record_field] = properties_definition
 
+                _logger.info('User #%i change definition of %r', records.env.user.id, container)
+
         return super().write(records, value)
 
     def _compute(self, records):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3633,7 +3633,7 @@ class PropertiesDefinition(Field):
     column_type = ('jsonb', 'jsonb')
     copy = True                         # containers may act like templates, keep definitions to ease usage
     readonly = False
-    prefetch = False
+    prefetch = True
 
     REQUIRED_KEYS = ('name', 'type')
     ALLOWED_KEYS = (

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3207,24 +3207,7 @@ class Properties(Field):
         if not value:
             return None
 
-        if isinstance(value, str):
-            # assume already JSONified
-            if not isinstance(json.loads(value), dict):
-                raise ValueError(f"Wrong property value {value!r}")
-            return value
-
-        if isinstance(value, dict):
-            return json.dumps(value)
-
-        if not isinstance(value, list):
-            raise ValueError(f"Wrong property type {type(value)!r}")
-
-        # Convert the list with all definitions into a simple dict
-        # {name: value} to store the strict minimum on the child
-        self._remove_display_name(value)
-        value = self._list_to_dict(value)
-
-        # the JSON value is sent as a string
+        value = self.convert_to_cache(value, record, validate=validate)
         return json.dumps(value)
 
     def convert_to_cache(self, value, record, validate=True):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -16,6 +16,7 @@ import enum
 import itertools
 import json
 import logging
+import uuid
 import warnings
 
 from markupsafe import Markup
@@ -3198,8 +3199,8 @@ class Properties(Field):
     # names to their corresponding value, like
     #
     #       {
-    #           '3adf37f3258cfe40f0907d9cbdd7d091': 'red',
-    #           'aa34746a6851ee4ea1f8d95746e45788': 1337,
+    #           '3adf37f3258cfe40': 'red',
+    #           'aa34746a6851ee4e': 1337,
     #       }
     #
     def convert_to_column(self, value, record, values=None, validate=True):
@@ -3254,13 +3255,13 @@ class Properties(Field):
     # corresponding value, like
     #
     #       [{
-    #           'name': '3adf37f3258cfe40f0907d9cbdd7d091',
+    #           'name': '3adf37f3258cfe40',
     #           'string': 'Color Code',
     #           'type': 'char',
     #           'default': 'blue',
     #           'value': 'red',
     #       }, {
-    #           'name': 'aa34746a6851ee4ea1f8d95746e45788',
+    #           'name': 'aa34746a6851ee4e',
     #           'string': 'Partner',
     #           'type': 'many2one',
     #           'comodel': 'test_new_api.partner',
@@ -3283,13 +3284,13 @@ class Properties(Field):
     # field values have a display name.
     #
     #       [{
-    #           'name': '3adf37f3258cfe40f0907d9cbdd7d091',
+    #           'name': '3adf37f3258cfe40',
     #           'string': 'Color Code',
     #           'type': 'char',
     #           'default': 'blue',
     #           'value': 'red',
     #       }, {
-    #           'name': 'aa34746a6851ee4ea1f8d95746e45788',
+    #           'name': 'aa34746a6851ee4e',
     #           'string': 'Partner',
     #           'type': 'many2one',
     #           'comodel': 'test_new_api.partner',
@@ -3344,7 +3345,7 @@ class Properties(Field):
                 if not definition.get('definition_deleted')
             ]
             for definition in value:
-                definition.pop('definition_changed', None)
+                definition_changed = definition.pop('definition_changed', None)
 
             # update the properties definition on the container
             container = records[self.definition_record]
@@ -3494,6 +3495,19 @@ class Properties(Field):
                     ]
 
     @classmethod
+    def _add_missing_names(cls, values_list):
+        """Generate new properties name if needed.
+
+        Modify in place "values_list".
+
+        :param values_list: List of properties definition with properties value
+        """
+        for definition in values_list:
+            if definition.get('definition_changed') and not definition.get('name'):
+                # keep only the first 64 bits
+                definition['name'] = str(uuid.uuid4()).replace('-', '')[:16]
+
+    @classmethod
     def _parse_json_types(cls, values_list, env, check_existence=True):
         """Parse the value stored in the JSON.
 
@@ -3563,13 +3577,13 @@ class Properties(Field):
         E.G.
             Input list:
             [{
-                'name': '3adf37f3258cfe40f0907d9cbdd7d091',
+                'name': '3adf37f3258cfe40',
                 'string': 'Color Code',
                 'type': 'char',
                 'default': 'blue',
                 'value': 'red',
             }, {
-                'name': 'aa34746a6851ee4ea1f8d95746e45788',
+                'name': 'aa34746a6851ee4e',
                 'string': 'Partner',
                 'type': 'many2one',
                 'comodel': 'test_new_api.partner',
@@ -3578,8 +3592,8 @@ class Properties(Field):
 
             Output dict:
             {
-                '3adf37f3258cfe40f0907d9cbdd7d091': 'red',
-                'aa34746a6851ee4ea1f8d95746e45788': 1337,
+                '3adf37f3258cfe40': 'red',
+                'aa34746a6851ee4e': 1337,
             }
 
         :param values_list: List of properties definition and value
@@ -3587,6 +3601,8 @@ class Properties(Field):
         """
         if not is_list_of(values_list, dict):
             raise ValueError(f'Wrong properties value {values_list!r}')
+
+        cls._add_missing_names(values_list)
 
         dict_value = {}
         for property_definition in values_list:
@@ -3650,13 +3666,13 @@ class PropertiesDefinition(Field):
         might contain the name_get of those records (and will be removed).
 
         [{
-            'name': '3adf37f3258cfe40f0907d9cbdd7d091',
+            'name': '3adf37f3258cfe40',
             'string': 'Color Code',
             'type': 'char',
             'default': 'blue',
             'default': 'red',
         }, {
-            'name': 'aa34746a6851ee4ea1f8d95746e45788',
+            'name': 'aa34746a6851ee4e',
             'string': 'Partner',
             'type': 'many2one',
             'comodel': 'test_new_api.partner',

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6830,9 +6830,26 @@ class BaseModel(metaclass=MetaModel):
                 for name, subnames in self['<tree>'].items():
                     if name == 'id':
                         continue
+                    field = record._fields[name]
+                    if (field.type == 'properties' and field.definition_record in field_name
+                       and other.get(name) == self[name] == []):
+                        # TODO: The parent field on "record" can be False, if it was changed,
+                        # (even if if was changed to a not Falsy value) because of
+                        # >>> initial_values = dict(values, **dict.fromkeys(names, False))
+                        # If it's the case when we will read the properties field on this record,
+                        # it will return False as well (no parent == no definition)
+                        # So record at the following line, will always return a empty properties
+                        # because the definition record is always False if it triggered the onchange
+                        # >>> snapshot0 = Snapshot(record, nametree, fetch=(not first_call))
+                        # but we need "snapshot0" to have the old value to be able
+                        # to compare it with the new one and trigger the onchange if necessary.
+                        # In that particular case, "other.get(name)" must contains the
+                        # non empty properties value.
+                        result[name] = []
+                        continue
+
                     if not force and other.get(name) == self[name]:
                         continue
-                    field = record._fields[name]
                     if field.type not in ('one2many', 'many2many'):
                         result[name] = field.convert_to_onchange(self[name], record, {})
                     else:
@@ -6959,18 +6976,6 @@ class BaseModel(metaclass=MetaModel):
 
         # make a snapshot based on the initial values of record
         snapshot0 = Snapshot(record, nametree, fetch=(not first_call))
-
-        for name in initial_values:
-            # TODO: The parent field on "record" can be False, if it was changed,
-            # (even if if was changed to a not Falsy value) because of
-            # >>> initial_values = dict(values, **dict.fromkeys(names, False))
-            # If it's the case when we will read the properties field on this record,
-            # it will return False as well (no parent == no definition) but we need
-            # "snapshot0" to have the old value to be able to compare it with the new one
-            # and trigger the onchange if necessary.
-            field = self._fields.get(name)
-            if field and field.type == 'properties':
-                snapshot0[name] = initial_values[name]
 
         # store changed values in cache; also trigger recomputations based on
         # subfields (e.g., line.a has been modified, line.b is computed stored

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -12,7 +12,7 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 # properly comparable using normal operators, for example:
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
-version_info = (15, 5, 0, ALPHA, 1, '')
+version_info = (16, 1, 0, ALPHA, 1, '')
 version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 series = serie = major_version = '.'.join(str(s) for s in version_info[:2])
 


### PR DESCRIPTION
Purpose
=======
Improve the usability of the properties field.

Specifications
==============
Add the properties field on project task.

Prefetch the properties to improve the performance.

Allow to display a avatar widget for the relational properties, hide the
move arrows if the action can not be done, show the many2many properties
even if one record in the list is not accessible, improve the behavior
of the relational properties when some records can not be accessed.

Task-2965523
See odoo/odoo/pull/95184