### PR TITLE
[FIX] stock: fix todo filter for product moves

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -119,7 +119,7 @@
                 <field name="result_package_id" string="Destination Package" groups="stock.group_tracking_lot"/>
                 <field name="owner_id" string="Owner" groups="stock.group_tracking_owner"/>
                 <separator/>
-                <filter string="To Do" name="todo" domain="[('state', 'not in', ['done', 'draft'])]"/>
+                <filter string="To Do" name="todo" domain="[('state', 'not in', ['done', 'draft', 'cancel'])]"/>
                 <filter string="Done" name="done" domain="[('state', '=', 'done')]"/>
                 <separator/>
                 <filter string="Incoming" name="incoming" domain="[('picking_id.picking_type_id.code', '=', 'incoming')]"/>


### PR DESCRIPTION
Steps to reproduce:
- Create a transfer and choose whatever operation
- Enable detailed operations option for the operation
- Check availability and set quantities
- Cancel the transfer then Go to Product Moves

Current behavior:
- todo filter is broken, it shows canceled moves

Desired behavior:
- Show only moves that are assigned or waiting

- Task id: #2981249


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
