### PR TITLE
[FIX] product: speedup _name_search for dynamic variants templates

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -489,8 +489,10 @@ class ProductTemplate(models.Model):
         # we don't see another way to do it
         tmpl_without_variant_ids = []
         if not limit or len(searched_ids) < limit:
+            # Set default order to search queries to avoid joining on ir.translation because of product.template._order = name, which is a translated field.
             tmpl_without_variant_ids = self.env['product.template'].search(
-                [('id', 'not in', self.env['product.template']._search([('product_variant_ids.active', '=', True)]))]
+                [('id', 'not in', self.env['product.template']._search([('product_variant_ids.active', '=', True)], order='id'))],
+                order='id'
             )
         if tmpl_without_variant_ids:
             domain = expression.AND([args or [], [('id', 'in', tmpl_without_variant_ids.ids)]])


### PR DESCRIPTION
When `product.template's _name_search` while loop returns less than `limit` products, we try to add product.templates without `product_variant_ids` (or with archived `product_variant_ids`). This happens when a product.template has dynamic
variant creation for some attributes (the variants will be created when used on an SO).

The issue is that since product.template has
`self._order = 'name'` and product.template.name
is a translated field, a search of the form
`self.env['product.template']._search(domain)` will generate a LEFT JOIN on ir.translaton. This LEFT JOIN comes from the `_generate_order_by` method of models.py.

On big databases (300K templates/products and 2M translations) the search for templates without product_variant_ids becomes slower because of this LEFT JOIN.

Using the default model order, which is order=id, removes this LEFT JOIN on ir.translation.
Since the results of both searches on product.template are only used in a domain with the 'IN' operator, we don't actually
care about the ordering of the templates

#### speedup

Customer DB 1: 384000 templates/products, 2.3M ir.translations, all products are active.
Customer DB 2: 480000 templates/products, 2.8M ir.translations, all products are active.

`product.template._name_search` returning 5 templates (limit=8) avg time:

- DB 1: 1.95s -> 1.25s
- DB 2: 2.3s -> 1.48s

Customer DB 1: 384000 templates/products, 2.3M ir.translations, 150000 archived products.
Customer DB 2: 480000 templates/products, 2.8M ir.translations, 200000 archived products.

- DB 1: 2.45s -> 0.95s
- DB 2: 1.92s -> 1.20s

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
