### PR TITLE
[IMP] website, *: review website tour utils

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -22,7 +22,7 @@ const wTourUtils = require('website.tour_utils');
  * -> ensure it was deleted
  */
 
-wTourUtils.registerEditionTour('test_custom_snippet', {
+wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
     url: '/',
     edition: true,
     test: true,

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -18,7 +18,7 @@ const selectImageSteps = [{
     trigger: "iframe #wrapwrap .s_text_image img",
 }];
 
-wTourUtils.registerEditionTour('test_image_link', {
+wTourUtils.registerWebsitePreviewTour('test_image_link', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -60,7 +60,7 @@ const setupSteps = [{
 
 const formatErrorMsg = "format is not supported. Try with: .gif, .jpe, .jpeg, .jpg, .png, .svg";
 
-wTourUtils.registerEditionTour('test_image_upload_progress', {
+wTourUtils.registerWebsitePreviewTour('test_image_upload_progress', {
     url: '/test_image_progress',
     test: true,
     edition: true,
@@ -202,7 +202,7 @@ wTourUtils.registerEditionTour('test_image_upload_progress', {
 ]);
 
 
-wTourUtils.registerEditionTour('test_image_upload_progress_unsplash', {
+wTourUtils.registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
     url: '/test_image_progress',
     test: true,
     edition: true,

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -9,7 +9,7 @@ const VIDEO_URL = 'https://www.youtube.com/watch?v=Dpq87YCHmJc';
 /**
  * The purpose of this tour is to check the media replacement flow.
  */
-wTourUtils.registerEditionTour('test_replace_media', {
+wTourUtils.registerWebsitePreviewTour('test_replace_media', {
     url: '/',
     test: true,
 }, [

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -13,7 +13,7 @@ var BROKEN_STEP = {
     trigger: 'body',
     run: function () {}
 };
-wTourUtils.registerEditionTour('test_reset_page_view_complete_flow_part1', {
+wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part1', {
     test: true,
     url: '/test_page_view',
     // 1. Edit the page through Edit Mode, it will COW the view
@@ -57,7 +57,7 @@ wTourUtils.registerEditionTour('test_reset_page_view_complete_flow_part1', {
     ]
 );
 
-wTourUtils.registerEditionTour('test_reset_page_view_complete_flow_part2', {
+wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2', {
     test: true,
     url: '/test_page_view',
 },

--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -3,7 +3,7 @@ odoo.define('website.tour.automatic_editor', function (require) {
 
 const wTourUtils = require("website.tour_utils");
 
-wTourUtils.registerEditionTour('automatic_editor_on_new_website', {
+wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
     test: true,
     url: '/',
 },

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour("carousel_content_removal", {
+wTourUtils.registerWebsitePreviewTour("carousel_content_removal", {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -1,10 +1,10 @@
 /** @odoo-module */
 
-import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
 
-tour.register('client_action_iframe_fallback', {
+wTourUtils.registerWebsitePreviewTour('client_action_iframe_fallback', {
     test: true,
-    url: '/@/',
+    url: '/',
 },
 [
     {

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -8,7 +8,7 @@ const snippets = [
         name: 'Text - Image',
     },
 ];
-wTourUtils.registerEditionTour('conditional_visibility_1', {
+wTourUtils.registerWebsitePreviewTour('conditional_visibility_1', {
     edition: true,
     url: '/',
     test: true,

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -3,7 +3,7 @@ odoo.define("website.tour.default_shape_gets_palette_colors", function (require)
 
 const wTourUtils = require('website.tour_utils');
 
-wTourUtils.registerEditionTour("default_shape_gets_palette_colors", {
+wTourUtils.registerWebsitePreviewTour("default_shape_gets_palette_colors", {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -24,7 +24,7 @@ const clickEditLink = [{
     in_modal: false,
 }];
 
-wTourUtils.registerEditionTour('edit_link_popover', {
+wTourUtils.registerWebsitePreviewTour('edit_link_popover', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -15,7 +15,7 @@ const toggleMegaMenu = (stepOptions) => Object.assign({}, {
     },
 }, stepOptions);
 
-wTourUtils.registerEditionTour('edit_megamenu', {
+wTourUtils.registerWebsitePreviewTour('edit_megamenu', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('edit_menus', {
+wTourUtils.registerWebsitePreviewTour('edit_menus', {
     test: true,
     url: '/',
 }, [

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('website_gray_color_palette', {
+wTourUtils.registerWebsitePreviewTour('website_gray_color_palette', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -7,7 +7,7 @@ const wTourUtils = require('website.tour_utils');
 const adminCssModif = '#wrap {display: none;}';
 const demoCssModif = '// demo_edition';
 
-wTourUtils.registerEditionTour('html_editor_multiple_templates', {
+wTourUtils.registerWebsitePreviewTour('html_editor_multiple_templates', {
     url: '/generic',
     edition: true,
     test: true,
@@ -68,7 +68,7 @@ wTourUtils.registerEditionTour('html_editor_multiple_templates', {
     ]
 );
 
-wTourUtils.registerEditionTour('test_html_editor_scss', {
+wTourUtils.registerWebsitePreviewTour('test_html_editor_scss', {
     url: '/contactus',
     test: true,
 },
@@ -154,7 +154,7 @@ wTourUtils.registerEditionTour('test_html_editor_scss', {
     ]
 );
 
-wTourUtils.registerEditionTour('test_html_editor_scss_2', {
+wTourUtils.registerWebsitePreviewTour('test_html_editor_scss_2', {
     url: '/',
     test: true,
 },

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -7,7 +7,7 @@ const clickOnImgStep = {
     trigger: 'iframe #wrap .s_text_image img',
 };
 
-wTourUtils.registerEditionTour('link_tools', {
+wTourUtils.registerWebsitePreviewTour('link_tools', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/restricted_editor.js
+++ b/addons/website/static/tests/tours/restricted_editor.js
@@ -3,7 +3,7 @@ odoo.define("website.tour.restricted_editor", function (require) {
 
 var wTourUtils = require("website.tour_utils");
 
-wTourUtils.registerEditionTour("restricted_editor", {
+wTourUtils.registerWebsitePreviewTour("restricted_editor", {
     test: true,
     url: "/",
 }, [{

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -10,7 +10,7 @@ var domReady = new Promise(function (resolve) {
 });
 var ready = Promise.all([domReady, session.is_bound, ajax.loadXML()]);
 
-wTourUtils.registerEditionTour('rte_translator', {
+wTourUtils.registerWebsitePreviewTour('rte_translator', {
     test: true,
     url: '/',
     wait_for: ready,

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -90,7 +90,7 @@ function updateAndCheckCustomGradient({updateStep, checkGradient}) {
     return steps;
 }
 
-wTourUtils.registerEditionTour('snippet_background_edition', {
+wTourUtils.registerWebsitePreviewTour('snippet_background_edition', {
     url: '/',
     edition: true,
     test: true,

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('snippet_countdown', {
+wTourUtils.registerWebsitePreviewTour('snippet_countdown', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('snippet_editor_panel_options', {
+wTourUtils.registerWebsitePreviewTour('snippet_editor_panel_options', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -10,7 +10,7 @@ function removeSelectedBlock() {
     };
 }
 
-wTourUtils.registerEditionTour('snippet_empty_parent_autoremove', {
+wTourUtils.registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('snippet_image_gallery', {
+wTourUtils.registerWebsitePreviewTour('snippet_image_gallery', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('snippet_popup_add_remove', {
+wTourUtils.registerWebsitePreviewTour('snippet_popup_add_remove', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -29,7 +29,7 @@ const addNewSocialNetwork = function (optionIndex, linkIndex, url) {
     }];
 };
 
-wTourUtils.registerEditionTour('snippet_social_media', {
+wTourUtils.registerWebsitePreviewTour('snippet_social_media', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -3,7 +3,7 @@ odoo.define("website.tour.snippet_version", function (require) {
 
 const wTourUtils = require('website.tour_utils');
 
-wTourUtils.registerEditionTour("snippet_version", {
+wTourUtils.registerWebsitePreviewTour("snippet_version", {
     edition: true,
     url: "/",
     test: true,

--- a/addons/website/static/tests/tours/start_cloned_snippet.js
+++ b/addons/website/static/tests/tours/start_cloned_snippet.js
@@ -9,7 +9,7 @@ const countdownSnippet = {
 const dragNDropOutOfFooter = wTourUtils.dragNDrop(countdownSnippet);
 dragNDropOutOfFooter.run = 'drag_and_drop iframe #wrapwrap #wrap';
 
-wTourUtils.registerEditionTour('website_start_cloned_snippet', {
+wTourUtils.registerWebsitePreviewTour('website_start_cloned_snippet', {
     edition: true,
     test: true,
     url: '/',

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -85,7 +85,7 @@ odoo.define('website.tour.form_editor', function (require) {
         return addField(`data-existing-field="${name}"`, name, type, label, required, display);
     };
 
-    wTourUtils.registerEditionTour("website_form_editor_tour", {
+    wTourUtils.registerWebsitePreviewTour("website_form_editor_tour", {
         url: '/',
         edition: true,
         test: true,
@@ -390,7 +390,7 @@ odoo.define('website.tour.form_editor', function (require) {
         ];
     }
 
-    wTourUtils.registerEditionTour('website_form_contactus_edition_with_email', {
+    wTourUtils.registerWebsitePreviewTour('website_form_contactus_edition_with_email', {
         url: '/contactus',
         edition: true,
         test: true,
@@ -401,7 +401,7 @@ odoo.define('website.tour.form_editor', function (require) {
             run: 'text test@test.test',
         },
     ]));
-    wTourUtils.registerEditionTour('website_form_contactus_edition_no_email', {
+    wTourUtils.registerWebsitePreviewTour('website_form_contactus_edition_no_email', {
         url: '/contactus',
         edition: true,
         test: true,

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('website_page_options', {
+wTourUtils.registerWebsitePreviewTour('website_page_options', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -5,7 +5,7 @@ const wTourUtils = require("website.tour_utils");
 
 const TARGET_FONT_SIZE = 30;
 
-wTourUtils.registerEditionTour("website_style_edition", {
+wTourUtils.registerWebsitePreviewTour("website_style_edition", {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -5,7 +5,7 @@ odoo.define("website_blog.tour", function (require) {
     const {Markup} = require('web.utils');
     const wTourUtils = require('website.tour_utils');
 
-    wTourUtils.registerEditionTour("blog", {
+    wTourUtils.registerWebsitePreviewTour("blog", {
         url: "/",
     }, [{
         trigger: "body:not(:has(#o_new_content_menu_choices)) .o_new_content_container > a",

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -4,7 +4,7 @@ odoo.define('website_crm.tour', function(require) {
     const tour = require('web_tour.tour');
     const wTourUtils = require('website.tour_utils');
 
-    wTourUtils.registerEditionTour('website_crm_pre_tour', {
+    wTourUtils.registerWebsitePreviewTour('website_crm_pre_tour', {
         test: true,
         url: '/contactus',
         edition: true,

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -7,7 +7,7 @@ odoo.define("website_event.tour", function (require) {
     const wTourUtils = require('website.tour_utils');
 
 
-    wTourUtils.registerEditionTour("website_event_tour", {
+    wTourUtils.registerWebsitePreviewTour("website_event_tour", {
         test: true,
         url: "/",
     }, [{

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -6,8 +6,7 @@ odoo.define("website_forum.tour_forum", function (require) {
 
     var _t = core._t;
 
-    wTourUtils.registerBackendAndFrontend("question", {
-        // url: wTourUtils.getClientActionUrl('/forum/1'),
+    wTourUtils.registerBackendAndFrontendTour("question", {
         url: '/forum/1',
     }, [{
         trigger: ".o_forum_ask_btn",

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -61,7 +61,7 @@ odoo.define('website_hr_recruitment.tour', function(require) {
         }),
     ]);
 
-    wTourUtils.registerEditionTour('website_hr_recruitment_tour_edit_form', {
+    wTourUtils.registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
         test: true,
         url: '/jobs',
     }, [{

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('newsletter_block_edition', {
+wTourUtils.registerWebsitePreviewTour('newsletter_block_edition', {
     test: true,
     url: '/',
     edition: true,

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -5,7 +5,7 @@ odoo.define("website_sale.tour_shop", function (require) {
     const {Markup} = require('web.utils');
     const wTourUtils = require("website.tour_utils");
 
-    wTourUtils.registerEditionTour("shop", {
+    wTourUtils.registerWebsitePreviewTour("shop", {
         url: '/shop',
         sequence: 130,
     }, [{

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -10,7 +10,7 @@ function editAddToCartSnippet() {
     ]
 }
 
-wTourUtils.registerEditionTour('add_to_cart_snippet_tour', {
+wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         url: '/',
         edition: true,
         test: true,

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
@@ -2,7 +2,7 @@
 
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('website_sale_tour_backend', {
+wTourUtils.registerWebsitePreviewTour('website_sale_tour_backend', {
     test: true,
     url: '/shop/cart',
     edition: true,

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -3,7 +3,7 @@
 import tourUtils from 'website_sale.tour_utils';
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('shop_customize', {
+wTourUtils.registerWebsitePreviewTour('shop_customize', {
     url: '/shop',
     edition: true,
     test: true,

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -3,7 +3,7 @@
 import tourUtils from 'website_sale.tour_utils';
 import wTourUtils from 'website.tour_utils';
 
-wTourUtils.registerEditionTour('shop_list_view_b2c', {
+wTourUtils.registerWebsitePreviewTour('shop_list_view_b2c', {
     test: true,
     url: '/shop?search=Test Product',
 },

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
@@ -3,7 +3,7 @@ odoo.define('website_sale_wishlist_admin.tour', function (require) {
 
 const wTourUtils = require("website.tour_utils");
 
-wTourUtils.registerEditionTour('shop_wishlist_admin', {
+wTourUtils.registerWebsitePreviewTour('shop_wishlist_admin', {
     url: '/shop?search=Rock',
     test: true,
 },

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -10,7 +10,7 @@ import wTourUtils from 'website.tour_utils';
  * they create some lessons in it;
  * they publish it;
  */
-wTourUtils.registerEditionTour('course_publisher_standard', {
+wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
     url: '/slides',
     test: true,
 }, [{

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -10,7 +10,7 @@ import slidesTourTools from '@website_slides/../tests/tours/slides_tour_tools';
  * they create some lessons in it;
  * they publishe it;
  */
-wTourUtils.registerEditionTour('course_publisher', {
+wTourUtils.registerWebsitePreviewTour('course_publisher', {
     // TODO: replace by wTourUtils.getClientActionURL when it's added
     url: '/slides',
     test: true

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -12,7 +12,7 @@ import wTourUtils from 'website.tour_utils';
  * See "Fullscreen#_onWebEditorClick" for more information.
  *
  */
- wTourUtils.registerEditionTour('full_screen_web_editor', {
+ wTourUtils.registerWebsitePreviewTour('full_screen_web_editor', {
     url: '/slides',
     test: true,
 }, [{


### PR DESCRIPTION
*: test_website, website_blog, website_crm, website_event,
   website_forum, website_hr_recruitment, website_mass_mailing,
   website_sale, website_sale_wishlist, website_slides

- Make sure that all website tours reaching the website preview before their first step use the related website util to register their tour.

- Rename the website util to register a tour starting on the website preview from `registerEditionTour` to `registerWebsitePreviewTour`. Having a method using "Edition" in its name and having a boolean parameter named `edition` was a bit... strange.

- For both non edit mode and edit mode as a first step, ensure the util sets a high timeout for the first step. Indeed loading both the backend and the frontend (in the iframe) and potentially starting the edit mode can take a long time in automatic tests. We'll try and decrease the need for this high timeout of course.

- Review the implementation of those utils to be more consistent and also fix one or two mistakes in them.
