### PR TITLE
[FIX] mail: emoji picker properly show last row in search

### DIFF
--- a/addons/mail/static/src/models/emoji_grid_view_row_registry.js
+++ b/addons/mail/static/src/models/emoji_grid_view_row_registry.js
@@ -43,10 +43,15 @@ registerModel({
             for (let emoji of emojis) {
                 currentItems.push({ emojiOrEmojiInCategory: { emoji } });
                 if (currentItems.length === this.emojiGridViewOwner.amountOfItemsPerRow) {
-                    index++;
                     value.push({ items: currentItems, index });
                     currentItems = [];
+                    index++;
                 }
+            }
+            if (currentItems.length > 0) {
+                value.push({ items: currentItems, index });
+                currentItems = [];
+                index++;
             }
             return value;
         },


### PR DESCRIPTION
Before this commit, when searching an emoji in emoji picker, the last row was frequently now showing. This is especially a problem with very specific search, whose results are not showing any result, like "bomb" for 💣

This commit fixes the issue by properly showing the last row.

Task-2976677
