### PR TITLE
[FIX] bus: make subscribe method only accept strings

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -33,6 +33,8 @@ class WebsocketController(Controller):
 
     @route('/websocket/peek_notifications', type='json', auth='public', cors='*')
     def peek_notifications(self, channels, last):
+        if not all(isinstance(c, str) for c in channels):
+            raise ValueError("bus.Bus only string channels are allowed.")
         channels = list(set(
             channel_with_db(request.db, c)
             for c in request.env['ir.websocket']._build_bus_channel_list(channels)

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -20,6 +20,8 @@ class IrWebsocket(models.AbstractModel):
         return channels
 
     def _subscribe(self, data):
+        if not all(isinstance(c, str) for c in data['channels']):
+            raise ValueError("bus.Bus only string channels are allowed.")
         channels = set(self._build_bus_channel_list(data['channels']))
         dispatch.subscribe(channels, data['last'], self.env.registry.db_name, wsrequest.ws)
 

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import common
 from . import test_assetsbundle
 from . import test_health
+from . import test_ir_websocket
 from . import test_websocket_caryall
 from . import test_websocket_rate_limiting

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+
+
+class TestIrWebsocket(common.HttpCase):
+    def test_only_allow_string_channels_from_frontend(self):
+        with self.assertRaises(ValueError):
+            self.env['ir.websocket']._subscribe({
+                'inactivity_period': 1000,
+                'last': 0,
+                'channels': [('odoo', 'mail.channel', 5)],
+            })


### PR DESCRIPTION
Before [1], only string channels were allowed for polling. This
ensured no one could send a server-side channel from the frontend,
this PR restores this behavior.

[1]: https://github.com/odoo/odoo/commit/a5623d2