### PR TITLE
[FIX] mail: emoji picker smooth scrolling position

### DIFF
--- a/addons/mail/static/src/components/emoji_grid_view/emoji_grid_view.xml
+++ b/addons/mail/static/src/components/emoji_grid_view/emoji_grid_view.xml
@@ -5,7 +5,7 @@
     <div class="o_EmojiGridView o_EmojiGridView_container" t-attf-style="--rowHeight: {{emojiGridView.rowHeight}}px; --itemWidth: {{emojiGridView.itemWidth}}px; height: {{emojiGridView.height}}; width: {{emojiGridView.width}};" t-on-scroll="emojiGridView.onScroll" t-ref="containerRef">
         <EmojiGridSearchNoContentView t-if="emojiGridView.searchNoContentView" record="emojiGridView.searchNoContentView"/>
         <div t-if="!emojiGridView.searchNoContentView" class="o_EmojiGridView_list" t-attf-style="height: {{emojiGridView.listHeight}}px; min-height: {{emojiGridView.listHeight}}px;" t-ref="listRef">
-            <div t-if="emojiGridView.lastRenderedRowIndex >= emojiGridView.firstRenderedRowIndex" class="o_EmojiGridView_viewBlock" t-attf-style="top: {{emojiGridView.distanceFromTop}}px; width: {{emojiGridView.width}};" t-ref="viewBlockRef">
+            <div t-if="emojiGridView.lastRenderedRowIndex >= emojiGridView.firstRenderedRowIndex" class="o_EmojiGridView_viewBlock" t-attf-style="top: {{ emojiGridView.distanceFromTop - emojiGridView.distanceInRowOffset }}px; width: {{ emojiGridView.width }};" t-ref="viewBlockRef">
                 <EmojiGridRowView t-foreach="emojiGridView.renderedRows" t-as="row" t-key="row" record="row"/>
             </div>
         </div>

--- a/addons/mail/static/src/models/emoji_grid_view.js
+++ b/addons/mail/static/src/models/emoji_grid_view.js
@@ -68,15 +68,13 @@ registerModel({
                 if (!this.listRef || !this.listRef.el) {
                     return clear();
                 }
-                let distanceFromTopValue;
-                const buffer = this.topBufferAmount * this.rowHeight;
-                let offset = this.scrollPercentage * this.listRef.el.clientHeight;
-                if (offset < buffer) {
-                    distanceFromTopValue = 0;
-                } else {
-                    distanceFromTopValue = offset - buffer;
-                }
-                return distanceFromTopValue;
+                return this.scrollPercentage * this.listRef.el.clientHeight;
+            },
+            default: 0,
+        }),
+        distanceInRowOffset: attr({
+            compute() {
+                return this.distanceFromTop % this.rowHeight;
             },
             default: 0,
         }),


### PR DESCRIPTION
Before this commit, scrolling in emoji picker grid had an undesirable "snapping" behaviour, which kept the 1st visible row in place.

This was caused by the computation of view block of virtual scroller not taking into account small offset inside a row.

For example, in the following scenario:
```
distanceFromTop = 1000
rowHeight = 150
```
The 1st visible row was 6th one (Math.floor(1000 / 150) = 6), which is correct.
However the row was fully visible, instead of partially cut (1000 % 150 = 100 => 66% overflow).

This commit takes this in-row offset into account, so that scroll position can now make a row partially visible.

Task-2985857
