### PR TITLE
[FIX] account: have transactions without statement in the demo

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -20,6 +20,7 @@ class AccountChartTemplate(models.Model):
         # created later but defined in this same function.
         yield self._get_demo_data_move()
         yield self._get_demo_data_statement()
+        yield self._get_demo_data_statement_line()
         yield self._get_demo_data_reconcile_model()
         yield self._get_demo_data_attachment()
         yield self._get_demo_data_mail_message()
@@ -108,7 +109,7 @@ class AccountChartTemplate(models.Model):
             limit=1,
         )
         return ('account.bank.statement', {
-            f'{cid}_demo_bank_statement_0': {
+            f'{cid}_demo_bank_statement': {
                 'name': f'{bnk_journal.name} - {time.strftime("%Y")}-01-01/1',
                 'balance_end_real': 5103.0,
                 'balance_start': 0.0,
@@ -121,58 +122,63 @@ class AccountChartTemplate(models.Model):
                     }),
                 ]
             },
-            f'{cid}_demo_bank_statement_1': {
-                'name': f'{bnk_journal.name} - {time.strftime("%Y")}-01-01/2',
-                'balance_end_real': 9944.87,
-                'balance_start': 5103.0,
-                'line_ids': [
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': time.strftime('INV/%Y/00002 and INV/%Y/00003'),
-                        'amount': 1275.0,
-                        'date': time.strftime('%Y-01-01'),
-                        'partner_id': ref('base.res_partner_12').id
-                    }),
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': 'Bank Fees',
-                        'amount': -32.58,
-                        'date': time.strftime('%Y-01-01'),
-                    }),
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': 'Prepayment',
-                        'amount': 650,
-                        'date': time.strftime('%Y-01-01'),
-                        'partner_id': ref('base.res_partner_12').id
-                    }),
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': time.strftime(f'First {formatLang(self.env, 2000, currency_obj=self.env.company.currency_id)} of invoice %Y/00001'),
-                        'amount': 2000,
-                        'date': time.strftime('%Y-01-01'),
-                        'partner_id': ref('base.res_partner_12').id
-                    }),
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': 'Last Year Interests',
-                        'amount': 102.78,
-                        'date': time.strftime('%Y-01-01'),
-                    }),
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': time.strftime('INV/%Y/00002'),
-                        'amount': 750,
-                        'date': time.strftime('%Y-01-01'),
-                        'partner_id': ref('base.res_partner_2').id
-                    }),
-                    Command.create({
-                        'journal_id': bnk_journal.id,
-                        'payment_ref': f'R:9772938  10/07 AX 9415116318 T:5 BRT: {formatLang(self.env, 100.0, digits=2)} C/ croip',
-                        'amount': 96.67,
-                        'date': time.strftime('%Y-01-01'),
-                    }),
-                ]
+        })
+
+    @api.model
+    def _get_demo_data_statement_line(self):
+        cid = self.env.company.id
+        ref = self.env.ref
+        bnk_journal = self.env['account.journal'].search(
+            domain=[('type', '=', 'bank'), ('company_id', '=', cid)],
+            limit=1,
+        )
+        return ('account.bank.statement.line', {
+            f'{cid}_demo_bank_transaction_1': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': time.strftime('INV/%Y/00002 and INV/%Y/00003'),
+                'amount': 1275.0,
+                'date': time.strftime('%Y-01-01'),
+                'partner_id': ref('base.res_partner_12').id
+            },
+            f'{cid}_demo_bank_transaction_2': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': 'Bank Fees',
+                'amount': -32.58,
+                'date': time.strftime('%Y-01-01'),
+            },
+            f'{cid}_demo_bank_transaction_3': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': 'Prepayment',
+                'amount': 650,
+                'date': time.strftime('%Y-01-01'),
+                'partner_id': ref('base.res_partner_12').id
+            },
+            f'{cid}_demo_bank_transaction_4': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': time.strftime(
+                    f'First {formatLang(self.env, 2000, currency_obj=self.env.company.currency_id)} of invoice %Y/00001'),
+                'amount': 2000,
+                'date': time.strftime('%Y-01-01'),
+                'partner_id': ref('base.res_partner_12').id
+            },
+            f'{cid}_demo_bank_transaction_5': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': 'Last Year Interests',
+                'amount': 102.78,
+                'date': time.strftime('%Y-01-01'),
+            },
+            f'{cid}_demo_bank_transaction_6': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': time.strftime('INV/%Y/00002'),
+                'amount': 750,
+                'date': time.strftime('%Y-01-01'),
+                'partner_id': ref('base.res_partner_2').id
+            },
+            f'{cid}_demo_bank_transaction_7': {
+                'journal_id': bnk_journal.id,
+                'payment_ref': f'R:9772938  10/07 AX 9415116318 T:5 BRT: {formatLang(self.env, 100.0, digits=2)} C/ croip',
+                'amount': 96.67,
+                'date': time.strftime('%Y-01-01'),
             },
         })
 
@@ -219,7 +225,7 @@ class AccountChartTemplate(models.Model):
                 'type': 'binary',
                 'name': 'bank_statement_yourcompany_demo.pdf',
                 'res_model': 'account.bank.statement',
-                'res_id': ref(f'account.{cid}_demo_bank_statement_1').id,
+                'res_id': ref(f'account.{cid}_demo_bank_statement').id,
                 'raw': file_open(
                     'account/static/demo/bank_statement_yourcompany_1.pdf', 'rb'
                 ).read()
@@ -251,7 +257,7 @@ class AccountChartTemplate(models.Model):
         return ('mail.message', {
             f'{cid}_mail_message_bank_statement_1': {
                 'model': 'account.bank.statement',
-                'res_id': ref(f'account.{cid}_demo_bank_statement_1').id,
+                'res_id': ref(f'account.{cid}_demo_bank_statement').id,
                 'body': 'Bank statement attachment',
                 'message_type': 'comment',
                 'author_id': ref('base.partner_demo').id,


### PR DESCRIPTION
Bank statements are now optional, so it makes sense to have some transactions without statement in the demo



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
