### PR TITLE
[IMP] web: remove useless tooltips in standard views

### DIFF
--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -34,18 +34,18 @@
     <t t-name="web.FormView.Buttons" owl="1">
         <div class="o_cp_buttons" role="toolbar" aria-label="Main actions" t-ref="cpButtons">
             <div t-if="model.root.isInEdition" class="o_form_buttons_edit">
-                <button type="button" class="btn btn-primary o_form_button_save" data-tooltip="Save record" data-hotkey="s" t-on-click.stop="() => this.save()">
+                <button type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.save()">
                     Save
                 </button>
-                <button type="button" class="btn btn-secondary o_form_button_cancel" data-tooltip="Discard changes" data-hotkey="j" t-on-click.stop="discard">
+                <button type="button" class="btn btn-secondary o_form_button_cancel" data-hotkey="j" t-on-click.stop="discard">
                     Discard
                 </button>
             </div>
             <div t-else="canEdit or canCreate" class="o_form_buttons_view">
-                <button t-if="canEdit" type="button" class="btn btn-primary o_form_button_edit" data-tooltip="Edit record" data-hotkey="a" data-bounce-button="" t-on-click.stop="edit">
+                <button t-if="canEdit" type="button" class="btn btn-primary o_form_button_edit" data-hotkey="a" data-bounce-button="" t-on-click.stop="edit">
                     Edit
                 </button>
-                <button t-if="canCreate" type="button" class="btn btn-secondary o_form_button_create" data-tooltip="Create record" data-hotkey="c" t-on-click.stop="create">
+                <button t-if="canCreate" type="button" class="btn btn-secondary o_form_button_create" data-hotkey="c" t-on-click.stop="create">
                     Create
                 </button>
             </div>

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -22,7 +22,7 @@
     <t t-name="web.KanbanView.Buttons" owl="1">
         <div t-if="props.showButtons" class="o_cp_buttons d-flex align-items-baseline" role="toolbar" aria-label="Main actions">
             <t t-if="canCreate">
-                <button type="button" class="btn btn-primary o-kanban-button-new" data-tooltip="Create record" aria-label="Create record" accesskey="c" t-on-click="() => this.createRecord(null)" data-bounce-button="">
+                <button type="button" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord(null)" data-bounce-button="">
                     Create
                 </button>
             </t>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -35,15 +35,15 @@
         <div class="o_list_buttons d-flex" role="toolbar" aria-label="Main actions">
             <t t-if="props.showButtons">
                 <t t-if="model.root.editedRecord">
-                    <button type="button" class="btn btn-primary o_list_button_save" data-tooltip="Save record" aria-label="Save record" data-hotkey="s" t-on-click.stop="onClickSave">
+                    <button type="button" class="btn btn-primary o_list_button_save" data-hotkey="s" t-on-click.stop="onClickSave">
                         Save
                     </button>
-                    <button type="button" class="btn btn-secondary o_list_button_discard" data-tooltip="Discard changes" aria-label="Discard changes" data-hotkey="j" t-on-click="onClickDiscard" t-on-mousedown="onMouseDownDiscard">
+                    <button type="button" class="btn btn-secondary o_list_button_discard" data-hotkey="j" t-on-click="onClickDiscard" t-on-mousedown="onMouseDownDiscard">
                         Discard
                     </button>
                 </t>
                 <t t-elif="activeActions['create'] and (!model.root.isGrouped or !editable)">
-                    <button type="button" class="btn btn-primary o_list_button_add" data-tooltip="Create record" aria-label="Create record" data-hotkey="c" t-on-click="onClickCreate" data-bounce-button="">
+                    <button type="button" class="btn btn-primary o_list_button_add" data-hotkey="c" t-on-click="onClickCreate" data-bounce-button="">
                         Create
                     </button>
                 </t>

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -10808,25 +10808,6 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
-    QUnit.test("display tooltips for save and discard buttons", async function (assert) {
-        await makeView({
-            type: "form",
-            resModel: "partner",
-            serverData,
-            arch: `<form><field name="foo"/></form>`,
-        });
-        assert.hasAttrValue(
-            target.querySelector(".o_form_button_save"),
-            "data-tooltip",
-            "Save record"
-        );
-        assert.hasAttrValue(
-            target.querySelector(".o_form_button_cancel"),
-            "data-tooltip",
-            "Discard changes"
-        );
-    });
-
     QUnit.test("resequence list lines when discardable lines are present", async function (assert) {
         var onchangeNum = 0;
         serverData.models.partner.onchanges = {


### PR DESCRIPTION
Tooltips (and aria-label) should be used when the content of the element is not self explanatory; but in the case of the create/save/edit buttons available in several view control panels (kanban,list,form), tooltips with dubious usefulness were added (e.g. "Create record" when you hover on a button labeled "CREATE" is not really an information bomb).

Since these buttons tend to be used in tours, and the "coucouilles" of the tours will also be some sort of tooltips, it means that you can have frequent weird visual interactions between nunuts and stupid tooltips.

This commit removes these stupid tooltips.

Note that this does not in any way impact a11y at all, even with the removal of the aria-labels: screen readers are perfectly capable (and motivated to!) read aloud the content of the button. In fact, I would argue that adding a useless one will generate noise.

Feedback-2973374