### PR TITLE
[FIX] web: Many2OneField: do not display a link if unset

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -26,6 +26,7 @@
             </t>
             <t t-else="">
                 <a
+                    t-if="props.value"
                     class="o_form_uri"
                     t-att-href="props.value ? `#id=${props.value[0]}&amp;model=${relation}` : '#'"
                     t-on-click.prevent="onClick"

--- a/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
@@ -187,7 +187,7 @@ QUnit.module("Fields", (hooks) => {
 
         assert.deepEqual(
             getNodesTextContent(target.querySelectorAll(".o_data_cell .o_form_uri span")),
-            ["Aline", "Christine", "Aline", ""]
+            ["Aline", "Christine", "Aline"]
         );
         const imgs = target.querySelectorAll(".o_m2o_avatar > img");
         assert.strictEqual(imgs[0].dataset.src, "/web/image/user/17/avatar_128");
@@ -205,7 +205,7 @@ QUnit.module("Fields", (hooks) => {
 
         assert.deepEqual(
             getNodesTextContent(target.querySelectorAll(".o_data_cell .o_form_uri span")),
-            ["Aline", "Christine", "Aline", ""]
+            ["Aline", "Christine", "Aline"]
         );
 
         const imgs = target.querySelectorAll(".o_m2o_avatar > img");

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -959,6 +959,18 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
+    QUnit.test("empty readonly many2one field", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><field name="trululu" readonly="1"/></form>`,
+        });
+
+        assert.containsOnce(target, "div.o_field_widget[name=trululu]");
+        assert.strictEqual(target.querySelector(".o_field_widget[name=trululu]").innerHTML, "");
+    });
+
     QUnit.test("empty many2one field with node options", async function (assert) {
         assert.expect(2);
 
@@ -1207,17 +1219,12 @@ QUnit.module("Fields", (hooks) => {
             "href should contain id and model"
         );
 
-        // Remove value from many2one and then save, there should not have href with id and model on m2o anchor
+        // Remove value from many2one and then save, there should be no link anymore
         await click(target, ".o_form_button_edit");
         await editInput(target, ".o_field_many2one input", "");
 
         await click(target, ".o_form_button_save");
-        assert.hasAttrValue(
-            target.querySelector("a.o_form_uri"),
-            "href",
-            "#",
-            "href should have #"
-        );
+        assert.containsNone(target, "a.o_form_uri");
     });
 
     QUnit.test("many2one with co-model whose name field is a many2one", async function (assert) {


### PR DESCRIPTION
Before this commit, an empty many2one field in readonly rendered an empty `<a href"...">` node. Even though that link was no visible, it had a non nul width, and was thus clickable (the cursor changed when hovering it). when clicked, it opened the form view of the comodel, in create mode.

This commit fixes the issue by not rendering anything if the value is false.


