### PR TITLE
[FIX] web: Empty irrelevant data in records

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -788,13 +788,17 @@ export class Record extends DataPoint {
      * @param {Object} [params.changes]
      */
     async load(params = {}) {
-        this.data = {};
         this._cache = {};
         for (const fieldName in this.activeFields) {
             const field = this.fields[fieldName];
             if (isX2Many(field)) {
                 const staticList = this._createStaticList(fieldName);
                 this._cache[fieldName] = staticList;
+            }
+        }
+        for (const fieldName in this.data) {
+            if (!(fieldName in this.activeFields)) {
+                delete this.data[fieldName];
             }
         }
 

--- a/addons/web/static/tests/views/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban_view_tests.js
@@ -11882,4 +11882,47 @@ QUnit.module("Views", (hooks) => {
             assert.containsNone(target, ".o_nocontent_help");
         }
     );
+
+    QUnit.test("Move multiple records in different columns simultaneously", async (assert) => {
+        let def;
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: /* xml */ `
+                <kanban>
+                    <templates>
+                        <div t-name="kanban-box">
+                            <field name="id" />
+                        </div>
+                    </templates>
+                </kanban>
+            `,
+            groupBy: ["state"],
+            async mockRPC(_route, { method }) {
+                if (method === "read") {
+                    await def;
+                }
+            },
+        });
+
+        def = makeDeferred();
+
+        assert.deepEqual(getCardTexts(), ["1", "2", "3", "4"]);
+
+        // Move 3 at end of 1st column
+        await dragAndDrop(".o_kanban_group:last-of-type .o_kanban_record", ".o_kanban_group");
+
+        assert.deepEqual(getCardTexts(), ["1", "3", "2", "4"]);
+
+        // Move 4 at end of 1st column
+        await dragAndDrop(".o_kanban_group:last-of-type .o_kanban_record", ".o_kanban_group");
+
+        assert.deepEqual(getCardTexts(), ["1", "3", "4", "2"]);
+
+        def.resolve();
+        await nextTick();
+
+        assert.deepEqual(getCardTexts(), ["1", "3", "4", "2"]);
+    });
 });


### PR DESCRIPTION
Before this PR, when a record from a relational model would start to load, it would empty its `data` object. The issue is that a rendering process can be initiated right after a record started loading. In kanban views, this causes a crash since all records are always assumed to contain values in their data objects.

This PR takes care to only clean strictly unwanted data when loading a record instead of removing all the values, ensuring that records always contain data.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
