### PR TITLE
[FIX] rating: fix ratings according to company

### DIFF
--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -37,6 +37,7 @@ class Rating(models.Model):
     parent_ref = fields.Reference(
         string='Parent Ref', selection='_selection_target_model',
         compute='_compute_parent_ref', readonly=True)
+    company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
     rated_partner_id = fields.Many2one('res.partner', string="Rated Operator", help="Owner of the rated resource")
     rated_partner_name = fields.Char(related="rated_partner_id.name")
     partner_id = fields.Many2one('res.partner', string='Customer', help="Author of the rating")

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -252,6 +252,12 @@
             </field>
         </record>
 
+        <record id="rating_rating_comp_rule" model="ir.rule">
+            <field name="name">Rating Company Rule</field>
+            <field name="model_id" ref="model_rating_rating"/>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        </record>
+
         <record id="rating_rating_action" model="ir.actions.act_window">
             <field name="name">Ratings</field>
             <field name="res_model">rating.rating</field>


### PR DESCRIPTION
Before this commit, in helpdesk > reporting > customer rating the ratings were visible to all companies even if they don't belong to that company

So in this commit, the ratings are visible to the respective company only

task-2995118

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
