### PR TITLE
[IMP] website: review frontend mini UI "Edit" button

### DIFF
--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -45,7 +45,7 @@ $-mini-nav-size: 40px;
         overflow: auto;
     }
 
-    @each $-name, $-color in ('edit': $o-enterprise-primary-color, 'apps': $o-enterprise-color) {
+    @each $-name, $-color in ('apps': $o-enterprise-color, 'edit': $o-we-bg-lighter) {
         .o_frontend_to_backend_#{$-name}_btn {
             background-color: $-color;
 
@@ -53,6 +53,12 @@ $-mini-nav-size: 40px;
                 background-color: darken($-color, 5%);
             }
         }
+    }
+
+    .o_frontend_to_backend_edit_btn > img {
+        height: 1.8em;
+        margin-right: 0.5em;
+        border-radius: 0.25rem;
     }
 
     &:hover {

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -192,7 +192,7 @@
                        t-attf-href="/web#menu_id=#{menu['id']}&amp;action=#{menu['action'] and menu['action'].split(',')[1] or ''}"/>
                 </div>
                 <a groups="website.group_website_restricted_editor" href="#" title="Edit this content" class="o_frontend_to_backend_edit_btn px-3 d-flex align-items-center justify-content-center text-decoration-none">
-                    <i class="fa fa-pencil me-1"/>Edit
+                    <img src="/website/static/description/icon.png"/>Editor
                 </a>
             </div>
         </div>


### PR DESCRIPTION
The mini UI on the frontend as a connected backend user was a bit confusing: the "Edit" button used the exact same design and wording as the "Edit" button in the backend but it had not the same effect as it did not enter edit mode but just redirected the user to the website preview (client action iframe).

We still want the same behavior, we just needed another button design:

- Change the label from "Edit" to "Editor".

- Change the "pencil" fa icon with the website app icon (same as app switcher in enterprise).

- Use a dark color instead of the primary color. This reuses a dark color of the website edit mode.

Before:
![image](https://user-images.githubusercontent.com/10338094/190607166-06a7d83e-1cfd-4a34-a2cb-6795c1bacde3.png)

After:
![image](https://user-images.githubusercontent.com/10338094/190607038-bc9761b8-0df3-41b8-a9e9-9dd0c2d0cced.png)

