### PR TITLE
[IMP] base, web: allow to search properties and to use them in kanban view

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -47,7 +47,7 @@
 
     <t t-name="web.SearchBar.Items" owl="1">
         <ul class="dropdown-menu o_searchview_autocomplete dropdown-menu show" role="menu">
-            <t t-foreach="items" t-as="item" t-key="item.id">
+            <t t-foreach="searchBarItems" t-as="item" t-key="item.id">
                 <li class="o_menu_item dropdown-item"
                     t-att-class="{ o_indent: item.isChild, focus: item_index === state.focusedIndex}"
                     t-att-id="item.id"
@@ -62,12 +62,15 @@
                             <i t-attf-class="fa fa-caret-{{ item.isExpanded ? 'down' : 'right' }}"/>
                         </a>
                     </t>
-                    <a href="#" t-on-click.prevent="">
+                    <a href="#" t-on-click.prevent="" t-att-class="item.isProperty ? 'ps-3 text-truncate' : ''">
                         <t t-if="item.isChild">
                             <t t-esc="item.label"/>
                         </t>
-                        <t t-else="">
+                        <t t-elif="!item.isProperty">
                             Search <b t-esc="item.searchItemDescription"/> <t t-esc="item.preposition"/>: <b class="fst-italic text-primary" t-esc="item.label"/>
+                        </t>
+                        <t t-else="">
+                            <t t-esc="item.searchItemDescription"/>
                         </t>
                     </a>
                 </li>

--- a/addons/web/static/src/views/fields/properties/kanban_properties_field.js
+++ b/addons/web/static/src/views/fields/properties/kanban_properties_field.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { PropertiesField } from "./properties_field";
+
+export class KanbanPropertiesField extends PropertiesField {
+
+}
+
+KanbanPropertiesField.template = "web.KanbanPropertiesField";
+
+registry.category("fields").add("kanban.properties", KanbanPropertiesField);

--- a/addons/web/static/src/views/fields/properties/kanban_properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/kanban_properties_field.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.KanbanPropertiesField" owl="1">
+        <div t-ref="properties" class="w-100">
+            <div class="o_kanban_property_field d-inline-flex flex-column justify-content-center align-items-start w-100 my-1"
+                t-foreach="propertiesList"
+                t-as="propertyConfiguration"
+                t-key="propertyConfiguration.name"
+                t-if="propertyConfiguration.value &amp;&amp; propertyConfiguration.view_in_kanban">
+                <span t-out="propertyConfiguration.string"/>
+                <PropertyValue
+                    readonly="props.readonly"
+                    canChangeDefinition="state.canChangeDefinition"
+                    type="propertyConfiguration.type"
+                    string="propertyConfiguration.string"
+                    value="propertyConfiguration.value"
+                    selection="propertyConfiguration.selection"
+                    tags="propertyConfiguration.tags"
+                    comodel="propertyConfiguration.comodel || ''"
+                    domain="propertyConfiguration.domain || '[]'"
+                    context="context"
+                    onChange.bind="() => {}"
+                    onTagsChange.bind="() => {}"
+                />
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -2,6 +2,7 @@
 
 import { _lt } from "@web/core/l10n/translation";
 import { PropertyValue } from "./property_value";
+import { CheckBox } from "@web/core/checkbox/checkbox";
 import { DomainSelector } from "@web/core/domain_selector/domain_selector";
 import { Domain } from "@web/core/domain";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -230,6 +231,20 @@ export class PropertyDefinition extends Component {
         this.state.propertyDefinition = propertyDefinition;
     }
 
+    /**
+     * We activate / deactivate the property in the kanban view.
+     *
+     * @param {boolean} newValue
+     */
+    onViewInKanbanChange(newValue) {
+        const propertyDefinition = {
+            ...this.state.propertyDefinition,
+            view_in_kanban: newValue,
+        };
+        this.props.onChange(propertyDefinition);
+        this.state.propertyDefinition = propertyDefinition;
+    }
+
     /* --------------------------------------------------------
      * Private methods
      * -------------------------------------------------------- */
