### PR TITLE
[IMP] stock: store and always allow editing done field

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -346,7 +346,7 @@ class StockMove(models.Model):
 
         self.env['stock.move'].browse(moves_ids_to_unlink).sudo().unlink()
         if phantom_moves_vals_list:
-            phantom_moves = self.env['stock.move'].create(phantom_moves_vals_list)
+            phantom_moves = self.env['stock.move'].with_context(from_mrp=True).create(phantom_moves_vals_list)
             phantom_moves._adjust_procure_method()
             moves_ids_to_return |= phantom_moves.action_explode().ids
         return self.env['stock.move'].browse(moves_ids_to_return)

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -316,6 +316,9 @@ class TestKitPicking(common.TestMrpCommon):
             'location_id':  self.test_supplier.id,
             'location_dest_id': self.warehouse_1.wh_input_stock_loc_id.id,
         })
+
+        self.env['stock.move.line'].create(dict(move_receipt_1._prepare_move_line_vals(), qty_done=3))
+
         picking.button_validate()
 
         # We check that the picking has the correct quantities after its move were splitted.

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -592,6 +592,8 @@ class TestUnbuild(TestMrpCommon):
         # Transfer it
         for ml in picking.move_ids_without_package:
             ml.quantity_done = 1
+            # NTR Remove this after merge auto-distribute done_qty
+            ml.move_line_ids.qty_done = 1
         picking._action_done()
 
         # Check the available quantity of components and final product in stock

--- a/addons/sale_stock/tests/test_sale_stock_report.py
+++ b/addons/sale_stock/tests/test_sale_stock_report.py
@@ -143,6 +143,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         picking = so.picking_ids
         picking.move_ids.quantity_done = 5
+        # NTR Remove this after merge auto-distribute done_qty
+        picking.move_ids.move_line_ids.qty_done = 5
         picking.button_validate()
 
         invoice = so._create_invoices()
@@ -182,6 +184,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         picking = so.picking_ids
         picking.move_ids.quantity_done = 4
