### PR TITLE
[IMP] account: hide dates and amounts of discounts in journal items

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -181,8 +181,8 @@
                     <field name="debit" sum="Total Debit" readonly="1"/>
                     <field name="credit" sum="Total Credit" readonly="1"/>
                     <field name="tax_tag_ids" string="Tax Grids" widget="many2many_tags" width="0.5" optional="hide"/>
-                    <field name="discount_date" string="Discount Date"/>
-                    <field name="discount_amount_currency" string="Discount Amount"/>
+                    <field name="discount_date" string="Discount Date" optional="hide" />
+                    <field name="discount_amount_currency" string="Discount Amount" optional="hide" />
                     <field name="tax_line_id" string="Originator Tax" optional="hide" readonly="1"/>
                     <field name="date_maturity" optional="hide"/>
                     <field name="balance" sum="Total Balance" optional="hide" readonly="1"/>


### PR DESCRIPTION
The fields added during the early payment cash discount tasks were systematically showing in the journal items view.

Made the showing optional.
