### PR TITLE
[FIX] web: Correctly compute count key to match server logic

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1011,7 +1011,8 @@ var MockServer = Class.extend({
 
             // compute count key to match dumb server logic...
             var countKey;
-            if (kwargs.lazy) {
+            const groupByNoLeaf = kwargs.context ? 'group_by_no_leaf' in kwargs.context : false;
+            if (kwargs.lazy && (groupBy.length >= 2 || !groupByNoLeaf)) {
                 countKey = groupBy[0].split(':')[0] + "_count";
             } else {
                 countKey = "__count";


### PR DESCRIPTION
Adapt `_mockReadGroup` to match `_read_group_raw`, to take account `group_by_no_leaf`.