### PR TITLE
[IMP] hr_contract: include cancelled contracts in contract history

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -33,7 +33,10 @@
                                 <span class="o_stat_value text-danger">
                                    <field name="contracts_count"/>
                                 </span>
-                                <span class="o_stat_text text-danger">
+                                <span attrs="{'invisible' : [('contracts_count', '!=', 1)]}" class="o_stat_text text-danger" >
+                                    Contract
+                                </span>
+                                <span attrs="{'invisible' : [('contracts_count', '=', 1)]}" class="o_stat_text text-danger">
                                     Contracts
                                 </span>
                             </div>


### PR DESCRIPTION
In order to avoid empty contract histories when there are existing but cancelled contracts, cancelled contracts are now also included in the contract history.

task-2939158

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
