### PR TITLE
[FIX] hr: fix typo in compute name

### DIFF
--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -60,7 +60,7 @@ class HrEmployeePublic(models.Model):
 
     @api.depends('user_partner_id')
     def _compute_related_contacts(self):
-        super()._computer_related_contacts()
+        super()._compute_related_contacts()
         for employee in self:
             employee.related_contact_ids |= employee.user_partner_id
 


### PR DESCRIPTION
There was an extra `r` in the name of the super method called, which produces a traceback.

