### PR TITLE
[FIX] Traceback when adding a picture inside T&C

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -540,9 +540,9 @@ class WebsiteSale(http.Controller):
 
         image_res_id = int(image_res_id)
         if image_res_model == 'product.product':
-            request.env['product.product'].browse(image_res_id).image_1920 = False
+            request.env['product.product'].browse(image_res_id).write({'image_1920': False})
         elif image_res_model == 'product.template':
-            request.env['product.template'].browse(image_res_id).image_1920 = False
+            request.env['product.template'].browse(image_res_id).write({'image_1920': False})
         else:
             request.env['product.image'].browse(image_res_id).unlink()
 

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -959,7 +959,7 @@ options.registry.ReplaceMedia.include({
      */
     async willStart() {
         const parent = this.$target.parent();
-        this.isProductPageImage = this.$target.closest('#product_detail').length > 0;
+        this.isProductPageImage = this.$target.closest('.o_wsale_product_images').length > 0;
         // Product Page images may be the product's image or a record of `product.image`
         this.recordModel = parent.data('oe-model');
         this.recordId = parent.data('oe-id');


### PR DESCRIPTION
This commits fixes the following things: 

- The fact that we were having a trace-back when putting an image inside a div that was in the div with the id `#product_detail` and clicking on the `remove` button in the editor. In reality this button should not have been available because the image is not in the carousel. We now check that the image is in the `o_wsale_product_images` div (which is the carousel) to display the `remove` button. To remove an image outside of this carousel, simply click on the `remove` block button.

- Also fixes a bug where removing the image wasn't working on the carousel

task_id=[2973363](https://www.odoo.com/web#id=2973363&cids=1&menu_id=4720&action=333&active_id=5157&model=project.task&view_type=form)
