### PR TITLE
[FIX] project: prevent traceback when creating a task in my task

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1300,7 +1300,6 @@
                                 <group>
                                     <field name="is_analytic_account_id_changed" invisible="1"/>
                                     <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
-                                    <field name="personal_stage_type_id" string="Personal Stage" groups="base.group_no_one" domain="[('user_id', '!=', False)]" context="{'default_user_id' : uid}" readonly="0" attrs="{'invisible': &quot;[('user_ids', 'not in', [uid])]&quot;}"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>


### PR DESCRIPTION
The field personal_stage_type_id is dupplicated in the form view. It is once in the status bar, once in the `Extra info` tab which is only displayed in debug mode. This causes a traceback as this is not supported by the actual web client code.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
