### PR TITLE
[FIX] bus: getItemFromStorage error when no dbuuid is provided

### DIFF
--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -51,7 +51,11 @@ export const multiTabService = {
 
         function getItemFromStorage(key, defaultValue) {
             const item = browser.localStorage.getItem(generateLocalStorageKey(key));
-            return item ? JSON.parse(item) : defaultValue;
+            try {
+                return item ? JSON.parse(item) : defaultValue;
+            } catch {
+                return item;
+            }
         }
 
         function setItemInStorage(key, value) {

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -27,7 +27,7 @@ export const busService = {
     dependencies: ['localization', 'multi_tab', 'notification'],
 
     start(env, { multi_tab: multiTab }) {
-        if (multiTab.getSharedValue('dbuuid') !== session.dbuuid) {
+        if (session.dbuuid && multiTab.getSharedValue('dbuuid') !== session.dbuuid) {
             multiTab.setSharedValue('dbuuid', session.dbuuid);
             multiTab.removeSharedValue('last_notification_id');
         }


### PR DESCRIPTION
The `bus_service` uses the `dbuuid` key from session in order to
know when to drop the last notification id from the local storage:
when the db changes.

The issue is that public pages don't fetch the session, this results
in undefined being added into the local storage. The multi tab service
speculates on the fact that the value stored will always be json
parsable.

This commit fixes the issue by taking into account the fact that session
dbuuid can be undefined. Moreover, the multi tab service has been
updated to return the raw value if it is not parsable.