### PR TITLE
[FIX] mail: guard ChatWindowHeaderView/onClick

### DIFF
--- a/addons/mail/static/src/models/chat_window_header_view.js
+++ b/addons/mail/static/src/models/chat_window_header_view.js
@@ -11,6 +11,9 @@ registerModel({
          * @param {MouseEvent} ev
          */
         onClick(ev) {
+            if (!this.exists()) {
+                return;
+            }
             if (
                 isEventHandled(ev, 'ChatWindow.onClickCommand') ||
                 isEventHandled(ev, 'ChatWindow.onClickHideMemberList') ||


### PR DESCRIPTION
This handler was not properly guarded, and made
`.TestMailChannelExpand` fail on runbot.
