### PR TITLE
[FIX] web_editor: change tag between br

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
@@ -35,6 +35,9 @@ HTMLElement.prototype.oShiftEnter = function (offset) {
 
     for (const el of brEls) {
         if (el.parentNode) {
+            if (el.parentNode.nodeName === "P") {
+                el.classList.add("oe_linebreak");
+            }
             setSelection(...rightPos(el));
             break;
         }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -165,7 +165,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteText(editor, 'a\nb\nc\nd');
                     },
-                    contentAfter: '<p>a<br>b<br>c<br>d[]<br></p>',
+                    contentAfter: '<p>a<br class="oe_linebreak">b<br class="oe_linebreak">c<br class="oe_linebreak">d[]<br></p>',
                 });
             });
             it('should paste text and understand \r\n newlines', async () => {
@@ -174,7 +174,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteText(editor, 'a\r\nb\r\nc\r\nd');
                     },
-                    contentAfter: '<p>a<br>b<br>c<br>d[]<br></p>',
+                    contentAfter: '<p>a<br class="oe_linebreak">b<br class="oe_linebreak">c<br class="oe_linebreak">d[]<br></p>',
                 });
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2924,7 +2924,7 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>[]<br></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><br>[]<br></p>',
+                        contentAfter: '<p><br class="oe_linebreak">[]<br></p>',
                     });
                     // TODO this cannot actually be tested currently as a
                     // backspace/delete in that case is not even detected
@@ -2945,34 +2945,34 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>[]abc</p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><br>[]abc</p>',
+                        contentAfter: '<p><br class="oe_linebreak">[]abc</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>[] abc</p>',
                         stepFunction: insertLineBreak,
                         // The space should have been parsed away.
-                        contentAfter: '<p><br>[]abc</p>',
+                        contentAfter: '<p><br class="oe_linebreak">[]abc</p>',
                     });
                 });
                 it('should insert a <br> within text', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[]cd</p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p>ab<br>[]cd</p>',
+                        contentAfter: '<p>ab<br class="oe_linebreak">[]cd</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab []cd</p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
-                        contentAfter: '<p>ab&nbsp;<br>[]cd</p>',
+                        contentAfter: '<p>ab&nbsp;<br class="oe_linebreak">[]cd</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[] cd</p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's after a <br>).
-                        contentAfter: '<p>ab<br>[]&nbsp;cd</p>',
+                        contentAfter: '<p>ab<br class="oe_linebreak">[]&nbsp;cd</p>',
                     });
                 });
                 it('should insert a line break (2 <br>) at the end of a paragraph', async () => {
@@ -2981,7 +2981,7 @@ X[]
                         stepFunction: insertLineBreak,
                         // The second <br> is needed to make the first
                         // one visible.
-                        contentAfter: '<p>abc<br>[]<br></p>',
+                        contentAfter: '<p>abc<br class="oe_linebreak">[]<br></p>',
                     });
                 });
             });
@@ -2993,7 +2993,7 @@ X[]
                             await insertLineBreak(editor);
                             await insertLineBreak(editor);
                         },
-                        contentAfter: '<p><br><br>[]<br></p>',
+                        contentAfter: '<p><br class="oe_linebreak"><br class="oe_linebreak">[]<br></p>',
                     });
                     // TODO this cannot actually be tested currently as a
                     // backspace/delete in that case is not even detected
@@ -3025,7 +3025,7 @@ X[]
                             await insertLineBreak(editor);
                             await insertLineBreak(editor);
                         },
-                        contentAfter: '<p><br><br>[]abc</p>',
+                        contentAfter: '<p><br class="oe_linebreak"><br class="oe_linebreak">[]abc</p>',
                     });
                 });
                 it('should insert two <br> within text', async () => {
@@ -3035,7 +3035,7 @@ X[]
                             await insertLineBreak(editor);
                             await insertLineBreak(editor);
                         },
-                        contentAfter: '<p>ab<br><br>[]cd</p>',
+                        contentAfter: '<p>ab<br class="oe_linebreak"><br class="oe_linebreak">[]cd</p>',
                     });
                 });
                 it('should insert two line breaks (3 <br>) at the end of a paragraph', async () => {
@@ -3047,7 +3047,7 @@ X[]
                         },
                         // the last <br> is needed to make the first one
                         // visible.
-                        contentAfter: '<p>abc<br><br>[]<br></p>',
+                        contentAfter: '<p>abc<br class="oe_linebreak"><br class="oe_linebreak">[]<br></p>',
                     });
                 });
             });