+        # NTR Remove this after merge auto-distribute done_qty
+        picking.move_ids.move_line_ids.qty_done = 4
         picking.button_validate()
 
         html = self.env['ir.actions.report']._render_qweb_html(
@@ -292,6 +296,8 @@ class TestSaleStockInvoices(TestSaleCommon):
         # Deliver 10 x LOT0001
         delivery01 = so.picking_ids
         delivery01.move_ids.quantity_done = 10
+        # NTR Remove this after merge auto-distribute done_qty
+        delivery01.move_ids.move_line_ids.qty_done = 10
         delivery01.button_validate()
         self.assertEqual(delivery01.move_line_ids.lot_id.name, 'LOT0001')
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1684,12 +1684,12 @@ class StockMove(models.Model):
     def _action_done(self, cancel_backorder=False):
         self.filtered(lambda move: move.state == 'draft')._action_confirm()  # MRP allows scrapping draft moves
 
-        for move in self:
-            if move.is_action_show_details_danger:
-                raise UserError(f'Move of product {move.product_id.name} with demand of {move.product_qty} has inconsistent done value {move._get_qty_done_mls()} vs {move.quantity_done}')
-
         moves = self.exists().filtered(lambda x: x.state not in ('done', 'cancel'))
         moves_ids_todo = OrderedSet()
+
+        for move in self.exists():
+            if move.is_action_show_details_danger:
+                raise UserError(f'Move of product {move.product_id.name} with demand of {move.product_qty} has inconsistent done value {move._get_qty_done_mls()} vs {move.quantity_done}')
 
         # Cancel moves where necessary ; we should do it before creating the extra moves because
         # this operation could trigger a merge of moves.

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -334,6 +334,8 @@ class StockMoveLine(models.Model):
                 next_moves = ml.move_id.move_dest_ids.filtered(lambda move: move.state not in ('done', 'cancel'))
                 next_moves._do_unreserve()
                 next_moves._action_assign()
+        if mls.move_id:
+            mls.move_id.quantity_done_need_compute = True
         return mls
 
     def write(self, vals):
@@ -471,6 +473,10 @@ class StockMoveLine(models.Model):
                 move.product_uom_qty = move.quantity_done
             next_moves._do_unreserve()
             next_moves._action_assign()
+
+        # There is update to qty_done -> re-enable compute done
+        if 'qty_done' in vals:
+            self.move_id.quantity_done_need_compute = True
 
         if moves_to_recompute_state:
             moves_to_recompute_state._recompute_state()

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -982,6 +982,9 @@ class Picking(models.Model):
         pickings_without_quantities = self.browse()
         pickings_without_lots = self.browse()
         products_without_lots = self.env['product.product']
+        pickings_with_inconsistent_done_qty = self.browse()
+        products_with_inconsistent_done_qty = self.env['product.product']
+
         for picking in self:
             if not picking.move_ids and not picking.move_line_ids:
                 pickings_without_moves |= picking
@@ -991,6 +994,12 @@ class Picking(models.Model):
             precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             no_quantities_done = all(float_is_zero(move_line.qty_done, precision_digits=precision_digits) for move_line in picking.move_line_ids.filtered(lambda m: m.state not in ('done', 'cancel')))
             no_reserved_quantities = all(float_is_zero(move_line.reserved_qty, precision_rounding=move_line.product_uom_id.rounding) for move_line in picking.move_line_ids)
+            inconsistent_done_qty = any(move.is_action_show_details_danger for move in picking.move_ids)
+
+            if inconsistent_done_qty:
+                pickings_with_inconsistent_done_qty |= picking
+                products_with_inconsistent_done_qty |= picking.move_ids.filtered(lambda m: m.is_action_show_details_danger).product_id
+
             if no_reserved_quantities and no_quantities_done:
                 pickings_without_quantities |= picking
 
@@ -1012,6 +1021,8 @@ class Picking(models.Model):
                 raise UserError(self._get_without_quantities_error_message())
             if pickings_without_lots:
                 raise UserError(_('You need to supply a Lot/Serial number for products %s.') % ', '.join(products_without_lots.mapped('display_name')))
+            if pickings_with_inconsistent_done_qty:
+                raise UserError(_('\n\nTransfers %s: You have inconsistent quantity done, open the wizard to solve for products %s.') % (', '.join(pickings_with_inconsistent_done_qty.mapped('name')), ', '.join(products_with_inconsistent_done_qty.mapped('display_name'))))
         else:
             message = ""
             if pickings_without_moves:
@@ -1020,6 +1031,8 @@ class Picking(models.Model):
                 message += _('\n\nTransfers %s: You cannot validate these transfers if no quantities are reserved nor done. To force these transfers, switch in edit more and encode the done quantities.') % ', '.join(pickings_without_quantities.mapped('name'))
             if pickings_without_lots:
                 message += _('\n\nTransfers %s: You need to supply a Lot/Serial number for products %s.') % (', '.join(pickings_without_lots.mapped('name')), ', '.join(products_without_lots.mapped('display_name')))
+            if pickings_with_inconsistent_done_qty:
+                message += _('\n\nTransfers %s: You have inconsistent quantity done, open the wizard to solve for products %s.') % (', '.join(pickings_with_inconsistent_done_qty.mapped('name')), ', '.join(products_with_inconsistent_done_qty.mapped('display_name')))
             if message:
                 raise UserError(message.lstrip())
 

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5114,6 +5114,7 @@ class StockMove(TransactionCase):
         move_out._action_confirm()
         move_out._action_assign()
         move_out.quantity_done = self.product.qty_available
+        self.env['stock.move.line'].create(dict(move_out._prepare_move_line_vals(), qty_done=move_out.quantity_done))
         move_out._action_done()
         self.product.detailed_type = 'consu'
 
@@ -5156,11 +5157,25 @@ class StockMove(TransactionCase):
         })
         picking.action_confirm()
         picking.action_assign()
+
         move1.quantity_done = 10
+        self.assertEqual(picking.move_ids.quantity_done, 10)
+        self.assertEqual(picking.move_ids._get_qty_done_mls(), 0)
+
+        self.env['stock.move.line'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product.id,
+            'product_uom_id': self.uom_unit.id,
+            'qty_done': 10.0,
+            'picking_id': picking.id,
+        })
         picking._action_done()
 
         self.assertEqual(len(picking.move_ids), 1, 'One move should exist for the picking.')
         self.assertEqual(len(picking.move_line_ids), 1, 'One move line should exist for the picking.')
+        self.assertEqual(picking.move_ids.quantity_done, 10)
+        self.assertEqual(picking.move_ids._get_qty_done_mls(), 10)
 
         ml = self.env['stock.move.line'].create({
             'location_id': self.stock_location.id,
@@ -5201,6 +5216,8 @@ class StockMove(TransactionCase):
         picking.action_assign()
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0)
         move1.quantity_done = 1
+        # NTR Remove this after merge auto-distribute done_qty
+        move1.move_line_ids.qty_done = 1
         picking.action_put_in_pack()
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0)
         self.assertEqual(len(picking.move_line_ids), 2)
@@ -5302,8 +5319,12 @@ class StockMove(TransactionCase):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(product1, self.stock_location), 0)
         move1.quantity_done = 1
