### PR TITLE
[FIX] web_editor: prevent TB when dropping a non-dropable block

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1644,7 +1644,9 @@ var SnippetsMenu = Widget.extend({
                     }
                 }
 
-                $dropZones.droppable('destroy');
+                if ($dropZones) {
+                    $dropZones.droppable('destroy');
+                }
                 self.getEditableArea().find('.oe_drop_zone').remove();
 
                 if (dropped) {
@@ -1681,6 +1683,7 @@ var SnippetsMenu = Widget.extend({
                 } else {
                     $toInsert.remove();
                 }
+                $dropZones = undefined;
             },
         });
     },


### PR DESCRIPTION
Before this commit when you grabbed a block that couldn't be dropped and dropped it back into the block list, a traceback was displayed. This commit makes it possible to not have this traceback anymore. Steps to reproduce the bug fixed by this commit:
- Install website
- Go to the home page of the website.
- Remove all the blocks of the page (remove also the footer)
- Grab an inner block (which is in red because it cannot be dropped)
- Drop this same block where you grabbed it (in the block list)

=> a traceback is displayed

task-2948895
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
