### PR TITLE
[FIX] base: rendering PDF should save ir.attachment

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -800,7 +800,7 @@ class IrActionsReport(models.Model):
         report_sudo = self._get_report(report_ref)
 
         # Generate the ir.attachment if needed.
-        if self.attachment:
+        if report_sudo.attachment:
             attachment_vals_list = []
             for res_id, stream_data in collected_streams.items():
                 # An attachment already exists.


### PR DESCRIPTION
Printing an invoice no longer saved the ir.attachment on the move.
This is due to the refactor in ffc525419a71aeb05ede6b59dda9e62286a5e66e, since the render methods are now `api.model`, `self.attachment` was always Falsy. To get the attachment name of a report, we need to call `self._get_report(report_ref)`.

