### PR TITLE
[IMP] core: allow `sequence` field to have a `group_operator`

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -66,7 +66,7 @@ export const computeReportMeasures = (
             continue;
         }
         if (
-            ["integer", "float", "monetary"].includes(field.type) ||
+            field.group_operator !== undefined ||
             additionalMeasures.includes(fieldName)
         ) {
             measures[fieldName] = field;

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1385,6 +1385,13 @@ class Integer(Field):
 
     group_operator = 'sum'
 
+    def _get_attrs(self, model_class, name):
+        attrs = super()._get_attrs(model_class, name)
+        # We don't want the 'sequence' field to have a group_operator by default
+        if 'group_operator' not in attrs and name == 'sequence':
+            attrs['group_operator'] = None
+        return attrs
+
     def convert_to_column(self, value, record, values=None, validate=True):
         return int(value or 0)
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2477,8 +2477,6 @@ class BaseModel(metaclass=MetaModel):
                 orderby_terms.append(' '.join(order_split))
             elif order_field not in self._fields:
                 raise ValueError("Invalid field %r on model %r" % (order_field, self._name))
-            elif order_field == 'sequence':
-                pass
             else:
                 # Cannot order by a field that will not appear in the results (needs to be grouped or aggregated)
                 _logger.warning('%s: read_group order by `%s` ignored, cannot sort on empty columns (not grouped/aggregated)',
@@ -2742,8 +2740,6 @@ class BaseModel(metaclass=MetaModel):
         fnames = []                     # list of fields to flush
 
         for fspec in fields:
-            if fspec == 'sequence':
-                continue
             if fspec == '__count':
                 # the web client sometimes adds this pseudo-field in the list
                 continue


### PR DESCRIPTION
In the `_read_group_raw`, we filter-out `sequence`. This behavior should be defined with the `group_operator` of the field for this particular case.

Functional Change: Sequence is not a Measure (for Pivot/Graph views) anymore! Does it make sense ?

task-2994273
