### PR TITLE
[FIX] pos_restaurant:save new split order on payment proceed

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
@@ -76,6 +76,8 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
 
                 this.env.pos.get('orders').add(this.newOrder);
                 this.env.pos.set('selectedOrder', this.newOrder);
+                // Save new order to server.
+                this.env.pos.push_single_order(this.newOrder);
             }
         }
         /**


### PR DESCRIPTION
Steps to reproduce:
-Activate split order option
-Create an order with two products
-On the splitting bill screen select one product and click on payment
-Don't validate the payment and click on back
-Refresh the page

Current behavior:
There is only one order with the unselected product

Expected behavior:
There is two orders with one product

Explanation:
When on the spliting page we remove product from the first order to add them to a new one if they are selected but the new order is not saved yet. We need to save the new order on payment proceed. 

opw-2989858
