### PR TITLE
[FIX] spreadsheet: correctly apply filter on chart in dashboard mode

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/index.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/index.js
@@ -4,7 +4,11 @@ import spreadsheet from "@spreadsheet/o_spreadsheet/o_spreadsheet_extended";
 
 const { chartComponentRegistry } = spreadsheet.registries;
 const { ChartJsComponent } = spreadsheet.components;
+const { invalidateEvaluationCommands, readonlyAllowedCommands } = spreadsheet;
 
 chartComponentRegistry.add("odoo_bar", ChartJsComponent);
 chartComponentRegistry.add("odoo_line", ChartJsComponent);
 chartComponentRegistry.add("odoo_pie", ChartJsComponent);
+
+invalidateEvaluationCommands.add("ADD_GRAPH_DOMAIN");
+readonlyAllowedCommands.add("ADD_GRAPH_DOMAIN");


### PR DESCRIPTION
Before this commit, a global filter did not update the domain of a chart in dashboard mode.

Task-id 2961578

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
