### PR TITLE
[IMP] stock_picking_batch: Allow auto-batch by date

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_type_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_type_views.xml
@@ -15,6 +15,11 @@
                             <label for="batch_group_by_partner" string="Contact"/>
                         </div>
                         <span attrs="{'invisible':[('auto_batch', '=', False)]}"/>
+                        <div name="batch_date" class="o_row" attrs="{'invisible':[('auto_batch', '=', False)]}">
+                            <field name="batch_group_by_date"/>
+                            <label for="batch_group_by_date" string="Scheduled Date"/>
+                        </div>
+                        <span attrs="{'invisible':[('auto_batch', '=', False)]}"/>
                         <div name="batch_destination" class="o_row" attrs="{'invisible':[('auto_batch', '=', False)]}">
                             <field name="batch_group_by_destination"/>
                             <label for="batch_group_by_destination"/>


### PR DESCRIPTION
Allows the auto-batch to work with the picking's scheduled_date.

Problem is that the user sees a different date in the client than the one stored in the database (UTC). So it won't work properly until a timezone is set company-wide (using the company's partner_id).

This solution is less than ideal, but it would be worse to use the user's client timezone.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
