### PR TITLE
[FIX] hr: make 'My Profile' available again to non-HR

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -72,6 +72,9 @@
             'hr/static/tests/m2x_avatar_employee_tests.js',
             'hr/static/tests/standalone_m2o_avatar_employee_tests.js',
         ],
+        'web.assets_tests': [
+            'hr/static/tests/tours/hr_employee_flow.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -169,6 +169,20 @@ class User(models.Model):
         return super().SELF_WRITEABLE_FIELDS + HR_WRITABLE_FIELDS
 
     @api.model
+    def get_views(self, views, options=None):
+        # Requests the My Profile form view as last.
+        # Otherwise the fields of the 'search' view will take precedence
+        # and will omit the fields that are requested as SUPERUSER
+        # in `get_view()`.
+        profile_view = self.env.ref("hr.res_users_view_form_profile")
+        profile_form = profile_view and [profile_view.id, 'form']
+        if profile_form and profile_form in views:
+            views.remove(profile_form)
+            views.append(profile_form)
+        result = super().get_views(views, options)
+        return result
+
+    @api.model
     def get_view(self, view_id=None, view_type='form', **options):
         # When the front-end loads the views it gets the list of available fields
         # for the user (according to its access rights). Later, when the front-end wants to

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -1,0 +1,29 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('hr_employee_tour', {
+    test: true,
+    url: '/web',
+}, [
+    tour.stepUtils.showAppsMenuItem(),
+    {
+        content: "Open Employees app",
+        trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
+        run: 'click',
+    },
+    {
+        content: "Open an Employee Profile",
+        trigger: ".o_kanban_record_title:contains('Johnny H.')",
+        run: 'click',
+    },
+    {
+        content: "Open user account menu",
+        trigger: ".o_user_menu .oe_topbar_name",
+        run: 'click',
+    }, {
+        content: "Open My Profile",
+        trigger: "[data-menu=settings]",
+        run: 'click',
+    },
+]);

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_channel
 from . import test_self_user_access
 from . import test_multi_company
 from . import test_resource
+from . import test_ui

--- a/addons/hr/tests/test_ui.py
+++ b/addons/hr/tests/test_ui.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged, new_test_user
+
+@tagged('-at_install', 'post_install')
+class TestEmployeeUi(HttpCase):
+    def test_employee_profile_tour(self):
+        user = new_test_user(self.env, login='davidelora', groups='base.group_user')
+
+        self.env['hr.employee'].create([{
+            'name': 'Johnny H.',
+        }, {
+            'name': 'David Elora',
+            'user_id': user.id,
+        }])
+
+        self.start_tour("/web", 'hr_employee_tour', login="davidelora")


### PR DESCRIPTION
It was no longer possible to load the My Profile for users with an employee that were not HR Officer.

In the `get_views()` method, the 'search' view was requested after the 'form', thus it omited the fields requested as SUPERUSER in `get_view()`.