### PR TITLE
[FIX] hr_org_chart: fix label in res_users form view

### DIFF
--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -41,7 +41,7 @@
                 <div id="o_employee_right" class="col-lg-4 px-0 ps-lg-5">
                     <group>
                         <field name="employee_ids" invisible="1"/>
-                        <div class="o_horizontal_separator o_org_chart_title">Organization Chart</div>
+                        <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
                         <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
                     </group>
                 </div>


### PR DESCRIPTION
The colspan attribute was missing for the form view making it look like there was a label for the org chart widget, which should not be there.

