### PR TITLE
[IMP] mail: remove legacy Dialog from call_view

### DIFF
--- a/addons/mail/static/src/components/call_view/call_view.js
+++ b/addons/mail/static/src/components/call_view/call_view.js
@@ -2,13 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-import Dialog from 'web.OwlDialog';
-
 const { Component } = owl;
-
-const components = {
-    Dialog,
-};
 
 // TODO a nice-to-have would be a resize handle under the videos.
 
@@ -28,7 +22,6 @@ export class CallView extends Component {
 }
 
 Object.assign(CallView, {
-    components,
     props: { record: Object },
     template: 'mail.CallView',
 });


### PR DESCRIPTION
The Dialog is no more used in the call_view.
Just clean up the code of the import

task-2783069

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
