### PR TITLE
[FIX] web: better content spacing in all PDF reports

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -13,6 +13,10 @@ body {
     font-family: $o-default-report-font;
 }
 
+p, span, strong, em {
+    line-height: 1.5;
+}
+
 span.o_force_ltr {
     display: inline;
 }


### PR DESCRIPTION
In the PDF reports, the general spacing is too narrow, for example in tables, in the address lines etc. This commit upsizes a bit the line-height for the majority of text/digits-based content.

taskID 2977261