### PR TITLE
[FIX] Stock: fix name in forecasted warehouse filter

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.xml
@@ -3,9 +3,9 @@
 
     <t t-name="stock.ForecastedWarehouseFilter" owl="1">
         <Dropdown t-if="displayWarehouseFilter" menuClass="o_filter_menu"
-        class="'btn-group o_stock_report_warehouse_filter'" togglerClass="'btn btn-secondary'">
+        class="'btn-group'" togglerClass="'btn btn-secondary'">
             <t t-set-slot="toggler">
-                <span class="fa fa-home"/> Warehouse: <t t-esc="active_warehouse['name']"/>
+                <span class="fa fa-home"/> Warehouse: <t t-out="activeWarehouse.name"/>
             </t>
             <t t-foreach="warehouses" t-as="wh" t-key='wh.id'>
                 <DropdownItem onSelected="() => this._onSelected(wh['id'])"><t t-esc="wh['name']"/></DropdownItem>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When multi-warehouse is enabled, an error is thrown by
ForecastedWarehouseFilter due to an undefined variable.
The variable name change in js wasn't applied in xml.

Current behavior before PR:
Stack trace at loading of Stock Forecast :

> Caused by: TypeError: Cannot read properties of undefined (reading 'name')
>     at ForecastedWarehouseFilter.slot1 (eval at compile (https://19799037-16-0-all.runbot84.odoo.com/web/assets/2350-d0b6012/web.assets_common.min.js:2005:370), <anonymous>:14:44)
>     at callSlot (https://19799037-16-0-all.runbot84.odoo.com/web/assets/2350-d0b6012/web.assets_common.min.js:1633:34)
>     at Dropdown.template (eval at compile (https://19799037-16-0-all.runbot84.odoo.com/web/assets/2350-d0b6012/web.assets_common.min.js:2005:370), <anonymous>:26:18)

Desired behavior after PR is merged:
When multi-warehouse is enabled, Stock forecast load properly.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
