### PR TITLE
[FIX] bus: handle session expired in peek notifications

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -42,9 +42,10 @@ class WebsocketController(Controller):
         notifications = request.env['bus.bus']._poll(channels, last)
         return {'channels': channels, 'notifications': notifications}
 
-    @route('/websocket/update_bus_presence', type='http', auth='public', cors='*')
+    @route('/websocket/update_bus_presence', type='json', auth='public', cors='*')
     def update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         request.env['ir.websocket']._update_bus_presence(int(inactivity_period), im_status_ids_by_model)
+        return {}
 
     @route('/bus/websocket_worker_bundle', type='http', auth='public', cors='*')
     def get_websocket_worker_bundle(self):

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -34,7 +34,7 @@ class IrWebsocket(models.AbstractModel):
         dispatch.subscribe(channels, data['last'], self.env.registry.db_name, wsrequest.ws)
 
     def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
-        if self.env.uid:
+        if self.env.user and not self.env.user._is_public():
             self.env['bus.presence'].update(
                 inactivity_period,
                 identity_field='user_id',

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -3,4 +3,5 @@ from . import test_assetsbundle
 from . import test_health
 from . import test_ir_websocket
 from . import test_websocket_caryall
+from . import test_websocket_controller
 from . import test_websocket_rate_limiting

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -1,0 +1,92 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from odoo.tests import common
+
+
+class TestWebsocketController(common.HttpCase):
+    def _make_rpc(self, route, params, headers=None):
+        data = json.dumps({
+            'id': 0,
+            'jsonrpc': '2.0',
+            'method': 'call',
+            'params': params,
+        }).encode()
+        headers = headers or {}
+        headers['Content-Type'] = 'application/json'
+        return self.url_open(route, data, headers=headers)
+
+    def test_websocket_peek(self):
+        response = json.loads(
+            self._make_rpc('/websocket/peek_notifications', {
+                'channels': [],
+                'last': 0,
+                'is_first_poll': True,
+            }).content.decode()
+        )
+        # Response containing channels/notifications is retrieved and is
+        # conform to excpectations.
+        result = response.get('result')
+        self.assertIsNotNone(result)
+        channels = result.get('channels')
+        self.assertIsNotNone(channels)
+        self.assertIsInstance(channels, list)
+        notifications = result.get('notifications')
+        self.assertIsNotNone(notifications)
+        self.assertIsInstance(notifications, list)
+
+        response = json.loads(
+            self._make_rpc('/websocket/peek_notifications', {
+                'channels': [],
+                'last': 0,
+                'is_first_poll': False,
+            }).content.decode()
+        )
+        # Reponse is received as long as the session is valid.
+        self.assertIn('result', response)
+
+    def test_websocket_peek_session_expired_login(self):
+        session = self.authenticate(None, None)
+        # first rpc should be fine
+        self._make_rpc('/websocket/peek_notifications', {
+            'channels': [],
+            'last': 0,
+            'is_first_poll': True,
+        })
+
+        self.authenticate('admin', 'admin')
+        # rpc with outdated session should lead to error.
+        headers = {'Cookie': f'session_id={session.sid};'}
+        response = json.loads(
+            self._make_rpc('/websocket/peek_notifications', {
+                'channels': [],
+                'last': 0,
+                'is_first_poll': False,
+            }, headers=headers).content.decode()
+        )
+        error = response.get('error')
+        self.assertIsNotNone(error, 'Sending a poll with an outdated session should lead to error')
+        self.assertEqual('odoo.http.SessionExpiredException', error['data']['name'])
+
+    def test_websocket_peek_session_expired_logout(self):
+        session = self.authenticate('demo', 'demo')
+        # first rpc should be fine
+        self._make_rpc('/websocket/peek_notifications', {
+            'channels': [],
+            'last': 0,
+            'is_first_poll': True,
+        })
+        self.url_open('/web/session/logout')
+        # rpc with outdated session should lead to error.
+        headers = {'Cookie': f'session_id={session.sid};'}
+        response = json.loads(
+            self._make_rpc('/websocket/peek_notifications', {
+                'channels': [],
+                'last': 0,
+                'is_first_poll': False,
+            }, headers=headers).content.decode()
+        )
+        error = response.get('error')
+        self.assertIsNotNone(error, 'Sending a poll with an outdated session should lead to error')
+        self.assertEqual('odoo.http.SessionExpiredException', error['data']['name'])

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -34,7 +34,7 @@ class IrWebsocket(models.AbstractModel):
 
     def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
-        if not self.env.uid:
+        if not self.env.user or self.env.user._is_public():
             #  This method can either be called due to an http or a
             #  websocket request. The request itself is necessary to
             #  retrieve the current guest. Let's retrieve the proper


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
