### PR TITLE
[FIX] models.py: `tree` instead of `list`

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1848,7 +1848,7 @@ class BaseModel(metaclass=MetaModel):
         :return: dict holding the models and field required by the web client given the view type.
         :rtype: list
         """
-        if view_type in ('kanban', 'list', 'form'):
+        if view_type in ('kanban', 'tree', 'form'):
             for model_fields in models.values():
                 model_fields.update({'id', self.CONCURRENCY_CHECK_FIELD})
         elif view_type == 'search':


### PR DESCRIPTION
Oversight in odoo/odoo#100376

The web client sends `list` rather than `tree` when requesting views.

However, once they went through `get_views`, they are converted back to `tree`.
https://github.com/odoo/odoo/blob/master/odoo/models.py#L1653

So, here, we should check against `tree`, not `list`.

Could be seen in Lunch > Manager > Today's Order.
With the `id` field missing, an error is raised
```
Uncaught (in promise) Error: The following error occurred in onWillStart: "field is undefined"
```
