### PR TITLE
[FIX] payment: small fixes 

### DIFF
--- a/addons/account_payment/models/account_payment_method.py
+++ b/addons/account_payment/models/account_payment_method.py
@@ -11,7 +11,7 @@ class AccountPaymentMethod(models.Model):
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
         for code, _desc in self.env['payment.provider']._fields['code'].selection:
-            if code in ('none', 'transfer'):
+            if code in ('none', 'custom'):
                 continue
             res[code] = {
                 'mode': 'unique',

--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -75,7 +75,7 @@ class Paymentprovider(models.Model):
 
     @api.model
     def _setup_payment_method(self, code):
-        if code not in ('none', 'transfer') and not self._get_provider_payment_method(code):
+        if code not in ('none', 'custom') and not self._get_provider_payment_method(code):
             providers_description = dict(self._fields['code']._description_selection(self.env))
             self.env['account.payment.method'].create({
                 'name': providers_description[code],

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -6,7 +6,7 @@
         <xpath expr="//t[@t-foreach='invoices']/tr/td[last()]" position="before">
             <td class="text-center">
                 <t t-set="tx_ids" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized', 'done'))"/>
-                <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.provider in ('none', 'transfer'))"/>
+                <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.provider in ('none', 'custom'))"/>
                 <a t-if="invoice.state == 'posted' and invoice.payment_state in ('not_paid', 'partial') and invoice.amount_total and invoice.move_type == 'out_invoice' and (pending_manual_txs or not tx_ids or invoice.amount_paid &lt; invoice.amount_total)"
                     t-att-href="invoice.get_portal_url(anchor='portal_pay')" title="Pay Now" aria-label="Pay now" class="btn btn-sm btn-primary" role="button">
                     <i class="fa fa-arrow-circle-right"/><span class='d-none d-md-inline'> Pay Now</span>
@@ -16,13 +16,13 @@
         <xpath expr="//t[@t-foreach='invoices']/tr/td[hasclass('tx_status')]" position="replace">
             <t t-set="last_tx" t-value="invoice.get_portal_last_transaction()"/>
             <td class="tx_status text-center">
-                <t t-if="invoice.state == 'posted' and invoice.payment_state in ('not_paid', 'partial') and (last_tx.state not in ['pending', 'authorized', 'done', 'cancel'] or (last_tx.state == 'pending' and last_tx.provider in ('none', 'transfer')))">
+                <t t-if="invoice.state == 'posted' and invoice.payment_state in ('not_paid', 'partial') and (last_tx.state not in ['pending', 'authorized', 'done', 'cancel'] or (last_tx.state == 'pending' and last_tx.provider in ('none', 'custom')))">
                     <span class="badge rounded-pill text-bg-info"><i class="fa fa-fw fa-clock-o"></i><span class="d-none d-md-inline"> Waiting for Payment</span></span>
                 </t>
                 <t t-if="invoice.state == 'posted' and last_tx.state == 'authorized'">
                     <span class="badge rounded-pill text-bg-primary"><i class="fa fa-fw fa-check"/><span class="d-none d-md-inline"> Authorized</span></span>
                 </t>
-                <t t-if="invoice.state == 'posted' and last_tx.state == 'pending' and last_tx.provider not in ('none', 'transfer')">
+                <t t-if="invoice.state == 'posted' and last_tx.state == 'pending' and last_tx.provider not in ('none', 'custom')">
                   <span class="badge rounded-pill text-bg-warning"><span class="d-none d-md-inline"> Pending</span></span>
                 </t>
                 <t t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment') or last_tx.state == 'done'">
@@ -65,7 +65,7 @@
     <template id="portal_invoice_page_inherit_payment" name="Payment on My Invoices" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-call='portal.portal_record_sidebar']//div[hasclass('o_download_pdf')]" position="before">
             <t t-set="tx_ids" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized', 'done'))"/>
-            <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.provider in ('none', 'transfer'))"/>
+            <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.provider in ('none', 'custom'))"/>
             <div class="d-grid">
                 <a href="#" t-if="invoice.state == 'posted' and invoice.payment_state in ('not_paid', 'partial') and invoice.amount_total and invoice.move_type == 'out_invoice' and (pending_manual_txs or not tx_ids or invoice.amount_paid &lt; invoice.amount_total)"
 
@@ -126,7 +126,7 @@
             <t t-if="success == 'pay_invoice'">
                 <t t-set="payment_tx_id" t-value="invoice.get_portal_last_transaction()"/>
                 <span t-if='payment_tx_id.provider_id.sudo().done_msg' t-out="payment_tx_id.provider_id.sudo().done_msg"/>
-                <div t-if="payment_tx_id.provider_id.sudo().pending_msg and payment_tx_id.provider_code == 'transfer' and invoice.ref">
+                <div t-if="payment_tx_id.provider_id.sudo().pending_msg and payment_tx_id.provider_code == 'custom' and invoice.ref">
                     <b>Communication: </b><span t-esc='invoice.ref'/>
                 </div>
             </t>

--- a/addons/account_payment/views/payment_provider_views.xml
+++ b/addons/account_payment/views/payment_provider_views.xml
@@ -14,7 +14,7 @@
             <group name="payment_followup" position="inside">
                 <field name="journal_id"
                     context="{'default_type': 'bank'}"
