### PR TITLE
[FIX] payment: fix crash when uninstalling payment providers

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -5,7 +5,6 @@ import werkzeug
 
 from odoo import _, http
 from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.fields import Command
 from odoo.http import request
 
 from odoo.addons.payment import utils as payment_utils
@@ -17,8 +16,8 @@ class PaymentPortal(portal.CustomerPortal):
 
     """ This controller contains the foundations for online payments through the portal.
 
-    It allows to complete a full payment flow without the need of going though a document-based flow
-    made available by another module's controller.
+    It allows to complete a full payment flow without the need of going through a document-based
+    flow made available by another module's controller.
 
     Such controllers should extend this one to gain access to the _create_transaction static method
     that implements the creation of a transaction before its processing, or to override specific
@@ -74,7 +73,7 @@ class PaymentPortal(portal.CustomerPortal):
         # Raise an HTTP 404 if a partner is provided with an invalid access token
         if partner_id:
             if not payment_utils.check_access_token(access_token, partner_id, amount, currency_id):
-                raise werkzeug.exceptions.NotFound  # Don't leak info about the existence of an id
+                raise werkzeug.exceptions.NotFound()  # Don't leak information about ids.
 
         user_sudo = request.env.user
         logged_in = not user_sudo._is_public()
@@ -105,7 +104,7 @@ class PaymentPortal(portal.CustomerPortal):
         # Make sure that the currency exists and is active
         currency = request.env['res.currency'].browse(currency_id).exists()
         if not currency or not currency.active:
-            raise werkzeug.exceptions.NotFound  # The currency must exist and be active
+            raise werkzeug.exceptions.NotFound()  # The currency must exist and be active.
 
         # Select all providers and tokens that match the constraints
         providers_sudo = request.env['payment.provider'].sudo()._get_compatible_providers(
@@ -371,7 +370,7 @@ class PaymentPortal(portal.CustomerPortal):
             if not payment_utils.check_access_token(
                 access_token, tx_sudo.partner_id.id, tx_sudo.amount, tx_sudo.currency_id.id
             ):
-                raise werkzeug.exceptions.NotFound  # Don't leak info about existence of an id
+                raise werkzeug.exceptions.NotFound()  # Don't leak information about ids.
 
             # Stop monitoring the transaction now that it reached a final state.
             PaymentPostProcessing.remove_transactions(tx_sudo)

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -550,9 +550,9 @@ class PaymentProvider(models.Model):
         :param str provider_code: The code of the provider to setup.
         :return: None
         """
-        providers = self.search([('provider', '=', provider_code)])
+        providers = self.search([('code', '=', provider_code)])
         providers.write({
-            'provider': 'none',
+            'code': 'none',
             'state': 'disabled',
         })
 


### PR DESCRIPTION
```
[FIX] payment: fix crash when uninstalling payment providers
```
---
```
[CLN] payment: code cleanup
    
This commit removes unused imports and renames some confusing variable
names and helper texts that were changed with commit f7b8f075 when
renaming the term "acquirer" to "provider".
```