### PR TITLE
[IMP] l10n_sg: income account notice

### DIFF
--- a/addons/l10n_sg/data/account_tax_data.xml
+++ b/addons/l10n_sg/data/account_tax_data.xml
@@ -239,43 +239,6 @@
                 ]"/>
         </record>
 
-        <record id="sg_sale_tax_srca_c_7" model="account.tax.template">
-            <field name="name">Sales Tax 7% SRCA-C</field>
-            <field name="description">7% SRCA-C</field>
-            <field name="price_include" eval="0"/>
-            <field name="amount">7</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">sale</field>
-            <field name="chart_template_id" ref="sg_chart_template"/>
-            <field name="tax_group_id" ref="tax_group_7"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'base',
-                        'plus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
-                    }),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'tax',
-                        'account_id': ref('account_account_798'),
-                        'plus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
-                    }),
-                ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'base',
-                        'minus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
-                    }),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'tax',
-                        'account_id': ref('account_account_798'),
-                        'minus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
-                    }),
-                ]"/>
-        </record>
-
         <!-- Purchases Tax -->
         <record id="sg_purchase_tax_tx7_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TX7</field>
@@ -310,6 +273,43 @@
                         'repartition_type': 'tax',
                         'account_id': ref('account_account_749'),
                         'minus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
+                    }),
+                ]"/>
+        </record>
+
+        <record id="sg_sale_tax_srca_c_7" model="account.tax.template">
+            <field name="name">Sales Tax 7% SRCA-C</field>
+            <field name="description">7% SRCA-C</field>
+            <field name="price_include" eval="0"/>
+            <field name="amount">-7</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="chart_template_id" ref="sg_chart_template"/>
+            <field name="tax_group_id" ref="tax_group_7"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'plus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
+                    }),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': ref('account_account_798'),
+                        'plus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
+                    }),
+                ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'minus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
+                    }),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': ref('account_account_798'),
+                        'minus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
                     }),
                 ]"/>
         </record>
@@ -704,26 +704,26 @@
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'base',
-                        'plus_report_line_ids': [ref('account_tax_report_line_total_taxable_purchases')],
+                        'plus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies'), ref('account_tax_report_line_total_taxable_purchases')],
                     }),
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'tax',
                         'account_id': ref('account_account_750'),
-                        'plus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
+                        'plus_report_line_ids': [ref('account_tax_report_line_output_tax_due'), ref('account_tax_report_line_inp_tax_refund_claim')],
                     }),
                 ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'base',
-                        'minus_report_line_ids': [ref('account_tax_report_line_total_taxable_purchases')],
+                        'minus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies'), ref('account_tax_report_line_total_taxable_purchases')],
                     }),
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'tax',
                         'account_id': ref('account_account_750'),
-                        'minus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
+                        'minus_report_line_ids': [ref('account_tax_report_line_output_tax_due'), ref('account_tax_report_line_inp_tax_refund_claim')],
                     }),
                 ]"/>
         </record>

--- a/addons/l10n_sg/data/account_tax_data.xml
+++ b/addons/l10n_sg/data/account_tax_data.xml
@@ -2,6 +2,43 @@
 <odoo>
     <data>
         <!-- Sales Tax -->
+        <record id="sg_sale_tax_sr_7" model="account.tax.template">
+            <field name="name">Sales Tax 7% SR</field>
+            <field name="description">7% SR</field>
+            <field name="price_include" eval="0"/>
+            <field name="amount">7</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">sale</field>
+            <field name="chart_template_id" ref="sg_chart_template"/>
+            <field name="tax_group_id" ref="tax_group_7"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'plus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
+                    }),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': ref('account_account_796'),
+                        'plus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
+                    }),
+                ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'minus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
+                    }),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': ref('account_account_796'),
+                        'minus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
+                    }),
+                ]"/>
+        </record>
+
         <record id="sg_sale_tax_es_0" model="account.tax.template">
             <field name="name">Sales Tax 0% ES33</field>
             <field name="description">0% ES33</field>
@@ -169,43 +206,6 @@
                 ]"/>
         </record>
 
