### PR TITLE
[FIX] crm: search phone-mobile leads

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -469,6 +469,21 @@ class Lead(models.Model):
                 lead.ribbon_message = False
 
     def _search_phone_mobile_search(self, operator, value):
+
+        if value is False and operator in ('=', '!='):
+            condition = 'IS NULL' if operator == '=' else 'IS NOT NULL'
+            query = """
+                SELECT model.id
+                FROM %s model
+                WHERE model.phone %s
+                AND model.mobile %s
+            """ % (self._table, condition, condition)
+            self._cr.execute(query, ())
+            res = self._cr.fetchall()
+            if not res:
+                return [(0, '=', 1)]
+            return [('id', 'in', [r[0] for r in res])]
+
         value = re.sub(r'[^\d+]+', '', value)
         if len(value) <= 2:
             raise UserError(_('Please enter at least 3 digits when searching on phone / mobile.'))

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -567,8 +567,24 @@ class TestCRMLead(TestCrmCommon):
             'country_id': self.env.ref('base.be').id,
             'phone': '+32485112233',
         })
+        lead_3 = self.env['crm.lead'].create({
+            'name': 'Lead 3',
+            'country_id': self.env.ref('base.be').id,
+            'phone': '+32495001122',
+            'mobile': '+32985001122',
+        })
+        lead_4 = self.env['crm.lead'].create({
+            'name': 'Lead 4',
+            'country_id': self.env.ref('base.be').id,
+        })
         self.assertEqual(lead_1, self.env['crm.lead'].search([
             ('phone_mobile_search', 'like', '+32485001122')
+        ]))
+        self.assertIn(lead_3, self.env['crm.lead'].search([
+            ('phone_mobile_search', '!=', False) # is set
+        ]))
+        self.assertIn(lead_4, self.env['crm.lead'].search([
+            ('phone_mobile_search', '=', False) # is not set
         ]))
 
         with self.assertRaises(UserError):


### PR DESCRIPTION
Version: 14.0 only

Steps to reproduce:
    - go to the crm app;
    - Add a custom filter "Phone/Mobile is not set";

Issue:
   The filter does not work, there is an error.

Cause:
   The filter by phone/mobile is a filter implemented in the "Lead" class. It does not take into account specific cases where the value to be compared in the query is False (for the case "is set" and "is not set").

Solution:
    Modify the function that performs the search taking into account the cases where the value to compare is False.

opw-2996233