### PR TITLE
[IMP] core: log beta version warning

### DIFF
--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -57,6 +57,8 @@ def report_configuration():
     """
     config = odoo.tools.config
     _logger.info("Odoo version %s", __version__)
+    if 'beta' in __version__:
+        _logger.runbot('⚠️ This version is not suitable for production usage ⚠️')
     if os.path.isfile(config.rcfile):
         _logger.info("Using configuration file at " + config.rcfile)
     _logger.info('addons paths: %s', odoo.addons.__path__)

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -32,6 +32,8 @@ class PostgreSQLHandler(logging.Handler):
     def emit(self, record):
         ct = threading.current_thread()
         ct_db = getattr(ct, 'dbname', None)
+        if not ct_db and tools.config['db_name'] and ',' not in tools.config['db_name']:
+            ct_db = tools.config['db_name']
         dbname = tools.config['log_db'] if tools.config['log_db'] and tools.config['log_db'] != '%d' else ct_db
         if not dbname:
             return

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -12,7 +12,7 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 # properly comparable using normal operators, for example:
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
-version_info = (16, 0, 0, ALPHA, 0, '')
+version_info = (16, 0, 0, BETA, 0, '')
 version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 series = serie = major_version = '.'.join(str(s) for s in version_info[:2])
 


### PR DESCRIPTION
From now, the yearly release will be named x.0 as the final version and not (x-1).5  but will be temporary in beta waiting for bugfix and last imps that may impact database structure.

To avoid this version to be use imediatly in a production environment, log a "warning" message while it is in beta.