### PR TITLE
[IMP] mail: handle removed models in `/mail/view` route

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -241,6 +241,7 @@ class MailController(http.Controller):
     def mail_action_assign(self, model, res_id, token=None):
         record_mapping = self.upgrade_record_mapping(model, res_id)
         if record_mapping:
+            model, res_id = record_mapping
             url = "/mail/assign?%s" % url_encode(
                 {"model": model, "res_id": res_id, "token": token}
             )

--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -213,6 +213,7 @@ class MailController(http.Controller):
         if model and res_id:
             record_mapping = self.upgrade_record_mapping(model, res_id)
             if record_mapping:
+                model, res_id = record_mapping
                 url = "/mail/view?%s" % url_encode(
                     {"model": model, "res_id": res_id, "access_token": access_token, **kwargs}
                 )


### PR DESCRIPTION
During version upgrade, it may happen that a model is merged into another one (like `account.invoice` into `account.move`).

Links received by mail pointing to old records should still work and redirect to the new one.

See odoo/upgrade#3917
