### PR TITLE
[FIX] product, sale, stock: remove deleted product from demo data

### DIFF
--- a/addons/l10n_in/demo/product_demo.xml
+++ b/addons/l10n_in/demo/product_demo.xml
@@ -24,10 +24,6 @@
         <field name="l10n_in_hsn_code">9403</field>
         <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
-    <record id="product.product_product_4d" model="product.product">
-        <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
-    </record>
     <record id="product.product_product_5" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
         <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>

--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -234,10 +234,6 @@
                 'xml_id': 'product.product_product_4c',
                 'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('product.product_4_attribute_1_value_2') + obj().env.ref('product.product_4_attribute_2_value_1')),
                 'noupdate': True,
-            }, {
-                'xml_id': 'product.product_product_4d',
-                'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('product.product_4_attribute_1_value_2') + obj().env.ref('product.product_4_attribute_2_value_2')),
-                'noupdate': True,
             },]"/>
         </function>
 
@@ -259,13 +255,6 @@
             <field name="standard_price">500.0</field>
             <field name="image_1920" type="base64" file="product/static/img/table03.png"/>
         </record>
-        <record id="product_product_4d" model="product.product">
-            <field name="default_code">DESK0004</field>
-            <field name="weight">0.01</field>
-            <field name="standard_price">500.0</field>
-            <field name="image_1920" type="base64" file="product/static/img/table01.png"/>
-        </record>
-
         <record id="product_product_5" model="product.product">
             <field name="name">Corner Desk Right Sit</field>
             <field name="categ_id" ref="product_category_5"/>

--- a/addons/sale/data/product_product_demo.xml
+++ b/addons/sale/data/product_product_demo.xml
@@ -101,14 +101,6 @@
             <field name="invoice_policy">delivery</field>
         </record>
 
-        <record id="product.product_product_4d" model="product.product">
-            <field name="invoice_policy">delivery</field>
-        </record>
-
-        <record id="product.product_product_4d" model="product.product">
-            <field name="invoice_policy">delivery</field>
-        </record>
-
         <record id="product.product_product_4c" model="product.product">
             <field name="invoice_policy">delivery</field>
         </record>

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -81,11 +81,6 @@
             <field name="inventory_quantity">55.0</field>
             <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
         </record>
-        <record id="stock_inventory_7d" model="stock.quant">
-            <field name="product_id" ref="product.product_product_4d"/>
-            <field name="inventory_quantity">60.0</field>
-            <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
-        </record>
         <record id="stock_inventory_11" model="stock.quant">
             <field name="product_id" ref="product.product_product_12"/>
             <field name="inventory_quantity">10.0</field>
@@ -124,7 +119,6 @@
                                             ref('stock_inventory_7'),
                                             ref('stock_inventory_7b'),
                                             ref('stock_inventory_7c'),
-                                            ref('stock_inventory_7d'),
                                             ref('stock_inventory_11'),
                                             ref('stock_inventory_12'),
                                             ref('stock_inventory_13'),


### PR DESCRIPTION
# Current behaviour
When installing Sales, then PoS, we get an error when loading the modules.

# Expected behaviour
No error should be present when installing PoS just after the Sales app.

# Steps to reproduce
(With demo data)
- Install Sales
- Install PoS
- Get Error

# Reason for the problem
When installing Sales, there is the Product dependency that creates a product variant, named product_product_4d.
Then in the Sales demo data there is the addition of an "exclude_for" record (basically an exclusivity rule for variant attributes, for ex: A AND B cannot be together). In our case it happens to be the attributes which product_product_4d was based of. Therefor the ORM deletes said record (from the database).
Then when installing PoS, it installs Stock as a dependency, which demo data references product_product_4d, which is not present anymore in the database.

# Fix
Remove the creation of product_product_4d and all the records that reference it.

# Affected versions
- 14.0 (separate PR)
- 15.0
- saas-15.2
- saas-15.3
- 16.0
- master
---
Linked to https://github.com/odoo/enterprise/pull/32185
---
opw-2999180
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
