### PR TITLE
[FIX] bus: fix interface error on server stop

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -6,9 +6,11 @@ import random
 import selectors
 import threading
 import time
+from psycopg2 import InterfaceError
 
 import odoo
 from odoo import api, fields, models
+from odoo.service.server import CommonServer
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools import date_utils
 
@@ -150,7 +152,7 @@ class ImDispatch(threading.Thread):
             cr.commit()
             conn = cr._cnx
             sel.register(conn, selectors.EVENT_READ)
-            while True:
+            while not stop_event.is_set():
                 if sel.select(TIMEOUT):
                     conn.poll()
                     channels = []
@@ -165,14 +167,18 @@ class ImDispatch(threading.Thread):
                         websocket.trigger_notification_dispatching()
 
     def run(self):
-        while True:
+        while not stop_event.is_set():
             try:
                 self.loop()
-            except Exception:
+            except Exception as exc:
+                if isinstance(exc, InterfaceError) and stop_event.is_set():
+                    continue
                 _logger.exception("Bus.loop error, sleep and retry")
                 time.sleep(TIMEOUT)
 
 dispatch = None
 if not odoo.multi_process or odoo.evented:
     # We only use the event dispatcher in threaded and gevent mode
+    stop_event = threading.Event()
     dispatch = ImDispatch()
+    CommonServer.on_stop(stop_event.set)


### PR DESCRIPTION
When stopping the server, all cursors are closed. The issue is that
the ImDispatch thread is kept alive until the main thread exits since
it's a daemon thread.

This can lead to errors during server stop: the ImDispatch thread
could try to poll an already closed connection thus raising a
`psycopg2.InterfaceError` exception.

This commit solves the issue by hiding the interface error when
it occurs during server stop.

Traceback :

```bash
Traceback (most recent call last):
  File "/data/build/odoo/addons/bus/models/bus.py", line 155, in loop
    conn.poll()
psycopg2.InterfaceError: connection already closed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/build/odoo/addons/bus/models/bus.py", line 170, in run
    self.loop()
  File "/data/build/odoo/addons/bus/models/bus.py", line 147, in loop
    with odoo.sql_db.db_connect('postgres').cursor() as cr, \
  File "/data/build/odoo/odoo/sql_db.py", line 206, in __exit__
    self.close()
  File "/data/build/odoo/odoo/sql_db.py", line 440, in close
    return self._close(False)
  File "/data/build/odoo/odoo/sql_db.py", line 461, in _close
    self.rollback()
  File "/data/build/odoo/odoo/sql_db.py", line 536, in rollback
    result = self._cnx.rollback()
psycopg2.InterfaceError: connection already closed

```