### PR TITLE
[FIX] web,stock: Fix filtering by progress bar in kanban

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -173,11 +173,11 @@ class FieldAdapter extends ComponentAdapter {
         } else if (evType === "reload") {
             const record = this.props.record;
             if (payload.db_id === record.id) {
-                await record.load();
+                await record.model.reloadRecords(record);
             } else {
                 await record.model.root.load();
+                record.model.notify();
             }
-            record.model.notify();
             if (payload.onSuccess) {
                 payload.onSuccess();
             }


### PR DESCRIPTION
This PR addresses 2 issues in kanban views with progress bars:

1) When updating the field on which the progress bars are computed in a record, an inert "Load more" button would appear

2) After updating said value, the progress bars would not be recomputed

Both of these problems have been fixed.

Enterprise PR: https://github.com/odoo/enterprise/pull/31126

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
