### PR TITLE
[FIX] web: rounding error in percentageField

### DIFF
--- a/addons/web/static/src/views/fields/percentage/percentage_field.js
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.js
@@ -13,7 +13,11 @@ const { Component } = owl;
 export class PercentageField extends Component {
     setup() {
         useInputField({
-            getValue: () => this.props.value * 100,
+            getValue: () =>
+                formatPercentage(this.props.value, {
+                    digits: this.props.digits,
+                    noSymbol: true,
+                }),
             refName: "numpadDecimal",
             parse: (v) => parsePercentage(v),
         });

--- a/addons/web/static/tests/views/fields/percentage_field_tests.js
+++ b/addons/web/static/tests/views/fields/percentage_field_tests.js
@@ -59,7 +59,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target.querySelector(".o_form_button_edit"));
         assert.strictEqual(
             target.querySelector(".o_field_widget[name=float_field] input").value,
-            "44.444",
+            "44.4",
             "The input should be rendered without the percentage symbol."
         );
         assert.strictEqual(
@@ -67,8 +67,8 @@ QUnit.module("Fields", (hooks) => {
             "%",
             "The input should be followed by a span containing the percentage symbol."
         );
-        const field = target.querySelector("input");
-        await editInput(target, "input", "24");
+        const field = target.querySelector("[name='float_field'] input");
+        await editInput(target, "[name='float_field'] input", "24");
         assert.strictEqual(field.value, "24", "The value should not be formated yet.");
         await click(target.querySelector(".o_form_button_save"));
         assert.strictEqual(
@@ -96,5 +96,19 @@ QUnit.module("Fields", (hooks) => {
             target.querySelector(".o_field_widget[name='float_field'] input").placeholder,
             "Placeholder"
         );
+    });
+
+    QUnit.test("PercentageField in form view without rounding error", async function (assert) {
+        await makeView({
+            serverData,
+            type: "form",
+            resModel: "partner",
+            arch: `
+                <form>
+                    <field name="float_field" widget="percentage"/>
+                </form>`,
+        });
+        await editInput(target, "[name='float_field'] input", "28");
+        assert.strictEqual(target.querySelector("[name='float_field'] input").value, "28");
     });
 });


### PR DESCRIPTION
Before this commit, some values entered in the percentage field could be changed due to a rounding error.
For example, the value 28 was replaced by 28.000000000000004

How to reproduce it:
- Go to a form view with percentage fields
- Enter the value 28 in the percentage field

Before this commit:
The value in the input was replaced by 28.000000000000004

After this commit:
The value in the input remains 28

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
