### PR TITLE
[FIX] web: fix two issues about leaving invalid form views

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -197,8 +197,10 @@ export class FormController extends Component {
                     limit: 1,
                     total: resIds.length,
                     onUpdate: async ({ offset }) => {
-                        await this.model.root.save({ stayInEdition: true });
-                        this.model.load({ resId: resIds[offset] });
+                        const canProceed = await this.model.root.save({ stayInEdition: true });
+                        if (canProceed) {
+                            this.model.load({ resId: resIds[offset] });
+                        }
                     },
                 };
             }

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -1159,6 +1159,25 @@ QUnit.module("ActionManager", (hooks) => {
         );
     });
 
+    QUnit.test("can't restore previous action if form is invalid", async function (assert) {
+        serverData.models.partner.fields.foo.required = true;
+
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 3);
+        assert.containsOnce(target, ".o_list_view");
+
+        await click(target.querySelector(".o_list_button_add"));
+        assert.containsOnce(target, ".o_form_view");
+        assert.hasClass(target.querySelector(".o_field_widget[name=foo]"), "o_required_modifier");
+
+        await editInput(target, ".o_field_widget[name=display_name] input", "make record dirty");
+        await click(target.querySelector(".breadcrumb .o_back_button"));
+        assert.containsNone(target, ".o_list_view");
+        assert.containsOnce(target, ".o_form_view");
+        assert.containsOnce(target, ".o_notification_manager .o_notification");
+        assert.hasClass(target.querySelector(".o_field_widget[name=foo]"), "o_field_invalid");
+    });
+
     QUnit.test("view switcher is properly highlighted in graph view", async function (assert) {
         assert.expect(4);
         serverData.actions[3].views.splice(1, 1, [false, "graph"]);


### PR DESCRIPTION
Issue 1:
From a (e.g.) list view, click on "Create". In the form view, fill in some fields, but leave a required field empty. Click on the breadcrumbs to come back to the list. Before this commit, a UserError dialog was displayed (because the record can't be saved), but we left the form to come back to the list anyway.

The desired behavior is to stay on the form view, and display a notification indicating that some fields are invalid.

In legacy views, we rejected promises to indicate that we couldn't leave. This is a pattern we tried not to use anymore in new code. Instead, we return a promise (if the method is async obviously) which resolves to a boolean value, indicating if it works or not. As a consequence, the action service wasn't properly dealing with new views, as the promises they return always resolve.

This commit fixes the issue by adapting the code in the action service.

Issue 2:
In a form view, modify a record s.t. a required field is unset, and then click on the pager to navigate to the next or previous     record. Before this commit, a notification was displayed (because a required field is unset), but we switched to the other record anyway.

This commit restores the desired behavior, which is to stay on the current record to let the user fix it or discard it.