### PR TITLE
[FIX] web: ListView: do not crash on aggregated date fields

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -30,6 +30,7 @@ const preloadedDataRegistry = registry.category("preloadedData");
 
 const { CREATE, UPDATE, DELETE, FORGET, LINK_TO, DELETE_ALL, REPLACE_WITH } = x2ManyCommands;
 const QUICK_CREATE_FIELD_TYPES = ["char", "boolean", "many2one", "selection"];
+const AGGREGATABLE_FIELD_TYPES = ["float", "integer", "monetary"]; // types that can be aggregated in grouped views
 const DEFAULT_HANDLE_FIELD = "sequence";
 const DEFAULT_QUICK_CREATE_FIELDS = {
     display_name: { string: "Display name", type: "char" },
@@ -2411,7 +2412,9 @@ export class DynamicGroupList extends DynamicList {
                     default: {
                         // other optional aggregated fields
                         if (key in this.fields) {
-                            groupParams.aggregates[key] = value;
+                            if (AGGREGATABLE_FIELD_TYPES.includes(this.fields[key].type)) {
+                                groupParams.aggregates[key] = value;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Have a model with date(time) field with a group_operator (e.g. "min"). Open a grouped list view of that model, containing that field. Before this commit it crashed, because the aggregated value of the date field, for each group, wasn't parsed (it was still a string), whereas the code trying to display it expected a luxon instance.

We could have easily fixed the issue by parsing the aggregated values for date fields. However, it wasn't supported in legacy views, and it would raise questions. For instance, views aren't designed with this in mind (aggregated fields are often positionned to the right, to leave enough space for the group's title). For that reason, this commit simply restores the legacy behavior, that is, we only consider aggregated values for "integer", "float" and "monetary" fields.

The issue occurred in the Journal Items list view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
