### PR TITLE
[FIX] web: kanban grouped by date: display None if not set

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -257,12 +257,17 @@ export class KanbanRenderer extends Component {
 
     getGroupName({ groupByField, count, displayName, isFolded }) {
         let name = displayName;
-        if (isNull(name)) {
-            name = this.env._t("None");
-        } else if (isRelational(groupByField)) {
-            name = name || this.env._t("None");
-        } else if (groupByField.type === "boolean") {
+        if (groupByField.type === "boolean") {
             name = name ? this.env._t("Yes") : this.env._t("No");
+        } else if (!name) {
+            if (
+                isRelational(groupByField) ||
+                groupByField.type === "date" ||
+                groupByField.type === "datetime" ||
+                isNull(name)
+            ) {
+                name = this.env._t("None");
+            }
         }
         return !this.env.isSmall && isFolded ? `${name} (${count})` : name;
     }

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -626,6 +626,29 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
+    QUnit.test("kanban grouped by date field", async (assert) => {
+        serverData.models.partner.records[0].date = "2007-06-10";
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban>
+                    <field name="date"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="foo"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["date"],
+        });
+
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_column_title")), [
+            "None",
+            "June 2007",
+        ]);
+    });
     QUnit.test("context can be used in kanban template", async (assert) => {
         await makeView({
             type: "kanban",


### PR DESCRIPTION
Before this commit, `false` was displayed as column title in kanban views grouped by date(time) fields, for the column containing records with unset value. When grouped by relational and date(time) fields, we expect `None` to be displayed. This commit restores the legacy behavior.
