### PR TITLE
[FIX] web: SelectCreateDialog: remove padding

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -34,7 +34,7 @@ tour.register('hr_skills_tour', {
     },
     {
         content: "Enter some company name",
-        trigger: ".o_form_view_dialog .o_field_widget[name='name'] input",
+        trigger: ".modal-body .o_field_widget[name='name'] input",
         run: "text Mamie Rock",
     },
     {

--- a/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
@@ -443,16 +443,16 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
     // add an other existing tag
     await selectDropdownItem(document.body, 'partner_ids', "silver");
 
-    assert.strictEqual(document.querySelectorAll('.modal-content.o_form_view_dialog').length, 1,
+    assert.strictEqual(document.querySelectorAll('.modal-content .o_form_view').length, 1,
         "there should be one modal opened to edit the empty email");
-    assert.strictEqual(document.querySelector(".modal-content.o_form_view_dialog .o_input#name").value, "silver",
+    assert.strictEqual(document.querySelector(".modal-content .o_form_view .o_input#name").value, "silver",
         "the opened modal in edit mode should be a form view dialog with the res.partner 14");
-    assert.strictEqual(document.querySelectorAll(".modal-content.o_form_view_dialog .o_input#email").length, 1,
+    assert.strictEqual(document.querySelectorAll(".modal-content .o_form_view .o_input#email").length, 1,
         "there should be an email field in the modal");
 
     // set the email and save the modal (will rerender the form view)
-    await testUtils.fields.editInput($('.modal-content.o_form_view_dialog .o_input#email'), 'coucou@petite.perruche');
-    await testUtils.dom.click($('.modal-content.o_form_view_dialog .o_form_button_save'));
+    await testUtils.fields.editInput($('.modal-content .o_form_view .o_input#email'), 'coucou@petite.perruche');
+    await testUtils.dom.click($('.modal-content .o_form_button_save'));
 
     assert.containsN(document.body, '.o_field_many2many_tags_email[name="partner_ids"] .badge.o_tag_color_0', 2,
         "should contain the second tag");

--- a/addons/survey/static/tests/components/description_page_field_tests.js
+++ b/addons/survey/static/tests/components/description_page_field_tests.js
@@ -81,10 +81,10 @@ QUnit.module("DescriptionPageField", (hooks) => {
             await clickEdit(target);
             await click(target.querySelector(".o_data_cell"));
             assert.containsOnce(target.querySelector(".o_data_row"), "button.o_icon_button");
-            assert.containsNone(target, ".modal .o_form_view_dialog");
+            assert.containsNone(target, ".modal .o_form_view");
 
             await click(target, "button.o_icon_button");
-            assert.containsOnce(target, ".modal .o_form_view_dialog");
+            assert.containsOnce(target, ".modal .o_form_view");
         }
     );
 });

--- a/addons/survey/static/tests/components/question_page_one2many_field_tests.js
+++ b/addons/survey/static/tests/components/question_page_one2many_field_tests.js
@@ -111,7 +111,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
         });
         await click(target.querySelector(".o_data_cell"));
         assert.containsNone(target, ".o_selected_row");
-        assert.containsOnce(target, ".modal .o_form_view_dialog");
+        assert.containsOnce(target, ".modal .o_form_view");
     });
 
     QUnit.test("click on section edit the section in place", async (assert) => {
@@ -134,7 +134,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
         await clickEdit(target);
         await click(target.querySelector(".o_data_cell"));
         assert.hasClass(target.querySelector(".o_is_section"), "o_selected_row");
-        assert.containsNone(target, ".modal .o_form_view_dialog");
+        assert.containsNone(target, ".modal .o_form_view");
     });
 
     QUnit.test("click on real line opens a dialog", async (assert) => {
@@ -158,7 +158,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
         await clickEdit(target);
         await click(target.querySelector(".o_data_row:nth-child(2) .o_data_cell"));
         assert.containsNone(target, ".o_selected_row");
-        assert.containsOnce(target, ".modal .o_form_view_dialog");
+        assert.containsOnce(target, ".modal .o_form_view");
     });
 
     QUnit.test("can create section inline", async (assert) => {
@@ -189,7 +189,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
 
         await click(target.querySelectorAll(".o_field_x2many_list_row_add a")[1]);
         assert.containsOnce(target, ".o_selected_row.o_is_section");
-        assert.containsNone(target, ".modal .o_form_view_dialog");
+        assert.containsNone(target, ".modal .o_form_view");
     });
 
     QUnit.test("creates real record in form dialog", async (assert) => {
@@ -218,7 +218,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
         await clickEdit(target);
         await click(target.querySelector(".o_field_x2many_list_row_add a"));
         assert.containsNone(target, ".o_selected_row");
-        assert.containsOnce(target, ".modal .o_form_view_dialog");
+        assert.containsOnce(target, ".modal .o_form_view");
     });
 
     QUnit.test(

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -44,6 +44,7 @@ Dialog.props = {
             footer: { type: Object, optional: true },
         },
     },
