### PR TITLE
[FIX] hr: fix misc UI issues

### DIFF
--- a/addons/hr/static/src/views/kanban_view.js
+++ b/addons/hr/static/src/views/kanban_view.js
@@ -7,7 +7,7 @@ import { KanbanModel } from '@web/views/kanban/kanban_model';
 
 export class EmployeeKanbanRecord extends KanbanModel.Record {
     async openChat(employeeId) {
-        const messaging = await this.model.messaging.get();
+        const messaging = await this.model.messagingService.get();
         messaging.openChat({ employeeId });
     }
 }

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -50,7 +50,10 @@
                                 <label for="name" string="Employee Name"/>
                                 <h1>
                                     <field name="name" placeholder="e.g. John Doe" required="True"/>
-                                    <a title="Chat" icon="fa-comments" t-on-click.prevent="() => openChat(props.record.resId)" href="#" class="ml8" invisible="not context.get('chat_icon')" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
+
+                                    <span invisible="not context.get('chat_icon')">
+                                        <a title="Chat" icon="fa-comments" t-on-click.prevent="() => openChat(props.record.resId)" href="#" class="ml8" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
+                                    </span>
                                 </h1>
                                 <h2>
                                     <field name="job_title" placeholder="Job Title" />

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -64,6 +64,9 @@
                         <field name="image_1920" widget='image' class="oe_avatar" options='{"zoom": true, "preview_image":"avatar_128"}'/>
                         <div class="oe_title">
                             <h1 class="d-flex">
+                                <span invisible="not context.get('chat_icon')">
+                                    <a title="Chat" icon="fa-comments" t-on-click.prevent="() => openChat(props.record.resId)" href="#" class="o_employee_chat_btn me-2" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments align-middle fs-6"/></a>
+                                </span>
                                 <field name="name" placeholder="Employee's Name" required="True" style="font-size: min(4vw, 2.6rem);" />
                                 <div class="d-flex align-items-end fs-6" style="height: min(4vw, 2.6rem); padding-bottom: 1px;">
                                     <div id="hr_presence_status" attrs="{'invisible': ['|', ('last_activity', '=', False), ('user_id', '=', False)]}" class="ms-1">
@@ -76,7 +79,6 @@
                                         <!-- Employee is not here but according to his work schedule, he should be connected -->
                                         <small role="img" class="fa fa-fw fa-circle text-warning o_button_icon hr_presence align-middle" attrs="{'invisible': [('hr_icon_display', '!=', 'presence_to_define')]}" aria-label="To define" title="To define" name="presence_to_define"/>
                                     </div>
-                                    <a title="Chat" icon="fa-comments" t-on-click.prevent="() => openChat(props.record.resId)" href="#" class="ml8 o_employee_chat_btn" invisible="not context.get('chat_icon')" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments align-middle fs-6"/></a>
                                 </div>
                             </h1>
                             <h2>

--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -7,10 +7,8 @@
         <field name="arch" type="xml">
             <div id="o_work_employee_main" position="after">
                 <div id="o_employee_right" class="col-lg-4 px-0 ps-lg-5 pe-lg-0">
-                    <group>
-                        <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
-                        <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
-                    </group>
+                    <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
+                    <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
                 </div>
             </div>
         </field>
@@ -23,10 +21,8 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='o_work_employee_main']" position="after">
                 <div id="o_employee_right" class="col-lg-4 px-0 ps-lg-5">
-                    <group>
-                        <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
-                        <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
-                    </group>
+                    <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
+                    <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
                 </div>
             </xpath>
         </field>
@@ -39,11 +35,9 @@
         <field name="arch" type="xml">
             <div id="o_work_employee_main" position="after">
                 <div id="o_employee_right" class="col-lg-4 px-0 ps-lg-5">
-                    <group>
-                        <field name="employee_ids" invisible="1"/>
-                        <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
-                        <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
-                    </group>
+                    <field name="employee_ids" invisible="1"/>
+                    <div class="o_horizontal_separator o_org_chart_title" colspan="2">Organization Chart</div>
+                    <field name="child_ids" class="position-relative" widget="hr_org_chart" readonly="1" nolabel="1"/>
                 </div>
             </div>
         </field>


### PR DESCRIPTION
- The org chart was squeezed and only taking half the space it could
- The messaging icon was displayed even when no user was set on the employee
- Wrong reference to messaging service on the kanban record, thus it was not possible to chat with an employee
