### PR TITLE
[ADD] pos_sale_loyalty: link between `pos_sale` and `pos_loyalty`

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -52,8 +52,11 @@ class SaleOrderLine(models.Model):
         for sale_line in self:
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
+    def _get_sale_order_fields(self):
+        return ["product_id", "name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
+
     def read_converted(self):
-        field_names = ["product_id", "name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
+        field_names = self._get_sale_order_fields()
         results = []
         for sale_line in self:
             if sale_line.product_type:

--- a/addons/pos_sale_loyalty/__init__.py
+++ b/addons/pos_sale_loyalty/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/pos_sale_loyalty/__manifest__.py
+++ b/addons/pos_sale_loyalty/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': 'pos_sale_loyalty',
+    'version': '1.0',
+    'category': 'Hidden',
+    'sequence': 6,
+    'summary': 'Link module between pos_sale and pos_loyalty',
+    'description': """
+This module correct some behaviors when both module are installed.
+""",
+    'depends': ['pos_sale', 'pos_loyalty'],
+    'installable': True,
+    'auto_install': True,
+    'assets': {
+        'point_of_sale.assets': [
+            'pos_sale_loyalty/static/src/js/**/*.js',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_sale_loyalty/models/__init__.py
+++ b/addons/pos_sale_loyalty/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order

--- a/addons/pos_sale_loyalty/models/sale_order.py
+++ b/addons/pos_sale_loyalty/models/sale_order.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    def _get_sale_order_fields(self):
+        field_names = super()._get_sale_order_fields()
+        field_names.append('reward_id')
+        return field_names

--- a/addons/pos_sale_loyalty/static/src/js/models.js
+++ b/addons/pos_sale_loyalty/static/src/js/models.js
@@ -1,0 +1,26 @@
+/** @odoo-module alias=pos_sale_loyalty.models **/
+
+
+import { Orderline } from 'point_of_sale.models';
+import Registries from 'point_of_sale.Registries';
+
+export const PosSaleLoyaltyOrderline = (Orderline) => class PosSaleLoyaltyOrderline extends Orderline {
+    //@override
+    ignoreLoyaltyPoints() {
+        if (this.sale_order_origin_id) {
+            return true;
+        }
+        return super.ignoreLoyaltyPoints(...arguments);
+    }
+    //@override
+    setQuantityFromSOL(saleOrderLine) {
+        // we need to consider reward product such as discount in a quotation
+        if (saleOrderLine.reward_id) {
+            this.set_quantity(saleOrderLine.product_uom_qty);
+        } else {
+            super.setQuantityFromSOL(...arguments);
+        }
+    }
+};
+
+Registries.Model.extend(Orderline, PosSaleLoyaltyOrderline);


### PR DESCRIPTION
This link module corrects some behaviors when both modules are installed and used. The loyalty programs of quotations and sales orders are properly handled by the Sale app and its corresponding loyalty module. Even when it is settled by the Point of Sale app, it is still properly being handled by the Sale loyalty module and it should continue as such. The loyalty programs of Point of Sale is not considering the order lines created by a quotation or sale order.