### PR TITLE
[MOV] sale_stock->sale: product_type field

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -252,6 +252,7 @@ class SaleOrderLine(models.Model):
         store=True)
 
     # Technical computed fields for UX purposes (hide/make fields readonly, ...)
+    product_type = fields.Selection(related='product_id.detailed_type', depends=['product_id'])
     product_updatable = fields.Boolean(
         string="Can Edit Product",
         compute='_compute_product_updatable')

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -15,7 +15,6 @@ class SaleOrderLine(models.Model):
     qty_delivered_method = fields.Selection(selection_add=[('stock_move', 'Stock Moves')])
     route_id = fields.Many2one('stock.route', string='Route', domain=[('sale_selectable', '=', True)], ondelete='restrict', check_company=True)
     move_ids = fields.One2many('stock.move', 'sale_line_id', string='Stock Moves')
-    product_type = fields.Selection(related='product_id.detailed_type', depends=['product_id'])
     virtual_available_at_date = fields.Float(compute='_compute_qty_at_date', digits='Product Unit of Measure')
     scheduled_date = fields.Datetime(compute='_compute_qty_at_date')
     forecast_expected_date = fields.Datetime(compute='_compute_qty_at_date')


### PR DESCRIPTION
This related field is useful in sale to simplify the logic of the  product configurators (incoming adaptation to OWL). Thanks to that, we'll be able to avoid an useless rpc to get the  detailed type of the SOL product.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
