### PR TITLE
[FIX] stock: fixed fetching product template 

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -724,7 +724,7 @@ class ProductTemplate(models.Model):
 
     def _compute_quantities_dict(self):
         variants_available = {
-            p['id']: p for p in self.product_variant_ids.read(['qty_available', 'virtual_available', 'incoming_qty', 'outgoing_qty'])
+            p['id']: p for p in self.env['product.product'].browse(self.product_variant_ids.ids).read(['qty_available', 'virtual_available', 'incoming_qty', 'outgoing_qty'])
         }
         prod_available = {}
         for template in self:
@@ -732,7 +732,7 @@ class ProductTemplate(models.Model):
             virtual_available = 0
             incoming_qty = 0
             outgoing_qty = 0
-            for p in template.product_variant_ids:
+            for p in self.env['product.product'].browse(template.product_variant_ids.ids):
                 qty_available += variants_available[p.id]["qty_available"]
                 virtual_available += variants_available[p.id]["virtual_available"]
                 incoming_qty += variants_available[p.id]["incoming_qty"]


### PR DESCRIPTION
Steps to reproduce:
on a cotact form add a many2many field (to product template) using studio

Bug:
an error pops up when editing the email / phone number "Database fetch misses ids ((<NewId origin= X >,)) and has extra ids ((X,)), may be caused by a type incoherence in a previous request" because fields created with studio have "NewId origin= " appended to them on _ids X refers to the id of the product template

Fix:
perofrom the check on the "ids" not "_ids"

opw-2956616
opw-2966229
opw-2980948
