### PR TITLE
[IMP] website: make code snippet more obvious to edit

### DIFF
--- a/addons/website/views/snippets/s_embed_code.xml
+++ b/addons/website/views/snippets/s_embed_code.xml
@@ -4,7 +4,10 @@
 <template name="Embed Code" id="s_embed_code">
     <section class="s_embed_code text-center pt64 pb64">
         <div class="s_embed_code_embedded container o_not_editable">
-            <div class="font-monospace pt8 bg-light">&#10;    Replace this with your own HTML code&#10;</div>
+            <!-- Keep the next line as a one-liner, this is to nicely show the
+            code in the ace editor when the user is replacing it. The `&#10;`
+            acts as line returns. -->
+            <div class="font-monospace pt8 bg-light">&#10;    Click on <b>"Edit"</b> in the right panel to replace this with your own HTML code&#10;</div>
         </div>
     </section>
 </template>


### PR DESCRIPTION
Some (most?) people keep trying to double click on it to edit it. The wording was not helping as "Replace this" doesn't really tell the user how to do it. He actually has to click on the "Edit" button on the right panel.

Personal experience, the first times I tried that code snippet, I didn't find that button and it took me a few times before understanding how it works.

The new wording and the shortcut button to edit it should be more clear. Another idea was to allow dblclick to enter edit mode, but this seems overkill and the 2 improvements here should be enough to make it easy to figure.

Also added a comment about the `&#10` and one-liner, it is far from obvious when reading the code..
