### PR TITLE
[FIX] base: fix mock smtplib connection for server with 'starttls' encryption

### DIFF
--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -249,6 +249,9 @@ class MockSmtplibCase:
             def login(self, user, password):
                 pass
 
+            def starttls(self, keyfile=None, certfile=None, context=None):
+                pass
+
         self.testing_smtp_session = TestingSMTPSession()
 
         IrMailServer = self.env['ir.mail_server']

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -254,6 +254,21 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
             from_filter='custom_domain.com',
         )
 
+        # Test when forcing the mail server and when smtp_encryption is "starttls"
+        self.server_domain.smtp_encryption = "starttls"
+        with self.mock_smtplib_connection():
+            # smtp_session = IrMailServer.connect(smtp_from='specific_user@test.com')
+            message = self._build_email(mail_from='specific_user@test.com')
+            IrMailServer.send_email(message, mail_server_id=self.server_domain.id)
+
+        self.connect_mocked.assert_called_once()
+        self.assert_email_sent_smtp(
+            smtp_from='specific_user@test.com',
+            message_from='specific_user@test.com',
+            from_filter='test.com',
+        )
+
+
     @mute_logger('odoo.models.unlink')
     def test_mail_server_send_email_smtp_session(self):
         """Test all the cases when we provide the SMTP session.


### PR DESCRIPTION
During tests, when matching ir.mail_server has `smtp_encryption` set to `starttls`, connect() will crash with an AttributeError as follows:

2022-09-21 15:28:01,099 4481 ERROR accounts-test odoo.addons.base.tests.test_ir_mail_server: ERROR: TestIrMailServer.test_mail_server_send_email Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-15.3/odoo/tools/misc.py", line 794, in deco
    return func(*args, **kwargs)
  File "/home/odoo/src/odoo/saas-15.3/odoo/addons/base/tests/test_ir_mail_server.py", line 262, in test_mail_server_send_email
    IrMailServer.send_email(message, mail_server_id=self.server_domain.id)
  File "/home/odoo/src/odoo/saas-15.3/odoo/addons/base/models/ir_mail_server.py", line 578, in send_email
    smtp = self.connect(
  File "/usr/lib/python3.8/unittest/mock.py", line 1081, in __call__
    return self._mock_call(*args, **kwargs)
  File "/usr/lib/python3.8/unittest/mock.py", line 1085, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
  File "/usr/lib/python3.8/unittest/mock.py", line 1146, in _execute_mock_call
    result = effect(*args, **kwargs)
  File "/home/odoo/src/odoo/saas-15.3/odoo/addons/base/models/ir_mail_server.py", line 313, in connect
    connection.starttls(context=ssl_context)
AttributeError: 'TestingSMTPSession' object has no attribute 'starttls'

This commit adds a dummy `starttls()` method to `TestingSMTPSession` to gracefully handle such case.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
