### PR TITLE
[FIX] account: exchange diff in payment widget reco

### DIFF
--- a/addons/account/tests/test_account_move_payments_widget.py
+++ b/addons/account/tests/test_account_move_payments_widget.py
@@ -97,13 +97,19 @@ class TestAccountMovePaymentsWidget(AccountTestInvoicingCommon):
             .filtered(lambda line: line.account_id == pay_term_lines.account_id)
         (pay_term_lines + to_reconcile).reconcile()
 
+        exchange_diff_move = pay_term_lines.full_reconcile_id.exchange_move_id
+
         # Check payments after reconciliation.
         reconciled_payments_widget_vals = json.loads(invoice.invoice_payments_widget)
 
         self.assertTrue(reconciled_payments_widget_vals)
 
         current_amounts = {vals['move_id']: vals['amount'] for vals in reconciled_payments_widget_vals['content']}
-        self.assertDictEqual(current_amounts, expected_amounts)
+
+        if exchange_diff_move:
+            self.assertDictEqual(current_amounts, {**expected_amounts, exchange_diff_move.id: exchange_diff_move.amount_total})
+        else:
+            self.assertDictEqual(current_amounts, expected_amounts)
 
     # -------------------------------------------------------------------------
     # TESTS


### PR DESCRIPTION
Display the exchange diff move in payment reconciliation$
widget.

Steps to reproduce:

- With multi currency
- Two rates for the secondary currency (curr2): first one > second one
- Make a bill in curr2 at first rate date
- Make a payment in curr2 at second rate date
-> Issue : the exchange diff move is created, but not displayed
   in the payment reconciliation widget

Retrieve the exchange move from the full reconcile and add it to
widget values.

opw-2985585