### PR TITLE
[FIX] mass_mailing: fix header size when editing

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -202,5 +202,5 @@ body.editor_enable.o_basic_theme.o_in_iframe {
 }
 
 :root {
-    font-size: 14px;
+    font-size: 16px !important;
 }


### PR DESCRIPTION
Steps to reproduce:
- Email marketing > create email
- apply header style on a text (h1/h2...)
- save

Bug:
font size is defined in "rem"
on the edit page 'webclient.scss.css' overwrites the :root font size which leads to the inconsistent size

Fix:
force :root size for mass_mailing to the default (16px)

opw-2952510