### PR TITLE
[FIX] loyalty: fix position of generate coupons button

### DIFF
--- a/addons/loyalty/static/src/xml/loyalty_templates.xml
+++ b/addons/loyalty/static/src/xml/loyalty_templates.xml
@@ -60,7 +60,7 @@
     </t>
 
     <t t-name="loyalty.LoyaltyCardListView.buttons" owl="1" t-inherit-mode="primary" t-inherit="web.ListView.Buttons">
-        <xpath expr="//t[@t-if='props.showButtons']" position="inside">
+        <xpath expr="//t[contains(@t-if, 'isExportEnable')]" position="before">
             <t t-set="supportedProgramTypes" t-value="['coupons', 'gift_card', 'ewallet']"/>
             <button t-if="supportedProgramTypes.includes(props.context.program_type)" type="button" class="btn btn-primary o_loyalty_card_list_button_generate" t-attf-data-tooltip="Generate {{props.context.program_item_name}}"
                 t-on-click.stop.prevent="() => this.actionService.doAction('loyalty.loyalty_generate_wizard_action', { additionalContext: this.props.context, onClose: () => {this.model.load()} })">


### PR DESCRIPTION
 The generate coupon button would appear after the export button prior
 to this commit.

