### PR TITLE
[FIX] website: empty website domain correctly in tests

### DIFF
--- a/addons/website/tests/test_get_current_website.py
+++ b/addons/website/tests/test_get_current_website.py
@@ -28,7 +28,7 @@ class TestGetCurrentWebsite(TransactionCase):
 
         # clean initial state
         website1 = self.website
-        website1.domain = ''
+        website1.domain = False
 
         website2 = Website.create({'name': 'My Website 2'})
 

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -186,7 +186,6 @@ class TestPage(common.TransactionCase):
 
         self.env['website'].create({
             'name': 'My Second Website',
-            'domain': '',
         })
 
         # currently the view unlink of website.page can't handle views with inherited views

--- a/addons/website/tests/test_website_reset_password.py
+++ b/addons/website/tests/test_website_reset_password.py
@@ -51,7 +51,7 @@ class TestWebsiteResetPassword(HttpCase):
             user.action_reset_password()
             self.assertIn(website_1.domain, user.signup_url)
 
-            (website_1 + website_2).domain = ""
+            (website_1 + website_2).domain = False
 
             user.action_reset_password()
             self.env.invalidate_all()


### PR DESCRIPTION
Emptying the domain should be setting it to False, not empty string, which is saved in DB as such.

This was not problematic at all before but since [1] the domain must be unique. As we removed the "multi website by domain" feature, we then were able to add that constraint.
But since then, having two website with domain == '' would raise the constraint error, while null values (False in python) would not.

[1]: https://github.com/odoo/odoo/commit/507db4e179514d171ec82e8ea0cbaf2323a6c30d

runbot-5041
