### PR TITLE
[IMP] base: Qweb avoid some lookups in odoo cache.

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -584,7 +584,7 @@ class IrQWeb(models.AbstractModel):
             return None
 
     @QwebTracker.wrap_compile
-    def _compile(self, template):
+    def _compile(self, template, cache=None):
         if isinstance(template, etree._Element):
             self = self.with_context(is_t_cache_disabled=True)
             ref = None
@@ -620,7 +620,7 @@ class IrQWeb(models.AbstractModel):
                 raise QWebException("Error when compiling xml template",
                     self, template, code=code, ref=ref) from e
 
-        return self._load_values(base_key_cache, generate_functions)
+        return self._load_values(base_key_cache, generate_functions, cache)
 
     def _generate_code(self, template):
         """ Compile the given template into a rendering function (generator)::
@@ -1607,7 +1607,7 @@ class IrQWeb(models.AbstractModel):
                                     ref, function_name, cached_values = item
                                     t_nocache_function = values['__qweb_loaded_values'].get(function_name)
                                     if not t_nocache_function:
-                                        t_call_template_functions, def_name = self._compile(ref)
+                                        t_call_template_functions, def_name = self._compile(ref, values.get('__qweb_loaded_values'))
                                         t_nocache_function = t_call_template_functions[function_name]
 
                                     nocache_values = values['__qweb_root_values'].copy()
@@ -2105,7 +2105,7 @@ class IrQWeb(models.AbstractModel):
             template = {template}
             if template.isnumeric():
                 template = int(template)
-            t_call_template_functions, def_name = irQweb._compile(template)
+            t_call_template_functions, def_name = irQweb._compile(template, values.get('__qweb_loaded_values'))
             render_template = t_call_template_functions[def_name]
             yield from render_template(irQweb, t_call_values)
             """, level))
@@ -2228,7 +2228,7 @@ class IrQWeb(models.AbstractModel):
                         ref, function_name, cached_values = item
                         t_nocache_function = loaded_values.get(function_name)
                         if not t_nocache_function:
-                            t_call_template_functions, def_name = self._compile(ref)
+                            t_call_template_functions, def_name = self._compile(ref, values.get('__qweb_loaded_values'))
                             t_nocache_function = t_call_template_functions[function_name]
 
                         nocache_values = values['__qweb_root_values'].copy()

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -295,11 +295,11 @@ class QwebTracker():
     @classmethod
     def wrap_compile(cls, method_compile):
         @functools.wraps(method_compile)
-        def _tracked_compile(self, template):
+        def _tracked_compile(self, template, cache=None):
             if not self.env.context.get('profile'):
-                return method_compile(self, template)
+                return method_compile(self, template, cache)
 
-            template_functions, def_name = method_compile(self, template)
+            template_functions, def_name = method_compile(self, template, cache)
             render_template = template_functions[def_name]
 
             def profiled_method_compile(self, values):


### PR DESCRIPTION
Use the cache dictionary containing the methods generated by the qweb when rendering. This change avoids some of the lookup in the cache.