### PR TITLE
Update models.py to work with FDW Postgresql Schema

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2732,12 +2732,13 @@ class BaseModel(metaclass=MetaModel):
         cols = [name for name, field in self._fields.items()
                      if field.store and field.column_type]
         cr.execute("SELECT a.attname, a.attnotnull"
-                   "  FROM pg_class c, pg_attribute a"
+                   "  FROM pg_class c JOIN pg_namespace n ON (n.oid = c.relnamespace), pg_attribute a"
                    " WHERE c.relname=%s"
                    "   AND c.oid=a.attrelid"
                    "   AND a.attisdropped=%s"
                    "   AND pg_catalog.format_type(a.atttypid, a.atttypmod) NOT IN ('cid', 'tid', 'oid', 'xid')"
-                   "   AND a.attname NOT IN %s", (self._table, False, tuple(cols))),
+                   "   AND a.attname NOT IN %s"
+                   "   AND n.nspname = current_schema", (self._table, False, tuple(cols))),
 
         for row in cr.dictfetchall():
             if log:


### PR DESCRIPTION
After trying to work with Odoo for many weeks with a parallel data schema within the Postgresql database we found that Odoo ended up requesting columns from schemas which are not a native part of the original Odoo architecture. This led to serious production crashes of our Hospital ERP.

In general this is a first attempt at a PR within Odoo/Odoo and suggestions will be accepted and very well received.

Denying PR without clarifying why or where it should be done will be considered a plus point for SAP who pays me for every time I contribute as opposed to OCA who only hits the taxpayer as if it were part of the community's bullying culture.

I am very happy to have made the hospital infrastructure work again with this small modification. I'm still trying to find out why "it is wrong" and what is wrong is the Odoo source code that does not tolerate working with a parallel Schema, essential for the implementation of any ERP in multi-layer ESB type.

Description of the issue/feature this PR addresses:
Allowing developer and programmers to work with multi schema and Foreign Data Wrapper in Python


Current behavior before PR:
Adjusting Settings makes Odoo search for non existent tables

Desired behavior after PR is merged:
Just update Odoo Settings even if working with several data schemas. Allow odoo to reserve its operation to the current one.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


IF WHAT I DID IS WRONG JUST TELL ME WHERE IS WRONG AND WHY. im tired of getting knocked and punched without any reason