### PR TITLE
[FIX] account: display actual amount in payment view

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -386,10 +386,8 @@ class AccountPayment(models.Model):
     @api.depends('amount_total_signed', 'payment_type')
     def _compute_amount_company_currency_signed(self):
         for payment in self:
-            if payment.payment_type == 'outbound':
-                payment.amount_company_currency_signed = -payment.amount_total_signed
-            else:
-                payment.amount_company_currency_signed = payment.amount_total_signed
+            liquidity_lines = payment._seek_for_lines()[0]
+            payment.amount_company_currency_signed = sum(liquidity_lines.mapped('balance'))
 
     @api.depends('amount', 'payment_type')
     def _compute_amount_signed(self):


### PR DESCRIPTION
The amount displayed in the payment list view was always the full amount of the invoice.

This would not always correspond to the actual amount of the payment, for example if a cash discount is applied.

Fix: the amount displayed is the amount actually registered.

task-2991745

