### PR TITLE
[IMP] website_sale_loyalty: allow gift card and coupon

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
@@ -1,24 +1,12 @@
 /** @odoo-module **/
 
 import tour from 'web_tour.tour';
-import tourUtils from 'website_sale.tour_utils';
+import wsTourUtils from 'website_sale.tour_utils';
+import wTourUtils from 'website.tour_utils';
 
-tour.register('shop_sale_gift_card', {
-    test: true,
-    url: '/shop?search=Small%20Drawer'
-},
-    [
-        // Add a small drawer to the order (50$)
-        {
-            content: 'select Small Drawer',
-            extra_trigger: '.oe_search_found',
-            trigger: '.oe_product_cart a:contains("TEST - Small Drawer")',
-        },
-        {
-            content: 'Add Small Drawer into cart',
-            trigger: 'a:contains(ADD TO CART)',
-        },
-        tourUtils.goToCart(),
+
+function applyCoupon(couponCode) {
+    return [
         {
             content: 'Click on "I have a promo code"',
             extra_trigger: '#cart_products',
@@ -27,64 +15,41 @@ tour.register('shop_sale_gift_card', {
         {
             content: 'insert gift card code',
             trigger: 'form[name="coupon_code"] input[name="promo"]',
-            run: 'text GIFT_CARD'
+            run: `text ${couponCode}`,
         },
-        {
-            content: 'validate the gift card',
-            trigger: 'form[name="coupon_code"] .a-submit',
-        },
+        wTourUtils.clickOnElement('validate the gift card', 'form[name="coupon_code"] .a-submit'),
+    ];
+}
+
+tour.register('shop_sale_gift_card', {
+        test: true,
+        url: '/shop'
+    },
+    [
+        // Add a small drawer to the order (50$)
+        ...wsTourUtils.addToCart({productName: 'Small Drawer'}),
+        wsTourUtils.goToCart({quantity: 1}),
+        ...applyCoupon('GIFT_CARD'),
         {
             content: 'check gift card line',
             trigger: '.td-product_name:contains("PAY WITH GIFT CARD")',
         },
         {
-            content: 'Click on "I have a promo code"',
-            trigger: '.show_coupon',
+            content: 'check gift card amount',
+            trigger: '.oe_currency_value:contains("-﻿50.00")',
+            run: function () {
+            },
         },
-        {
-            content: 'insert gift card code',
-            extra_trigger: 'form[name="coupon_code"]',
-            trigger: 'form[name="coupon_code"] input[name="promo"]',
-            run: 'text 10PERCENT'
-        },
-        {
-            content: 'validate the gift card',
-            trigger: 'form[name="coupon_code"] .a-submit',
-        },
+        ...applyCoupon('10PERCENT'),
+
         {
             content: 'check gift card amount',
-            trigger: '.oe_currency_value:contains("-45.00")',
-            trigger: '.oe_website_sale .oe_cart',
-            run: function () {}, // it's a check
+            trigger: '.oe_currency_value:contains("-﻿45.00")',
+            run: function () {
+            },
         },
-        {
-            content: 'go to shop',
-            trigger: 'a:contains("Shop")',
-        },
-        {
-            content: "type Gift Card in search",
-            trigger: 'form input[name="search"]',
-            run: "text Gift Card",
-        },
-        {
-            content: "start search",
-            trigger: 'form:has(input[name="search"]) .oe_search_button',
-        },
-        {
-            content: "select Gift Card",
-            extra_trigger: '.oe_search_found', // Wait to be on search results or it sometimes throws concurent error (sent search form + click on product on /shop)
-            trigger: '.oe_product_cart a:containsExact("TEST - Gift Card")',
-        },
-        {
-            content: "click on 'Add to Cart' button",
-            trigger: "a:contains(ADD TO CART)",
-        },
-            tourUtils.goToCart({quantity: 2}),
-        {
-            content: 'check gift card amount',
-            trigger: '.oe_currency_value:contains("-45.00")',
-            trigger: '.oe_website_sale .oe_cart',
-            run: function () {}, // it's a check
-        },
+        ...wsTourUtils.addToCart({productName: 'TEST - Gift Card'}),
+        wsTourUtils.goToCart({quantity: 2}),
     ],
 );
+


### PR DESCRIPTION
This PR adds the possibility to use a gift card and a coupon together in the loyalty system

Also improves the shop_sale_gift_card tour.

task_id=2862485
