### PR TITLE
[FIX] mail: linkPreviewDeleteConfirm modal size

### DIFF
--- a/addons/mail/static/src/models/dialog.js
+++ b/addons/mail/static/src/models/dialog.js
@@ -63,7 +63,7 @@ registerModel({
          * @returns {string}
          */
         _computeComponentClassName() {
-            if (this.attachmentDeleteConfirmView) {
+            if (this.attachmentDeleteConfirmView || this.linkPreviewDeleteConfirmView) {
                 return 'o_Dialog_componentMediumSize align-self-start mt-5';
             }
             if (this.deleteMessageConfirmView) {


### PR DESCRIPTION
Prior to this commit, the size of the modal for removing a link preview was stretched vertically.

This commit fixes this issue.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
