### PR TITLE
[FIX] sale_timesheet: prevent undeterministic error in tour

### DIFF
--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -160,7 +160,7 @@ tour.register('sale_timesheet_tour', {
     content: 'Select a Sales Order Item as Default Sales Order Item for each task in this project.',
     run: 'text S',
 }, {
-    trigger: 'ul.ui-autocomplete > li:first-child > a',
+    trigger: 'ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
     content: 'Select the Sales Order Item in the autocomplete dropdown.',
 }, {
     trigger: 'div[name="sale_line_employee_ids"] td.o_field_x2many_list_row_add > a[role="button"]',
@@ -168,8 +168,9 @@ tour.register('sale_timesheet_tour', {
 }, {
     trigger: 'div[name="sale_line_employee_ids"] div[name="employee_id"] input',
     content: 'Select an employee to link a Sales Order Item on his timesheets into this project.',
+    run: 'click',
 }, {
-    trigger: 'ul.ui-autocomplete > li:first-child > a',
+    trigger: 'ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
     content: 'Select the first employee in the autocomplete dropdown',
 }, {
     trigger: 'div[name="sale_line_employee_ids"] div[name="sale_line_id"] input',
@@ -177,7 +178,7 @@ tour.register('sale_timesheet_tour', {
     position: 'bottom',
     run: 'text S',
 }, {
-    trigger: 'ul.ui-autocomplete > li:first-child > a',
+    trigger: 'ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
     content: 'Select the first Sales Order Item in the autocomplete dropdown.',
 }, {
     trigger: 'h1 > div[name="name"] > input',
@@ -212,7 +213,7 @@ tour.register('sale_timesheet_tour', {
     content: 'Select the first sale order of the list',
     run: 'text Prepaid',
 }, {
-    trigger: 'ul.ui-autocomplete > li:first-child > a',
+    trigger: 'ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
     content: 'Select the first item on the autocomplete dropdown',
 }, {
     trigger: '.o_form_button_save',


### PR DESCRIPTION
Prior to this commit:
- Some of the `trigger` on a many2one fields where made on
  `ul.ui-autocomplete > li:first-child > a` which could lead
  to click on the loading if the rpc was not yet finished.
- A text command `Text` was used instead of a click as it is
  the default behavior for input elements.

This commit ensure that the `loading` is not taken by the tour
and that a click is done instead of a text command typing `Text`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
