### PR TITLE
[FIX] base: remove default address type value from view

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -235,7 +235,7 @@
 
                     <notebook colspan="4">
                         <page string="Contacts &amp; Addresses" name="contact_addresses" autofocus="autofocus">
-                            <field name="child_ids" mode="kanban" context="{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': lang, 'default_user_id': user_id, 'default_type': 'other'}">
+                            <field name="child_ids" mode="kanban" context="{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': lang, 'default_user_id': user_id}">
                                 <kanban>
                                     <field name="id"/>
                                     <field name="color"/>


### PR DESCRIPTION
To Reproduce
============

Go to Contacts

-Go to "Contact & Address" Tab

-Open Studio

-Click on the tab

-Choose Modify Form View

-Set a default contact type other than "Other Address"

-Close Studio

-Click on "ADD" under the "Contact & Address" Tab

Problem
=======

Default won't be set

Solution
========

remove the default value from the view because it's set in python or will be changed by studio

opw-2969536