@@ -305,6 +320,7 @@ export class PropertyDefinition extends Component {
 
 PropertyDefinition.template = "web.PropertyDefinition";
 PropertyDefinition.components = {
+    CheckBox,
     DomainSelector,
     Dropdown,
     DropdownItem,

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -163,6 +163,18 @@
                         />
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <b>View In Kanban</b>
+                    </td>
+                    <td>
+                        <CheckBox
+                            value="props.propertyDefinition.view_in_kanban"
+                            disabled="props.readonly"
+                            onChange.bind="onViewInKanbanChange"
+                        />
+                    </td>
+                </tr>
             </table>
         </div>
     </t>

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -154,6 +154,7 @@ class PropertiesCase(TransactionCase):
         self.assertEqual(sql_values_1, {'discussion_color_code': 'orange', 'moderator_partner_id': self.partner_2.id, 'state': 'done'})
         self.assertEqual(sql_values_3, {'discussion_color_code': 'orange', 'moderator_partner_id': self.partner_2.id, 'state': 'done'})
 
+    @mute_logger('odoo.models.unlink')
     def test_properties_field_read_batch(self):
         values = self.message_1.read(['attributes'])[0]['attributes']
         self.assertEqual(len(values), 2)
@@ -179,11 +180,35 @@ class PropertiesCase(TransactionCase):
         with self.assertQueryCount(5), self.assertQueries(expected_queries):
             self.message_1.read(['attributes'])
 
+        # read in batch a lot of records
+        discussions = [self.discussion_1, self.discussion_2]
+        partners = self.env['test_new_api.partner'].create([{'name': f'Test {i}'} for i in range(50)])
+        messages = self.env['test_new_api.message'].create([{
+            'name': f'Test Message {i}',
+            'discussion': discussions[i % 2].id,
+            'author': self.user.id,
+            'attributes': [{
+                'name': 'partner_id',
+                'type': 'many2one',
+                'comodel': 'test_new_api.partner',
+                'value': partner.id,
+                'definition_changed': True,
+            }]
+        } for i, partner in enumerate(partners)])
+
         self.env.invalidate_all()
-        expected_queries += expected_queries[-2:]
-        with self.assertQueryCount(7), self.assertQueries(expected_queries):
-            # 2 more queries for message 2 to verify his partner existence / name_get
-            (self.message_1 | self.message_2).read(['attributes'])
+
+        with self.assertQueryCount(5), self.assertQueries(expected_queries):
+            values = messages.read(['attributes'])
+
+        # remove some partners in the list
+        partners[:20].unlink()
+        self.env.invalidate_all()
+        # 5 queries instead of 25 queries, thanks to the cache values that has been
+        # cleaned (the properties field can trust the cached value, the deleted ids
+        # are not in the cache even if they still exists in the database)
+        with self.assertQueryCount(5):
+            values = messages.read(['attributes'])
 
     def test_properties_field_delete(self):
         """Test to delete a property using the flag "definition_deleted"."""
@@ -807,7 +832,7 @@ class PropertiesCase(TransactionCase):
             'comodel': 'test_new_api.partner',
         }]
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(2):
             self.message_1.attributes = [
                 {
                     "name": "moderator_partner_ids",
@@ -820,7 +845,7 @@ class PropertiesCase(TransactionCase):
             self.assertEqual(self.message_1.attributes[0]['value'], partners[:10].ids)
 
         partners[:5].unlink()
-        with self.assertQueryCount(4):
+        with self.assertQueryCount(5):
             self.assertEqual(self.message_1.attributes[0]['value'], partners[5:10].ids)
 
         partners[5].unlink()
@@ -830,7 +855,9 @@ class PropertiesCase(TransactionCase):
 
         # need to wait next write to clean data in database
         # a single read won't clean the removed many2many
-        self.message_1.attributes = self.message_1.read(['attributes'])[0]['attributes']
+        attributes = self.message_1.read(['attributes'])[0]['attributes']
+        self.message_1.invalidate_recordset()
+        self.message_1.attributes = attributes
 
         sql_values = self._get_sql_properties(self.message_1)
         self.assertEqual(sql_values, {'moderator_partner_ids': partners[6:10].ids})
@@ -898,14 +925,12 @@ class PropertiesCase(TransactionCase):
             }])
 
     def test_properties_field_performance(self):
