### PR TITLE
[ADD] pos_restaurant_stripe: support adding tip after payment

### DIFF
--- a/addons/pos_restaurant_stripe/__init__.py
+++ b/addons/pos_restaurant_stripe/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/pos_restaurant_stripe/__manifest__.py
+++ b/addons/pos_restaurant_stripe/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'POS Restaurant Stripe',
+    'version': '1.0',
+    'category': 'Point of Sale',
+    'sequence': 6,
+    'summary': 'Adds American style tipping to Stripe',
+    'depends': ['pos_stripe', 'pos_restaurant', 'payment_stripe'],
+    'auto_install': True,
+    'assets': {
+        'point_of_sale.assets': [
+            'pos_restaurant_stripe/static/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_restaurant_stripe/models/__init__.py
+++ b/addons/pos_restaurant_stripe/models/__init__.py
@@ -1,0 +1,5 @@
+# coding: utf-8
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_payment
+from . import pos_order

--- a/addons/pos_restaurant_stripe/models/pos_order.py
+++ b/addons/pos_restaurant_stripe/models/pos_order.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    def set_no_tip(self):
+        """Capture the payment when no tip is set."""
+        res = super(PosOrder, self).set_no_tip()
+
+        for payment in self.payment_ids:
+            if payment.payment_method_id.use_payment_terminal == 'stripe':
+                payment.payment_method_id.stripe_capture_payment(payment.transaction_id)
+
+        return res

--- a/addons/pos_restaurant_stripe/models/pos_payment.py
+++ b/addons/pos_restaurant_stripe/models/pos_payment.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class PosPayment(models.Model):
+    _inherit = 'pos.payment'
+
+    def _update_payment_line_for_tip(self, tip_amount):
+        """Capture the payment when a tip is set."""
+        res = super(PosPayment, self)._update_payment_line_for_tip(tip_amount)
+
+        if self.payment_method_id.use_payment_terminal == 'stripe':
+            self.payment_method_id.stripe_capture_payment(self.transaction_id, amount=self.amount)
+
+        return res

--- a/addons/pos_restaurant_stripe/static/src/js/payment_stripe.js
+++ b/addons/pos_restaurant_stripe/static/src/js/payment_stripe.js
@@ -1,0 +1,21 @@
+odoo.define('pos_restaurant_stripe.payment', function (require) {
+    "use strict";
+
+    var PaymentStripe = require('pos_stripe.payment');
+
+    PaymentStripe.include({
+        captureAfterPayment: async function (processPayment, line) {
+            // Don't capture if the customer can tip, in that case we
+            // will capture later.
+            if (! this.canBeAdjusted(line.cid)) {
+                return this._super(...arguments);
+            }
+        },
+
+        canBeAdjusted: function (cid) {
+            var order = this.pos.get_order();
+            var line = order.get_paymentline(cid);
+            return this.pos.config.set_tip_after_payment && line.payment_method.use_payment_terminal === "stripe";
+        }
+    });
+});


### PR DESCRIPTION
This is analogous to pos_restaurant_adyen and adds support for the two American tipping flows:

- customer tips immediately themselves after paying using the TipScreen
- waiter adds tips end-of-day using paper receipts using the TicketScreen

To allow for tipping an optional amount= parameter was added to stripe_capture_payment and the transaction_id on the paymentline was saved a bit sooner so it can be used in the backend in set_no_tip and _update_payment_line_for_tip.

Stripe docs:
https://stripe.com/docs/terminal/features/collecting-tips/on-receipt

task-2979312

PR note: to test this needs a Stripe account with over-capture enabled (see task).
