### PR TITLE
[FIX] web_tour,project: tours: can drag&drop in wowl kanban

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -79,7 +79,7 @@ tour.register('project_tour', {
     extra_trigger: '.o_kanban_project_tasks',
     content: Markup(_t("<b>Drag &amp; drop</b> the card to change your task from stage.")),
     position: "bottom",
-    run: "drag_and_drop .o_kanban_group:eq(1) ",
+    run: "drag_and_drop_native .o_kanban_group:eq(1) ",
 }, {
     trigger: ".o_kanban_record:first",
     extra_trigger: '.o_kanban_project_tasks',


### PR DESCRIPTION
This commit allows to define steps in tours that drag&drop records in (wowl) kanban views. The former helper is based on jQuery, mostly because the drag&drop feature comes from jQuery. This feature is still necessary for the legacy codebase using jQuery. This commit thus introduces a new helper to allow the drag&drop in wowl Component using, for instance, the `useSortable` hook.

This commit also fixes the project tour by making it use that new helper. Note that even though the tour was broken (when run "automatically", not in a user onboarding), runbot was green because there's no test running this tour. It would be nice to add one.

