### PR TITLE
[FIX] sale: transaction amount diff than so amount mail update

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -52,20 +52,29 @@
         Hello,
         <br/><br/>
         <t t-set="transaction" t-value="object.get_portal_last_transaction()"/>
-        Your order <strong t-out="object.name or ''">S00049</strong> amounting in <strong t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</strong>
-        <t t-if="object.state == 'sale' or (transaction and transaction.state in ('done', 'authorized'))">
-            has been confirmed.<br/>
-            Thank you for your trust!
+        <t t-if="object.state != 'sale' and transaction and transaction.state in ('done', 'authorized') and object.amount_total != transaction.amount">
+            A payment was received for you order <strong t-out="object.name or ''">S00049</strong>
+            but its amount (<strong t-out="format_amount(transaction.amount, object.currency_id) or ''">$ 20.00</strong>)
+            does not match the order amount (<strong t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</strong>).
+            Please contact customer service.
+            <br/><br/>
         </t>
-        <t t-elif="transaction and transaction.state == 'pending'">
-            is pending. It will be confirmed when the payment is received.
-            <t t-if="object.reference">
-                Your payment reference is <strong t-out="object.reference or ''"></strong>.
+        <t t-else="">
+            Your order <strong t-out="object.name or ''">S00049</strong> amounting in <strong t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</strong>
+            <t t-if="object.state == 'sale' or (transaction and transaction.state in ('done', 'authorized') and object.amount_total == transaction.amount)">
+                has been confirmed.<br/>
+                Thank you for your trust!
             </t>
+            <t t-elif="transaction and transaction.state == 'pending'">
+                is pending. It will be confirmed when the payment is received.
+                <t t-if="object.reference">
+                    Your payment reference is <strong t-out="object.reference or ''"></strong>.
+                </t>
+            </t>
+            <br/><br/>
+            Do not hesitate to contact us if you have any questions.
+            <br/><br/>
         </t>
-        <br/><br/>
-        Do not hesitate to contact us if you have any questions.
-        <br/><br/>
     </p>
 <t t-if="hasattr(object, 'website_id') and object.website_id">
     <div style="margin: 0px; padding: 0px;">


### PR DESCRIPTION
Steps to reproduce:
-Use ecommerce and the mollie payment
-Open two tabs, on one pay via mollie, on the other while the mollie payment is in progress add or remove items to the cart

Current behavior:
The customer receives a mail saying that its order was confirmed while the order was not because of the amount mismatch between the order and the transaction

Expected behavior:
The customer should not be able to edit the cart while a payment is in progress but such a fix was not yet found so at least the mail the customer receives should warn him of the situation

opw-2983494
