### PR TITLE
[FIX] web: SettingsPage propagate NoContentHelper slot

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_compiler.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_compiler.js
@@ -6,7 +6,7 @@ import { getModifier } from "@web/views/view_compiler";
 
 function compileSettingsPage(el, params) {
     const settingsPage = createElement("SettingsPage");
-    settingsPage.setAttribute("slots", "props.slots");
+    settingsPage.setAttribute("slots", "{NoContentHelper:props.slots.NoContentHelper}");
     settingsPage.setAttribute("initialTab", "props.initialApp");
     settingsPage.setAttribute("t-slot-scope", "settings");
 

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -1424,7 +1424,7 @@ QUnit.module("SettingsFormView", (hooks) => {
 
         const expectedCompiled = `
         <div class="o_setting_container">
-            <SettingsPage slots="props.slots" initialTab="props.initialApp" t-slot-scope="settings" modules="[{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;/crm/static/description/icon.png&quot;,&quot;isVisible&quot;:false}]" class="'settings'">
+            <SettingsPage slots="{NoContentHelper:props.slots.NoContentHelper}" initialTab="props.initialApp" t-slot-scope="settings" modules="[{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;/crm/static/description/icon.png&quot;,&quot;isVisible&quot;:false}]" class="'settings'">
                 <SettingsApp t-props="{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;/crm/static/description/icon.png&quot;,&quot;isVisible&quot;:false}" selectedTab="settings.selectedTab" class="'app_settings_block'">
                     <FormLabel t-props="{id:'display_name',fieldName:'display_name',record:props.record,fieldInfo:props.archInfo.fieldNodes['display_name'],className:&quot;highhopes&quot;}" string="\`My&quot; little '  Label\`"/>
                     <Field id="'display_name'" name="'display_name'" record="props.record" fieldInfo="props.archInfo.fieldNodes['display_name']"/>


### PR DESCRIPTION
Before this commit, we propagate all the slots to the SettingsPage. This could raise an issue if the default slot (propagated) has a content, for more information see: https://github.com/odoo/owl/issues/1256

Now, to avoid this, we only propagate the slots that are used on the SettingsPage component, ie: NoContentHelper.

Co-authored-by: Lucas Perais <lpe@odoo.com>