### PR TITLE
[REF] website, *: convert website service currentWebsite to reactive

### DIFF
--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -153,7 +153,9 @@ export class PagePropertiesDialog extends FormViewDialog {
     }
 
     get resId() {
-        return this.props.resId || (this.website.currentWebsite && this.website.currentWebsite.metadata.mainObject.id);
+        return this.props.resId
+            || (this.website.currentWebsite.metadata.mainObject
+                && this.website.currentWebsite.metadata.mainObject.id);
     }
 
     clonePage() {

--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -1,11 +1,13 @@
 /** @odoo-module **/
 
 import { NavBar } from '@web/webclient/navbar/navbar';
-import { useService, useBus } from '@web/core/utils/hooks';
+import { useService } from '@web/core/utils/hooks';
 import { registry } from "@web/core/registry";
 import { patch } from 'web.utils';
 
 const websiteSystrayRegistry = registry.category('website_systray');
+
+const { useState, useEffect } = owl;
 
 patch(NavBar.prototype, 'website_navbar', {
     setup() {
@@ -13,23 +15,26 @@ patch(NavBar.prototype, 'website_navbar', {
         this.websiteService = useService('website');
         this.websiteCustomMenus = useService('website_custom_menus');
 
-        // The navbar is rerendered with an event, as it can not naturally be
-        // with props/state (the WebsitePreview client action and the navbar
-        // are not related).
-        useBus(websiteSystrayRegistry, 'EDIT-WEBSITE', () => this.render(true));
-
         if (this.env.debug && !websiteSystrayRegistry.contains('web.debug_mode_menu')) {
             websiteSystrayRegistry.add('web.debug_mode_menu', registry.category('systray').get('web.debug_mode_menu'), {sequence: 100});
         }
 
-        useBus(websiteSystrayRegistry, 'CONTENT-UPDATED', () => this.render(true));
+        this.currentWebsite = useState(this.websiteService.currentWebsite);
+
+        useEffect(isLoaded => {
+            // When the website is loaded, all the website systray elements
+            // have been rendered and the navbar must be adapted accordingly.
+            if (isLoaded) {
+                this.adapt();
+            }
+        }, () => [this.isWebsiteLoaded()]);
     },
 
     /**
      * @override
      */
     get systrayItems() {
-        if (this.websiteService.currentWebsite && this.websiteService.isRestrictedEditor) {
+        if (this.websiteService.isRestrictedEditor && this.isWebsiteLoaded()) {
             return websiteSystrayRegistry
                 .getEntries()
                 .map(([key, value], index) => ({ key, ...value, index }))
@@ -59,5 +64,15 @@ patch(NavBar.prototype, 'website_navbar', {
             return this.websiteCustomMenus.open(menu);
         }
         return this._super(menu);
+    },
+
+    /**
+     * A website is considered as loaded when it has metadata. When that value
+     * is updated, the navbar will rerender and adapt.
+     *
+     * @returns {boolean}
+     */
+    isWebsiteLoaded() {
+        return !!Object.keys(this.currentWebsite.metadata).length;
     },
 });

--- a/addons/website/static/src/services/website_custom_menus.js
+++ b/addons/website/static/src/services/website_custom_menus.js
@@ -72,30 +72,26 @@ registry.category('services').add('website_custom_menus', websiteCustomMenus);
 
 registry.category('website_custom_menus').add('website.menu_edit_menu', {
     Component: EditMenuDialog,
-    isDisplayed: (env) => !!env.services.website.currentWebsite
+    isDisplayed: (env) => env.services.website.currentWebsite.id
         && env.services.website.isDesigner
         && !env.services.ui.isSmall
         && !env.services.website.currentWebsite.metadata.translatable,
 });
 registry.category('website_custom_menus').add('website.menu_optimize_seo', {
     Component: OptimizeSEODialog,
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && !!env.services.website.currentWebsite.metadata.mainObject,
+    isDisplayed: (env) => !!env.services.website.currentWebsite.metadata.mainObject,
 });
 registry.category('website_custom_menus').add('website.menu_current_page', {
-    isDisplayed: (env) => !!env.services.website.currentWebsite
-        && !!env.services.website.pageDocument,
+    isDisplayed: (env) => !!env.services.website.pageDocument,
 },);
 registry.category('website_custom_menus').add('website.menu_ace_editor', {
     openWidget: (services) => services.website.context.showAceEditor = true,
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && env.services.website.currentWebsite.metadata.viewXmlid
+    isDisplayed: (env) => env.services.website.currentWebsite.metadata.viewXmlid
         && !env.services.ui.isSmall,
 });
 registry.category('website_custom_menus').add('website.menu_page_properties', {
     Component: PagePropertiesDialog,
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && !!env.services.website.currentWebsite.metadata.mainObject
+    isDisplayed: (env) => !!env.services.website.currentWebsite.metadata.mainObject
         && env.services.website.currentWebsite.metadata.mainObject.model === 'website.page',
     getProps: (services) => ({
         onRecordSaved: (record) => {

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -127,7 +127,10 @@ export const websiteService = {
                 // Chrome.
                 const isWebsitePage = dataset && dataset.websiteId;
                 if (!isWebsitePage) {
-                    currentWebsite.metadata = {};
+                    orm.call('website', 'get_current_website').then((website) => {
+                        this.currentWebsiteId = unslugHtmlDataObject(website).id;
+                        currentWebsite.metadata = { externalOrNonEditableXML: true };
+                    });
                 } else {
                     const { mainObject, seoObject, isPublished, canPublish, editableInBackend, translatable, viewXmlid, websiteId } = dataset;
                     this.currentWebsiteId = parseInt(websiteId, 10);

--- a/addons/website/static/src/systray_items/edit_in_backend.js
+++ b/addons/website/static/src/systray_items/edit_in_backend.js
@@ -1,11 +1,9 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { useService, useBus } from "@web/core/utils/hooks";
+import { useService } from "@web/core/utils/hooks";
 
-const { Component, onWillStart, useState } = owl;
-
-const websiteSystrayRegistry = registry.category('website_systray');
+const { Component, onWillStart, useState, useEffect } = owl;
 
 export class EditInBackendSystray extends Component {
     setup() {
@@ -14,7 +12,10 @@ export class EditInBackendSystray extends Component {
         this.state = useState({mainObjectName: ''});
 
         onWillStart(this._updateMainObjectName);
-        useBus(websiteSystrayRegistry, 'CONTENT-UPDATED', this._updateMainObjectName);
+
+        useEffect(() => {
+            this._updateMainObjectName();
+        }, () => [this.websiteService.currentWebsite.metadata]);
     }
 
     editInBackend() {
@@ -36,7 +37,7 @@ EditInBackendSystray.template = "website.EditInBackendSystray";
 
 export const systrayItem = {
     Component: EditInBackendSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.editableInBackend,
+    isDisplayed: env => env.services.website.currentWebsite.metadata.editableInBackend,
 };
 
 registry.category("website_systray").add("EditInBackend", systrayItem, { sequence: 9 });

--- a/addons/website/static/src/systray_items/edit_website.js
+++ b/addons/website/static/src/systray_items/edit_website.js
@@ -9,6 +9,7 @@ class EditWebsiteSystray extends Component {
     setup() {
         this.websiteService = useService('website');
         this.websiteContext = useState(this.websiteService.context);
+        this.currentWebsite = useState(this.websiteService.currentWebsite);
 
         this.state = useState({
             isLoading: false,
@@ -28,7 +29,7 @@ class EditWebsiteSystray extends Component {
     }
 
     get translatable() {
-        return this.websiteService.currentWebsite && this.websiteService.currentWebsite.metadata.translatable;
+        return this.currentWebsite.metadata.translatable;
     }
 
     get label() {

--- a/addons/website/static/src/systray_items/new_content.js
+++ b/addons/website/static/src/systray_items/new_content.js
@@ -261,7 +261,7 @@ class NewContentSystray extends Component {
     }
 
     onClick() {
-        this.websiteContext.showNewContentModal = !this.websiteContext.showNewContentModal;
+        this.website.context.showNewContentModal = !this.website.context.showNewContentModal;
     }
 }
 NewContentSystray.template = "website.NewContentSystray";

--- a/addons/website/static/src/systray_items/publish.js
+++ b/addons/website/static/src/systray_items/publish.js
@@ -2,7 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { Switch } from '@website/components/switch/switch';
-import { useService, useBus } from '@web/core/utils/hooks';
+import { useService } from '@web/core/utils/hooks';
 
 const { Component, xml, useState } = owl;
 
@@ -13,19 +13,15 @@ class PublishSystray extends Component {
         this.website = useService('website');
         this.rpc = useService('rpc');
 
-        this.state = useState({
-            published: this.website.currentWebsite.metadata.isPublished,
-        });
-
-        useBus(websiteSystrayRegistry, 'CONTENT-UPDATED', () => this.state.published = this.website.currentWebsite.metadata.isPublished);
+        this.currentWebsite = useState(this.website.currentWebsite);
     }
 
     get label() {
-        return this.state.published ? this.env._t("Published") : this.env._t("Unpublished");
+        return this.currentWebsite.metadata.isPublished ? this.env._t("Published") : this.env._t("Unpublished");
     }
 
     publishContent() {
-        this.state.published = !this.state.published;
+        this.website.currentWebsite.metadata.isPublished = !this.website.currentWebsite.metadata.isPublished;
         const { metadata: { mainObject } } = this.website.currentWebsite;
         return this.rpc('/website/publish', {
             id: mainObject.id,
@@ -36,7 +32,7 @@ class PublishSystray extends Component {
 PublishSystray.template = xml`
 <div t-on-click="publishContent" class="o_menu_systray_item d-md-flex ms-auto" data-hotkey="p">
     <a href="#">
-        <Switch value="state.published" extraClasses="'mb-0 o_switch_danger_success'"/>
+        <Switch value="currentWebsite.metadata.isPublished" extraClasses="'mb-0 o_switch_danger_success'"/>
         <span class="d-none d-md-block ms-2" t-esc="this.label"/>
     </a>
 </div>`;
@@ -46,7 +42,7 @@ PublishSystray.components = {
 
 export const systrayItem = {
     Component: PublishSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.canPublish,
+    isDisplayed: env => env.services.website.currentWebsite.metadata.canPublish,
 };
 
 websiteSystrayRegistry.add("Publish", systrayItem, { sequence: 12 });

--- a/addons/website/static/src/systray_items/translate_website.js
+++ b/addons/website/static/src/systray_items/translate_website.js
@@ -29,7 +29,7 @@ TranslateWebsiteSystray.template = "website.TranslateWebsiteSystray";
 
 export const systrayItem = {
     Component: TranslateWebsiteSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.translatable,
+    isDisplayed: env => env.services.website.currentWebsite.metadata.translatable,
 };
 
 registry.category("website_systray").add("TranslateWebsiteSystray", systrayItem, { sequence: 8 });

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -6,11 +6,12 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import wUtils from 'website.utils';
 
-const { Component } = owl;
+const { Component, useState } = owl;
 
 export class WebsiteSwitcherSystray extends Component {
     setup() {
         this.websiteService = useService('website');
+        this.currentWebsite = useState(this.websiteService.currentWebsite);
     }
 
     getElements() {

--- a/addons/website/static/src/systray_items/website_switcher.xml
+++ b/addons/website/static/src/systray_items/website_switcher.xml
@@ -4,7 +4,7 @@
     <Dropdown class="'o_menu_systray_item o_website_switcher_container'" hotkey="'w'">
         <t t-set-slot="toggler">
             <div class="d-none d-md-block">
-                <span t-esc="websiteService.currentWebsite.name" class="me-2"/>
+                <span t-esc="currentWebsite.name" class="me-2"/>
                 <i class="fa fa-caret-down"/>
             </div>
             <div class="d-md-none">

--- a/addons/website/static/tests/website_service_mock.js
+++ b/addons/website/static/tests/website_service_mock.js
@@ -4,14 +4,22 @@ import { patch } from '@web/core/utils/patch';
 import { registry } from '@web/core/registry';
 import { utils, clearRegistryWithCleanup } from '@web/../tests/helpers/mock_env';
 
+const { reactive } = owl;
+
 const { prepareRegistriesWithCleanup } = utils;
 
 function makeFakeWebsiteService() {
     return {
         start() {
+            const currentWebsite = reactive({
+                metadata: {},
+            });
             return {
                 get context() {
                     return {};
+                },
+                get currentWebsite() {
+                    return currentWebsite;
                 },
                 get isRestrictedEditor() {
                     return true;

--- a/addons/website_links/static/src/services/website_custom_menus.js
+++ b/addons/website_links/static/src/services/website_custom_menus.js
@@ -4,5 +4,5 @@ import { registry } from '@web/core/registry';
 
 registry.category('website_custom_menus').add('website_links.menu_link_tracker', {
     openWidget: (services) => services.website.goToWebsite({ path: `/r?u=${encodeURIComponent(services.website.contentWindow.location.href)}` }),
-    isDisplayed: (env) => env.services.website.currentWebsite && env.services.website.contentWindow,
+    isDisplayed: (env) => !!env.services.website.contentWindow,
 });


### PR DESCRIPTION
[FIX] website: avoid replaying the website_preview action when possible

Before this commit, the website service goToWebsite method was always
calling the action service doAction method, even when already on the
client action.
Therefore, when a component was asking for a redirection/a reload of the
iframe, the whole action was unmounted and mounted again.

Now that the currentWebsite is a reactive value, we can use it to
trigger reload or redirections from there: an effect will be triggered
when the currentWebsite.reload is set to true. The goToWebsite method
is adapted to act on that currentWebsite reactive value when the client
action is already displayed.

This improves performances, as the component's state is updated, instead
of being recreated.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506

-----

[REF] website, *: convert website service currentWebsite to reactive

*: website_event, website_links

Before this commit, two events were sent when updating values from the
website service's currentWebsite: CONTENT-UPDATED and EDIT-WEBSITE,
introduced in [1]. This goes against the flow of owl, instead of doing
that, the components that need to be rerendered when the currentWebsite
is updated with new metadata could use an effect on the currentWebsite
reactive variable.

Now, the currentWebsite.id is set when parsing the iframe's document.
The custom systray is shown when the currentWebsite.isDisplayed is true,
so when the WebsitePreview client action is displayed.

Reworking the currentWebsite this way allows to optmize the initial
queries from the WebsitePreview to start the iframe:
- the websites are not fetched if the user does not have the group
multi_websites,
- the get_current_website is not called anymore.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
