### PR TITLE
[FIX] web: wrap the display name of many2one

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -217,7 +217,7 @@
             <t t-foreach="getColumns(record)" t-as="column" t-key="column.id">
                 <t t-if="column.type === 'field'">
                     <td t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group, record)"
-                        class="o_data_cell cursor-pointer"
+                        class="o_data_cell cursor-pointer text-wrap"
                         t-att-class="getCellClass(column, record)"
                         t-att-name="column.name"
                         t-att-colspan="column.colspan"


### PR DESCRIPTION
Before, a many2one field in a list view will take as much space as it needs because the container of the text is "nowrap".

Wrapping the text when in non-edit mode is better ux since the many2one's column won't take a lot of one-line space.

Before: https://youtu.be/2mjaCrwZ8Ns
After: https://youtu.be/GcATpS22IeE

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
