### PR TITLE
[IMP] mail, *: inverse of identifying is automatically causal

### DIFF
--- a/addons/im_livechat/static/src/models/chatbot.js
+++ b/addons/im_livechat/static/src/models/chatbot.js
@@ -598,7 +598,6 @@ registerModel({
         }),
         currentStep: one('ChatbotStep', {
             inverse: 'chabotOwner',
-            isCausal: true,
         }),
         debouncedAwaitUserInput: attr({
             compute: '_computeDebouncedAwaitUserInput',

--- a/addons/im_livechat/static/src/models/discuss.js
+++ b/addons/im_livechat/static/src/models/discuss.js
@@ -24,6 +24,5 @@ addFields('Discuss', {
     categoryLivechat: one('DiscussSidebarCategory', {
         default: {},
         inverse: 'discussAsLivechat',
-        isCausal: true,
     }),
 });

--- a/addons/im_livechat/static/src/models/public_livechat_global.js
+++ b/addons/im_livechat/static/src/models/public_livechat_global.js
@@ -197,15 +197,12 @@ registerModel({
         chatbot: one('Chatbot', {
             default: {},
             inverse: 'publicLivechatGlobalOwner',
-            isCausal: true,
         }),
         chatWindow: one('PublicLivechatWindow', {
             inverse: 'publicLivechatGlobalOwner',
-            isCausal: true,
         }),
         feedbackView: one('PublicLivechatFeedbackView', {
             inverse: 'publicLivechatGlobalOwner',
-            isCausal: true,
         }),
         hasLoadedQWebTemplate: attr({
             default: false,
@@ -232,20 +229,17 @@ registerModel({
         livechatButtonView: one('LivechatButtonView', {
             compute: '_computeLivechatButtonView',
             inverse: 'publicLivechatGlobalOwner',
-            isCausal: true,
         }),
         livechatInit: attr(),
         messages: many('PublicLivechatMessage'),
         notificationHandler: one('PublicLivechatGlobalNotificationHandler', {
             inverse: 'publicLivechatGlobalOwner',
-            isCausal: true,
         }),
         options: attr({
             default: {},
         }),
         publicLivechat: one('PublicLivechat', {
             inverse: 'publicLivechatGlobalOwner',
-            isCausal: true,
         }),
         rule: attr(),
         serverUrl: attr({

--- a/addons/im_livechat/static/src/models/public_livechat_window.js
+++ b/addons/im_livechat/static/src/models/public_livechat_window.js
@@ -94,7 +94,6 @@ registerModel({
         publicLivechatView: one('PublicLivechatView', {
             default: {},
             inverse: 'publicLivechatWindowOwner',
-            isCausal: true,
         }),
         widget: attr(),
     },

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -1169,6 +1169,10 @@ export class ModelManager {
                     continue;
                 }
                 if (field.inverse) {
+                    // Automatically make causal the inverse of an identifying.
+                    if (field.identifying) {
+                        this.models[field.to].fields[field.inverse].isCausal = true;
+                    }
                     continue;
                 }
                 const relatedModel = this.models[field.to];

--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -262,7 +262,6 @@ registerModel({
     fields: {
         activityViews: many('ActivityView', {
             inverse: 'activity',
-            isCausal: true,
         }),
         assignee: one('User', {
             inverse: 'activitiesAsAssignee',

--- a/addons/mail/static/src/models/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view.js
@@ -27,7 +27,6 @@ registerModel({
         activityViews: many('ActivityView', {
             compute: '_computeActivityViews',
             inverse: 'activityBoxView',
-            isCausal: true,
         }),
         chatter: one('Chatter', {
             identifying: true,

--- a/addons/mail/static/src/models/activity_group.js
+++ b/addons/mail/static/src/models/activity_group.js
@@ -38,7 +38,6 @@ registerModel({
         actions: attr(),
         activityGroupViews: many('ActivityGroupView', {
             inverse: 'activityGroup',
-            isCausal: true,
         }),
         domain: attr(),
         irModel: one('ir.model', {

--- a/addons/mail/static/src/models/activity_menu_view.js
+++ b/addons/mail/static/src/models/activity_menu_view.js
@@ -89,7 +89,6 @@ registerModel({
         activityGroupViews: many('ActivityGroupView', {
             compute: '_computeActivityGroupViews',
             inverse: 'activityMenuViewOwner',
-            isCausal: true,
         }),
         component: attr(),
         counter: attr({

--- a/addons/mail/static/src/models/activity_view.js
+++ b/addons/mail/static/src/models/activity_view.js
@@ -187,7 +187,6 @@ registerModel({
                 },
             },
             inverse: 'activityViewOwner',
-            isCausal: true,
         }),
         /**
          * States the OWL component of this activity view.
@@ -202,7 +201,6 @@ registerModel({
         fileUploader: one('FileUploader', {
             compute: '_computeFileUploader',
             inverse: 'activityView',
-            isCausal: true,
         }),
         /**
          * Format the create date to something human reabable.
@@ -219,12 +217,10 @@ registerModel({
         mailTemplateViews: many('MailTemplateView', {
             compute: '_computeMailTemplateViews',
             inverse: 'activityViewOwner',
-            isCausal: true,
         }),
         markDoneButtonRef: attr(),
         markDonePopoverView: one('PopoverView', {
             inverse: 'activityViewOwnerAsMarkDone',
-            isCausal: true,
         }),
         /**
          * Label for mark as done. This is just for translations purpose.

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -302,7 +302,6 @@ registerModel({
         }),
         attachmentViewerViewable: one('AttachmentViewerViewable', {
             inverse: 'attachmentOwner',
-            isCausal: true,
         }),
         checksum: attr(),
         /**

--- a/addons/mail/static/src/models/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view.js
@@ -30,7 +30,6 @@ registerModel({
         attachmentList: one('AttachmentList', {
             compute: '_computeAttachmentList',
             inverse: 'attachmentBoxViewOwner',
-            isCausal: true,
         }),
         chatter: one('Chatter', {
             identifying: true,
@@ -43,7 +42,6 @@ registerModel({
         fileUploader: one('FileUploader', {
             default: {},
             inverse: 'attachmentBoxView',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card.js
@@ -51,7 +51,6 @@ registerModel({
         }),
         attachmentDeleteConfirmDialog: one('Dialog', {
             inverse: 'attachmentCardOwnerAsAttachmentDeleteConfirm',
-            isCausal: true,
         }),
         /**
          * States the attachmentList displaying this card.

--- a/addons/mail/static/src/models/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image.js
@@ -118,7 +118,6 @@ registerModel({
         }),
         attachmentDeleteConfirmDialog: one('Dialog', {
             inverse: 'attachmentImageOwnerAsAttachmentDeleteConfirm',
-            isCausal: true,
         }),
         /**
          * States the attachmentList displaying this attachment image.

--- a/addons/mail/static/src/models/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list.js
@@ -138,7 +138,6 @@ registerModel({
         attachmentCards: many('AttachmentCard', {
             compute: '_computeAttachmentCards',
             inverse: 'attachmentList',
-            isCausal: true,
         }),
         /**
          * States the attachment images that are displaying this imageAttachments.
@@ -146,11 +145,9 @@ registerModel({
         attachmentImages: many('AttachmentImage', {
             compute: '_computeAttachmentImages',
             inverse: 'attachmentList',
-            isCausal: true,
         }),
         attachmentListViewDialog: one('Dialog', {
             inverse: 'attachmentListOwnerAsAttachmentView',
-            isCausal: true,
         }),
         /**
          * States the attachments to be displayed by this attachment list.

--- a/addons/mail/static/src/models/blur_manager.js
+++ b/addons/mail/static/src/models/blur_manager.js
@@ -195,7 +195,6 @@ registerModel({
         }),
         frameRequestTimer: one('Timer', {
             inverse: 'blurManagerOwnerAsFrameRequest',
-            isCausal: true,
         }),
         isVideoDataLoaded: attr({
             default: false,

--- a/addons/mail/static/src/models/call_action_list_view.js
+++ b/addons/mail/static/src/models/call_action_list_view.js
@@ -179,7 +179,6 @@ registerModel({
         moreButtonRef: attr(),
         moreMenuPopoverView: one('PopoverView', {
             inverse: 'callActionListViewOwnerAsMoreMenu',
-            isCausal: true,
         }),
         screenSharingButtonTitle: attr({
             compute: '_computeScreenSharingButtonTitle',

--- a/addons/mail/static/src/models/call_main_view.js
+++ b/addons/mail/static/src/models/call_main_view.js
@@ -161,7 +161,6 @@ registerModel({
         callActionListView: one('CallActionListView', {
             default: {},
             inverse: 'callMainView',
-            isCausal: true,
             readonly: true,
         }),
         callView: one('CallView', {
@@ -181,7 +180,6 @@ registerModel({
         mainTiles: many('CallMainViewTile', {
             compute: '_computeMainTiles',
             inverse: 'callMainViewOwner',
-            isCausal: true,
         }),
         /**
          * Determines if we show the overlay with the control buttons.
@@ -191,7 +189,6 @@ registerModel({
         }),
         showOverlayTimer: one('Timer', {
             inverse: 'callMainViewAsShowOverlay',
-            isCausal: true,
         }),
         thread: one('Thread', {
             related: 'callView.thread',

--- a/addons/mail/static/src/models/call_main_view_tile.js
+++ b/addons/mail/static/src/models/call_main_view_tile.js
@@ -16,7 +16,6 @@ registerModel({
         participantCard: one('CallParticipantCard', {
             default: {},
             inverse: 'mainViewTileOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_participant_card.js
+++ b/addons/mail/static/src/models/call_participant_card.js
@@ -107,7 +107,6 @@ registerModel({
     fields: {
         callParticipantCardPopoverView: one('PopoverView', {
             inverse: 'callParticipantCardOwner',
-            isCausal: true,
         }),
         channelMember: one('ChannelMember', {
             compute: '_computeChannelMember',
@@ -149,7 +148,6 @@ registerModel({
         callParticipantVideoView: one('CallParticipantVideoView', {
             compute: '_computeCallParticipantVideoView',
             inverse: 'callParticipantCardOwner',
-            isCausal: true,
         }),
         volumeMenuAnchorRef: attr(),
     },

--- a/addons/mail/static/src/models/call_sidebar_view.js
+++ b/addons/mail/static/src/models/call_sidebar_view.js
@@ -22,7 +22,6 @@ registerModel({
         sidebarTiles: many('CallSidebarViewTile', {
             compute: '_computeSidebarTiles',
             inverse: 'callSidebarViewOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_sidebar_view_tile.js
+++ b/addons/mail/static/src/models/call_sidebar_view_tile.js
@@ -16,7 +16,6 @@ registerModel({
         participantCard: one('CallParticipantCard', {
             default: {},
             inverse: 'sidebarViewTileOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/call_view.js
+++ b/addons/mail/static/src/models/call_view.js
@@ -171,13 +171,11 @@ registerModel({
         callMainView: one('CallMainView', {
             default: {},
             inverse: 'callView',
-            isCausal: true,
             readonly: true,
         }),
         callSidebarView: one('CallSidebarView', {
             compute: '_computeCallSideBarView',
             inverse: 'callView',
-            isCausal: true,
         }),
         channel: one('Channel', {
             related: 'thread.channel',

--- a/addons/mail/static/src/models/canned_response.js
+++ b/addons/mail/static/src/models/canned_response.js
@@ -83,7 +83,6 @@ registerModel({
         suggestable: one('ComposerSuggestable', {
             default: {},
             inverse: 'cannedResponse',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -226,7 +226,6 @@ registerModel({
         }),
         channelPreviewViews: many('ChannelPreviewView', {
             inverse: 'channel',
-            isCausal: true,
         }),
         channel_type: attr(),
         correspondent: one('Partner', {
@@ -260,7 +259,6 @@ registerModel({
         discussSidebarCategoryItem: one('DiscussSidebarCategoryItem', {
             compute: '_computeDiscussSidebarCategoryItem',
             inverse: 'channel',
-            isCausal: true,
         }),
         displayName: attr({
             compute: '_computeDisplayName',

--- a/addons/mail/static/src/models/channel_command.js
+++ b/addons/mail/static/src/models/channel_command.js
@@ -131,7 +131,6 @@ registerModel({
         suggestable: one('ComposerSuggestable', {
             default: {},
             inverse: 'channelCommand',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -297,7 +297,6 @@ registerModel({
         selectablePartnerViews: many('ChannelInvitationFormSelectablePartnerView', {
             compute: '_computeSelectablePartnerViews',
             inverse: 'channelInvitationFormOwner',
-            isCausal: true,
         }),
         /**
          * Determines all partners that are currently selected.
@@ -306,7 +305,6 @@ registerModel({
         selectedPartnerViews: many('ChannelInvitationFormSelectedPartnerView', {
             compute: '_computeSelectedPartnerViews',
             inverse: 'channelInvitationFormOwner',
-            isCausal: true,
         }),
         /**
          * States the thread on which this list operates (if any).

--- a/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
+++ b/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
@@ -27,7 +27,6 @@ registerModel({
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'channelInvitationFormSelectablePartnerViewOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/channel_member.js
+++ b/addons/mail/static/src/models/channel_member.js
@@ -101,7 +101,6 @@ registerModel({
         }),
         channelMemberViews: many('ChannelMemberView', {
             inverse: 'channelMember',
-            isCausal: true,
         }),
         id: attr({
             identifying: true,
@@ -118,7 +117,6 @@ registerModel({
         }),
         otherMemberLongTypingInThreadTimers: many('OtherMemberLongTypingInThreadTimer', {
             inverse: 'member',
-            isCausal: true,
         }),
         persona: one('Persona', {
             inverse: 'channelMembers',

--- a/addons/mail/static/src/models/channel_member_list_category_view.js
+++ b/addons/mail/static/src/models/channel_member_list_category_view.js
@@ -85,7 +85,6 @@ registerModel({
         channelMemberViews: many('ChannelMemberView', {
             compute: '_computeChannelMemberViews',
             inverse: 'channelMemberListCategoryViewOwner',
-            isCausal: true,
         }),
         members: many('ChannelMember', {
             compute: '_computeMembers',

--- a/addons/mail/static/src/models/channel_member_list_view.js
+++ b/addons/mail/static/src/models/channel_member_list_view.js
@@ -64,12 +64,10 @@ registerModel({
         offlineCategoryView: one('ChannelMemberListCategoryView', {
             compute: '_computeOfflineCategoryView',
             inverse: 'channelMemberListViewOwnerAsOffline',
-            isCausal: true,
         }),
         onlineCategoryView: one('ChannelMemberListCategoryView', {
             compute: '_computeOnlineCategoryView',
             inverse: 'channelMemberListViewOwnerAsOnline',
-            isCausal: true,
         }),
         threadViewOwner: one('ThreadView', {
             identifying: true,

--- a/addons/mail/static/src/models/channel_member_view.js
+++ b/addons/mail/static/src/models/channel_member_view.js
@@ -62,7 +62,6 @@ registerModel({
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'channelMemberViewOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/channel_preview_view.js
+++ b/addons/mail/static/src/models/channel_preview_view.js
@@ -123,7 +123,6 @@ registerModel({
         messageAuthorPrefixView: one('MessageAuthorPrefixView', {
             compute: '_computeMessageAuthorPrefixView',
             inverse: 'channelPreviewViewOwner',
-            isCausal: true,
         }),
         notificationListViewOwner: one('NotificationListView', {
             identifying: true,
@@ -132,7 +131,6 @@ registerModel({
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'channelPreviewViewOwner',
-            isCausal: true,
         }),
         thread: one('Thread', {
             related: 'channel.thread',

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -593,7 +593,6 @@ registerModel({
         callSettingsMenu: one('CallSettingsMenu', {
             compute: '_computeCallSettingsMenu',
             inverse: 'chatWindowOwner',
-            isCausal: true,
         }),
         /**
          * Determines the channel invitation form displayed by this chat window
@@ -601,17 +600,14 @@ registerModel({
          */
         channelInvitationForm: one('ChannelInvitationForm', {
             inverse: 'chatWindow',
-            isCausal: true,
         }),
         channelMemberListView: one('ChannelMemberListView', {
             compute: '_computeChannelMemberListView',
             inverse: 'chatWindowOwner',
-            isCausal: true,
         }),
         chatWindowHeaderView: one('ChatWindowHeaderView', {
             default: {},
             inverse: 'chatWindowOwner',
-            isCausal: true,
         }),
         componentStyle: attr({
             compute: '_computeComponentStyle',
@@ -706,7 +702,6 @@ registerModel({
         newMessageAutocompleteInputView: one('AutocompleteInputView', {
             compute: '_computeNewMessageAutocompleteInputView',
             inverse: 'chatWindowOwnerAsNewMessage',
-            isCausal: true,
         }),
         /**
          * The content of placeholder for the autocomplete input of
@@ -735,7 +730,6 @@ registerModel({
         threadViewer: one('ThreadViewer', {
             compute: '_computeThreadViewer',
             inverse: 'chatWindow',
-            isCausal: true,
             required: true,
         }),
         /**

--- a/addons/mail/static/src/models/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager.js
@@ -350,7 +350,6 @@ registerModel({
         }),
         newMessageChatWindow: one('ChatWindow', {
             inverse: 'managerAsNewMessage',
-            isCausal: true,
         }),
         startGapWidth: attr({
             compute: '_computeStartGapWidth',

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -335,15 +335,12 @@ registerModel({
         activityBoxView: one('ActivityBoxView', {
             compute: '_computeActivityBoxView',
             inverse: 'chatter',
-            isCausal: true,
         }),
         attachmentBoxView: one('AttachmentBoxView', {
             inverse: 'chatter',
-            isCausal: true,
         }),
         attachmentsLoaderTimer: one('Timer', {
             inverse: 'chatterOwnerAsAttachmentsLoader',
-            isCausal: true,
         }),
         /**
          * States the OWL Chatter component of this chatter.
@@ -354,7 +351,6 @@ registerModel({
          */
         composerView: one('ComposerView', {
             inverse: 'chatter',
-            isCausal: true,
         }),
         context: attr({
             default: {},
@@ -362,22 +358,18 @@ registerModel({
         dropZoneView: one('DropZoneView', {
             compute: '_computeDropZoneView',
             inverse: 'chatterOwner',
-            isCausal: true,
         }),
         fileUploader: one('FileUploader', {
             compute: '_computeFileUploader',
             inverse: 'chatterOwner',
-            isCausal: true,
         }),
         followButtonView: one('FollowButtonView', {
             compute: '_computeFollowButtonView',
             inverse: 'chatterOwner',
-            isCausal: true,
         }),
         followerListMenuView: one('FollowerListMenuView', {
             compute: '_computeFollowerListMenuView',
             inverse: 'chatterOwner',
-            isCausal: true,
         }),
         /**
          * Determines whether `this` should display an activity box.
@@ -483,18 +475,15 @@ registerModel({
         threadViewer: one('ThreadViewer', {
             compute: '_computeThreadViewer',
             inverse: 'chatter',
-            isCausal: true,
             required: true,
         }),
         topbar: one('ChatterTopbar', {
             default: {},
             inverse: 'chatter',
-            isCausal: true,
         }),
         useDragVisibleDropZone: one('UseDragVisibleDropZone', {
             default: {},
             inverse: 'chatterOwner',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/composer_suggestable.js
+++ b/addons/mail/static/src/models/composer_suggestable.js
@@ -17,11 +17,9 @@ registerModel({
         }),
         composerSuggestionListViewExtraComposerSuggestionViewItems: many('ComposerSuggestionListViewExtraComposerSuggestionViewItem', {
             inverse: 'suggestable',
-            isCausal: true,
         }),
         composerSuggestionListViewMainComposerSuggestionViewItems: many('ComposerSuggestionListViewMainComposerSuggestionViewItem', {
             inverse: 'suggestable',
-            isCausal: true,
         }),
         partner: one('Partner', {
             identifying: true,

--- a/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
@@ -51,7 +51,6 @@ registerModel({
         composerSuggestedRecipientViews: many('ComposerSuggestedRecipientView', {
             compute: '_computeComposerSuggestedRecipientViews',
             inverse: 'composerSuggestedRecipientListViewOwner',
-            isCausal: true,
         }),
         composerViewOwner: one('ComposerView', {
             identifying: true,

--- a/addons/mail/static/src/models/composer_suggestion_list_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view.js
@@ -102,12 +102,10 @@ registerModel({
         composerSuggestionListViewExtraComposerSuggestionViewItems: many('ComposerSuggestionListViewExtraComposerSuggestionViewItem', {
             compute: '_computeComposerSuggestionListViewExtraComposerSuggestionViewItems',
             inverse: 'composerSuggestionListViewOwner',
-            isCausal: true,
         }),
         composerSuggestionListViewMainComposerSuggestionViewItems: many('ComposerSuggestionListViewMainComposerSuggestionViewItem', {
             compute: '_computeComposerSuggestionListViewMainComposerSuggestionViewItems',
             inverse: 'composerSuggestionListViewOwner',
-            isCausal: true,
         }),
         composerViewOwner: one('ComposerView', {
             identifying: true,

--- a/addons/mail/static/src/models/composer_suggestion_list_view_extra_composer_suggestion_view_item.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view_extra_composer_suggestion_view_item.js
@@ -18,7 +18,6 @@ registerModel({
         composerSuggestionView: one('ComposerSuggestionView', {
             default: {},
             inverse: 'composerSuggestionListViewExtraComposerSuggestionViewItemOwner',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/composer_suggestion_list_view_main_composer_suggestion_view_item.js
+++ b/addons/mail/static/src/models/composer_suggestion_list_view_main_composer_suggestion_view_item.js
@@ -18,7 +18,6 @@ registerModel({
         composerSuggestionView: one('ComposerSuggestionView', {
             default: {},
             inverse: 'composerSuggestionListViewMainComposerSuggestionViewItemOwner',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/composer_suggestion_view.js
+++ b/addons/mail/static/src/models/composer_suggestion_view.js
@@ -131,7 +131,6 @@ registerModel({
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'composerSuggestionViewOwner',
-            isCausal: true,
         }),
         suggestable: one('ComposerSuggestable', {
             compute: '_computeSuggestable',

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -1332,7 +1332,6 @@ registerModel({
         attachmentList: one('AttachmentList', {
             compute: '_computeAttachmentList',
             inverse: 'composerViewOwner',
-            isCausal: true,
         }),
         /**
          * States the ref to the html node of the emojis button.
@@ -1360,12 +1359,10 @@ registerModel({
         composerSuggestedRecipientListView: one('ComposerSuggestedRecipientListView', {
             compute: '_computeComposerSuggestedRecipientListView',
             inverse: 'composerViewOwner',
-            isCausal: true,
         }),
         composerSuggestionListView: one('ComposerSuggestionListView', {
             compute: '_computeComposerSuggestionListView',
             inverse: 'composerViewOwner',
-            isCausal: true,
         }),
         /**
          * Current partner image URL.
@@ -1380,20 +1377,17 @@ registerModel({
         dropZoneView: one('DropZoneView', {
             compute: '_computeDropZoneView',
             inverse: 'composerViewOwner',
-            isCausal: true,
         }),
         /**
          * Determines the emojis popover that is active on this composer view.
          */
         emojisPopoverView: one('PopoverView', {
             inverse: 'composerViewOwnerAsEmoji',
-            isCausal: true,
         }),
         extraSuggestions: many('ComposerSuggestable'),
         fileUploader: one('FileUploader', {
             default: {},
             inverse: 'composerView',
-            isCausal: true,
             readonly: true,
             required: true,
         }),
@@ -1576,7 +1570,6 @@ registerModel({
         useDragVisibleDropZone: one('UseDragVisibleDropZone', {
             default: {},
             inverse: 'composerViewOwner',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/delete_message_confirm_view.js
+++ b/addons/mail/static/src/models/delete_message_confirm_view.js
@@ -57,7 +57,6 @@ registerModel({
         messageView: one('MessageView', {
             compute: '_computeMessageView',
             inverse: 'deleteMessageConfirmViewOwner',
-            isCausal: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/dialog.js
+++ b/addons/mail/static/src/models/dialog.js
@@ -200,7 +200,6 @@ registerModel({
         attachmentDeleteConfirmView: one('AttachmentDeleteConfirmView', {
             compute: '_computeAttachmentDeleteConfirmView',
             inverse: 'dialogOwner',
-            isCausal: true,
         }),
         attachmentImageOwnerAsAttachmentDeleteConfirm: one('AttachmentImage', {
             identifying: true,
@@ -213,7 +212,6 @@ registerModel({
         attachmentViewer: one('AttachmentViewer', {
             compute: '_computeAttachmentViewer',
             inverse: 'dialogOwner',
-            isCausal: true,
         }),
         backgroundOpacity: attr({
             compute: '_computeBackgroundOpacity',
@@ -228,7 +226,6 @@ registerModel({
         deleteMessageConfirmView: one('DeleteMessageConfirmView', {
             compute: '_computeDeleteMessageConfirmView',
             inverse: 'dialogOwner',
-            isCausal: true,
         }),
         linkPreviewAsideViewOwnerAsLinkPreviewDeleteConfirm: one('LinkPreviewAsideView', {
             inverse: 'linkPreviewDeleteConfirmDialog',
@@ -237,7 +234,6 @@ registerModel({
         linkPreviewDeleteConfirmView: one('LinkPreviewDeleteConfirmView', {
             compute: '_computeLinkPreviewDeleteConfirmView',
             inverse: 'dialogOwner',
-            isCausal: true,
         }),
         followerOwnerAsSubtypeList: one('Follower', {
             identifying: true,
@@ -246,7 +242,6 @@ registerModel({
         followerSubtypeList: one('FollowerSubtypeList', {
             compute: '_computeFollowerSubtypeList',
             inverse: 'dialogOwner',
-            isCausal: true,
         }),
         isCloseable: attr({
             compute: '_computeIsCloseable',

--- a/addons/mail/static/src/models/discuss.js
+++ b/addons/mail/static/src/models/discuss.js
@@ -296,7 +296,6 @@ registerModel({
         categoryChannel: one('DiscussSidebarCategory', {
             default: {},
             inverse: 'discussAsChannel',
-            isCausal: true,
         }),
         /**
          * Discuss sidebar category for `chat` type channel threads.
@@ -304,11 +303,9 @@ registerModel({
         categoryChat: one('DiscussSidebarCategory', {
             default: {},
             inverse: 'discussAsChat',
-            isCausal: true,
         }),
         discussView: one('DiscussView', {
             inverse: 'discuss',
-            isCausal: true,
         }),
         /**
          * Determines whether `this.thread` should be displayed.
@@ -345,7 +342,6 @@ registerModel({
         notificationListView: one('NotificationListView', {
             compute: '_computeNotificationListView',
             inverse: 'discussOwner',
-            isCausal: true,
         }),
         /**
          * The navbar view on the discuss app when in mobile and when not
@@ -354,7 +350,6 @@ registerModel({
         mobileMessagingNavbarView: one('MobileMessagingNavbarView', {
             compute: '_computeMobileMessagingNavbarView',
             inverse: 'discuss',
-            isCausal: true,
         }),
         /**
          * Quick search input value in the discuss sidebar (desktop). Useful
@@ -376,7 +371,6 @@ registerModel({
         threadViewer: one('ThreadViewer', {
             compute: '_computeThreadViewer',
             inverse: 'discuss',
-            isCausal: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view.js
@@ -79,14 +79,12 @@ registerModel({
          */
         threadViewer: one('ThreadViewer', {
             inverse: 'discussPublicView',
-            isCausal: true,
         }),
         /**
          * States the welcome view linked to this discuss public view.
          */
         welcomeView: one('WelcomeView', {
             inverse: 'discussPublicView',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -340,7 +340,6 @@ registerModel({
         addingItemAutocompleteInputView: one('AutocompleteInputView', {
             compute: '_computeAddingItemAutocompleteInputView',
             inverse: 'discussSidebarCategoryOwnerAsAddingItem',
-            isCausal: true,
         }),
         /**
          * Determines how the autocomplete of this category should behave.
@@ -363,7 +362,6 @@ registerModel({
          */
         categoryItems: many('DiscussSidebarCategoryItem', {
             inverse: 'category',
-            isCausal: true,
             sort: '_sortDefinitionCategoryItems',
         }),
         /**

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -144,12 +144,10 @@ registerModel({
         historyView: one('DiscussSidebarMailboxView', {
             default: {},
             inverse: 'discussViewOwnerAsHistory',
-            isCausal: true,
         }),
         inboxView: one('DiscussSidebarMailboxView', {
             default: {},
             inverse: 'discussViewOwnerAsInbox',
-            isCausal: true,
         }),
         /**
          * Determines whether current user is adding a channel from the sidebar.
@@ -166,7 +164,6 @@ registerModel({
         mobileAddItemHeaderAutocompleteInputView: one('AutocompleteInputView', {
             compute: '_computeMobileAddItemHeaderAutocompleteInputView',
             inverse: 'discussViewOwnerAsMobileAddItemHeader',
-            isCausal: true,
         }),
         orderedMailboxes: many('Mailbox', {
             related: 'messaging.allMailboxes',
@@ -182,7 +179,6 @@ registerModel({
         starredView: one('DiscussSidebarMailboxView', {
             default: {},
             inverse: 'discussViewOwnerAsStarred',
-            isCausal: true,
         }),
     },
     onChanges: [

--- a/addons/mail/static/src/models/emoji.js
+++ b/addons/mail/static/src/models/emoji.js
@@ -46,7 +46,6 @@ registerModel({
                 return this.emojiCategories.map(category => ({ category }));
             },
             inverse: 'emoji',
-            isCausal: true,
         }),
         codepoints: attr({
             identifying: true,
@@ -63,7 +62,6 @@ registerModel({
         emojiDataCategory: one('EmojiCategory'),
         emojiOrEmojiInCategory: many('EmojiOrEmojiInCategory', {
             inverse: 'emoji',
-            isCausal: true,
         }),
         emojiRegistry: one('EmojiRegistry', {
             compute() {
@@ -78,7 +76,6 @@ registerModel({
         emojiViews: many('EmojiView', {
             inverse: 'emoji',
             readonly: true,
-            isCausal: true,
         }),
         emoticons: attr(),
         keywords: attr(),

--- a/addons/mail/static/src/models/emoji_category.js
+++ b/addons/mail/static/src/models/emoji_category.js
@@ -8,11 +8,9 @@ registerModel({
     fields: {
         allEmojiInCategoryOfCurrent: many('EmojiInCategory', {
             inverse: 'category',
-            isCausal: true,
         }),
         allEmojiPickerViewCategory: many('EmojiPickerView.Category', {
             inverse: 'category',
-            isCausal: true,
         }),
         allEmojis: many('Emoji', {
             inverse: 'emojiCategories',

--- a/addons/mail/static/src/models/emoji_category_bar_view.js
+++ b/addons/mail/static/src/models/emoji_category_bar_view.js
@@ -11,7 +11,6 @@ registerModel({
                 return this.emojiPickerViewOwner.categories.map(category => ({ viewCategory: category }));
             },
             inverse: 'emojiCategoryBarViewOwner',
-            isCausal: true,
         }),
         emojiPickerViewOwner: one('EmojiPickerView', {
             identifying: true,

--- a/addons/mail/static/src/models/emoji_grid_item_view.js
+++ b/addons/mail/static/src/models/emoji_grid_item_view.js
@@ -26,7 +26,6 @@ registerModel({
                 return clear();
             },
             inverse: 'emojiGridItemViewOwner',
-            isCausal: true,
         }),
         width: attr({
             compute() {

--- a/addons/mail/static/src/models/emoji_grid_row_view.js
+++ b/addons/mail/static/src/models/emoji_grid_row_view.js
@@ -14,7 +14,6 @@ registerModel({
             identifying: true,
         }),
         items: many('EmojiGridItemView', {
-            isCausal: true,
             inverse: 'emojiGridRowViewOwner',
         }),
         sectionView: one('EmojiGridSectionView', {
@@ -24,7 +23,6 @@ registerModel({
                 }
                 return clear();
             },
-            isCausal: true,
             inverse: 'emojiGridRowViewOwner',
         }),
         emojiGridViewRowRegistryOwner: one('EmojiGridViewRowRegistry', {

--- a/addons/mail/static/src/models/emoji_grid_view.js
+++ b/addons/mail/static/src/models/emoji_grid_view.js
@@ -123,14 +123,12 @@ registerModel({
         nonSearchRowRegistry: one('EmojiGridViewRowRegistry', {
             default: {},
             inverse: 'emojiGridViewOwnerAsNonSearch',
-            isCausal: true,
         }),
         onScrollThrottle: one('Throttle', {
             compute() {
                 return { func: () => this.update({ scrollRecomputeCount: increment() }) };
             },
             inverse: 'emojiGridViewAsOnScroll',
-            isCausal: true,
         }),
         renderedRows: many('EmojiGridRowView', {
             compute() {
@@ -190,12 +188,10 @@ registerModel({
                 return clear();
             },
             inverse: 'emojiGridViewOwner',
-            isCausal: true,
         }),
         searchRowRegistry: one('EmojiGridViewRowRegistry', {
             default: {},
             inverse: 'emojiGridViewOwnerAsSearch',
-            isCausal: true,
         }),
         topBufferAmount: attr({
             default: 2,

--- a/addons/mail/static/src/models/emoji_grid_view_row_registry.js
+++ b/addons/mail/static/src/models/emoji_grid_view_row_registry.js
@@ -74,7 +74,6 @@ registerModel({
                 }
                 return clear();
             },
-            isCausal: true,
             inverse: 'emojiGridViewRowRegistryOwner',
             sort: '_sortRows',
         }),

--- a/addons/mail/static/src/models/emoji_in_category.js
+++ b/addons/mail/static/src/models/emoji_in_category.js
@@ -16,7 +16,6 @@ registerModel({
         }),
         emojiOrEmojiInCategory: many('EmojiOrEmojiInCategory', {
             inverse: 'emojiInCategory',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/emoji_or_emoji_in_category.js
+++ b/addons/mail/static/src/models/emoji_or_emoji_in_category.js
@@ -16,7 +16,6 @@ registerModel({
             inverse: 'emojiOrEmojiInCategory',
         }),
         emojiGridItemViews: many('EmojiGridItemView', {
-            isCausal: true,
             inverse: 'emojiOrEmojiInCategory',
         }),
     },

--- a/addons/mail/static/src/models/emoji_picker_view.js
+++ b/addons/mail/static/src/models/emoji_picker_view.js
@@ -28,7 +28,6 @@ registerModel({
                 return this.messaging.emojiRegistry.allCategories.map(category => ({ category }));
             },
             inverse: 'emojiPickerViewOwner',
-            isCausal: true,
         }),
         defaultActiveCategory: one('EmojiPickerView.Category', {
             compute() {
@@ -43,20 +42,17 @@ registerModel({
             inverse: 'emojiPickerViewOwner',
             readonly: true,
             required: true,
-            isCausal: true,
         }),
         emojiGridView: one('EmojiGridView', {
             default: {},
             inverse: 'emojiPickerViewOwner',
             readonly: true,
             required: true,
-            isCausal: true,
         }),
         emojiSearchBarView: one('EmojiSearchBarView', {
             default: {},
             inverse: 'emojiPickerView',
             readonly: true,
-            isCausal: true,
         }),
         popoverViewOwner: one('PopoverView', {
             identifying: true,

--- a/addons/mail/static/src/models/emoji_picker_view__category.js
+++ b/addons/mail/static/src/models/emoji_picker_view__category.js
@@ -23,7 +23,6 @@ registerModel({
         }),
         emojiCategoryView: one('EmojiCategoryView', {
             inverse: 'viewCategory',
-            isCausal: true,
         }),
         emojiGridRowView: one('EmojiGridRowView', {
             inverse: 'viewCategory',

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -176,11 +176,9 @@ registerModel({
         }),
         followerSubtypeListDialog: one('Dialog', {
             inverse: 'followerOwnerAsSubtypeList',
-            isCausal: true,
         }),
         followerViews: many('FollowerView', {
             inverse: 'follower',
-            isCausal: true,
         }),
         id: attr({
             identifying: true,

--- a/addons/mail/static/src/models/follower_list_menu_view.js
+++ b/addons/mail/static/src/models/follower_list_menu_view.js
@@ -50,7 +50,6 @@ registerModel({
         followerViews: many('FollowerView', {
             compute: '_computeFollowerViews',
             inverse: 'followerListMenuViewOwner',
-            isCausal: true,
         }),
         isDisabled: attr({
             compute: '_computeIsDisabled',

--- a/addons/mail/static/src/models/follower_subtype.js
+++ b/addons/mail/static/src/models/follower_subtype.js
@@ -39,7 +39,6 @@ registerModel({
     fields: {
         followerSubtypeViews: many('FollowerSubtypeView', {
             inverse: 'subtype',
-            isCausal: true,
         }),
         id: attr({
             identifying: true,

--- a/addons/mail/static/src/models/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list.js
@@ -78,7 +78,6 @@ registerModel({
         followerSubtypeViews: many('FollowerSubtypeView', {
             compute: '_computeFollowerSubtypeViews',
             inverse: 'followerSubtypeListOwner',
-            isCausal: true,
             sort: '_sortFollowerSubtypeViews',
         }),
     },

--- a/addons/mail/static/src/models/guest.js
+++ b/addons/mail/static/src/models/guest.js
@@ -55,7 +55,6 @@ registerModel({
         persona: one('Persona', {
             default: {},
             inverse: 'guest',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/ir_model.js
+++ b/addons/mail/static/src/models/ir_model.js
@@ -23,7 +23,6 @@ registerModel({
         }),
         activityGroup: one('ActivityGroup', {
             inverse: 'irModel',
-            isCausal: true,
         }),
         iconUrl: attr(),
         id: attr({

--- a/addons/mail/static/src/models/link_preview.js
+++ b/addons/mail/static/src/models/link_preview.js
@@ -70,15 +70,12 @@ registerModel({
         }),
         linkPreviewCardView: many('LinkPreviewCardView', {
             inverse: 'linkPreview',
-            isCausal: true,
         }),
         linkPreviewImageView: many('LinkPreviewImageView', {
             inverse: 'linkPreview',
-            isCausal: true,
         }),
         linkPreviewVideoView: many('LinkPreviewVideoView', {
             inverse: 'linkPreview',
-            isCausal: true,
         }),
         message: one('Message', {
             inverse: 'linkPreviews',

--- a/addons/mail/static/src/models/link_preview_card_view.js
+++ b/addons/mail/static/src/models/link_preview_card_view.js
@@ -47,7 +47,6 @@ registerModel({
         linkPreviewAsideView: one('LinkPreviewAsideView', {
             compute: '_computeLinkPreviewAsideView',
             inverse: 'linkPreviewCardView',
-            isCausal: true,
         }),
         linkPreviewListViewOwner: one('LinkPreviewListView', {
             identifying: true,

--- a/addons/mail/static/src/models/link_preview_image_view.js
+++ b/addons/mail/static/src/models/link_preview_image_view.js
@@ -57,7 +57,6 @@ registerModel({
         linkPreviewAsideView: one('LinkPreviewAsideView', {
             compute: '_computeLinkPreviewAsideView',
             inverse: 'linkPreviewImageView',
-            isCausal: true,
         }),
         linkPreviewListViewOwner: one('LinkPreviewListView', {
             identifying: true,

--- a/addons/mail/static/src/models/link_preview_list_view.js
+++ b/addons/mail/static/src/models/link_preview_list_view.js
@@ -35,17 +35,14 @@ registerModel({
         linkPreviewAsCardViews: many('LinkPreviewCardView', {
             compute: '_computeLinkPreviewAsCardViews',
             inverse: 'linkPreviewListViewOwner',
-            isCausal: true,
         }),
         linkPreviewAsImageViews: many('LinkPreviewImageView', {
             compute: '_computeLinkPreviewAsImageViews',
             inverse: 'linkPreviewListViewOwner',
-            isCausal: true,
         }),
         linkPreviewAsVideoViews: many('LinkPreviewVideoView', {
             compute: '_computeLinkPreviewAsVideoViews',
             inverse: 'linkPreviewListViewOwner',
-            isCausal: true,
         }),
         messageViewOwner: one('MessageView', {
             identifying: true,

--- a/addons/mail/static/src/models/link_preview_video_view.js
+++ b/addons/mail/static/src/models/link_preview_video_view.js
@@ -47,7 +47,6 @@ registerModel({
         linkPreviewAsideView: one('LinkPreviewAsideView', {
             compute: '_computeLinkPreviewAsideView',
             inverse: 'linkPreviewVideoView',
-            isCausal: true,
         }),
         linkPreviewListViewOwner: one('LinkPreviewListView', {
             identifying: true,

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -784,7 +784,6 @@ registerModel({
          */
         messageReactionGroups: many('MessageReactionGroup', {
             inverse: 'message',
-            isCausal: true,
         }),
         messageTypeText: attr({
             compute: '_computeMessageTypeText',
@@ -803,7 +802,6 @@ registerModel({
         }),
         messageListViewItems: many('MessageListViewItem', {
             inverse: 'message',
-            isCausal: true,
         }),
         notifications: many('Notification', {
             inverse: 'message',

--- a/addons/mail/static/src/models/message_action.js
+++ b/addons/mail/static/src/models/message_action.js
@@ -127,7 +127,6 @@ registerModel({
         messageActionView: one('MessageActionView', {
             compute: '_computeMessageActionView',
             inverse: 'messageAction',
-            isCausal: true,
         }),
         /**
          * States the listing sequence of the action inside of the aciton list.

--- a/addons/mail/static/src/models/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list.js
@@ -128,37 +128,30 @@ registerModel({
         actionDelete: one('MessageAction', {
             compute: '_computeActionDelete',
             inverse: 'messageActionListOwnerAsDelete',
-            isCausal: true,
         }),
         actionEdit: one('MessageAction', {
             compute: '_computeActionEdit',
             inverse: 'messageActionListOwnerAsEdit',
-            isCausal: true,
         }),
         actionMarkAsRead: one('MessageAction', {
             compute: '_computeActionMarkAsRead',
             inverse: 'messageActionListOwnerAsMarkAsRead',
-            isCausal: true,
         }),
         actionReaction: one('MessageAction', {
             compute: '_computeActionReaction',
             inverse: 'messageActionListOwnerAsReaction',
-            isCausal: true,
         }),
         actionReplyTo: one('MessageAction', {
             compute: '_computeActionReplyTo',
             inverse: 'messageActionListOwnerAsReplyTo',
-            isCausal: true,
         }),
         actionToggleCompact: one('MessageAction', {
             compute: '_computeActionToggleCompact',
             inverse: 'messageActionListOwnerAsToggleCompact',
-            isCausal: true,
         }),
         actionToggleStar: one('MessageAction', {
             compute: '_computeActionToggleStar',
             inverse: 'messageActionListOwnerAsToggleStar',
-            isCausal: true,
         }),
         compactThreshold: attr({
             default: 2,

--- a/addons/mail/static/src/models/message_action_view.js
+++ b/addons/mail/static/src/models/message_action_view.js
@@ -188,7 +188,6 @@ registerModel({
         }),
         deleteConfirmDialog: one('Dialog', {
             inverse: 'messageActionViewOwnerAsDeleteConfirm',
-            isCausal: true,
         }),
         messageAction: one('MessageAction', {
             identifying: true,
@@ -200,7 +199,6 @@ registerModel({
         }),
         reactionPopoverView: one('PopoverView', {
             inverse: 'messageActionViewOwnerAsReaction',
-            isCausal: true,
         }),
         tabindex: attr({
             compute: '_computeTabindex',

--- a/addons/mail/static/src/models/message_list_view.js
+++ b/addons/mail/static/src/models/message_list_view.js
@@ -116,7 +116,6 @@ registerModel({
         messageListViewItems: many('MessageListViewItem', {
             compute: '_computeMessageListViewMessageViewItems',
             inverse: 'messageListViewOwner',
-            isCausal: true,
         }),
         scrollHeight: attr(),
         scrollTop: attr(),

--- a/addons/mail/static/src/models/message_list_view_item.js
+++ b/addons/mail/static/src/models/message_list_view_item.js
@@ -47,12 +47,10 @@ registerModel({
         notificationMessageView: one('NotificationMessageView', {
             compute: '_computeNotificationMessageView',
             inverse: 'messageListViewItemOwner',
-            isCausal: true,
         }),
         messageView: one('MessageView', {
             compute: '_computeMessageView',
             inverse: 'messageListViewItemOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -469,7 +469,6 @@ registerModel({
         attachmentList: one('AttachmentList', {
             compute: '_computeAttachmentList',
             inverse: 'messageViewOwner',
-            isCausal: true,
         }),
         authorTitleText: attr({
             compute: '_computeAuthorTitleText',
@@ -481,7 +480,6 @@ registerModel({
                 },
             },
             inverse: 'messageViewOwner',
-            isCausal: true,
         }),
         /**
          * States the component displaying this message view (if any).
@@ -489,14 +487,12 @@ registerModel({
         component: attr(),
         composerForEditing: one('Composer', {
             inverse: 'messageViewInEditing',
-            isCausal: true,
         }),
         /**
         * Determines the composer that is used to edit this message (if any).
         */
         composerViewInEditing: one('ComposerView', {
             inverse: 'messageViewInEditing',
-            isCausal: true,
         }),
         /**
          * States the time elapsed since date up to now.
@@ -543,7 +539,6 @@ registerModel({
          */
         highlightTimer: one('Timer', {
             inverse: 'messageViewOwnerAsHighlight',
-            isCausal: true,
         }),
         /**
          * Whether the message is "active", ie: hovered or clicked, and should
@@ -617,7 +612,6 @@ registerModel({
         linkPreviewListView: one('LinkPreviewListView', {
             compute: '_computeLinkPreviewListView',
             inverse: 'messageViewOwner',
-            isCausal: true,
         }),
         /**
          * Determines the message action list of this message view (if any).
@@ -625,7 +619,6 @@ registerModel({
         messageActionList: one('MessageActionList', {
             compute: '_computeMessageActionList',
             inverse: 'messageView',
-            isCausal: true,
         }),
         /**
          * Determines the message that is displayed by this message view.
@@ -642,7 +635,6 @@ registerModel({
         messageInReplyToView: one('MessageInReplyToView', {
             compute: '_computeMessageInReplyToView',
             inverse: 'messageView',
-            isCausal: true,
         }),
         messageListViewItemOwner: one('MessageListViewItem', {
             identifying: true,
@@ -651,7 +643,6 @@ registerModel({
         messageSeenIndicatorView: one('MessageSeenIndicatorView', {
             compute: '_computeMessageSeenIndicatorView',
             inverse: 'messageViewOwner',
-            isCausal: true,
         }),
         messagingAsClickedMessageView: one('Messaging', {
             inverse: 'clickedMessageView',
@@ -667,12 +658,10 @@ registerModel({
         notificationIconRef: attr(),
         notificationPopoverView: one('PopoverView', {
             inverse: 'messageViewOwnerAsNotificationContent',
-            isCausal: true,
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'messageViewOwner',
-            isCausal: true,
         }),
         /**
          * States whether this message view is the last one of its thread view.

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -406,7 +406,6 @@ registerModel({
         }),
         fetchImStatusTimer: one('Timer', {
             inverse: 'messagingOwnerAsFetchImStatusTimer',
-            isCausal: true,
         }),
         fetchImStatusTimerDuration: attr({
             default: 50 * 1000,
@@ -415,12 +414,10 @@ registerModel({
         history: one('Mailbox', {
             default: {},
             inverse: 'messagingAsHistory',
-            isCausal: true,
         }),
         inbox: one('Mailbox', {
             default: {},
             inverse: 'messagingAsInbox',
-            isCausal: true,
         }),
         /**
          * Promise that will be resolved when messaging is initialized.
@@ -513,7 +510,6 @@ registerModel({
         starred: one('Mailbox', {
             default: {},
             inverse: 'messagingAsStarred',
-            isCausal: true,
         }),
         userNotificationManager: one('UserNotificationManager', {
             default: {},

--- a/addons/mail/static/src/models/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu.js
@@ -212,20 +212,17 @@ registerModel({
         notificationListView: one('NotificationListView', {
             compute: '_computeNotificationListView',
             inverse: 'messagingMenuOwner',
-            isCausal: true,
         }),
         /**
          * The navbar view on the messaging menu when in mobile.
          */
-         mobileMessagingNavbarView: one('MobileMessagingNavbarView', {
+        mobileMessagingNavbarView: one('MobileMessagingNavbarView', {
             compute: '_computeMobileMessagingNavbarView',
             inverse: 'messagingMenu',
-            isCausal: true,
         }),
         mobileNewMessageAutocompleteInputView: one('AutocompleteInputView', {
             compute: '_computeMobileNewMessageAutocompleteInputView',
             inverse: 'messagingMenuOwnerAsMobileNewMessageInput',
-            isCausal: true,
         }),
         mobileNewMessageInputPlaceholder: attr({
             compute: '_computeMobileNewMessageInputPlaceholder',

--- a/addons/mail/static/src/models/notification_group.js
+++ b/addons/mail/static/src/models/notification_group.js
@@ -118,7 +118,6 @@ registerModel({
         }),
         notificationGroupViews: many('NotificationGroupView', {
             inverse: 'notificationGroup',
-            isCausal: true,
         }),
         res_id: attr({
             identifying: true,

--- a/addons/mail/static/src/models/notification_list_view.js
+++ b/addons/mail/static/src/models/notification_list_view.js
@@ -163,7 +163,6 @@ registerModel({
         channelPreviewViews: many('ChannelPreviewView', {
             compute: '_computeChannelPreviewViews',
             inverse: 'notificationListViewOwner',
-            isCausal: true,
         }),
         discussOwner: one('Discuss', {
             identifying: true,
@@ -182,12 +181,10 @@ registerModel({
         notificationGroupViews: many('NotificationGroupView', {
             compute: '_computeNotificationGroupViews',
             inverse: 'notificationListViewOwner',
-            isCausal: true,
         }),
         notificationRequestView: one('NotificationRequestView', {
             compute: '_computeNotificationRequestView',
             inverse: 'notificationListViewOwner',
-            isCausal: true,
         }),
         notificationViews: many('Record', {
             compute: '_computeNotificationViews',
@@ -196,7 +193,6 @@ registerModel({
         threadNeedactionPreviewViews: many('ThreadNeedactionPreviewView', {
             compute: '_computeThreadNeedactionPreviewViews',
             inverse: 'notificationListViewOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/notification_request_view.js
+++ b/addons/mail/static/src/models/notification_request_view.js
@@ -41,7 +41,6 @@ registerModel({
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'notificationRequestViewOwner',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/other_member_long_typing_in_thread_timer.js
+++ b/addons/mail/static/src/models/other_member_long_typing_in_thread_timer.js
@@ -22,7 +22,6 @@ registerModel({
         timer: one('Timer', {
             default: {},
             inverse: 'otherMemberLongTypingInThreadTimerOwner',
-            isCausal: true,
             required: true,
         }),
     },

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -316,11 +316,9 @@ registerModel({
         }),
         channelInvitationFormSelectablePartnerViews: many('ChannelInvitationFormSelectablePartnerView', {
             inverse: 'partner',
-            isCausal: true,
         }),
         channelInvitationFormSelectedPartnerViews: many('ChannelInvitationFormSelectedPartnerView', {
             inverse: 'partner',
-            isCausal: true,
         }),
         country: one('Country'),
         /**
@@ -372,14 +370,12 @@ registerModel({
         persona: one('Persona', {
             default: {},
             inverse: 'partner',
-            isCausal: true,
             readonly: true,
             required: true,
         }),
         suggestable: one('ComposerSuggestable', {
             default: {},
             inverse: 'partner',
-            isCausal: true,
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/popover_view.js
+++ b/addons/mail/static/src/models/popover_view.js
@@ -230,7 +230,6 @@ registerModel({
         activityMarkDonePopoverContentView: one('ActivityMarkDonePopoverContentView', {
             compute: '_computeActivityMarkDonePopoverContentView',
             inverse: 'popoverViewOwner',
-            isCausal: true,
         }),
         activityViewOwnerAsMarkDone: one('ActivityView', {
             identifying: true,
@@ -250,7 +249,6 @@ registerModel({
         callOptionMenuView: one('CallOptionMenu', {
             compute: '_computeCallOptionMenuView',
             inverse: 'popoverViewOwner',
-            isCausal: true,
         }),
         callParticipantCardOwner: one('CallParticipantCard', {
             identifying: true,
@@ -259,7 +257,6 @@ registerModel({
         callParticipantCardPopoverContentView: one('CallParticipantCardPopoverContentView', {
             compute: '_computeCallParticipantCardPopoverContentView',
             inverse: 'popoverViewOwner',
-            isCausal: true,
         }),
         /**
          * The record that represents the content inside the popover view.
@@ -267,7 +264,6 @@ registerModel({
         channelInvitationForm: one('ChannelInvitationForm', {
             compute: '_computeChannelInvitationForm',
             inverse: 'popoverViewOwner',
-            isCausal: true,
         }),
         /**
          * States the OWL component of this popover view.
@@ -309,7 +305,6 @@ registerModel({
         emojiPickerView: one('EmojiPickerView', {
             compute: '_computeEmojiPickerView',
             inverse: 'popoverViewOwner',
-            isCausal: true,
         }),
         manager: one('PopoverManager', {
             compute: '_computeManager',
@@ -325,7 +320,6 @@ registerModel({
         messageNotificationPopoverContentView: one('MessageNotificationPopoverContentView', {
             compute: '_computeMessageNotificationPopoverContentView',
             inverse: 'popoverViewOwner',
-            isCausal: true,
         }),
         messageViewOwnerAsNotificationContent: one('MessageView', {
             identifying: true,

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -1132,7 +1132,6 @@ registerModel({
         audioTrack: attr(),
         blurManager: one('BlurManager', {
             inverse: 'rtc',
-            isCausal: true,
         }),
         /**
          * The channel that is hosting the current RTC call.
@@ -1258,7 +1257,6 @@ registerModel({
         callSystrayMenu: one('CallSystrayMenu', {
             default: {},
             inverse: 'rtc',
-            isCausal: true,
         }),
         /**
          * True if we want to enable the video track of the current partner.

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -354,7 +354,6 @@ registerModel({
         audioStream: attr(),
         broadcastTimer: one('Timer', {
             inverse: 'rtcSessionOwnerAsBroadcast',
-            isCausal: true,
         }),
         /**
          * The mail.channel of the session, rtc sessions are part and managed by
@@ -492,14 +491,12 @@ registerModel({
         }),
         rtcPeerConnection: one('RtcPeerConnection', {
             inverse: 'rtcSession',
-            isCausal: true,
         }),
         /**
          * Contains the RTCDataChannel of the rtc session.
          */
         rtcDataChannel: one('RtcDataChannel', {
             inverse: 'rtcSession',
-            isCausal: true,
         }),
         /**
          * MediaStream of the user's video.

--- a/addons/mail/static/src/models/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info.js
@@ -45,7 +45,6 @@ registerModel({
     fields: {
         composerSuggestedRecipientViews: many('ComposerSuggestedRecipientView', {
             inverse: 'suggestedRecipientInfo',
-            isCausal: true,
         }),
         dialogText: attr({
             compute: '_computeDialogText',

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1587,7 +1587,6 @@ registerModel({
         cache: one('ThreadCache', {
             default: {},
             inverse: 'thread',
-            isCausal: true,
             readonly: true,
             required: true,
         }),
@@ -1601,7 +1600,6 @@ registerModel({
          */
         chatWindow: one('ChatWindow', {
             inverse: 'thread',
-            isCausal: true,
         }),
         /**
          * Determines the composer state of this thread.
@@ -1609,7 +1607,6 @@ registerModel({
         composer: one('Composer', {
             compute: '_computeComposer',
             inverse: 'thread',
-            isCausal: true,
         }),
         creator: one('User'),
         /**
@@ -1621,7 +1618,6 @@ registerModel({
          */
         currentPartnerInactiveTypingTimer: one('Timer', {
             inverse: 'threadAsCurrentPartnerInactiveTypingTimerOwner',
-            isCausal: true,
         }),
         /**
          * Last 'is_typing' status of current partner that has been notified
@@ -1649,7 +1645,6 @@ registerModel({
          */
         currentPartnerLongTypingTimer: one('Timer', {
             inverse: 'threadAsCurrentPartnerLongTypingTimerOwner',
-            isCausal: true,
         }),
         /**
          * Determines the default display mode of this channel. Should contain
@@ -1918,7 +1913,6 @@ registerModel({
          */
         messageSeenIndicators: many('MessageSeenIndicator', {
             inverse: 'thread',
-            isCausal: true,
         }),
         messagingAsAllCurrentClientThreads: one('Messaging', {
             compute: '_computeMessagingAsAllCurrentClientThreads',
@@ -1984,7 +1978,6 @@ registerModel({
          */
         otherMembersLongTypingTimers: many('OtherMemberLongTypingInThreadTimer', {
             inverse: 'thread',
-            isCausal: true,
         }),
         /**
          * States the `Activity` that belongs to `this` and that are
@@ -1999,7 +1992,6 @@ registerModel({
          */
         partnerSeenInfos: many('ThreadPartnerSeenInfo', {
             inverse: 'thread',
-            isCausal: true,
         }),
         /**
          * Determine if there is a pending seen message change, which is a change
@@ -2019,7 +2011,6 @@ registerModel({
         callInviteRequestPopup: one('CallInviteRequestPopup', {
             compute: '_computeCallInviteRequestPopup',
             inverse: 'thread',
-            isCausal: true,
         }),
         /**
          * The session that invited the current user, it is only set when the
@@ -2055,7 +2046,6 @@ registerModel({
         suggestable: one('ComposerSuggestable', {
             default: {},
             inverse: 'thread',
-            isCausal: true,
             readonly: true,
             required: true,
         }),
@@ -2110,7 +2100,6 @@ registerModel({
         throttleNotifyCurrentPartnerTypingStatus: one('Throttle', {
             compute: '_computeThrottleNotifyCurrentPartnerTypingStatus',
             inverse: 'threadAsThrottleNotifyCurrentPartnerTypingStatus',
-            isCausal: true,
         }),
         /**
          * States the `Activity` that belongs to `this` and that are due
@@ -2121,7 +2110,6 @@ registerModel({
         }),
         threadNeedactionPreviewViews: many('ThreadNeedactionPreviewView', {
             inverse: 'thread',
-            isCausal: true,
         }),
         /**
          * Members that are currently typing something in the composer of this

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -109,7 +109,6 @@ registerModel({
         messageAuthorPrefixView: one('MessageAuthorPrefixView', {
             compute: '_computeMessageAuthorPrefixView',
             inverse: 'threadNeedactionPreviewViewOwner',
-            isCausal: true,
         }),
         notificationListViewOwner: one('NotificationListView', {
             identifying: true,
@@ -118,7 +117,6 @@ registerModel({
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',
             inverse: 'threadNeedactionPreviewViewOwner',
-            isCausal: true,
         }),
         thread: one('Thread', {
             identifying: true,

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -334,12 +334,10 @@ registerModel({
         callSettingsMenu: one('CallSettingsMenu', {
             compute: '_computeCallSettingsMenu',
             inverse: 'threadViewOwner',
-            isCausal: true,
         }),
         channelMemberListView: one('ChannelMemberListView', {
             compute: '_computeChannelMemberListView',
             inverse: 'threadViewOwner',
-            isCausal: true,
         }),
         compact: attr({
             related: 'threadViewer.compact',
@@ -368,7 +366,6 @@ registerModel({
         composerView: one('ComposerView', {
             compute: '_computeComposerView',
             inverse: 'threadView',
-            isCausal: true,
         }),
         /**
          * Determines which extra class this thread view component should have.
@@ -475,7 +472,6 @@ registerModel({
         messageListView: one('MessageListView', {
             compute: '_computeMessageListView',
             inverse: 'threadViewOwner',
-            isCausal: true,
         }),
         messages: many('Message', {
             related: 'threadCache.messages',
@@ -497,7 +493,6 @@ registerModel({
         callView: one('CallView', {
             compute: '_computeCallView',
             inverse: 'threadView',
-            isCausal: true,
         }),
         /**
          * Determines the `Thread` currently displayed by `this`.
@@ -546,7 +541,6 @@ registerModel({
         topbar: one('ThreadViewTopbar', {
             compute: '_computeTopbar',
             inverse: 'threadView',
-            isCausal: true,
         }),
     },
     onChanges: [

--- a/addons/mail/static/src/models/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar.js
@@ -624,7 +624,6 @@ registerModel({
          * open in the topbar.
          */
         invitePopoverView: one('PopoverView', {
-            isCausal: true,
             inverse: 'threadViewTopbarOwnerAsInvite',
         }),
         /**

--- a/addons/mail/static/src/models/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_viewer.js
@@ -160,7 +160,6 @@ registerModel({
         threadView: one('ThreadView', {
             compute: '_computeThreadView',
             inverse: 'threadViewer',
-            isCausal: true,
         }),
         threadView_hasComposerThreadTyping: attr({
             compute: '_computeThreadView_hasComposerThreadTyping',

--- a/addons/mail/static/src/models/throttle.js
+++ b/addons/mail/static/src/models/throttle.js
@@ -59,7 +59,6 @@ registerModel({
     fields: {
         cooldownTimer: one('Timer', {
             inverse: 'throttleOwner',
-            isCausal: true,
         }),
         /**
          * Duration, in milliseconds, of the cool down phase.

--- a/addons/mail/static/src/models/tracking_value.js
+++ b/addons/mail/static/src/models/tracking_value.js
@@ -38,11 +38,9 @@ registerModel({
         }),
         newValue: one('TrackingValueItem', {
             inverse: 'trackingValueAsNewValue',
-            isCausal: true,
         }),
         oldValue: one('TrackingValueItem', {
             inverse: 'trackingValueAsOldValue',
-            isCausal: true,
         }),
     },
 });

--- a/addons/mail/static/src/models/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view.js
@@ -181,7 +181,6 @@ registerModel({
         callDemoView: one('CallDemoView', {
             compute: '_computeCallDemoView',
             inverse: 'welcomeView',
-            isCausal: true,
         }),
         /**
          * States the name the guest had when landing on the welcome view.

--- a/addons/mail/static/tests/models/qunit_test.js
+++ b/addons/mail/static/tests/models/qunit_test.js
@@ -8,23 +8,18 @@ registerModel({
     fields: {
         clockWatcher: one('ClockWatcher', {
             inverse: 'qunitTestOwner',
-            isCausal: true,
         }),
         throttle1: one('Throttle', {
             inverse: 'qunitTestOwner1',
-            isCausal: true,
         }),
         throttle2: one('Throttle', {
             inverse: 'qunitTestOwner2',
-            isCausal: true,
         }),
         timer1: one('Timer', {
             inverse: 'qunitTestOwner1',
-            isCausal: true,
         }),
         timer2: one('Timer', {
             inverse: 'qunitTestOwner2',
-            isCausal: true,
         }),
     },
 });

--- a/addons/snailmail/static/src/models/dialog.js
+++ b/addons/snailmail/static/src/models/dialog.js
@@ -14,7 +14,6 @@ addFields('Dialog', {
     snailmailErrorView: one('SnailmailErrorView', {
         compute: '_computeSnailmailErrorView',
         inverse: 'dialogOwner',
-        isCausal: true,
     }),
 });
 

--- a/addons/snailmail/static/src/models/message_view.js
+++ b/addons/snailmail/static/src/models/message_view.js
@@ -9,11 +9,9 @@ import '@mail/models/message_view';
 addFields('MessageView', {
     snailmailErrorDialog: one('Dialog', {
         inverse: 'messageViewOwnerAsSnailmailError',
-        isCausal: true,
     }),
     snailmailNotificationPopoverView: one('PopoverView', {
         inverse: 'messageViewOwnerAsSnailmailNotificationContent',
-        isCausal: true,
     }),
 });
 

--- a/addons/snailmail/static/src/models/popover_view.js
+++ b/addons/snailmail/static/src/models/popover_view.js
@@ -14,7 +14,6 @@ addFields('PopoverView', {
     snailmailNotificationPopoverContentView: one('SnailmailNotificationPopoverContentView', {
         compute: '_computeSnailmailNotificationPopoverContentView',
         inverse: 'popoverViewOwner',
-        isCausal: true,
     }),
 });
 


### PR DESCRIPTION
\* = im_livechat, snailmail

The model manager will now automatically add `isCausal: true` to inverse of identifying fields. This commit implements the feature and removes now unnecessary declarations of `isCausal: true` from the code.

Task-2741402
Enterprise: https://github.com/odoo/enterprise/pull/31290