### PR TITLE
[IMP] sale_product_matrix: add related field to reduce rpc calls

### DIFF
--- a/addons/sale_product_matrix/models/__init__.py
+++ b/addons/sale_product_matrix/models/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import sale_order
+
 from . import product_template
+from . import sale_order
+from . import sale_order_line

--- a/addons/sale_product_matrix/models/sale_order_line.py
+++ b/addons/sale_product_matrix/models/sale_order_line.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    product_add_mode = fields.Selection(related='product_template_id.product_add_mode', depends=['product_template_id'])


### PR DESCRIPTION
The matrix configurators makes a rpc call to know if the edited line is  configurable through matrix or standard configurator. This rpc can be avoided (and the logic simplified while converting the  widget to owl) with a related field on the lines.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