+    withBodyPadding: { type: Boolean, optional: true },
 };
 Dialog.defaultProps = {
     contentClass: "",
@@ -53,4 +54,5 @@ Dialog.defaultProps = {
     size: "lg",
     technical: true,
     title: "Odoo",
+    withBodyPadding: true,
 };

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -30,7 +30,7 @@
                                 </button>
                             </t>
                         </footer>
-                        <main class="modal-body">
+                        <main class="modal-body" t-att-class="{'p-0': !props.withBodyPadding}">
                             <t t-slot="default" close="data.close" />
                         </main>
                     </div>

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.X2ManyFieldDialog" owl="1">
-    <Dialog title="title" contentClass="'o_form_view_dialog'" modalRef="modalRef">
+    <Dialog title="title" withBodyPadding="false" modalRef="modalRef">
         <FormRenderer class="'o_form_view'" record="record" fields="archInfo.fields" archInfo="archInfo"/>
         <t t-set-slot="footer">
             <t t-if="footerArchInfo">

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.scss
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.scss
@@ -1,5 +1,0 @@
-.o_form_view_dialog {
-    .modal-body {
-        padding: 0;
-    }
-}

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.FormViewDialog" owl="1">
-    <Dialog size="props.size" title="props.title" contentClass="'o_form_view_dialog'" modalRef="modalRef" t-if="!state.error">
+    <Dialog size="props.size" title="props.title" withBodyPadding="false" modalRef="modalRef" t-if="!state.error">
       <View t-props="viewProps"/>
       <t t-set-slot="footer">
         <t t-if="props.preventEdit and props.preventCreate">

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.SelectCreateDialog" owl="1">
-        <Dialog title="props.title">
+        <Dialog title="props.title" withBodyPadding="false">
             <View t-props="viewProps" />
             <t t-set-slot="footer">
                 <t t-if="props.multiSelect">

--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -45,6 +45,10 @@ ActionDialog.props = {
     actionType: { optional: true },
     title: { optional: true },
 };
+ActionDialog.defaultProps = {
+    ...Dialog.defaultProps,
+    withBodyPadding: false,
+};
 
 /**
  * This LegacyAdaptedActionDialog class will disappear when legacy code will be entirely rewritten.

--- a/addons/web/static/src/webclient/actions/action_dialog.scss
+++ b/addons/web/static/src/webclient/actions/action_dialog.scss
@@ -1,7 +1,0 @@
-.o_dialog {
-  .modal-body {
-    &.o_act_window {
-      padding: 0;
-    }
-  }
-}

--- a/addons/website_slides/static/tests/qunit_suite_tests/components/slide_category_one2many_field_tests.js
+++ b/addons/website_slides/static/tests/qunit_suite_tests/components/slide_category_one2many_field_tests.js
@@ -106,7 +106,7 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
         });
         await click(target.querySelector(".o_data_cell"));
         assert.containsNone(target, ".o_selected_row");
-        assert.containsOnce(target, ".modal .o_form_view_dialog");
+        assert.containsOnce(target, ".modal .o_form_view");
     });
 
     QUnit.test("click on section edit the section in place", async (assert) => {
@@ -129,7 +129,7 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
         await clickEdit(target);
         await click(target.querySelector(".o_data_cell"));
         assert.hasClass(target.querySelector(".o_is_section"), "o_selected_row");
-        assert.containsNone(target, ".modal .o_form_view_dialog");
+        assert.containsNone(target, ".modal .o_form_view");
     });
 
     QUnit.test("click on real line opens a dialog", async (assert) => {
@@ -153,7 +153,7 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
         await clickEdit(target);
         await click(target.querySelector(".o_data_row:nth-child(2) .o_data_cell"));
         assert.containsNone(target, ".o_selected_row");
-        assert.containsOnce(target, ".modal .o_form_view_dialog");
+        assert.containsOnce(target, ".modal .o_form_view");
     });
 
     QUnit.test("can create section inline", async (assert) => {
@@ -184,7 +184,7 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
 
         await click(target.querySelectorAll(".o_field_x2many_list_row_add a")[1]);
         assert.containsOnce(target, ".o_selected_row.o_is_section");
-        assert.containsNone(target, ".modal .o_form_view_dialog");
+        assert.containsNone(target, ".modal .o_form_view");
     });
 
     QUnit.test("creates real record in form dialog", async (assert) => {
@@ -213,6 +213,6 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
         await clickEdit(target);
         await click(target.querySelector(".o_field_x2many_list_row_add a"));
         assert.containsNone(target, ".o_selected_row");
-        assert.containsOnce(target, ".modal .o_form_view_dialog");
+        assert.containsOnce(target, ".modal .o_form_view");
     });
 });


### PR DESCRIPTION
We don't want any padding in those dialogs. The presence of the padding was a consequence of the rewritte of that dialog in owl.


