### PR TITLE
[IMP] web: binary formatter

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -388,9 +388,20 @@ export function formatText(value) {
     return value || "";
 }
 
+/**
+ * Returns the value or an empty string if it's an object.
+ *
+ * @param {Object|String|null} value
+ * @returns {string}
+ */
+export function formatBinary(value) {
+    return typeof(value) === "object" ? "" : value;
+}
+
 registry
     .category("formatters")
     .add("boolean", formatBoolean)
+    .add("binary", formatBinary)
     .add("char", formatChar)
     .add("date", formatDate)
     .add("datetime", formatDateTime)


### PR DESCRIPTION
When using a binary field in a list renderer the tooltip displays either:
1. `[Object object]` - for non stored json data
2. File size - for attachment data

to resolve case 1, the formatter checks the type of the data and returns an empty string, while maintaining the behaviour for case 2.

This can be seen when using the `analytic_distribution` widget (see invoices odoo/odoo#98914)
