### PR TITLE
[IMP] payment: use ondelete to restrict deletion

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -82,12 +82,14 @@ class PaymentProvider(models.Model):
         comodel_name='ir.ui.view',
         help="The template rendering the inline payment form when making a payment by token.",
         domain=[('type', '=', 'qweb')],
+        ondelete='restrict',
     )
     express_checkout_form_view_id = fields.Many2one(
         string="Express Checkout Form Template",
         comodel_name='ir.ui.view',
         help="The template rendering the express payment methods' form.",
         domain=[('type', '=', 'qweb')],
+        ondelete='restrict',
     )
 
     # Availability fields.


### PR DESCRIPTION
Restrict deletion of token and express checkout inline forms when a payment provider is using it.

Continuity of https://github.com/odoo/odoo/commit/efbf0c08382a9eddaa48bb386912e5c1925bbfc0

task-2883630
