### PR TITLE
[IMP] hr_recruitment_skills: give read rights to interviewers

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -44,8 +44,8 @@
                                         <small><i class="fa fa-envelope-o" role="img" aria-label="Alias" title="Alias"></i> <field name="alias_id"/></small>
                                     </div>
                                 </div>
-                                <div class="o_kanban_manage_button_section">
-                                    <a class="o_kanban_manage_toggle_button" href="#" groups="hr_recruitment.group_hr_recruitment_user"><i class="fa fa-ellipsis-v" role="img" aria-label="Manage" title="Manage"/></a>
+                                <div class="o_kanban_manage_button_section" groups="hr_recruitment.group_hr_recruitment_user">
+                                    <a class="o_kanban_manage_toggle_button" href="#"><i class="fa fa-ellipsis-v" role="img" aria-label="Manage" title="Manage"/></a>
                                 </div>
                             </div>
                             <div class="container o_recruitment_job_container o_kanban_card_content mt-0 mt-sm-3">
@@ -57,9 +57,12 @@
                                     </div>
                                     <ul class="col-5 o_job_activities">
                                         <li>
-                                            <a name="edit_job" type="edit" t-attf-class="{{ record.no_of_recruitment.raw_value > 0 ? 'to-recruit' : 'text-secondary' }}">
+                                            <a name="edit_job" type="edit" t-attf-class="{{ record.no_of_recruitment.raw_value > 0 ? 'to-recruit' : 'text-secondary' }}" groups="!hr_recruitment.group_hr_recruitment_interviewer">
                                                 <field name="no_of_recruitment"/> To Recruit
                                             </a>
+                                            <span t-attf-class="{{ record.no_of_recruitment.raw_value > 0 ? 'to-recruit' : 'text-secondary' }}" groups="hr_recruitment.group_hr_recruitment_interviewer">
+                                                <field name="no_of_recruitment"/> To Recruit
+                                            </span>
                                         </li>
                                         <li t-if="record.application_count.raw_value > 0">
                                             <field name="application_count"/> Applications

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -117,14 +117,16 @@
                 </div>
                 <widget name="web_ribbon" title="Refused" bg_color="bg-danger" attrs="{'invisible': ['|', ('active', '=', True), ('refuse_reason_id', '=', False)]}"/>
                 <widget name="web_ribbon" title="Hired" attrs="{'invisible': [('date_closed', '=', False)]}" />
-                <field name="kanban_state" widget="state_selection"/>
                 <field name="active" invisible="1"/>
                 <field name="legend_normal" invisible="1"/>
                 <field name="legend_blocked" invisible="1"/>
                 <field name="legend_done" invisible="1"/>
-                <div class="oe_title">
+                <div class="oe_title pe-0">
                     <label for="name" class="oe_edit_only"/>
-                    <h1><field name="name" placeholder="e.g. Sales Manager 2 year experience"/></h1>
+                    <h1 class="d-flex justify-content-between align-items-center">
+                        <field name="name" placeholder="e.g. Sales Manager 2 year experience"/>
+                        <field name="kanban_state" widget="state_selection"/>
+                    </h1>
                     <h2 class="o_row">
                         <div>
                             <label for="partner_name" class="oe_edit_only"/>

--- a/addons/hr_recruitment_skills/__manifest__.py
+++ b/addons/hr_recruitment_skills/__manifest__.py
@@ -10,6 +10,7 @@
     'description': """""",
     'depends': ['hr_skills', 'hr_recruitment'],
     'data': [
+        'security/hr_recruitment_skills_security.xml',
         'views/hr_applicant_views.xml',
         'views/hr_applicant_skill_views.xml',
         'security/ir.model.access.csv',

--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -9,6 +9,14 @@ class HrApplicant(models.Model):
 
     applicant_skill_ids = fields.One2many('hr.applicant.skill', 'applicant_id', string="Skills")
     skill_ids = fields.Many2many('hr.skill', compute='_compute_skill_ids', store=True)
+    is_interviewer = fields.Boolean(compute='_compute_is_interviewer')
+
+    @api.depends_context('uid')
+    @api.depends('interviewer_ids', 'job_id.interviewer_ids')
+    def _compute_is_interviewer(self):
+        is_recruiter = self.user_has_groups('hr_recruitment.group_hr_recruitment_user')
+        for applicant in self:
+            applicant.is_interviewer = not is_recruiter and self.env.user in (applicant.interviewer_ids | applicant.job_id.interviewer_ids)
 
     @api.depends('applicant_skill_ids.skill_id')
     def _compute_skill_ids(self):

--- a/addons/hr_recruitment_skills/security/hr_recruitment_skills_security.xml
+++ b/addons/hr_recruitment_skills/security/hr_recruitment_skills_security.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Interviewer Access Rules -->
+    <record id="hr_applicant_skill_interviewer_rule" model="ir.rule">
+        <field name="name">Applicant Skill: Interviewer</field>
+        <field name="model_id" ref="model_hr_applicant_skill"/>
+        <field name="domain_force">[
+            '|',
+                ('applicant_id.job_id.interviewer_ids', 'in', user.id),
+                ('applicant_id.interviewer_ids', 'in', user.id),
+        ]</field>
+        <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_interviewer'))]"/>
+    </record>
+</odoo>

--- a/addons/hr_recruitment_skills/security/ir.model.access.csv
+++ b/addons/hr_recruitment_skills/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 hr_recruitment_skills.access_hr_applicant_skill,access_hr_applicant_skill,hr_recruitment_skills.model_hr_applicant_skill,hr_recruitment.group_hr_recruitment_user,1,1,1,1
+hr_recruitment_skills.access_hr_applicant_skill_interviewer,access_hr_applicant_skill_interviewer,hr_recruitment_skills.model_hr_applicant_skill,hr_recruitment.group_hr_recruitment_interviewer,1,0,0,0

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -10,7 +10,9 @@
                     <div class="row">
                         <div class="o_hr_skills_editable o_hr_skills_group o_group_skills col-lg-5 d-flex flex-column">
                             <field name="id" invisible="1"/>
-                            <field mode="tree" nolabel="1" name="applicant_skill_ids" widget="skills_one2many" context="{'default_applicant_id': id}">
+                            <field name="is_interviewer" invisible="1"/>
+                            <field mode="tree" nolabel="1" name="applicant_skill_ids" widget="skills_one2many"
+                                context="{'default_applicant_id': id}" attrs="{'readonly': [('is_interviewer', '=', True)]}">
                                 <tree>
                                     <field name="skill_type_id" invisible="1"/>
                                     <field name="skill_id"/>


### PR DESCRIPTION
Members of the Interviewer groups couldn't access the applicant records due to missing read rights on the hr.applicant.skill model.

task-2986177

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
