### PR TITLE
[FIX] stock: Vendor column in Inventory Replenish view not sorting co…

### DIFF
--- a/addons/purchase_stock/views/stock_views.xml
+++ b/addons/purchase_stock/views/stock_views.xml
@@ -32,7 +32,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_stock_replenishment_info']" position="before">
                     <field name="show_supplier" invisible="1"/>
-                    <field name="supplier_id" string="Vendor" optional="show" attrs="{'invisible': [('show_supplier', '=', False)]}" options="{'no_create': True}"/>
+                    <field name="vendor_id" string="Vendor" optional="show" attrs="{'invisible': [('show_supplier', '=', False)]}" options="{'no_create': True}"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
…rrectly

This PR changes the `'stock.warehouse.orderpoint.tree.editable.inherit.mrp'` view to reference `vendor_id` instead of `supplier_id` as sorting through `supplier_id` results in bogus behavior (does not sort alphabetically) on the Inventory Replenishment view. `vendor_id` works here as it is stored (hence sortable) and stores the value of `supplier_id.name`.

https://github.com/odoo/odoo/blob/e113bae04a64a8bd341a80736086ab7c25079dd3/addons/purchase_stock/models/stock.py#L215-L218

Current behavior before PR: Sorting using 'Vendor' does not sort alphabetically as expected.

Desired behavior after PR is merged: Sorting using 'Vendor' sorts alphabetically as expected.

Support ticket number via odoo.com/help: OPW #2978118


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
