### PR TITLE
[IMP][FIX] account,l10n_X,web_tour: adapt tours to handle l10n extra steps

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -30,6 +30,7 @@ from . import account_incoterms
 from . import digest
 from . import res_users
 from . import ir_actions_report
+from . import ir_http
 from . import res_currency
 from . import res_bank
 from . import mail_thread

--- a/addons/account/models/ir_http.py
+++ b/addons/account/models/ir_http.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.http import request
+
+
+class Http(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def session_info(self):
+        result = super().session_info()
+        company = request.env.user.company_id
+        result['company_name'] = company.name
+        result['company_account_fiscal_country_code'] = company.account_fiscal_country_id.code
+        return result

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -1,4 +1,4 @@
-odoo.define('account.tour', function(require) {
+odoo.define('account.tour', function (require) {
 "use strict";
 
 var core = require('web.core');
@@ -13,21 +13,21 @@ tour.register('account_tour', {
 }, [
     ...tour.stepUtils.goToAppSteps('account.menu_finance', _t('Send invoices to your customers in no time with the <b>Invoicing app</b>.')),
     {
-        trigger: "a.o_onboarding_step_action[data-method=action_open_base_onboarding_company]",
+        trigger: "a[data-method=action_open_base_onboarding_company]",
         content: _t("Start by checking your company's data."),
         position: "bottom",
     }, {
         trigger: "button[name=action_save_onboarding_company_step]",
-        extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_onboarding_company]",
+        extra_trigger: "a[data-method=action_open_base_onboarding_company]",
         content: _t("Looks good. Let's continue."),
         position: "bottom",
     }, {
-        trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
+        trigger: "a[data-method=action_open_base_document_layout]",
         content: _t("Customize your layout."),
         position: "bottom",
     }, {
         trigger: "button[name=document_layout_save]",
-        extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
+        extra_trigger: "a[data-method=action_open_base_document_layout]",
         content: _t("Once everything is as you want it, validate."),
         position: "top",
     }, {
@@ -90,5 +90,4 @@ tour.register('account_tour', {
         position: "top"
     }
 ]);
-
 });

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -1,26 +1,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
 import odoo.tests
-
+from odoo.tests.common import users
 
 @odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
 
+    @users('admin')
     def test_01_account_tour(self):
-        # Reset country and fiscal country, so that fields added by localizations are
-        # hidden and non-required, and don't make the tour crash.
-        # Also remove default taxes from the company and its accounts, to avoid inconsistencies
-        # with empty fiscal country.
-        self.env.company.write({
-            'country_id': None, # Also resets account_fiscal_country_id
-            'account_sale_tax_id': None,
-            'account_purchase_tax_id': None,
-        })
-        account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_id', '=', self.env.company.id)])
-        account_with_taxes.write({
-            'tax_ids': [Command.clear()],
-        })
+        # For some l10n modules some required data are needed to complete the tour.
+        # e.g. l10n_mx_edi required some certificates files to be upload and set on the company.
+        # Since (most of the time) the extra data are added to a new company
+        # (except for the country_id field that might be changed on the main company
+        # but not account_fiscal_country_id), to maximise the chance to have a fully
+        # configured company, we chose the one that have the same country as fiscal country.
+        if self.env.company.country_id != self.env.company.account_fiscal_country_id:
+            country_id = self.env.company.account_fiscal_country_id or self.env.company.country_id
+            company = self.env.user.company_ids.filtered(lambda c: c.country_id.id == c.account_fiscal_country_id.id == country_id.id)
+            if company:
+                self.env.company = company[0]
+                self.env.user.company_id = company[0]
         # This tour doesn't work with demo data on runbot
         all_moves = self.env['account.move'].search([('move_type', '!=', 'entry')])
         all_moves.button_draft()

--- a/addons/l10n_ar/static/src/js/tours/account.js
+++ b/addons/l10n_ar/static/src/js/tours/account.js
@@ -1,24 +1,26 @@
-odoo.define('l10n_ar.account_tour', function(require) {
+odoo.define('l10n_ar.account_tour', function (require) {
 "use strict";
 
-    let tour = require('web_tour.tour');
-    let account_tour = tour.tours.account_tour;
-    // Remove the step suggesting to change the name as it is done another way (document number)
-    account_tour.steps = _.filter(account_tour.steps, step => step.trigger != "input[name=name]");
+require('account.tour');
+let session = require('web.session');
+let tour = require('web_tour.tour');
 
+if (session.company_account_fiscal_country_code === 'AR') {
+    const stepsToAdd = [
     // Configure the AFIP Responsibility
-    let partner_step_idx = _.findIndex(account_tour.steps, step => step.trigger == 'div[name=partner_id] input');
-    account_tour.steps.splice(partner_step_idx + 2, 0, {
+    {
         trigger: "div[name=l10n_ar_afip_responsibility_type_id] input",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",
         position: "bottom",
         content: "Set the AFIP Responsability",
         run: "text IVA",
-    })
-    account_tour.steps.splice(partner_step_idx + 3, 0, {
+    }, {
         trigger: ".ui-menu-item > a:contains('IVA').ui-state-active",
         auto: true,
         in_modal: false,
-    })
-
-})
+    }];
+    const accountTour = tour.tours.account_tour;
+    const addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'div[name=partner_id] input');
+    accountTour.steps.splice(addIndex + 2, 0, ...stepsToAdd);
+}
+});

--- a/addons/l10n_ar_website_sale/__manifest__.py
+++ b/addons/l10n_ar_website_sale/__manifest__.py
@@ -21,4 +21,9 @@
     'auto_install': True,
     'application': False,
     'license': 'LGPL-3',
+    'assets': {
+        'web.assets_tests': [
+            'l10n_ar_website_sale/static/tests/**/*',
+        ],
+    },
 }

--- a/addons/l10n_ar_website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/l10n_ar_website_sale/static/tests/tours/website_sale_buy.js
@@ -1,0 +1,35 @@
+odoo.define('l10n_ar_website_sale.shop_buy_product_tour', function (require) {
+"use strict";
+
+require('website_sale.tour');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+if (session.company_account_fiscal_country_code === 'AR') {
+    const stepsToAdd = [
+    // Configure the AFIP Responsibility
+    {
+        content: "Fulfill shipping address form",
+        trigger: 'select[name="country_id"]',
+        run: function () {
+            $('select[name="l10n_ar_afip_responsibility_type_id"] option').filter(function () {
+                return $(this).html().trim() === "Consumidor Final";
+            }).attr('selected', true);
+            $('select[name="l10n_latam_identification_type_id"] option').filter(function () {
+                return $(this).html().trim() === "Foreign ID";
+            }).attr('selected', true);
+            $('input[name="vat"]').val('12345678-9');
+        },
+    }, {
+        content: "Click on Next button",
+        trigger: '.oe_cart .btn:contains("Next")',
+    }, {
+        content: "Click on Confirm button",
+        trigger: '.oe_cart .btn:contains("Confirm")',
+    }];
+
+    const shopBuyProductTour = tour.tours.shop_buy_product;
+    const addIndex = shopBuyProductTour.steps.findIndex(({trigger}) => trigger === 'a[href*="/shop/checkout"]');
+    shopBuyProductTour.steps.splice(addIndex + 1, 0, ...stepsToAdd);
+}
+});

--- a/addons/l10n_ar_website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/l10n_ar_website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -1,0 +1,26 @@
+odoo.define('l10n_ar_website_sale.website_sale_tour', function (require) {
+"use strict";
+
+require('website_sale_tour.tour');
+let tour = require('web_tour.tour');
+
+let website_sale_tour = tour.tours.website_sale_tour;
+
+if (website_sale_tour.extra && (website_sale_tour.extra.company_account_fiscal_country_code || "") === 'AR') {
+    // Extend run function to add the AFIP Responsibility
+    const websiteSaleTour = tour.tours.website_sale_tour;
+    const stepIndex = websiteSaleTour.steps.findIndex(({trigger, content}) => trigger === 'select[name="country_id"]' && content === 'Fulfill billing address form');
+    const run = website_sale_tour.steps[stepIndex].run;
+    const new_run = function () {
+        run();
+        $('select[name="l10n_ar_afip_responsibility_type_id"] option').filter(function () {
+            return $(this).html().trim() === "Consumidor Final";
+        }).attr('selected', true);
+        $('select[name="l10n_latam_identification_type_id"] option').filter(function () {
+            return $(this).html().trim() === "Foreign ID";
+        }).attr('selected', true);
+        $('input[name="vat"]').val('12345678-9');
+    };
+    websiteSaleTour.steps[stepIndex].run = new_run;
+}
+});

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -49,5 +49,10 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes
         'demo/demo_company.xml',
         'demo/partner_demo.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_cl/static/src/js/**/*',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/l10n_cl/static/src/js/tours/account.js
+++ b/addons/l10n_cl/static/src/js/tours/account.js
@@ -1,0 +1,48 @@
+odoo.define('l10n_cl.account_tour', function (require) {
+"use strict";
+
+require('account.tour');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+if (session.company_account_fiscal_country_code === 'CL') {
+    const stepsToAdd = [
+    // Configure the partner country
+    {
+        trigger: "div[name=country_id] input",
+        position: "bottom",
+        content: "Select a country for the partner",
+        run: "text Chile",
+    }, {
+        trigger: ".ui-menu-item > a:contains('Chile').ui-state-active",
+        auto: true,
+        in_modal: false,
+    },
+    // Configure the Identification Type and Number
+    {
+        trigger: "div[name=l10n_latam_identification_type_id] input",
+        position: "bottom",
+        content: "Set the Identification Type",
+        run: "text Foreign ID",
+    }, {
+        trigger: ".ui-menu-item > a:contains('Foreign ID').ui-state-active",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: "input[name=vat]",
+        position: "bottom",
+        content: "Set the Identification Number",
+        run: "text 12345678-9",
+    },
+    // Configure the Taxpayer Type
+    {
+        trigger: "select[name=l10n_cl_sii_taxpayer_type]",
+        position: "bottom",
+        content: "Set the Taxpayer Type",
+        run: 'text "3"',
+    }];
+    const accountTour = tour.tours.account_tour;
+    const addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'div[name=partner_id] input');
+    accountTour.steps.splice(addIndex + 2, 0, ...stepsToAdd);
+}
+});

--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -76,6 +76,11 @@ Master Data:
     "demo": [
         "demo/demo_company.xml",
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_ec/static/src/js/**/*',
+        ],
+    },
     "installable": True,
     "auto_install": False,
     "application": False,

