### PR TITLE
[FIX] website: avoid reloading the window from js tours

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -23,8 +23,7 @@ const wTourUtils = require('website.tour_utils');
  */
 
 wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
     test: true,
 }, [
     {

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -20,8 +20,7 @@ const selectImageSteps = [{
 
 wTourUtils.registerWebsitePreviewTour('test_image_link', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -61,9 +61,8 @@ const setupSteps = [{
 const formatErrorMsg = "format is not supported. Try with: .gif, .jpe, .jpeg, .jpg, .png, .svg";
 
 wTourUtils.registerWebsitePreviewTour('test_image_upload_progress', {
-    url: '/test_image_progress',
+    url: '/@/test_image_progress?enable_editor=1',
     test: true,
-    edition: true,
 }, [
     ...setupSteps,
     // 1. Check multi image upload
@@ -203,9 +202,8 @@ wTourUtils.registerWebsitePreviewTour('test_image_upload_progress', {
 
 
 wTourUtils.registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
-    url: '/test_image_progress',
+    url: '/@/test_image_progress?enable_editor=1',
     test: true,
-    edition: true,
 }, [
     ...setupSteps,
     // 1. Check multi image upload

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -10,7 +10,7 @@ const VIDEO_URL = 'https://www.youtube.com/watch?v=Dpq87YCHmJc';
  * The purpose of this tour is to check the media replacement flow.
  */
 wTourUtils.registerWebsitePreviewTour('test_replace_media', {
-    url: '/',
+    url: '/@/',
     test: true,
 }, [
     wTourUtils.clickOnEdit(),

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -15,9 +15,8 @@ var BROKEN_STEP = {
 };
 wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part1', {
     test: true,
-    url: '/test_page_view',
+    url: '/@/test_page_view?enable_editor=1',
     // 1. Edit the page through Edit Mode, it will COW the view
-    edition: true,
 },
     [
         {
@@ -59,7 +58,7 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part1'
 
 wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2', {
     test: true,
-    url: '/test_page_view',
+    url: '/@/test_page_view',
 },
     [
         {

--- a/addons/test_website/tests/test_custom_snippet.py
+++ b/addons/test_website/tests/test_custom_snippet.py
@@ -10,4 +10,4 @@ class TestCustomSnippet(odoo.tests.HttpCase):
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_run_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_custom_snippet', login="admin")
+        self.start_tour('/@/?enable_editor=1', 'test_custom_snippet', login="admin")

--- a/addons/test_website/tests/test_image_upload_progress.py
+++ b/addons/test_website/tests/test_image_upload_progress.py
@@ -13,7 +13,7 @@ from odoo import http
 class TestImageUploadProgress(odoo.tests.HttpCase):
 
     def test_01_image_upload_progress(self):
-        self.start_tour(self.env['website'].get_client_action_url('/test_image_progress'), 'test_image_upload_progress', login="admin")
+        self.start_tour('/@/test_image_progress?enable_editor=1', 'test_image_upload_progress', login="admin")
 
     def test_02_image_upload_progress_unsplash(self):
         BASE_URL = self.base_url()
@@ -53,4 +53,4 @@ class TestImageUploadProgress(odoo.tests.HttpCase):
         media_library_search.routing_type = 'json'
         Web_Editor.media_library_search = http.route(['/web_editor/media_library_search'], type='json', auth="user", website=True)(media_library_search)
 
-        self.start_tour(self.env['website'].get_client_action_url('/test_image_progress'), 'test_image_upload_progress_unsplash', login="admin")
+        self.start_tour('/@/test_image_progress?enable_editor=1', 'test_image_upload_progress_unsplash', login="admin")

--- a/addons/test_website/tests/test_media.py
+++ b/addons/test_website/tests/test_media.py
@@ -19,7 +19,7 @@ class TestMedia(odoo.tests.HttpCase):
             'mimetype': 'image/svg+xml',
             'datas': SVG,
         })
-        self.start_tour("/", 'test_replace_media', login="admin")
+        self.start_tour("/@/", 'test_replace_media', login="admin")
 
     def test_02_image_link(self):
-        self.start_tour("/", 'test_image_link', login="admin")
+        self.start_tour("/@/?enable_editor=1", 'test_image_link', login="admin")

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -90,9 +90,9 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
     @mute_logger('odoo.http')
     def test_07_reset_page_view_complete_flow(self):
-        self.start_tour(self.env['website'].get_client_action_url('/test_page_view'), 'test_reset_page_view_complete_flow_part1', login="admin")
+        self.start_tour('/@/test_page_view?enable_editor=1', 'test_reset_page_view_complete_flow_part1', login="admin")
         self.fix_it('/test_page_view')
-        self.start_tour(self.env['website'].get_client_action_url('/test_page_view'), 'test_reset_page_view_complete_flow_part2', login="admin")
+        self.start_tour('/@/test_page_view', 'test_reset_page_view_complete_flow_part2', login="admin")
         self.fix_it('/test_page_view')
 
     @mute_logger('odoo.http')

--- a/addons/web_tour/static/src/js/tour_manager.js
+++ b/addons/web_tour/static/src/js/tour_manager.js
@@ -213,7 +213,7 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
         this._to_next_step(tour_name, 0);
         local_storage.setItem(get_step_key(tour_name), tour.current_step);
 
-        if (tour.url) {
+        if (tour.url && this._shouldRedirect(tour.url)) {
             this.pause();
             do_before_unload(null, (function () {
                 this.play();
@@ -281,6 +281,20 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
                 this.update(tour_name);
             }
         }
+    },
+    /**
+     * The browser should not reload the window if already located at the
+     * tour's url.
+     *
+     * @param {String} tourUrl
+     * @returns {boolean}
+     */
+    _shouldRedirect(tourUrl) {
+        const windowUrl = new URL(window.location.href);
+        // 'watch' is a technical parameter added by the python test suite that
+        // should not be taken into account for the comparison.
+        windowUrl.searchParams.delete('watch');
+        return windowUrl.href !== `${window.location.origin}${tourUrl}`;
     },
     /**
      *  Check (and activate or update) a help tooltip for a tour.

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -283,6 +283,7 @@
             'website/static/src/client_actions/*/*.xml',
             'website/static/src/components/website_loader/*.xml',
             'website/static/src/js/backend/**/*',
+            'website/static/src/js/tours/tour_manager.js',
 
             # Don't include dark mode files in light mode
             ('remove', 'website/static/src/components/dialog/*.dark.scss'),

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -291,6 +291,7 @@ export class WebsitePreview extends Component {
         this.currentTitle = this.iframe.el.contentDocument.title;
         history.replaceState({}, this.currentTitle, currentUrl.href);
         this.title.setParts({ action: this.currentTitle });
+        core.bus.trigger('WEBSITE-FRONTEND-URL-SET');
     }
 
     _onPageLoaded() {

--- a/addons/website/static/src/js/tours/tour_manager.js
+++ b/addons/website/static/src/js/tours/tour_manager.js
@@ -17,4 +17,15 @@ TourManager.include({
         }
         return res;
     },
+    /**
+     * @override
+     */
+    _shouldRedirect(tourUrl) {
+        // The "enable_editor" search param should be removed to follow the /@/
+        // controller.
+        const fullUrl = new URL(tourUrl, window.location);
+        fullUrl.searchParams.delete('enable_editor');
+        const updatedTourUrl = `${fullUrl.pathname}${fullUrl.search}${fullUrl.hash}`;
+        return this._super(updatedTourUrl);
+    }
 });

--- a/addons/website/static/src/js/tours/tour_manager.js
+++ b/addons/website/static/src/js/tours/tour_manager.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+
+import TourManager from 'web_tour.TourManager';
+import core from 'web.core';
+
+TourManager.include({
+    /**
+     * @override
+     */
+    async _waitBeforeTourStart() {
+        const res = await this._super(...arguments);
+        if (window.location.href.indexOf('/web#action=website.website_preview') > 0) {
+            // The tour manager waits for the final WebsitePreview client
+            // action's url to start the tour, in order to avoid reloading the
+            // browser if the it is already at the right location.
+            await new Promise(resolve => core.bus.once('WEBSITE-FRONTEND-URL-SET', this, resolve));
+        }
+        return res;
+    },
+});

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -315,14 +315,13 @@ function clickOnExtraMenuItem(stepOptions, backend = false) {
  */
 function registerWebsitePreviewTour(name, options, steps) {
     const tourSteps = [...steps];
-    const url = getClientActionUrl(options.url, !!options.edition);
 
     // Note: for both non edit mode and edit mode, we set a high timeout for the
     // first step. Indeed loading both the backend and the frontend (in the
     // iframe) and potentially starting the edit mode can take a long time in
     // automatic tests. We'll try and decrease the need for this high timeout
     // of course.
-    if (options.edition) {
+    if (options.url.indexOf('enable_editor=1') > -1) {
         tourSteps.unshift({
             content: "Wait for the edit mode to be started",
             trigger: '.o_website_preview.editor_enable.editor_has_snippets',
@@ -333,13 +332,12 @@ function registerWebsitePreviewTour(name, options, steps) {
         tourSteps[0].timeout = 20000;
     }
 
-    return tour.register(name, Object.assign({}, options, { url }), tourSteps);
+    return tour.register(name, options, tourSteps);
 }
 
 function registerThemeHomepageTour(name, steps) {
     return registerWebsitePreviewTour(name, {
-        url: '/',
-        edition: true,
+        url: '/@/?enable_editor=1',
         sequence: 1010,
         saveAs: "homepage",
     }, prepend_trigger(
@@ -349,7 +347,7 @@ function registerThemeHomepageTour(name, steps) {
 }
 
 function registerBackendAndFrontendTour(name, options, steps) {
-    if (window.location.pathname === '/web') {
+    if (window.location.pathname === '/web' || window.location.pathname.startsWith('/@/')) {
         const newSteps = [];
         for (const step of steps) {
             const newStep = Object.assign({}, step);
@@ -359,7 +357,8 @@ function registerBackendAndFrontendTour(name, options, steps) {
             }
             newSteps.push(newStep);
         }
-        return registerWebsitePreviewTour(name, options, newSteps);
+        const clientActionUrl = `/@${options.url}`;
+        return registerWebsitePreviewTour(name, Object.assign({}, options, { url: clientActionUrl }), newSteps);
     }
 
     return tour.register(name, {

--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -5,7 +5,7 @@ const wTourUtils = require("website.tour_utils");
 
 wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
     test: true,
-    url: '/',
+    url: '/@/',
 },
 [
     {

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour("carousel_content_removal", {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [{
     trigger: "#snippet_structure .oe_snippet:has(span:contains('Carousel')) .oe_snippet_thumbnail",
     content: "Drag the Carousel block and drop it in your page.",

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -4,7 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('client_action_iframe_fallback', {
     test: true,
-    url: '/',
+    url: '/@/',
 },
 [
     {

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -9,8 +9,7 @@ const snippets = [
     },
 ];
 wTourUtils.registerWebsitePreviewTour('conditional_visibility_1', {
-    edition: true,
-    url: '/',
+    url: '/@/?enable_editor=1',
     test: true,
 }, [
 wTourUtils.dragNDrop(snippets[0]),

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -5,8 +5,7 @@ const wTourUtils = require('website.tour_utils');
 
 wTourUtils.registerWebsitePreviewTour("default_shape_gets_palette_colors", {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -26,8 +26,7 @@ const clickEditLink = [{
 
 wTourUtils.registerWebsitePreviewTour('edit_link_popover', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     // 1. Test links in page content (web_editor)
     wTourUtils.dragNDrop({

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -17,8 +17,7 @@ const toggleMegaMenu = (stepOptions) => Object.assign({}, {
 
 wTourUtils.registerWebsitePreviewTour('edit_megamenu', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     // Add a megamenu item to the top menu.
     {

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -4,7 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('edit_menus', {
     test: true,
-    url: '/',
+    url: '/@/',
 }, [
     // Add a megamenu item from the menu.
     {

--- a/addons/website/static/tests/tours/focus_blur_snippets.js
+++ b/addons/website/static/tests/tours/focus_blur_snippets.js
@@ -2,7 +2,7 @@ odoo.define('website.tour.focus_blur_snippets', function (require) {
 'use strict';
 
 const { loadJS } = require('@web/core/assets');
-const tour = require('web_tour.tour');
+const wTourUtils = require('website.tour_utils');
 
 const blockIDToData = {
     parent: {
@@ -50,8 +50,8 @@ function clickAndCheck(blockID, expected) {
 
 window.focusBlurSnippetsResult = [];
 
-tour.register('focus_blur_snippets', {
-    url: '/?enable_editor=1',
+wTourUtils.registerWebsitePreviewTour('focus_blur_snippets', {
+    url: '/@/?enable_editor=1',
 }, [
     {
         content: 'First load our custom JS options',

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -3,8 +3,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('website_gray_color_palette', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     {
         content: "Go to theme options",

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('website_replace_grid_image', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -8,8 +8,7 @@ const adminCssModif = '#wrap {display: none;}';
 const demoCssModif = '// demo_edition';
 
 wTourUtils.registerWebsitePreviewTour('html_editor_multiple_templates', {
-    url: '/generic',
-    edition: true,
+    url: '/@/generic?enable_editor=1',
     test: true,
 },
     [
@@ -69,7 +68,7 @@ wTourUtils.registerWebsitePreviewTour('html_editor_multiple_templates', {
 );
 
 wTourUtils.registerWebsitePreviewTour('test_html_editor_scss', {
-    url: '/contactus',
+    url: '/@/contactus',
     test: true,
 },
     [
@@ -155,7 +154,7 @@ wTourUtils.registerWebsitePreviewTour('test_html_editor_scss', {
 );
 
 wTourUtils.registerWebsitePreviewTour('test_html_editor_scss_2', {
-    url: '/',
+    url: '/@/',
     test: true,
 },
     [

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -9,8 +9,7 @@ const clickOnImgStep = {
 
 wTourUtils.registerWebsitePreviewTour('link_tools', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     // 1. Create a new link from scratch.
     wTourUtils.dragNDrop({

--- a/addons/website/static/tests/tours/multi_edition.js
+++ b/addons/website/static/tests/tours/multi_edition.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('website_multi_edition', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     {
         content: 'Check the current page has not the elements that will be added',

--- a/addons/website/static/tests/tours/restricted_editor.js
+++ b/addons/website/static/tests/tours/restricted_editor.js
@@ -5,7 +5,7 @@ var wTourUtils = require("website.tour_utils");
 
 wTourUtils.registerWebsitePreviewTour("restricted_editor", {
     test: true,
-    url: "/",
+    url: "/@/",
 }, [{
     trigger: '.o_edit_website_container a',
     content: "Click \"EDIT\" button of website as Restricted Editor",

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -11,7 +11,7 @@ var ready = Promise.all([domReady, session.is_bound]);
 
 wTourUtils.registerWebsitePreviewTour('rte_translator', {
     test: true,
-    url: '/',
+    url: '/@/',
     wait_for: ready,
 }, [{
     content: "click language dropdown",

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -91,8 +91,7 @@ function updateAndCheckCustomGradient({updateStep, checkGradient}) {
 }
 
 wTourUtils.registerWebsitePreviewTour('snippet_background_edition', {
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
     test: true,
 },
 [

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -3,9 +3,8 @@
 import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('snippet_cache_across_websites', {
-    edition: true,
     test: true,
-    url: '/@/'
+    url: '/@/?enable_editor=1'
 }, [
     {
         content: "Check that the custom snippet is displayed",

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('snippet_countdown', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({id: 's_countdown', name: 'Countdown'}),
     wTourUtils.clickOnSnippet({id: 's_countdown', name: 'Countdown'}),

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('snippet_editor_panel_options', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
 wTourUtils.dragNDrop({
     id: 's_text_image',

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -12,8 +12,7 @@ function removeSelectedBlock() {
 
 wTourUtils.registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     // Base case: remove both columns from text - image
     wTourUtils.dragNDrop({

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('snippet_image_gallery', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({id: 's_image_gallery', name: 'Images Wall'}),
     ...wTourUtils.clickOnSave(),

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('snippet_popup_add_remove', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [{
     content: 'Drop s_popup snippet',
     trigger: '#oe_snippets.o_loaded .oe_snippet:has( > [data-snippet="s_popup"]) .oe_snippet_thumbnail',

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -31,8 +31,7 @@ const addNewSocialNetwork = function (optionIndex, linkIndex, url) {
 
 wTourUtils.registerWebsitePreviewTour('snippet_social_media', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({id: 's_social_media', name: 'Social Media'}),
     wTourUtils.clickOnSnippet({id: 's_social_media', name: 'Social Media'}),

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -3,8 +3,7 @@
 import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('snippet_translation', {
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
     test: true,
 }, [
     wTourUtils.dragNDrop({name: 'Cover'}),

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -4,8 +4,7 @@ odoo.define("website.tour.snippet_version", function (require) {
 const wTourUtils = require('website.tour_utils');
 
 wTourUtils.registerWebsitePreviewTour("snippet_version", {
-    edition: true,
-    url: "/",
+    url: '/@/?enable_editor=1',
     test: true,
 }, [{
     content: "Drop s_test_snip snippet",

--- a/addons/website/static/tests/tours/start_cloned_snippet.js
+++ b/addons/website/static/tests/tours/start_cloned_snippet.js
@@ -10,9 +10,8 @@ const dragNDropOutOfFooter = wTourUtils.dragNDrop(countdownSnippet);
 dragNDropOutOfFooter.run = 'drag_and_drop iframe #wrapwrap #wrap';
 
 wTourUtils.registerWebsitePreviewTour('website_start_cloned_snippet', {
-    edition: true,
     test: true,
-    url: '/',
+    url: '/@/?enable_editor=1',
 }, [
     dragNDropOutOfFooter,
     wTourUtils.clickOnSnippet(countdownSnippet),

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -3,9 +3,8 @@
 import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('translate_menu_name', {
-    url: '/pa_GB',
+    url: '/@/pa_GB',
     test: true,
-    edition: false,
 }, [
     {
         content: "activate translate mode",

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -86,8 +86,7 @@ odoo.define('website.tour.form_editor', function (require) {
     };
 
     wTourUtils.registerWebsitePreviewTour("website_form_editor_tour", {
-        url: '/',
-        edition: true,
+        url: '/@/?enable_editor=1',
         test: true,
     }, [
         // Drop a form builder snippet and configure it
@@ -391,8 +390,7 @@ odoo.define('website.tour.form_editor', function (require) {
     }
 
     wTourUtils.registerWebsitePreviewTour('website_form_contactus_edition_with_email', {
-        url: '/contactus',
-        edition: true,
+        url: '/@/contactus?enable_editor=1',
         test: true,
     }, editContactUs([
         {
@@ -402,8 +400,7 @@ odoo.define('website.tour.form_editor', function (require) {
         },
     ]));
     wTourUtils.registerWebsitePreviewTour('website_form_contactus_edition_no_email', {
-        url: '/contactus',
-        edition: true,
+        url: '/@/contactus?enable_editor=1',
         test: true,
     }, editContactUs([
         {

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('website_page_options', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
     wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -1,11 +1,10 @@
 /** @odoo-module **/
 
-import tour from 'web_tour.tour';
 import wTourUtils from 'website.tour_utils';
 
-tour.register("website_snippets_menu_tabs", {
+wTourUtils.registerWebsitePreviewTour("website_snippets_menu_tabs", {
     test: true,
-    url: "/?enable_editor=1",
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.goToTheme(),
     {

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -14,8 +14,7 @@ const checkFontSize = function (actions) {
 
 wTourUtils.registerWebsitePreviewTour("website_style_edition", {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [{
     content: "Go to theme options",
     extra_trigger: '#oe_snippets.o_loaded',

--- a/addons/website/tests/test_automatic_editor.py
+++ b/addons/website/tests/test_automatic_editor.py
@@ -14,4 +14,4 @@ class TestAutomaticEditor(TestConfiguratorCommon):
             'iso_code': 'pa_GB',
             'url_code': 'pa_GB',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'automatic_editor_on_new_website', login='admin')
+        self.start_tour('/@/', 'automatic_editor_on_new_website', login='admin')

--- a/addons/website/tests/test_grid_layout.py
+++ b/addons/website/tests/test_grid_layout.py
@@ -21,4 +21,4 @@ class TestWebsiteGridLayout(odoo.tests.HttpCase):
             'res_model': 'ir_ui_view',
             'datas': base64.b64encode(req.content),
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_replace_grid_image', login="admin")
+        self.start_tour('/@/?enable_editor=1', 'website_replace_grid_image', login="admin")

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -12,7 +12,7 @@ from odoo.addons.website.tools import MockRequest
 class TestSnippets(HttpCase):
 
     def test_01_empty_parents_autoremove(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_empty_parent_autoremove', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_empty_parent_autoremove', login='admin')
 
     def test_02_default_shape_gets_palette_colors(self):
         self.start_tour('/@/?enable_editor=1', "default_shape_gets_palette_colors", login='admin')
@@ -34,10 +34,10 @@ class TestSnippets(HttpCase):
         self.start_tour("/web#action=website.website_preview&%s" % path, "snippets_all_drag_and_drop", login='admin', timeout=300)
 
     def test_04_countdown_preview(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_countdown', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_countdown', login='admin')
 
     def test_05_social_media(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_social_media', login="admin")
+        self.start_tour('/@/?enable_editor=1', 'snippet_social_media', login="admin")
         self.assertEqual(
             self.env['website'].browse(1).social_instagram,
             'https://instagram.com/odoo.official/',
@@ -45,7 +45,7 @@ class TestSnippets(HttpCase):
         )
 
     def test_06_snippet_popup_add_remove(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_add_remove', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_popup_add_remove', login='admin')
 
     def test_07_image_gallery(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_image_gallery', login='admin')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -92,7 +92,7 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
         '''
         generic_page.arch = oe_structure_layout
         oe_structure_layout = generic_page.arch
-        self.start_tour(self.env['website'].get_client_action_url('/generic'), 'html_editor_multiple_templates', login='admin')
+        self.start_tour('/@/generic?enable_editor=1', 'html_editor_multiple_templates', login='admin')
         self.assertEqual(View.search_count([('key', '=', 'test.generic_view')]), 2, "homepage view should have been COW'd")
         self.assertTrue(generic_page.arch == oe_structure_layout, "Generic homepage view should be untouched")
         self.assertEqual(len(generic_page.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 0, "oe_structure view should have been deleted when aboutus was COW")
@@ -107,8 +107,8 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
                 self.env.ref('website.group_website_designer').id
             ])]
         })
-        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'test_html_editor_scss', login='admin')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_html_editor_scss_2', login='demo')
+        self.start_tour('/@/contactus', 'test_html_editor_scss', login='admin')
+        self.start_tour('/@/', 'test_html_editor_scss_2', login='demo')
 
     def media_dialog_undraw(self):
         self.start_tour("/", 'website_media_dialog_undraw', login='admin')
@@ -123,7 +123,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'iso_code': 'pa_GB',
             'url_code': 'pa_GB',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'rte_translator', login='admin', timeout=120)
+        self.start_tour('/@/', 'rte_translator', login='admin', timeout=120)
 
     def test_translate_menu_name(self):
         lang_en = self.env.ref('base.lang_en')
@@ -146,7 +146,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'url': '/englishURL',
         })
 
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_menu_name', login='admin')
+        self.start_tour('/@/pa_GB', 'translate_menu_name', login='admin')
 
         self.assertNotEqual(new_menu.name, 'value pa-GB', msg="The new menu should not have its value edited, only its translation")
         self.assertEqual(new_menu.with_context(lang=parseltongue.code).name, 'value pa-GB', msg="The new translation should be set")
@@ -190,7 +190,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_admin_tour_homepage(self):
-        self.start_tour("/web", 'homepage', login='admin')
+        self.start_tour("/@/?enable_editor=1", 'homepage', login='admin')
 
     def test_02_restricted_editor(self):
         self.restricted_editor = self.env['res.users'].create({
@@ -202,7 +202,7 @@ class TestUi(odoo.tests.HttpCase):
                 self.ref('website.group_website_restricted_editor')
             ])]
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'restricted_editor', login='restricted')
+        self.start_tour('/@/', 'restricted_editor', login='restricted')
 
     def test_04_website_navbar_menu(self):
         website = self.env['website'].search([], limit=1)
@@ -271,17 +271,17 @@ class TestUi(odoo.tests.HttpCase):
                 </xpath>
             """,
         }])
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_version', login='admin')
 
     def test_08_website_style_custo(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'website_style_edition', login='admin')
 
     def test_09_website_edit_link_popover(self):
         self.start_tour('/@/?enable_editor=1', "edit_link_popover", login="admin")
 
     def test_10_website_conditional_visibility(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_1', login='admin')
-        self.start_tour('/web', 'conditional_visibility_2', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'conditional_visibility_1', login='admin')
+        self.start_tour('/?utm_medium=Email', 'conditional_visibility_2', login='admin')
 
     def test_11_website_snippet_background_edition(self):
         self.env['ir.attachment'].create({
@@ -291,7 +291,7 @@ class TestUi(odoo.tests.HttpCase):
             'name': 'test.png',
             'mimetype': 'image/png',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_background_edition', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_background_edition', login='admin')
 
     def test_12_edit_translated_page_redirect(self):
         lang = self.env['res.lang']._activate_lang('nl_NL')
@@ -347,37 +347,37 @@ class TestUi(odoo.tests.HttpCase):
             """,
         }])
 
-        self.start_tour("/?enable_editor=1", "focus_blur_snippets", login="admin")
+        self.start_tour("/@/?enable_editor=1", "focus_blur_snippets", login="admin")
 
     def test_14_carousel_snippet_content_removal(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'carousel_content_removal', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'carousel_content_removal', login='admin')
 
     def test_15_website_link_tools(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'link_tools', login="admin")
+        self.start_tour('/@/?enable_editor=1', 'link_tools', login="admin")
 
     def test_16_website_edit_megamenu(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'edit_megamenu', login='admin')
 
     def test_17_website_edit_menus(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_menus', login='admin')
+        self.start_tour('/@/', 'edit_menus', login='admin')
 
     def test_18_website_snippets_menu_tabs(self):
-        self.start_tour("/?enable_editor=1", "website_snippets_menu_tabs", login="admin")
+        self.start_tour("/@/?enable_editor=1", "website_snippets_menu_tabs", login="admin")
 
     def test_19_website_page_options(self):
-        self.start_tour("/web", "website_page_options", login="admin")
+        self.start_tour("/@/?enable_editor=1", "website_page_options", login="admin")
 
     def test_20_snippet_editor_panel_options(self):
         self.start_tour("/@/?enable_editor=1", "snippet_editor_panel_options", login="admin")
 
     def test_21_website_start_cloned_snippet(self):
-        self.start_tour('/web', 'website_start_cloned_snippet', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'website_start_cloned_snippet', login='admin')
 
     def test_22_website_gray_color_palette(self):
-        self.start_tour('/web', 'website_gray_color_palette', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'website_gray_color_palette', login='admin')
 
     def test_23_website_multi_edition(self):
-        self.start_tour('/@?enable_editor=1', 'website_multi_edition', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'website_multi_edition', login='admin')
 
     def test_24_snippet_cache_across_websites(self):
         default_website = self.env.ref('website.default_website')
@@ -391,4 +391,4 @@ class TestUi(odoo.tests.HttpCase):
             thumbnail_url='/website/static/src/img/snippets_thumbs/s_text_block.svg',
             snippet_key='s_text_block',
             template_key='website.snippets')
-        self.start_tour('/@/', 'snippet_cache_across_websites', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'snippet_cache_across_websites', login='admin')

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -7,12 +7,12 @@ import odoo.tests
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteFormEditor(odoo.tests.HttpCase):
     def test_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin', timeout=120)
+        self.start_tour('/@/?enable_editor=1', 'website_form_editor_tour', login='admin', timeout=120)
         self.start_tour('/', 'website_form_editor_tour_submit')
         self.start_tour('/', 'website_form_editor_tour_results', login="admin")
 
     def test_website_form_contact_us_edition_with_email(self):
-        self.start_tour('/web', 'website_form_contactus_edition_with_email', login="admin")
+        self.start_tour('/@/contactus?enable_editor=1', 'website_form_contactus_edition_with_email', login="admin")
         self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)
         self.assertEqual(
@@ -21,7 +21,7 @@ class TestWebsiteFormEditor(odoo.tests.HttpCase):
             'The email was edited, the form should have been sent to the configured email')
 
     def test_website_form_contact_us_edition_no_email(self):
-        self.start_tour('/web', 'website_form_contactus_edition_no_email', login="admin")
+        self.start_tour('/@/contactus?enable_editor=1', 'website_form_contactus_edition_no_email', login="admin")
         self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)
         self.assertEqual(

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -6,7 +6,7 @@ odoo.define("website_blog.tour", function (require) {
     const wTourUtils = require('website.tour_utils');
 
     wTourUtils.registerWebsitePreviewTour("blog", {
-        url: "/",
+        url: "/@/",
     }, [{
         trigger: "body:not(:has(#o_new_content_menu_choices)) .o_new_content_container > a",
         content: _t("Click here to add new content to your website."),

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -19,4 +19,4 @@ class TestUi(odoo.tests.HttpCase):
             'mimetype': 'image/png',
         })
 
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog', login='admin')
+        self.start_tour('/@/', 'blog', login='admin')

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -6,12 +6,11 @@ odoo.define('website_crm.tour', function(require) {
 
     wTourUtils.registerWebsitePreviewTour('website_crm_pre_tour', {
         test: true,
-        url: '/contactus',
-        edition: true,
+        url: '/@/contactus?enable_editor=1',
     }, [{
         content: "Select contact form",
         trigger: "iframe #wrap.o_editable section.s_website_form",
-        extra_trigger: "iframe body.editor_enable",
+        extra_trigger: "#oe_snippets.o_loaded",
     }, {
         content: "Open action select",
         trigger: "we-select:has(we-button:contains('Create an Opportunity')) we-toggler",

--- a/addons/website_crm/tests/test_website_crm.py
+++ b/addons/website_crm/tests/test_website_crm.py
@@ -12,7 +12,7 @@ class TestWebsiteCrm(odoo.tests.HttpCase):
         utm_medium = self.env['utm.medium'].create({'name': 'Medium'})
         utm_source = self.env['utm.source'].create({'name': 'Source'})
         # change action to create opportunity
-        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_crm_pre_tour', login='admin')
+        self.start_tour('/@/contactus?enable_editor=1', 'website_crm_pre_tour', login='admin')
         self.start_tour("/?utm_source=Source&utm_medium=Medium&utm_campaign=New campaign", 'website_crm_tour')
 
         # check result
@@ -35,15 +35,15 @@ class TestWebsiteCrm(odoo.tests.HttpCase):
         partner_phone = user_partner.phone
 
         # no edit on prefilled data from logged partner : propagate partner_id on created lead
-        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_crm_pre_tour', login=user_login)
+        self.start_tour('/@/contactus?enable_editor=1', 'website_crm_pre_tour', login=user_login)
 
         with odoo.tests.RecordCapturer(self.env['crm.lead'], []) as capt:
-            self.start_tour("/", "website_crm_catch_logged_partner_info_tour", login=user_login)
+            self.start_tour("/contactus", "website_crm_catch_logged_partner_info_tour", login=user_login)
         self.assertEqual(capt.records.partner_id, user_partner)
 
         # edited contact us partner info : do not propagate partner_id on lead
         with odoo.tests.RecordCapturer(self.env['crm.lead'], []) as capt:
-            self.start_tour("/", "website_crm_tour", login=user_login)
+            self.start_tour("/contactus", "website_crm_tour", login=user_login)
         self.assertFalse(capt.records.partner_id)
 
         # check partner has not been changed

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -8,7 +8,7 @@ odoo.define("website_event.tour", function (require) {
 
     wTourUtils.registerWebsitePreviewTour("website_event_tour", {
         test: true,
-        url: "/",
+        url: "/@/",
     }, [{
         content: _t("Click here to add new content to your website."),
         trigger: ".o_menu_systray .o_new_content_container > a",

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -15,7 +15,7 @@ from odoo.tools import mute_logger
 class TestUi(HttpCaseWithUserDemo):
 
     def test_website_event_tour_admin(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_event_tour', login='admin', step_delay=100)
+        self.start_tour('/@/', 'website_event_tour', login='admin', step_delay=100)
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/website_event_questions/tests/test_event_ui.py
+++ b/addons/website_event_questions/tests/test_event_ui.py
@@ -48,7 +48,7 @@ class TestUi(tests.HttpCase):
             })]
         })
 
-        self.start_tour("/", 'test_tickets_questions', login="portal")
+        self.start_tour("/event", 'test_tickets_questions', login="portal")
 
         registrations = self.env['event.registration'].search([
             ('email', 'in', ['attendee-a@gmail.com', 'attendee-b@gmail.com'])

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -96,7 +96,7 @@ class TestUi(HttpCaseWithUserDemo):
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
 
-        self.start_tour("/", 'event_buy_tickets', login="admin")
+        self.start_tour("/event", 'event_buy_tickets', login="admin")
 
     def test_demo(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
@@ -109,7 +109,7 @@ class TestUi(HttpCaseWithUserDemo):
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
 
-        self.start_tour("/", 'event_buy_tickets', login="demo")
+        self.start_tour("/event", 'event_buy_tickets', login="demo")
 
     def test_buy_last_ticket(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -63,7 +63,7 @@ odoo.define('website_hr_recruitment.tour', function(require) {
 
     wTourUtils.registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
         test: true,
-        url: '/jobs',
+        url: '/@/jobs',
     }, [{
         content: 'Go to the Guru job page',
         trigger: 'iframe a[href*="guru"]',
@@ -98,7 +98,7 @@ odoo.define('website_hr_recruitment.tour', function(require) {
         content: 'Go back to /jobs page after save',
         trigger: 'iframe body:not(.editor_enable)',
         run: () => {
-            window.location.href = wTourUtils.getClientActionUrl('/jobs');
+            window.location.href = '/@/jobs';
         }
     }, {
         content: 'Go to the Internship job page',

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -16,10 +16,10 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
             'name': 'Internship',
             'is_published': True,
         })
-        self.start_tour(self.env['website'].get_client_action_url('/jobs'), 'website_hr_recruitment_tour_edit_form', login='admin')
+        self.start_tour('/@/jobs', 'website_hr_recruitment_tour_edit_form', login='admin')
 
         with odoo.tests.RecordCapturer(self.env['hr.applicant'], []) as capt:
-            self.start_tour("/", 'website_hr_recruitment_tour')
+            self.start_tour("/jobs", 'website_hr_recruitment_tour')
 
         # check result
         self.assertEqual(len(capt.records), 2)

--- a/addons/website_links/tests/test_ui.py
+++ b/addons/website_links/tests/test_ui.py
@@ -24,4 +24,4 @@ class TestUi(odoo.tests.HttpCase):
             'source_id': 2,
             'url': self.env["ir.config_parameter"].sudo().get_param("web.base.url") + '/contactus',
         })
-        self.start_tour("/", 'website_links_tour', login="admin")
+        self.start_tour("/r", 'website_links_tour', login="admin")

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('newsletter_block_edition', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 }, [
     // Put a Newsletter block.
     wTourUtils.dragNDrop({

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_popup.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_popup.js
@@ -1,13 +1,12 @@
 odoo.define("website_mass_mailing.tour.newsletter_popup_edition", function (require) {
 "use strict";
 
-const tour = require('web_tour.tour');
 const wTourUtils = require('website.tour_utils');
 const newsletterPopupUseTour = require('website_mass_mailing.tour.newsletter_popup_use');
 
-tour.register('newsletter_popup_edition', {
+wTourUtils.registerWebsitePreviewTour('newsletter_popup_edition', {
     test: true,
-    url: '/?enable_editor=1',
+    url: '/@/?enable_editor=1',
 }, [
     wTourUtils.dragNDrop({
         id: 's_newsletter_subscribe_popup',

--- a/addons/website_mass_mailing/tests/test_snippets.py
+++ b/addons/website_mass_mailing/tests/test_snippets.py
@@ -9,11 +9,11 @@ import odoo.tests
 class TestSnippets(odoo.tests.HttpCase):
 
     def test_01_newsletter_popup(self):
-        self.start_tour("/?enable_editor=1", "newsletter_popup_edition", login='admin')
+        self.start_tour("/@/?enable_editor=1", "newsletter_popup_edition", login='admin')
         self.start_tour("/", "newsletter_popup_use", login=None)
         mailing_list = self.env['mailing.list'].search([], limit=1)
         emails = mailing_list.contact_ids.mapped('email')
         self.assertIn("hello@world.com", emails)
 
     def test_02_newsletter_block_edition(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'newsletter_block_edition', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'newsletter_block_edition', login='admin')

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -6,7 +6,7 @@ odoo.define("website_sale.tour_shop", function (require) {
     const wTourUtils = require("website.tour_utils");
 
     wTourUtils.registerWebsitePreviewTour("shop", {
-        url: '/shop',
+        url: '/@/shop',
         sequence: 130,
     }, [{
         trigger: ".o_menu_systray .o_new_content_container > a",

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -11,8 +11,7 @@ function editAddToCartSnippet() {
 }
 
 wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
-        url: '/',
-        edition: true,
+        url: '/@/?enable_editor=1',
         test: true,
     },
     [

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
@@ -4,8 +4,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('website_sale_tour_backend', {
     test: true,
-    url: '/shop/cart',
-    edition: true,
+    url: '/@/shop/cart?enable_editor=1',
 }, [
         {
             content: "open customize tab",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -4,8 +4,7 @@ import tourUtils from 'website_sale.tour_utils';
 import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('shop_customize', {
-    url: '/shop',
-    edition: true,
+    url: '/@/shop?enable_editor=1',
     test: true,
 },
     [

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
 
-tour.register('shop_editor', {
+wTourUtils.registerWebsitePreviewTour('shop_editor', {
     test: true,
-    url: '/shop?enable_editor=1',
+    url: '/@/shop?enable_editor=1',
 }, [{
     content: "Click on pricelist dropdown",
     trigger: "iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -5,7 +5,7 @@ import wTourUtils from 'website.tour_utils';
 
 wTourUtils.registerWebsitePreviewTour('shop_list_view_b2c', {
     test: true,
-    url: '/shop?search=Test Product',
+    url: '/@/shop?search=Test+Product',
 },
     [
         {

--- a/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
+++ b/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
@@ -39,8 +39,7 @@ for (const templateKey of templates) {
 }
 wTourUtils.registerWebsitePreviewTour('website_sale.snippet_products', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 },
 [
     wTourUtils.dragNDrop(productsSnippet),
@@ -57,8 +56,7 @@ wTourUtils.registerWebsitePreviewTour('website_sale.snippet_products', {
 
 wTourUtils.registerWebsitePreviewTour('website_sale.products_snippet_recently_viewed', {
     test: true,
-    url: '/',
-    edition: true,
+    url: '/@/?enable_editor=1',
 },
 [
     wTourUtils.dragNDrop(productsSnippet),
@@ -73,7 +71,6 @@ wTourUtils.registerWebsitePreviewTour('website_sale.products_snippet_recently_vi
         run: function () {
             const $iframe = $('.o_iframe').contents();
             const $productCard = $iframe.find('.o_carousel_product_card:has(a img[alt="Storage Box"])');
-            console.log($productCard);
             $productCard.find('.js_remove').attr('style', 'display: block;');
         }
     },

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -62,7 +62,7 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
     def test_01_admin_shop_customize_tour(self):
         # Enable Variant Group
         self.env.ref('product.group_product_variant').write({'users': [(4, self.env.ref('base.user_admin').id)]})
-        self.start_tour(self.env['website'].get_client_action_url('/shop?search=Test Product'), 'shop_customize', login="admin", timeout=120)
+        self.start_tour('/@/shop?enable_editor=1', 'shop_customize', login="admin", timeout=120)
 
     def test_02_admin_shop_custom_attribute_value_tour(self):
         # Make sure pricelist rule exist
@@ -315,10 +315,10 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         config.show_line_subtotals_tax_selection = "tax_included"
         config.execute()
 
-        self.start_tour(self.env['website'].get_client_action_url('/shop?search=Test Product'), 'shop_list_view_b2c', login="admin")
+        self.start_tour('/@/shop?search=Test Product', 'shop_list_view_b2c', login="admin")
 
     def test_07_editor_shop(self):
-        self.start_tour("/", 'shop_editor', login="admin")
+        self.start_tour("/@/shop?enable_editor=1", 'shop_editor', login="admin")
 
     def test_08_portal_tour_archived_variant_multiple_attributes(self):
         """The goal of this test is to make sure that an archived variant with multiple

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -64,7 +64,7 @@ class TestUi(HttpCaseWithUserDemo):
         })
 
     def test_01_admin_shop_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/shop'), 'shop', login='admin')
+        self.start_tour('/@/shop', 'shop', login='admin')
 
     def test_02_admin_checkout(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
@@ -123,7 +123,7 @@ class TestUi(HttpCaseWithUserDemo):
         }).execute()
 
         self.start_tour("/", 'website_sale_tour_1')
-        self.start_tour(self.env['website'].get_client_action_url('/shop/cart'), 'website_sale_tour_backend', login='admin')
+        self.start_tour('/@/shop/cart?enable_editor=1', 'website_sale_tour_backend', login='admin')
         self.start_tour("/", 'website_sale_tour_2', login="admin")
 
     def test_05_google_analytics_tracking(self):

--- a/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
+++ b/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
@@ -33,4 +33,4 @@ class TestAddToCartSnippet(HttpCase):
     def test_configure_product(self):
         # Reset the company country id, which ensure that no country dependant fields are blocking the address form.
         self.env.company.country_id = self.env.ref('base.us')
-        self.start_tour("/", 'add_to_cart_snippet_tour', login="admin")
+        self.start_tour("/@/?enable_editor=1", 'add_to_cart_snippet_tour', login="admin")

--- a/addons/website_sale/tests/test_website_sale_snippets.py
+++ b/addons/website_sale/tests/test_website_sale_snippets.py
@@ -8,7 +8,7 @@ from odoo.addons.website.tools import MockRequest
 class TestSnippets(HttpCase):
 
     def test_01_snippet_products_edition(self):
-        self.start_tour('/', 'website_sale.snippet_products', login='admin')
+        self.start_tour('/@/?enable_editor=1', 'website_sale.snippet_products', login='admin')
 
     def test_02_snippet_products_remove(self):
         self.user = self.env['res.users'].search([('login', '=', 'admin')])
@@ -25,6 +25,6 @@ class TestSnippets(HttpCase):
                 'description_sale': 'Pedal-based opening system',
             })
             self.website_visitor._add_viewed_product(self.product.id)
-            self.start_tour('/', 'website_sale.products_snippet_recently_viewed', login='admin')
+            self.start_tour('/@/?enable_editor=1', 'website_sale.products_snippet_recently_viewed', login='admin')
             after_tour_product_ids = self.website_visitor.product_ids.ids
             self.assertEqual(before_tour_product_ids, after_tour_product_ids, "There shouldn't be any new product in recently viewed after this tour")

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
@@ -4,7 +4,7 @@ odoo.define('website_sale_wishlist_admin.tour', function (require) {
 const wTourUtils = require("website.tour_utils");
 
 wTourUtils.registerWebsitePreviewTour('shop_wishlist_admin', {
-    url: '/shop?search=Rock',
+    url: '/@/shop?search=Rock',
     test: true,
 },
     [

--- a/addons/website_sale_wishlist/tests/test_wishlist_process.py
+++ b/addons/website_sale_wishlist/tests/test_wishlist_process.py
@@ -89,4 +89,4 @@ class TestUi(odoo.tests.HttpCase):
                 ],
             })],
         })
-        self.start_tour("/", 'shop_wishlist_admin', login="admin")
+        self.start_tour("/@/shop?search=Rock", 'shop_wishlist_admin', login="admin")

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -11,7 +11,7 @@ import wTourUtils from 'website.tour_utils';
  * they publish it;
  */
 wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
-    url: '/slides',
+    url: '/@/slides',
     test: true,
 }, [{
     content: 'eLearning: click on New (top-menu)',

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -11,8 +11,7 @@ import slidesTourTools from '@website_slides/../tests/tours/slides_tour_tools';
  * they publishe it;
  */
 wTourUtils.registerWebsitePreviewTour('course_publisher', {
-    // TODO: replace by wTourUtils.getClientActionURL when it's added
-    url: '/slides',
+    url: '/@/slides',
     test: true
 }, [{
     content: 'eLearning: click on New (top-menu)',

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -13,7 +13,7 @@ import wTourUtils from 'website.tour_utils';
  *
  */
  wTourUtils.registerWebsitePreviewTour('full_screen_web_editor', {
-    url: '/slides',
+    url: '/@/slides',
     test: true,
 }, [{
     // open to the course

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -142,7 +142,7 @@ class TestUi(TestUICommon):
         })
 
         self.browser_js(
-            self.env['website'].get_client_action_url('/slides'),
+            '/@/slides',
             'odoo.__DEBUG__.services["web_tour.tour"].run("full_screen_web_editor")',
             'odoo.__DEBUG__.services["web_tour.tour"].tours.full_screen_web_editor.ready',
             login=user_demo.login)
@@ -162,7 +162,7 @@ class TestUiPublisher(HttpCaseWithUserDemo):
         })
 
         self.browser_js(
-            self.env['website'].get_client_action_url('/slides'),
+            '/@/slides',
             'odoo.__DEBUG__.services["web_tour.tour"].run("course_publisher_standard")',
             'odoo.__DEBUG__.services["web_tour.tour"].tours.course_publisher_standard.ready',
             login=user_demo.login)
@@ -192,7 +192,7 @@ class TestUiPublisherYoutube(HttpCaseWithUserDemo):
         })
 
         self.browser_js(
-            self.env['website'].get_client_action_url('/slides'),
+            '/@/slides',
             'odoo.__DEBUG__.services["web_tour.tour"].run("course_publisher")',
             'odoo.__DEBUG__.services["web_tour.tour"].tours.course_publisher.ready',
             login=user_demo.login)


### PR DESCRIPTION
[IMP] website, *: match python and javascript tour urls

*: test_website, website_blog, website_crm, website_event,
website_event_questions, website_event_sale, website_hr_recruitment,
website_links, website_mass_mailing, website_sale,
website_sale_wishlist, website_slides

With the previous commit avoiding useless reloads when the python tests
are defined with the correct javascript tour url, some tests had to be
changed as they were using urls unrelated to the tour (/web, /, ...).

This commit also removes the getClientActionUrl util, not useful anymore
after [1].

[1]: https://github.com/odoo/odoo/commit/030d3cb10ee79aa1f010134578f4bcf65a1cfcde

-----

[IMP] web_tour, website: avoid reloading the window from js tours

Before this commit, launching a tour would always redirect the window to
the tour's url, even when the browser was already at the correct url.

So from the python test suite, defining the correct starting url had no
effect: it was reloaded anyway.

On top of reloading the assets when it was not needed, for the website
tours, the WebsitePreview component was mounted twice, therefore
launching twice its onWillStart queries.

To improve that, the web_tour tour_manager run method is changed to
stay on the page if the browser is already at the tour's url.

With that, the iframe observers that update the tours need to be
reworked: as the page is not always reloaded, if an iframe is already
there when starting the tour, it should be observed.

Also, as the WebsitePreview client action changes the browser's url to
display the frontend's url (see [1]), tours should wait before this
change happened before starting.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

-----
Related to https://github.com/odoo/odoo/pull/100055#discussion_r969715777

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
