### PR TITLE
16.0 duplicate main object gdi

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -614,7 +614,9 @@ class EventEvent(models.Model):
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):
         self.ensure_one()
-        default = dict(default or {}, name=_("%s (copy)") % (self.name))
+        default = dict(default or {})
+        if 'name' not in default:
+            default['name'] = _("%s (copy)") % (self.name)
         return super(EventEvent, self).copy(default)
 
     @api.model

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -642,6 +642,25 @@ class Website(Home):
             return bool(record.website_published)
         return False
 
+    @http.route('/website/duplicate', type='json', auth="user", website=True, methods=['POST'])
+    def duplicate(self, model, object_id, new_name):
+        """ Duplicate an object.
+        :param model: model name of the object we want to duplicate.
+        :param object_id: id of the object currently browsed.
+        :param new_name: name of the new object.
+        :return the url to the new object created
+        """
+        current_object = request.env[model].browse(int(object_id))
+        requested_name = new_name
+        counter = 1
+        while request.env[model].search([('name', '=', new_name)], limit=1):
+            new_name = '%s-%s' % (requested_name, str(counter))
+            counter += 1
+        new_object = current_object.copy(default={'name': new_name})
+        if 'website_url' in new_object:
+            return new_object.website_url
+        return new_object.go_to_website()['url']
+
     @http.route(['/website/seo_suggest'], type='json', auth="user", website=True)
     def seo_suggest(self, keywords=None, lang=None):
         language = lang.split("_")

--- a/addons/website/static/src/components/dialog/duplicate_object.js
+++ b/addons/website/static/src/components/dialog/duplicate_object.js
@@ -1,0 +1,54 @@
+/** @odoo-module **/
+
+import {useService, useAutofocus} from '@web/core/utils/hooks';
+import {WebsiteDialog} from './dialog';
+const {Component, useState, onWillStart} = owl;
+
+export class DuplicateObjectDialog extends Component {
+    setup() {
+        this.orm = useService('orm');
+        this.website = useService('website');
+        this.notification = useService('notification');
+        this.rpc = useService('rpc');
+        useAutofocus();
+        this.title = this.env._t('Duplicate');
+        this.state = useState({
+            name: '',
+        });
+        onWillStart(this._updateModalTitle);
+    }
+    async duplicate() {
+        if (!this.state.name) {
+            this.notification.add(this.env._t('Please enter a name.'), {
+                title: this.env._t('Attention'),
+                type: 'warning',
+            });
+            return;
+        }
+        const mainObject = this.website.currentWebsite.metadata.mainObject;
+        let url;
+        if (mainObject.model === 'website.page') {
+            url = await this.orm.call(
+                mainObject.model,
+                'clone_page',
+                [mainObject.id, this.state.name],
+            );
+        } else {
+            url = await this.rpc('/website/duplicate', {
+                model: mainObject.model,
+                object_id: mainObject.id,
+                new_name: this.state.name,
+            });
+        }
+        this.website.goToWebsite({path: url, edition: true});
+        this.props.close();
+        if (this.props.onDuplicate) {
+            this.props.onDuplicate();
+        }
+    }
+    async _updateModalTitle() {
+        this.objectName = await this.website.getUserModelName();
+    }
+}
+DuplicateObjectDialog.components = {WebsiteDialog};
+DuplicateObjectDialog.template = 'website.DuplicateObjectDialog';

--- a/addons/website/static/src/components/dialog/duplicate_object.xml
+++ b/addons/website/static/src/components/dialog/duplicate_object.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+
+<t t-name="website.DuplicateObjectDialog" owl="1">
+    <WebsiteDialog title="title" closeOnClick="false" close="props.close" primaryClick.bind="duplicate" secondaryClick="props.close">
+    <div class="mb-3 row">
+        <label class="col-form-label col-md-3">
+            Name
+        </label>
+        <div class="col-md-9">
+            <input type="text" t-model="state.name" class="form-control" required="required" t-ref="autofocus"/>
+        </div>
+    </div>
+    <b><t t-esc="objectName"/></b> will be duplicated.
+    </WebsiteDialog>
+</t>
+
+</templates>

--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -1,11 +1,12 @@
 /** @odoo-module **/
 
 import {CheckBox} from '@web/core/checkbox/checkbox';
