### PR TITLE
[FIX] mail: open composer with template in recipient lang from contextual menu

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -552,6 +552,9 @@ class MailComposer(models.TransientModel):
         """
         if template_id and composition_mode == 'mass_mail':
             template = self.env['mail.template'].browse(template_id)
+            lang = template._render_lang([res_id])[res_id]
+            if lang:
+                template = template.with_context(lang=lang)
             values = dict(
                 (field, template[field])
                 for field in ['subject', 'body_html',

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1232,11 +1232,10 @@ class TestMessagePostLang(TestMailCommon, TestRecipients):
             self.assertTrue(customer_email)
             body = customer_email['body']
             # check content
-            # self.assertIn('SpanishBody for %s' % record.name, body, 'Body based on template should be translated')
-            self.assertIn('EnglishBody for %s' % record.name, body, 'Fixme: this should be translated')
+            self.assertIn('SpanishBody for %s' % record.name, body, 'Body based on template should be translated')
             # check subject
-            # self.assertEqual('SpanishSubject for %s' % record.name, customer_email['subject'], 'Subject based on template should be translated')
-            self.assertEqual('EnglishSubject for %s' % record.name, customer_email['subject'], 'Fixme: this should be translated')
+            self.assertEqual('SpanishSubject for %s' % record.name, customer_email['subject'],
+                             'Subject based on template should be translated')
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')


### PR DESCRIPTION
When sending a mail template from a contextual menu configured to be sent in the user language, it was always in the default language. This solves the problem.

Technical note: using the contextual menu force the mass mode which doesn't render the template as there might be more than one recipient. We face the same problem for recipient language. Here we have chosen to set the message in the language determined by the first record selected.

Task-2742033

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
