### PR TITLE
[FIX] http_routing: handle url with special symbols

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -210,6 +210,8 @@ def is_multilang_url(local_url, lang_url_codes=None):
            either `multilang` specified to True or if not specified, with `type='http'`.
         2. If not matching 1., everything not under /static/ or /web/ will be translatable
     '''
+    if not local_url:
+        return False
     if not lang_url_codes:
         lang_url_codes = [url_code for _, url_code, *_ in request.env['res.lang'].get_available()]
     spath = local_url.split('/')


### PR DESCRIPTION
Method `is_multilang_url` may get empty string for `local_url`, which lead to error 500 instead of 404. Fix it by checking this edge case.

opw-2968495

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
