### PR TITLE
[FIX] google_account: some queries send string as params to _do_request

### DIFF
--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -8,6 +8,7 @@ import requests
 from werkzeug import urls
 
 from odoo import api, fields, models, _
+from odoo.tools.json import scriptsafe as json_safe
 
 _logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ class GoogleService(models.AbstractModel):
             headers = {}
 
         # Remove client_secret key from logs
-        _log_params = (params or {}).copy()
+        _log_params = isinstance(params, dict) and params.copy() or (params or '').startswith('{"') and json_safe.loads(params) or {}
         if _log_params.get('client_secret'):
             _log_params['client_secret'] = _log_params['client_secret'][0:4] + 'x' * 12
 


### PR DESCRIPTION
Some params are the output of json.dumps, so the .copy() will fail. Now if it is a dict, we make a copy, if it seems to be a json, we parse it else we just don't log params.

Goal is to never leak the secret key in log.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
