### PR TITLE
[FIX] project: don't require personal stage in all cases when editing tasks

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2043,6 +2043,9 @@ class Task(models.Model):
         # Track user_ids to send assignment notifications
         old_user_ids = {t: t.user_ids for t in self}
 
+        if "personal_stage_type_id" in vals and not vals['personal_stage_type_id']:
+            del vals['personal_stage_type_id']
+
         result = super(Task, tasks).write(vals)
 
         self._task_message_auto_subscribe_notify({task: task.user_ids - old_user_ids[task] - self.env.user for task in self})

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1300,7 +1300,7 @@
                                 <group>
                                     <field name="is_analytic_account_id_changed" invisible="1"/>
                                     <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
-                                    <field name="personal_stage_type_id" string="Personal Stage" groups="base.group_no_one" domain="[('user_id', '!=', False)]" context="{'default_user_id' : uid}" readonly="0" required="1" attrs="{'invisible': &quot;[('user_ids', 'not in', [uid])]&quot;}"/>
+                                    <field name="personal_stage_type_id" string="Personal Stage" groups="base.group_no_one" domain="[('user_id', '!=', False)]" context="{'default_user_id' : uid}" readonly="0" attrs="{'invisible': &quot;[('user_ids', 'not in', [uid])]&quot;}"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1300,7 +1300,7 @@
                                 <group>
                                     <field name="is_analytic_account_id_changed" invisible="1"/>
                                     <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
-                                    <field name="personal_stage_type_id" string="Personal Stage" groups="base.group_no_one" domain="[('user_id', '!=', False)]" context="{'default_user_id' : uid}" readonly="0" required="1"/>
+                                    <field name="personal_stage_type_id" string="Personal Stage" groups="base.group_no_one" domain="[('user_id', '!=', False)]" context="{'default_user_id' : uid}" readonly="0" required="1" attrs="{'invisible': &quot;[('user_ids', 'not in', [uid])]&quot;}"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>


### PR DESCRIPTION
This PR fixes two bugs related to https://github.com/odoo/odoo/pull/90588 adding the personal stage as a required field in the task form view:
- It doesn't make sense to force the user to place a task they are not assigned to in one of their personal stages.
- Personal stages are created for a given user when they are first assigned to a task. If they try to create their first task and assign it to themselves, they therefore cannot also give it a personal stage.