### PR TITLE
[FIX] l10n_ar: demo data mixing taxes

### DIFF
--- a/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
@@ -147,32 +147,32 @@
             (0, 0, {
                 'name': 'FOB Total',
                 'price_unit': 28936.06,
-                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_21_ventas'.format(ref('company_ri')))])],
+                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_21_compras'.format(ref('company_ri')))])],
             }),
             (0, 0, {
                 'name': 'Flete',
                 'price_unit': 1350.00,
-                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_21_ventas'.format(ref('company_ri')))])],
+                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_21_compras'.format(ref('company_ri')))])],
             }),
             (0, 0, {
                 'name': 'Seguro',
                 'price_unit': 130.21,
-                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_21_ventas'.format(ref('company_ri')))])],
+                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_21_compras'.format(ref('company_ri')))])],
             }),
             (0, 0, {
                 'name': '-FOB Total',
                 'price_unit': -28936.06,
-                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_no_gravado_ventas'.format(ref('company_ri')))])],
+                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_no_gravado_compras'.format(ref('company_ri')))])],
             }),
             (0, 0, {
                 'name': '-Flete',
                 'price_unit': -1350.00,
-                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_no_gravado_ventas'.format(ref('company_ri')))])],
+                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_no_gravado_compras'.format(ref('company_ri')))])],
             }),
             (0, 0, {
                 'name': '-Seguro',
                 'price_unit': -130.21,
-                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_no_gravado_ventas'.format(ref('company_ri')))])],
+                'tax_ids': [(6, 0, [ref('l10n_ar.{}_ri_tax_vat_no_gravado_compras'.format(ref('company_ri')))])],
             }),
         ]"/>
     </record>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Supplier invoice demo data was badly initialized with sales taxes. This was given problems in some VAT reports. Fixed and they are all purchase taxes. Document type "Despacho de Importación" xml id demo_despacho_1

### Current behavior before PR:

The tax report show a vendor bill on sales scope

![image](https://user-images.githubusercontent.com/7593953/190495339-0674889b-3fca-471f-89f5-40e958449fbf.png)

Also form the vendor bill form view,  if you add suffix purchase on the taxes you can see the sales taxes that does not belongs

![image](https://user-images.githubusercontent.com/7593953/190496533-1cedef37-90c2-4fc2-ad64-fa6323e14870.png)

 
### Desired behavior after PR is merged:

Now the DI16052IC04000605L document does not appears in sales book only appears in purchase book
![image](https://user-images.githubusercontent.com/7593953/190497240-56412ddb-b9bd-45cf-8473-5911b4830181.png)

Also if you make the same test add the purchase suffix to the taxes you can check that they are all ok 
![image](https://user-images.githubusercontent.com/7593953/190497757-027e9e10-4d2e-4ee4-8e60-b8137833fd1d.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
