### PR TITLE
[FIX] account: allow out payments by default when creating a bank account manually

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -269,14 +269,16 @@
                                 <field name="payment_method_line_id" required="1" options="{'no_create': True, 'no_open': True}"
                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>
 
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Customer Bank Account"
+                                <field name="partner_bank_id" string="Customer Bank Account"
+                                      context="{'default_partner_id': partner_id, 'default_allow_out_payment': True}"
                                         attrs="{
                                             'invisible': ['|', '|', '|', ('show_partner_bank_account', '=', False), ('partner_type','!=','customer'), ('is_internal_transfer', '=', True), ('payment_type', '=', 'inbound')],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
                                             'readonly': [('state', '!=', 'draft')],
                                         }"/>
 
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Vendor Bank Account"
+                                <field name="partner_bank_id" string="Vendor Bank Account"
+                                        context="{'default_partner_id': partner_id, 'default_allow_out_payment': True}"
                                         attrs="{
                                             'invisible': ['|', '|', '|', ('show_partner_bank_account', '=', False), ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True), ('payment_type', '=', 'inbound')],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
@@ -285,7 +287,8 @@
 
                                 <!-- This field should always be readonly but using readonly="1" overrides the other partner_bank_id
                                 fields readonly condition in the framework, preventing the modification of these fields -->
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Company Bank Account"
+                                <field name="partner_bank_id" string="Company Bank Account"
+                                        context="{'default_partner_id': partner_id, 'default_allow_out_payment': True}"
                                         attrs="{
                                             'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('is_internal_transfer', '=', True), ('payment_type', '=', 'outbound')],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -34,7 +34,8 @@
                                    required="1"  options="{'no_create': True, 'no_open': True}"/>
                             <field name="partner_bank_id"
                                    attrs="{'invisible': ['|', ('show_partner_bank_account', '=', False), '|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)],
-                                           'required': [('require_partner_bank_account', '=', True), ('can_edit_wizard', '=', True), '|', ('can_group_payments', '=', False), ('group_payment', '=', False)], 'readonly': [('payment_type', '=', 'inbound')]}"/>
+                                           'required': [('require_partner_bank_account', '=', True), ('can_edit_wizard', '=', True), '|', ('can_group_payments', '=', False), ('group_payment', '=', False)], 'readonly': [('payment_type', '=', 'inbound')]}"
+                                    context="{'default_allow_out_payment': True}"/>
                             <field name="group_payment"
                                    attrs="{'invisible': [('can_group_payments', '=', False)]}"/>
                         </group>


### PR DESCRIPTION
This was already the behavior when creating a res.partner.bank from the res.partner form view. 
Other views allowing such manual creation were missing this behavior.
The purpose is to allow frictionless payments to accounts created specifically for those payments (while any other account has an extra check performed before allowing payments to it).


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
