### PR TITLE
[FIX] website, web: make the website page's visibility field required

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -23,7 +23,7 @@ class View(models.Model):
     page_ids = fields.One2many('website.page', 'view_id')
     first_page_id = fields.Many2one('website.page', string='Website Page', help='First page linked to this view', compute='_compute_first_page_id')
     track = fields.Boolean(string='Track', default=False, help="Allow to specify for one page of the website to be trackable or not")
-    visibility = fields.Selection([('', 'All'), ('connected', 'Signed In'), ('restricted_group', 'Restricted Group'), ('password', 'With Password')], default='')
+    visibility = fields.Selection([('public', 'Public'), ('connected', 'Signed In'), ('restricted_group', 'Restricted Group'), ('password', 'With Password')], default='public', required=True)
     visibility_password = fields.Char(groups='base.group_system', copy=False)
     visibility_password_display = fields.Char(compute='_get_pwd', inverse='_set_pwd', groups='website.group_website_designer')
 
@@ -382,7 +382,7 @@ class View(models.Model):
 
         visibility = self._get_cached_visibility()
 
-        if visibility and not request.env.user.has_group('website.group_website_designer'):
+        if visibility != 'public' and not request.env.user.has_group('website.group_website_designer'):
             if (visibility == 'connected' and request.website.is_public_user()):
                 error = werkzeug.exceptions.Forbidden()
             elif visibility == 'password' and \

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1217,10 +1217,10 @@ class Website(models.Model):
         # '/' already has a http.route & is in the routing_map so it will already have an entry in the xml
         domain = [('url', '!=', '/')]
         if not force:
-            domain += [('website_indexed', '=', True), ('visibility', '=', False)]
+            domain += [('website_indexed', '=', True), ('visibility', '=', 'public')]
             # is_visible
             domain += [
-                ('website_published', '=', True), ('visibility', '=', False),
+                ('website_published', '=', True), ('visibility', '=', 'public'),
                 '|', ('date_publish', '=', False), ('date_publish', '<=', fields.Datetime.now())
             ]
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2531,6 +2531,7 @@ class Selection(Field):
     def setup_nonrelated(self, model):
         super().setup_nonrelated(model)
         assert self.selection is not None, "Field %s without selection" % self
+        assert (not isinstance(self.selection, list)) or all(map(lambda o: o[0], self.selection)), "Field %s has selection without key" % self
 
     def setup_related(self, model):
         super().setup_related(model)


### PR DESCRIPTION
In the page properties form, the visibility field could be set to an
empty value.

This commit makes the visibility field required. It also replaces its
empty string key by "public", so that it works properly in the dropdown
UI component.

This PR also prevent empty strings from being used a Selection field's option's keys.

task-2687506