### PR TITLE
[15.0] [FIX] sale_timesheet: views using timesheet_ids should be based on hr_timesheet

### DIFF
--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -4,7 +4,7 @@
     <record id="project_sharing_inherit_project_task_view_form" model="ir.ui.view">
         <field name="name">project.task.form.inherit.timesheet</field>
         <field name="model">project.task</field>
-        <field name="inherit_id" ref="project.project_sharing_project_task_view_form"/>
+        <field name="inherit_id" ref="hr_timesheet.project_sharing_inherit_project_task_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
                 <attribute name="decoration-muted">timesheet_invoice_id != False</attribute>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -125,7 +125,7 @@
             <field name="name">sale.service.form.view.inherit</field>
             <field name="model">project.task</field>
             <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
-            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
             <field name="arch" type="xml">
                 <xpath expr="//header" position='inside'>
                     <field name="allow_billable" invisible="1"/>
@@ -136,7 +136,7 @@
         <record id="project_task_view_form_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">project.task.form.inherit.timesheet</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
             <field name="groups_id" eval="[(6,0, (ref('hr_timesheet.group_hr_timesheet_user'),))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
@@ -195,7 +195,7 @@
         <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">view.task.form2.inherit</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sale_line_id']" position="attributes">
                     <attribute name="context">{'with_remaining_hours': True, 'with_price_unit': True}</attribute>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -125,7 +125,7 @@
             <field name="name">sale.service.form.view.inherit</field>
             <field name="model">project.task</field>
             <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
-            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+            <field name="inherit_id" ref="project.view_task_form2"/>
             <field name="arch" type="xml">
                 <xpath expr="//header" position='inside'>
                     <field name="allow_billable" invisible="1"/>
@@ -195,7 +195,7 @@
         <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">view.task.form2.inherit</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+            <field name="inherit_id" ref="sale_project.view_sale_project_inherit_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sale_line_id']" position="attributes">
                     <attribute name="context">{'with_remaining_hours': True, 'with_price_unit': True}</attribute>


### PR DESCRIPTION
In some cases database updates fail when hr_timesheet inherited views are loaded before sale_timesheet inherited views.

Views referring to timesheet_ids field should be based on the views that include this field. That is on the views in hr_timesheet.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