-        <record id="sg_sale_tax_sr_7" model="account.tax.template">
-            <field name="name">Sales Tax 7% SR</field>
-            <field name="description">7% SR</field>
-            <field name="price_include" eval="0"/>
-            <field name="amount">7</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">sale</field>
-            <field name="chart_template_id" ref="sg_chart_template"/>
-            <field name="tax_group_id" ref="tax_group_7"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'base',
-                        'plus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
-                    }),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'tax',
-                        'account_id': ref('account_account_796'),
-                        'plus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
-                    }),
-                ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'base',
-                        'minus_report_line_ids': [ref('account_tax_report_line_std_rated_supplies')],
-                    }),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'tax',
-                        'account_id': ref('account_account_796'),
-                        'minus_report_line_ids': [ref('account_tax_report_line_output_tax_due')],
-                    }),
-                ]"/>
-        </record>
-
         <record id="sg_sale_tax_srca_s_na" model="account.tax.template">
             <field name="name">Sales Tax SRCA-S</field>
             <field name="description">SRCA-S</field>
@@ -277,6 +277,42 @@
         </record>
 
         <!-- Purchases Tax -->
+        <record id="sg_purchase_tax_tx7_7" model="account.tax.template">
+            <field name="name">Purchase Tax 7% TX7</field>
+            <field name="description">7% TX7</field>
+            <field name="price_include" eval="0"/>
+            <field name="amount">7</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="chart_template_id" ref="sg_chart_template"/>
+            <field name="tax_group_id" ref="tax_group_7"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'plus_report_line_ids': [ref('account_tax_report_line_total_taxable_purchases')],
+                    }),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': ref('account_account_749'),
+                        'plus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
+                    }),
+                ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'minus_report_line_ids': [ref('account_tax_report_line_total_taxable_purchases')],
+                    }),
+                    (0,0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': ref('account_account_749'),
+                        'minus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
+                    }),
+                ]"/>
+        </record>
 
         <record id="sg_purchase_tax_txn33_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TX-N33</field>
@@ -651,43 +687,6 @@
                     (0,0, {
                         'factor_percent': 100,
                         'repartition_type': 'tax',
-                    }),
-                ]"/>
-        </record>
-
-        <record id="sg_purchase_tax_tx7_7" model="account.tax.template">
-            <field name="name">Purchase Tax 7% TX7</field>
-            <field name="description">7% TX7</field>
-            <field name="price_include" eval="0"/>
-            <field name="amount">7</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="chart_template_id" ref="sg_chart_template"/>
-            <field name="tax_group_id" ref="tax_group_7"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'base',
-                        'plus_report_line_ids': [ref('account_tax_report_line_total_taxable_purchases')],
-                    }),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'tax',
-                        'account_id': ref('account_account_749'),
-                        'plus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
-                    }),
-                ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'base',
-                        'minus_report_line_ids': [ref('account_tax_report_line_total_taxable_purchases')],
-                    }),
-                    (0,0, {
-                        'factor_percent': 100,
-                        'repartition_type': 'tax',
-                        'account_id': ref('account_account_749'),
-                        'minus_report_line_ids': [ref('account_tax_report_line_inp_tax_refund_claim')],
                     }),
                 ]"/>
         </record>

--- a/addons/l10n_sg/models/__init__.py
+++ b/addons/l10n_sg/models/__init__.py
@@ -6,3 +6,4 @@
 from . import account_move
 from . import res_company
 from . import res_partner
+from . import account_account

--- a/addons/l10n_sg/models/account_account.py
+++ b/addons/l10n_sg/models/account_account.py
@@ -1,0 +1,22 @@
+from odoo import api, models
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+    @api.onchange('user_type_id')
+    def _onchange_user_type_id(self):
+        income_revenue = self.env.ref("account.data_account_type_revenue")
+        other_income_revenue = self.env.ref("account.data_account_type_other_income")
+        message = ""
+        if self.user_type_id == income_revenue:
+            message = "Please note that this account will be reflected in the Box 13: Revenus of the GST Return"
+        elif self.user_type_id == other_income_revenue:
+            message = "Please note that this account will not be reflected in the Box 13: Revenues of the GST Return"
+
+        if self.user_type_id in income_revenue | other_income_revenue:
+            return {
+                'warning': {
+                    'title': "Warning",
+                    'message': message
+                }
+            }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Give warning to user when they are creating a new CoA that income accounts are going to be counted towards Box 13.

2860997
Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
