### PR TITLE
[IMP] spreadsheet: add last 90/180 days gloabl filters

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -68,6 +68,18 @@ export function getRelativeDateDomain(now, offset, rangeType, fieldName, fieldTy
             startDate = now.minus({ day: 30 }).plus(offsetParam);
             break;
         }
+        case "last_three_months": {
+            const offsetParam = { day: 90 * offset };
+            endDate = endDate.plus(offsetParam);
+            startDate = now.minus({ day: 90 }).plus(offsetParam);
+            break;
+        }
+        case "last_six_months": {
+            const offsetParam = { day: 180 * offset };
+            endDate = endDate.plus(offsetParam);
+            startDate = now.minus({ day: 180 }).plus(offsetParam);
+            break;
+        }
         case "last_year": {
             const offsetParam = { day: 365 * offset };
             endDate = endDate.plus(offsetParam);

--- a/addons/spreadsheet/static/src/helpers/constants.js
+++ b/addons/spreadsheet/static/src/helpers/constants.js
@@ -21,6 +21,8 @@ export const UNTITLED_SPREADSHEET_NAME = _lt("Untitled spreadsheet");
 export const RELATIVE_DATE_RANGE_TYPES = [
     { type: "last_week", description: _lt("Last 7 Days") },
     { type: "last_month", description: _lt("Last 30 Days") },
+    { type: "last_three_months", description: _lt("Last 90 Days") },
+    { type: "last_six_months", description: _lt("Last 180 Days") },
     { type: "last_year", description: _lt("Last 365 Days") },
     { type: "last_three_years", description: _lt("Last 3 Years") },
 ];

--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper_test.js
@@ -22,6 +22,20 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         assertDateDomainEqual(assert, "field", "2022-04-16", "2022-05-15", domain);
     });
 
+    QUnit.test("getRelativeDateDomain > last_three_months (last 90 days)", async function (assert) {
+        const now = DateTime.fromISO("2022-05-16");
+        const domain = getRelativeDateDomain(now, 0, "last_three_months", "field", "date");
+        assert.equal(getDateDomainDurationInDays(domain), 90);
+        assertDateDomainEqual(assert, "field", "2022-02-15", "2022-05-15", domain);
+    });
+
+    QUnit.test("getRelativeDateDomain > last_six_months (last 180 days)", async function (assert) {
+        const now = DateTime.fromISO("2022-05-16");
+        const domain = getRelativeDateDomain(now, 0, "last_six_months", "field", "date");
+        assert.equal(getDateDomainDurationInDays(domain), 180);
+        assertDateDomainEqual(assert, "field", "2021-11-17", "2022-05-15", domain);
+    });
+
     QUnit.test("getRelativeDateDomain > last_year (last 365 days)", async function (assert) {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, 0, "last_year", "field", "date");

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -1319,6 +1319,16 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
         assert.equal(getDateDomainDurationInDays(computedDomain), 30);
         assertDateDomainEqual(assert, "date", "2022-04-16", "2022-05-15", computedDomain);
 
+        await setGlobalFilterValue(model, { id: "42", value: "last_three_months" });
+        computedDomain = model.getters.getPivotComputedDomain("1");
+        assert.equal(getDateDomainDurationInDays(computedDomain), 90);
+        assertDateDomainEqual(assert, "date", "2022-02-15", "2022-05-15", computedDomain);
+
+        await setGlobalFilterValue(model, { id: "42", value: "last_six_months" });
+        computedDomain = model.getters.getPivotComputedDomain("1");
+        assert.equal(getDateDomainDurationInDays(computedDomain), 180);
+        assertDateDomainEqual(assert, "date", "2021-11-17", "2022-05-15", computedDomain);
+
         await setGlobalFilterValue(model, { id: "42", value: "last_year" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 365);
@@ -1351,6 +1361,16 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 30);
         assertDateDomainEqual(assert, "date", "2022-03-17", "2022-04-15", computedDomain);
+
+        await setGlobalFilterValue(model, { id: "42", value: "last_three_months" });
+        computedDomain = model.getters.getPivotComputedDomain("1");
+        assert.equal(getDateDomainDurationInDays(computedDomain), 90);
+        assertDateDomainEqual(assert, "date", "2021-11-17", "2022-02-14", computedDomain);
+
+        await setGlobalFilterValue(model, { id: "42", value: "last_six_months" });
+        computedDomain = model.getters.getPivotComputedDomain("1");
+        assert.equal(getDateDomainDurationInDays(computedDomain), 180);
+        assertDateDomainEqual(assert, "date", "2021-05-21", "2021-11-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_year" });
         computedDomain = model.getters.getPivotComputedDomain("1");


### PR DESCRIPTION
Add a relative global filter for the last 90 days, and one for the last 180 days.

Odoo task 2968572



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
