### PR TITLE
[FIX] web: `FormView`, inner_group title margin

### DIFF
--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -14,9 +14,11 @@
 <t t-name="web.Form.InnerGroup" owl="1">
   <table t-attf-class="{{ allClasses }}" class="o_inner_group o_group" t-if="props.slots" t-att-style="props.style">
       <tbody>
-          <td t-if="props.slots.title" t-attf-colspan="{{ props.maxCols }}" style="width: 100%">
-              <t t-slot="title" />
-          </td>
+          <tr t-if="props.slots.title">
+            <td t-attf-colspan="{{ props.maxCols }}" style="width: 100%">
+                <t t-slot="title" />
+            </td>
+          </tr>
           <tr t-foreach="getRows()" t-as="row" t-key="row_index">
             <t t-foreach="row" t-as="cell" t-key="cell_index" >
 


### PR DESCRIPTION
Since commit https://github.com/odoo-dev/odoo/commit/8fa6e923d0fc8695d92e0b114e230d3abab7d9bc, the
`o_horizontal_separator` no longer has a right margin and did not have
enough space between each `o_inner_group`.

This commit fixes this issue.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
