### PR TITLE
[FIX] website: hide the 'discuss' window when in edit mode

### DIFF
--- a/addons/website/static/src/components/editor/editor.scss
+++ b/addons/website/static/src/components/editor/editor.scss
@@ -2,6 +2,9 @@
     .o_notification_manager {
         @include o-position-absolute($top: map-get($spacers, 2), $right: calc(#{$o-we-sidebar-width} + 0.5rem));
     }
+    .o_ChatWindowManager {
+        display: none !important;
+    }
 }
 
 .ui-autocomplete.o_website_ui_autocomplete {


### PR DESCRIPTION
With [1] moving the website in backend, it is now possible to display a backend discuss chat window while browsing your website.

This window is unfortunately hidden behind the SnippetEditor when it is open.

The choice was made to hide the chat window when the edit mode is activated, as it could hide some content of the page.

Steps to reproduce:
- Open a Discuss chat window using the systray item from the app grid
- Open website
- Click on Edit

Chat window is hidden.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
