### PR TITLE
[IMP] mail: remove isPostingMessage from updateMessage

### DIFF
--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -690,17 +690,10 @@ registerModel({
                 body: body,
                 attachment_ids: composer.attachments.concat(this.messageViewInEditing.message.attachments).map(attachment => attachment.id),
             };
-            try {
-                composer.update({ isPostingMessage: true });
-                const messageViewInEditing = this.messageViewInEditing;
-                await messageViewInEditing.message.updateContent(data);
-                if (messageViewInEditing.exists()) {
-                    messageViewInEditing.stopEditing();
-                }
-            } finally {
-                if (composer.exists()) {
-                    composer.update({ isPostingMessage: false });
-                }
+            const messageViewInEditing = this.messageViewInEditing;
+            await messageViewInEditing.message.updateContent(data);
+            if (messageViewInEditing.exists()) {
+                messageViewInEditing.stopEditing();
             }
         },
         /**


### PR DESCRIPTION
Since we are not using `postMessage` in `updateMessage`, setting isPostingMessage is not useful.
