### PR TITLE
[FIX] l10n_in_edi: correct reference of tag_ids

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -434,19 +434,19 @@ class AccountEdiFormat(models.Model):
             tags = tax_values['tax_repartition_line'].tag_ids
             line_code = "other"
             if not invl.currency_id.is_zero(tax_values['tax_amount_currency']):
-                if any(tag in tags for tag in self.env.ref("l10n_in.tax_report_line_cess").sudo().tag_ids):
+                if any(tag in tags for tag in self.env.ref("l10n_in.tax_tag_cess").sudo()):
                     if tax.amount_type != "percent":
                         line_code = "cess_non_advol"
                     else:
                         line_code = "cess"
-                elif any(tag in tags for tag in self.env.ref("l10n_in.tax_report_line_state_cess").sudo().tag_ids):
+                elif any(tag in tags for tag in self.env.ref("l10n_in.tax_tag_state_cess").sudo()):
                     if tax.amount_type != "percent":
                         line_code = "state_cess_non_advol"
                     else:
                         line_code = "state_cess"
                 else:
                     for gst in ["cgst", "sgst", "igst"]:
-                        if any(tag in tags for tag in self.env.ref("l10n_in.tax_report_line_%s"%(gst)).sudo().tag_ids):
+                        if any(tag in tags for tag in self.env.ref("l10n_in.tax_tag_%s"%(gst)).sudo()):
                             line_code = gst
             return {
                 "tax": tax,

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -58,7 +58,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
         cls.invoice_zero_qty.action_post()
 
     def test_edi_json(self):
-        # json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice)
+        json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice)
         expected = {
             "Version": "1.1",
             "TranDtls": {"TaxSch": "GST", "SupTyp": "B2B", "RegRev": "N", "IgstOnIntra": "N"},
@@ -101,7 +101,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
                 "StCesVal": 0.0, "RndOffAmt": 0.0, "TotInvVal": 1999.59
             }
         }
-        # self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
+        self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
 
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_full_discount)


### PR DESCRIPTION
Before this commit
==============

before this commit it will raise the error when submit EDI because tax report line does not exist and it will be removed from this PR https://github.com/odoo/odoo/pull/99401

After this commit
==============

no error will be raise and it will get related tag_ids

PR: #99994

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
