### PR TITLE
[FIX] web_editor: always hide table ui on mouse leave the table

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2252,6 +2252,10 @@ export class OdooEditor extends EventTarget {
         } else {
             this._columnUi.style.visibility = 'hidden';
         }
+        if (row || column) {
+            const table = closestElement(row || column, 'table');
+            table && table.addEventListener('mouseleave', () => this._toggleTableUi(), { once: true });
+        }
     }
     /**
      * Position the table row/column tools (depending on whether a row or a cell


### PR DESCRIPTION
When hovering the first row and/or first column of a table, the buttons appear to edit it. These are removed in the callback of a mousemove event on the editable. If we click for instance on the code view button while still over the table, the mouse didn't move so the buttons are not removed. Then after that moving the mouse doesn't trigger the callback since the editable is not visible anymore. So the buttons stay. This fixes that case by adding a listener to the table on mouseleave, that will remove the buttons, then self-destroy.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
