### PR TITLE
[IMP] *: review website content pages views and minors in related apps

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -128,13 +128,13 @@
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="show"/>
                 <field name="date_begin" readonly="1" widget="date"/>
                 <field name="date_end" readonly="1" widget="date"/>
-                <field name="stage_id" readonly="1"/>
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                 <field name="seats_expected" string="Expected Attendees" sum="Total" readonly="1"/>
                 <field name="seats_used" sum="Total" readonly="1"/>
                 <field name="seats_max" string="Maximum Seats" sum="Total" readonly="1" optional="hide"/>
                 <field name="seats_reserved" sum="Total" readonly="1" optional="hide"/>
                 <field name="seats_unconfirmed" string="Unconfirmed Seats" sum="Total" readonly="1" optional="hide"/>
+                <field name="stage_id" readonly="1"/>
                 <field name="message_needaction" invisible="1" readonly="1"/>
                 <field name="activity_exception_decoration" widget="activity_exception" readonly="1"/>
             </tree>

--- a/addons/website_event/views/website_pages_views.xml
+++ b/addons/website_event/views/website_pages_views.xml
@@ -14,15 +14,25 @@
             <attribute name="action">open_website_url</attribute>
         </xpath>
 
+        <field name="address_id" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+        <field name="date_end" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+        <field name="seats_used" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+
         <field name="name" position="after">
             <field name="website_url"/>
         </field>
-        <xpath expr="//tree">
+        <field name="stage_id" position="before">
             <field name="is_seo_optimized"/>
             <field name="is_published"/>
 
             <field name="website_id" position="move"/>
-        </xpath>
+        </field>
     </field>
 </record>
 

--- a/addons/website_sale/views/website_pages_views.xml
+++ b/addons/website_sale/views/website_pages_views.xml
@@ -16,6 +16,16 @@
 
         <field name="is_published" position="replace"/>
 
+        <field name="default_code" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+        <field name="product_tag_ids" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+        <field name="standard_price" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+
         <field name="name" position="after">
             <field name="website_url"/>
         </field>

--- a/addons/website_sale_stock/__manifest__.py
+++ b/addons/website_sale_stock/__manifest__.py
@@ -20,6 +20,7 @@ Then it can be made specific at the product level.
         'views/res_config_settings_views.xml',
         'views/website_sale_stock_templates.xml',
         'views/stock_picking_views.xml',
+        'views/website_pages_views.xml',
         'data/template_email.xml',
         'data/ir_cron_data.xml',
     ],

--- a/addons/website_sale_stock/views/website_pages_views.xml
+++ b/addons/website_sale_stock/views/website_pages_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<odoo>
+
+<record id="product_pages_tree_view" model="ir.ui.view">
+    <field name="name">Product Pages Tree (stock inherit)</field>
+    <field name="model">product.template</field>
+    <field name="inherit_id" ref="website_sale.product_pages_tree_view"/>
+    <field name="arch" type="xml">
+        <field name="responsible_id" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+        <field name="virtual_available" position="attributes">
+            <attribute name="optional">hide</attribute>
+        </field>
+    </field>
+</record>
+
+</odoo>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -162,7 +162,7 @@
                     <field name="user_id" widget="many2one_avatar_user"/>
                     <field name="website_id" groups="website.group_multi_website"/>
                     <field name="channel_type" string="Course Type"/>
-                    <field name="visibility"/>
+                    <field name="visibility" optional="hide"/>
                     <field name="enroll" widget="badge" decoration-success="enroll == 'public'" decoration-info="enroll == 'invite'" decoration-warning="enroll == 'payment'"/>
                     <field name="active" invisible="1"/>
                 </tree>


### PR DESCRIPTION
*: event, website_event, website_sale, website_sale_stock, website_slides

With [1], new list views were created in the website app to display all key models in the "Site" menu. Each view is based on the related model base view in their related app, with some more website-related fields (like the content URL, the SEO optimization, ...), etc. This commit simplifies those views by removing some columns (make them optional) to not make them feel bloated. Some changes were done in the base views.

- Products: simplify the website view by hiding 5 columns. Two were stock related so it had to be done in a new view in website_sale_stock.

- Events: simplify the website view by hiding 3 columns. Also move the "stage" column at the end, in the base view too.

- Courses: simplify the view by hiding 1 column, this change is done in the base view.

[1]: https://github.com/odoo/odoo/commit/da3f4c2aff92cca23ca2d7a87fa0eb5b1d7ce5fe
