### PR TITLE
[FIX] auth_password_policy_signup: port to modern js and fix

### DIFF
--- a/addons/auth_password_policy/__manifest__.py
+++ b/addons/auth_password_policy/__manifest__.py
@@ -10,11 +10,11 @@
     ],
     'assets': {
         'web.assets_backend': [
-            'auth_password_policy/static/src/css/password_field.css',
             'auth_password_policy/static/src/password_meter.js',
             'auth_password_policy/static/src/password_field.js',
         ],
         'web.assets_common': [
+            'auth_password_policy/static/src/css/password_field.css',
             'auth_password_policy/static/src/password_policy.js',
         ],
     },

--- a/addons/auth_password_policy_signup/static/src/js/password_meter.js
+++ b/addons/auth_password_policy_signup/static/src/js/password_meter.js
@@ -1,0 +1,44 @@
+/** @odoo-module */
+
+import { _t } from "web.core";
+import Widget from "web.Widget";
+import { computeScore } from "@auth_password_policy/password_policy";
+
+export default Widget.extend({
+    tagName: "meter",
+    className: "o_password_meter",
+    attributes: {
+        min: 0,
+        low: 0.5,
+        high: 0.99,
+        max: 1,
+        length: 0,
+        value: 0,
+        optimum: 1,
+    },
+    init(parent, required, recommended) {
+        this._super(parent);
+        this._required = required;
+        this._recommended = recommended;
+    },
+    start() {
+        var helpMessage = _t(
+            "Required: %s.\n\nHint: increase length, use multiple words and use non-letter characters to increase your password's strength."
+        );
+        this.el.setAttribute(
+            "title",
+            _.str.sprintf(helpMessage, String(this._required) || _t("no requirements"))
+        );
+        return this._super().then(function () {});
+    },
+    /**
+     * Updates the meter with the information of the new password: computes
+     * the (required x recommended) score and sets the widget's value as that
+     *
+     * @param {String} password
+     */
+    update(password) {
+        this.el.setAttribute("length", password.length);
+        this.el.value = computeScore(password, this._required, this._recommended);
+    },
+});

--- a/addons/auth_password_policy_signup/static/src/js/signup_policy.js
+++ b/addons/auth_password_policy_signup/static/src/js/signup_policy.js
@@ -1,23 +1,18 @@
-odoo.define('auth_password_policy_signup.policy', function (require) {
-"use strict";
+/** @odoo-module */
 
-require('web.dom_ready');
-var policy = require('auth_password_policy');
-var PasswordMeter = require('auth_password_policy.Meter');
+import "web.dom_ready";
+import { ConcretePolicy, recommendations } from "@auth_password_policy/password_policy";
+import PasswordMeter from "@auth_password_policy_signup/js/password_meter";
 
-var $signupForm = $('.oe_signup_form, .oe_reset_password_form');
-if (!$signupForm.length) { return; }
-
-// hook in password strength meter
-// * requirement is the password field's minlength
-// * recommendations are from the module
-var $password = $('[type=password][minlength]');
-var minlength = Number($password.attr('minlength'));
-if (isNaN(minlength)) { return; }
-
-var meter = new PasswordMeter(null, new policy.Policy({minlength: minlength}), policy.recommendations);
-meter.insertAfter($password);
-$password.on('input', function () {
-    meter.update($password.val());
-});
-});
+const signupForm = document.querySelector('.oe_signup_form, .oe_reset_password_form');
+if (signupForm) {
+    const password = document.querySelector("[type=password][minlength]");
+    const minlength = Number(password.getAttribute("minlength"));
+    if (!isNaN(minlength)) {
+        const meter = new PasswordMeter(null, new ConcretePolicy({minlength}), recommendations);
+        meter.insertAfter(password);
+        password.addEventListener("input", (e) => {
+            meter.update(e.target.value);
+        });
+    }
+}


### PR DESCRIPTION
b3b85cae9b1951b82053d7c6b55e559cbc48307d unwittingly broke auth_password_policy_signup when it ported everything to owl.

- move the CSS file back to assets_common
- reintroduce the old password gauge, moved over to signup (as it's not used anymore by auth_password_policy), and converted to modern JS style
- convert signup_policy to more modern JS style (for consistency)

Manifest file doesn't need to be updated because it globs.
