### PR TITLE
[IMP] hr_expense: allow default for the company journal

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -848,8 +848,12 @@ class HrExpenseSheet(models.Model):
 
     @api.model
     def _default_bank_journal_id(self):
+        company_journal_id = self.env.company.company_expense_journal_id
+        if company_journal_id:
+            return company_journal_id
         default_company_id = self.default_get(['company_id'])['company_id']
-        return self.env['account.journal'].search([('type', 'in', ['cash', 'bank']), ('company_id', '=', default_company_id)], limit=1)
+        journal = self.env['account.journal'].search([('type', 'in', ['cash', 'bank']), ('company_id', '=', default_company_id)], limit=1)
+        return journal
 
     name = fields.Char('Expense Report Summary', required=True, tracking=True)
     expense_line_ids = fields.One2many('hr.expense', 'sheet_id', string='Expense Lines', copy=False)

--- a/addons/hr_expense/models/res_company.py
+++ b/addons/hr_expense/models/res_company.py
@@ -2,8 +2,21 @@
 
 from odoo import fields, models
 
+
 class ResCompany(models.Model):
     _inherit = "res.company"
 
-    expense_journal_id = fields.Many2one('account.journal', string='Default Expense Journal', check_company=True, domain="[('type', '=', 'purchase'), ('company_id', '=', company_id)]",
-        help="The Default journal for the company used when the expense is done.")
+    expense_journal_id = fields.Many2one(
+        "account.journal",
+        string="Default Expense Journal",
+        check_company=True,
+        domain="[('type', '=', 'purchase'), ('company_id', '=', company_id)]",
+        help="The company's default journal used when an employee expense is created.",
+    )
+    company_expense_journal_id = fields.Many2one(
+        "account.journal",
+        string="Default Company Expense Journal",
+        check_company=True,
+        domain="[('type', 'in', ['cash', 'bank']), ('company_id', '=', company_id)]",
+        help="The company's default journal used when a company expense is created.",
+    )

--- a/addons/hr_expense/models/res_config_settings.py
+++ b/addons/hr_expense/models/res_config_settings.py
@@ -17,6 +17,7 @@ class ResConfigSettings(models.TransientModel):
     module_hr_payroll_expense = fields.Boolean(string='Reimburse Expenses in Payslip')
     module_hr_expense_extract = fields.Boolean(string='Send bills to OCR to generate expenses')
     expense_journal_id = fields.Many2one('account.journal', related='company_id.expense_journal_id', readonly=False)
+    company_expense_journal_id = fields.Many2one('account.journal', related='company_id.company_expense_journal_id', readonly=False)
 
     @api.model
     def get_values(self):

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -61,19 +61,31 @@
                                 </div>   
                             </div>
                         </div>
-                        <h2>Default Expense Journal</h2>
+                        <h2>Default Journals</h2>
                         <div class="row mt16 o_settings_container">
                             <div class="col-12 col-lg-6 o_setting_box">
                                 <div class="o_setting_left_pane"></div>
                                 <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Expense Journal</span>
+                                    <span class="o_form_label">Employee Expense Journal</span>
                                     <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
                                     <div class="text-muted">
                                         Default accounting journal for expenses paid by employees.
                                     </div>
                                     <div class="row mt8">
-                                        <label for="expense_journal_id" class="col-lg-2 o_light_label" string="Journal"/>
                                         <field name="expense_journal_id"/>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane"></div>
+                                <div class="o_setting_right_pane">
+                                    <span class="o_form_label">Company Expense Journal</span>
+                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                    <div class="text-muted">
+                                        Default accounting journal for expenses paid by the company.
+                                    </div>
+                                    <div class="row mt8">
+                                        <field name="company_expense_journal_id"/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Revision 26a5653f48016d20f4bf050051a0844a760e4470 introduced the possibility to set up a default journal for accounting entries created by "employee-paid" expenses

This commit adds the same possibility for the "company-paid" expenses (because why allow it for one and not the other?).