### PR TITLE
[FIX] web: Allow to hide model in ReferenceField

### DIFF
--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -118,9 +118,18 @@ ReferenceField.displayName = _lt("Reference");
 ReferenceField.supportedTypes = ["reference", "char"];
 
 ReferenceField.extractProps = ({ attrs, field }) => {
+    /*
+    1 - <field name="ref" options="{'model_field': 'model_id'}" />
+    2 - <field name="ref" options="{'hide_model': True}" />
+    3 - <field name="ref" options="{'model_field': 'model_id' 'hide_model': True}" />
+    4 - <field name="ref"/>
+
+    We want to display the model selector only in the 4th case.
+    */
+    const displayModelSelector = !attrs.options["hide_model"] && !attrs.options["model_field"];
     return {
         ...Many2OneField.extractProps({ attrs, field }),
-        hideModelSelector: !!attrs.options["model_field"],
+        hideModelSelector: !displayModelSelector,
     };
 };
 

--- a/addons/web/static/tests/views/fields/reference_field_tests.js
+++ b/addons/web/static/tests/views/fields/reference_field_tests.js
@@ -918,4 +918,55 @@ QUnit.module("Fields", (hooks) => {
             );
         }
     );
+
+    QUnit.test("model selector is displayed only when it should be", async function (assert) {
+        //The model selector should be only displayed if
+        //there is no hide_model=True options AND no model_field specified
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `
+                <form>
+                    <group>
+                        <field name="reference" options="{'model_field': 'model_id'}" />
+                    </group>
+                    <group>
+                        <field name="reference" options="{'model_field': 'model_id', 'hide_model': True}" />
+                    </group>
+                    <group>
+                        <field name="reference" options="{'hide_model': True}" />
+                    </group>
+                    <group>
+                        <field name="reference" />
+                    </group>
+                </form>`,
+        });
+
+        await click(target, ".o_form_button_edit");
+
+        const groups = target.querySelectorAll(".o_group");
+
+        assert.containsNone(
+            groups[0],
+            "select",
+            "the selection list of the reference field should not exist when model_field is specified."
+        );
+        assert.containsNone(
+            groups[1],
+            "select",
+            "the selection list of the reference field should not exist when model_field is specified and hide_model=True."
+        );
+        assert.containsNone(
+            groups[2],
+            "select",
+            "the selection list of the reference field should not exist when hide_model=True."
+        );
+        assert.containsOnce(
+            groups[3],
+            "select",
+            "the selection list of the reference field should exist when hide_model=False and no model_field specified."
+        );
+    });
 });


### PR DESCRIPTION
In legacy, hide_model attribut on FieldReference was used to hide the model input, but it was not implemented in ReferenceField (new version).