### PR TITLE
[FIX] Update POL Analytic Account/Tag if Rules exist

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1104,7 +1104,8 @@ class PurchaseOrderLine(models.Model):
                     date=rec.date_order,
                     company_id=rec.company_id.id,
                 )
-                rec.account_analytic_id = default_analytic_account.analytic_id
+                if default_analytic_account:
+                    rec.account_analytic_id = default_analytic_account.analytic_id
 
     @api.depends('product_id', 'date_order')
     def _compute_analytic_tag_ids(self):
@@ -1117,7 +1118,8 @@ class PurchaseOrderLine(models.Model):
                     date=rec.date_order,
                     company_id=rec.company_id.id,
                 )
-                rec.analytic_tag_ids = default_analytic_account.analytic_tag_ids
+                if default_analytic_account:
+                    rec.analytic_tag_ids = default_analytic_account.analytic_tag_ids
 
     @api.onchange('product_id')
     def onchange_product_id(self):


### PR DESCRIPTION
Improvement on commit #99692

Description of the issue/feature this PR addresses: If user set default values (or context) of analytic account or tags, current code overwrites such changes.

Current behavior before PR: Analytic Account is updating even if no Default Analytic Rules are found.

Desired behavior after PR is merged: System should only update Analytic Account/Tags field on POL when there a Default Analytic Rule exists.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
