### PR TITLE
[FIX] web: kanban: display no content helper

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -226,12 +226,13 @@ export class KanbanRenderer extends Component {
             return true;
         }
         if (isGrouped) {
-            if (!this.state.columnQuickCreateIsFolded) {
+            if (this.canCreateGroup() && !this.state.columnQuickCreateIsFolded) {
                 return false;
             }
             if (groups.length === 0) {
-                return true;
+                return !this.props.list.groupedBy("m2o");
             }
+            return this.props.list.records.length === 0;
         }
         return !model.hasData();
     }

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -143,24 +143,24 @@
                         exampleData="exampleData"
                         groupByFieldString="props.list.groupByField.string"
                     />
-                </t>
-                <!-- Kanban Example Background -->
-                <div t-if="props.list.groups.length === 0" class="o_kanban_example_background_container d-flex opacity-50">
-                    <div class="o_kanban_example_background flex-grow-1">
-                        <div class="o_kanban_examples d-flex p-2">
-                            <div t-foreach="ghostColumns" t-as="column" t-key="column" class="o_kanban_examples_group flex-grow-1 m-3">
-                                <h6><b t-esc="column.name"/></h6>
-                                <div t-foreach="column.cards" t-as="card" t-key="card_index" class="o_kanban_examples_ghost d-flex flex-wrap justify-content-between mb-3 p-2 border bg-white">
-                                    <div class="o_ghost_content w-100 pb-3 bg-300"/>
-                                    <div class="o_ghost_content o_ghost_tag d-inline-block w-50 mt-3 pb-3 bg-300"/>
-                                    <span class="mt-2 rounded-circle bg-300">
-                                        <img class="o_ghost_avatar" src="/base/static/img/avatar.png" alt="Avatar"/>
-                                    </span>
+                    <!-- Kanban Example Background -->
+                    <div t-if="props.list.groups.length === 0" class="o_kanban_example_background_container d-flex opacity-50">
+                        <div class="o_kanban_example_background flex-grow-1">
+                            <div class="o_kanban_examples d-flex p-2">
+                                <div t-foreach="ghostColumns" t-as="column" t-key="column" class="o_kanban_examples_group flex-grow-1 m-3">
+                                    <h6><b t-esc="column.name"/></h6>
+                                    <div t-foreach="column.cards" t-as="card" t-key="card_index" class="o_kanban_examples_ghost d-flex flex-wrap justify-content-between mb-3 p-2 border bg-white">
+                                        <div class="o_ghost_content w-100 pb-3 bg-300"/>
+                                        <div class="o_ghost_content o_ghost_tag d-inline-block w-50 mt-3 pb-3 bg-300"/>
+                                        <span class="mt-2 rounded-circle bg-300">
+                                            <img class="o_ghost_avatar" src="/base/static/img/avatar.png" alt="Avatar"/>
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </t>
             </t>
             <t t-else="">
                 <!-- kanban ghost cards are used to properly space last elements. -->

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -6272,7 +6272,7 @@ QUnit.module("Views", (hooks) => {
     );
 
     QUnit.test(
-        "nocontent helper for grouped kanban with no records with no group_create",
+        "nocontent helper for grouped kanban (on m2o field) with no records with no group_create",
         async (assert) => {
             serverData.models.partner.records = [];
 
@@ -6302,6 +6302,35 @@ QUnit.module("Views", (hooks) => {
                 ".o_column_quick_create",
                 "there should not be a column quick create"
             );
+        }
+    );
+
+    QUnit.test(
+        "nocontent helper for grouped kanban (on date field) with no records with no group_create",
+        async (assert) => {
+            serverData.models.partner.records = [];
+
+            await makeView({
+                type: "kanban",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <kanban group_create="false">
+                        <templates>
+                            <t t-name="kanban-box">
+                                <div><field name="foo"/></div>
+                            </t>
+                        </templates>
+                    </kanban>`,
+                groupBy: ["date"],
+                noContentHelp: "No content helper",
+            });
+
+            assert.containsNone(target, ".o_kanban_group");
+            assert.containsNone(target, ".o_kanban_record");
+            assert.containsOnce(target, ".o_view_nocontent");
+            assert.containsNone(target, ".o_column_quick_create");
+            assert.containsNone(target, ".o_kanban_example_background");
         }
     );
 


### PR DESCRIPTION
The no content helper logic (determining when it is displayed) in kanban is quite complicated. Appearently, in a kanban view grouped on a field that isn't a many2one, with no groups (and thus no records), and where we don't have the "group_create" permission, we want the no content helper to be displayed. At least, this is how is worked in the legacy kanban view. This commit restores the previous behavior and encodes this situation in a test. In the future, it would probably be a good idea to sit down and challenge the corner cases of this feature.

