### PR TITLE
[FIX] web_editor,mass_mailing: fix history in new mass massmailing

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -95,7 +95,10 @@ export class MassMailingHtmlField extends HtmlField {
 
         const $editorEnable = $editable.closest('.editor_enable');
         $editorEnable.removeClass('editor_enable');
+        // Prevent history reverts.
+        this.wysiwyg.odooEditor.observerUnactive('toInline');
         await toInline($editable, this.cssRules, this.wysiwyg.$iframe);
+        this.wysiwyg.odooEditor.observerActive('toInline');
         const inlineHtml = $editable.html();
         $editorEnable.addClass('editor_enable');
         this.wysiwyg.odooEditor.resetContent(initialHtml);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -551,10 +551,6 @@ async function toInline($editable, cssRules, $iframe) {
     $editable.removeClass('odoo-editor-editable');
     const editable = $editable.get(0);
     const iframe = $iframe && $iframe.get(0);
-    const wysiwyg = $editable.data('wysiwyg');
-    if (wysiwyg) {
-        wysiwyg.odooEditor.historyPauseSteps(); // Prevent history reverts.
-    }
     const doc = editable.ownerDocument;
     cssRules = cssRules || doc._rulesCache;
     if (!cssRules) {

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -388,7 +388,10 @@ export class HtmlField extends Component {
         $odooEditor.removeClass('odoo-editor-editable');
         $editable.html(html);
 
+        // Prevent history reverts.
+        this.wysiwyg.odooEditor.observerUnactive('toInline');
         await toInline($editable, this.cssRules, this.wysiwyg.$iframe);
+        this.wysiwyg.odooEditor.observerActive('toInline');
         $odooEditor.addClass('odoo-editor-editable');
 
         this.wysiwyg.setValue($editable.html());


### PR DESCRIPTION
Before this commit
When creating a new mass_mailing and hitting multiples times enter, the content was reset.

task-2985162





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
