### PR TITLE
[FIX] project: prevent selecting 'Set Status' as project status

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -85,9 +85,7 @@
             'project/static/src/js/portal_rating.js',
         ],
         'web.qunit_suite_tests': [
-            'project/static/tests/project_test_utils.js',
-            'project/static/tests/burndown_chart_tests.js',
-            'project/static/tests/project_form_tests.js',
+            'project/static/tests/**/*.js',
         ],
         'web.assets_tests': [
             'project/static/tests/tours/**/*',

--- a/addons/project/static/src/components/project_state_selection/project_state_selection.js
+++ b/addons/project/static/src/components/project_state_selection/project_state_selection.js
@@ -12,9 +12,19 @@ export class ProjectStateSelectionField extends StateSelectionField {
         this.colors = STATUS_COLORS;
     }
 
+    /**
+     * @override
+     */
     get showLabel() {
         return !this.props.hideLabel;
     }
+
+    /**
+     * @override
+     */
+    get options() {
+        return super.options.filter(o => o[0] !== 'to_define');
+    }
 }
 
-registry.category('fields').add('project_state_selection', ProjectStateSelectionField);
+registry.category('fields').add('kanban.project_state_selection', ProjectStateSelectionField);

--- a/addons/project/static/tests/project_state_selection_tests.js
+++ b/addons/project/static/tests/project_state_selection_tests.js
@@ -1,0 +1,64 @@
+/** @odoo-module */
+
+import { getFixture, click } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let makeViewParams, target;
+
+QUnit.module("Project", (hooks) => {
+        hooks.beforeEach(() => {
+        makeViewParams = {
+            type: "kanban",
+            resModel: "project.project",
+            serverData: {
+                models: {
+                    "project.project": {
+                        fields: {
+                            id: {string: "Id", type: "integer"},
+                            last_update_status: {
+                                string: "Status",
+                                type: "selection",
+                                selection: [
+                                    ["on_track", "On Track"],
+                                    ["at_risk", "At Risk"],
+                                    ["off_track", "Off Track"],
+                                    ["on_hold", "On Hold"],
+                                    ["to_define", "Set Status"],
+                                ],
+                            },
+                            last_update_color: {
+                                string: "Update State Color",
+                                type: "integer",
+                            },
+                        },
+                        records: [
+                            {id: 1, last_update_status: "on_track", last_update_color: 20},
+                        ],
+                    },
+                },
+            },
+            arch: `
+                <kanban  class="o_kanban_test">
+                    <field name="last_update_status"/>
+                    <field name="last_update_color"/>
+                    <template>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="last_update_status" widget="project_state_selection" options="{'color_field': 'last_update_color'}"/>
+                            </div>
+                        </t>
+                    </template>
+                </kanban>`,
+        };
+        target = getFixture();
+        setupViewRegistries();
+    });
+        QUnit.module("Components", (hooks) => {
+            QUnit.module("ProjectStateSelectionField");
+            QUnit.test("Check that ProjectStateSelectionField does not propose `Set Status`", async function (assert) {
+                await makeView(makeViewParams);
+                await click(target, 'div[name="last_update_status"] button.dropdown-toggle');
+                assert.containsNone(target, 'div[name="last_update_status"] .dropdown-menu .dropdown-item:contains("Set Status")');
+            });
+        });
+    });


### PR DESCRIPTION
Since odoo/odoo#98380, the `Set Status` can be selected in the `project.project` kanban view, which was not previously feasible as considered as not suitable.

This commit prevents selecting that value.

task-2989015


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
