### PR TITLE
[FIX] stock: forecast report reserve/unreserve

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2015,6 +2015,13 @@ class StockMove(models.Model):
                 dst._rollup_move_dests(seen)
         return seen
 
+    def _rollup_move_origs(self, seen):
+        for org in self.move_orig_ids:
+            if org.id not in seen:
+                seen.add(org.id)
+                org._rollup_move_origs(seen)
+        return seen
+
     def _get_forecast_availability_outgoing(self, warehouse):
         """ Get forcasted information (sum_qty_expected, max_date_expected) of self for in_locations_ids as the in locations.
         It differ from _get_report_lines because it computes only the necessary information and return a

--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -123,7 +123,7 @@
                                     Reserved from stock
                                     <button t-if="line['move_out'] and line['move_out'].picking_id"
                                         class="btn btn-sm btn-primary o_report_replenish_unreserve"
-                                        t-attf-model="stock.picking"
+                                        t-attf-model="report.stock.report_product_product_replenishment"
                                         t-att-model-id="line['move_out'].picking_id.id"
                                         name="unreserve_link">
                                         Unreserve
@@ -131,9 +131,9 @@
                                 </t>
                                 <t t-elif="line['replenishment_filled']">
                                     <t t-if="line['document_out']">Inventory On Hand
-                                        <button t-if="line['move_out'] and line['move_out'].state in ('confirmed', 'partially_available') and line['move_out'].picking_id"
+                                        <button t-if="line['move_out'] and line['move_out'].picking_id"
                                             class="btn btn-sm btn-primary o_report_replenish_reserve"
-                                            t-attf-model="stock.picking"
+                                            t-attf-model="report.stock.report_product_product_replenishment"
                                             t-att-model-id="line['move_out'].picking_id.id"
                                             name="reserve_link">
                                             Reserve

--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -342,8 +342,8 @@ const ReplenishReport = clientAction.extend({
         const modelId = parseInt(ev.target.getAttribute('model-id'));
         return this._rpc( {
             model,
-            args: [[modelId]],
-            method: 'do_unreserve'
+            args: [modelId],
+            method: 'unreserve_pg_picks'
         }).then(() => this._reloadReport());
     },
 
@@ -357,8 +357,8 @@ const ReplenishReport = clientAction.extend({
         const modelId = parseInt(ev.target.getAttribute('model-id'));
         return this._rpc( {
             model,
-            args: [[modelId]],
-            method: 'action_assign'
+            args: [modelId],
+            method: 'reserve_pg_picks'
         }).then(() => this._reloadReport());
     },
 


### PR DESCRIPTION
Before this commit, the reserve/unreserve buttons did not work / were
hidden with multi-step delivery settings. The report now works with the
entire chain of moves linked to the delivery

TaskId: 2858139





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
