### PR TITLE
[FIX] web_editor: prevent reset the editor on blur

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -45,15 +45,15 @@ export class HtmlFieldWysiwygAdapterComponent extends ComponentAdapter {
     }
 
     updateWidget(newProps) {
+        const lastValue = String(this.props.widgetArgs[0].value || '');
+        const lastCollaborationChannel = this.props.widgetArgs[0].collaborationChannel;
         const newValue = String(newProps.widgetArgs[0].value || '');
         const newCollaborationChannel = newProps.widgetArgs[0].collaborationChannel;
 
-        if ((newValue !== newProps.editingValue && this._lastValue !== newValue) || this._lastCollaborationChannel !== newCollaborationChannel) {
+        if ((newValue !== newProps.editingValue && lastValue !== newValue) || !_.isEqual(lastCollaborationChannel, newCollaborationChannel)) {
             this.widget.resetEditor(newValue, {
                 collaborationChannel: newCollaborationChannel,
             });
-            this._lastValue = newValue;
-            this._lastCollaborationChannel = newCollaborationChannel;
         }
     }
     renderWidget() {}


### PR DESCRIPTION
When the editor blur, the odoo editor gets reset but shouldn't. One of the side effect is to loose the history.

task-2981508




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
