### PR TITLE
[FIX] mail: fix composer attachment upload test

### DIFF
--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -46,6 +46,7 @@ registerModel({
             if (this.chatterOwner && !this.chatterOwner.attachmentBoxView) {
                 this.chatterOwner.openAttachmentBoxView();
             }
+            this.messaging.messagingBus.trigger('o-file-uploader-upload', { files });
         },
         /**
          * Create an HTML element that will serve as file input.

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -1324,9 +1324,14 @@ QUnit.test('remove an attachment from composer does not need any confirmation', 
         contentType: 'text/plain',
         name: 'text.txt',
     });
-    await afterNextRender(() =>
-        inputFiles(messaging.discuss.threadView.composerView.fileUploader.fileInput, [file])
-    );
+    await afterNextRender(() => afterEvent({
+        eventName: 'o-file-uploader-upload',
+        func() {
+            inputFiles(messaging.discuss.threadView.composerView.fileUploader.fileInput, [file]);
+        },
+        message: 'should wait until files are uploaded',
+        predicate: ({ files: uploadedFiles }) => uploadedFiles[0] === file,
+    }));
     assert.containsOnce(
         document.body,
         '.o_Composer_attachmentList',


### PR DESCRIPTION
Before this PR, the `remove an attachment..does not need any confirmation` test would fail because the attachment was deleted while still uploading. Since the abort controller does not worke in the mock server, the attachment would have finished its upload after its deletion. This commit solves this issue by waiting for the attachment to be uploaded before deleting it.

