### PR TITLE
[IMP] hr_contract: add DISTINCT to hr_contract_history query

### DIFF
--- a/addons/hr_contract/report/hr_contract_history.py
+++ b/addons/hr_contract/report/hr_contract_history.py
@@ -99,13 +99,13 @@ class ContractHistory(models.Model):
                     RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                 )
             )
-            SELECT     employee.id AS id,
-                       employee.id AS employee_id,
-                       employee.active AS active_employee,
-                       contract.id AS contract_id,
-                       contract_information.is_under_contract::bool AS is_under_contract,
-                       employee.first_contract_date AS date_hired,
-                       %s
+            SELECT DISTINCT employee.id AS id,
+                            employee.id AS employee_id,
+                            employee.active AS active_employee,
+                            contract.id AS contract_id,
+                            contract_information.is_under_contract::bool AS is_under_contract,
+                            employee.first_contract_date AS date_hired,
+                            %s
             FROM       hr_contract AS contract
             INNER JOIN contract_information ON contract.id = contract_information.id
             RIGHT JOIN hr_employee AS employee


### PR DESCRIPTION
Following https://github.com/odoo/enterprise/pull/31202, it happens that the query for the contract history returns several times the same id if the employee has several contracts.

This commit fixes it by adding a DISTINCT to the SQL query so that ID returned are unique.

task-2974531

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
