### PR TITLE
[FIX] web: form: keep data-hotkey attribute on buttons

### DIFF
--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -130,6 +130,7 @@ ViewButton.props = [
     "className?",
     "context?",
     "clickParams?",
+    "hotkey?",
     "icon?",
     "defaultRank?",
     "disabled?",

--- a/addons/web/static/src/views/view_button/view_button.xml
+++ b/addons/web/static/src/views/view_button/view_button.xml
@@ -11,6 +11,7 @@
         t-att-href="props.tag === 'a' and '#'"
         t-att-style="props.style"
         t-att-type="clickParams.type"
+        t-att-data-hotkey="props.hotkey"
         t-att-data-tooltip-template="hasBigTooltip ? 'views.ViewButtonTooltip' : false"
         t-att-data-tooltip-info="hasBigTooltip ? tooltip : false"
         t-att-data-tooltip="hasSmallToolTip ? props.title : false"

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -345,6 +345,9 @@ export class ViewCompiler {
                 button.setAttribute(name, toStringExpression(value));
             }
         }
+        if (el.hasAttribute("data-hotkey")) {
+            button.setAttribute("hotkey", toStringExpression(el.getAttribute("data-hotkey")));
+        }
 
         button.setAttribute("clickParams", JSON.stringify(clickParams));
         combineAttributes(

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -2982,6 +2982,35 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(["get_views", "onchange", "create", "read", "execute_action", "read"]);
     });
 
+    QUnit.test("buttons with data-hotkey attribute", async function (assert) {
+        const mockedActionService = {
+            start() {
+                return {
+                    doActionButton(params) {
+                        assert.step(params.name);
+                    },
+                };
+            },
+        };
+        serviceRegistry.add("action", mockedActionService, { force: true });
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <button name="validate" string="Validate" type="object" data-hotkey="v"/>
+                </form>`,
+            resId: 2,
+        });
+
+        assert.containsOnce(target, ".o_form_readonly button[data-hotkey=v]");
+        triggerHotkey("alt+v");
+        await nextTick();
+        assert.verifySteps(["validate"]);
+    });
+
     QUnit.test("change and save char", async function (assert) {
         assert.expect(6);
 


### PR DESCRIPTION
Before this commit, the data-hotkey attribute set on button nodes in form views was ignored. This commit re-introduces the feature, enabling the keynav on those buttons.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
