### PR TITLE
[FIX] web: add nbsp support in ArchParser

### DIFF
--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -256,7 +256,7 @@
 
                     <xpath expr="//div[hasclass('o_primary')]" position="after">
                         <div t-if="record.alias_name.value and record.alias_domain.value">
-                            <span t-translation="off"><i class="fa fa-envelope-o" aria-label="Leads" title="Leads" role="img"></i>&amp;nbsp; <field name="alias_id"/></span>
+                            <span t-translation="off"><i class="fa fa-envelope-o" aria-label="Leads" title="Leads" role="img"></i> <field name="alias_id"/></span>
                         </div>
                     </xpath>
 

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -74,7 +74,7 @@
                                     <strong><field name="name"/></strong>
                                 </div>
                                 <div>
-                                    <span><field name="department_id"/>&amp;nbsp;</span>
+                                    <span><field name="department_id"/></span>
                                 </div>
                                 <div t-if="!selection_mode">
                                     <span>Vacancies : <field name="expected_employees"/></span>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -521,10 +521,10 @@
                                     <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" context="{'default_partner_id': partner_id}" groups="analytic.group_analytic_accounting"/>
                                     <field name="privacy_visibility" widget="radio"/>
                                     <span colspan="2" class="text-muted" attrs="{'invisible':[('access_instruction_message', '=', '')]}">
-                                        <i class="fa fa-lightbulb-o"/>&amp;nbsp;<field name="access_instruction_message" class="d-inline" nolabel="1"/>
+                                        <i class="fa fa-lightbulb-o"/> <field name="access_instruction_message" class="d-inline" nolabel="1"/>
                                     </span>
                                     <span colspan="2" class="text-muted" attrs="{'invisible':[('privacy_visibility_warning', '=', '')]}">
-                                        <i class="fa fa-warning"/>&amp;nbsp;<field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
+                                        <i class="fa fa-warning"/> <field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
                                     </span>
                                 </group>
                                 <group>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -521,11 +521,10 @@
                                     <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" context="{'default_partner_id': partner_id}" groups="analytic.group_analytic_accounting"/>
                                     <field name="privacy_visibility" widget="radio"/>
                                     <span colspan="2" class="text-muted" attrs="{'invisible':[('access_instruction_message', '=', '')]}">
-                                        <i class="fa fa-lightbulb-o"/>&amp;nbsp;<field name="access_instruction_message" nolabel="1"/>
+                                        <i class="fa fa-lightbulb-o"/>&amp;nbsp;<field name="access_instruction_message" class="d-inline" nolabel="1"/>
                                     </span>
                                     <span colspan="2" class="text-muted" attrs="{'invisible':[('privacy_visibility_warning', '=', '')]}">
-                                        <i class="fa fa-warning">&amp;nbsp;</i>
-                                        <field name="privacy_visibility_warning" nolabel="1"/>
+                                        <i class="fa fa-warning"/>&amp;nbsp;<field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
                                     </span>
                                 </group>
                                 <group>

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -14,8 +14,7 @@
                     </small>
                 </div>
                 <div class="me-3" title="Quotations" groups="sales_team.group_sale_salesman">
-                    <i class="fa fa-money text-muted"></i>
-                    <small class="fw-bold">
+                    <i class="fa fa-money text-muted"/>&amp;nbsp;<small class="fw-bold">
                         <field name="quotation_count"/>
                     </small>
                 </div>

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -14,7 +14,7 @@
                     </small>
                 </div>
                 <div class="me-3" title="Quotations" groups="sales_team.group_sale_salesman">
-                    <i class="fa fa-money text-muted"/>&amp;nbsp;<small class="fw-bold">
+                    <i class="fa fa-money text-muted"/> <small class="fw-bold">
                         <field name="quotation_count"/>
                     </small>
                 </div>

