### PR TITLE
[IMP] test_mail: improve coverage of post helpers

### DIFF
--- a/addons/test_mail/data/mail_template_data.xml
+++ b/addons/test_mail/data/mail_template_data.xml
@@ -34,7 +34,7 @@
     </template>
 
     <template id="mail_template_simple_test">
-        <p>Hello <t t-out="partner.name"/>,</p>
+        <p>Hello <t t-out="partner.name"/>, this comes from <t t-out="object.name"/>.</p>
     </template>
 
 </odoo>

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -50,6 +50,16 @@ class MailTestGatewayGroups(models.Model):
             values['alias_parent_thread_id'] = self.id
         return values
 
+    def _message_get_default_recipients(self):
+        return dict(
+            (record.id, {
+                'email_cc': False,
+                'email_to': record.email_from if not record.customer_id.ids else False,
+                'partner_ids': record.customer_id.ids,
+            })
+            for record in self
+        )
+
 
 class MailTestStandard(models.Model):
     """ This model can be used in tests when automatic subscription and simple
@@ -104,6 +114,16 @@ class MailTestTicket(models.Model):
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=2)
     user_id = fields.Many2one('res.users', 'Responsible', tracking=1)
     container_id = fields.Many2one('mail.test.container', tracking=True)
+
+    def _message_get_default_recipients(self):
+        return dict(
+            (record.id, {
+                'email_cc': False,
+                'email_to': record.email_from if not record.customer_id.ids else False,
+                'partner_ids': record.customer_id.ids,
+            })
+            for record in self
+        )
 
     def _notify_get_recipients_groups(self, msg_vals=None):
         """ Activate more groups to test query counters notably (and be backward
@@ -162,6 +182,16 @@ class MailTestContainer(models.Model):
     alias_id = fields.Many2one(
         'mail.alias', 'Alias',
         delegate=True)
+
+    def _message_get_default_recipients(self):
+        return dict(
+            (record.id, {
+                'email_cc': False,
+                'email_to': False,
+                'partner_ids': record.customer_id.ids,
+            })
+            for record in self
+        )
 
     def _notify_get_recipients_groups(self, msg_vals=None):
         """ Activate more groups to test query counters notably (and be backward

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -412,12 +412,20 @@ class TestMessageNotify(TestMessagePostCommon):
 
 
 @tagged('mail_post')
-class TestMessagePost(TestMessagePostCommon, CronMixinCase):
+class TestMessageLog(TestMessagePostCommon):
 
-    def test_initial_values(self):
-        self.assertFalse(self.test_record.message_ids)
-        self.assertFalse(self.test_record.message_follower_ids)
-        self.assertFalse(self.test_record.message_partner_ids)
+    @classmethod
+    def setUpClass(cls):
+        super(TestMessageLog, cls).setUpClass()
+        # ensure employee can create partners, necessary for templates
+        cls.user_employee.write({
+            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
+        })
+
+        cls.test_records, cls.test_partners = cls._create_records_for_batch(
+            'mail.test.ticket',
+            10,
+        )
 
     @users('employee')
     def test_message_log(self):
@@ -441,6 +449,67 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
              'subtype_id': self.env.ref('mail.mt_note'),
             }
         )
+
+    @users('employee')
+    def test_message_log_batch(self):
+        test_records = self.test_records.with_env(self.env)
+        test_records.message_subscribe(self.partner_employee_2.ids)
+
+        new_notes = test_records._message_log_batch(
+            bodies=dict(
+                (test_record.id, '<p>Test _message_log_batch</p>')
+                for test_record in test_records
+            ),
+        )
+        for test_record, new_note in zip(test_records, new_notes):
+            self.assertMessageFields(
+                new_note,
+                {'author_id': self.partner_employee,
+                 'body': '<p>Test _message_log_batch</p>',
+                 'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                 'is_internal': True,
+                 'message_type': 'notification',
+                 'model': test_record._name,
+                 'notified_partner_ids': self.env['res.partner'],
+                 'reply_to': formataddr((self.company_admin.name, '%s@%s' % (self.alias_catchall, self.alias_domain))),
+                 'res_id': test_record.id,
+                 'subtype_id': self.env.ref('mail.mt_note'),
+                }
+            )
+
+    @users('employee')
+    def test_message_log_with_view(self):
+        test_records = self.test_records.with_env(self.env)
+        test_records.message_subscribe(self.partner_employee_2.ids)
+
+        new_notes = test_records._message_log_with_view(
+            'test_mail.mail_template_simple_test',
+            values={'partner': self.user_employee.partner_id}
+        )
+        for test_record, new_note in zip(test_records, new_notes):
+            self.assertMessageFields(
+                new_note,
+                {'author_id': self.partner_employee,
+                 'body': f'<p>Hello {self.user_employee.name}, this comes from {test_record.name}.</p>',
+                 'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                 'is_internal': True,
+                 'message_type': 'notification',
+                 'model': test_record._name,
+                 'notified_partner_ids': self.env['res.partner'],
+                 'reply_to': formataddr((self.company_admin.name, '%s@%s' % (self.alias_catchall, self.alias_domain))),
+                 'res_id': test_record.id,
+                 'subtype_id': self.env.ref('mail.mt_note'),
+                }
+            )
+
+
+@tagged('mail_post')
+class TestMessagePost(TestMessagePostCommon, CronMixinCase):
+
+    def test_initial_values(self):
+        self.assertFalse(self.test_record.message_ids)
+        self.assertFalse(self.test_record.message_follower_ids)
+        self.assertFalse(self.test_record.message_partner_ids)
 
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
@@ -507,6 +576,37 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                 subtype_xmlid='mail.mt_comment',
                 partner_ids=self.partner_portal.ids,
             )
+
+    @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
+    @users('employee')
+    def test_message_post_defaults(self):
+        """ Test default values when posting a classic message. """
+        test_record = self.env['mail.test.simple'].create([{'name': 'Defaults'}])
+        creation_msg = test_record.message_ids
+        self.assertEqual(len(creation_msg), 1)
+
+        with self.mock_mail_app():
+            new_message = test_record.message_post(
+                body='Body',
+                partner_ids=[self.partner_employee_2.id],
+            )
+
+        self.assertMessageFields(
+            new_message,
+            {'author_id': self.partner_employee,
+             'body': '<p>Body</p>',
+             'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+             'is_internal': False,
+             'message_type': 'notification',
+             'model': test_record._name,
+             'notified_partner_ids': self.partner_employee_2,
+             'parent_id': creation_msg,
+             'record_name': test_record.name,
+             'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+             'res_id': test_record.id,
+             'subtype_id': self.env.ref('mail.mt_note'),
+            }
+        )
 
     @users('employee')
     def test_message_post_inactive_follower(self):
@@ -854,100 +954,202 @@ class TestMessagePostHelpers(TestMessagePostCommon):
             'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
         })
 
+        cls.user_employee.write({
+            'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
+        })
+
+        cls.test_records, cls.test_partners = cls._create_records_for_batch(
+            'mail.test.ticket',
+            10,
+        )
+
     @users('employee')
-    def test_message_log_with_view(self):
-        test_record = self.env['mail.test.simple'].browse(self.test_record.ids)
-        new_note = test_record._message_log_with_view(
-            'test_mail.mail_template_simple_test',
-            values={'partner': self.user_employee.partner_id}
-        )
-        self.assertMessageFields(
-            new_note,
-            {'author_id': self.partner_employee,
-             'body': '<p>Hello %s,</p>' % self.user_employee.name,
-             'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
-             'is_internal': True,
-             'message_type': 'notification',
-             'model': test_record._name,
-             'notified_partner_ids': self.env['res.partner'],
-             'reply_to': formataddr((self.company_admin.name, '%s@%s' % (self.alias_catchall, self.alias_domain))),
-             'res_id': test_record.id,
-             'subtype_id': self.env.ref('mail.mt_note'),
-            }
-        )
-
     @mute_logger('odoo.addons.mail.models.mail_mail')
-    def test_message_post_w_template(self):
-        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
-
+    def test_message_mail_with_template(self):
+        """ Test sending mass mail on documents based on a template """
         _attachments = self._generate_attachments_data(count=2, res_id=0, res_model='mail.template')
         email_1 = 'test1@example.com'
         email_2 = 'test2@example.com'
-        email_3 = self.partner_1.email
-        template = self._create_template('mail.test.simple', {
+        template = self._create_template('mail.test.ticket', {
             'attachment_ids': [(0, 0, attach_vals) for attach_vals in _attachments],
-            'partner_to': '%s,%s' % (self.partner_2.id, self.user_admin.partner_id.id),
-            'email_to': '%s, %s' % (email_1, email_2),
-            'email_cc': '%s' % email_3,
+            'auto_delete': True,
+            # After the HTML sanitizer, it will become "<p>Body for: <t t-out="object.name" /><a href="">link</a></p>"
+            'body_html': 'Body for: <t t-out="object.name" /><script>test</script><a href="javascript:alert(1)">link</a>',
+            'email_cc': self.partner_1.email,
+            'email_to': f'{email_1}, {email_2}',
+            'partner_to': '{{ object.customer_id.id }},%s' % self.partner_2.id,
         })
         template.attachment_ids.write({'res_id': template.id})
 
-        # admin should receive emails
-        self.user_admin.write({'notification_type': 'email'})
+        test_records = self.test_records.with_env(self.env)
+        with self.mock_mail_gateway():
+            _new_mails, _new_messages = test_records.with_user(self.user_employee).message_post_with_template(
+                template.id,
+                composition_mode='mass_mail',
+            )
+
+        # created partners from inline email addresses
+        new_partners = self.env['res.partner'].search([('email', 'in', (email_1, email_2))])
+        self.assertEqual(len(new_partners), 2,
+                         'Post with template: should have created partners based on template emails')
+
+        # sent emails (mass mail mode)
+        for test_record in test_records:
+            self.assertMailMail(
+                new_partners + self.partner_1 + self.partner_2 + test_record.customer_id,
+                'sent',
+                author=self.user_employee.partner_id,
+                email_values={
+                    'attachments': [
+                        ('AttFileName_00.txt', b'AttContent_00', 'text/plain'),
+                        ('AttFileName_01.txt', b'AttContent_01', 'text/plain'),
+                    ],
+                    'subject': f'About {test_record.name}',
+                    'body_content': test_record.name,
+                },
+                fields_values={
+                    'auto_delete': True,
+                    'is_internal': False,
+                    'is_notification': True,  # not auto_delete_message -> keep underlying mail.message
+                    'message_type': 'email',
+                    'model': test_record._name,
+                    'notified_partner_ids': self.env['res.partner'],
+                    'to_delete': True,
+                    'subtype_id': self.env['mail.message.subtype'],
+                    'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                    'res_id': test_record.id,
+                }
+            )
+
+    @users('employee')
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_message_mail_with_view(self):
+        """ Test sending a mass mailing on documents based on a view """
+        test_records = self.test_records.with_env(self.env)
+        for test_record in test_records:
+            test_record.message_subscribe(test_record.customer_id.ids)
+
+        with self.mock_mail_gateway():
+            res_messages = test_records.message_post_with_view(
+                'test_mail.mail_template_simple_test',
+                values={'partner': self.user_employee.partner_id},
+                composition_mode='mass_mail',
+                subject='About mass mailing',
+            )
+        self.assertEqual(len(res_messages), 0)
+        self.assertEqual(len(self._new_mails), 10)
+
+        # sent emails (mass mail mode)
+        for test_record in test_records:
+            self.assertMailMail(
+                [test_record.customer_id], 'sent',
+                author=self.user_employee.partner_id,
+                email_values={
+                    'body_content': f'<p>Hello {self.user_employee.partner_id.name}, this comes from {test_record.name}.</p>',
+                    'subject': 'About mass mailing',
+                },
+                fields_values={
+                    'auto_delete': False,
+                    'is_internal': False,
+                    'is_notification': True,  # not auto_delete_message -> keep underlying mail.message
+                    'message_type': 'email',
+                    'model': test_record._name,
+                    'notified_partner_ids': self.env['res.partner'],
+                    'recipient_ids': test_record.customer_id,
+                    'to_delete': False,
+                    'subtype_id': self.env['mail.message.subtype'],
+                    'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                    'res_id': test_record.id,
+                }
+            )
+
+    @users('employee')
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_message_post_with_template(self):
+        """ Test posting on a document based on a template content """
+        _attachments = self._generate_attachments_data(count=2, res_id=0, res_model='mail.template')
+        email_1 = 'test1@example.com'
+        email_2 = 'test2@example.com'
+        template = self._create_template('mail.test.ticket', {
+            'attachment_ids': [(0, 0, attach_vals) for attach_vals in _attachments],
+            'auto_delete': True,
+            'email_cc': self.partner_1.email,
+            'email_to': f'{email_1}, {email_2}',
+            'partner_to': '{{ object.customer_id.id }},%s' % self.partner_2.id,
+        })
+        template.attachment_ids.write({'res_id': template.id})
         # Force the attachments of the template to be in the natural order.
         self.email_template.invalidate_recordset(['attachment_ids'])
 
+        test_record = self.test_records.with_env(self.env)[0]
+        test_record.message_subscribe(test_record.customer_id.ids)
         with self.mock_mail_gateway():
-            test_record.with_user(self.user_employee).message_post_with_template(self.email_template.id, composition_mode='comment')
+            _new_mail, new_message = test_record.with_user(self.user_employee).message_post_with_template(
+                self.email_template.id,
+                composition_mode='comment'
+            )
 
+        # created partners from inline email addresses
         new_partners = self.env['res.partner'].search([('email', 'in', [email_1, email_2])])
-        for r in [self.partner_1, self.partner_2, new_partners[0], new_partners[1], self.partner_admin]:
-            self.assertSentEmail(
-                self.user_employee.partner_id,
-                [r],
-                subject='About %s' % test_record.name,
-                body_content=test_record.name,
-                attachments=[
-                    ('AttFileName_00.txt', b'AttContent_00', 'text/plain'),
-                    ('AttFileName_01.txt', b'AttContent_01', 'text/plain'),
-                ]
-            )
+        self.assertEqual(len(new_partners), 2,
+                         'Post with template: should have created partners based on template emails')
 
-    @mute_logger('odoo.addons.mail.models.mail_mail')
-    def test_message_post_w_template_mass_mode(self):
-        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
-        self.user_employee.write({
-            'groups_id': [(4, self.env.ref('base.group_partner_manager').id)],
-        })
+        # check notifications have been sent
+        self.assertMailNotifications(new_message, [{
+            'content': f'<p>Hello {test_record.name}</p>',
+            'message_type': 'notification',
+            'notif': [
+                {'partner': self.partner_1, 'type': 'email'},
+                {'partner': self.partner_2, 'type': 'email'},
+                {'partner': new_partners[0], 'type': 'email'},
+                {'partner': new_partners[1], 'type': 'email'},
+                {'partner': test_record.customer_id, 'type': 'email'},
+            ],
+            'subtype': 'mail.mt_comment',
+        }])
+        self.assertMessageFields(
+            new_message,
+            {'author_id': self.partner_employee,
+             'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+             'is_internal': False,
+             'model': test_record._name,
+             'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+             'res_id': test_record.id,
+            }
+        )
 
-        _attachments = self._generate_attachments_data(count=2, res_id=0, res_model='mail.template')
-        template = self._create_template('mail.test.simple', {
-            'attachment_ids': [(0, 0, attach_vals) for attach_vals in _attachments],
-            # After the HTML sanitizer, it will become "<p>Body for: <t t-out="object.name" /><a href="">link</a></p>"
-            'body_html': 'Body for: <t t-out="object.name" /><script>test</script><a href="javascript:alert(1)">link</a>',
-            'email_to': 'test@example.com',
-            'email_cc': self.partner_1.email,
-            'partner_to': '%s,%s' % (self.partner_2.id, self.user_admin.partner_id.id),
-        })
-        template.attachment_ids.write({'res_id': template.id})
+    @users('employee')
+    @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.tests')
+    def test_message_post_with_view(self):
+        """ Test posting on documents based on a view """
+        test_record = self.test_records.with_env(self.env)[0]
+        test_record.message_subscribe(test_record.customer_id.ids)
 
         with self.mock_mail_gateway():
-            test_record.with_user(self.user_employee).message_post_with_template(
-                template.id,
-                composition_mode='mass_mail'
+            new_message = test_record.message_post_with_view(
+                'test_mail.mail_template_simple_test',
+                values={'partner': self.user_employee.partner_id}
             )
 
-        new_partner = self.env['res.partner'].search([('email', '=', 'test@example.com')])
-
-        self.assertSentEmail(
-            self.user_employee.partner_id,
-            [new_partner],
-            subject='About %s' % test_record.name,
-            body_content=test_record.name,
-            attachments=[
-                ('AttFileName_00.txt', b'AttContent_00', 'text/plain'),
-                ('AttFileName_01.txt', b'AttContent_01', 'text/plain'),
-            ]
+        # check notifications have been sent
+        self.assertMailNotifications(new_message, [{
+            'content': f'<p>Hello {self.user_employee.partner_id.name}, this comes from {test_record.name}.</p>',
+            'message_type': 'notification',
+            'notif': [
+                {'partner': test_record.customer_id, 'type': 'email'},
+            ],
+            'subtype': 'mail.mt_comment',
+        }])
+        self.assertMessageFields(
+            new_message,
+            {'author_id': self.partner_employee,
+             'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+             'is_internal': False,
+             'message_type': 'notification',
+             'model': test_record._name,
+             'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+             'res_id': test_record.id,
+            }
         )
 
 


### PR DESCRIPTION
Purpose of this commit is to add some test about MailThread helpers built on top of ``message_post`` / ``composer`` (log, post with view, ...). Some tests about batch are also added.

Some performance tests are also added for those helpers.

Task-2710804 (MailThread Api Cleaning)
