### PR TITLE
[FIX] web_editor: restore columns drag and drop (grid)

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -83,6 +83,7 @@ Odoo Web Editor widget.
             'web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js',
 
             'web_editor/static/src/xml/editor.xml',
+            'web_editor/static/src/xml/grid_layout.xml',
             'web_editor/static/src/xml/snippets.xml',
             'web_editor/static/src/xml/wysiwyg.xml',
             'web_editor/static/src/xml/wysiwyg_colorpicker.xml',


### PR DESCRIPTION
A recent refactoring allowing to declare static XML files as part of asset bundles at [1] broke the drag and drop of columns inside the editor. Indeed, since the recent merge of the grid mode at [2], drag and dropping requires a grid to be drawn when dragging a column. the XML template needed for that grid to be drawn was not loaded at all anymore (it was previously added in assets_qweb via a wildcard path but it was not adapted).

[1]: https://github.com/odoo/odoo/commit/f05adbc8b59c67cbec4847687a1ee07e620c2a7a
[2]: https://github.com/odoo/odoo/commit/cc406afcea7bf5846233a9f97a4a8ac5f618f3ec
