### PR TITLE
[FIX] account: settings view: set invisible on correct node

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -24,8 +24,8 @@
                         <field name="has_chart_of_accounts" invisible="1"/>
                         <field name="has_accounting_entries" invisible="1"/>
                         <h2 attrs="{'invisible': [('has_accounting_entries','!=',False)]}">Fiscal Localization</h2>
-                        <div class="row mt16 o_settings_container" name="fiscal_localization_setting_container">
-                            <div class="col-12 o_setting_box" attrs="{'invisible': [('has_accounting_entries','!=',False)]}">
+                        <div class="row mt16 o_settings_container" name="fiscal_localization_setting_container" attrs="{'invisible': [('has_accounting_entries','!=',False)]}">
+                            <div class="col-12 o_setting_box">
                                 <div class="o_setting_left_pane"/>
                                 <div class="o_setting_right_pane">
                                     <span class="o_form_label">Fiscal Localization</span>


### PR DESCRIPTION
Before this commit, the title of the container "Fiscal Localization" was always displayed, even though it has an invisible modifier. The reason is that the container was never hidden (it always contained at least an empty div), because the corresponding modifier was set on a child in the container (its unique child). This commit fixes the issue by moving the modifier to the container itself. Note that it also prevents from having an empty div in the DOM.

