### PR TITLE
[FIX] hr_expense: introduce analytic changes to hr.expense.split

### DIFF
--- a/addons/hr_expense/wizard/hr_expense_split.py
+++ b/addons/hr_expense/wizard/hr_expense_split.py
@@ -8,6 +8,7 @@ from odoo.tools import float_compare
 class HrExpenseSplit(models.TransientModel):
 
     _name = 'hr.expense.split'
+    _inherit = ['analytic.mixin']
     _description = 'Expense Split'
 
     def default_get(self, fields):
@@ -19,7 +20,7 @@ class HrExpenseSplit(models.TransientModel):
             result['tax_ids'] = expense.tax_ids
             result['product_id'] = expense.product_id
             result['company_id'] = expense.company_id
-            result['analytic_account_id'] = expense.analytic_account_id
+            result['analytic_distribution'] = expense.analytic_distribution
             result['employee_id'] = expense.employee_id
             result['currency_id'] = expense.currency_id
         return result
@@ -31,7 +32,6 @@ class HrExpenseSplit(models.TransientModel):
     tax_ids = fields.Many2many('account.tax', domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase')]")
     total_amount = fields.Monetary("Total In Currency", required=True, compute='_compute_from_product_id', store=True, readonly=False)
     amount_tax = fields.Monetary(string='Tax amount in Currency', compute='_compute_amount_tax')
-    analytic_account_id = fields.Many2one('account.analytic.account', string='Analytic Account', check_company=True)
     employee_id = fields.Many2one('hr.employee', string="Employee", required=True)
     company_id = fields.Many2one('res.company')
     currency_id = fields.Many2one('res.currency')
@@ -71,7 +71,7 @@ class HrExpenseSplit(models.TransientModel):
             'product_id': self.product_id.id,
             'total_amount': self.total_amount,
             'tax_ids': self.tax_ids.ids,
-            'analytic_account_id': self.analytic_account_id.id,
+            'analytic_distribution': self.analytic_distribution,
             'employee_id': self.employee_id.id,
             'product_uom_id': self.product_id.uom_id.id,
             'unit_amount': self.product_id.price_compute('standard_price', currency=self.currency_id)[self.product_id.id]

--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -20,7 +20,10 @@
                             <field name="total_amount" force_save="1" attrs="{'readonly': [('product_has_cost', '=', True)]}"/>
                             <field name="tax_ids" widget="many2many_tags" attrs="{'readonly': [('product_has_tax', '=', False)]}"/>
                             <field name="amount_tax"/>
-                            <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" groups="analytic.group_analytic_accounting"/>
+                            <field name="analytic_distribution_stored_char" invisible="1"/>
+                            <field name="analytic_distribution" widget="analytic_distribution"
+                                optional="show"
+                                groups="analytic.group_analytic_accounting"/>
                             <field name="employee_id" widget="many2one_avatar_employee"/>
                         </tree>
                     </field>
@@ -34,7 +37,7 @@
                     </group>
                     <field name="split_possible" invisible="1"/>
                     <footer>
-                        <button name="action_split_expense" disabled="disabled" attrs="{'invisible': [ ('split_possible', '=', True)]}" string="Split Expense" type="object" class="oe_highlight"  data-hotkey="q"/>
+                        <button name="action_split_expense" attrs="{'invisible': [ ('split_possible', '=', True)]}" string="Split Expense" type="object" class="oe_highlight disabled"  data-hotkey="q"/>
                         <button name="action_split_expense" string="Split Expense" attrs="{'invisible': [('split_possible', '=', False)]}" type="object" class="oe_highlight"  data-hotkey="q"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
                     </footer>


### PR DESCRIPTION
The following PR - #98914 introduced changes in
accounting analytic.
The changes were applied to 'hr.expense' but they were not applied to 'hr.expense.split'. Which lead to traceback.

task - 2997510


