### PR TITLE
[FIX] web: ListView: no crash when group by date and select

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1445,7 +1445,10 @@ class DynamicList extends DataPoint {
     }
 
     get isM2MGrouped() {
-        return this.groupBy.some((fieldName) => this.fields[fieldName].type === "many2many");
+        return this.groupBy.some((groupBy) => {
+            const fieldName = groupBy.split(":")[0];
+            return this.fields[fieldName].type === "many2many";
+        });
     }
 
     get selection() {

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -2646,6 +2646,26 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target.querySelector(".o_cp_buttons"), ".o_list_selection_box");
     });
 
+    QUnit.test("select a record in list grouped by date with granularity", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree><field name="foo"/><field name="bar"/></tree>',
+            groupBy: ["date:year"],
+            // keep the actionMenus, it is relevant as it calls isM2MGrouped which crashes if we
+            // don't correctly extract the fieldName/granularity from the groupBy
+            actionMenus: {},
+        });
+
+        assert.containsN(target, ".o_group_header", 2);
+        assert.containsNone(target.querySelector(".o_cp_buttons"), ".o_list_selection_box");
+        await click(target.querySelector(".o_group_header"));
+        assert.containsOnce(target, ".o_data_row");
+        await click(target.querySelector(".o_data_row .o_list_record_selector"));
+        assert.containsOnce(target.querySelector(".o_cp_buttons"), ".o_list_selection_box");
+    });
+
     QUnit.test("aggregates are computed correctly", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
In a list view, group by a date or datetime field, then open a group and select a record. Before this commit, it crashed, because we didn't correctly consider the groupBy value, which is of the form "fieldName:granularity" for a date(time) field.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
