### PR TITLE
[FIX] mail: mail template preview uses internal source

### DIFF
--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -34,7 +34,7 @@ class MailTemplatePreview(models.TransientModel):
     mail_template_id = fields.Many2one('mail.template', string='Related Mail Template', required=True)
     model_id = fields.Many2one('ir.model', string='Targeted model', related="mail_template_id.model_id")
     resource_ref = fields.Reference(string='Record', selection='_selection_target_model')
-    lang = fields.Selection(_selection_languages, string='Template Preview Language')
+    lang = fields.Selection(_selection_languages, string='Template Preview Language', default=lambda self: self.env.user.lang)
     no_record = fields.Boolean('No Record', compute='_compute_no_record')
     error_msg = fields.Char('Error Message', readonly=True)
     # Fields same than the mail.template model, computed with resource_ref and lang


### PR DESCRIPTION
- Have a database with two active languages
- Create a mail template
- Save the name and subject of the template (because I can't edit the body before saving)
- Create the body and save again
- Change language in the user preferences
- Edit the translations in both languages
- Save and click on preview without forcing the language

-> the preview shows the "source version" (in the language of the user at creation) before the translation was edited

As the source version cannot be edited anymore, show the translated version in the user's default language

opw:2978523

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
