### PR TITLE
[IMP] base: only pass to the webclient the fields it requires

### DIFF
--- a/addons/mail/models/ir_ui_view.py
+++ b/addons/mail/models/ir_ui_view.py
@@ -11,5 +11,6 @@ class View(models.Model):
         if node.xpath("ancestor::div[hasclass('oe_chatter')]"):
             # Pass the postprocessing of the mail thread fields
             # The web client makes it completely custom, and this is therefore pointless.
+            name_manager.has_field(node, node.get('name'), {})
             return
         return super()._postprocess_tag_field(node, name_manager, node_info)


### PR DESCRIPTION
The main goal is to reduce the number of KB sent by the `get_views` method to the web client by getting rid of things not used by the web client.

This revision aims to only pass the `fields_get` info of fields actually required by the web client.

Before this revision, for each view, the list of all fields of all models implied in the view are passed.
For the main view, it's required to pass all the fields, for the search view: The advanced search needs to know all fields of the model to be able to let the user to do advanced filters and groupbys on the model fields.

But, for the models of the subviews (one2many/many2many embbeded views), this is not required. Only the fields included in the view are required. Also, if the search view is not requested by the web client, then it's also not required to pass all the fields of the main model.

After this revision, for each view, pass the `fields_get` info of only the fields actually implied in the view. For the search view, info of all fields are passed, not only the ones implied in the view.

For instance, on the `get_views` of `account.move`, this allows a gain of an extra 18,05KB,
reducing from 165.82 to 147.77KB.

In addition, before this revision, the whole content of `fields_get` was stored in the cache of `_get_view_cache`, meaning per view. If 3 views were requested on `get_views`
let's say kanban, list, form,
the same whole `fields_get` info, of all fields,
was stored 3 times in the cache.

This revision removes the content of fields_get of the cache for `get_views`, to avoid storing multiple times the exact same information in the cache, therefore gaining tremendous memory, while not loosing that processing time.
The decrease of speed is only 1~3ms per call to `get_views`. This is mainly because all the information gathered by `fields_get` is already in the cache. For instance, it doesn't require any SQL request (at the moment). e.g. the translations (string, help, selection) are already cached.
