### PR TITLE
[IMP] website_hr_recruitment: fix job apply page colors

### DIFF
--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -24,7 +24,7 @@
                 'description',
                 'email_from',
                 'partner_name',
-                'partner_phone',
+                'partner_mobile',
                 'job_id',
                 'department_id',
                 'linkedin_profile',

--- a/addons/website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js
@@ -23,7 +23,7 @@ FormEditorRegistry.add('apply_job', {
         type: 'char',
         required: true,
         fillWith: 'phone',
-        name: 'partner_phone',
+        name: 'partner_mobile',
         string: 'Phone Number',
     }, {
         type: 'char',

--- a/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
+++ b/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
@@ -48,16 +48,18 @@
     filter: invert(1);
 }
 
-.o_small_font {
-    font-size: 0.8rem;
+.o_apply_description_link:hover {
+    filter: brightness(90%);
+    background-color: #fff;
+    color: #35979c;
+}
+
+.o_resume_input {
+    border-color: #35979c;
 }
 
 .o_resume_input::file-selector-button {
-    color: #fff;
-    background-color: #35979c;
-}
-
-.o_resume_input:hover::file-selector-button,
-.o_resume_input:focus::file-selector-button {
-    background-color: #2e8286!important;
+    color: #35979c;
+    border-color: #35979c;
+    background-color: #fff;
 }

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -21,7 +21,7 @@ odoo.define('website_hr_recruitment.tour', function(require) {
             run: `text ${application.email}`,
         }, {
             content: "Complete phone number",
-            trigger: "input[name=partner_phone]",
+            trigger: "input[name=partner_mobile]",
             run: `text ${application.phone}`,
         }, {
             content: "Complete Subject",

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -27,13 +27,13 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         guru_applicant = capt.records[1]
         self.assertEqual(guru_applicant.partner_name, 'John Smith')
         self.assertEqual(guru_applicant.email_from, 'john@smith.com')
-        self.assertEqual(guru_applicant.partner_phone, '118.218')
+        self.assertEqual(guru_applicant.partner_mobile, '118.218')
         self.assertEqual(html2plaintext(guru_applicant.description), '### [GURU] HR RECRUITMENT TEST DATA ###')
         self.assertEqual(guru_applicant.job_id, job_guru)
 
         internship_applicant = capt.records[0]
         self.assertEqual(internship_applicant.partner_name, 'Jack Doe')
         self.assertEqual(internship_applicant.email_from, 'jack@doe.com')
-        self.assertEqual(internship_applicant.partner_phone, '118.712')
+        self.assertEqual(internship_applicant.partner_mobile, '118.712')
         self.assertEqual(html2plaintext(internship_applicant.description), '### HR [INTERN] RECRUITMENT TEST DATA ###')
         self.assertEqual(internship_applicant.job_id, job_intern)

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -184,7 +184,7 @@
                                         <div class="col-sm">
                                             <input id="recruitment3" type="tel"
                                                 class="form-control s_website_form_input"
-                                                name="partner_phone" required=""
+                                                name="partner_mobile" required=""
                                                 data-fill-with="phone"/>
                                         </div>
                                     </div>
@@ -258,14 +258,14 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="col-12 s_website_form_submit mt64" data-name="Submit Button">
+                                <div class="col-12 s_website_form_submit mb64" data-name="Submit Button">
                                     <div style="width: 200px" class="s_website_form_label"/>
                                     <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send">I'm feeling lucky</a>
                                     <span id="s_website_form_result"></span>
                                 </div>
                             </section>
-                            <section class="col-4">
-                                <a role="button" t-attf-href="/jobs/detail/#{job.id}" class="btn btn-primary btn-lg mb16">
+                            <section class="col-3 ms-5">
+                                <a role="button" t-attf-href="/jobs/detail/#{job.id}" class="btn btn-outline-primary btn-lg mb16 o_apply_description_link">
                                     <i class="fa fa-arrow-left"></i> Job Description
                                 </a>
                                 <div t-if="job.name" class="d-flex flex-column align-items-baseline">
@@ -287,7 +287,7 @@
                                     <span class="text-muted small">Employment Type</span>
                                     <h6 t-field="job.contract_type_id"/>
                                 </div>
-                                <hr t-if="job.job_details" class="w-50" style="margin: 1rem auto"/>
+                                <hr t-if="job.job_details" class="w-50 my-3"/>
                                 <span t-esc="job.job_details"/>
                             </section>
                         </form>


### PR DESCRIPTION
On the application page, too much elements are set in the primary color, creating confusion as of where is located the main page action.

Also changes the phone field in the job application page to be stored as a mobile phone instead of a home phone.

task-2980889