### PR TITLE
[IMP] base: add cache_longterm (type memo) should never be invalidated

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -34,14 +34,12 @@ class TestTOTP(HttpCase):
                 return totp.generate(time.time() + 30).token
         # because not preprocessed by ControllerType metaclass
         totp_hook.routing_type = 'json'
-        self.env['ir.http']._clear_routing_map()
         # patch Home to add test endpoint
         Home.totp_hook = http.route('/totphook', type='json', auth='none')(totp_hook)
         # remove endpoint and destroy routing map
         @self.addCleanup
         def _cleanup():
             del Home.totp_hook
-            self.env['ir.http']._clear_routing_map()
 
     def test_totp(self):
         # 1. Enable 2FA

--- a/addons/auth_totp_portal/tests/test_tour.py
+++ b/addons/auth_totp_portal/tests/test_tour.py
@@ -31,12 +31,10 @@ class TestTOTPortal(HttpCase):
         totp_hook.routing_type = 'json'
         # patch Home to add test endpoint
         Home.totp_hook = http.route('/totphook', type='json', auth='none')(totp_hook)
-        self.env['ir.http']._clear_routing_map()
         # remove endpoint and destroy routing map
         @self.addCleanup
         def _cleanup():
             del Home.totp_hook
-            self.env['ir.http']._clear_routing_map()
 
         self.start_tour('/my/security', 'totportal_tour_setup', login='portal')
         # also disables totp otherwise we can't re-login

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -650,7 +650,10 @@ class IrHttp(models.AbstractModel):
         return response
 
     @api.model
-    @tools.ormcache('path', 'query_args')
+    @tools.ormcache_longterm(
+        'self.env["website"]._get_cache_longterm_key()',
+        'self.env["website.rewrite"]._get_cache_longterm_key()',
+        'path', 'query_args')
     def url_rewrite(self, path, query_args=None):
         new_url = False
         router = http.root.get_db_router(request.db).bind('')

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -67,11 +67,6 @@ class Http(models.AbstractModel):
         return super(Http, cls).routing_map(key=key)
 
     @classmethod
-    def clear_caches(cls):
-        super()._clear_routing_map()
-        return super().clear_caches()
-
-    @classmethod
     def _slug_matching(cls, adapter, endpoint, **kw):
         for arg in kw:
             if isinstance(kw[arg], models.BaseModel):
@@ -86,6 +81,8 @@ class Http(models.AbstractModel):
         domain = [('redirect_type', 'in', ('308', '404')), '|', ('website_id', '=', False), ('website_id', '=', website_id)]
 
         rewrites = dict([(x.url_from, x) for x in request.env['website.rewrite'].sudo().search(domain)])
+        if not hasattr(cls, '_rewrite_len'):
+            cls._rewrite_len = {}
         cls._rewrite_len[website_id] = len(rewrites)
 
         for url, endpoint in super()._generate_routing_rules(modules, converters):

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -56,6 +56,11 @@ class IrQWeb(models.AbstractModel):
         """ Return the list of context keys to use for caching ``_compile``. """
         return super()._get_template_cache_keys() + ['website_id']
 
