### PR TITLE
[FIX] web: form: do not display sample data in x2many

### DIFF
--- a/addons/web/static/src/views/model.js
+++ b/addons/web/static/src/views/model.js
@@ -111,7 +111,7 @@ export function useModel(ModelClass, params, options = {}) {
             ? globalState.useSampleModel
             : component.props.useSampleModel
     );
-    model.useSampleModel = useSampleModel;
+    model.useSampleModel = !options.ignoreUseSampleModel ? useSampleModel : false;
     const orm = model.orm;
     let sampleORM = globalState.sampleORM;
     const user = useService("user");
@@ -153,16 +153,15 @@ export function useModel(ModelClass, params, options = {}) {
         started = true;
     });
     onWillUpdateProps((nextProps) => {
-        useSampleModel = false;
+        if (!options.ignoreUseSampleModel) {
+            useSampleModel = false;
+        }
         load(nextProps);
     });
 
     useSetupView({
         getGlobalState() {
-            return {
-                sampleORM,
-                useSampleModel: model.useSampleModel,
-            };
+            return { sampleORM, useSampleModel };
         },
     });
 

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -2393,37 +2393,4 @@ QUnit.module("ActionManager", (hooks) => {
         // mode is "edit" because target="new"
         assert.containsOnce(target, ".o_form_view .o_form_editable");
     });
-
-    QUnit.test("action group_by of type string", async function (assert) {
-        serverData.models.partner.records = [];
-        serverData.views["partner,false,list"] = `
-            <tree sample="1">
-                <field name="name"/>
-            </tree>    
-        `;
-        serverData.views["partner,false,form"] = `
-            <form>
-                <field name="name"/>
-            </form>
-        `;
-        registry.category("services").add("user", makeFakeUserService());
-        const webClient = await createWebClient({ serverData });
-        await doAction(webClient, {
-            name: "Partner",
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            views: [
-                [false, "list"],
-                [false, "form"],
-            ],
-        });
-
-        assert.containsOnce(target, ".o_list_view .o_content.o_view_sample_data");
-
-        await click(target.querySelector(".o_list_view .o_list_button_add"));
-
-        await click(target.querySelector(".o_form_view .breadcrumb-item a"));
-
-        assert.containsOnce(target, ".o_list_view .o_content.o_view_sample_data");
-    });
 });


### PR DESCRIPTION
Let's assume the following scenario:
 - be on a list or kanban view with sample data
 - click on "Create" (-> opens the form view)
 - in the form view, there's a kanban x2many field

Before this commit, the no content helper was displayed in the form view, whereas it obviously should not.

The issue occurred since [1], as this commit has the unwanted since effect to set the property `useSampleModel` to true on the form view model, which is used in the x2many kanban renderer to determine whether or not to display the no content helper.

This commit forces that property to `false` on views that explicitely ask to ignore sample data.

[1] 2600d1f2ae0ad5e478bd01ca7fdc69933576bff5

