### PR TITLE
[IMP] account: move account.move's attachment_ids field from account_accountant to account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -236,6 +236,7 @@ class AccountMove(models.Model):
     show_name_warning = fields.Boolean(store=False)
     type_name = fields.Char('Type Name', compute='_compute_type_name')
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')
 
     # === Hash Fields === #
     restrict_mode_hash_table = fields.Boolean(related='journal_id.restrict_mode_hash_table')


### PR DESCRIPTION
This field is needed in l10n_mx_edi, as the dependency of a computed field. However, this module only depends from account_accountant, not account. The field thus needs to be moved to a more generic place.
