### PR TITLE
[FIX] web_editor: do not apply neutral style if not configured

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -976,8 +976,12 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
                     const splitNode = splitAroundUntil(selectedTextNode, lastAncestorInlineFormat);
                     removeFormat(splitNode, formatSpec);
                 } else {
-                    if (firstBlockOrClassHasFormat && !applyStyle) {
-                        formatSpec.addNeutralStyle(getOrCreateSpan(selectedTextNode, inlineAncestors));
+                    if (firstBlockOrClassHasFormat) {
+                        if (!applyStyle && formatSpec.addNeutralStyle) {
+                            formatSpec.addNeutralStyle(getOrCreateSpan(selectedTextNode, inlineAncestors));
+                        } else {
+                            removeFormat(blockOrInlineClass, formatSpec);
+                        }
                     } else if (!firstBlockOrClassHasFormat && applyStyle) {
                         const tag = formatSpec.tagName && document.createElement(formatSpec.tagName);
                         if (tag) {


### PR DESCRIPTION
Steps to reproduce:
- Send a message
- Expand the window to a template
- Attempt to remove strikethrough on text.
- Traceback

task-3000711
