### PR TITLE
[FIX] base: evaluate context dependent modifiers after cache

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1832,6 +1832,7 @@ class BaseModel(metaclass=MetaModel):
 
         node = etree.fromstring(result['arch'])
         node = self.env['ir.ui.view']._postprocess_access_rights(node)
+        node = self.env['ir.ui.view']._postprocess_context_dependent(node)
         result['arch'] = etree.tostring(node, encoding="unicode").replace('\t', '')
 
         return result


### PR DESCRIPTION
A feature allows to set the modifiers invisible, readonly, required according to a key in the context

e.g.
```xml
<field name="date_approve" invisible="context.get('quotation_only', False)" optional="show"/>
```

Following odoo/odoo#99417,
back-end views are now cached.

These expressions are currently evaluated server-side, before serving the view to the web client.
Hence, the modifier becomes for instance `invisible="1"` or `invisible="0"` according to the context passed when calling `get_view`.

The key used to cache the views doesn't take into account such context keys. Hence, when you asked for a view using for instance `invisible="context.get('quotation_only')"`
A first time using the context `{'quotation_only': True}` and a second time using the context `{'quotation_only': False}`, on the second time, you received the view from the first time you requested the view, where the modifier is evaluated as if the the context was `{'quotation_only': True}`.

As we do not want to store a cached version of the view for each possible key in the context, postprocess the evaluation of the modifiers using the context after retrieving the view from the cache.

A better alternative would be to delegate this evaluation to the web client, because it already has the information it needs, it has the context value.
Modifiers using domains are already evaluated client-side, it would make sense modifiers using context would too. Nevertheless, as this bug has been introduced by odoo/odoo#99417, and as we are close to the release, solve this server-side, to keep a similar behavior than before.

We might re-consider the implementation of this later on.