### PR TITLE
[FIX] web: hide the phone field if empty

### DIFF
--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.PhoneField" owl="1">
         <t t-if="props.readonly">
-            <a class="o_form_uri o_phone_link" t-att-href="'tel:'+props.value" t-esc="props.value"/>
+            <a t-if="props.value" class="o_form_uri o_phone_link" t-att-href="'tel:'+props.value" t-esc="props.value"/>
         </t>
         <t t-else="">
             <input

--- a/addons/web/static/tests/views/fields/phone_field_tests.js
+++ b/addons/web/static/tests/views/fields/phone_field_tests.js
@@ -185,4 +185,27 @@ QUnit.module("Fields", (hooks) => {
             "Placeholder"
         );
     });
+
+    QUnit.test("unset and readonly PhoneField", async function (assert) {
+        serverData.models.partner.fields.foo.default = false;
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="foo" widget="phone" readonly="1" placeholder="Placeholder"/>
+                        </group>
+                    </sheet>
+                </form>`,
+        });
+        assert.containsNone(
+            target.querySelector(".o_field_widget[name='foo']"),
+            "a",
+            "The readonly field don't contain a link if no value is set"
+        );
+    });
 });


### PR DESCRIPTION
This commit hides the <a> representing the phone
number if it is unset. Before this commit, it
could display "false" instead of being invisible.
Now, the <a> element is no longer added to the DOM. A test has been adapted to assert that behavior.
