### PR TITLE
[FIX] hw_drivers: printers disconnecting issue fixed

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface.py
@@ -3,6 +3,7 @@
 
 from cups import Connection as cups_connection
 from re import sub
+from time import sleep
 from threading import Lock
 
 from odoo.addons.hw_drivers.interface import Interface
@@ -16,26 +17,34 @@ class PrinterInterface(Interface):
     connection_type = 'printer'
 
     def get_devices(self):
-        printer_devices = {}
-        with cups_lock:
-            printers = conn.getPrinters()
-            devices = conn.getDevices()
-            for printer_name, printer in printers.items():
-                path = printer.get('device-uri', False)
-                if printer_name != self.get_identifier(path):
-                    printer.update({'supported': True}) # these printers are automatically supported
-                    device_class = 'network'
-                    if 'usb' in printer.get('device-uri'):
-                        device_class = 'direct'
-                    printer.update({'device-class': device_class})
-                    printer.update({'device-make-and-model': printer}) # give name setted in Cups
-                    printer.update({'device-id': ''})
-                    devices.update({printer_name: printer})
-        for path, device in devices.items():
-            identifier = self.get_identifier(path)
-            device.update({'identifier': identifier})
-            device.update({'url': path})
-            printer_devices.update({identifier: device})
+        max_retry = 3
+        # Before deleting printer from the list retry 3 times to see if it's really removed
+        for _ in range(max_retry):
+            with cups_lock:
+                printer_devices = {}
+                printers = conn.getPrinters()
+                devices = conn.getDevices()
+                for printer_name, printer in printers.items():
+                    path = printer.get('device-uri', False)
+                    if printer_name != self.get_identifier(path):
+                        printer.update({'supported': True}) # these printers are automatically supported
+                        device_class = 'network'
+                        if 'usb' in printer.get('device-uri'):
+                            device_class = 'direct'
+                        printer.update({'device-class': device_class})
+                        printer.update({'device-make-and-model': printer}) # give name setted in Cups
+                        printer.update({'device-id': ''})
+                        devices.update({printer_name: printer})
+            for path, device in devices.items():
+                identifier = self.get_identifier(path)
+                device.update({'identifier': identifier})
+                device.update({'url': path})
+                printer_devices.update({identifier: device})
+            removed = self._detected_devices - printer_devices.keys()
+            if removed:
+                sleep(10)
+            else:
+                break
         return printer_devices
 
     def get_identifier(self, path):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When some printers are disconnected the user has to wait for 2 minutes to update their status / add them to the list of available printers again even if he connects them straight away.

Current behavior before PR: some printers are disconnected and the user needs to wait for 2 minutes to get their status update

Desired behavior after PR is merged: the printers are only removed from the list after being checked multiple times that they are indeed unavailable


[Task 2891909](https://www.odoo.com/web#id=2891909&cids=1&menu_id=4720&action=333&active_id=1428&model=project.task&view_type=form)

Fixes [2687380](https://www.odoo.com/web#id=2687380&menu_id=4720&cids=1&action=3531&model=project.task&view_type=form)
Fixes [2856101](https://www.odoo.com/web#id=2856101&cids=1&model=project.task&view_type=form)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr