### PR TITLE
[FIX] mass_mailing: prevent removing structural block

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -488,7 +488,7 @@ export class MassMailingHtmlField extends HtmlField {
                 class: 'container o_mail_wrapper o_mail_regular oe_unremovable',
             });
             $newWrapperContent = $('<div/>', {
-                class: 'col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable'
+                class: 'col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable oe_unremovable',
             });
             $newWrapper.append($('<div class="row"/>').append($newWrapperContent));
         }


### PR DESCRIPTION
Commit [1] removed a hack that hid a SnippetEditor if its only option was SnippetMove and introduced a way to detect and hide empty SnippetEditors. Unfortunately, the SnippetEditor that [1] was hiding is now visible because it is removable.

This commit makes the block un-removable, as attempting to remove it does not work anyway.

[1]: https://github.com/odoo/odoo/commit/39d073ccafddf4b3fbe9ec9f5f11849d77c9bdaa
