### PR TITLE
[FIX] bus: fix incorrect login colors

### DIFF
--- a/addons/bus/__manifest__.py
+++ b/addons/bus/__manifest__.py
@@ -8,6 +8,7 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
+    'auto_install': True,
     'assets': {
         'web.assets_common': [
             'bus/static/src/*.js',


### PR DESCRIPTION
Before [[1]](https://github.com/odoo/odoo/commit/a5623d24b77f523aeeafbb8c2bfaf27241ef3c8e), the web_editor module was auto installed. After that commit,
the bus module has been added to the web_editor dependencies. Since
the bus module is not auto installed, the web_editor module is not
either which means the login colors are wrong (blue instead of green).

This commit fixes this error by adding the `auto_install` flag to the
bus module.

[1] odoo@a5623d24b77f523aeeafbb8c2bfaf27241ef3c8e