### PR TITLE
[FIX] website: prevent favicon removal to crash

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -252,7 +252,7 @@ class Website(models.Model):
 
     @api.model
     def _handle_favicon(self, vals):
-        if 'favicon' in vals:
+        if vals.get('favicon'):
             vals['favicon'] = base64.b64encode(tools.image_process(base64.b64decode(vals['favicon']), size=(256, 256), crop='center', output_format='ICO'))
 
     @api.model


### PR DESCRIPTION
Before this commit, when one would remove the favicon of a website in the settings it would crash.
This is because since [1] the introduction of `base64.b64encode()` in the `_handle_favicon()` method make it crash with `False` value.

Steps to reproduce:
- Settings > website
- Delete favicon

[1]: https://github.com/odoo/odoo/commit/6b8752604898bf2b583b7f5334e35f6a1583595e

opw-2958836
