### PR TITLE
[FIX] web: use command hook in component

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.js
+++ b/addons/web/static/src/views/fields/priority/priority_field.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { useService } from "@web/core/utils/hooks";
+import { useCommand } from "@web/core/commands/command_hook";
 import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
 import { standardFieldProps } from "../standard_field_props";
@@ -13,7 +13,27 @@ export class PriorityField extends Component {
             index: -1,
         });
         if (this.props.record.activeFields[this.props.name].viewType === "form") {
-            this.initiateCommand();
+            const commandName = this.env._t("Set priority...");
+            useCommand(
+                commandName,
+                () => {
+                    return {
+                        placeholder: commandName,
+                        providers: [
+                            {
+                                provide: () =>
+                                    this.options.map((value) => ({
+                                        name: value[1],
+                                        action: () => {
+                                            this.props.update(value[0]);
+                                        },
+                                    })),
+                            },
+                        ],
+                    };
+                },
+                { category: "smart_action", hotkey: "alt+r" }
+            );
         }
     }
 
@@ -41,33 +61,6 @@ export class PriorityField extends Component {
             this.props.update(this.options[0][0]);
         } else {
             this.props.update(value);
-        }
-    }
-    initiateCommand() {
-        try {
-            const commandService = useService("command");
-            const provide = () => {
-                return this.options.map((value) => ({
-                    name: value[1],
-                    action: () => {
-                        this.props.update(value[0]);
-                    },
-                }));
-            };
-            const name = this.env._t("Set priority...");
-            const action = () => {
-                return {
-                    placeholder: this.env._t("Set a priority..."),
-                    providers: [{ provide }],
-                };
-            };
-            const options = {
-                category: "smart_action",
-                hotkey: "alt+r",
-            };
-            commandService.add(name, action, options);
-        } catch {
-            console.log("Could not add command to service");
         }
     }
 }

--- a/addons/web/static/tests/views/fields/priority_field_tests.js
+++ b/addons/web/static/tests/views/fields/priority_field_tests.js
@@ -1,7 +1,5 @@
 /** @odoo-module **/
 
-import { registry } from "@web/core/registry";
-import { commandService } from "@web/core/commands/command_service";
 import {
     click,
     getFixture,
@@ -13,8 +11,6 @@ import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
 let serverData;
 let target;
-
-const serviceRegistry = registry.category("services");
 
 QUnit.module("Fields", (hooks) => {
     hooks.beforeEach(() => {
@@ -590,8 +586,6 @@ QUnit.module("Fields", (hooks) => {
     QUnit.test(
         'PriorityField edited by the smart action "Set priority..."',
         async function (assert) {
-            serviceRegistry.add("command", commandService);
-
             await makeView({
                 type: "form",
                 resModel: "partner",

--- a/addons/web/static/tests/views/fields/state_selection_field_tests.js
+++ b/addons/web/static/tests/views/fields/state_selection_field_tests.js
@@ -1,14 +1,10 @@
 /** @odoo-module **/
 
-import { registry } from "@web/core/registry";
-import { commandService } from "@web/core/commands/command_service";
 import { click, getFixture, nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
 let serverData;
 let target;
-
-const serviceRegistry = registry.category("services");
 
 QUnit.module("Fields", (hooks) => {
     hooks.beforeEach(() => {
@@ -440,8 +436,6 @@ QUnit.module("Fields", (hooks) => {
     QUnit.test(
         'StateSelectionField edited by the smart action "Set kanban state..."',
         async function (assert) {
-            serviceRegistry.add("command", commandService);
-
             await makeView({
                 type: "form",
                 resModel: "partner",

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser/browser";
-import { commandService } from "@web/core/commands/command_service";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
@@ -19,8 +18,6 @@ const { EventBus } = owl;
 
 let serverData;
 let target;
-
-const serviceRegistry = registry.category("services");
 
 QUnit.module("Fields", (hooks) => {
     hooks.beforeEach(() => {
@@ -527,8 +524,6 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test('statusbar edited by the smart action "Move to stage..."', async function (assert) {
-        serviceRegistry.add("command", commandService);
-
         await makeView({
             serverData,
             type: "form",

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -16,6 +16,7 @@ import {
     makeFakeRouterService,
     makeFakeUserService,
 } from "../helpers/mock_services";
+import { commandService } from "@web/core/commands/command_service";
 import { dialogService } from "@web/core/dialog/dialog_service";
 import { popoverService } from "@web/core/popover/popover_service";
 import { createDebugContext } from "@web/core/debug/debug_context";
@@ -110,6 +111,7 @@ export function setupViewRegistries() {
     serviceRegistry.add("dialog", dialogService), { force: true };
     serviceRegistry.add("popover", popoverService), { force: true };
     serviceRegistry.add("company", fakeCompanyService);
+    serviceRegistry.add("command", commandService);
 }
 
 /**


### PR DESCRIPTION
Before: the command service was used inside components instead of the hook. It introduced problems as the commands were not unregistered. The commands were added multiple time to the registry.

After: It uses the hook, "it just works".