### PR TITLE
[FIX] sale_project: fix default billable for non fsm project

### DIFF
--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -3,4 +3,13 @@
     <record id="project.open_view_project_all_config" model="ir.actions.act_window">
         <field name="context">{'default_allow_billable': True}</field>
     </record>
+    <record id="project.open_view_project_all_config_group_stage" model="ir.actions.act_window">
+        <field name="context">{'default_allow_billable': True}</field>
+    </record>
+    <record id="project.open_view_project_all" model="ir.actions.act_window">
+        <field name="context">{'default_allow_billable': True}</field>
+    </record>
+    <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
+        <field name="context">{'default_allow_billable': True}</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit, While creating project from configuration billable was not set true after enabling all fields from settings in project

After this commit, using context in action billable was set true

task-2995118

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
