### PR TITLE
[REF] web_editor: use the Notebook component

### DIFF
--- a/addons/web/static/src/core/notebook/notebook.scss
+++ b/addons/web/static/src/core/notebook/notebook.scss
@@ -1,7 +1,7 @@
 .o_notebook {
     --notebook-margin-x: 0;
     --notebook-padding-x: 0;
-    --notebook-link-border-color: transparent; 
+    --notebook-link-border-color: transparent;
     --notebook-link-border-color-active: #{$border-color};
     --notebook-link-border-color-hover: #{$gray-200};
     --notebook-link-border-color-active-accent: #{$border-color};
@@ -18,7 +18,7 @@
     .nav-item {
         white-space: nowrap;
     }
-    
+
     .nav-link {
         border: 1px solid var(--notebook-link-border-color, transparent);
 
@@ -47,7 +47,7 @@
             width: max-content;
             border-bottom: 1px solid var(--notebook-link-border-color);
         }
-        
+
         .nav-item {
             margin: 0 -1px -1px 0;
 
@@ -55,7 +55,7 @@
                 border-top-width: 0;
             }
         }
-        
+
         .nav-link {
             border: 1px solid var(--notebook-link-border-color, transparent);
 

--- a/addons/web/static/src/core/notebook/notebook.xml
+++ b/addons/web/static/src/core/notebook/notebook.xml
@@ -10,7 +10,7 @@
                     </li>
                 </ul>
             </div>
-            <div class="o_notebook_content bg-white pt-3 tab-content">
+            <div class="o_notebook_content tab-content">
                 <div class="tab-pane active" t-ref="activePane">
                     <t t-if="page" t-component="page.Component" t-key="state.currentPage" t-props="page.props" />
                     <t t-else="" t-slot="{{ state.currentPage }}" />

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -3,6 +3,7 @@
 import { useService } from '@web/core/utils/hooks';
 import { useWowlService } from '@web/legacy/utils';
 import { Dialog } from '@web/core/dialog/dialog';
+import { Notebook } from '@web/core/notebook/notebook';
 import { ImageSelector } from './image_selector';
 import { DocumentSelector } from './document_selector';
 import { IconSelector } from './icon_selector';
@@ -206,6 +207,10 @@ export class MediaDialog extends Component {
         }
         this.props.close();
     }
+
+    onTabChange(tab) {
+        this.state.activeTab = tab;
+    }
 }
 MediaDialog.template = 'web_editor.MediaDialog';
 MediaDialog.defaultProps = {
@@ -214,6 +219,7 @@ MediaDialog.defaultProps = {
 MediaDialog.components = {
     ...Object.keys(TABS).map(key => TABS[key].Component),
     Dialog,
+    Notebook,
 };
 
 export class MediaDialogWrapper extends Component {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
@@ -4,21 +4,7 @@
     <Dialog contentClass="contentClass"
         size="size"
         title="title">
-        <div class="o_notebook">
-            <div class="o_notebook_headers">
-                <ul class="nav nav-tabs" role="tablist">
-                    <li t-foreach="tabs" t-as="tab" t-key="tab.id" class="nav-item cursor-pointer">
-                        <a class="nav-link" t-att-class="{ active:  tab.id === state.activeTab }" t-on-click="() => state.activeTab = tab.id"><t t-esc="tab.title"/></a>
-                    </li>
-                </ul>
-            </div>
-            <!-- Tab panes -->
-            <div class="o_notebook_content tab-content">
-                <t t-foreach="tabs" t-as="tab" t-key="tab.id">
-                    <div class="tab-pane fade" t-att-class="tab.id === state.activeTab ? 'active show' : ''"><t t-component="tab.Component" t-props="tab.props"/></div>
-                </t>
-            </div>
-        </div>
+        <Notebook pages="tabs" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">
             <button class="btn btn-primary" t-on-click="() => this.save()">Add</button>
             <button class="btn btn-secondary" t-on-click="() => this.props.close()">Discard</button>


### PR DESCRIPTION
This commit makes use of the Notebook component in the MediaDialog component. Since odoo#98706, the design used by tabs and the Notebook is more consistent, which allow us to replace that part of the template by the component.

The Notebook receives the list of pages to render, and will generate the right subcomponents in the content part of its template.

=> Less code, same functionality and behavior