### PR TITLE
[ADD] web_editor: show user avatars in collaborative edition

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -403,3 +403,29 @@ i.oe-powerbox-commandImg {
         }
     }
 }
+.oe-collaboration-caret-avatar {
+    position: absolute;
+    height: 1.5rem;
+    width: 1.5rem;
+    border-radius: 50%;
+    transition: top 0.5s, left 0.5s;
+
+    > img {
+        height: 100%;
+        width: 100%;
+        border-radius: 50%;
+    }
+
+    &[data-overlapping-avatars]::after {
+        content: attr(data-overlapping-avatars);
+        background-color: green;
+        color: white;
+        border-radius: 50%;
+        font-size: 9px;
+        padding: 0 4px;
+        position: absolute;
+        top: 11px;
+        right: -5px;
+        z-index: 1;
+    }
+}

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -6,6 +6,7 @@ const { MediaDialogWrapper } = require('@web_editor/components/media_dialog/medi
 const { saveVideos, videoSpecificClasses } = require('@web_editor/components/media_dialog/video_selector');
 const dom = require('web.dom');
 const core = require('web.core');
+const { browser } = require('@web/core/browser/browser');
 const Widget = require('web.Widget');
 const Dialog = require('web.Dialog');
 const customColors = require('web_editor.custom_colors');
@@ -191,6 +192,7 @@ const Wysiwyg = Widget.extend({
             categories: powerboxOptions.categories,
             plugins: options.editorPlugins,
             direction: localization.direction || 'ltr',
+            collaborationClientAvatarUrl: `${browser.location.origin}/web/image?model=res.users&field=avatar_128&id=${this.getSession().uid}`,
         }, editorCollaborationOptions));
 
         this.odooEditor.addEventListener('contentChanged', function () {
@@ -469,6 +471,7 @@ const Wysiwyg = Widget.extend({
                         }
                         return this._userName;
                     },
+                    get_client_avatar: () => `${browser.location.origin}/web/image?model=res.users&field=avatar_128&id=${this.getSession().uid}`,
                     get_missing_steps: (params) => this.odooEditor.historyGetMissingSteps(params.requestPayload),
                     get_history_from_snapshot: () => this.odooEditor.historyGetSnapshotSteps(),
                     get_collaborative_selection: () => this.odooEditor.getCurrentCollaborativeSelection(),
@@ -493,6 +496,9 @@ const Wysiwyg = Widget.extend({
                             this.ptp.clientsInfos[fromClientId].startTime = await this.ptp.requestClient(fromClientId, 'get_start_time', undefined, { transport: 'rtc' });
                             this.ptp.requestClient(fromClientId, 'get_client_name', undefined, { transport: 'rtc' }).then((clientName) => {
                                 this.ptp.clientsInfos[fromClientId].clientName = clientName;
+                            });
+                            this.ptp.requestClient(fromClientId, 'get_client_avatar', undefined, { transport: 'rtc' }).then(clientAvatarUrl => {
+                                this.ptp.clientsInfos[fromClientId].clientAvatarUrl = clientAvatarUrl;
                             });
 
                             if (!historySyncAtLeastOnce) {
@@ -521,6 +527,7 @@ const Wysiwyg = Widget.extend({
                             }
                             const selection = notificationPayload;
                             selection.clientName = client.clientName;
+                            selection.clientAvatarUrl = client.clientAvatarUrl;
                             this.odooEditor.onExternalMultiselectionUpdate(selection);
                             break;
                         }

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -1,7 +1,6 @@
 .oe_form_field_html {
     position: relative;
     word-wrap: break-word;
-    overflow: hidden;
 
     #codeview-btn-group {
         position: absolute;


### PR DESCRIPTION
This adds a feature that displays the avatars of the users editing a document collaboratively, in front of the block they are editing.

task-2947368

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