+    def _get_cache_longterm_key(self, view_id):
+        """ Add the website information to take care the website cdn in compiled view.
+        """
+        return super()._get_cache_longterm_key(view_id) + self.env['website']._get_cache_longterm_key()
+
     def _prepare_frontend_environment(self, values):
         """ Update the values and context with website specific value
             (required to render website layout template)
@@ -113,7 +118,7 @@ class IrQWeb(models.AbstractModel):
         return irQweb
 
     def _get_asset_bundle(self, xmlid, files, env=None, css=True, js=True):
-        return AssetsBundleMultiWebsite(xmlid, files, env=env)
+        return AssetsBundleMultiWebsite(xmlid, files, env=env, css=css, js=js)
 
     def _post_processing_att(self, tagName, atts):
         if atts.get('data-no-post-process'):

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -105,6 +105,8 @@ class TestQwebProcessAtt(TransactionCase):
         self.website.cdn_activated = True
         self.website.cdn_url = "http://test.cdn"
         self.website.cdn_filters = "\n".join(["^(/[a-z]{2}_[A-Z]{2})?/a$", "^(/[a-z]{2})?/a$", "^/b$"])
+        TransactionCase.update_write_date_for_cache_longterm(self.website)
+        self.website.flush_recordset()
 
     def _test_att(self, url, expect, tag='a', attribute='href'):
         self.assertEqual(

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -217,6 +217,7 @@ class TestViewSaving(TestViewSavingCommon):
         # common text nodes should be be escaped client side
         replacement = u'world &amp;amp; &amp;lt;b&amp;gt;cie'
         view.save(replacement, xpath='/t/p')
+        common.TransactionCase.update_write_date_for_cache_longterm(view)
         self.assertIn(replacement, view.arch, 'common text node should not be escaped server side')
         self.assertIn(
             replacement,

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -621,6 +621,9 @@ class IrAttachment(models.Model):
             return True
         self.check('unlink')
 
+        if any(a.name.endswith('.css') or a.name.endswith('.js') for a in self):
+            self.clear_caches()
+
         # First delete in the database, *then* in the filesystem if the
         # database allowed it. Helps avoid errors when concurrent transactions
         # are deleting the same file, and some of the transactions are

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -384,6 +384,7 @@ from odoo.tools.safe_eval import assert_valid_codeobj, _BUILTINS, to_opcodes, _E
 from odoo.tools.json import scriptsafe
 from odoo.tools.misc import str2bool
 from odoo.tools.image import image_data_uri
+from odoo.tools.lru import LRU
 from odoo.http import request
 from odoo.modules.module import get_resource_path, get_module_path
 from odoo.tools.profiler import QwebTracker
@@ -436,6 +437,12 @@ SPECIAL_DIRECTIVES = {'t-translation', 't-ignore', 't-title'}
 # Name of the variable to insert the content in t-call in the template.
 # The slot will be replaced by the `t-call` tag content of the caller.
 T_CALL_SLOT = '0'
+
+
+# This cache does not communicate with other workers, and should never
+# be invalidated! Cache keys should be chosen wisely. The keys
+# themselves may partly be in the normal orm cache.
+qweb_cache = LRU(8192)
 
 
 def indent_code(code, level):
@@ -549,6 +556,7 @@ class IrQWeb(models.AbstractModel):
             * ``inherit_branding_auto`` (bool) add the branding on fields
             * ``minimal_qcontext``(bool) To use the minimum context and options
                 from ``_prepare_environment``
+            * ``preserve_comments``(bool) To preserve xml comment in the final render
 
         :returns: bytes marked as markup-safe (decode to :class:`markupsafe.Markup`
                   instead of `str`)
@@ -572,37 +580,32 @@ class IrQWeb(models.AbstractModel):
     # assume cache will be invalidated by third party on write to ir.ui.view
     def _get_template_cache_keys(self):
         """ Return the list of context keys to use for caching ``_compile``. """
-        return ['lang', 'inherit_branding', 'edit_translations', 'profile']
+        return ['lang', 'inherit_branding', 'edit_translations', 'profile', 'preserve_comments']
 
-    @tools.conditional(
-        'xml' not in tools.config['dev_mode'],
-        tools.ormcache('template', 'tuple(self.env.context.get(k) for k in self._get_template_cache_keys())'),
-    )
-    def _get_view_id(self, template):
-        try:
-            return self.env['ir.ui.view'].sudo().with_context(load_all_views=True)._get_view_id(template)
-        except Exception:
-            return None
+    def _get_cache_longterm_key(self, view_id):
+        return ((view_id,)
+            + self.env["ir.ui.view"]._get_cache_longterm_key(view_id)
+            + tuple(self.env.context.get(k) for k in self._get_template_cache_keys()))
 
     @QwebTracker.wrap_compile
     def _compile(self, template, cache=None):
+        ref, cache_key = None, None
         if isinstance(template, etree._Element):
             self = self.with_context(is_t_cache_disabled=True)
-            ref = None
         else:
-            ref = self._get_view_id(template)
-
-        # define the base key cache for code in cache and t-cache feature
-        base_key_cache = None
-        if ref:
-            base_key_cache = self._get_cache_key(tuple([ref] + [self.env.context.get(k) for k in self._get_template_cache_keys()]))
-        self = self.with_context(__qweb_base_key_cache=base_key_cache)
+            try:
+                ref = self.env['ir.ui.view'].sudo().with_context(load_all_views=True)._get_view_id(template)
+                # define the base key cache for code in cache and t-cache feature
+                cache_key = ref and self._get_cache_longterm_key(ref)
+            except Exception:
+                pass
 
         # generate the template functions and the root function name
         def generate_functions():
             code, options, def_name = self._generate_code(template)
             code = '\n'.join([
                 "def generate_functions():",
+                f"    cache_longterm_key = {cache_key!r}",
                 "    template_functions = {}",
                 indent_code(code, 1),
                 f"    template_functions['options'] = {options if self.env.context.get('profile') else None!r}",
@@ -621,7 +624,7 @@ class IrQWeb(models.AbstractModel):
                 raise QWebException("Error when compiling xml template",
                     self, template, code=code, ref=ref) from e
 
-        return self._load_values(base_key_cache, generate_functions, cache)
+        return self._load_values(cache_key, generate_functions, cache)
 
     def _generate_code(self, template):
         """ Compile the given template into a rendering function (generator)::
