### PR TITLE
[FIX] core: correctly order by nullable many2one fields 

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4813,9 +4813,12 @@ class BaseModel(metaclass=MetaModel):
 
         # Join the dest m2o table if it's not joined yet. We use [LEFT] OUTER join here
         # as we don't want to exclude results that have NULL values for the m2o
+        # but we still want to differentiate null left joins vs null values
         dest_alias = query.left_join(alias, order_field, dest_model._table, 'id', order_field)
-        return dest_model._generate_order_by_inner(dest_alias, m2o_order, query,
+        res = ['"%s"."id" %s NULL' % (dest_alias, 'IS NOT' if reverse_direction else 'IS')]
+        res += dest_model._generate_order_by_inner(dest_alias, m2o_order, query,
                                                    reverse_direction, seen)
+        return res
 
     @api.model
     def _generate_order_by_inner(self, alias, order_spec, query, reverse_direction=False, seen=None):


### PR DESCRIPTION
When ordering by a many2one field the ORM extends the ORDER BY clause
with the `_order_` field of the target model. This causes issues when
ordering via a many2one field if we modify the `_order` of the target
model **even** if the modification does not change the internal order of
the target model.

The reason is that when we order by a nullable many2one we may effective
add null values to order over. That can change the order. This is
especially relevant if DESC is used in the order of the target model.

For example let's say we have
```
+----------------------+       +---------------------+
|        Foo           |<--+   |        Bar          |
+----------------------+   |   +---------------------+
|_order = 'id'         |   +---|foo_id: many2one(Foo)|
|fool: Char -> required|       +---------------------+
+----------------------+
```

Then if we do `Bar.search([], order="foo_id")` we may get
inconsistent ordering. By consistent here we understand that if none of
the elements of `Foo` model changed its relative order then the elements
of `Bar` must also keep their relative order. Before this patch this was
not true as the added tests shows.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
