### PR TITLE
[FIX] web_editor: fix wrong reference for onIframeUpdated

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -44,7 +44,7 @@ export class MassMailingHtmlField extends HtmlField {
     get wysiwygOptions() {
         return {
             ...super.wysiwygOptions,
-            onIframeUpdated: this.env.onIframeUpdated,
+            onIframeUpdated: () => this.onIframeUpdated(),
             snippets: 'mass_mailing.email_designer_snippets',
             resizable: false,
             defaultDataForLinkTools: { isNewWindow: true },


### PR DESCRIPTION
Steps to reproduce the issue:
- Open an Automation Campaign
- Open a mailing
- Click edit
- Traceback: this.options.onIframeUpdated is not a function