### PR TITLE
[FIX] CRM: fix expected revenue and probability fields in edit mode

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -55,7 +55,7 @@
                                     <label for="expected_revenue" class="oe_edit_only" />
                                     <div class="o_row">
                                         <field name="company_currency" invisible="1"/>
-                                        <field name="expected_revenue" class="oe_inline" widget='monetary' options="{'currency_field': 'company_currency'}"/>
+                                        <field name="expected_revenue" class="o_field_monetary_responsive" widget='monetary' options="{'currency_field': 'company_currency'}"/>
                                         <span class="oe_grey p-2" groups="crm.group_use_recurring_revenues"> + </span>
                                         <span class="oe_grey p-2" groups="!crm.group_use_recurring_revenues"> at </span>
                                     </div>
@@ -85,7 +85,7 @@
                                     </div>
                                     <div id="probability" class="o_row d-flex">
                                         <field name="is_automated_probability" invisible="1"/>
-                                        <field name="probability" widget="float" class="oe_inline"/>
+                                        <field name="probability" widget="float"/>
                                         <span class="oe_grey"> %</span>
                                     </div>
                                 </div>

--- a/addons/web/static/src/views/fields/monetary/monetary_field.scss
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.scss
@@ -1,3 +1,6 @@
 .o_field_widget.o_field_monetary input {
     width: 100px;
 }
+.o_field_widget.o_field_monetary_responsive input{
+    width: 100% !important;
+}


### PR DESCRIPTION
In edit mode probability and expected revenue fields do not show up
correctly. Expected revenue does not show up correctly because
o_field_monetary now has width of 100px, and for probabilty
oe_inline class makes the width shorter and makes % sign float away.
This fix fixes both issues.

Task-2991227




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