-        with self.assertQueryCount(4):
-            self.message_1.attributes
+        self.env.invalidate_all()
+        with self.assertQueryCount(5):
+            # read to put the partner name in cache
+            self.message_1.read(['attributes'])
 
-        expected = ['SELECT "test_new_api_partner".id FROM "test_new_api_partner" WHERE "test_new_api_partner".id IN %s']
-        with self.assertQueryCount(1, msg='Must read value from cache'), self.assertQueries(expected):
-            # still cost 1 SQL query to check existence because the ORM stores
-            # the raw SQL response in cache (not the result of convert_to_cache)
-            # so the value in cache is not verified (see models.py@_read)
+        with self.assertQueryCount(0, msg='Must read value from cache'):
             self.message_1.attributes
 
         expected = ['UPDATE "test_new_api_message" SET "attributes" = %s, "write_date" = %s, "write_uid" = %s WHERE id IN %s']
@@ -1034,7 +1059,7 @@ class PropertiesCase(TransactionCase):
 
         # change the definition record, change the definition and add default values
         self.assertEqual(message.discussion, self.discussion_2)
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(5):
             message.discussion = self.discussion_1
         self.assertEqual(
             self.discussion_1.attributes_definition,
@@ -1189,8 +1214,10 @@ class PropertiesCase(TransactionCase):
         """Check the access right related to the Properties fields."""
         MultiTag = type(self.env['test_new_api.multi.tag'])
 
-        def _mocked_check_access_rights(*args, **kwargs):
-            raise AccessError('')
+        def _mocked_check_access_rights(operation, raise_exception=True):
+            if raise_exception:
+                raise AccessError('')
+            return False
 
         # a user read a properties with a many2one to a record he doesn't have access to
         tag = self.env['test_new_api.multi.tag'].create({'name': 'Test Tag'})

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3702,7 +3702,7 @@ class PropertiesDefinition(Field):
     REQUIRED_KEYS = ('name', 'type')
     ALLOWED_KEYS = (
         'name', 'string', 'type', 'comodel', 'default',
-        'selection', 'tags', 'domain',
+        'selection', 'tags', 'domain', 'view_in_kanban',
     )
 
     def convert_to_column(self, value, record, values=None, validate=True):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3164,6 +3164,7 @@ class Properties(Field):
     column_type = ('jsonb', 'jsonb')
     copy = False
     prefetch = False
+    unaccent = True
     write_sequence = 10              # because it must be written after the definition field
 
     # the field is computed editable by design (see the compute method below)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3273,7 +3273,7 @@ class Properties(Field):
         if not value or not definition:
             return definition or []
 
-        assert isinstance(value, dict)
+        assert isinstance(value, dict), f"Wrong type {value!r}"
         value = self._dict_to_list(value, definition)
         self._parse_json_types(value, record.env)
 
@@ -3314,6 +3314,78 @@ class Properties(Field):
     def convert_to_onchange(self, value, record, names):
         self._add_display_name(value, record.env)
         return value
+
+    def read(self, records):
+        """Read everything needed in batch for the given records.
+
+        To retrieve relational properties names, or to check their existence,
+        we need to do some SQL queries. To reduce the number of queries when we read
+        in batch, we put in cache everything needed before calling
+        convert_to_record / convert_to_read.
+        """
+        definition_records_map = {
+            record: record[self.definition_record][self.definition_record_field]
+            for record in records
+        }
+
+        # ids per model we need to fetch in batch to put in cache
+        ids_per_model = defaultdict(OrderedSet)
+
+        cached_values = list(records.env.cache.get_values(records, self))
+
+        for record, values in zip(records, cached_values):
+            definition = definition_records_map.get(record)
+            if not values or not definition:
+                continue
+            for property_definition in definition:
+                comodel = property_definition.get('comodel')
+                type_ = property_definition.get('type')
+                name = property_definition.get('name')
+                if not comodel or type_ not in ('many2one', 'many2many') or name not in values:
+                    continue
+
+                default = property_definition.get('default') or []
+                value = values[name] or []
+
+                if type_ == 'many2one':
+                    default = [default] if default else []
+                    value = [value] if value else []
+
+                ids_per_model[comodel].update(default)
+                ids_per_model[comodel].update(value)
+
+        # check existence and pre-fetch in batch
+        existing_ids_per_model = {}
+        for model, ids in ids_per_model.items():
+            try:
+                rec = records.env[model].browse(ids).exists()
+                existing_ids_per_model[model] = rec.ids
+                # read a field to pre-fetch the recordset
+                rec._filter_access_rules('read').mapped('display_name')
+            except AccessError:
+                pass
+
+        # update the cache and remove non-existing ids
+        for record, values in zip(records, cached_values):
+            definition = definition_records_map.get(record)
+            if not values or not definition:
+                continue
+
+            for property_definition in definition:
+                comodel = property_definition.get('comodel')
+                type_ = property_definition.get('type')
+                name = property_definition.get('name')
+                if not comodel or type_ not in ('many2one', 'many2many') or not values.get(name):
+                    continue
+
+                value = values[name]
+
+                if type_ == 'many2one':
+                    values[name] = value if value in existing_ids_per_model[comodel] else False
+                else:
+                    values[name] = [id_ for id_ in value if id_ in existing_ids_per_model[comodel]]
+
+            records.env.cache.update(record, self, [values], check_dirty=False)
 
     def write(self, records, value):
         """Check if the properties definition has been changed.
@@ -3494,7 +3566,7 @@ class Properties(Field):
                     ]
 
     @classmethod
-    def _parse_json_types(cls, values_list, env, check_existence=True):
+    def _parse_json_types(cls, values_list, env):
         """Parse the value stored in the JSON.
 
         Check for records existence, if we removed a selection option, ...
@@ -3506,7 +3578,6 @@ class Properties(Field):
         for property_definition in values_list:
             property_value = property_definition.get('value')
             property_type = property_definition.get('type')
-            res_model = property_definition.get('comodel')
 
             if property_type not in cls.ALLOWED_TYPES:
                 raise ValueError(f'Wrong property type {property_type!r}')
@@ -3535,10 +3606,6 @@ class Properties(Field):
                 if not isinstance(property_value, int):
                     raise ValueError(f'Wrong many2one value: {property_value!r}.')
 
-                if check_existence and property_value:
-                    # many2one might have been deleted
-                    property_value = env[res_model].browse(property_value).exists().id
-
             elif property_type == 'many2many' and property_value:
                 if not is_list_of(property_value, int):
                     raise ValueError(f'Wrong many2many value: {property_value!r}.')
@@ -3546,10 +3613,6 @@ class Properties(Field):
                 if len(property_value) != len(set(property_value)):
                     # remove duplicated value and preserve order
                     property_value = list(dict.fromkeys(property_value))
-
-                elif check_existence and property_value:
-                    # many2many might have been deleted
-                    property_value = env[res_model].browse(property_value).exists().ids
 
             property_definition['value'] = property_value
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -71,6 +71,7 @@ _unlink = logging.getLogger(__name__ + '.unlink')
 
 regex_order = re.compile(r'^(\s*([a-z0-9:_]+|"[a-z0-9:_]+")(\.id)?(\s+(desc|asc))?\s*(,|$))+(?<!,)$', re.I)
 regex_object_name = re.compile(r'^[a-z0-9_.]+$')
+regex_alphanumeric = re.compile(r'^[a-z0-9]+$')
 regex_pg_name = re.compile(r'^[a-z_][a-z0-9_$]*$', re.I)
 regex_field_agg = re.compile(r'(\w+)(?::(\w+)(?:\((\w+)\))?)?')
 
@@ -120,6 +121,12 @@ def check_method_name(name):
     """ Raise an ``AccessError`` if ``name`` is a private method name. """
     if regex_private.match(name):
         raise AccessError(_('Private methods (such as %s) cannot be called remotely.', name))
+
+
+def check_property_name(property_name):
+    if not regex_alphanumeric.match(property_name):
+        raise ValueError(_("Wrong property name %r.", property_name))
+
 
 def fix_import_export_id_paths(fieldname):
     """
@@ -1871,7 +1878,7 @@ class BaseModel(metaclass=MetaModel):
         :rtype: list
         """
         return [
-            'context', 'currency_field', 'definition_record', 'digits', 'domain', 'group_operator', 'groups', 'help',
+            'context', 'currency_field', 'definition_record', 'definition_record_field', 'digits', 'domain', 'group_operator', 'groups', 'help',
             'name', 'readonly', 'related', 'relation', 'relation_field', 'required', 'searchable', 'selection', 'size',
             'sortable', 'store', 'string', 'translate', 'trim', 'type',
         ]

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3677,6 +3677,12 @@ class BaseModel(metaclass=MetaModel):
             if field.store and field.translate:
                 translated_field_names.append(field.name)
 
+            if field.type == 'properties':
+                # force calling fields.read for properties field because
+                # we want to read all relational properties in batch
+                # (and check their existence in batch as well)
+                other_fields.append(field)
+
         if column_fields:
             cr, context = self.env.cr, self.env.context
 

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -114,6 +114,7 @@ start the server specifying the ``--unaccent`` flag.
 
 """
 import collections.abc
+import json
 import logging
 import reprlib
 import traceback
@@ -123,7 +124,7 @@ from datetime import date, datetime, time
 from psycopg2.sql import Composable, SQL
 
 import odoo.modules
-from ..models import BaseModel
+from ..models import BaseModel, check_property_name
 from odoo.tools import pycompat, Query, _generate_table_alias
 
 
@@ -710,6 +711,44 @@ class expression(object):
                 query = comodel.with_context(**field.context)._where_calc(domain)
                 subquery, subparams = query.select('"%s"."%s"' % (comodel._table, field.inverse_name))
                 push(('id', 'inselect', (subquery, subparams)), model, alias, internal=True)
+
+            elif field.type == 'properties':
+                assert len(path) == 2 and "." not in path[1]
+                assert operator in ('=', '!=', '>', '>=', '<', '<=', 'in', 'not in', 'like', 'ilike', 'not like', 'not ilike'), \
+                    f"Wrong search operator {operator!r}"
+                check_property_name(path[1])
+
+                def _convert_json_type(value):
+                    if isinstance(value, str):
+                        return value
+                    elif isinstance(value, (int, float, bool)):
+                        return json.dumps(value)
+                    elif isinstance(right, (list, tuple)):
+                        return [_convert_json_type(r) for r in right]
+
+                    raise ValueError(f"Wrong value {value!r}.")
+
+                if 'like' in operator:
+                    right = f'%{pycompat.to_text(right)}%'
+                    unaccent = self._unaccent(field)
+                else:
+                    unaccent = lambda x: x
+
+                inverse = ''
+                if operator in ('in', 'not in'):
+                    if operator == 'not in':
+                        inverse = 'NOT'
+                    arrow = '->'  # raw value
+                    operator = '@>'
+                    right = json.dumps(right)
+                else:
+                    arrow = '->>'  # JSONified value
+                    right = _convert_json_type(right)
+
+                sql_path = f""""{alias}"."{path[0]}" {arrow} '{path[1]}'"""
+                expr = f"""({inverse} ({unaccent(sql_path)}) {operator} ({unaccent('%s')}))"""
+
+                push_result(expr, [right])
 
             elif len(path) > 1 and field.store and field.auto_join:
                 raise NotImplementedError('auto_join attribute not supported on field %s' % field)


### PR DESCRIPTION
Purpose
=======
Check the existence of the relational properties (many2one / many2many) in batch and prefetch the values in batch as well to reduce the number of SQL queries.

Allow to search properties.

Allow to add the properties field in the kanban view. An option has been added in the property definition, "View In Kanban", to decide which field must be visible in the kanban view.