### PR TITLE
[FIX] web: Correctly unpack groups data in kanban

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1113,21 +1113,24 @@ export class MockServer {
 
     mockReadProgressBar(modelName, kwargs) {
         const { domain, group_by: groupBy, progress_bar: progressBar } = kwargs;
-        const records = this.getRecords(modelName, domain || []);
+        const groups = this.mockReadGroup(modelName, { domain, fields: [], groupby: [groupBy] });
 
+        // Find group by field
         const data = {};
-        for (const record of records) {
-            const groupByValue = record[groupBy]; // always technical value here
+        for (const group of groups) {
+            const records = this.getRecords(modelName, group.__domain || []);
+            const groupByValue = group[groupBy]; // always technical value here
             if (!(groupByValue in data)) {
                 data[groupByValue] = {};
                 for (const key in progressBar.colors) {
                     data[groupByValue][key] = 0;
                 }
             }
-
-            const fieldValue = record[progressBar.field];
-            if (fieldValue in data[groupByValue]) {
-                data[groupByValue][fieldValue]++;
+            for (const record of records) {
+                const fieldValue = record[progressBar.field];
+                if (fieldValue in data[groupByValue]) {
+                    data[groupByValue][fieldValue]++;
+                }
             }
         }
 
@@ -2221,7 +2224,10 @@ export async function makeMockServer(serverData, mockRPC) {
                 if (res === undefined) {
                     res = await loadJS(ressource);
                 } else {
-                    console.log("%c[assets] fetch (mock) JS ressource " + ressource, "color: #66e; font-weight: bold;");
+                    console.log(
+                        "%c[assets] fetch (mock) JS ressource " + ressource,
+                        "color: #66e; font-weight: bold;"
+                    );
                 }
                 return res;
             },
@@ -2230,7 +2236,10 @@ export async function makeMockServer(serverData, mockRPC) {
                 if (res === undefined) {
                     res = await loadCSS(ressource);
                 } else {
-                    console.log("%c[assets] fetch (mock) CSS ressource " + ressource, "color: #66e; font-weight: bold;");
+                    console.log(
+                        "%c[assets] fetch (mock) CSS ressource " + ressource,
+                        "color: #66e; font-weight: bold;"
+                    );
                 }
                 return res;
             },

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -1121,6 +1121,52 @@ QUnit.module("MockServer", (hooks) => {
         }
     );
 
+    QUnit.test("performRPC: read_progress_bar grouped by boolean", async (assert) => {
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "bar",
+            method: "read_progress_bar",
+            args: [],
+            kwargs: {
+                domain: [],
+                group_by: "bool",
+                progress_bar: {
+                    colors: { new: "success", dev: "warning", done: "danger" },
+                    field: "select",
+                },
+            },
+        });
+
+        assert.deepEqual(result, {
+            false: { new: 0, dev: 0, done: 2 },
+            true: { new: 3, dev: 1, done: 0 },
+        });
+    });
+
+    QUnit.test("performRPC: read_progress_bar grouped by datetime", async (assert) => {
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "bar",
+            method: "read_progress_bar",
+            args: [],
+            kwargs: {
+                domain: [],
+                group_by: "datetime:week",
+                progress_bar: {
+                    colors: { new: "aaa", dev: "bbb", done: "ccc" },
+                    field: "select",
+                },
+            },
+        });
+
+        assert.deepEqual(result, {
+            "W01 2020": { dev: 0, done: 0, new: 1 },
+            "W15 2016": { dev: 0, done: 0, new: 1 },
+            "W43 2016": { dev: 0, done: 0, new: 1 },
+            "W50 2016": { dev: 1, done: 2, new: 0 },
+        });
+    });
+
     QUnit.test("many2one_ref should auto fill inverse field", async function (assert) {
         data.models.bar.records = [{ id: 1 }];
         data.models.foo.records = [


### PR DESCRIPTION
1) This PR aims to make the behavior of the mocked 'read_progress_bar'
requests closer to their server implementation.
Namely, the returned dictionnary is supposed to contains the display
names of the current groups in its keys. This was not the case and has
been fixed.

2) Before this PR, the groups returned by `web_read_group` were
unpacked using the current 'group by' field name, and not the entire
'group by' value (potentially including a granularity for date/datetime
fields). This caused mismatches in some cases and the value couldn't be
retrieved.

Also, a needless 'sum_field' parameter was passed to the
'read_progres_bar' calls, which does not exist in the request API.

This PR fixes the issues above and removed the excess parameter.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
