### PR TITLE
[REM] website: remove multi-website by country

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -549,7 +549,6 @@
         <!-- Default Website -->
         <record id="default_website" model="website">
             <field name="name">My Website</field>
-            <field name="domain"></field>
             <field name="company_id" ref="base.main_company"/>
             <field name="user_id" ref="base.public_user"/>
         </record>

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -384,7 +384,6 @@
     <data noupdate="1">
         <record id="website2" model="website">
             <field name="name">My Website 2</field>
-            <field name="domain"></field>
             <field name="sequence">20</field>
         </record>
 

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -29,9 +29,6 @@ class ResConfigSettings(models.TransientModel):
         readonly=False)
     website_homepage_url = fields.Char(
         related='website_id.homepage_url', readonly=False)
-    website_country_group_ids = fields.Many2many(
-        related='website_id.country_group_ids',
-        readonly=False)
     website_company_id = fields.Many2one(
         related='website_id.company_id',
         string='Website Company',

--- a/addons/website/tests/test_get_current_website.py
+++ b/addons/website/tests/test_get_current_website.py
@@ -29,104 +29,55 @@ class TestGetCurrentWebsite(TransactionCase):
         # clean initial state
         website1 = self.website
         website1.domain = ''
-        website1.country_group_ids = False
 
-        website2 = Website.create({
-            'name': 'My Website 2',
-            'domain': '',
-            'country_group_ids': False,
-        })
+        website2 = Website.create({'name': 'My Website 2'})
 
-        country1 = self.env['res.country'].create({'name': "My Country 1"})
-        country2 = self.env['res.country'].create({'name': "My Country 2"})
-        country3 = self.env['res.country'].create({'name': "My Country 3"})
-        country4 = self.env['res.country'].create({'name': "My Country 4"})
-        country5 = self.env['res.country'].create({'name': "My Country 5"})
-
-        country_group_1_2 = self.env['res.country.group'].create({
-            'name': "My Country Group 1-2",
-            'country_ids': [(6, 0, (country1 + country2 + country5).ids)],
-        })
-        country_group_3 = self.env['res.country.group'].create({
-            'name': "My Country Group 3",
-            'country_ids': [(6, 0, (country3 + country5).ids)],
-        })
-
-        # CASE: no domain, no country: get first
-        self.assertEqual(Website._get_current_website_id('', False), website1.id)
-        self.assertEqual(Website._get_current_website_id('', country3.id), website1.id)
-
-        # CASE: no domain, given country: get by country
-        website1.country_group_ids = country_group_1_2
-        website2.country_group_ids = country_group_3
-
-        self.assertEqual(Website._get_current_website_id('', country1.id), website1.id)
-        self.assertEqual(Website._get_current_website_id('', country2.id), website1.id)
-        self.assertEqual(Website._get_current_website_id('', country3.id), website2.id)
-
-        # CASE: no domain, wrong country: get first
-        self.assertEqual(Website._get_current_website_id('', country4.id), Website.search([]).sorted('country_group_ids')[0].id)
-
-        # CASE: no domain, multiple country: get first
-        self.assertEqual(Website._get_current_website_id('', country5.id), website1.id)
+        # CASE: no domain: get first
+        self.assertEqual(Website._get_current_website_id(''), website1.id)
 
         # setup domain
         website1.domain = 'my-site-1.fr'
         website2.domain = 'https://my2ndsite.com:80'
 
-        website1.country_group_ids = False
-        website2.country_group_ids = False
-
         # CASE: domain set: get matching domain
-        self.assertEqual(Website._get_current_website_id('my-site-1.fr', False), website1.id)
+        self.assertEqual(Website._get_current_website_id('my-site-1.fr'), website1.id)
 
         # CASE: domain set: get matching domain (scheme and port supported)
-        self.assertEqual(Website._get_current_website_id('my-site-1.fr:8069', False), website1.id)
+        self.assertEqual(Website._get_current_website_id('my-site-1.fr:8069'), website1.id)
 
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com:80', False), website2.id)
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com:8069', False), website2.id)
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com', False), website2.id)
+        self.assertEqual(Website._get_current_website_id('my2ndsite.com:80'), website2.id)
+        self.assertEqual(Website._get_current_website_id('my2ndsite.com:8069'), website2.id)
+        self.assertEqual(Website._get_current_website_id('my2ndsite.com'), website2.id)
 
         # CASE: domain set, wrong domain: get first
-        self.assertEqual(Website._get_current_website_id('test.com', False), website1.id)
+        self.assertEqual(Website._get_current_website_id('test.com'), website1.id)
 
         # CASE: subdomain: not supported
-        self.assertEqual(Website._get_current_website_id('www.my2ndsite.com', False), website1.id)
+        self.assertEqual(Website._get_current_website_id('www.my2ndsite.com'), website1.id)
 
-        # CASE: domain set, given country: get by domain in priority
-        website1.country_group_ids = country_group_1_2
-        website2.country_group_ids = country_group_3
-
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com', country1.id), website2.id)
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com', country2.id), website2.id)
-        self.assertEqual(Website._get_current_website_id('my-site-1.fr', country3.id), website1.id)
-
-        # CASE: domain set, wrong country: get first for domain
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com', country4.id), website2.id)
-
-        # CASE: domain set, multiple country: get first for domain
-        website1.domain = website2.domain
-        self.assertEqual(Website._get_current_website_id('my2ndsite.com', country5.id), website1.id)
+        # CASE: domain set: get by domain in priority
+        self.assertEqual(Website._get_current_website_id('my2ndsite.com'), website2.id)
+        self.assertEqual(Website._get_current_website_id('my-site-1.fr'), website1.id)
 
         # CASE: overlapping domain: get exact match
         website1.domain = 'site-1.com'
         website2.domain = 'even-better-site-1.com'
-        self.assertEqual(Website._get_current_website_id('site-1.com', False), website1.id)
-        self.assertEqual(Website._get_current_website_id('even-better-site-1.com', False), website2.id)
+        self.assertEqual(Website._get_current_website_id('site-1.com'), website1.id)
+        self.assertEqual(Website._get_current_website_id('even-better-site-1.com'), website2.id)
 
         # CASE: case insensitive
         website1.domain = 'Site-1.com'
         website2.domain = 'Even-Better-site-1.com'
-        self.assertEqual(Website._get_current_website_id('sitE-1.com', False), website1.id)
-        self.assertEqual(Website._get_current_website_id('even-beTTer-site-1.com', False), website2.id)
+        self.assertEqual(Website._get_current_website_id('sitE-1.com'), website1.id)
+        self.assertEqual(Website._get_current_website_id('even-beTTer-site-1.com'), website2.id)
 
         # CASE: same domain, different port
         website1.domain = 'site-1.com:80'
         website2.domain = 'site-1.com:81'
-        self.assertEqual(Website._get_current_website_id('site-1.com:80', False), website1.id)
-        self.assertEqual(Website._get_current_website_id('site-1.com:81', False), website2.id)
-        self.assertEqual(Website._get_current_website_id('site-1.com:82', False), website1.id)
-        self.assertEqual(Website._get_current_website_id('site-1.com', False), website1.id)
+        self.assertEqual(Website._get_current_website_id('site-1.com:80'), website1.id)
+        self.assertEqual(Website._get_current_website_id('site-1.com:81'), website2.id)
+        self.assertEqual(Website._get_current_website_id('site-1.com:82'), website1.id)
+        self.assertEqual(Website._get_current_website_id('site-1.com'), website1.id)
 
     def test_02_signup_user_website_id(self):
         website = self.website

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -47,10 +47,6 @@
                                         <label class="col-lg-3" string="Homepage URL" for="website_homepage_url"/>
                                         <field name="website_homepage_url" placeholder="/" title="Main page of your website served to visitors"/>
                                     </div>
-                                    <div class="row mt8" groups="base.group_no_one">
-                                        <label class="col-lg-3" string="Country Groups" for="website_country_group_ids"/>
-                                        <field name="website_country_group_ids" widget="many2many_tags" title="Once the selection of available websites by domain is done, you can filter by country group. You can have 2 websites with same domain AND a condition on country group to select which website to use."/>
-                                    </div>
                                     <div class="row mt8">
                                         <label class="col-lg-3" string="Languages" for="language_ids"/>
                                         <field name="language_ids" widget="many2many_tags" options="{'no_create': True, 'no_open': True}" attrs="{'required': [('website_id', '!=', False)]}" title="Languages available on your website"/>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -85,7 +85,6 @@
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="domain"/>
-                    <field name="country_group_ids" widget="many2many_tags"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="default_lang_id"/>
                     <field name="theme_id" groups="base.group_no_one"/>


### PR DESCRIPTION
Short summary:
- People can now use the snippets option to show/hide based on country
- We never use / test / maintain this feature, if it still works since its introduction 4 years ago that's by luck
- It is probably barely used, we never got a single question or issue about it

-----------

When we introduced the multi-website feature, it came with 2 main use cases:
1. Multi website by domain -> Every website has its own domain and based on that we serve the expected website
2. Multi website by geoip -> Multiple website can have the same domain and based on GEOIP/country we serve the expected website

We never really supported, highlighted or promoted the geoip case. We actually never use it ourselves when doing tests, and we don't consider it when doing specs / improvements.
At most, only a very few people know about it in Odoo.

That GEOIP case is probably not useful at all, as displaying a whole new website based on lang is not easy since nothing can be shared out of the box -> Every website has its own COW records.

For instance, one could think of having its main website A and another website B on which he just added 3 products specific to that website B country.
But such a case won't even work properly, as any adaption on website A won't be reflected on website B (design, theme etc).