--- a/addons/l10n_ec/static/src/js/tours/account.js
+++ b/addons/l10n_ec/static/src/js/tours/account.js
@@ -1,0 +1,23 @@
+odoo.define('l10n_ec.account_tour', function (require) {
+"use strict";
+
+require('account.tour');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+if (session.company_account_fiscal_country_code === 'EC') {
+    // Configure the Document Number: In case there isn't already a posted invoice,
+    // the document number will not be set automaticly and therefore should be manually set.
+    const stepToAdd = {
+        trigger: "div[name=l10n_latam_document_type_id]",
+        auto: true,
+        in_modal: false,
+        run: function () {
+            $('input[name="l10n_latam_document_number"]').val('001-001-123456789').trigger('change');
+        }
+    };
+    const accountTour = tour.tours.account_tour;
+    const addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'button[name=action_post]');
+    accountTour.steps.splice(addIndex - 1, 0, stepToAdd);
+}
+});

--- a/addons/l10n_eg_edi_eta/__manifest__.py
+++ b/addons/l10n_eg_edi_eta/__manifest__.py
@@ -33,6 +33,7 @@
     'assets': {
         'web.assets_backend': [
             'l10n_eg_edi_eta/static/src/js/sign_invoice.js',
+            'l10n_eg_edi_eta/static/src/js/tours/*.js',
         ],
     },
     'external_dependencies': {

--- a/addons/l10n_eg_edi_eta/static/src/js/tours/account.js
+++ b/addons/l10n_eg_edi_eta/static/src/js/tours/account.js
@@ -1,0 +1,199 @@
+odoo.define('l10n_eg_edi_eta.account_tour', function (require) {
+"use strict";
+
+require('account.tour');
+
+var core = require('web.core');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+var _t = core._t;
+
+if (session.company_account_fiscal_country_code === 'EG') {
+
+    const accountTour = tour.tours.account_tour;
+    const companyName = session.company_name;
+
+    let stepsToAdd = [
+    // Configure ETA settings on the Customer Invoices journal
+    {
+        trigger: 'button[data-menu-xmlid="account.menu_finance_configuration"]',
+        extra_trigger: 'body:not(:has(span:contains("Unsaved changes")))',
+        content: _t("Let's configure ETA settings on the Customer Invoices journal."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: 'a[data-menu-xmlid="account.menu_action_account_journal_form"]',
+        content: _t("Open the Journals."),
+        position: "right",
+        run: "click",
+    }, {
+        trigger: 'td[name=code]:contains("INV")',
+        content: _t("Select the Customer Invoice journal."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: '.o_form_button_edit',
+        content: _t("Edit the journal."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: 'a:contains("' + _t('Advanced Settings') + '")',
+        extra_trigger: '.o_form_button_save',
+        content: _t("Select Advanced Settings tab."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: "div[name=l10n_eg_branch_id] input",
+        content: _t("Set the Branch"),
+        position: "bottom",
+        run: "text " + companyName,
+    }, {
+        trigger: ".ui-menu-item > a:contains('" + companyName + "').ui-state-active",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: "div[name=l10n_eg_activity_type_id] input",
+        content: _t("Set the ETA Activity Code"),
+        position: "bottom",
+    }, {
+        trigger: ".ui-menu-item > a",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: "input[name=l10n_eg_branch_identifier]",
+        content: _t("Set the ETA Branch ID	"),
+        position: "bottom",
+        run: "text ABCD123456789",
+    }, {
+        trigger: '.o_form_button_save',
+        content: _t("Save the journal."),
+        position: "bottom",
+        run: "click",
+    },
+    // Set the building number on the branch (required field for the invoice)
+    {
+        trigger: "a[name=l10n_eg_branch_id]",
+        content: _t("Let's set the building number on the branch."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: '.o_form_button_edit',
+        extra_trigger: 'span[name=l10n_eg_building_no]',
+        content: _t("Edit the branch."),
+        position: "bottom",
+    }, {
+        trigger: 'input[name=l10n_eg_building_no]',
+        content: _t("Set a building number."),
+        position: "bottom",
+        run: "text 112",
+    }, {
+        trigger: '.o_form_button_save',
+        content: _t("Save the branch."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: 'a[data-menu-xmlid="account.menu_finance"], a[data-menu-xmlid="account_accountant.menu_accounting"]',
+        content: _t("Go back to dashboard."),
+        position: "bottom",
+        run: "click",
+    }];
+
+
+    let addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'button[name=action_save_onboarding_company_step]');
+    accountTour.steps.splice(addIndex + 1, 0, ...stepsToAdd);
+
+    stepsToAdd = [
+    // Fill all required fields in the customer details
+    {
+        trigger: "input[name=l10n_eg_building_no]",
+        position: "right",
+        content: _t("Set a building number."),
+        run: "text 123",
+    }, {
+        trigger: "input[name=street]",
+        position: "right",
+        content: "Set a Street",
+        run: "text Test Street 123",
+    }, {
+        trigger: "input[name=city]",
+        position: "right",
+        content: "Set a City",
+        run: "text Alexandria",
+    }, {
+        trigger: "input[name=zip]",
+        position: "right",
+        content: "Set a Zip Code",
+        run: "text 39020",
+    }, {
+        trigger: "div[name=state_id] input",
+        position: "right",
+        content: "Set a State",
+        run: "text Alexandria",
+    }, {
+        trigger: ".ui-menu-item > a:contains('Alexandria (EG)').ui-state-active",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: "div[name=country_id] input",
+        position: "right",
+        content: "Set a Country",
+        run: "text Egypt",
+    }, {
+        trigger: ".ui-menu-item > a:contains('Egypt').ui-state-active",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: "div[name=vat] input",
+        position: "bottom",
+        content: "Set a VAT",
+        run: "text 12345678-9",
+    }];
+
+    addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'div[name=partner_id] input');
+    accountTour.steps.splice(addIndex + 2, 0, ...stepsToAdd);
+
+    stepsToAdd = [
+    // Make sure the EGS/GS1 Barcode is set correctly on product (auto only)
+    {
+        trigger: ".o_field_widget[name=product_id] input, .o_field_widget[name=product_template_id] input",
+        content: _t("Select a product, or create a new one on the fly."),
+        auto: true,
+        position: "right",
+    }, {
+        trigger: ".ui-menu-item > a",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: ".o_field_widget[name=product_id] button, .o_field_widget[name=product_template_id] button",
+        content: _t("Select a product, or create a new one on the fly."),
+        auto: true,
+        position: "right",
+    }, {
+        trigger: 'a:contains("' + _t('Accounting') + '")',
+        extra_trigger: '.modal-content button.btn-primary',
+        content: _t("Select Accounting tab."),
+        position: "bottom",
+        auto: true,
+        run: "click",
+    }, {
+        trigger: "input[name=l10n_eg_eta_code]",
+        position: "bottom",
+        content: "Set an ETA Code",
+        auto: true,
+        run: "text ABCD123456798",
+    }, {
+        trigger: ".modal-content button.btn-primary",
+        content: _t("Save the product."),
+        auto: true,
+    }, {
+        trigger: "div[name=invoice_line_ids] span[name=name]",
+        content: _t("Fill in the details of the line."),
+        auto: true,
+        position: "bottom",
+    }];
+
+    addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'div[name=invoice_line_ids] .o_field_x2many_list_row_add a:not([data-context])');
+    accountTour.steps.splice(addIndex + 1, 0, ...stepsToAdd);
+}
+});

--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -52,5 +52,10 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'demo/account_payment_demo.xml',
         'demo/account_invoice_demo.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_in/static/src/js/**/*',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/l10n_in/static/src/js/tours/account.js
+++ b/addons/l10n_in/static/src/js/tours/account.js
@@ -1,0 +1,25 @@
+odoo.define('l10n_in.account_tour', function (require) {
+"use strict";
+
+require('account.tour');
+var core = require('web.core');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+var _t = core._t;
+
+if (session.company_account_fiscal_country_code === 'IN') {
+    // Set the GST Treatment
+    const stepToAdd = {
+        trigger: "select[name=l10n_in_gst_treatment]",
+        extra_trigger: "body:not(.modal-open)",
+        position: "bottom",
+        content: "Set the GST Treatment",
+        in_modal: false,
+        run: 'text "consumer"',
+    };
+    const accountTour = tour.tours.account_tour;
+    const addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'div[name=invoice_line_ids] .o_field_x2many_list_row_add a:not([data-context])');
+    accountTour.steps.splice(addIndex, 0, stepToAdd);
+}
+});

--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -26,6 +26,11 @@ E-invoice implementation
     'demo': [
         'data/account_invoice_demo.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_it_edi/static/src/js/**/*',
+        ],
+    },
     'post_init_hook': '_l10n_it_edi_post_init',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_it_edi/static/src/js/tours/account.js
+++ b/addons/l10n_it_edi/static/src/js/tours/account.js
@@ -1,0 +1,49 @@
+odoo.define('l10n_it_edi.account_tour', function (require) {
+"use strict";
+
+require('account.tour');
+var core = require('web.core');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+var _t = core._t;
+
+if (session.company_account_fiscal_country_code === 'IT') {
+    const stepsToAdd = [
+    // Configure the partner address and vat
+    {
+        trigger: "input[name=street]",
+        position: "right",
+        content: "Set a Street",
+        run: "text Test Street 123",
+    }, {
+        trigger: "input[name=city]",
+        position: "right",
+        content: "Set a City",
+        run: "text Rome",
+    }, {
+        trigger: "input[name=zip]",
+        position: "right",
+        content: "Set a Zip Code",
+        run: "text 39020",
+    }, {
+        trigger: "div[name=country_id] input",
+        position: "right",
+        content: "Set a country",
+        run: "text Italy",
+    }, {
+        trigger: ".ui-menu-item > a:contains('Italy').ui-state-active",
+        auto: true,
+        in_modal: false,
+    }, {
+        trigger: "div[name=vat] input",
+        position: "bottom",
+        content: "Set a VAT",
+        run: "text IT07643520567",
+    }];
+
+    const accountTour = tour.tours.account_tour;
+    const addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'div[name=partner_id] input');
+    accountTour.steps.splice(addIndex + 2, 0, ...stepsToAdd);
+}
+});

--- a/addons/l10n_it_edi_sdicoop/__manifest__.py
+++ b/addons/l10n_it_edi_sdicoop/__manifest__.py
@@ -21,6 +21,11 @@ and then fetched by this module.
         'views/l10n_it_view.xml',
         'views/res_config_settings_views.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_it_edi_sdicoop/static/src/js/**/*',
+        ],
+    },
     'post_init_hook': '_disable_pec_mail_post_init',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_it_edi_sdicoop/static/src/js/tours/account.js
