### PR TITLE
[FIX] Add an option to disable graphs in the accounting dashboard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -22,9 +22,9 @@ class account_journal(models.Model):
 
     def _kanban_dashboard_graph(self):
         for journal in self:
-            if (journal.type in ['sale', 'purchase']) and journal.company_id.dashboard_graphs:
+            if (journal.type in ['sale', 'purchase']):
                 journal.kanban_dashboard_graph = json.dumps(journal.get_bar_graph_datas())
-            elif (journal.type in ['cash', 'bank']) and journal.company_id.dashboard_graphs:
+            elif (journal.type in ['cash', 'bank']):
                 journal.kanban_dashboard_graph = json.dumps(journal.get_line_graph_datas())
             else:
                 journal.kanban_dashboard_graph = False

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -22,9 +22,9 @@ class account_journal(models.Model):
 
     def _kanban_dashboard_graph(self):
         for journal in self:
-            if (journal.type in ['sale', 'purchase']):
+            if (journal.type in ['sale', 'purchase']) and journal.company_id.dashboard_graphs:
                 journal.kanban_dashboard_graph = json.dumps(journal.get_bar_graph_datas())
-            elif (journal.type in ['cash', 'bank']):
+            elif (journal.type in ['cash', 'bank']) and journal.company_id.dashboard_graphs:
                 journal.kanban_dashboard_graph = json.dumps(journal.get_line_graph_datas())
             else:
                 journal.kanban_dashboard_graph = False

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -7,7 +7,7 @@ from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.release import version
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF
-from odoo.tools.misc import formatLang, format_date as odoo_format_date, get_lang
+from odoo.tools.misc import formatLang, format_date as odoo_format_date, get_lang, profile
 import random
 
 import ast
@@ -83,7 +83,7 @@ class account_journal(models.Model):
               JOIN res_company company ON company.id = move.company_id
              WHERE move.journal_id = ANY(%(journal_ids)s)
                AND move.state = 'posted'
