### PR TITLE
[FIX] web: fix BooleanField in editable list

### DIFF
--- a/addons/web/static/src/core/checkbox/checkbox.js
+++ b/addons/web/static/src/core/checkbox/checkbox.js
@@ -38,6 +38,7 @@ export class CheckBox extends Component {
     onClick(ev) {
         if (ev.composedPath().find((el) => ["INPUT", "LABEL"].includes(el.tagName))) {
             // The onChange will handle these cases.
+            ev.stopPropagation();
             return;
         }
 
@@ -45,6 +46,7 @@ export class CheckBox extends Component {
         const input = this.rootRef.el.querySelector("input");
         input.focus();
         if (!this.props.disabled) {
+            ev.stopPropagation();
             input.checked = !input.checked;
         }
         this.props.onChange(input.checked);

--- a/addons/web/static/src/core/checkbox/checkbox.xml
+++ b/addons/web/static/src/core/checkbox/checkbox.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.CheckBox" owl="1">
-    <div class="o-checkbox" t-attf-class="{{ props.slots ? 'form-check' : '' }}"  t-att-class="props.className" t-on-click.stop="onClick" t-ref="root">
+    <div class="o-checkbox" t-attf-class="{{ props.slots ? 'form-check' : '' }}"  t-att-class="props.className" t-on-click="onClick" t-ref="root">
         <input
             t-att-id="props.id or id"
             type="checkbox"

--- a/addons/web/static/tests/views/fields/boolean_field_tests.js
+++ b/addons/web/static/tests/views/fields/boolean_field_tests.js
@@ -193,6 +193,16 @@ QUnit.module("Fields", (hooks) => {
             cell.querySelector(".o-checkbox input:checked").disabled,
             "input should be disabled in readonly mode"
         );
+        await click(cell, ".o-checkbox");
+        assert.hasClass(
+            document.querySelector("tr.o_data_row:nth-child(1)"),
+            "o_selected_row",
+            "the row is now selected, in edition"
+        );
+        assert.ok(
+            !cell.querySelector(".o-checkbox input:checked").disabled,
+            "input should now be enabled"
+        );
         await click(cell);
         assert.notOk(
             cell.querySelector(".o-checkbox input:checked").disabled,


### PR DESCRIPTION
This commit fixes the BooleanField which didn't
turned the row in edition when clicked on it since the event was stopped by the Checkbox component.
The disabled input should not stop the event, since the component do not need to handle a click being
done on it.

The test in editable list has been adapted to add
this assertion.