### PR TITLE
[FIX] website_sale_picking: fix access error as public user

### DIFF
--- a/addons/website_sale_picking/controllers/main.py
+++ b/addons/website_sale_picking/controllers/main.py
@@ -15,7 +15,7 @@ class PaymentPortalOnsite(PaymentPortal):
         Also sets the sale order's warehouse id to the carrier's if it exists
         """
         super()._validate_transaction_for_order(transaction, sale_order_id)
-        sale_order = request.env['sale.order'].browse(sale_order_id).exists()
+        sale_order = request.env['sale.order'].browse(sale_order_id).exists().sudo()
 
         # This should never be triggered unless the user intentionally forges a request.
         if sale_order.carrier_id.delivery_type != 'onsite' and (


### PR DESCRIPTION
When selecting on site picking and/or onsite payment the public user was presented with an access error while it shouldn't.
