### PR TITLE
[FIX] mrp_workorder, sign: missing styles for the pdf_viewer

### DIFF
--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -555,7 +555,7 @@
     }
 
     // PDF Viewer
-    &.o_field_pdfviewer, .o_pdfview_iframe {
+    &.o_field_pdfviewer, &.o_field_pdf_viewer .o_pdfview_iframe {
         width: 100%;
         height: 450px;
         border: 0;


### PR DESCRIPTION
The class for the pdf_viewer field changed from `o_field_pdfviewer` to `o_field_pdf_viewer`