### PR TITLE
[IMP] mail: improve after event error stack trace

### DIFF
--- a/addons/web/static/tests/owl2_compatibility_app.js
+++ b/addons/web/static/tests/owl2_compatibility_app.js
@@ -54,7 +54,7 @@
                 if (runningSchedulers.length) {
                     error = stopError;
                 }
-                console.error(
+                console.warn(
                     error,
                     runningSchedulers.map((s) => [...s.tasks].map((f) => [f, f.node.status])),
                     runningSchedulers


### PR DESCRIPTION
Before this commit the error raised/logged when rejecting the afterEvent
promise was imcomplete. This is due to the fact we're creating the
error inside the promise itself. In order to get a better stack trace,
the error is now declared outside of the promise.

Moreover, both `afterNextRender` and `afterEvent` functions were using
`console.error` before rejecting the promise. This is also a problem
since runbot will show the error printed by `console.error` instead of
the one of the test failure. In order to solve this issue, those two
`console.error` have been replaced by `console.warn`.