### PR TITLE
[FIX] web: x2many: send field context to x2many dialogs

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -1506,7 +1506,7 @@ var BasicModel = AbstractModel.extend({
         var makeDefaultRecords = [];
         if (additionalContexts){
             _.each(additionalContexts, function (context) {
-                params.context = self._getContext(list, {additionalContext: context, sanitize_default_values: true});
+                params.context = self._getContext(list, {additionalContext: context, full: true, sanitize_default_values: true});
                 makeDefaultRecords.push(self._makeDefaultRecord(list.model, params));
             });
         } else {

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -215,9 +215,7 @@ export class X2ManyField extends Component {
     async onAdd({ context, editable } = {}) {
         const record = this.props.record;
         const domain = record.getFieldDomain(this.props.name).toList();
-        if (context) {
-            context = makeContext([record.getFieldContext(this.props.name), context]);
-        }
+        context = makeContext([record.getFieldContext(this.props.name), context]);
         if (this.isMany2Many) {
             return this.selectCreate({ domain, context });
         }

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -2570,6 +2570,38 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
+    QUnit.test("add record in a one2many non editable list with context", async function (assert) {
+        assert.expect(1);
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="int_field"/>
+                    <field name="turtles" context="{'abc': int_field}">
+                        <tree><field name="display_name"/></tree>
+                        <form><field name="display_name"/></form>
+                    </field>
+                </form>`,
+            mockRPC(route, args) {
+                if (args.method === "onchange" && args.model === "turtle") {
+                    // done by the X2ManyFieldDialog
+                    assert.deepEqual(args.kwargs.context, {
+                        abc: 2,
+                        lang: "en",
+                        tz: "taht",
+                        uid: 7,
+                    });
+                }
+            },
+        });
+
+        await editInput(target, ".o_field_widget[name=int_field] input", "2");
+        await click(target.querySelector(".o_field_x2many_list_row_add a"));
+    });
+
     QUnit.test(
         "edition of one2many field, with onchange and not inline sub view",
         async function (assert) {


### PR DESCRIPTION
Have a x2ManyField displayed as a (non-editable) list view, and
with a context defined on the x2m field node in the arch. Before
this commit, this context wasn't propagated to the dialog opened,
for instance, when adding a new record. It is now the case.

To make the tests pass, we also needed to make a slight change in
the BasicModel, as it didn't correctly process the context when
adding a new record with additional contexts (e.g. in x2many list
views with custom `<creates>`.