### PR TITLE
[FIX] web: FormView: ensure defaultFields to fields

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -1264,6 +1264,7 @@ export class RelationalModel extends Model {
                             const fieldViews = fieldInfo.views || fieldInfo.fieldsInfo || {};
                             const defaultFieldInfo = legRec.data[name].fieldsInfo.default;
                             _.each(fieldViews, function (fieldView) {
+                                _.defaults(fieldView.fields, defaultFieldInfo);
                                 _.each(fieldView.fieldsInfo, function (x2mFieldInfo) {
                                     _.defaults(x2mFieldInfo, defaultFieldInfo);
                                 });


### PR DESCRIPTION
Since [1], a call to getView no longer returns the all models the list of all their fields, because a lot of them aren't necessary.

However, it caused an issue in the following situation:
    - have a form view with an x2many displayed as a list
    - in the list, have a field using the widget many2many_tags
    along the color_field option
    - in the arch, the x2many form view isn't inline
    - in readonly mode, the user clicks on a row, which will open
    the x2many form view
    - since the form view isn't inline, a call to getView is done
    - in the returned form view, the color field isn't present,
      the field using many2many_tags/color_field in the
      list is present, and without the color_field option.

Since [1], it crashed at this point because A wasn't part of the known fields in the form view (but it was in the fieldsInfo, since they are shared between the x2many list and form).

This commit fixes the issue by adding the color field not only in fieldsInfo, but also in fields.

[1] odoo/odoo@4636620004f0cc0e504cd6694fe8ddb6758ba811
