### PR TITLE
[FIX] website: fix mega-menu layout

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -539,6 +539,7 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
      * @private
      */
     _dropdownHover: function () {
+        this.$dropdownMenus.attr('data-bs-popper', 'none');
         if (config.device.size_class > config.device.SIZES.SM) {
             this.$dropdownMenus.css('margin-top', '0');
             this.$dropdownMenus.css('top', 'unset');

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -813,7 +813,7 @@ $-transition-duration: 200ms;
             box-shadow: none;
         }
         > .o_mega_menu .row > div { // remove mega menu col-lg-* style
-            max-width: none;
+            width: 100%;
             flex: auto;
         }
     }


### PR DESCRIPTION
In this commit two errors in the rendering of the mega menu are fixed:
* the position of the mega menu when the option `Sub Menus` is `On Hover`
  this bug is due that we show the mega menu manually adding the `show`
  class on the element in our code. However, in the `On Click` mode,
  it's Bootstrap's javascript that handle the show/hide state.
  Bootstrap adds the `show` class and also adds the attribute
  `data-bs-popper="none"` to the element. In `On Hover` mode this
  attribute was missing.

* the render of mega menu in the `+ icon` (`o_extra_menu_items`).
  This error occurs because in Bootstrap 5 the width is set with the
  `width` property and in Boostrap 4 it was `max-width`. In Odoo
  `col-XX-YY` CSS rules are overridden when the mega menu is in the
  `+ icon`, but the `max-width` was not changed by `width` during the
  Bootstrap 5 migration.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