-                    attrs="{'required': [('state', '!=', 'disabled'), ('code', 'not in', ['none', 'transfer'])]}"/>
+                    attrs="{'required': [('state', '!=', 'disabled'), ('code', 'not in', ['none', 'custom'])]}"/>
             </group>
         </field>
     </record>

--- a/addons/payment_custom/__init__.py
+++ b/addons/payment_custom/__init__.py
@@ -7,7 +7,7 @@ from odoo.addons.payment import setup_provider, reset_payment_provider
 
 
 def post_init_hook(cr, registry):
-    setup_provider(cr, registry, 'transfer')
+    setup_provider(cr, registry, 'custom')
 
 
 def uninstall_hook(cr, registry):

--- a/addons/payment_demo/__init__.py
+++ b/addons/payment_demo/__init__.py
@@ -7,7 +7,7 @@ from odoo.addons.payment import setup_provider, reset_payment_provider
 
 
 def post_init_hook(cr, registry):
-    setup_provider(cr, registry, 'test')
+    setup_provider(cr, registry, 'demo')
 
 
 def uninstall_hook(cr, registry):

--- a/addons/payment_stripe/views/payment_views.xml
+++ b/addons/payment_stripe/views/payment_views.xml
@@ -40,14 +40,14 @@
                 </div>
             </xpath>
             <field name="allow_express_checkout" position="replace">
-                <label for="allow_express_checkout"/>
-                <div class="o_row" col="2">
+                <label for="allow_express_checkout" attrs="{'invisible': ['|', ('support_express_checkout', '=', False), ('show_allow_express_checkout', '=', False)]}"/>
+                <div class="o_row" col="2" attrs="{'invisible': ['|', ('support_express_checkout', '=', False), ('show_allow_express_checkout', '=', False)]}">
                     <field name="allow_express_checkout"/>
-                <button string="Enable Apple Pay"
-                        type="object"
-                        name="action_stripe_verify_apple_pay_domain"
-                        class="btn btn-primary"
-                        attrs="{'invisible': [('allow_express_checkout', '!=', True)]}"/>
+                    <button string="Enable Apple Pay"
+                            type="object"
+                            name="action_stripe_verify_apple_pay_domain"
+                            class="btn btn-primary"
+                            attrs="{'invisible': [('allow_express_checkout', '!=', True)]}"/>
                 </div>
             </field>
         </field>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -843,7 +843,7 @@ class SaleOrder(models.Model):
     def action_done(self):
         for order in self:
             tx = order.sudo().transaction_ids._get_last()
-            if tx and tx.state == 'pending' and tx.provider_id.code == 'transfer':
+            if tx and tx.state == 'pending' and tx.provider_id.code == 'custom':
                 tx._set_done()
                 tx.write({'is_post_processed': True})
         self.write({'state': 'done'})

--- a/addons/sale/views/payment_views.xml
+++ b/addons/sale/views/payment_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
             <group name="payment_form" position="inside">
-                <field name="so_reference_type" attrs="{'invisible': [('code', '!=', 'transfer')]}"/>
+                <field name="so_reference_type" attrs="{'invisible': [('code', '!=', 'custom')]}"/>
             </group>
         </field>
     </record>

--- a/addons/website_payment/views/payment_provider.xml
+++ b/addons/website_payment/views/payment_provider.xml
@@ -7,9 +7,9 @@
             <field name="model">payment.provider</field>
             <field name="inherit_id" ref="payment.payment_provider_form"/>
             <field name="arch" type="xml">
-                <field name='company_id' position='after'>
+                <group name="payment_state" position='inside'>
                     <field name="website_id" options="{'no_open': True, 'no_create_edit': True}" groups="website.group_multi_website"/>
-                </field>
+                </group>
             </field>
         </record>
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1958,7 +1958,7 @@
                         <span t-esc="payment_tx_id.state_message"/>
                     </t>
                 </div>
-                <t t-if="payment_tx_id.provider_code == 'transfer'">
+                <t t-if="payment_tx_id.provider_code == 'custom'">
                     <div t-if="order.reference" class="card-body">
                         <b>Communication: </b><span t-esc='order.reference'/>
                     </div>


### PR DESCRIPTION
Fine-tuning of https://github.com/odoo/odoo/commit/0501bbd62e517f6c215d9e7e36d61747c7f5816b.

Now that `company_id` is present in the header, the XPath of the
provider form view defined in the `website_payment` module puts the
field `website_id` in the wrong place.

This commit moves the field where it belongs.
****
Fine-tuning of https://github.com/odoo/odoo/commit/61b8c0c1a2be6e7966413bf3c60b4475ae0e9a94.

Missing rename of `transfer` to `custom` following commit https://github.com/odoo/odoo/commit/5f41f15e6b1d59bb99e3d304e6728a72547d2235.
****
Before this commit, when Stripe was installed, all providers would
display the option `Allow Express Checkout`.

Now, the `Allow Express Checkout` field is only shown on providers that
support this feature, even if Stripe is installed.
****
[FIX] payment_demo: test provider code doesn't exists anymore
Missing rename of `test` to `demo` following commit e64848940116684a22eaec538b58e79c21b7e9c3.