### PR TITLE
[FIX] product: label is not visible for Sales Price

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -375,6 +375,9 @@
                    <attribute name="attrs">{'readonly': [('product_variant_count', '&gt;', 1)]}</attribute>
                    <attribute name="invisible">1</attribute>
                 </field>
+                <xpath expr="//label[@for='list_price']" position="replace">
+                    <label for="lst_price"/>
+                </xpath>
                 <field name="list_price" position="after">
                    <field name="lst_price" class="oe_inline" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                 </field>


### PR DESCRIPTION
Before this commit, when trying to create or edit a product from add a line and
open the 'Create Product' popup, the label 'Sales Price' is not visible.

This issue happened due to this commit
https://github.com/odoo/odoo/commit/46526f629f7645eaac8ce86e81e806cfa392b8b8

Due to the above fix, in the product template, the label for the list_price field 
becomes invisible. So here we replaced it with a label of the lst_price field.

task-2983733

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