+++ b/addons/l10n_it_edi_sdicoop/static/src/js/tours/account.js
@@ -1,0 +1,46 @@
+odoo.define('l10n_it_edi_sdicoop.account_tour', function (require) {
+"use strict";
+
+require('account.tour');
+var core = require('web.core');
+let session = require('web.session');
+let tour = require('web_tour.tour');
+
+var _t = core._t;
+
+if (session.company_account_fiscal_country_code === 'IT') {
+    const stepsToAdd = [
+    // Accept the terms and conditions in the settings to use FatturaPA.
+    {
+        trigger: 'button[data-menu-xmlid="account.menu_finance_configuration"]',
+        content: _t("Let's accept the terms and conditions in the settings to use FatturaPA."),
+        position: "bottom",
+        run: "click",
+    }, {
+        trigger: 'a[data-menu-xmlid="account.menu_account_config"]',
+        content: _t("Open the Settings."),
+        position: "right",
+        run: "click",
+    }, {
+        trigger: "div[name=l10n_it_edi_sdicoop_register] input",
+        position: "right",
+        content: _t('Accept the terms.'),
+        run: "click",
+    }, {
+        trigger: "button[name=execute]",
+        position: "right",
+        content: _t('Save the changes.'),
+        run: "click",
+    }, {
+        trigger: 'a[data-menu-xmlid="account.menu_finance"], a[data-menu-xmlid="account_accountant.menu_accounting"]',
+        extra_trigger: 'body:not(:has(span:contains("Unsaved changes")))',
+        content: _t("Go back to dashboard."),
+        position: "bottom",
+        run: "click",
+    }];
+
+    const accountTour = tour.tours.account_tour;
+    const addIndex = accountTour.steps.findIndex(({trigger}) => trigger === 'button[name=document_layout_save]');
+    accountTour.steps.splice(addIndex + 1, 0, ...stepsToAdd);
+}
+});

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -51,12 +51,12 @@ tour.register('google_analytics_view_item', {
 
 tour.register('google_analytics_add_to_cart', {
     test: true,
-    url: '/shop?search=Acoustic Bloc Screens',
+    url: '/shop?search=Storage Box',
 },
 [
     {
-        content: "select Acoustic Bloc Screens",
-        trigger: '.oe_product_cart a:contains("Acoustic Bloc Screens")',
+        content: "select Storage Box",
+        trigger: '.oe_product_cart a:contains("Storage Box")',
     },
     {
         content: "click add to cart button on product page",

--- a/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
+++ b/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
@@ -1,7 +1,6 @@
 odoo.define('website_sale_coupon.test', function (require) {
 'use strict';
 
-require("website_sale.tour");
 var tour = require("web_tour.tour");
 var ajax = require('web.ajax');
 const tourUtils = require('website_sale.tour_utils');


### PR DESCRIPTION
# Multiple FIX/IMP on tests/tours in l10n_X modules.

Impacted modules that had account_tour failing: account, l10n_ar, l10n_cl,
l10n_ec, l10n_eg_edi_eta, l10n_in, l10n_it_edi, l10n_it_edi_sdicoop:

- All impacted modules:
  Add check in extended account tour to add extra steps only if fiscal
  country is the right one + add extra steps.
- test_01_account_tour:
  - For some l10n modules, some required data are needed to complete
  the tour.
  e.g. l10n_mx_edi required some certificates files to be upload and
  set on the company.
  Since (most of the time) the extra data are added to a new company
  (except for the country_id field that might be changed on the main
  company but not account_fiscal_country_id), to maximize the chance
  to have a fully configured company, we chose the one that have the
  same country as fiscal country.
- account_tour (the main tour):
  - Remove class `.o_onboarding_step_action` on triggers to be able to
    re-run the tour if fails (otherwise unable to continue or restart
    tour since the `o_onboarding_step_action` is replaced by
    `o_onboarding_all_done` as soon as we complete the step).
- website_sale_tour & shop_buy_product:
  - in l10n_ar_website_sale module:
    Extend tours to add extra steps to configure AFIP Responsibility
    on shipping address form.
- website_sale_coupon:
  Remove require for `website_sale.tour` since not needed in this tour
  (and therefore waiting the tour to be ready for nothing).
- google_analytics_add_to_cart:
  The following commit changed the name of the product
  `product.product_product_25` from `Acoustic Bloc Screens`
  to `Laptop E5023 (IVA 10,5`, and since the tour is looking for
  the original name of the product and therefore not available,
  the tour fails. (commit: https://github.com/odoo/odoo/commit/ebe291560ac9c573cdd6e1b73fc9ea3c658ce070#diff-958b2f65570de219b51598626056199b5c945629c4033cc4aebecdd7b4956f82R90-R95 )
  Instead, use the `Storage Box` product that is created before running
  the test tour.