### PR TITLE
[FIX] web_editor: fix update of html field

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -186,7 +186,7 @@ export class HtmlField extends Component {
     }
     updateValue() {
         const value = this.getEditingValue();
-        if (value !== null && value !== this.props.value) {
+        if (value !== null && value !== this.props.value.toString()) {
             if (this.props.setDirty) {
                 this.props.setDirty(true);
             }


### PR DESCRIPTION
At some point, we could compare a string and a Markup value.
This was leading to unnecessary update which was also leading to weird
behaviour where a record just created then deleted, was then recreated
from the update.