--- a/addons/web/static/src/core/utils/xml.js
+++ b/addons/web/static/src/core/utils/xml.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+import { nbsp } from "@web/core/utils/strings";
+
 /**
  * XML document to create new elements from. The fact that this is a "text/xml"
  * document ensures that tagNames and attribute names are case sensitive.
@@ -47,12 +49,22 @@ export class XMLParser {
      * @returns {Element}
      */
     parseXML(arch) {
-        const cleanedArch = arch.replace(/&amp;nbsp;/g, "");
+        const cleanedArch = arch.replace(/&amp;nbsp;/g, "<nbsp/>");
         const xml = parser.parseFromString(cleanedArch, "text/xml");
         if (hasParsingError(xml)) {
             throw new Error(
                 `An error occured while parsing ${arch}: ${xml.getElementsByTagName("parsererror")}`
             );
+        }
+        // We don't want to remove nbsp from xml templates completely
+        // but we have to replace them during the parsing, so if there
+        // were nbsp in the arch, we replace the temporary <nbsp/> by
+        // the appropriate nbsp character
+        if (cleanedArch !== arch) {
+            const nbspList = xml.querySelectorAll("nbsp");
+            for (const space of nbspList) {
+                space.replaceWith(nbsp);
+            }
         }
         return xml.documentElement;
     }

--- a/addons/web/static/src/core/utils/xml.js
+++ b/addons/web/static/src/core/utils/xml.js
@@ -49,22 +49,12 @@ export class XMLParser {
      * @returns {Element}
      */
     parseXML(arch) {
-        const cleanedArch = arch.replace(/&amp;nbsp;/g, "<nbsp/>");
-        const xml = parser.parseFromString(cleanedArch, "text/xml");
+        // const cleanedArch = arch.replace(/&amp;nbsp;/g, "");
+        const xml = parser.parseFromString(arch, "text/xml");
         if (hasParsingError(xml)) {
             throw new Error(
                 `An error occured while parsing ${arch}: ${xml.getElementsByTagName("parsererror")}`
             );
-        }
-        // We don't want to remove nbsp from xml templates completely
-        // but we have to replace them during the parsing, so if there
-        // were nbsp in the arch, we replace the temporary <nbsp/> by
-        // the appropriate nbsp character
-        if (cleanedArch !== arch) {
-            const nbspList = xml.querySelectorAll("nbsp");
-            for (const space of nbspList) {
-                space.replaceWith(nbsp);
-            }
         }
         return xml.documentElement;
     }

--- a/odoo/addons/base/data/ir_demo_data.xml
+++ b/odoo/addons/base/data/ir_demo_data.xml
@@ -15,7 +15,7 @@
                     <div class="col-12 text-center">
                       <div class="card text-white bg-danger mb-3 w-75 ml64">
                         <div class="card-header">
-                                <span class="fa fa-2x fa-warning" t-translation="off">&amp;nbsp;</span>
+                                <span class="fa fa-2x fa-warning" t-translation="off"></span>
                                 <span class="text-white text-uppercase">Danger Zone</span>
                         </div>
                         <div class="card-body bg-transparent text-center">

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -191,7 +191,7 @@
                         <img t-attf-src="#{record.icon.value}" class="oe_module_icon" alt="Icon"/>
                         <div class="oe_module_desc" t-att-title="record.shortdesc.value">
                           <h4 class="o_kanban_record_title">
-                            <field name="shortdesc"/>&amp;nbsp;
+                            <field name="shortdesc"/>
                           </h4>
                           <p class="oe_module_name">
                             <field groups="!base.group_no_one" name="summary"/>

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -30,7 +30,7 @@
                                             <img t-attf-src="#{record.icon.value}" class="oe_module_icon" alt="Icon" />
                                             <div class="oe_module_desc" t-att-title="record.shortdesc.value">
                                                 <h4 class="o_kanban_record_title">
-                                                    <field name="shortdesc" />&amp;nbsp;
+                                                    <field name="shortdesc" />
                                                 </h4>
                                                 <p class="oe_module_name">
                                                     <field groups="!base.group_no_one" name="summary" />


### PR DESCRIPTION
This commit fixes the absence of nbsp characters after parsing the Arch. Many spaces were missing in views since their rewrite in Owl.
NOT YET READY
