### PR TITLE
[FIX] website: do not cache footer based on website_id

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -140,7 +140,10 @@
         <attribute name="data-name">Footer</attribute>
         <!-- Background now controlled by css configuration, using color combinations -->
         <attribute name="t-attf-class" add="o_colored_level o_cc" remove="bg-light" separator=" "/>
-        <attribute name="t-cache">no_footer,no_copyright,website</attribute>
+        <!-- Add the main object as a cache key so that the footer_visible page
+        option is properly reflected across pages. Controllers and other objects
+        do not have any page option (yet) so they can share the same cache -->
+        <attribute name="t-cache" add="website,main_object._name == 'website.page' and main_object"/>
     </xpath>
     <xpath expr="//div[hasclass('o_footer_copyright')]" position="attributes">
         <attribute name="data-name">Copyright</attribute>


### PR DESCRIPTION
Commit [1] introduced t-cache on the footer making it cached depending on its website id. This is wrong as the footer can be visible or hidden depending on the page it is currently rendered in.

This commit adapt the t-cache so that the footer is cached based on the page.

Steps to reproduce:
 - Go in edit mode and click on the footer
 - Turn off "Page Visibility"
 - Save

 Footer is now hidden on every page depending on which page rendered it
 first.

[1]: https://github.com/odoo/odoo/commit/b0a2a41d78292cb8b9e53788d40c6dc5915a466d

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
