### PR TITLE
[FIX] pos_sale_product_configurator: fix reading variable pos

### DIFF
--- a/addons/pos_sale_product_configurator/static/src/js/models.js
+++ b/addons/pos_sale_product_configurator/static/src/js/models.js
@@ -24,7 +24,7 @@ odoo.define('pos_sale_product_configurator.models', function (require) {
                 );
                 if (isProductLoaded) {
                     const quantity = this.get_selected_orderline().get_quantity();
-                    const info = await this.env.pos.getProductInfo(product, quantity);
+                    const info = await this.pos.getProductInfo(product, quantity);
                     Gui.showPopup('ProductInfoPopup', {info: info , product: product});
                 }
             }


### PR DESCRIPTION
For `Order` class, the `pos` variable is available directly [1], while `env` available in `PosModel` class only [2]
`undefined`.

To reproduce:

- One product with two optional products set in the "Optional Products" field
- POS with "Open Product Info" activated in the POS settings (not needed in v16)
- Add product to the POS Cart

[1]: https://github.com/odoo/odoo/blob/4fa5829a885362763a9162908c282631ce8770b5/addons/point_of_sale/static/src/js/models.js#L2946-L2953 [2]: https://github.com/odoo/odoo/blob/4fa5829a885362763a9162908c282631ce8770b5/addons/point_of_sale/static/src/js/models.js#L36-L42

opw-2992398

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
