### PR TITLE
[FIX] stock_account: Inventory valuation report shows negative values when it must be zero

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, tools
+from odoo import fields, models, tools, api
 
 
 class StockValuationLayer(models.Model):
@@ -55,3 +55,14 @@ class StockValuationLayer(models.Model):
     def _validate_analytic_accounting_entries(self):
         for svl in self:
             svl.stock_move_id._account_analytic_entry_move()
+
+    @api.model
+    def create(self, data_list):
+        try:
+            currency_rounding = self.env['res.company'].browse(data_list.get('company_id')).currency_id.rounding
+            n_digits = len(str(currency_rounding).split(".")[1])
+            data_list['value'] = round(data_list['value'], n_digits)
+            data_list['unit_cost'] = round(data_list['unit_cost'], n_digits)
+        except KeyError:
+            pass
+        return super(StockValuationLayer, self).create(data_list)


### PR DESCRIPTION
Steps to reproduce:
- Create a product with cost = 15.62
- Update the quantity to 3
- Create and validate the delivery order of the product with quantity 1
- Create another delivery order with this time quantity 2
- Go to inventory -> reporting -> inventory valuation
- You will see a total value of -0 and when switching to the pivot view and downloading the xlsx the real value is -3E-15

Solution:
Some real numbers such as 15.62 are not valid float, that means there is no float value that is exactly equal to 15.62. When converting it to float we just get an approximation, that's why the core functions float_round() and round() (from res_currency)  of odoo will always returns 15.620000000000001. To fix that I round the value of the 'value' field on the creation of a stock_value_layer record.

opw-2955202