### PR TITLE
Only enable spellcheck on focus with a hook (textarea)

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -59,6 +59,51 @@ export function useAutofocus({ refName, selectAll } = {}) {
     return ref;
 }
 
+/**
+ * To avoid elements to keep their spellcheck appearance when they are no
+ * longer in focus. We only add this attribute when needed. To disable this
+ * behavior, use the spellcheck attribute on the element.
+ */
+export function useSpellCheck() {
+    const listeners = [];
+    const ref = useRef("spellcheck");
+    function toggleSpellcheck(ev) {
+        ev.target.spellcheck = document.activeElement === ev.target;
+    }
+    const enableSpellCheckHook = () => {
+        if (ref.el) {
+            const inputs =
+                ref.el.nodeName === "TEXTAREA"
+                    ? [ref.el]
+                    : ref.el.querySelectorAll("[contenteditable=true], textarea");
+            inputs.forEach((input) => {
+                if (input.spellcheck !== false) {
+                    listeners.push(input);
+                    input.addEventListener("focus", toggleSpellcheck);
+                    input.addEventListener("blur", toggleSpellcheck);
+                }
+            });
+        }
+    };
+    const disableSpellCheckHook = () => {
+        listeners.forEach((input) => {
+            input.removeEventListener("focus", toggleSpellcheck);
+            input.removeEventListener("blur", toggleSpellcheck);
+        });
+    };
+    useEffect(
+        (el) => {
+            enableSpellCheckHook();
+            return disableSpellCheckHook;
+        },
+        () => [ref.el]
+    );
+    return {
+        disable: disableSpellCheckHook,
+        enable: enableSpellCheckHook,
+    };
+}
+
 // -----------------------------------------------------------------------------
 // useBus
 // -----------------------------------------------------------------------------

--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
+import { useSpellCheck } from "@web/core/utils/hooks";
 import { useInputField } from "../input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
 import { TranslationButton } from "../translation_button";
@@ -10,8 +11,9 @@ const { Component, useEffect, useRef } = owl;
 
 export class TextField extends Component {
     setup() {
-        this.textareaRef = useRef("textarea");
-        useInputField({ getValue: () => this.props.value || "", refName: "textarea" });
+        this.textareaRef = useRef("spellcheck");
+        useInputField({ getValue: () => this.props.value || "", refName: "spellcheck" });
+        useSpellCheck();
 
         useEffect(() => {
             if (!this.props.readonly) {

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -13,7 +13,7 @@
                 t-att-placeholder="props.placeholder"
                 t-att-rows="rowCount"
                 t-on-input="onInput"
-                t-ref="textarea"
+                t-ref="spellcheck"
             />
             <t t-if="props.isTranslatable">
                 <TranslationButton

--- a/addons/web/static/tests/views/fields/html_field_tests.js
+++ b/addons/web/static/tests/views/fields/html_field_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { click, editInput, getFixture } from "@web/../tests/helpers/utils";
+import { click, editInput, getFixture, triggerEvent } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { registry } from "@web/core/registry";
 import { HtmlField } from "@web/views/fields/html/html_field";
@@ -109,5 +109,35 @@ QUnit.module("Fields", ({ beforeEach }) => {
         const txt = target.querySelector(".kek");
         assert.strictEqual(txt.textContent, "some text");
         assert.strictEqual(txt.style.color, "red");
+    });
+
+    QUnit.test("html fields: spellcheck is disabled on blur", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: /* xml */ `<form><field name="txt" /></form>`,
+        });
+
+        const textarea = target.querySelector(".o_field_html textarea");
+        assert.strictEqual(textarea.spellcheck, true, "by default, spellcheck is enabled");
+        textarea.focus();
+
+        await editInput(textarea, null, "nev walue");
+        textarea.blur();
+        assert.strictEqual(
+            textarea.spellcheck,
+            false,
+            "spellcheck is disabled once the field has lost its focus"
+        );
+        textarea.focus();
+
+        await triggerEvent(textarea, null, "focus");
+        assert.strictEqual(
+            textarea.spellcheck,
+            true,
+            "spellcheck is re-enabled once the field is focused"
+        );
     });
 });

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -13,6 +13,7 @@ import ajax from 'web.ajax';
 import {
     useBus,
     useService,
+    useSpellCheck,
 } from "@web/core/utils/hooks";
 import { getAdjacentPreviousSiblings, getAdjacentNextSiblings } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 import { toInline } from 'web_editor.convertInline';
@@ -78,8 +79,15 @@ export class HtmlField extends Component {
         useBus(this.env.bus, "RELATIONAL_MODEL:WILL_SAVE_URGENTLY", () => this.commitChanges({ urgent: true }));
         useBus(this.env.bus, "RELATIONAL_MODEL:NEED_LOCAL_CHANGES", ({detail}) => detail.proms.push(this.commitChanges()));
 
+        const spellCheckHook = useSpellCheck();
+
         this._onUpdateIframeId = 'onLoad_' + _.uniqueId('FieldHtml');
 
+        onMounted(() => {
+            // We must wait for the editor to add the contenteditable
+            // property to the root element to use this hook properly
+            setTimeout(() => spellCheckHook.enable(), 3000);
+        });
         onWillStart(async () => {
             this.Wysiwyg = await this._getWysiwygClass();
             if (this.props.cssReadonlyAssetId) {

--- a/addons/web_editor/static/src/js/backend/html_field.xml
+++ b/addons/web_editor/static/src/js/backend/html_field.xml
@@ -10,7 +10,7 @@
                 <div  t-ref="readonlyElement" class="o_readonly" t-out="markupValue" />
             </t>
         </t>
-        <t t-else="">
+        <div t-else="" t-ref="spellcheck">
             <t t-if="state.showCodeView">
                 <textarea t-ref="codeView" class="o_codeview" t-att-value="markupValue"/>
                 <div t-ref="codeViewButton" id="codeview-btn-group" class="btn-group" t-on-click="toggleCodeView">
@@ -34,7 +34,7 @@
                     />
                 </span>
             </t>
-        </t>
+        </div>
     </t>
 
 </templates>


### PR DESCRIPTION
Since views are displayed in edition by default, textarea elements can become
difficult to read properly because of the spellcheck red underline. With this
hook, spellcheck is disabled when the textarea is blurred, and re-enabled on
focus.

Task: 2861428