### PR TITLE
[FIX] sale: assume several sale_lines per move_line

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -12,7 +12,7 @@ class AccountMove(models.Model):
     def action_post(self):
         #inherit of the function from account.move to validate a new tax and the priceunit of a downpayment
         res = super(AccountMove, self).action_post()
-        line_ids = self.mapped('line_ids').filtered(lambda line: line.sale_line_ids.is_downpayment)
+        line_ids = self.mapped('line_ids').filtered(lambda line: any(line.sale_line_ids.mapped('is_downpayment')))
         for line in line_ids:
             try:
                 line.sale_line_ids.tax_id = line.tax_ids


### PR DESCRIPTION
Since sale_line_ids is a m2m relation, there might be several sale lines per move line. In this case, this code raised a ValueError (is_downpayment expects a singleton).

With this commit, we select all the invoice lines that are linked to at least one sale line which is a downpayment.
