### PR TITLE
[IMP] mrp_subcontracting: hide is_subcontracting_location setting

### DIFF
--- a/addons/mrp_subcontracting/views/stock_location_views.xml
+++ b/addons/mrp_subcontracting/views/stock_location_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_location_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='return_location']" position='after'>
-                <field name="is_subcontracting_location" attrs="{'invisible': [('usage', '!=', 'internal')]}" readonly="context.get('default_is_subcontracting_location', False)"/>
+                <field name="is_subcontracting_location" groups="base.group_no_one" attrs="{'invisible': [('usage', '!=', 'internal')]}" readonly="context.get('default_is_subcontracting_location', False)"/>
             </xpath>
         </field>
     </record>

--- a/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
@@ -8,7 +8,9 @@ class StockRule(models.Model):
     _inherit = 'stock.rule'
 
     def _prepare_purchase_order(self, company_id, origins, values):
-        if 'partner_id' not in values[0] and self.location_dest_id.is_subcontracting_location:
+        if 'partner_id' not in values[0] \
+            and (company_id.subcontracting_location_id.parent_path in self.location_dest_id.parent_path
+                 or self.location_dest_id.is_subcontracting_location):
             values[0]['partner_id'] = values[0]['group_id'].partner_id.id
         return super()._prepare_purchase_order(company_id, origins, values)
 

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -146,7 +146,7 @@ class Location(models.Model):
             else:
                 location.next_inventory_date = False
 
-    @api.depends('warehouse_view_ids')
+    @api.depends('warehouse_view_ids', 'location_id')
     def _compute_warehouse_id(self):
         warehouses = self.env['stock.warehouse'].search([('view_location_id', 'parent_of', self.ids)])
         view_by_wh = OrderedDict((wh.view_location_id.id, wh.id) for wh in warehouses)


### PR DESCRIPTION
Related Upgrade PR: https://github.com/odoo/upgrade/pull/3901

The `is_subcontracting_location` setting is intended only for
complicated route/rule use cases therefore we make it visible
only in debug mode to prevent users from setting this value and
unintentionally creating a lot of new routes/rules unnecessary.

Additionally, it is expected that users who previously set these up
manually will not want their custom rules/routes changed but will still
need the existing behavior to continue, so we restore the previous check
for subcontracting locations set as sublocations of the primary company
subcontracting location.

Follow up to task: 2720393

---
Additionally does the following fix since it was noticed the `is_subcontracting_location` validation constrain was not working due to warehouse_id not being correctly set.

[FIX] stock: correctly trigger loc warehouse compute

Commit [1] made it so the computed stock_location.warehouse_id field is
stored. Unfortunately it did not correctly add the additional depends
value of `location_id` so when this value is changed after the record
has been initially created+saved without a location_id, the warehouse
will never be correctly computed.
    
[1] https://github.com/odoo/odoo/commit/9978bcb366d0ea48ed25a7891e0c7653a2f96bfb

Followup to task: 2882539


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