-import {useService, useAutofocus} from "@web/core/utils/hooks";
+import {useService} from "@web/core/utils/hooks";
 import {useWowlService} from '@web/legacy/utils';
 import {WebsiteDialog} from './dialog';
 import {FormViewDialog} from "@web/views/view_dialogs/form_view_dialog";
 import {qweb, _t} from 'web.core';
+import {DuplicateObjectDialog} from '@website/components/dialog/duplicate_object';
 
 const {Component, onWillStart, useState, xml, useRef, markup} = owl;
 
@@ -117,48 +118,6 @@ DeletePageDialog.props = {
     close: Function,
 };
 
-export class DuplicatePageDialog extends Component {
-    setup() {
-        this.orm = useService('orm');
-        this.website = useService('website');
-        useAutofocus();
-
-        this.state = useState({
-            name: '',
-        });
-    }
-
-    async duplicate() {
-        if (this.state.name) {
-            const res = await this.orm.call(
-                'website.page',
-                'clone_page',
-                [this.props.pageId, this.state.name]
-            );
-            this.website.goToWebsite({path: res, edition: true});
-        }
-        this.props.onDuplicate();
-    }
-}
-DuplicatePageDialog.components = {WebsiteDialog};
-DuplicatePageDialog.template = xml`
-<WebsiteDialog close="props.close" primaryClick="() => this.duplicate()">
-    <div class="mb-3 row">
-        <label class="col-form-label col-md-3">
-            Page Name
-        </label>
-        <div class="col-md-9">
-            <input type="text" t-model="state.name" class="form-control" required="required" t-ref="autofocus"/>
-        </div>
-    </div>
-</WebsiteDialog>
-`;
-DuplicatePageDialog.props = {
-    onDuplicate: {type: Function, optional: true},
-    close: Function,
-    pageId: Number,
-};
-
 export class PagePropertiesDialog extends FormViewDialog {
     setup() {
         super.setup();
@@ -173,7 +132,7 @@ export class PagePropertiesDialog extends FormViewDialog {
     }
 
     clonePage() {
-        this.dialog.add(DuplicatePageDialog, {
+        this.dialog.add(DuplicateObjectDialog, {
             pageId: this.resId,
             onDuplicate: () => {
                 this.props.close();

--- a/addons/website/static/src/services/website_custom_menus.js
+++ b/addons/website/static/src/services/website_custom_menus.js
@@ -4,6 +4,7 @@ import { registry } from "@web/core/registry";
 import { EditMenuDialog } from '@website/components/dialog/edit_menu';
 import { OptimizeSEODialog } from '@website/components/dialog/seo';
 import {PagePropertiesDialog} from '@website/components/dialog/page_properties';
+import {DuplicateObjectDialog} from '@website/components/dialog/duplicate_object';
 
 /**
  * This service displays contextual menus, depending of the state of the
@@ -82,4 +83,11 @@ registry.category('website_custom_menus').add('website.menu_page_properties', {
             });
         },
     })
+});
+registry.category('website_custom_menus').add('website.menu_duplicate_object', {
+    Component: DuplicateObjectDialog,
+    isDisplayed: (env) => env.services.website.currentWebsite && (
+        env.services.website.currentWebsite.metadata.editableInBackend
+        || (env.services.website.currentWebsite.metadata.mainObject &&
+            env.services.website.currentWebsite.metadata.mainObject.model === 'website.page')),
 });

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -457,6 +457,12 @@
             name="HTML / CSS Editor"
             action="website.website_preview"/>
 
+        <menuitem id="menu_duplicate_object"
+            parent="menu_current_page"
+            sequence="40"
+            name="Duplicate"
+            action="website.website_preview"/>
+
         <menuitem id="menu_reporting"
             name="Reporting"
             sequence="30"

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -254,8 +254,9 @@ class BlogPost(models.Model):
     @api.returns('self', lambda value: value.id)
     def copy_data(self, default=None):
         self.ensure_one()
-        name = _("%s (copy)", self.name)
-        default = dict(default or {}, name=name)
+        default = dict(default or {})
+        if 'name' not in default:
+            default['name'] = _("%s (copy)") % (self.name)
         return super(BlogPost, self).copy_data(default)
 
     def _get_access_action(self, access_uid=None, force_website=False):


### PR DESCRIPTION
This commit adds an item in the Site > This page menu that duplicates
the main object of the currently visited page. For example, this allows
to duplicate pages, products, blog posts, job offers, ...

task-2687506
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
