### PR TITLE
[ADD] web_editor: insert inline code by wrapping it in backticks

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -429,3 +429,10 @@ i.oe-powerbox-commandImg {
         z-index: 1;
     }
 }
+code.o_inline_code {
+    background-color: #c5c5c5;
+    padding: 2px;
+    margin: 2px;
+    color: black;
+    font-size: inherit;
+}

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -5122,4 +5122,58 @@ X[]
             });
         });
     });
+
+    describe('markdown', () => {
+        describe('inline code', () => {
+            it('should convert text into inline code (start)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>`ab[]cd</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>\u200B<code class="o_inline_code">ab</code>\u200B[]cd</p>',
+                });
+            });
+            it('should convert text into inline code (middle)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab`cd[]ef</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>ab<code class="o_inline_code">cd</code>\u200B[]ef</p>',
+                });
+            });
+            it('should convert text into inline code (end)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab`cd[]</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>ab<code class="o_inline_code">cd</code>\u200B[]</p>',
+                });
+            });
+            it('should convert text into inline code and leave an earlier and a later backtick alone', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a`b`cd[]e`f</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>a`b<code class="o_inline_code">cd</code>\u200B[]e`f</p>',
+                });
+            });
+            it('should not convert text into inline code when traversing HTMLElements', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab`c<strong>d</strong>e[]fg</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>ab`c<strong>d</strong>e`[]fg</p>',
+                });
+            });
+            it('should not convert text into inline code when interrupted by linebreak', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab`c<br>d[]ef</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>ab`c<br>d`[]ef</p>',
+                });
+            });
+            it('should not convert text into inline code when inside inline code', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<code class="o_inline_code">b`cd[]e</code>f</p>',
+                    stepFunction: async editor => insertText(editor, '`'),
+                    contentAfter: '<p>a<code class="o_inline_code">b`cd`[]e</code>f</p>',
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This transforms text between two backticks into a `code` element, when typing the closing backtick.

task-2985108

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
