### PR TITLE
[FIX] web: fix tests failing randomly

### DIFF
--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { browser } from "@web/core/browser/browser";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import {
     click,
@@ -14,7 +15,6 @@ import {
     patchWithCleanup,
 } from "@web/../tests/helpers/utils";
 import { editSearch, validateSearch } from "@web/../tests/search/helpers";
-import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { session } from "@web/session";
 import { companyService } from "@web/webclient/company_service";
@@ -1837,8 +1837,8 @@ QUnit.module("Fields", (hooks) => {
             "partner_type,false,search": `<search />`,
         };
 
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
 
         patchWithCleanup(Many2XAutocomplete.defaultProps, {
@@ -1900,8 +1900,8 @@ QUnit.module("Fields", (hooks) => {
 
         registry.category("services").add("company", companyService, { force: true });
 
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
 
         await makeView({
@@ -1956,8 +1956,8 @@ QUnit.module("Fields", (hooks) => {
 
         registry.category("services").add("company", companyService, { force: true });
 
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
 
         await makeView({
@@ -2017,8 +2017,8 @@ QUnit.module("Fields", (hooks) => {
             });
             registry.category("services").add("company", companyService, { force: true });
 
-            patchWithCleanup(AutoComplete, {
-                timeout: 0,
+            patchWithCleanup(browser, {
+                setTimeout: (fn) => Promise.resolve().then(fn),
             });
 
             await makeView({

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+import { browser } from "@web/core/browser/browser";
 import { Many2ManyTagsField } from "@web/views/fields/many2many_tags/many2many_tags_field";
 import {
     click,
@@ -1587,8 +1588,8 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("Many2ManyTagsField supports 'create' props to be a Boolean", async (assert) => {
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
         await makeView({
             type: "form",
@@ -1630,8 +1631,8 @@ QUnit.module("Fields", (hooks) => {
         serverData.views = {
             "partner_type,false,form": `<form><field name="name"/><field name="color"/></form>`,
         };
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
         await makeView({
             type: "form",
@@ -1662,8 +1663,8 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("Many2ManyTagsField with option 'no_create' set to true", async (assert) => {
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
         await makeView({
             type: "form",
@@ -1678,8 +1679,8 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("Many2ManyTagsField with attribute 'can_create' set to false", async (assert) => {
-        patchWithCleanup(AutoComplete, {
-            timeout: 0,
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => Promise.resolve().then(fn),
         });
         await makeView({
             type: "form",


### PR DESCRIPTION
This commit fixes several tests involving an Autocomplete component that would sometimes fail because it delays it's next rendering on input (by a setTimeout 0 in the tests). This is sometimes not enough as it may imply that the next rendering occurs after the next animation frame, which isn't what we wait for in the tests (we expect the next rendering to be applied in the next animation frame).

This commit fixes remaining tests that we forgot in [1]

[1] de6cd189a40a7145b6750bc582ca3cf0644c9bab
