### PR TITLE
[FIX] hr_appraisal_skills: enable editable skills in appraisal

### DIFF
--- a/addons/hr_skills/static/src/fields/skills_one2many.js
+++ b/addons/hr_skills/static/src/fields/skills_one2many.js
@@ -25,9 +25,10 @@ export class SkillsListRenderer extends CommonSkillsListRenderer {
 SkillsListRenderer.template = 'hr_skills.SkillsListRenderer';
 
 export class SkillsX2ManyField extends X2ManyField {
-    async onAdd({ context } = {}) {
+    async onAdd({ context, editable } = {}) {
         const employeeId = this.props.record.resId;
         return super.onAdd({
+            editable,
             context: {
                 ...context,
                 default_employee_id: employeeId,


### PR DESCRIPTION
Since odoo/odoo#97984 the "Add new skills" button was opening a dialog and was not considering the `editable` attribute of the list view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