@@ -3056,7 +3056,7 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abc[]<b>def</b></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p>abc<br><b>[]def</b></p>',
+                        contentAfter: '<p>abc<br class="oe_linebreak"><b>[]def</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to []<b>
@@ -3085,7 +3085,7 @@ X[]
                         contentBefore: '<p><b>abc</b>[]def</p>',
                         stepFunction: insertLineBreak,
                         // JW cAfter: '<p><b>abc[]<br></b>def</p>',
-                        contentAfter: '<p><b>abc</b><br>[]def</p>',
+                        contentAfter: '<p><b>abc</b><br class="oe_linebreak">[]def</p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to </b>[]
@@ -3117,7 +3117,7 @@ X[]
                         contentBefore: '<p>[]<b>abc</b></p>',
                         stepFunction: insertLineBreak,
                         // JW cAfter: '<p><b><br>[]abc</b></p>',
-                        contentAfter: '<p><br><b>[]abc</b></p>',
+                        contentAfter: '<p><br class="oe_linebreak"><b>[]abc</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to []<b>
@@ -3160,7 +3160,7 @@ X[]
                         // The second <br> is needed to make the first
                         // one visible.
                         // JW cAfter: '<p><b>abc<br>[]<br></b></p>',
-                        contentAfter: '<p><b>abc</b><br>[]<br></p>',
+                        contentAfter: '<p><b>abc</b><br class="oe_linebreak">[]<br></p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to </b>[]
@@ -3205,13 +3205,13 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[ab]cd</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]cd</p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]cd</p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>]ab[cd</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]cd</p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]cd</p>',
                 });
             });
             it('should delete part of a paragraph, then insert a <br>', async () => {
@@ -3219,13 +3219,13 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a[bc]d</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p>a<br>[]d</p>',
+                    contentAfter: '<p>a<br class="oe_linebreak">[]d</p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a]bc[d</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p>a<br>[]d</p>',
+                    contentAfter: '<p>a<br class="oe_linebreak">[]d</p>',
                 });
             });
             it('should delete the last half of a paragraph, then insert a line break (2 <br>)', async () => {
@@ -3235,7 +3235,7 @@ X[]
                     stepFunction: insertLineBreak,
                     // the second <br> is needed to make the first one
                     // visible.
-                    contentAfter: '<p>ab<br>[]<br></p>',
+                    contentAfter: '<p>ab<br class="oe_linebreak">[]<br></p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
@@ -3243,7 +3243,7 @@ X[]
                     stepFunction: insertLineBreak,
                     // the second <br> is needed to make the first one
                     // visible.
-                    contentAfter: '<p>ab<br>[]<br></p>',
+                    contentAfter: '<p>ab<br class="oe_linebreak">[]<br></p>',
                 });
             });
             it('should delete all contents of a paragraph, then insert a line break', async () => {
@@ -3251,13 +3251,13 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[abcd]</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]<br></p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]<br></p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>]abcd[</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]<br></p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]<br></p>',
                 });
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -116,7 +116,7 @@ describe('Link', () => {
                         await insertLineBreak(editor);
                     },
                     // Writing at the end of a link writes outside the link.
-                    contentAfter: '<p>a<a href="#">link</a>b<br>[]c</p>',
+                    contentAfter: '<p>a<a href="#">link</a>b<br class="oe_linebreak">[]c</p>',
                 });
             });
             it('should insert a link and write a character insert a <br> and another character', async () => {
@@ -129,7 +129,7 @@ describe('Link', () => {
                         await insertText(editor, 'c');
                     },
                     // Writing at the end of a link writes outside the link.
-                    contentAfter: '<p>a<a href="#">link</a>b<br>c[]d</p>',
+                    contentAfter: '<p>a<a href="#">link</a>b<br class="oe_linebreak">c[]d</p>',
                 });
             });
             it('should insert a <br> inside a link', async () => {


### PR DESCRIPTION
**Current behavior before PR:**

When we copy-paste the text into the editor (as text, not HTML) and try to
change one line, it changes the whole pasted text.

**Desired behavior after PR is merged:**

Introduce a new class 'oe_linebreak' on `BR` to keep the property of the header
style being applied to the whole paragraph written by Shift+Enter.  And
restricting the case like when we copy-paste text from other content and 
now it will only change one line instead of the whole pasted text.

Task-2936891



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
