### PR TITLE
[FIX] mrp: fix report_bom_structure

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -200,7 +200,7 @@ class ReportBomStructure(models.AbstractModel):
             if line._skip_bom_line(product):
                 continue
             if line.child_bom_id:
-                qty = line.product_uom_id._compute_quantity(line.product_qty * (factor / bom.product_qty) , line.child_bom_id.product_uom_id) / line.child_bom_id.product_qty
+                qty = line.product_uom_id._compute_quantity(line.product_qty * (factor / bom.product_qty), line.child_bom_id.product_uom_id)
                 sub_price = self._get_price(line.child_bom_id, qty, line.product_id)
                 price += sub_price
             else:

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -897,7 +897,7 @@ class TestBoM(TestMrpCommon):
 
         report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_finished.id, searchQty=80)
 
-        self.assertAlmostEqual(report_values['lines']['total'], 0.58)
+        self.assertAlmostEqual(report_values['lines']['total'], 2.92)
 
     def test_validate_no_bom_line_with_same_product(self):
         """


### PR DESCRIPTION
## Description
When there are 3 levels or more on the BoM structure, the BoM cost is incorrect.
![image](https://user-images.githubusercontent.com/29302288/192525955-4a1452fc-f506-4975-901b-b5a7ba0638b6.png)

## How to reproduce in v.14 to v.15.3 (fixed in v.16):
- Create products M1, M2, M3 and C1.
- Create BoM for 1 unit of M1, using 1 unit of M2
- Create BoM for 1 unit of M2, using 1 unit of M3
- Create BoM for 3 units of M3, using 1 unit of C1
- Set cost of C1 to $ 10.00.
- Go to the BoM of M1 -> 'BoM Structure & Cost' => BoM cost of M1 is $ 1.11, it should be $ 3.33

## Explanation
When there are 3 levels or more on the BoM structure, the 3rd level BoM Cost is divided twice by its quantity (instead of only 1).
It is only when there is 3 level of BoM that _get_price() call itself.
1 level: Computation done in `_get_bom_lines()`
2 levels: Computation done in `_get_bom_lines()` -> `_get_price()`
3 levels: Computation done in `_get_bom_lines()` -> `_get_price()` -> `_get_price()`
The issue is when `get_price()` calls itself, it doesn't send a correct `factor`:
![image](https://user-images.githubusercontent.com/29302288/192524066-978e5632-90e8-4f9d-ae3a-87d1336de98c.png)
The `factor` is already divided by the current `bom.product_qty`, so doing it before recalling `_get_price()` make no sens.

**Result:**
![image](https://user-images.githubusercontent.com/29302288/192526098-6857487d-d64b-415d-8c4c-797f74f7904c.png)


**Concerning the Test:**
The original final value was 2.92, it was changed for no reason in this PR: https://github.com/odoo/odoo/pull/79241
I had to put back the original value, else the fix fail the test.

---

UP to saas-15.3

---

OPW-2859407

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
