### PR TITLE
[IMP] test_lint : strict testing

### DIFF
--- a/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
@@ -126,8 +126,6 @@ class OdooBaseChecker(checkers.BaseChecker):
             node.func.attrname in ('execute', 'executemany') and
             # cursor expr (see above)
             self._get_cursor_name(node.func) in DFTL_CURSOR_EXPR and
-            # cr.execute("select * from %s" % foo, [bar]) -> probably a good reason for string formatting
-            len(node.args) <= 1 and
             # ignore in test files, probably not accessible
             not current_file_bname.startswith('test_')
         ):

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -79,12 +79,6 @@ class TestSqlLint(TransactionCase):
         self.assertFalse(r, f"unnecessary fstring should be innocuous\n{errs}")
 
         r, errs = self.check("""
-        def do_the_thing(cr, name, value):
-            cr.execute(f'select {name} from thing where field = %s', [value])
-        """)
-        self.assertFalse(r, f"probably has a good reason for the extra arg\n{errs}")
-
-        r, errs = self.check("""
         def do_the_thing(self):
             self.env.cr.execute(f'select name from {self._table}')
         """)


### PR DESCRIPTION
Prior to this change:

This would not get caught:
```
def test(self,injectable_variable):
    query = """SELECT * FROM %s WHERE """ + injectable_variable
    self.env.cr.execute(query,("some safe text",))
```

While this would get flagged:
```
def test2(self,injectable_variable):
    query = """SELECT * FROM table WHERE """ + injectable_variable
    self.env.cr.execute(query)
```

I don't think we should discard from checking all cr.execute that use more than 1 arg.

If such query is indeed needed, the test can be disabled with the comment 
```
# pylint: disable=sql-injection
```
And this will trigger CI/security for manual review
