### PR TITLE
[FIX] account: do not check sequence name in an onchange

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1571,59 +1571,6 @@ class AccountMove(models.Model):
                     self.partner_id = False
                 return {'warning': warning}
 
-    @api.onchange('name', 'highest_name')
-    def _onchange_name_warning(self):
-        if self.name and self.name != '/' and self.name <= (self.highest_name or '') and not self.quick_edit_mode:
-            self.show_name_warning = True
-        else:
-            self.show_name_warning = False
-
-        origin_name = self._origin.name
-        if not origin_name or origin_name == '/':
-            origin_name = self.highest_name
-        if (
-            self.name and self.name != '/'
-            and origin_name and origin_name != '/'
-            and self.date == self._origin.date
-            and self.journal_id == self._origin.journal_id
-        ):
-            new_format, new_format_values = self._get_sequence_format_param(self.name)
-            origin_format, origin_format_values = self._get_sequence_format_param(origin_name)
-
-            if (
-                new_format != origin_format
-                or dict(new_format_values, seq=0) != dict(origin_format_values, seq=0)
-            ):
-                changed = _(
-                    "It was previously '%(previous)s' and it is now '%(current)s'.",
-                    previous=origin_name,
-                    current=self.name,
-                )
-                reset = self._deduce_sequence_number_reset(self.name)
-                if reset == 'month':
-                    detected = _(
-                        "The sequence will restart at 1 at the start of every month.\n"
-                        "The year detected here is '%(year)s' and the month is '%(month)s'.\n"
-                        "The incrementing number in this case is '%(formatted_seq)s'."
-                    )
-                elif reset == 'year':
-                    detected = _(
-                        "The sequence will restart at 1 at the start of every year.\n"
-                        "The year detected here is '%(year)s'.\n"
-                        "The incrementing number in this case is '%(formatted_seq)s'."
-                    )
-                else:
-                    detected = _(
-                        "The sequence will never restart.\n"
-                        "The incrementing number in this case is '%(formatted_seq)s'."
-                    )
-                new_format_values['formatted_seq'] = "{seq:0{seq_length}d}".format(**new_format_values)
-                detected = detected % new_format_values
-                return {'warning': {
-                    'title': _("The sequence format has changed."),
-                    'message': "%s\n\n%s" % (changed, detected)
-                }}
-
     @api.onchange('journal_id')
     def _onchange_journal_id(self):
         if not self.quick_edit_mode and self._get_last_sequence(lock=False):
@@ -2389,7 +2336,7 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
 
     def _must_check_constrains_date_sequence(self):
-        return not self.posted_before and not self.quick_edit_mode
+        return not self.posted_before or not self.quick_edit_mode
 
     def _get_last_sequence_domain(self, relaxed=False):
         # EXTENDS account sequence.mixin

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -81,22 +81,12 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         copy2.journal_id = new_journal
         self.assertEqual(copy2.name, 'MISC2/2016/01/0001')
         with Form(copy2) as move_form:  # It is editable in the form
-            with mute_logger('odoo.tests.common.onchange'):
-                move_form.name = 'MyMISC/2016/0001'
-                self.assertIn(
-                    'The sequence will restart at 1 at the start of every year',
-                    move_form._perform_onchange(['name'])['warning']['message'],
-                )
+            move_form.name = 'MyMISC/2016/0001'
             move_form.journal_id = self.test_move.journal_id
             self.assertEqual(move_form.name, '/')
             move_form.journal_id = new_journal
             self.assertEqual(move_form.name, 'MISC2/2016/01/0001')
-            with mute_logger('odoo.tests.common.onchange'):
-                move_form.name = 'MyMISC/2016/0001'
-                self.assertIn(
-                    'The sequence will restart at 1 at the start of every year',
-                    move_form._perform_onchange(['name'])['warning']['message'],
-                )
+            move_form.name = 'MyMISC/2016/0001'
         copy2.action_post()
         self.assertEqual(copy2.name, 'MyMISC/2016/0001')
 


### PR DESCRIPTION
If the sequence and the date do not match upon saving, it is an issue.
But we should not block the user during the process by raising a warning when the sequence is changed before the date, if it's ok to change the date then the sequence.

The onchange check on the sequence is thus removed, and we will rely on the error raised upon saving when the sequence and the date don't match to make sure the user does not break the sequencing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
