### PR TITLE
[FIX] web: FormView: add fieldDependencies to fields

### DIFF
--- a/addons/web/static/src/views/form/form_arch_parser.js
+++ b/addons/web/static/src/views/form/form_arch_parser.js
@@ -29,14 +29,22 @@ export class FormArchParser extends XMLParser {
                 if (archParseBoolean(node.getAttribute("default_focus") || "")) {
                     autofocusFieldId = fieldId;
                 }
-                addFieldDependencies(activeFields, fieldInfo.FieldComponent.fieldDependencies);
+                addFieldDependencies(
+                    activeFields,
+                    models[modelName],
+                    fieldInfo.FieldComponent.fieldDependencies
+                );
                 return false;
             } else if (node.tagName === "div" && node.classList.contains("oe_chatter")) {
                 // remove this when chatter fields are declared as attributes on the root node
                 return false;
             } else if (node.tagName === "widget") {
                 const { WidgetComponent } = Widget.parseWidgetNode(node);
-                addFieldDependencies(activeFields, WidgetComponent.fieldDependencies);
+                addFieldDependencies(
+                    activeFields,
+                    models[modelName],
+                    WidgetComponent.fieldDependencies
+                );
             }
         });
         // TODO: generate activeFields for the model based on fieldNodes (merge duplicated fields)

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -84,11 +84,19 @@ export class KanbanArchParser extends XMLParser {
                 if (fieldInfo.widget === "handle") {
                     handleField = name;
                 }
-                addFieldDependencies(activeFields, fieldInfo.FieldComponent.fieldDependencies);
+                addFieldDependencies(
+                    activeFields,
+                    models[modelName],
+                    fieldInfo.FieldComponent.fieldDependencies
+                );
             }
             if (node.tagName === "widget") {
                 const { WidgetComponent } = Widget.parseWidgetNode(node);
-                addFieldDependencies(activeFields, WidgetComponent.fieldDependencies);
+                addFieldDependencies(
+                    activeFields,
+                    models[modelName],
+                    WidgetComponent.fieldDependencies
+                );
             }
 
             // Keep track of last update so images can be reloaded when they may have changed.

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -86,7 +86,11 @@ export class ListArchParser extends XMLParser {
                 if (fieldInfo.widget === "handle") {
                     handleField = fieldInfo.name;
                 }
-                addFieldDependencies(activeFields, fieldInfo.FieldComponent.fieldDependencies);
+                addFieldDependencies(
+                    activeFields,
+                    models[modelName],
+                    fieldInfo.FieldComponent.fieldDependencies
+                );
                 if (fieldInfo.modifiers.column_invisible !== true) {
                     const label = fieldInfo.FieldComponent.label;
                     columns.push({

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -13,12 +13,15 @@ const NUMERIC_TYPES = ["integer", "float", "monetary"];
  * @param {Object} activeFields
  * @param {Object} [dependencies={}]
  */
-export function addFieldDependencies(activeFields, dependencies = {}) {
+export function addFieldDependencies(activeFields, fields, dependencies = {}) {
     for (const [name, dependency] of Object.entries(dependencies)) {
         if (!(name in activeFields)) {
             activeFields[name] = Object.assign({ name, rawAttrs: {} }, dependency, {
                 modifiers: { invisible: true },
             });
+        }
+        if (!(name in fields)) {
+            fields[name] = { ...dependency };
         }
     }
 }


### PR DESCRIPTION
Since [1], a call to getView no longer returns the all models the list of all their fields, because a lot of them aren't necessary.

However, it caused an issue in the following situation:
 - have a form view with an x2many displayed as a list
 - in the list, have a field or widget with fieldDependencies (dependency on field A)
 - in the arch, the x2many form view isn't inline
 - in readonly mode, the user clicks on a row, which will open the x2many form view
 - since the form view isn't inline, a call to getView is done
 - in the returned form view, field A isn't present.

Since [1], it crashed at this point because A wasn't part of the known fields in the form view (but it was in the activeFields, since they are shared between the x2many list and form).

This commit fixes the issue by adding fieldDependencies not only in activeFields, but also in fields if not already there.

[1] 4636620004f0cc0e504cd6694fe8ddb6758ba811

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
