### PR TITLE
[FIX] website_sale: Add inline class for base_unit_price

### DIFF
--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -107,7 +107,7 @@
                     <field name="base_unit_count" attrs="{'invisible': [('product_variant_count', '>', 1)]}" />
                     <field name="base_unit_id" options="{'no_open': True}" attrs="{'invisible': [('product_variant_count', '>', 1)]}" />
                     <span attrs="{'invisible': ['|', ('base_unit_price','=', 0), ('product_variant_count', '>', 1)]}">
-                        (<field name="base_unit_price"/> / <field name="base_unit_name"/>)
+                        (<field name="base_unit_price" class="oe_inline"/> / <field name="base_unit_name" class="oe_inline"/>)
                     </span>
                     <span class='text-muted' attrs="{'invisible': [('product_variant_count', '&lt;=', 1)]}">Based on variants</span>
                 </div>
@@ -126,7 +126,7 @@
                     <field name="base_unit_count"/>
                     <field name="base_unit_id" options="{'no_open': True}"/>
                     <span attrs="{'invisible': [('base_unit_price','=', 0)]}">
-                        (<field name="base_unit_price"/> / <field name="base_unit_name"/>)
+                        (<field name="base_unit_price" class="oe_inline"/> / <field name="base_unit_name" class="oe_inline"/>)
                     </span>
                 </div>
             </xpath>
@@ -179,7 +179,7 @@
                     <field name="base_unit_count"/>
                     <field name="base_unit_id" options="{'no_open': True}"/>
                     <span attrs="{'invisible': [('base_unit_price','=', 0)]}">
-                        (<field name="base_unit_price"/> / <field name="base_unit_name"/>)
+                        (<field name="base_unit_price" class="oe_inline"/> / <field name="base_unit_name" class="oe_inline"/>)
                     </span>
                 </div>
             </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Now that fields are wrapped in divs, if not using the `oe_inline` class, the divs wrapping field will cause a line return at each displayed field.

Current behavior before PR:
![image](https://user-images.githubusercontent.com/18055894/191993362-acf86eb6-84c6-4024-9746-68d2e00327ab.png)

Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/18055894/191993635-b6fa6d7e-7f69-4a7e-8123-82111294f44f.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
