### PR TITLE
[FIX] base, tools: create a new model with studio (calendar)

### DIFF
--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -25,6 +25,7 @@
             <rng:optional><rng:attribute name="create"/></rng:optional>
             <rng:optional><rng:attribute name="delete"/></rng:optional>
             <rng:optional><rng:attribute name="scales"/></rng:optional>
+            <rng:optional><rng:attribute name="edit"/></rng:optional>
             <rng:optional>
                 <rng:attribute name="mode">
                     <rng:choice>

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -159,13 +159,13 @@ def validate(*view_types):
 def relaxng(view_type):
     """ Return a validator for the given view type, or None. """
     if view_type not in _relaxng_cache:
-        with tools.file_open(os.path.join('base', 'rng', '%s_view.rng' % view_type)) as frng:
-            try:
-                relaxng_doc = etree.parse(frng)
-                _relaxng_cache[view_type] = etree.RelaxNG(relaxng_doc)
-            except Exception:
-                _logger.exception('Failed to load RelaxNG XML schema for views validation')
-                _relaxng_cache[view_type] = None
+        fileRngPath = os.path.join(os.path.dirname(os.path.relpath(__file__)), '..', 'addons', 'base', 'rng', '%s_view.rng' % view_type)
+        try:
+            relaxng_doc = etree.parse(fileRngPath)
+            _relaxng_cache[view_type] = etree.RelaxNG(relaxng_doc)
+        except Exception:
+            _logger.exception('Failed to load RelaxNG XML schema for views validation')
+            _relaxng_cache[view_type] = None
     return _relaxng_cache[view_type]
 
 


### PR DESCRIPTION
Steps to reproduce:
  - install Studio app (web_studio module);
  - inside an app create a new model with Studio;
  - choose the "Date & Calendar" feature for the new model;
  - create the model.

Issue:
  An error occurs "Invalid view Default calendar view for x_modelName definition in False".

Causes:

   **(1) V14**
   Server log: 
       `odoo.tools.view_validation: <string>:1:0:ERROR:RELAXNGV:RELAXNG_ERR_INVALIDATTR: Invalid attribute edit for element calendar`
       `odoo.tools.view_validation: Invalid XML:  Get RNG validator and validate RNG file.`

   Explanation:
       ".xml" files must be verified with the grammar inside the ".rng" files. The "edit" attribute is missing in the calendar tag grammar (calendar_view.rng file).

   **(2) V14 & V15**
   Server log:
       `odoo.tools.view_validation: Failed to load RelaxNG XML schema for views validation`

   Explanation:
       When the ".rng" files have been parsed, an exception is triggered. The argument of the function "etree.parse" is not correct. The argument must be a file path.

Solutions:

   **(1) V14**
   Add the "edit" attribute inside the "calendar_view.rng".

   **(2) V14 & V15**
   Modify the argument of the "etree.parse" function with the path of the ".rng" file which is in the base module.

opw-2972415