### PR TITLE
[IMP] analytic: enable creation of analytic accounts from the widget

### DIFF
--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -33,6 +33,7 @@
                             </group>
                             <group>
                                 <field name="plan_id" options="{'no_quick_create': True}"/>
+                                <field name="root_plan_id" invisible="1"/>
                                 <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                                 <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                             </group>

--- a/addons/analytic/views/analytic_distribution_model_views.xml
+++ b/addons/analytic/views/analytic_distribution_model_views.xml
@@ -45,5 +45,6 @@
         <field name="name">Analytic Distribution Models</field>
         <field name="res_model">account.analytic.distribution.model</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'create_accounts': 1}</field>
     </record>
 </odoo>


### PR DESCRIPTION
From the distribution model form view (only), users should have the ability to create/ quick create analytic accounts using the widget. This is considered as a configuration view.

When using the save icon from an invoice - this should not be available.