### PR TITLE
[IMP] account: add amount to quick search in payment list view

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -103,6 +103,7 @@
                     <field name="partner_id" string="Customer/Vendor"/>
                     <field name="journal_id"/>
                     <field name="is_internal_transfer"/>
+                    <field name="amount_company_currency_signed" string="Amount"/>
                     <separator/>
                     <filter string="Customer Payments"
                             name="inbound_filter"


### PR DESCRIPTION
It should be possible to quickly search by `amount_company_currency_signed` in `account.payment` view.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
