### PR TITLE
[IMP] base: simplify modifiers `column_invisible`

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -125,7 +125,7 @@ def transfer_node_to_modifiers(node, modifiers, context=None):
 
 
 def simplify_modifiers(modifiers):
-    for a in ('invisible', 'readonly', 'required'):
+    for a in ('column_invisible', 'invisible', 'readonly', 'required'):
         if a in modifiers and not modifiers[a]:
             del modifiers[a]
 

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1760,7 +1760,7 @@ class TestViews(ViewCase):
         ''')
         _test_modifiers(tree[0][0], {"invisible": True})
         _test_modifiers(tree[1], {})
-        _test_modifiers(tree[2], {"column_invisible": False})
+        _test_modifiers(tree[2], {})
         _test_modifiers(tree[3], {"column_invisible": True})
         _test_modifiers(tree[4], {"invisible": [['b', '=', 'c']]})
 


### PR DESCRIPTION
Also get rid of {'column_invisible': False} in modifiers

e.g. in the account move list

Before:
```xml
<field name="invoice_partner_display_name" string="Customer" modifiers="{&quot;readonly&quot;: true, &quot;column_invisible&quot;: false}"/>
```

After:
```xml
<field name="invoice_partner_display_name" string="Customer" modifiers="{&quot;readonly&quot;: true}"/>
```
