### PR TITLE
[FIX] account : fix payment term example display

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -85,7 +85,7 @@
                             <div class="col-12 col-lg-6 o_setting_box">
                                 <div class="o_setting_left_pane"/>
                                 <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Cash Discount Tax computation</span>
+                                    <span class="o_form_label">Cash Discount Tax Reduction</span>
                                     <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
                                     <div class="text-muted">
                                         When will the tax be reduced when offering a cash discount


### PR DESCRIPTION
The payment term example display was not functional anymore and always displayed 0.

This was because of a inversed condition.