-               AND (company.fiscalyear_lock_date IS NULL OR move.date >= company.fiscalyear_lock_date) 
+               AND (company.fiscalyear_lock_date IS NULL OR move.date >= company.fiscalyear_lock_date)
           GROUP BY move.journal_id, move.sequence_prefix
             HAVING COUNT(*) != MAX(move.sequence_number) - MIN(move.sequence_number) + 1
         """, {
@@ -117,6 +117,7 @@ class account_journal(models.Model):
             return ['', _('Bank: Balance')]
 
     # Below method is used to get data of bank and cash statemens
+    @profile('/temp/dashboard_line_graph.profile')
     def get_line_graph_datas(self):
         """Computes the data used to display the graph for bank and cash journals in the accounting dashboard"""
         currency = self.currency_id or self.company_id.currency_id
@@ -177,6 +178,7 @@ class account_journal(models.Model):
 
         return [{'values': data, 'title': graph_title, 'key': graph_key, 'area': True, 'color': color, 'is_sample_data': is_sample_data}]
 
+    @profile('/temp/dashboard_bar_graph.profile')
     def get_bar_graph_datas(self):
         data = []
         today = fields.Date.today()
@@ -257,6 +259,7 @@ class account_journal(models.Model):
             'journal_id': self.id
         })
 
+    @profile('/temp/dashboard_data.profile')
     def get_journal_dashboard_datas(self):
         currency = self.currency_id or self.company_id.currency_id
         number_to_reconcile = number_to_check = last_balance = 0

--- a/addons/account/populate/account_move.py
+++ b/addons/account/populate/account_move.py
@@ -23,7 +23,7 @@ class AccountMove(models.Model):
     _populate_sizes = {
         'small': 1000,
         'medium': 10000,
-        'large': 500000,
+        'large': 100000,
     }
 
     _populate_dependencies = ['res.partner', 'account.journal', 'product.product']
@@ -214,7 +214,7 @@ class AccountMove(models.Model):
                 ['entry', 'in_invoice', 'out_invoice', 'in_refund', 'out_refund', 'in_receipt', 'out_receipt'],
                 [0.2, 0.3, 0.3, 0.07, 0.07, 0.03, 0.03],
             )),
-            ('company_id', populate.randomize(company_ids.ids)),
+            ('company_id', populate.randomize([company_ids.ids[0]])),
             ('currency_id', populate.randomize(currencies.ids)),
             ('journal_id', populate.compute(get_journal)),
             ('date', populate.randdatetime(relative_before=relativedelta(years=-4), relative_after=relativedelta(years=1))),
@@ -225,9 +225,9 @@ class AccountMove(models.Model):
 
     def _populate(self, size):
         records = super()._populate(size)
-        _logger.info('Posting Journal Entries')
-        to_post = records.filtered(lambda r: r.date < fields.Date.today())
-        to_post.action_post()
+        # _logger.info('Posting Journal Entries')
+        # to_post = records.filtered(lambda r: r.date < fields.Date.today())
+        # to_post.action_post()
 
         # TODO add some reconciliations. Not done initially because of perfs.
         # _logger.info('Registering Payments for Invoices and Bills')

--- a/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.js
+++ b/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+import { DashboardKanbanRecord } from '@account/components/bills_upload/bills_upload';
+import { useService } from "@web/core/utils/hooks";
+const { Component, onMounted, useState } = owl;
+
+export class AccountAsynchronousDashboard extends Component {
+
+    setup() {
+        this.orm = useService('orm');
+        onMounted(this.fetchData);
+        this.state = useState({
+            info: {}
+        })
+    }
+
+    async fetchData() {
+        const data = await this.orm.silent.read('account.journal', [this.props.journalId],['kanban_dashboard'], {});
+        console.log(this.props);
+        this.formatData(data.find((d) => d.id === this.props.journalId));
+        console.log('finish');
+    }
+
+    get dashboard() {
+        return this.state.info;
+    }
+
+    formatData(props) {
+        this.state.info = JSON.parse(props.kanban_dashboard);
+        console.log(this.state.info);
+    }
+
+}
+AccountAsynchronousDashboard.template = "account.AccountAsynchronousDashboard";
+
+DashboardKanbanRecord.components = {
+    ...DashboardKanbanRecord.components,
+    AccountAsynchronousDashboard,
+};

--- a/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.js
+++ b/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.js
@@ -9,7 +9,8 @@ export class AccountAsynchronousDashboard extends Component {
         this.orm = useService('orm');
         onMounted(this.fetchData);
         this.state = useState({
-            info: {}
+            info: {},
+            isLoading : true,
         })
     }
 
@@ -17,7 +18,6 @@ export class AccountAsynchronousDashboard extends Component {
         const data = await this.orm.silent.read('account.journal', [this.props.journalId],['kanban_dashboard'], {});
         console.log(this.props);
         this.formatData(data.find((d) => d.id === this.props.journalId));
-        console.log('finish');
     }
 
     get dashboard() {
@@ -26,7 +26,7 @@ export class AccountAsynchronousDashboard extends Component {
 
     formatData(props) {
         this.state.info = JSON.parse(props.kanban_dashboard);
-        console.log(this.state.info);
+        this.state.isLoading = false;
     }
 
 }

--- a/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.xml
+++ b/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.xml
@@ -2,6 +2,9 @@
 
 <templates>
     <t t-name="account.AccountAsynchronousDashboard" owl="1">
+        <div t-if="state.isLoading">
+            <i class="fa fa-spin fa-circle-o-notch"></i>
+        </div>
         <t t-if='Object.keys(dashboard).length != 0'>
             <t t-slot="default" t-props="dashboard"/>
         </t>

--- a/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.xml
+++ b/addons/account/static/src/components/account_asynchronous_dashboard/account_asynchronous_dashboard.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="account.AccountAsynchronousDashboard" owl="1">
+        <t t-if='Object.keys(dashboard).length != 0'>
+            <t t-slot="default" t-props="dashboard"/>
+        </t>
+    </t>
+
+</templates>

--- a/addons/account/static/src/components/journal_dashboard_values/journal_dashboard_values.js
+++ b/addons/account/static/src/components/journal_dashboard_values/journal_dashboard_values.js
@@ -1,0 +1,27 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+const { Component, onWillStart } = owl;
+
+export class JournalDashboardValues extends Component {
+
+    setup() {
+        this.orm = useService('orm');
+        onWillStart(this.fetchData);
+    }
+
+    async fetchData() {
+        const data = await this.orm.read(this.props.record.model, [this.props.record.resId],['json_activity_data'], {});
+        this.formatData(data)
+    }
+
+    formatData(props) {
+        this.info = JSON.parse(props);
+    }
+
+}
+JournalDashboardValues.template = "account.JournalDashboardValues";
+
+registry.category("fields").add("kanban_vat_activity", JournalDashboardValues);

--- a/addons/account/static/src/components/journal_dashboard_values/journal_dashboard_values.xml
+++ b/addons/account/static/src/components/journal_dashboard_values/journal_dashboard_values.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+
+     <t t-name="account.JournalDashboardValues" owl="1">
+        <t t-foreach="info.activities" t-as="activity" t-key="activity_index">
+
+        </t>
+        <!-- <a t-if="info.more_activities" class="float-end see_all_activities" href="#" t-on-click.stop.prevent="(ev) => this.openAllActivities(ev)">See all activities</a> -->
+    </t>
+
+</templates>

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -9,20 +9,21 @@
                 <field name="type"/>
                 <field name="color"/>
                 <field name="show_on_dashboard"/>
-                <field name="kanban_dashboard"/>
+                <!-- <field name="kanban_dashboard"/> -->
                 <field name="activity_ids"/>
                 <field name="activity_state"/>
                 <field name="alias_domain"/>
-                <field name="kanban_dashboard_graph"/>
+                <!-- <field name="kanban_dashboard_graph"/> -->
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                            <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
+                            <!-- <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/> -->
                             <t t-value="record.type.raw_value" t-set="journal_type"/>
-                            <t t-value="record.kanban_dashboard_graph.raw_value" t-set="dashboard_graph"/>
+                            <t t-value="0" t-set="dashboard_graph"/>
+                            <t t-set="journalId" t-value="record.id.raw_value"/>
                             <t t-call="AccountDropZoneUploader"/>
                             <t t-call="JournalTop"/>
-                            <div t-att-class="'container o_kanban_card_content' + (dashboard.is_sample_data ? ' o_sample_data' : '')">
+                            <div t-att-class="'container o_kanban_card_content'">
                                 <div class="row">
                                     <t t-if="(journal_type == 'bank' || journal_type == 'cash')" t-call="JournalBodyBankCash"/>
                                     <t t-if="journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodySalePurchase"/>
@@ -31,8 +32,9 @@
                                     <div class="col-12 col-sm-7 o_kanban_primary_right">
                                         <t t-call="HasSequenceHoles"/>
                                     </div>
+
                                 </div>
-                                <t t-if="(journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase') and dashboard_graph !== false" t-call="JournalBodyGraph"/>
+                                <t t-if="(journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase') and dashboard_graph == true" t-call="JournalBodyGraph"/>
                             </div><div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">
                                 <t t-call="JournalManage"/>
                             </div>
@@ -64,13 +66,15 @@
                         <div t-attf-class="o_kanban_card_header">
                             <div class="o_kanban_card_header_title">
                                 <div class="o_primary">
-                                    <a type="object" name="open_action"><field name="name"/></a>
-                                    <t t-if="dashboard.company_count > 1">
-                                        <span groups="base.group_multi_company" class="small">- <field name="company_id"/></span>
-                                    </t>
-                                </div>
-                                <div class="o_secondary" t-att-title="dashboard.title" t-if="journal_type == 'purchase' &amp;&amp; record.alias_domain.raw_value">
-                                    <field name="alias_id"/>
+                                    <div class="o_secondary" t-att-title="record.name.raw_value" t-if="journal_type == 'purchase' &amp;&amp; record.alias_domain.raw_value">
+                                        <field name="alias_id"/>
+                                    </div>
+                                    <!-- <AccountAsynchronousDashboard journalId="journalId" t-slot-scope="dashboard"> -->
+                                        <a type="object" name="open_action"><field name="name"/></a>
+                                        <t t-if="record.company_ids > 1">
+                                            <span groups="base.group_multi_company" class="small">- <field name="company_id"/></span>
+                                        </t>
+                                    <!-- </AccountAsynchronousDashboard> -->
                                 </div>
                             </div>
                             <div class="o_kanban_manage_button_section">
@@ -80,15 +84,14 @@
                     </t>
 
                     <t t-name="HasSequenceHoles">
-                        <field name="has_sequence_holes" invisible="1"/>
+                        <!-- <field name="has_sequence_holes" invisible="1"/>
                         <a t-if="record.has_sequence_holes.raw_value and journal_type == 'sale'" name="show_sequence_holes" type="object" class="text-warning">
                             <i class="fa fa-exclamation-triangle"/>
                             Gaps in the sequence
-                        </a>
+                        </a> -->
                     </t>
 
                     <t t-name="JournalManage">
-
                         <!-- For bank and cash -->
                         <div t-if="journal_type == 'bank' || journal_type == 'cash'" class="row">
                              <div class="col-4 o_kanban_card_manage_section o_kanban_manage_view">
@@ -255,16 +258,19 @@
                         </div>
                         <div class="col-12 col-sm-8 o_kanban_primary_right">
                             <field name="json_activity_data" widget="kanban_vat_activity"/>
-                            <t t-if="dashboard.number_to_check > 0">
-                                <div class="row">
-                                    <div class="col overflow-hidden text-start">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_move_journal_line', 'search_default_to_check': True}"><t t-esc="dashboard.number_to_check"/> to check</a>
+                            <AccountAsynchronousDashboard journalId="journalId" t-slot-scope="dashboard">
+                                <t t-if="dashboard.number_to_check > 0">
+
+                                    <div class="row">
+                                        <div class="col overflow-hidden text-start">
+                                            <a type="object" name="open_action" context="{'action_name': 'action_move_journal_line', 'search_default_to_check': True}"><t t-esc="dashboard.number_to_check"/> to check</a>
+                                        </div>
+                                        <div class="col-auto text-end">
+                                            <span><t t-esc="dashboard.to_check_balance"/></span>
+                                        </div>
                                     </div>
-                                    <div class="col-auto text-end">
-                                        <span><t t-esc="dashboard.to_check_balance"/></span>
-                                    </div>
-                                </div>
-                            </t>
+                                </t>
+                            </AccountAsynchronousDashboard>
                         </div>
                     </t>
 
@@ -272,48 +278,51 @@
                         <!-- On the left, display :
                             - A button corresponding to the bank_statements_source, if it wasn't configured, a button for each of them
                             - If there are statements to reconcile, a link to reconcile them -->
-                        <div id="dashboard_bank_cash_left" class="col-12 col-sm-5 mb-3 mb-sm-0 o_kanban_primary_left">
-                            <t t-if="journal_type == 'bank'">
-                                <t t-if="dashboard.bank_statements_source == 'undefined'">
-                                    <a t-if="dashboard.number_to_reconcile > 0" name="action_configure_bank_journal" type="object" class="oe_inline" groups="account.group_account_invoice">Connect</a>
-                                    <button t-if="dashboard.number_to_reconcile == 0" name="action_configure_bank_journal" type="object" class="btn btn-primary" groups="account.group_account_invoice">Connect</button>
-                                </t>
-                                <div name="bank_journal_cta" class="mt-3 mt-sm-0"/>
-                            </t>
-                            <t t-if="journal_type == 'cash'">
-                                <a t-if="dashboard.number_to_reconcile > 0" type="object" name="create_cash_statement" class="oe_inline" groups="account.group_account_invoice">New Transaction</a>
-                                <button t-if="dashboard.number_to_reconcile == 0" type="object" name="create_cash_statement" class="btn btn-primary" groups="account.group_account_invoice">New Transaction</button>
-                            </t>
-                        </div>
+                            <AccountAsynchronousDashboard journalId="journalId" t-slot-scope="dashboard">
+                                <div id="dashboard_bank_cash_left" class="col-12 col-sm-5 mb-3 mb-sm-0 o_kanban_primary_left">
+                                    <t t-if="journal_type == 'bank'">
+                                        <t t-if="dashboard.bank_statements_source == 'undefined'">
+                                            <a t-if="dashboard.number_to_reconcile > 0" name="action_configure_bank_journal" type="object" class="oe_inline" groups="account.group_account_invoice">Connect</a>
+                                            <button t-if="dashboard.number_to_reconcile == 0" name="action_configure_bank_journal" type="object" class="btn btn-primary" groups="account.group_account_invoice">Connect</button>
+                                        </t>
+                                    </t>
+                                    <div name="bank_journal_cta" class="mt-3 mt-sm-0"/>
+                                    <t t-if="journal_type == 'cash'">
+                                        <a t-if="dashboard.number_to_reconcile > 0" type="object" name="create_cash_statement" class="oe_inline" groups="account.group_account_invoice">New Transaction</a>
+                                        <button t-if="dashboard.number_to_reconcile == 0" type="object" name="create_cash_statement" class="btn btn-primary" groups="account.group_account_invoice">New Transaction</button>
+                                    </t>
+                                </div>
+
                         <!-- On the right, show other common informations/actions -->
-                        <div id="dashboard_bank_cash_right" class="col-12 col-sm-7 o_kanban_primary_right">
-                            <div class="row" t-if="dashboard.nb_lines_bank_account_balance > 0">
-                                <div id="dashboard_bank_cash_balance" class="col overflow-hidden text-start">
-                                    <span title="Balance in General Ledger">Balance in GL</span>
-                                </div>
-                                <div class="col-auto text-end">
-                                    <span><t t-esc="dashboard.account_balance"/></span>
-                                </div>
-                            </div>
-                            <div class="row" t-if="dashboard.nb_lines_outstanding_pay_account_balance > 0">
-                                <div id="dashboard_bank_cash_outstanding_balance" class="col overflow-hidden text-start">
-                                    <span title="Outstanding Payments/Receipts">Outstanding Payments/Receipts</span>
-                                </div>
-                                <div class="col-auto text-end">
-                                    <span><t t-esc="dashboard.outstanding_pay_account_balance"/></span>
-                                </div>
-                            </div>
-                            <t t-if="dashboard.has_at_least_one_statement and dashboard.account_balance != dashboard.last_balance">
-                                <div class="row" name="latest_statement">
-                                    <div class="col overflow-hidden text-start">
-                                        <span title="Latest Statement">Latest Statement</span>
+                            <div id="dashboard_bank_cash_right" class="col-12 col-sm-7 o_kanban_primary_right">
+                                <div class="row" t-if="dashboard.nb_lines_bank_account_balance > 0">
+                                    <div id="dashboard_bank_cash_balance" class="col overflow-hidden text-start">
+                                        <span title="Balance in General Ledger">Balance in GL</span>
                                     </div>
                                     <div class="col-auto text-end">
-                                        <span><t t-esc="dashboard.last_balance"/></span>
+                                        <span><t t-esc="dashboard.account_balance"/></span>
                                     </div>
                                 </div>
-                            </t>
-                        </div>
+                                <div class="row" t-if="dashboard.nb_lines_outstanding_pay_account_balance > 0">
+                                    <div id="dashboard_bank_cash_outstanding_balance" class="col overflow-hidden text-start">
+                                        <span title="Outstanding Payments/Receipts">Outstanding Payments/Receipts</span>
+                                    </div>
+                                    <div class="col-auto text-end">
+                                        <span><t t-esc="dashboard.outstanding_pay_account_balance"/></span>
+                                    </div>
+                                </div>
+                                <t t-if="dashboard.has_at_least_one_statement and dashboard.account_balance != dashboard.last_balance">
+                                    <div class="row" name="latest_statement">
+                                        <div class="col overflow-hidden text-start">
+                                            <span title="Latest Statement">Latest Statement</span>
+                                        </div>
+                                        <div class="col-auto text-end">
+                                            <span><t t-esc="dashboard.last_balance"/></span>
+                                        </div>
+                                    </div>
+                                </t>
+                            </div>
+                        </AccountAsynchronousDashboard>
                     </t>
                     <t t-name="JournalBodySalePurchase" id="account.JournalBodySalePurchase">
                         <div class="col-12 col-sm-5 mb-3 mb-sm-0 o_kanban_primary_left">
@@ -323,7 +332,7 @@
                                 </button>
                             </t>
                             <t t-if="journal_type == 'purchase'">
-                                <field name="entries_count" invisible="1"/>
+                                <!-- <field name="entries_count" invisible="1"/>
                                 <t t-if="record.entries_count.raw_value > 0">
                                     <t t-call="AccountKanbanUploaderButton">
                                         <a role="button" class="btn btn-primary oe_kanban_action_button" groups="account.group_account_invoice">
@@ -331,67 +340,70 @@
                                         </a>
                                     </t>
                                 </t>
-                                <t t-else="">
+                                <t t-else=""> -->
                                     <button type="object" name="action_create_vendor_bill" class="btn btn-primary oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">
                                         <span>Upload</span>
                                     </button>
-                                </t>
+                                <!-- </t> -->
                                 <a type="object" name="action_create_new" class="o_invoice_new" groups="account.group_account_invoice">Create Manually</a>
                             </t>
                         </div>
-                        <div class="col-12 col-sm-7 o_kanban_primary_right">
-                            <div class="row" t-if="dashboard.number_draft">
-                                <div class="col overflow-hidden text-start">
-                                    <a type="object" name="open_action" context="{'search_default_draft': '1'}">
-                                        <span t-if="journal_type == 'sale'" title="Invoices to Validate"><t t-esc="dashboard.number_draft"/> Invoices to Validate</span>
-                                        <span t-if="journal_type == 'purchase'" title="Bills to Validate"><t t-esc="dashboard.number_draft"/> Bills to Validate</span>
-                                    </a>
-                                </div>
-                                <div class="col-auto text-end">
-                                    <span><t t-esc="dashboard.sum_draft"/></span>
-                                </div>
-                            </div>
-                            <div class="row" t-if="dashboard.number_waiting">
-                                <div class="col overflow-hidden text-start">
-                                    <a type="object" t-if="journal_type == 'sale'" name="open_action"
-                                    context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_sale_pay_link">
-                                        <t t-esc="dashboard.number_waiting"/> Unpaid Invoices
-                                    </a>
-
-                                    <a type="object" t-if="journal_type == 'purchase'" name="open_action"
-                                    context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_purchase_pay_link">
-                                        <t t-esc="dashboard.number_waiting"/> Bills to Pay
-                                    </a>
-                                </div>
-                                <div class="col-auto text-end">
-                                    <span><t t-esc="dashboard.sum_waiting"/></span>
-                                </div>
-                            </div>
-                            <div class="row" t-if="dashboard.number_late">
-                                <div class="col overflow-hidden text-start">
-                                    <a type="object" name="open_action" context="{'search_default_late': '1'}">
-                                        <span t-if="journal_type == 'sale'" title="Late Invoices"><t t-esc="dashboard.number_late"/> Late Invoices</span>
-                                        <span t-if="journal_type == 'purchase'" title="Late Bills"><t t-esc="dashboard.number_late"/> Late Bills</span>
-                                    </a>
-                                </div>
-                                <div class="col-auto text-end">
-                                    <span><t t-esc="dashboard.sum_late"/></span>
-                                </div>
-                            </div>
-                            <t t-if="dashboard.number_to_check > 0">
-                                <div class="row">
+                        <AccountAsynchronousDashboard journalId="journalId" t-slot-scope="dashboard">
+                            <t t-log="dashboard"/>
+                            <div class="col-12 col-sm-7 o_kanban_primary_right">
+                                <div class="row" t-if="dashboard.number_draft">
                                     <div class="col overflow-hidden text-start">
-                                        <a type="object" name="open_action" context="{'search_default_to_check': True}"><t t-esc="dashboard.number_to_check"/> to check</a>
+                                        <a type="object" name="open_action" context="{'search_default_draft': '1'}">
+                                            <span t-if="journal_type == 'sale'" title="Invoices to Validate"><t t-esc="dashboard.number_draft"/> Invoices to Validate</span>
+                                            <span t-if="journal_type == 'purchase'" title="Bills to Validate"><t t-esc="dashboard.number_draft"/> Bills to Validate</span>
+                                        </a>
                                     </div>
                                     <div class="col-auto text-end">
-                                        <span><t t-esc="dashboard.to_check_balance"/></span>
+                                        <span><t t-esc="dashboard.sum_draft"/></span>
                                     </div>
                                 </div>
-                            </t>
-                        </div>
+                                <div class="row" t-if="dashboard.number_waiting">
+                                    <div class="col overflow-hidden text-start">
+                                        <a type="object" t-if="journal_type == 'sale'" name="open_action"
+                                        context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_sale_pay_link">
+                                            <t t-esc="dashboard.number_waiting"/> Unpaid Invoices
+                                        </a>
+
+                                        <a type="object" t-if="journal_type == 'purchase'" name="open_action"
+                                        context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_purchase_pay_link">
+                                            <t t-esc="dashboard.number_waiting"/> Bills to Pay
+                                        </a>
+                                    </div>
+                                    <div class="col-auto text-end">
+                                        <span><t t-esc="dashboard.sum_waiting"/></span>
+                                    </div>
+                                </div>
+                                <div class="row" t-if="dashboard.number_late">
+                                    <div class="col overflow-hidden text-start">
+                                        <a type="object" name="open_action" context="{'search_default_late': '1'}">
+                                            <span t-if="journal_type == 'sale'" title="Late Invoices"><t t-esc="dashboard.number_late"/> Late Invoices</span>
+                                            <span t-if="journal_type == 'purchase'" title="Late Bills"><t t-esc="dashboard.number_late"/> Late Bills</span>
+                                        </a>
+                                    </div>
+                                    <div class="col-auto text-end">
+                                        <span><t t-esc="dashboard.sum_late"/></span>
+                                    </div>
+                                </div>
+                                <t t-if="dashboard.number_to_check > 0">
+                                    <div class="row">
+                                        <div class="col overflow-hidden text-start">
+                                            <a type="object" name="open_action" context="{'search_default_to_check': True}"><t t-esc="dashboard.number_to_check"/> to check</a>
+                                        </div>
+                                        <div class="col-auto text-end">
+                                            <span><t t-esc="dashboard.to_check_balance"/></span>
+                                        </div>
+                                    </div>
+                                </t>
+                            </div>
+                        </AccountAsynchronousDashboard>
                     </t>
                     <t t-name="JournalBodyGraph">
-                        <field name="kanban_dashboard_graph" t-att-graph_type="['cash','bank'].includes(journal_type) ? 'line' : 'bar'" widget="dashboard_graph"/>
+                        <!-- <field name="kanban_dashboard_graph" t-att-graph_type="['cash','bank'].includes(journal_type) ? 'line' : 'bar'" widget="dashboard_graph"/> -->
                     </t>
             </templates>
             </kanban>

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -13,11 +13,13 @@
                 <field name="activity_ids"/>
                 <field name="activity_state"/>
                 <field name="alias_domain"/>
+                <field name="kanban_dashboard_graph"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
                             <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
                             <t t-value="record.type.raw_value" t-set="journal_type"/>
+                            <t t-value="record.kanban_dashboard_graph.raw_value" t-set="dashboard_graph"/>
                             <t t-call="AccountDropZoneUploader"/>
                             <t t-call="JournalTop"/>
                             <div t-att-class="'container o_kanban_card_content' + (dashboard.is_sample_data ? ' o_sample_data' : '')">
@@ -30,7 +32,7 @@
                                         <t t-call="HasSequenceHoles"/>
                                     </div>
                                 </div>
-                                <t t-if="journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodyGraph"/>
+                                <t t-if="(journal_type == 'bank' || journal_type == 'cash' || journal_type == 'sale' || journal_type == 'purchase') and dashboard_graph !== false" t-call="JournalBodyGraph"/>
                             </div><div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">
                                 <t t-call="JournalManage"/>
                             </div>

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -9,6 +9,7 @@ from lxml import etree
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError
 from odoo.tools import parse_date
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF
 
 _logger = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ class Currency(models.Model):
                                   LIMIT 1), 1.0) AS rate
                    FROM res_currency c
                    WHERE c.id IN %s"""
-        self._cr.execute(query, (date, company.id, tuple(self.ids)))
+        self._cr.execute(query, (date.strftime(DF), company.id, tuple(self.ids)))
         currency_rates = dict(self._cr.fetchall())
         return currency_rates
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: This PR add a new option in the settings to disable the graphs in the accounting dashboards. Those graphs can make the longer to load, so if the user don't need it, he can remove them.

Current behavior before PR: In the accounting dashboard the graphs are automatically loaded

Desired behavior after PR is merged: The user can select in the options if he want the graph or not for better performance




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
