### PR TITLE
[FIX] payment_*: show stripe button only for stripe

### DIFF
--- a/addons/payment_stripe/views/payment_views.xml
+++ b/addons/payment_stripe/views/payment_views.xml
@@ -7,8 +7,7 @@
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='code']" position="before">
-                <group invisible="context.get('stripe_onboarding', False)"
-                       name="stripe_onboarding_group"
+                <group name="stripe_onboarding_group"
                        attrs="{'invisible': ['|', '|', ('code', '!=', 'stripe'), ('stripe_secret_key', '!=', False), ('stripe_publishable_key', '!=', False)]}">
                     <button string="Connect Stripe"
                             type="object"


### PR DESCRIPTION
The "Connect Stripe" button was shown for every payment provider and is now only displayed for the Stripe provider.

task-3002253
