### PR TITLE
[FIX] web_editor: should not use extra space in edit mode 

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1345,6 +1345,11 @@ var SnippetsMenu = Widget.extend({
         defs.push((async () => {
             await this._loadSnippetsTemplates();
             await this._updateInvisibleDOM();
+            this.snippetEditors.forEach(editor => {
+                if (!editor.$target[0].dataset.visibility) {
+                    editor.toggleTargetVisibility(false);
+                }
+            });
         })());
 
         // Prepare snippets editor environment


### PR DESCRIPTION
**Current behavior before PR:**

The editor seems to add the contenteditable=true on the div in edit mode
i.e. cookie bar, due to which chrome adds height style on contenteditable elements,
which makes empty elements use space in edit mode.

**Desired behavior after PR is merged:**

After adding the 'd-none' class for empty contenteditable elements, will get rid
of the spacing issue in edit mode.

**Task**-2754108