+        # NTR Remove this after merge auto-distribute done_qty
+        move1.move_line_ids.qty_done = 1
         picking.action_put_in_pack()
-        move2.quantity_done = 2
+        move2.quantity_done = 1
+        # NTR Remove this after merge auto-distribute done_qty
+        move2.move_line_ids.qty_done = 2
         picking.action_put_in_pack()
         self.assertEqual(len(picking.move_line_ids), 2)
         line1_result_package = picking.move_line_ids[0].result_package_id
@@ -5534,6 +5555,8 @@ class StockMove(TransactionCase):
         picking.action_confirm()
         picking.action_assign()
         move1.quantity_done = 5
+        # NTR Remove this after merge auto-distribute done_qty
+        move1.move_line_ids.qty_done = 5
         picking.action_put_in_pack()  # Create a first package
         self.assertEqual(len(picking.move_line_ids), 2)
 
@@ -5576,6 +5599,9 @@ class StockMove(TransactionCase):
             'picking_type_id': self.env.ref('stock.picking_type_out').id,
         })
         move1.quantity_done = 5
+        self.env['stock.move.line'].create(dict(
+            move1._prepare_move_line_vals(),
+            qty_done=5))
         picking.action_put_in_pack()  # Create a package
 
         delivery_form = Form(picking)

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -1520,6 +1520,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         # do not set a lot_id or lot_name, it should work
         delivery_order._action_done()
 
@@ -1553,6 +1556,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         move_line = delivery_order.move_ids.move_line_ids
 
         # not lot_name set, should raise
@@ -1593,6 +1599,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         move_line = delivery_order.move_ids.move_line_ids
 
         # not lot_name set, should raise
@@ -1633,6 +1642,9 @@ class TestSinglePicking(TestStockCommon):
 
         delivery_order.action_confirm()
         delivery_order.move_ids.quantity_done = 2
+        self.env['stock.move.line'].create(dict(
+            delivery_order.move_ids._prepare_move_line_vals(),
+            qty_done=2))
         move_line = delivery_order.move_ids.move_line_ids
 
         # not lot_name set, should raise

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -117,6 +117,9 @@ class TestWarehouse(TestStockCommon):
         self.assertEqual(product.virtual_available, -5.0)
 
         customer_move.quantity_done = 5
+        self.env['stock.move.line'].create(dict(
+            customer_move._prepare_move_line_vals(),
+            qty_done=5))
         customer_move._action_done()
         self.assertEqual(product.qty_available, -5.0)
 
@@ -157,7 +160,7 @@ class TestWarehouse(TestStockCommon):
             'location_id': stock_location.id,
             'location_dest_id': customer_location.id,
         })
-        self.env['stock.move'].create({
+        move = self.env['stock.move'].create({
             'name': productA.name,
             'product_id': productA.id,
             'product_uom_qty': 1,
@@ -168,6 +171,9 @@ class TestWarehouse(TestStockCommon):
         })
         picking_out.action_confirm()
         picking_out.move_ids.quantity_done = 1
+        self.env['stock.move.line'].create(dict(
+            move._prepare_move_line_vals(),
+            qty_done=1))
         picking_out._action_done()
 
         quant = self.env['stock.quant'].search([('product_id', '=', productA.id), ('location_id', '=', stock_location.id)])
@@ -181,6 +187,9 @@ class TestWarehouse(TestStockCommon):
         return_pick = self.env['stock.picking'].browse(stock_return_picking_action['res_id'])
         return_pick.action_assign()
         return_pick.move_ids.quantity_done = 1
+        self.env['stock.move.line'].create(dict(
+            return_pick.move_ids._prepare_move_line_vals(),
+            qty_done=1))
         return_pick._action_done()
 
         quant = self.env['stock.quant'].search([('product_id', '=', productA.id), ('location_id', '=', stock_location.id)])
@@ -200,7 +209,7 @@ class TestWarehouse(TestStockCommon):
             'location_id': stock_location.id,
             'location_dest_id': customer_location.id,
         })
