### PR TITLE
[IMP] account_payment, sale: improvements in payment flows

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, SUPERUSER_ID, _
 
 
 class PaymentTransaction(models.Model):
@@ -180,6 +180,7 @@ class PaymentTransaction(models.Model):
         :return: None
         """
         self.ensure_one()
+        self = self.with_user(SUPERUSER_ID)  # Log messages as 'OdooBot'
         if self.source_transaction_id.payment_id:
             self.source_transaction_id.payment_id.message_post(body=message)
             for invoice in self.source_transaction_id.invoice_ids:

--- a/addons/account_payment/wizards/payment_link_wizard.py
+++ b/addons/account_payment/wizards/payment_link_wizard.py
@@ -7,6 +7,15 @@ class PaymentLinkWizard(models.TransientModel):
     _inherit = 'payment.link.wizard'
 
     def _get_additional_link_values(self):
+        """ Override of `payment` to add `invoice_id` to the payment link values.
+
+        The other values related to the invoice are directly read from the invoice.
+
+        Note: self.ensure_one()
+
+        :return: The additional payment link values.
+        :rtype: dict
+        """
         res = super()._get_additional_link_values()
         if self.res_model != 'account.move':
             return res

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -145,6 +145,13 @@ class PaymentLinkWizard(models.TransientModel):
             payment_link.link = f'{base_url}/payment/pay?{urls.url_encode(url_params)}'
 
     def _get_additional_link_values(self):
+        """ Return the additional values to append to the payment link.
+
+        Note: self.ensure_one()
+
+        :return: The additional payment link values.
+        :rtype: dict
+        """
         self.ensure_one()
         return {
             'currency_id': self.currency_id.id,

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -98,6 +98,7 @@ class PaymentTransaction(models.Model):
         :return: None
         """
         super()._log_message_on_linked_documents(message)
+        self = self.with_user(SUPERUSER_ID)  # Log messages as 'OdooBot'
         for order in self.sale_order_ids:
             order.message_post(body=message)
 

--- a/addons/sale/wizard/payment_link_wizard.py
+++ b/addons/sale/wizard/payment_link_wizard.py
@@ -23,6 +23,15 @@ class PaymentLinkWizard(models.TransientModel):
         return super()._get_payment_provider_available(**kwargs)
 
     def _get_additional_link_values(self):
+        """ Override of `payment` to add `sale_order_id` to the payment link values.
+
+        The other values related to the sales order are directly read from the sales order.
+
+        Note: self.ensure_one()
+
+        :return: The additional payment link values.
+        :rtype: dict
+        """
         res = super()._get_additional_link_values()
         if self.res_model != 'sale.order':
             return res


### PR DESCRIPTION
```
[IMP] account_payment, sale: log message with superuser
When payment providers receive a notification from a webhooks and log
something in the chatter of transactions, sale orders or invoices, the
message is shown as from 'Public User'.

Now, all messages will be logged as 'OdooBot'.
```
****
```
[IMP] sale: check state bef exec in _set_pending()
Check state before execution in _set_pending()

When using webhooks, _set_pending() can be called two times (when the
user comes back and when the webhooks notify the db). To avoid doing
the same treatment twice, we add a check in _set_pending to see if the
transaction is not already pending before doing anything else.
```
****
```
[IMP] (account_)payment, sale: add docstrings
Add docstrings to clarify methods in the payment link wizard.
```
****

Note: some of these commits were part of https://github.com/odoo/odoo/pull/78137

