### PR TITLE
[FIX][15.0] calendar: error when updating all calendar event occurences

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -876,7 +876,7 @@ class Meeting(models.Model):
                 if not start_update:
                     # Apply the same shift for start
                     start = base_time_values['start'] + (stop_update - self.stop)
-                    start_date = base_time_values['start_date'] + (stop_update.date() - self.stop.date())
+                    start_date = base_time_values['start'] + (stop_update.date() - self.stop.date())
                     update_dict.update({'start': start, 'start_date': start_date})
                 stop = base_time_values['stop'] + (stop_update - self.stop)
                 stop_date = base_time_values['stop'].date() + (stop_update.date() - self.stop.date())


### PR DESCRIPTION
Description of the issue/feature this PR addresses: There is an Odoo server error when we try to modify all calendar event occurrences.
This PR fix this: Add a recurrent calendar event and modify all occurrences.

Current behavior before PR:
There is a Odoo Server Error modifying all calendar occurrences before this PR.

Desired behavior after PR is merged:
We want to be able to modify all calendar event occurrences



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
