### PR TITLE
[FIX] account: fix mixed early pay payment term with multi lines 

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -993,22 +993,29 @@ class AccountMoveLine(models.Model):
     @api.depends('move_id.needed_terms', 'account_id', 'analytic_account_id', 'analytic_tag_ids', 'tax_ids', 'tax_tag_ids', 'company_id')
     def _compute_epd_needed(self):
         for line in self:
+            needed_terms = line.move_id.needed_terms
             line.epd_dirty = True
             line.epd_needed = False
             if line.display_type != 'product' or not line.tax_ids.ids or line.company_id.early_pay_discount_computation != 'mixed':
                 continue
 
-            discount_percentages = [
-                x['discount_percentage']
-                for x in line.move_id.needed_terms.values()
-                if x.get('discount_percentage')
-            ]
-            if not discount_percentages:
+            percentages_to_apply = []
+            names = []
+            for term in needed_terms.values():
+                if term.get('discount_percentage'):
+                    percentages_to_apply.append({
+                        'discount_percentage': term['discount_percentage'],
+                        'term_percentage': abs(term['amount_currency'] / line.move_id.amount_total) if line.move_id.amount_total else 0
+                    })
+                    names.append(f"{term['discount_percentage']}%")
+            if not (any(percentage.get('discount_percentage') for percentage in percentages_to_apply)):
                 continue
 
+            discount_percentage_name = ', '.join(names)
             epd_needed = {}
-            for discount_percentage in discount_percentages:
-                percentage = discount_percentage / 100
+            for percentages in percentages_to_apply:
+                percentage = percentages['discount_percentage'] / 100
+                line_percentage = percentages['term_percentage']
                 epd_needed_vals = epd_needed.setdefault(
                     frozendict({
                         'move_id': line.move_id.id,
@@ -1020,15 +1027,15 @@ class AccountMoveLine(models.Model):
                         'display_type': 'epd',
                     }),
                     {
-                        'name': _("Early Payment Discount (%s%%)", discount_percentage),
+                        'name': _("Early Payment Discount (%s)", discount_percentage_name),
                         'amount_currency': 0.0,
                         'balance': 0.0,
                         'price_subtotal': 0.0,
                     },
                 )
-                epd_needed_vals['amount_currency'] -= line.amount_currency * percentage
-                epd_needed_vals['balance'] -= line.balance * percentage
-                epd_needed_vals['price_subtotal'] -= line.price_subtotal * percentage
+                epd_needed_vals['amount_currency'] -= line.amount_currency * percentage * line_percentage
+                epd_needed_vals['balance'] -= line.balance * percentage * line_percentage
+                epd_needed_vals['price_subtotal'] -= line.price_subtotal * percentage * line_percentage
                 epd_needed_vals = epd_needed.setdefault(
                     frozendict({
                         'move_id': line.move_id.id,
@@ -1036,16 +1043,16 @@ class AccountMoveLine(models.Model):
                         'display_type': 'epd',
                     }),
                     {
-                        'name': _("Early Payment Discount (%s%%)", discount_percentage),
+                        'name': _("Early Payment Discount (%s)", discount_percentage_name),
                         'amount_currency': 0.0,
                         'balance': 0.0,
                         'price_subtotal': 0.0,
                         'tax_ids': [],
                     },
                 )
-                epd_needed_vals['amount_currency'] += line.amount_currency * percentage
-                epd_needed_vals['balance'] += line.balance * percentage
-                epd_needed_vals['price_subtotal'] += line.price_subtotal * percentage
+                epd_needed_vals['amount_currency'] += line.amount_currency * percentage * line_percentage
+                epd_needed_vals['balance'] += line.balance * percentage * line_percentage
+                epd_needed_vals['price_subtotal'] += line.price_subtotal * percentage * line_percentage
             line.epd_needed = {k: frozendict(v) for k, v in epd_needed.items()}
 
     @api.depends('move_id.move_type', 'balance', 'tax_ids')

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -217,9 +217,9 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
-            {'amount_currency': -2902.50},
+            {'amount_currency': -2913.75},
             {'amount_currency': -225.0},
-            {'amount_currency': 3127.50},
+            {'amount_currency': 3138.75},
         ])
 
     def test_register_discounted_payment_multi_line_multi_discount_tax_mixed_too_late(self):


### PR DESCRIPTION
Some payment terms with early payment cash discount weren't giving out the correct computation.

Example of a problematic set up :
Payment term with multiple lines (percentage X, percentage Y, balance)
Cash Discount tax computation : mixed

The journal items of the invoice and the total amount wouldn't correctly take into account the different discount percentages of the payment term lines.

Fixed it by applying the line percentage to the epd lines computation.

