### PR TITLE
[IMP] website_links: move "Link Tracker" menu in "This page" section

### DIFF
--- a/addons/website_links/views/link_tracker_views.xml
+++ b/addons/website_links/views/link_tracker_views.xml
@@ -14,6 +14,6 @@
     <menuitem id="menu_link_tracker"
         name="Link Tracker"
         sequence="25"
-        parent="website.menu_site"
+        parent="website.menu_current_page"
         action="website.website_preview"/>
 </odoo>


### PR DESCRIPTION
With the menu reorganization at [1], "Link Tracker" was moved as a main menu inside the "Site" menu. It better be in the "This page" section after all since the UI is autocompleted with the current page being visited (to create a tracking link for it).

[1]: https://github.com/odoo/odoo/commit/7aaef54fe2fee39979e643b7579c1b1e1d9f6799
