### PR TITLE
[IMP] board: move board app to Dashboard app

### DIFF
--- a/addons/base_install_request/__init__.py
+++ b/addons/base_install_request/__init__.py
@@ -14,7 +14,7 @@ def _auto_install_apps(cr, registry):
     env['ir.module.module'].sudo().search([
         ('name', 'in', [
             # Community
-            'board', 'hr', 'mass_mailing', 'project', 'survey',
+            'hr', 'mass_mailing', 'project', 'survey',
             # Enterprise
             'appointment', 'knowledge', 'planning', 'sign',
         ]),

--- a/addons/board/__manifest__.py
+++ b/addons/board/__manifest__.py
@@ -13,12 +13,12 @@ Lets the user create a custom dashboard.
 
 Allows users to create custom dashboard.
     """,
-    'depends': ['base', 'web'],
+    'depends': ['spreadsheet_dashboard'],
     'data': [
         'security/ir.model.access.csv',
         'views/board_views.xml',
         ],
-    'application': True,
+    'application': False,
     'assets': {
         'web.assets_backend': [
             'board/static/src/**/*.scss',

--- a/addons/board/views/board_views.xml
+++ b/addons/board/views/board_views.xml
@@ -27,10 +27,11 @@
     <data>
 
         <!--My Dashboard Menu-->
-        <menuitem 
+        <menuitem
             id="menu_board_my_dash"
-            parent="base.menu_board_root"
+            name="My Dashboard"
+            parent="spreadsheet_dashboard.spreadsheet_dashboard_menu_root"
             action="open_board_my_dash_action"
-            sequence="5"/>
+            sequence="100"/>
     </data>
 </odoo>


### PR DESCRIPTION
Due to business decision, `board` module is removed.

Task 2984963


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
