### PR TITLE
[FIX] mrp_workorder: fix status badge on kanban card

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -419,7 +419,7 @@
                                 <div class="o_kanban_workorder_date">
                                     <h5><span class="d-flex" t-esc="record.date_planned_start.value or record.production_date.value"/></h5>
                                 </div>
-                                <div class="o_kanban_manage_button_section">
+                                <div>
                                     <h2 class="ml8">
                                         <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'waiting', 'pending'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
                                             <t t-out="record.state.value"/>


### PR DESCRIPTION
The status badge on workorder kanban card was hidden behind a dropdown widget because of a wrongly used class.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
