### PR TITLE
[IMP] stock: add index on `stock.quant.package_id`

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -79,7 +79,7 @@ class StockQuant(models.Model):
     package_id = fields.Many2one(
         'stock.quant.package', 'Package',
         domain="[('location_id', '=', location_id)]",
-        help='The package containing this quant', ondelete='restrict', check_company=True)
+        help='The package containing this quant', ondelete='restrict', check_company=True, index=True)
     owner_id = fields.Many2one(
         'res.partner', 'Owner',
         help='This is the owner of the quant', check_company=True)


### PR DESCRIPTION
Because `quant_ids` (`stock.quant.package`) is a one2many inverse of `package_id` and some depends use it,
It is important to have in index on package_id on `stock.quant`