### PR TITLE
[IMP] hr_expense: stop tracking the approver on expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -97,7 +97,7 @@ class HrExpense(models.Model):
     ], compute='_compute_state', string='Status', copy=False, index=True, readonly=True, store=True, default='draft')
     sheet_id = fields.Many2one('hr.expense.sheet', string="Expense Report", domain="[('employee_id', '=', employee_id), ('company_id', '=', company_id)]", readonly=True, copy=False)
     sheet_is_editable = fields.Boolean(compute='_compute_sheet_is_editable')
-    approved_by = fields.Many2one('res.users', string='Approved By', related='sheet_id.user_id')
+    approved_by = fields.Many2one('res.users', string='Approved By', related='sheet_id.user_id', tracking=False)
     approved_on = fields.Datetime(string='Approved On', related='sheet_id.approval_date')
     reference = fields.Char("Bill Reference")
     is_refused = fields.Boolean("Explicitly Refused by manager or accountant", readonly=True, copy=False)


### PR DESCRIPTION
The field is related towards the 'manager' field of the expense sheet, which means that when the approver is suggested automatically based on hr data, the expense records get written a value for this field (which is not in the view) which gets logged as:
- None -> Mitchell Admin (Approved By)

which seems to suggest that:
- the expense has been approved (it has not, a report was created)
- Mitchell Admin has approved: it may not be him (as when approving, the 'manager' field does not log who did the approval but who was supposed to initially)

Disabling tracking for this field (which contained no actionable information at best, and incorrect suggestions at worst) makes this problem go away.
