### PR TITLE
[FIX] base, web: graph and pivot views requires more field descriptions

### DIFF
--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1992,7 +1992,7 @@ patch(MockServer.prototype, 'mail', {
      * Simulates `_message_track` on `mail.thread`
      */
     _mockMailThread_MessageTrack(modelName, trackedFieldNames, initialTrackedFieldValuesByRecordId) {
-        const trackFieldNamesToField = this.mockFieldsGet(modelName, [trackedFieldNames]);
+        const trackFieldNamesToField = this.mockFieldsGet(modelName, trackedFieldNames);
         const tracking = {};
         const records = this.models[modelName].records;
         for (const record of records) {

--- a/addons/web/static/tests/views/view_tests.js
+++ b/addons/web/static/tests/views/view_tests.js
@@ -124,7 +124,7 @@ QUnit.module("Views", (hooks) => {
                 this._super();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,false,toy"]);
-                assert.deepEqual(fields, serverData.models.animal.fields);
+                assert.deepEqual(fields, {});
                 assert.strictEqual(info.actionMenus, undefined);
                 assert.strictEqual(this.env.config.viewId, false);
             },
@@ -162,7 +162,7 @@ QUnit.module("Views", (hooks) => {
                 this._super();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,1,toy"]);
-                assert.deepEqual(fields, serverData.models.animal.fields);
+                assert.deepEqual(fields, {});
                 assert.strictEqual(info.actionMenus, undefined);
                 assert.strictEqual(this.env.config.viewId, 1);
             },
@@ -199,7 +199,7 @@ QUnit.module("Views", (hooks) => {
                 this._super();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,1,toy"]);
-                assert.deepEqual(fields, serverData.models.animal.fields);
+                assert.deepEqual(fields, {});
                 assert.strictEqual(info.actionMenus, undefined);
                 assert.strictEqual(this.env.config.viewId, 1);
             },
@@ -240,7 +240,7 @@ QUnit.module("Views", (hooks) => {
                     this._super();
                     const { arch, fields, info } = this.props;
                     assert.strictEqual(arch, serverData.views["animal,false,toy"]);
-                    assert.deepEqual(fields, serverData.models.animal.fields);
+                    assert.deepEqual(fields, {});
                     assert.strictEqual(info.actionMenus, undefined);
                     assert.strictEqual(this.env.config.viewId, false);
                 },
@@ -283,7 +283,7 @@ QUnit.module("Views", (hooks) => {
                 this._super();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,1,toy"]);
-                assert.deepEqual(fields, serverData.models.animal.fields);
+                assert.deepEqual(fields, {});
                 assert.strictEqual(info.actionMenus, undefined);
                 assert.strictEqual(this.env.config.viewId, 1);
             },
@@ -362,7 +362,7 @@ QUnit.module("Views", (hooks) => {
                 this._super();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,false,toy"]);
-                assert.deepEqual(fields, serverData.models.animal.fields);
+                assert.deepEqual(fields, {});
                 assert.deepEqual(info.actionMenus, {});
                 assert.strictEqual(this.env.config.viewId, false);
             },


### PR DESCRIPTION
Following odoo/odoo@4636620004f0cc0e504cd6694fe8ddb6758ba811 `get_views` only pass the model fields included in the view architecture, except for the main model when the search views is requested. Because the search views requires all fields for the user to be able to make advanced filters and advanced group by using any fields of the model.

However, other views requires more field descriptions as well than just the fields included in their architecture:
- the graph view requires all integer and float fields, to automatically add suggestions of measures in the measures dropdown menu. It's a bit like the search view, the user should be able to choose any measure available in the model (as long as this is integer or float fields)
- the pivot view requires all groupable fields, so the user can group by any groupable fields of the model.

The JS MockServer `getViews` is adapted to include the changes added by the above revision as well as the current revision,
for the qunit tests suite to be able to reflect these API changes from the server side.
