### PR TITLE
[FIX] web: kanban drag and drop farther than initial screen width

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -24,6 +24,11 @@
     --KanbanColumn__highlight-border: #{$o-info};
     // ----------------------------------------------------------------------------
 
+    // Necessary for the drag and drop. Otherwise, with the flex system, nothing can be dropped farther than the initial screen width.
+    // Drawback: the scroll bar is only visible if fully scrolled down on the y axis. So big stack of kanban records can be annoying for 
+    // users not using the MAJ-Scroll shortcup to scroll horizontally.
+    overflow-x: scroll;
+
     .dropdown,
     .o_kanban_manage_button_section {
         position: inherit;


### PR DESCRIPTION
Add with css the overflow scroll x property on the kanban renderer. 
Necessary for the drag and drop. Otherwise, with the flex system, nothing can be dropped farther than the initial screen width. No really sure why unfortunately.

=> ! Drawback: the scroll bar is only visible if fully scrolled down on the y axis. So big stack of kanban records can be annoying for users not using the MAJ-Scroll shortcup to scroll horizontally.