### PR TITLE
[FIX] website_sale: restrict cart edition with so transaction states

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -504,7 +504,7 @@ class WebsiteSale(http.Controller):
         revive: Revival method when abandoned cart. Can be 'merge' or 'squash'
         """
         order = request.website.sale_get_order()
-        if order and order.state != 'draft':
+        if order and not order.is_cart_editable:
             request.session['sale_order_id'] = None
             order = request.website.sale_get_order()
         values = {}

--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -16,10 +16,11 @@ class ResPartner(models.Model):
             is_public = any(u._is_public() for u in partner.with_context(active_test=False).user_ids)
             website = ir_http.get_request_website()
             if website and not is_public:
-                partner.last_website_so_id = SaleOrder.search([
+                last_website_so_id = SaleOrder.search([
                     ('partner_id', '=', partner.id),
                     ('website_id', '=', website.id),
                     ('state', '=', 'draft'),
                 ], order='write_date desc', limit=1)
+                partner.last_website_so_id = last_website_so_id if last_website_so_id.is_cart_editable else SaleOrder
             else:
                 partner.last_website_so_id = SaleOrder  # Not in a website context or public User

--- a/addons/website_sale_product_configurator/controllers/main.py
+++ b/addons/website_sale_product_configurator/controllers/main.py
@@ -64,7 +64,7 @@ class WebsiteSale(main.WebsiteSale):
             request.website = request.website.with_context(lang=lang)
 
         order = request.website.sale_get_order(force_create=True)
-        if order.state != 'draft':
+        if not order.is_cart_editable:
             request.session['sale_order_id'] = None
             order = request.website.sale_get_order(force_create=True)
 


### PR DESCRIPTION
Steps to reproduce:
-create a cart and pay in a way to have a pending transaction for the cart
-open a new tab and add elements to the cart

Current behavior:
The so (and its total amount) is modified with the new elements added. If the pending transaction succeeded, the total on the so does not match the amount of the transaction and they are not reconciled (the so is not confiremd). The client can access his cart and pay a second time even if the first transaction was validated.

Expected behavior:
If a payment is in process the user should not be able to modify its cart.

Solution:
We restrict the ability to recover and modify the cart to carts that have no transaction in progress or done (in state 'pending', 'done' or 'authorized').

Note:
The state "draft" of a transaction is ambiguous it can mean that a transaction is in progress or that the user came back to his cart to modify it. Hence we can not prevent the user to modify the cart if its cart has transaction in draft state. Because of that part of the bug remains.

opw-2983494


