### PR TITLE
Fix traceback when clicking around tables in form view

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3024,7 +3024,7 @@ export class OdooEditor extends EventTarget {
         } else if (ev.key === 'Tab') {
             // Tab
             const sel = this.document.getSelection();
-            const closestTag = (closestElement(sel.anchorNode, 'li, table', true) || {}).tagName;
+            const closestTag = (closestElement(sel.anchorNode, 'li, table') || {}).tagName;
 
             if (closestTag === 'LI') {
                 this._applyCommand('indentList', ev.shiftKey ? 'outdent' : 'indent');
@@ -3659,11 +3659,11 @@ export class OdooEditor extends EventTarget {
             this._handleSelectionInTable(ev);
         }
         if (!this._rowUi.classList.contains('o_open') && !this._columnUi.classList.contains('o_open')) {
-            const column = closestElement(ev.target, 'td', true);
+            const column = closestElement(ev.target, 'td');
             if (this._isResizingTable || !column || !ev.target || ev.target.nodeType !== Node.ELEMENT_NODE) {
                 this._toggleTableUi(false, false);
             } else {
-                const row = closestElement(column, 'tr', true);
+                const row = closestElement(column, 'tr');
                 const isFirstColumn = column === row.querySelector('td');
                 const table = column && closestElement(column, 'table');
                 const isFirstRow = table && row === table.querySelector('tr');

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3116,6 +3116,13 @@ export class OdooEditor extends EventTarget {
      */
     _onSelectionChange() {
         const selection = this.document.getSelection();
+        if (
+            !this.editable.contains(selection.anchorNode) &&
+            !this.editable.contains(selection.focusNode)
+        ) {
+            // Do not affect selection outside of the editable.
+            return;
+        }
         // When CTRL+A in the editor, sometimes the browser use the editable
         // element as an anchor & focus node. This is an issue for the commands
         // and the toolbar so we need to fix the selection to be based on the

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -941,7 +941,7 @@ export const editorCommands = {
     columnize: (editor, numberOfColumns, addParagraphAfter=true) => {
         const sel = editor.document.getSelection();
         const anchor = sel.anchorNode;
-        const hasColumns = !!closestElement(anchor, '.o_text_columns', true);
+        const hasColumns = !!closestElement(anchor, '.o_text_columns');
         if (!numberOfColumns && hasColumns) {
             // Remove columns.
             const restore = preserveCursor(editor.document);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -196,7 +196,7 @@ class Sanitize {
                 if (isEditorTab(tabPreviousSibling)) {
                     node.style.width = '40px';
                 } else {
-                    const editable = closestElement(node, '.odoo-editor-editable', true);
+                    const editable = closestElement(node, '.odoo-editor-editable');
                     if (editable && editable.firstElementChild) {
                         const nodeRect = node.getBoundingClientRect();
                         const referenceRect = editable.firstElementChild.getBoundingClientRect();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -287,9 +287,9 @@ export function getFurthestUneditableParent(node, parentLimit) {
  * @param {boolean} [restrictToEditable=false]
  * @returns {HTMLElement}
  */
-export function closestElement(node, selector, restrictToEditable=false) {
+export function closestElement(node, selector) {
     const element = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
-    if (restrictToEditable && selector && element) {
+    if (selector && element) {
         const elementFound = element.closest(selector);
         return elementFound && elementFound.querySelector('.odoo-editor-editable') ? null : elementFound;
     }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1982,7 +1982,7 @@ const Wysiwyg = Widget.extend({
                 callback: () => this.odooEditor.execCommand('columnize', 2, editorOptions.insertParagraphAfterColumns),
                 isDisabled: () => {
                     const anchor = this.odooEditor.document.getSelection().anchorNode;
-                    const row = closestElement(anchor, '.o_text_columns .row', true);
+                    const row = closestElement(anchor, '.o_text_columns .row');
                     return row && row.childElementCount === 2;
                 },
             },
@@ -1995,7 +1995,7 @@ const Wysiwyg = Widget.extend({
                 callback: () => this.odooEditor.execCommand('columnize', 3, editorOptions.insertParagraphAfterColumns),
                 isDisabled: () => {
                     const anchor = this.odooEditor.document.getSelection().anchorNode;
-                    const row = closestElement(anchor, '.o_text_columns .row', true);
+                    const row = closestElement(anchor, '.o_text_columns .row');
                     return row && row.childElementCount === 3;
                 },
             },
@@ -2008,7 +2008,7 @@ const Wysiwyg = Widget.extend({
                 callback: () => this.odooEditor.execCommand('columnize', 4, editorOptions.insertParagraphAfterColumns),
                 isDisabled: () => {
                     const anchor = this.odooEditor.document.getSelection().anchorNode;
-                    const row = closestElement(anchor, '.o_text_columns .row', true);
+                    const row = closestElement(anchor, '.o_text_columns .row');
                     return row && row.childElementCount === 4;
                 },
             },
@@ -2021,7 +2021,7 @@ const Wysiwyg = Widget.extend({
                 callback: () => this.odooEditor.execCommand('columnize', 0),
                 isDisabled: () => {
                     const anchor = this.odooEditor.document.getSelection().anchorNode;
-                    const row = closestElement(anchor, '.o_text_columns .row', true);
+                    const row = closestElement(anchor, '.o_text_columns .row');
                     return !row;
                 },
             },


### PR DESCRIPTION
Steps to reproduce:
odoo community > manufacturing > configuration > settings > enable work orders and save
Then configuration > work centers > open a record > edit > click multiple times in the white space between the tab "general information" and the group "product information"