### PR TITLE
Small cleans of read_group

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -168,15 +168,15 @@ class Product(models.Model):
         Quant = self.env['stock.quant'].with_context(active_test=False)
         domain_move_in_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_in
         domain_move_out_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_out
-        moves_in_res = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_in_todo, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-        moves_out_res = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_out_todo, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-        quants_res = dict((item['product_id'][0], (item['quantity'], item['reserved_quantity'])) for item in Quant._read_group(domain_quant, ['product_id', 'quantity', 'reserved_quantity'], ['product_id'], orderby='id'))
+        moves_in_res = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_in_todo, ['product_qty'], ['product_id']))
+        moves_out_res = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_out_todo, ['product_qty'], ['product_id']))
+        quants_res = dict((item['product_id'][0], (item['quantity'], item['reserved_quantity'])) for item in Quant._read_group(domain_quant, ['quantity', 'reserved_quantity'], ['product_id']))
         if dates_in_the_past:
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
-            moves_in_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_in_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-            moves_out_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_out_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
+            moves_in_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_in_done, ['product_qty'], ['product_id']))
+            moves_out_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_out_done, ['product_qty'], ['product_id']))
 
         res = dict()
         for product in self.with_context(prefetch_fields=False):
@@ -367,7 +367,7 @@ class Product(models.Model):
             domain_quant.append(('owner_id', '=', owner_id))
         if package_id:
             domain_quant.append(('package_id', '=', package_id))
-        quants_groupby = self.env['stock.quant']._read_group(domain_quant, ['product_id', 'quantity'], ['product_id'], orderby='id')
+        quants_groupby = self.env['stock.quant']._read_group(domain_quant, ['quantity'], ['product_id'])
 
         # check if we need include zero values in result
         include_zero = (
@@ -588,7 +588,7 @@ class Product(models.Model):
         :rtype: defaultdict(float)
         """
         domain_quant = expression.AND([self._get_domain_locations()[0], [('product_id', 'in', self.ids)]])
-        quants_groupby = self.env['stock.quant']._read_group(domain_quant, ['product_id', 'quantity'], ['product_id'], orderby='id')
+        quants_groupby = self.env['stock.quant']._read_group(domain_quant, ['quantity'], ['product_id'])
         currents = defaultdict(float)
         for c in quants_groupby:
             currents[c['product_id'][0]] = c['quantity']

--- a/odoo/addons/test_read_group/tests/test_m2m_grouping.py
+++ b/odoo/addons/test_read_group/tests/test_m2m_grouping.py
@@ -133,8 +133,7 @@ class TestM2MGrouping(common.TransactionCase):
         # as superuser, ir.rule should not apply
         expected = """
             SELECT
-                min("test_read_group_task".id) AS id,
-                count("test_read_group_task".id) AS "user_ids_count",
+                COUNT(*) AS "user_ids_count",
                 array_agg("test_read_group_task"."name") AS "name",
                 "test_read_group_task__user_ids"."user_id" AS "user_ids"
             FROM "test_read_group_task"
@@ -178,8 +177,7 @@ class TestM2MGrouping(common.TransactionCase):
 
         expected = """
             SELECT
-                min("test_read_group_task".id) AS id,
-                count("test_read_group_task".id) AS "user_ids_count",
+                count(*) AS "user_ids_count",
                 array_agg("test_read_group_task"."name") AS "name",
                 "test_read_group_task__user_ids"."user_id" AS "user_ids"
             FROM "test_read_group_task"

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2407,7 +2407,7 @@ class BaseModel(metaclass=MetaModel):
         else:
             existing = sorted(set().union(existing, required_dates))
 
-        empty_item = {'id': False, (groupby_name.split(':')[0] + '_count'): 0}
+        empty_item = {(groupby_name.split(':')[0] + '_count'): 0}
         empty_item.update({key: False for key in aggregated_fields})
         empty_item.update({key: False for key in [group['groupby'] for group in annotated_groupbys[1:]]})
 
@@ -2461,7 +2461,7 @@ class BaseModel(metaclass=MetaModel):
             is_many2one_id = order_field.endswith(".id")
             if is_many2one_id:
                 order_field = order_field[:-3]
-            if order_field == 'id' or order_field in groupby_fields:
+            if order_field in groupby_fields:
                 order_field_name = order_field.split(':')[0]
                 if self._fields[order_field_name].type == 'many2one' and not is_many2one_id:
                     order_clause = self._generate_order_by(order_part, query)
@@ -2632,7 +2632,6 @@ class BaseModel(metaclass=MetaModel):
         data['__domain'] = expression.AND(sections)
         if len(groupby) - len(annotated_groupbys) >= 1:
             data['__context'] = { 'group_by': groupby[len(annotated_groupbys):]}
-        del data['id']
         return data
 
     @api.model
@@ -2805,7 +2804,7 @@ class BaseModel(metaclass=MetaModel):
         prefix_term = lambda prefix, term: ('%s %s' % (prefix, term)) if term else ''
 
         query = """
-            SELECT min("%(table)s".id) AS id, count("%(table)s".id) AS "%(count_field)s" %(extra_fields)s
+            SELECT COUNT(*) AS "%(count_field)s" %(extra_fields)s
             FROM %(from)s
             %(where)s
             %(groupby)s
@@ -2813,7 +2812,6 @@ class BaseModel(metaclass=MetaModel):
             %(limit)s
             %(offset)s
         """ % {
-            'table': self._table,
             'count_field': count_field,
             'extra_fields': prefix_terms(',', select_terms),
             'from': from_clause,


### PR DESCRIPTION
[IMP] core: simplify SQL query generated from read_group

- The query aggreagate the `min(<table>.id)` but the result of it is
removed later in `_read_group_format_result`. Then it generates a waste
of CPU/IO for PostgreSQL. It was usefull only to able to sort only by
`id`, but it always better to sort on the groupby key, because
PostgreSQL need to already do to create groups.
- Also `<table>.id` inside the `count` generate extra work from
PostgreSQL because it needs to check if each `id` is NOT NULL (always)
and fetch `id` from disk for nothing.

task-2994273