### PR TITLE
[FIX] website: do not set a current website when fetching websites

### DIFF
--- a/addons/website/static/src/services/website_custom_menus.js
+++ b/addons/website/static/src/services/website_custom_menus.js
@@ -61,7 +61,8 @@ registry.category('website_custom_menus').add('website.menu_optimize_seo', {
         && !!env.services.website.currentWebsite.metadata.mainObject,
 });
 registry.category('website_custom_menus').add('website.menu_current_page', {
-    isDisplayed: (env) => !!env.services.website.currentWebsite,
+    isDisplayed: (env) => !!env.services.website.currentWebsite
+        && !!env.services.website.pageDocument,
 },);
 registry.category('website_custom_menus').add('website.menu_ace_editor', {
     openWidget: (services) => services.website.context.showAceEditor = true,


### PR DESCRIPTION
[FIX] website: do not set a current website when fetching websites
Before this commit, the website service method fetchWebsites was not
clearly defined: it was fetching the user groups, the websites, the
current website and it was also setting the service's current website.

There is a difference between the get_current_website backend method and
the getter from the website service, introduced in [1]: the
websiteService.currentWebsite value referes to the website currently
edited in the WebsitePreview client action. From that value depend other
components visibility (like the contextual menus).

So when a fetchWebsites call was done from outside the client action,
from a PageListController with [2], it was breaking the flow by setting
a currentWebsite outside the client action and it could lead to bugged
flows:
- Go to the "Pages" list view
=> The contextual "This page" menu is not shown, it's correct
- Refresh the page
=> The "This Page" menu is shown (and broken).

To fix that, the fetchWebsites method is divided into a fetchUserGroups,
the searchRead on the websites, and another call to get_current_website,
located in the client action. It allows to load the client action iframe
with the last viewed/edited website.
Also, the menu "This Page" is shown only when there is a pageDocument at
the website service level.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b
[2]: https://github.com/odoo/odoo/commit/940f4ee875332dafa1f379970a7683be6b3ee606

task-2687506

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