-        self.env['stock.move'].create({
+        move = self.env['stock.move'].create({
             'name': productA.name,
             'product_id': productA.id,
             'product_uom_qty': 1,
@@ -211,6 +220,9 @@ class TestWarehouse(TestStockCommon):
         })
         picking_out.action_confirm()
         picking_out.move_ids.quantity_done = 1
+        self.env['stock.move.line'].create(dict(
+            move._prepare_move_line_vals(),
+            qty_done=1))
         picking_out._action_done()
 
         # Make an inventory adjustment to set the quantity to 0
@@ -385,16 +397,24 @@ class TestWarehouse(TestStockCommon):
         self.assertTrue(picking_stock_transit)
         picking_stock_transit.action_assign()
         picking_stock_transit.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_stock_transit.move_ids[0].move_line_ids.qty_done = 1.0
         picking_stock_transit._action_done()
 
         picking_transit_shop_namur = self.env['stock.picking'].search([('location_dest_id', '=', warehouse_shop_namur.lot_stock_id.id)])
         self.assertTrue(picking_transit_shop_namur)
         picking_transit_shop_namur.action_assign()
         picking_transit_shop_namur.move_ids[0].quantity_done = 1.0
+        self.env['stock.move.line'].create(dict(
+            picking_transit_shop_namur.move_ids[0]._prepare_move_line_vals(),
+            qty_done=1))
         picking_transit_shop_namur._action_done()
 
         picking_out_namur.action_assign()
         picking_out_namur.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_out_namur.move_ids[0].move_line_ids.qty_done = 1.0
+
         picking_out_namur._action_done()
 
         # Check that the correct quantity has been provided to customer
@@ -429,16 +449,23 @@ class TestWarehouse(TestStockCommon):
         self.assertTrue(picking_stock_transit)
         picking_stock_transit.action_assign()
         picking_stock_transit.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_stock_transit.move_ids[0].move_line_ids.qty_done = 1.0
         picking_stock_transit._action_done()
 
         picking_transit_shop_wavre = self.env['stock.picking'].search([('location_dest_id', '=', warehouse_shop_wavre.lot_stock_id.id)])
         self.assertTrue(picking_transit_shop_wavre)
         picking_transit_shop_wavre.action_assign()
         picking_transit_shop_wavre.move_ids[0].quantity_done = 1.0
+        self.env['stock.move.line'].create(dict(
+            picking_transit_shop_wavre.move_ids[0]._prepare_move_line_vals(),
+            qty_done=1))
         picking_transit_shop_wavre._action_done()
 
         picking_out_wavre.action_assign()
         picking_out_wavre.move_ids[0].quantity_done = 1.0
+        # NTR Remove this after merge auto-distribute done_qty
+        picking_out_wavre.move_ids[0].move_line_ids.qty_done = 1.0
         picking_out_wavre._action_done()
 
         # Check that the correct quantity has been provided to customer

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -274,6 +274,7 @@
                                     <field name="date_deadline" optional="hide"/>
                                     <field name="is_initial_demand_editable" invisible="1"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
+                                    <field name="is_action_show_details_danger" invisible="1"/>
                                     <field name="product_packaging_id" groups="product.group_stock_packaging"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" 
@@ -287,7 +288,9 @@
                                         attrs="{'column_invisible': ['|', '|', ('parent.state', 'in', ['draft', 'done']), ('parent.picking_type_code', 'in', ['incoming', 'outgoing']), ('parent.immediate_transfer', '=', True)]}"/>
                                     <field name="product_qty" invisible="1" readonly="1"/>
                                     <field name="quantity_done" string="Done" attrs="{'readonly': [('is_quantity_done_editable', '=', False)], 'column_invisible':[('parent.state', '=', 'draft'), ('parent.immediate_transfer', '=', False)]}"/>
-                                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
+                                    <button name="action_show_details" type="object" icon="fa-list" title="Details" attrs="{'invisible': ['|', ('is_action_show_details_danger', '=', True), ('show_details_visible', '=', False)]}" options='{"warn": true}'/>
+                                    <button name="action_show_details" type="object" icon="fa-list text-danger" title="Details" attrs="{'invisible': ['|', ('is_action_show_details_danger', '=', False), ('show_details_visible', '=', False)]}" options='{"warn": true}'/>
+                                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit" groups="uom.group_uom"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         groups="stock.group_production_lot"
                                         attrs="{'invisible': ['|', ('show_details_visible', '=', False), ('has_tracking', '!=', 'serial')]}"
@@ -296,8 +299,6 @@
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"
                                         domain="[('product_id','=',product_id)]"
                                     />
-                                    <button name="action_show_details" type="object" icon="fa-list" width="0.1" title="Details"
-                                            attrs="{'invisible': [('show_details_visible', '=', False)]}" options='{"warn": true}'/>
                                     <button name="action_assign_serial" type="object"
                                             icon="fa-plus-square"
                                             width="0.1"


### PR DESCRIPTION
The goal of this PR is to always allow editing the done field of
stock move. We archive this by storing the done field with a flag.
Directly editing the quantity done field will distribute to the move
lines only if the product is not track and in a no multi-locations
settings. Otherwise, the editing the done field will disable compute
of the done field until we make changes in the stock_move's move lines
(e.g. action_show_details). Furthermore, the moves with the done field
value that is different from the done quantity of the move lines will
has the color red and unable to validate the stock move




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