@@ -2124,6 +2127,11 @@ class IrQWeb(models.AbstractModel):
         if len(el) > 0:
             raise SyntaxError("t-call-assets cannot contain children nodes")
 
+        if not compile_context.get('call_assets_nocache'):
+            compile_context['call_assets_nocache'] = True
+            el.attrib['t-nocache'] = ''
+            return self._compile_node(el, compile_context, level)
+
         code = self._flush_text(compile_context, level)
         xmlid = el.attrib.pop('t-call-assets')
         css = self._compile_bool(el.attrib.pop('t-css', True))
@@ -2203,7 +2211,7 @@ class IrQWeb(models.AbstractModel):
         code.append(indent_code(f"""
             template_cache_key = {self._compile_expr(expr)} if not self.env.context.get('is_t_cache_disabled') else None
             cache_key = self._get_cache_key(template_cache_key) if template_cache_key else None
-            uniq_cache_key = cache_key and ({str(self.env.context['__qweb_base_key_cache'])!r}, '{def_name}_cache', cache_key)
+            uniq_cache_key = cache_key and (cache_longterm_key, '{def_name}_cache', cache_key)
             loaded_values = values['__qweb_loaded_values']
             def {def_name}_cache():
                 content = []
@@ -2408,15 +2416,18 @@ class IrQWeb(models.AbstractModel):
             cache_key = (cache_key,)
         keys = []
         for item in cache_key:
-            try:
-                # use try catch instead of isinstance to detect lazy values
-                keys.append(item._name)
-                keys.append(tuple(item.ids))
-                dates = item.mapped('write_date')
-                if dates:
-                    keys.append(max(dates).timestamp())
-            except AttributeError:
-                keys.append(repr(item))
+            if hasattr(item, '_get_qweb_t_cache_key'):
+                keys.append(item._get_qweb_t_cache_key())
+            else:
+                try:
+                    # use try catch instead of isinstance to detect lazy values
+                    keys.append(item._name)
+                    keys.append(tuple(item.ids))
+                    dates = item.mapped('write_date')
+                    if dates:
+                        keys.append(max(dates).timestamp())
+                except AttributeError:
+                    keys.append(repr(item))
         return tuple(keys)
 
     def _load_values(self, cache_key, get_value, loaded_values=None):
@@ -2433,26 +2444,33 @@ class IrQWeb(models.AbstractModel):
 
     # The cache does not need to be invalidated if the 'base_key_cache'
     # in '_compile' method contains the write_date of all inherited views.
-    @tools.conditional(
-        'xml' not in tools.config['dev_mode'],
-        tools.ormcache('cache_key'),
-    )
     def _get_cached_values(self, cache_key, get_value):
         """ generate value from the function if the result is not cached. """
-        return get_value()
+        if not cache_key or 'xml' in tools.config['dev_mode']:
+            return get_value()
+        try:
+            return qweb_cache[cache_key]
+        except KeyError:
+            qweb_cache[cache_key] = get_value()
+            return qweb_cache[cache_key]
+
+    def _get_asset_cache_key(self):
+        context_key = tuple(self.context.get(k) for k in self._get_template_cache_keys())
+        return (
+            frozenset(self.env.registry._init_modules)
+            + self.env["ir.asset"]._get_cache_longterm_key()
+            + context_key)
 
     # other methods used for the asset bundles
-    @tools.conditional(
-        # in non-xml-debug mode we want assets to be cached forever, and the admin can force a cache clear
-        # by restarting the server after updating the source code (or using the "Clear server cache" in debug tools)
-        'xml' not in tools.config['dev_mode'],
-        tools.ormcache('bundle', 'css', 'js', 'debug', 'async_load', 'defer_load', 'lazy_load', 'media', 'tuple(self.env.context.get(k) for k in self._get_template_cache_keys())'),
-    )
     def _generate_asset_nodes_cache(self, bundle, css=True, js=True, debug=False, async_load=False, defer_load=False, lazy_load=False, media=None):
-        return self._generate_asset_nodes(bundle, css, js, debug, async_load, defer_load, lazy_load, media)
+        cache_key = self._get_asset_cache_key() + (bundle, css, js, debug, async_load, defer_load, lazy_load, media)
+        self._get_cached_values(cache_key, lambda: self._generate_asset_nodes(bundle, css, js, debug, async_load, defer_load, lazy_load, media))
 
-    @tools.ormcache('bundle', 'defer_load', 'lazy_load', 'media', 'tuple(self.env.context.get(k) for k in self._get_template_cache_keys())')
     def _get_asset_content(self, bundle, defer_load=False, lazy_load=False, media=None):
+        cache_key = self._get_asset_cache_key() + (bundle, defer_load, lazy_load, media)
+        self._get_cached_values(cache_key, lambda: self.__get_asset_content(bundle, defer_load, lazy_load, media))
+
+    def __get_asset_content(self, bundle, defer_load=False, lazy_load=False, media=None):
         asset_paths = self.env['ir.asset']._get_asset_paths(bundle=bundle, css=True, js=True)
 
         files = []

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -585,7 +585,7 @@ class IrQWeb(models.AbstractModel):
             return None
 
     @QwebTracker.wrap_compile
-    def _compile(self, template):
+    def _compile(self, template, cache=None):
         if isinstance(template, etree._Element):
             self = self.with_context(is_t_cache_disabled=True)
             ref = None
@@ -621,7 +621,7 @@ class IrQWeb(models.AbstractModel):
                 raise QWebException("Error when compiling xml template",
                     self, template, code=code, ref=ref) from e
 
-        return self._load_values(base_key_cache, generate_functions)
+        return self._load_values(base_key_cache, generate_functions, cache)
 
     def _generate_code(self, template):
         """ Compile the given template into a rendering function (generator)::
@@ -1608,7 +1608,7 @@ class IrQWeb(models.AbstractModel):
                                     ref, function_name, cached_values = item
                                     t_nocache_function = values['__qweb_loaded_values'].get(function_name)
                                     if not t_nocache_function:
-                                        t_call_template_functions, def_name = self._compile(ref)
+                                        t_call_template_functions, def_name = self._compile(ref, values.get('__qweb_loaded_values'))
                                         t_nocache_function = t_call_template_functions[function_name]
 
                                     nocache_values = values['__qweb_root_values'].copy()
@@ -2106,7 +2106,7 @@ class IrQWeb(models.AbstractModel):
             template = {template}
             if template.isnumeric():
                 template = int(template)
-            t_call_template_functions, def_name = irQweb._compile(template)
+            t_call_template_functions, def_name = irQweb._compile(template, values.get('__qweb_loaded_values'))
             render_template = t_call_template_functions[def_name]
             yield from render_template(irQweb, t_call_values)
             """, level))
@@ -2229,7 +2229,7 @@ class IrQWeb(models.AbstractModel):
                         ref, function_name, cached_values = item
                         t_nocache_function = loaded_values.get(function_name)
                         if not t_nocache_function:
-                            t_call_template_functions, def_name = self._compile(ref)
+                            t_call_template_functions, def_name = self._compile(ref, values.get('__qweb_loaded_values'))
                             t_nocache_function = t_call_template_functions[function_name]
 
                         nocache_values = values['__qweb_root_values'].copy()

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1531,10 +1531,12 @@ class TestQWebBasic(TransactionCase):
 
         partner.barcode = '4012345678901'
         view.arch = """<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"/>"""
+        TransactionCase.update_write_date_for_cache_longterm(view)
         ean_rendered = self.env['ir.qweb']._render(view.id, values={'partner': partner}).strip()
         self.assertRegex(ean_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
         view.arch = """<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"/>"""
+        TransactionCase.update_write_date_for_cache_longterm(view)
         auto_rendered = self.env['ir.qweb']._render(view.id, values={'partner': partner}).strip()
         self.assertRegex(auto_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
@@ -1575,7 +1577,6 @@ class TestQWebBasic(TransactionCase):
             QWeb.with_context(preserve_comments=False)._render(view.id),
             markupsafe.Markup('<p></p>'),
             "Should not have the comment")
-        QWeb.clear_caches()
         self.assertEqual(
             QWeb.with_context(preserve_comments=True)._render(view.id),
             markupsafe.Markup(f'<p>{comment}</p>'),
@@ -1596,7 +1597,6 @@ class TestQWebBasic(TransactionCase):
             QWeb.with_context(preserve_comments=False)._render(view.id),
             markupsafe.Markup('<p></p>'),
             "Should not have the processing instruction")
-        QWeb.clear_caches()
         self.assertEqual(
             QWeb.with_context(preserve_comments=True)._render(view.id),
             markupsafe.Markup(f'<p>{p_instruction}</p>'),

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -110,6 +110,8 @@ class TestJavascriptAssetsBundle(FileTouchable):
         super(TestJavascriptAssetsBundle, self).setUp()
         self.jsbundle_name = 'test_assetsbundle.bundle1'
         self.cssbundle_name = 'test_assetsbundle.bundle2'
+        # unlink generated asset form _pregenerate_assets_bundles
+        self.env['ir.attachment'].search([('name', 'like', '%test_assetsbundle%')]).unlink()
         self.env['res.lang']._activate_lang('ar_SY')
 
     def _get_asset(self, bundle, env=None):

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -283,8 +283,6 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
                 if not needs_update:
                     registry.setup_models(cr)
                 # Python tests
-                env['ir.http']._clear_routing_map()     # force routing map to be rebuilt
-
                 tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
                 test_results = loader.run_suite(suite, module_name)
                 report.update(test_results)

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -120,6 +120,11 @@ class Registry(Mapping):
         self._constraint_queue = deque()
         self.__cache = LRU(8192)
 
+        # This cache does not communicate with other workers, and should never
+        # be invalidated! Cache keys should be chosen wisely. The keys
+        # themselves may partly be in the normal orm cache.
+        self.__cache_longterm = LRU(8192)
+
         # modules fully loaded (maintained during init phase by `loading` module)
         self._init_modules = set()
         self.updated_modules = []       # installed/updated modules
@@ -584,6 +589,15 @@ class Registry(Mapping):
         """ Clear the cache and mark it as invalidated. """
         self.__cache.clear()
         self.cache_invalidated = True
+
+    def _clear_ormcache_longterm(self):
+        """ Clear the cache long term.
+            This method should only be used for testing because the cache long
+            term is not supposed to be invalidated.
+        """
+        # if not self.in_test_mode():
+        #     _logger.warning("The long term cache cannot be invalidated.")
+        self.__cache_longterm.clear()
 
     def clear_caches(self):
         """ Clear the caches associated to methods decorated with

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -27,6 +27,7 @@ class ormcache_counter(object):
 
 # statistic counters dictionary, maps (dbname, modelname, method) to counter
 STAT = defaultdict(ormcache_counter)
+STAT_LONGTERM = defaultdict(ormcache_counter)
 
 
 class ormcache(object):
@@ -116,12 +117,34 @@ class ormcache_context(ormcache):
         sign = signature(self.method)
         args = str(sign)[1:-1]
         cont_expr = "(context or {})" if 'context' in sign.parameters else "self._context"
-        keys_expr = "tuple(%s.get(k) for k in %r)" % (cont_expr, self.keys)
+        if isinstance(self.keys, str):
+            keys_expr = "tuple(%s.get(k) for k in %s)" % (cont_expr, self.keys)
+        else:
+            keys_expr = "tuple(%s.get(k) for k in %r)" % (cont_expr, self.keys)
         if self.args:
             code = "lambda %s: (%s, %s)" % (args, ", ".join(self.args), keys_expr)
         else:
             code = "lambda %s: (%s,)" % (args, keys_expr)
         self.key = unsafe_eval(code)
+
+
+class ormcache_longterm(ormcache):
+    """Long-term LRU cache decorator, using a dedicated cache
+
+    The long-term cache is meant to hold data that is more expensive to compute
+    and is nerver be invalidate.
+    """
+    def lru(self, model):
+        counter = STAT_LONGTERM[(model.pool.db_name, model._name, self.method)]
+        return model.pool._Registry__cache_longterm, (model._name, self.method), counter
+
+    def clear(self, model, *args):
+        """ Override clear cache, raise error."""
+        raise ValueError("Should not clear the cache longterm.")
+
+
+class ormcache_longterm_context(ormcache_context, ormcache_longterm):
+    pass
 
 
 class ormcache_multi(ormcache):
@@ -204,18 +227,24 @@ def log_ormcache_stats(sig=None, frame=None):
     me = threading.current_thread()
     me_dbname = getattr(me, 'dbname', 'n/a')
 
-    for dbname, reg in sorted(Registry.registries.d.items()):
-        # set logger prefix to dbname
-        me.dbname = dbname
-        entries = Counter(k[:2] for k in reg._Registry__cache.d)
+    def _log_cache_stats(cache, stats, suffix=None):
+        entries = Counter(k[:2] for k in cache)
         # show entries sorted by model name, method name
         for key in sorted(entries, key=lambda key: (key[0], key[1].__name__)):
             model, method = key
-            stat = STAT[(dbname, model, method)]
+            stat = stats[(dbname, model, method)]
             _logger.info(
-                "%6d entries, %6d hit, %6d miss, %6d err, %4.1f%% ratio, for %s.%s",
+                "%6d entries, %6d hit, %6d miss, %6d err, %4.1f%% ratio, for %s.%s%s",
                 entries[key], stat.hit, stat.miss, stat.err, stat.ratio, model, method.__name__,
+                suffix or '',
             )
+
+    for dbname, reg in sorted(Registry.registries.d.items()):
+        # set logger prefix to dbname
+        me.dbname = dbname
+        # show entries sorted by model name, method name
+        _log_cache_stats(reg._Registry__cache.d, STAT)
+        _log_cache_stats(reg._Registry__cache_longterm.d, STAT_LONGTERM, suffix="(LT)")
 
     me.dbname = me_dbname
 

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -295,11 +295,11 @@ class QwebTracker():
     @classmethod
     def wrap_compile(cls, method_compile):
         @functools.wraps(method_compile)
-        def _tracked_compile(self, template):
+        def _tracked_compile(self, template, cache=None):
             if not self.env.context.get('profile'):
-                return method_compile(self, template)
+                return method_compile(self, template, cache)
 
-            template_functions, def_name = method_compile(self, template)
+            template_functions, def_name = method_compile(self, template, cache)
             render_template = template_functions[def_name]
 
             def profiled_method_compile(self, values):

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -263,6 +263,7 @@ _BUILTINS = {
     'dict': dict,
     'list': list,
     'tuple': tuple,
+    'frozenset': frozenset,
     'map': map,
     'abs': abs,
     'min': min,


### PR DESCRIPTION
[IMP] base: add cache_longterm (type memo) should never be invalidated

Aim:
This cache allows you to put elements that will never be invalidated and
whose key is chosen appropriately.
Since there is no invalidation, there is no need to communicate with other
workers, thus allowing the introduction of other systems for storing data
such as shared memory.

Previously:
Prior to this commit there was only one cache. The elements could become
invalid and therefore the cache as well as that of the other workers had
to be deleted. Off, a lot of elements, very resource-intensive to
generate, were also deleted. For example compiling QWeb views takes
hundreds of milliseconds and was invalidated for changes made in products.

Advantage:
Retention of items despite cache invalidation. For example, when editing
QWeb views, only the actually edited view needs to be compiled again.

Disadvantage:
Cache keys can be more complicated and depend on more parameters. However,
they can be stored in the standard ormcache.

opw-2977912