### PR TITLE
[FIX] test_assetsbundle: no pregenerate when ready

### DIFF
--- a/odoo/addons/test_assetsbundle/models/ir_qweb.py
+++ b/odoo/addons/test_assetsbundle/models/ir_qweb.py
@@ -7,5 +7,6 @@ class IrQweb(models.AbstractModel):
         super()._register_hook()
         # if this module is installed, we are in a test environement.
         # pregenerate assets at the end of the loading to speedup tests
-        if self.env.registry.updated_modules:
+        registry = self.env.registry
+        if registry.updated_modules and not registry.ready:
             self._pregenerate_assets_bundles()


### PR DESCRIPTION
The pregenerate of assets_bundle should be done maximum two times
- at the end of an install/update if the module test_assetsbundle is
installed

- at the beginning of post_install tests

Currently, during the nightly (install and all tests are ran at the
same time), the pregeration of assets is triggered at the end of some
tests

  File "/home/xdo/osrc/master/odoo/odoo/tests/common.py", line 319, in _tearDownPreviousClass
    super()._tearDownPreviousClass(test, result)
  File "/usr/lib/python3.8/unittest/suite.py", line 300, in _tearDownPreviousClass
    previousClass.doClassCleanups()
  File "/usr/lib/python3.8/unittest/case.py", line 731, in doClassCleanups
    function(*args, **kwargs)
  File "/home/xdo/osrc/master/odoo/odoo/modules/registry.py", line 704, in reset_changes
    self.setup_models(cr)
  File "/home/xdo/osrc/master/odoo/odoo/modules/registry.py", line 306, in setup_models
    model._register_hook()
  File "/home/xdo/osrc/master/odoo/odoo/addons/test_assetsbundle/models/ir_qweb.py", line 13, in _register_hook

The registry.updated_modules is set to allow post_install tests
to select the right tests to execute. This is a way to define if we
updated some modules loading this registry. This list is unfortunatelly
not emptied before running the test, meaning that if register hook are
called on the same registry again, pregenerate will be executed
a second time.

A solution here is to check if the registry is not ready,
meaning that this is the load_modules call to register_hook
and not the setup_models one
