### PR TITLE
[FIX] l10n_sg: remove VAT string override

### DIFF
--- a/addons/l10n_sg/views/res_company_view.xml
+++ b/addons/l10n_sg/views/res_company_view.xml
@@ -9,9 +9,6 @@
                 <xpath expr="//field[@name='email']" position="after">
                   <field name="l10n_sg_unique_entity_number"/>
                 </xpath>
-                <xpath expr="//field[@name='vat']" position="attributes">
-                  <attribute name="string" >GST No.</attribute>
-                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
When l10n_sg is installed, it overrides the VAT field string in the company form to GST No. for every other company.

The override should be removed, VAT labels will be fixed in master.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
