### PR TITLE
[IMP] web_editor: give editor code view a minimum height of 400px

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -694,3 +694,6 @@ img::selection {
         }
     }
 }
+textarea.o_codeview {
+    min-height: 400px;
+}


### PR DESCRIPTION
The editor's code view had no minimum height so it was impractically small.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
