### PR TITLE
[FIX] web: legacy fields

### DIFF
--- a/addons/web/static/src/legacy/legacy_fields.js
+++ b/addons/web/static/src/legacy/legacy_fields.js
@@ -109,7 +109,7 @@ class FieldAdapter extends ComponentAdapter {
             const proms = [];
             for (const fieldName in payload.changes) {
                 let value = payload.changes[fieldName];
-                const fieldType = record.fields[name].type;
+                const fieldType = record.fields[fieldName].type;
                 if (fieldType === "many2one" && value) {
                     value = [value.id, value.display_name];
                 } else if (fieldType === "one2many" || fieldType === "many2many") {


### PR DESCRIPTION
If the source field widget emitting a field_changed event is a m2o, the field changes of the event will all be considered as changes targeting a m2o and converted accordingly, resulting in server errors because the `onchange` call received a [None, None] value for a standard field (e.g. float).


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
