### PR TITLE
[FIX] pos_loyalty: convert string date to accept by all browsers

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -91,7 +91,7 @@ const PosLoyaltyGlobalState = (PosGlobalState) => class PosLoyaltyGlobalState ex
         for (const program of this.programs) {
             this.program_by_id[program.id] = program;
             if (program.date_to) {
-                program.date_to = new Date(program.date_to);
+                program.date_to = new Date(program.date_to.replace(/ /g, 'T').concat('Z'));
             }
             program.rules = [];
             program.rewards = [];


### PR DESCRIPTION
Before this commit: `new Date(stringDate)` in the safari browser doesn't accept this date format:
"2020-08-26 12:29:33"
Instate it should be:
"2020-08-26T12:29:33Z"

The solution is to convert it to the accepted format.

opw-2901785

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
