### PR TITLE
[IMP] {purchase_}stock: add "Order to max" feature in replenishment

### DIFF
--- a/addons/purchase_stock/views/stock_views.xml
+++ b/addons/purchase_stock/views/stock_views.xml
@@ -37,4 +37,15 @@
             </field>
         </record>
 
+        <record id="stock_reorder_report_search_inherited_purchase_stock" model="ir.ui.view">
+            <field name="name">stock.warehouse.orderpoint.search.inherit.purchase.stock</field>
+            <field name="model">stock.warehouse.orderpoint</field>
+            <field name="inherit_id" ref="stock.stock_reorder_report_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//search" position="inside">
+                    <field name="vendor_id"/>
+                </xpath>
+            </field>
+        </record>
+
 </odoo>

--- a/addons/stock/static/src/views/stock_orderpoint_list_buttons.xml
+++ b/addons/stock/static/src/views/stock_orderpoint_list_buttons.xml
@@ -3,13 +3,17 @@
 
     <t t-name="stock.StockOrderpoint.Buttons" t-inherit="web.ListView.Buttons" owl="1">
         <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
-            <button t-if="nbSelected" type="button" t-on-click="onClickOrder"
+            <button t-if="nbSelected" type="button" t-on-click="() => this.onClickOrder(false)"
                     class="o_button_order btn btn-primary me-1">
                 Order
             </button>
             <button t-if="nbSelected" type="button" t-on-click="onClickSnooze"
                     class="o_button_snooze btn btn-primary me-1">
                 Snooze
+            </button>
+            <button t-if="nbSelected" type="button" t-on-click="() => this.onClickOrder(true)"
+                    class="o_button_order_max btn btn-primary me-1">
+                Order To Max
             </button>
         </xpath>
     </t>

--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -3,10 +3,11 @@
 import { ListController } from '@web/views/list/list_controller';
 
 export class StockOrderpointListController extends ListController {
-    async onClickOrder() {
+    async onClickOrder(force_to_max) {
         const resIds = await this.getSelectedResIds();
         const action = await this.model.orm.call(this.props.resModel, 'action_replenish', [resIds], {
             context: this.props.context,
+            force_to_max: force_to_max,
         });
         if (action) {
             await this.actionService.doAction(action);


### PR DESCRIPTION
Before this commit, there was no functionality to trigger replenishment before
min qty is reached. This commit adds a "Order to max" button to top of list view
of replenishment when orderpoint(s) are selected. This button will trigger
replenishment for lines where Max Quantity - forecast > 0.
Also, with this commit User can search Vendor wise replenishments.

TaskID: 2964309