### PR TITLE
[IMP] spreadsheet: update o_spreadsheet to latest version

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml
@@ -1993,12 +1993,12 @@
       t-attf-style="font-weight:{{currentStyle.bold ?'bold':'normal'}};
                        text-decoration:{{getTextDecoration(currentStyle)}};
                        font-style:{{currentStyle.italic?'italic':'normal'}};
-                       color:{{currentStyle.textColor}};
+                       color:{{currentStyle.textColor || '#000'}};
                        border-radius: 4px;
-                       background-color:{{currentStyle.fillColor}};"
-    />
-    <t t-if="previewText" t-esc="previewText"/>
-    <t t-else="">Preview text</t>
+                       background-color:{{currentStyle.fillColor}};">
+      <t t-if="previewText" t-esc="previewText"/>
+      <t t-else="">Preview text</t>
+    </div>
   </t>
 
   <t t-name="o-spreadsheet-CellIsRuleEditor" owl="1">


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/fd4cd7cf [FIX] style: use cell computed style to compute the text width
https://github.com/odoo/o-spreadsheet/commit/d0f02506 [IMP] link: do not display hover in dashboard mode
https://github.com/odoo/o-spreadsheet/commit/adc180a9 [IMP] InteractiveTests: Moved sort interactive tests to ui helper tests
https://github.com/odoo/o-spreadsheet/commit/e2f1f436 [IMP] menu_items_actions: default chart title
https://github.com/odoo/o-spreadsheet/commit/f19fdbfa [FIX] composer: ctrl clears topbar composer selection
https://github.com/odoo/o-spreadsheet/commit/c4ec1d78 [IMP] selection: dont select chart when it's updated
https://github.com/odoo/o-spreadsheet/commit/14b899ab [FIX] CF: Fix preview test for single color cf
https://github.com/odoo/o-spreadsheet/commit/5de0414b [FIX] charts: duplicating a sheet preserves figure dimensions
https://github.com/odoo/o-spreadsheet/commit/fe2e93f0 [FIX] scorecard: use evaluated format for baseline value
