### PR TITLE
[FIX] project: fix project profitabilitycalculation

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -12,7 +12,7 @@ export class ProjectProfitability extends Component {
     }
 
     get margin() {
-        const invoiced_billed = this.revenues.total.invoiced - this.costs.total.billed;
+        const invoiced_billed = this.revenues.total.invoiced + this.costs.total.billed;
         const to_invoice_to_bill = this.revenues.total.to_invoice - this.costs.total.to_bill;
         return {
             invoiced_billed,


### PR DESCRIPTION
Before this commit, In Project > Set Status >Right Panel in Profitability the Margin calculation was shown negative

After this commit,  Margin calculation is shown Positive

task-2979890

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
