### PR TITLE
[FIX][15.0] web: attributes translate incorrect location

### DIFF
--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -813,6 +813,8 @@ $o-form-label-margin-right: 0px;
         }
     }
     &.o_form_editable .o_address_format {
+		display: flex;
+		flex-wrap: wrap;
         .o_address_city {
             width: 38%;
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Correct the position of field_translate to the correct position

Current behavior before PR:

1. Inherit or create a module with fields "address" (street, street2, cty,..)
2. add attribute translation on fields "address"(street, street2, cty, ...)
3. views: o_filed_translate in wrong place

I have image
![Screenshot from 2022-09-28 13-56-20](https://user-images.githubusercontent.com/94814697/193311630-195fdd24-64df-43e8-ac43-b347d0b2e7ee.png)


Desired behavior after PR is merged:

field_translate (EN) on the "address" fields to the end of the line.
this is my video after learning and fixing
[Screencast from 28-09-2022 13:56:42.webm](https://user-images.githubusercontent.com/94814697/193311754-b7b6242d-b00f-46c7-9911-9a2357cf935c.webm)

@Ngquang review for me

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
