### PR TITLE
[IMP] bus, mail: remove im status route 

### DIFF
--- a/addons/bus/__manifest__.py
+++ b/addons/bus/__manifest__.py
@@ -26,7 +26,7 @@
             'bus/static/tests/**/*.js',
         ],
         'web.qunit_mobile_suite_tests': [
-            'bus/static/tests/helpers/*.js',
+            'bus/static/tests/helpers/**/*.js',
         ],
         'bus.websocket_worker_assets': [
             'web/static/src/legacy/js/promise_extension.js',

--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -6,12 +6,6 @@ from odoo.http import Controller, request, route
 
 
 class BusController(Controller):
-    @route('/bus/im_status', type="json", auth="user")
-    def im_status(self, partner_ids):
-        return {
-            'partners': request.env['res.partner'].with_context(active_test=False).search([('id', 'in', partner_ids)]).read(['im_status'])
-        }
-
     @route('/bus/get_model_definitions', methods=['POST'], type='http', auth='user')
     def get_model_definitions(self, model_names_to_fetch, **kwargs):
         return request.make_response(json.dumps(

--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -43,8 +43,8 @@ class WebsocketController(Controller):
         return {'channels': channels, 'notifications': notifications}
 
     @route('/websocket/update_bus_presence', type='http', auth='public', cors='*')
-    def update_bus_presence(self, inactivity_period):
-        request.env['ir.websocket']._update_bus_presence(int(inactivity_period))
+    def update_bus_presence(self, inactivity_period, im_status_ids_by_model):
+        request.env['ir.websocket']._update_bus_presence(int(inactivity_period), im_status_ids_by_model)
 
     @route('/bus/websocket_worker_bundle', type='http', auth='public', cors='*')
     def get_websocket_worker_bundle(self):

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -6,11 +6,11 @@ from psycopg2 import OperationalError
 
 from odoo import api, fields, models
 from odoo import tools
-from odoo.addons.bus.models.bus import TIMEOUT
 from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
-DISCONNECTION_TIMER = TIMEOUT + 5
+UPDATE_PRESENCE_DELAY = 60
+DISCONNECTION_TIMER = UPDATE_PRESENCE_DELAY + 5
 AWAY_TIMER = 1800  # 30 minutes
 
 

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -8,6 +8,14 @@ class IrWebsocket(models.AbstractModel):
     _name = 'ir.websocket'
     _description = 'websocket message handling'
 
+    def _get_im_status(self, im_status_ids_by_model):
+        im_status = {}
+        if 'res.partner' in im_status_ids_by_model:
+            im_status['partners'] = self.env['res.partner'].with_context(active_test=False).search(
+                [('id', 'in', im_status_ids_by_model['res.partner'])]).read(['im_status']
+            )
+        return im_status
+
     def _build_bus_channel_list(self, channels):
         """
             Return the list of channels to subscribe to. Override this
@@ -25,13 +33,16 @@ class IrWebsocket(models.AbstractModel):
         channels = set(self._build_bus_channel_list(data['channels']))
         dispatch.subscribe(channels, data['last'], self.env.registry.db_name, wsrequest.ws)
 
-    def _update_bus_presence(self, inactivity_period):
+    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         if self.env.uid:
             self.env['bus.presence'].update(
                 inactivity_period,
                 identity_field='user_id',
                 identity_value=self.env.uid
             )
+            im_status_notification = self._get_im_status(im_status_ids_by_model)
+            if im_status_ids_by_model:
+                self.env['bus.bus']._sendone(self.env.user.partner_id, 'bus/im_status', im_status_notification)
 
     @classmethod
     def _authenticate(cls):

--- a/addons/bus/static/tests/helpers/mock_server/models/ir_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_server/models/ir_websocket.js
@@ -1,0 +1,28 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { MockServer } from "@web/../tests/helpers/mock_server";
+
+patch(MockServer.prototype, 'bus/models/ir_websocket', {
+    /**
+     * Simulates `_update_presence` on `ir.websocket`.
+     *
+     * @param inactivityPeriod
+     * @param imStatusIdsByModel
+     */
+     _mockIrWebsocket__updatePresence(inactivityPeriod, imStatusIdsByModel) {
+        this._mockBusBus__sendone(this.currentPartnerId, 'bus/im_status', this._mockIrWebsocket__getImStatus(imStatusIdsByModel));
+    },
+    /**
+     * Simulates `_get_im_status` on `ir.websocket`.
+     *
+     * @param {Object} imStatusIdsByModel
+     * @param {Number[]|undefined} res.partner ids of res.partners whose im_status
+     * should be monitored.
+     */
+    _mockIrWebsocket__getImStatus({ 'res.partner': partnerIds }) {
+        return {
+            'partners': this.mockSearchRead('res.partner', [[['id', 'in', partnerIds]]], { context: { 'active_test': false }, fields: ['im_status'] })
+        };
+    },
+});

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -766,7 +766,7 @@ class WebsocketRequest:
         if event_name == 'subscribe':
             ir_websocket._subscribe(data)
         if event_name == 'update_presence':
-            ir_websocket._update_bus_presence(data)
+            ir_websocket._update_bus_presence(**data)
 
     def _get_session(self):
         session = root.session_store.get(self.ws._session.sid)

--- a/addons/hr_holidays/static/tests/qunit_suite_tests/components/persona_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/tests/qunit_suite_tests/components/persona_im_status_icon_tests.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+import { UPDATE_BUS_PRESENCE_DELAY } from '@bus/im_status_service';
+
 import { start, startServer } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('hr_holidays', {}, function () {
@@ -18,7 +20,7 @@ QUnit.test('on leave & online', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -27,7 +29,7 @@ QUnit.test('on leave & online', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.hasClass(
         document.querySelector('.o_PersonaImStatusIcon_icon'),
         'o-online',
@@ -52,7 +54,7 @@ QUnit.test('on leave & away', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -61,7 +63,7 @@ QUnit.test('on leave & away', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.hasClass(
         document.querySelector('.o_PersonaImStatusIcon_icon'),
         'o-away',
@@ -86,7 +88,7 @@ QUnit.test('on leave & offline', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -95,7 +97,7 @@ QUnit.test('on leave & offline', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.hasClass(
         document.querySelector('.o_PersonaImStatusIcon_icon'),
         'o-offline',

--- a/addons/hr_presence/models/ir_websocket.py
+++ b/addons/hr_presence/models/ir_websocket.py
@@ -9,8 +9,8 @@ from odoo.addons.bus.websocket import wsrequest
 class IrWebsocket(models.AbstractModel):
     _inherit = 'ir.websocket'
 
-    def _update_bus_presence(self, inactivity_period):
-        super()._update_bus_presence(inactivity_period)
+    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
+        super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
         #  This method can either be called due to an http or a
         #  websocket request. The request itself is necessary to
         #  retrieve the current guest. Let's retrieve the proper

--- a/addons/mail/controllers/bus.py
+++ b/addons/mail/controllers/bus.py
@@ -50,10 +50,3 @@ class MailChatController(BusController):
             return []
         else:
             return channel._channel_fetch_message(last_id, limit)
-
-    @route('/bus/im_status', type="json", auth="user")
-    def im_status(self, partner_ids, guest_ids=None):
-        im_status = super().im_status(partner_ids)
-        if guest_ids:
-            im_status['guests'] = request.env['mail.guest'].sudo().with_context(active_test=False).search([('id', 'in', guest_ids)]).read(['im_status'])
-        return im_status

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -6,6 +6,12 @@ from odoo.addons.bus.websocket import wsrequest
 class IrWebsocket(models.AbstractModel):
     _inherit = 'ir.websocket'
 
+    def _get_im_status(self, data):
+        im_status = super()._get_im_status(data)
+        if 'mail.guest' in data:
+            im_status['guests'] = self.env['mail.guest'].sudo().with_context(active_test=False).search([('id', 'in', data['mail.guest'])]).read(['im_status'])
+        return im_status
+
     def _build_bus_channel_list(self, channels):
         #  This method can either be called due to an http or a
         #  websocket request. The request itself is necessary to
@@ -26,8 +32,8 @@ class IrWebsocket(models.AbstractModel):
             channels.append(mail_channel)
         return super()._build_bus_channel_list(channels)
 
-    def _update_bus_presence(self, inactivity_period):
-        super()._update_bus_presence(inactivity_period)
+    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
+        super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
         if not self.env.uid:
             #  This method can either be called due to an http or a
             #  websocket request. The request itself is necessary to

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -33,7 +33,7 @@ registerModel({
                 discuss.openInitThread();
             }
             if (this.messaging.currentUser) {
-                this.messaging.startFetchImStatus();
+                this.messaging.updateImStatusRegistration();
                 this._loadMessageFailures();
             }
         },

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -48,6 +48,8 @@ registerModel({
             const proms = notifications.map(message => {
                 if (typeof message === 'object') {
                     switch (message.type) {
+                        case 'bus/im_status':
+                            return this._handleNotificationBusImStatus(message.payload);
                         case 'ir.attachment/delete':
                             return this._handleNotificationAttachmentDelete(message.payload);
                         case 'mail.channel.member/seen':
@@ -149,6 +151,20 @@ registerModel({
          * @param {Object} message
          */
         _handleNotification(message) {},
+        /**
+         * @private
+         * @param {Object} payload
+         * @param {Object[]} [payload.partners]
+         * @param {Object[]|undefined} [payload.guests]
+         */
+        _handleNotificationBusImStatus({ partners, guests }) {
+            if (partners) {
+                this.models['Partner'].insert(partners);
+            }
+            if (guests) {
+                this.models['Guest'].insert(guests);
+            }
+        },
         /**
          * @private
          * @param {Object} payload

--- a/addons/mail/static/src/models/persona.js
+++ b/addons/mail/static/src/models/persona.js
@@ -60,6 +60,11 @@ registerModel({
         im_status: attr({
             compute: '_computeImStatus',
         }),
+        messagingAsAnyPersona: one('Messaging', {
+            default: {},
+            inverse: 'allPersonas',
+        }),
+
         name: attr({
             compute: '_computeName',
         }),

--- a/addons/mail/static/src/models/throttle.js
+++ b/addons/mail/static/src/models/throttle.js
@@ -53,6 +53,9 @@ registerModel({
             if (this.threadAsThrottleNotifyCurrentPartnerTypingStatus) {
                 return 2.5 * 1000;
             }
+            if (this.messagingAsUpdateImStatusRegister) {
+                return 10 * 1000;
+            }
             return clear();
         },
     },
@@ -75,6 +78,10 @@ registerModel({
          * Inner function to be invoked and throttled.
          */
         func: attr(),
+        messagingAsUpdateImStatusRegister: one('Messaging', {
+            identifying: true,
+            inverse: 'updateImStatusRegisterThrottle',
+        }),
         shouldInvoke: attr({
             default: false,
         }),

--- a/addons/mail/static/src/models/timer.js
+++ b/addons/mail/static/src/models/timer.js
@@ -33,9 +33,6 @@ registerModel({
             if (this.messageViewOwnerAsHighlight) {
                 return 2 * 1000;
             }
-            if (this.messagingOwnerAsFetchImStatusTimer) {
-                return this.messagingOwnerAsFetchImStatusTimer.fetchImStatusTimerDuration;
-            }
             if (this.rtcSessionOwnerAsBroadcast) {
                 return 3 * 1000;
             }
@@ -72,10 +69,6 @@ registerModel({
             }
             if (this.messageViewOwnerAsHighlight) {
                 this.messageViewOwnerAsHighlight.onHighlightTimerTimeout();
-                return;
-            }
-            if (this.messagingOwnerAsFetchImStatusTimer) {
-                this.messagingOwnerAsFetchImStatusTimer.onFetchImStatusTimerTimeout();
                 return;
             }
             if (this.rtcSessionOwnerAsBroadcast) {
@@ -133,10 +126,6 @@ registerModel({
         duration: attr({
             compute: '_computeDuration',
             required: true,
-        }),
-        messagingOwnerAsFetchImStatusTimer: one('Messaging', {
-            identifying: true,
-            inverse: 'fetchImStatusTimer',
         }),
         messageViewOwnerAsHighlight: one('MessageView', {
             identifying: true,

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -62,12 +62,6 @@ patch(MockServer.prototype, 'mail', {
      */
     async _performRPC(route, args) {
         // routes
-        if (route === '/bus/im_status') {
-            const { partner_ids } = args;
-            return {
-                'partners': this.pyEnv['res.partner'].searchRead([['id', 'in', partner_ids]], { context: { 'active_test': false }, fields: ['im_status'] })
-            };
-        }
         if (route === '/mail/message/post') {
             if (args.thread_model === 'mail.channel') {
                 return this._mockMailChannelMessagePost(args.thread_id, args.post_data, args.context);

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { busService } from '@bus/services/bus_service';
+import { imStatusService } from '@bus/im_status_service';
 import { multiTabService } from '@bus/multi_tab_service';
 import { makeMultiTabToLegacyEnv } from '@bus/services/legacy/make_multi_tab_to_legacy_env';
 import { makeBusServiceToLegacyEnv } from '@bus/services/legacy/make_bus_service_to_legacy_env';
@@ -84,6 +85,7 @@ function setupMessagingServiceRegistries({
 
     services = {
         bus_service: busService,
+        im_status: imStatusService,
         messaging: messagingService,
         messagingValues,
         presence: makeFakePresenceService({

--- a/addons/mail/static/tests/qunit_suite_tests/components/persona_im_status_icon_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/persona_im_status_icon_tests.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+import { UPDATE_BUS_PRESENCE_DELAY } from '@bus/im_status_service';
+
 import { start, startServer } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
@@ -18,7 +20,7 @@ QUnit.test('initially online', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -27,7 +29,7 @@ QUnit.test('initially online', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-online`).length,
         1,
@@ -47,7 +49,7 @@ QUnit.test('initially offline', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -56,7 +58,7 @@ QUnit.test('initially offline', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-offline`).length,
         1,
@@ -76,7 +78,7 @@ QUnit.test('initially away', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -85,7 +87,7 @@ QUnit.test('initially away', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-away`).length,
         1,
@@ -105,7 +107,7 @@ QUnit.test('change icon on change partner im_status', async function (assert) {
         model: 'mail.channel',
         res_id: mailChannelId,
     });
-    const { advanceTime, afterNextRender, messaging, openDiscuss } = await start({
+    const { advanceTime, afterNextRender, openDiscuss } = await start({
         discuss: {
             params: {
                 default_active_id: mailChannelId,
@@ -114,7 +116,7 @@ QUnit.test('change icon on change partner im_status', async function (assert) {
         hasTimeControl: true,
     });
     await openDiscuss();
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-online`).length,
         1,
@@ -122,7 +124,7 @@ QUnit.test('change icon on change partner im_status', async function (assert) {
     );
 
     pyEnv['res.partner'].write([partnerId], { im_status: 'offline' });
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-offline`).length,
         1,
@@ -130,7 +132,7 @@ QUnit.test('change icon on change partner im_status', async function (assert) {
     );
 
     pyEnv['res.partner'].write([partnerId], { im_status: 'away' });
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-away`).length,
         1,
@@ -138,7 +140,7 @@ QUnit.test('change icon on change partner im_status', async function (assert) {
     );
 
     pyEnv['res.partner'].write([partnerId], { im_status: 'online' });
-    await afterNextRender(() => advanceTime(messaging.fetchImStatusTimerDuration));
+    await afterNextRender(() => advanceTime(UPDATE_BUS_PRESENCE_DELAY));
     assert.strictEqual(
         document.querySelectorAll(`.o_PersonaImStatusIcon.o-online`).length,
         1,


### PR DESCRIPTION
The `/bus/im_status` route polls the server every minute in order for
the user im_status to be up to date. This commit removes this poll
by sending the im_status on the bus when updating the current user
presence.

Moreover, before [1], the user bus presence was updated on each poll.
When the user didn't poll for 50s, we assumed the user was disconnected.
Since [1], the bus presence is updated each 30s by the `im_status`
service. This is too frequent: there is no need to update the user
presence so often.

In order not to overhelm the server with useless requests, the update
presence interval as well as the delay to be considered disconnected
have been updated: the former from 30 to 60 seconds, the later from
55 to 120 seconds.

[1]: https://github.com/odoo/odoo/commit/a5623d2