### PR TITLE
[FIX] web: adapt views to invisible attr removal in archs

### DIFF
--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -110,11 +110,9 @@ export class SearchArchParser extends XMLParser {
     visitField(node) {
         this.pushGroup("field");
         const preField = { type: "field" };
-        if (node.hasAttribute("modifiers")) {
-            const modifiers = JSON.parse(node.getAttribute("modifiers"));
-            if (modifiers.invisible) {
-                preField.invisible = true;
-            }
+        const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+        if (modifiers.invisible === true) {
+            preField.invisible = true;
         }
         if (node.hasAttribute("domain")) {
             preField.domain = node.getAttribute("domain");
@@ -222,17 +220,15 @@ export class SearchArchParser extends XMLParser {
                 preSearchItem.domain = stringRepr;
             }
         }
-        if (node.hasAttribute("modifiers")) {
-            const modifiers = JSON.parse(node.getAttribute("modifiers"));
-            if (modifiers.invisible) {
-                preSearchItem.invisible = true;
-                const fieldName = preSearchItem.fieldName;
-                if (fieldName && !this.fields[fieldName]) {
-                    // In some case when a field is limited to specific groups
-                    // on the model, we need to ensure to discard related filter
-                    // as it may still be present in the view (in 'invisible' state)
-                    return;
-                }
+        const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+        if (modifiers.invisible === true) {
+            preSearchItem.invisible = true;
+            const fieldName = preSearchItem.fieldName;
+            if (fieldName && !this.fields[fieldName]) {
+                // In some case when a field is limited to specific groups
+                // on the model, we need to ensure to discard related filter
+                // as it may still be present in the view (in 'invisible' state)
+                return;
             }
         }
         preSearchItem.groupNumber = this.groupNumber;
@@ -293,8 +289,8 @@ export class SearchArchParser extends XMLParser {
             if (node.nodeType !== 1 || node.tagName !== "field") {
                 continue;
             }
-            const isInvisible = Boolean(evaluateExpr(node.getAttribute("invisible") || "0"));
-            if (isInvisible) {
+            const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+            if (modifiers.invisible === true) {
                 continue;
             }
             const attrs = {};

--- a/addons/web/static/src/views/graph/graph_arch_parser.js
+++ b/addons/web/static/src/views/graph/graph_arch_parser.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { evaluateExpr } from "@web/core/py_js/py";
 import { XMLParser } from "@web/core/utils/xml";
 import { GROUPABLE_TYPES } from "@web/search/utils/misc";
 import { archParseBoolean } from "@web/views/utils";
@@ -51,10 +50,8 @@ export class GraphArchParser extends XMLParser {
                         }
                         archInfo.fieldAttrs[fieldName].string = string;
                     }
-                    const isInvisible = Boolean(
-                        evaluateExpr(node.getAttribute("invisible") || "0")
-                    );
-                    if (isInvisible) {
+                    const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+                    if (modifiers.invisible === true) {
                         if (!archInfo.fieldAttrs[fieldName]) {
                             archInfo.fieldAttrs[fieldName] = {};
                         }

--- a/addons/web/static/src/views/pivot/pivot_arch_parser.js
+++ b/addons/web/static/src/views/pivot/pivot_arch_parser.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { evaluateExpr } from "@web/core/py_js/py";
 import { XMLParser } from "@web/core/utils/xml";
 import { archParseBoolean } from "@web/views/utils";
 
@@ -43,12 +42,10 @@ export class PivotArchParser extends XMLParser {
                     if (node.hasAttribute("string")) {
                         archInfo.fieldAttrs[fieldName].string = node.getAttribute("string");
                     }
-                    if (node.hasAttribute("invisible")) {
-                        const isInvisible = Boolean(evaluateExpr(node.getAttribute("invisible")));
-                        if (isInvisible) {
-                            archInfo.fieldAttrs[fieldName].isInvisible = true;
-                            break;
-                        }
+                    const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+                    if (modifiers.invisible === true) {
+                        archInfo.fieldAttrs[fieldName].isInvisible = true;
+                        break;
                     }
 
                     if (node.hasAttribute("interval")) {

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -1238,18 +1238,6 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(mockServer.models.bar.records[0].one2many_field, []);
     });
     QUnit.test("List View: invisible on processed Arch", async function (assert) {
-        /**
-         * Note that, the server have two different responses for invisible:
-         * - if the invisible is in the arch (invisible=1), the parsed arch will contain:
-         *      --"invisible=1" on the arch;
-         *      -- "column_invisible: 1" on the modifiers.
-         * - if there is a group in the arch (groups=no_group), and that the user don't have access to the group, the parsed arch will contain:
-         *      -- "invisible=1" on the arch;
-         *      -- "column_invisible: 1" on the modifiers;
-         *      -- "invisible: 1" on the modifiers.
-         * As it's possible (on the groups case) to have an invisible: 1 on the modifiers, on the mock_server we set it all the time.
-         */
-
         data.views = {
             "bar,10001,list": `
                 <tree>
@@ -1260,7 +1248,7 @@ QUnit.module("MockServer", (hooks) => {
             "bar,10001,search": `<search></search>`,
         };
         const expectedList = `<tree>
-                    <field name="bool" invisible="1" modifiers="{&quot;invisible&quot;:true,&quot;column_invisible&quot;:true}"/>
+                    <field name="bool" modifiers="{&quot;column_invisible&quot;:true}"/>
                     <field name="foo"/>
                 </tree>`;
         const mockServer = new MockServer(data);

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -2350,8 +2350,8 @@ QUnit.module("Views", (hooks) => {
             <graph type="pie">
                 <field name="revenue" type="measure"/>
                 <field name="date" interval="day"/>
-                <field name="foo" invisible="0"/>
-                <field name="bar" invisible="1" string="My invisible field"/>
+                <field name="foo" modifiers='{"invisible": false}'/>
+                <field name="bar" modifiers='{"invisible": true}' string="My invisible field"/>
                 <field name="id"/>
                 <field name="fighters" string="FooFighters"/>
             </graph>


### PR DESCRIPTION
PR [1] removes some `<field/>` node attributes from view archs that
were transfered into the `modifiers` attribute (e.g. `invisible`).
However, the `invisible` attribute was still used in some views
(e.g. graph, pivot, search and cohort). This issue hasn't been
spotted by the tests as the MockServer was still sending archs
with both `invisible` and `modifiers` attributes.

This commit adapts the MockServer to make it behave like the real
server, which makes some tests fail, and adapts the impacted
views to make them look into the `modifiers` attribute, which fixes
the failing tests.

Closes https://github.com/odoo/odoo/pull/99920

[1] https://github.com/odoo/odoo/pull/99619