### PR TITLE
[FIX] website_sale{_renting,}: datepicker option position

### DIFF
--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -92,7 +92,7 @@
                            data-no-preview="true"
                            data-reload="/"/>
             </we-row>
-            <we-checkbox string="Collapse Category Recursive"
+            <we-checkbox id="collapse_category_recursive" string="Collapse Category Recursive"
                          class="o_we_sublevel_1"
                          data-customize-website-views="website_sale.option_collapse_products_categories"
                          data-dependencies="categories_opt"


### PR DESCRIPTION
When you add the categories on the left you can tell if the categories are collapsible or not. But the field appears below "datepicker" that we added with rental search

Taskid: 3004243