### PR TITLE
[FIX] web: Many2ManyField: use correct title in dialog

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -3,6 +3,7 @@
 import { makeContext } from "@web/core/context";
 import { registry } from "@web/core/registry";
 import { Pager } from "@web/core/pager/pager";
+import { sprintf } from "@web/core/utils/strings";
 import {
     useActiveActions,
     useAddInlineRecord,
@@ -219,7 +220,9 @@ export class X2ManyField extends Component {
             context = makeContext([record.getFieldContext(this.props.name), context]);
         }
         if (this.isMany2Many) {
-            return this.selectCreate({ domain, context });
+            const { string } = this.props.record.activeFields[this.props.name];
+            const title = sprintf(this.env._t("Add: %s"), string);
+            return this.selectCreate({ domain, context, title });
         }
         if (editable) {
             if (this.list.editedRecord) {

--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -479,6 +479,44 @@ QUnit.module("Fields", (hooks) => {
         }
     );
 
+    QUnit.test("field string is used in the SelectCreateDialog", async function (assert) {
+        serverData.views = {
+            "partner_type,false,list": '<tree><field name="display_name"/></tree>',
+            "partner_type,false,search": '<search><field name="display_name"/></search>',
+            "turtle,false,list": '<tree><field name="display_name"/></tree>',
+            "turtle,false,search": '<search><field name="display_name"/></search>',
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="timmy">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                    <field name="turtles" widget="many2many" string="Abcde">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+        });
+
+        await click(target.querySelectorAll(".o_field_x2many_list_row_add a")[0]);
+        assert.containsOnce(target, ".modal");
+        assert.strictEqual(target.querySelector(".modal .modal-title").innerText, "Add: pokemon");
+
+        await click(target.querySelector(".modal .o_form_button_cancel"));
+        assert.containsNone(target, ".modal");
+
+        await click(target.querySelectorAll(".o_field_x2many_list_row_add a")[1]);
+        assert.containsOnce(target, ".modal");
+        assert.strictEqual(target.querySelector(".modal .modal-title").innerText, "Add: Abcde");
+    });
+
     QUnit.test("many2many kanban: create action disabled", async function (assert) {
         serverData.models.partner.records[0].timmy = [12, 14];
 


### PR DESCRIPTION
Before this commit, the title of the SelectCreateDialog opened when clicking on "Add a line" in a Many2ManyField was always "Select Records" (the default value), whereas in this case, we want to see "Add: something", where `something` is the `string` attribute of the field (which can be overriden by an attrs on the field node in the arch. This commit restores the desired behavior.

