### PR TITLE
[FIX] purchase_requisition: Change Call for Tender field with type of requisition

### DIFF
--- a/addons/purchase_requisition/report/report_purchaserequisition.xml
+++ b/addons/purchase_requisition/report/report_purchaserequisition.xml
@@ -8,11 +8,11 @@
                 <div class="page">
                     <div class="oe_structure"/>
 
-                    <h2>Call for Tenders <span t-field="o.name"/></h2>
+                    <h2><span t-out="o.type_id.name"/> <span t-field="o.name"/></h2>
 
                     <div class="row mt32 mb32">
                         <div class="col-3">
-                            <strong>Call for Tender Reference:</strong><br/>
+                            <strong><span t-out="o.type_id.name"/> Reference:</strong><br/>
                             <span t-field="o.name"/>
                         </div>
                         <div class="col-3">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In Purchase requisition report, the report title and description does not match with the type of the agreement. The bug is fixed in V15 in this commit  (https://github.com/odoo/odoo/commit/c3b9de36e40c24d0bb521ec0f161d4415b1d86ff).

Reported here: https://www.odoo.com/web#id=2985777&cids=1&model=project.task&view_type=form

Current behavior before PR:
Constant texts in the report as Call for Tenders even though user selects Blanket Order type of agreement.

Desired behavior after PR is merged:
The report name will be changed according to user selection



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
