### PR TITLE
[FIX] website: align fields in page properties dialog

### DIFF
--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -37,8 +37,6 @@
                 <page string="Name">
                     <group class="mt-4">
                         <field name="name" string="Page Name" widget="page_name" placeholder="e.g. Home Page"/>
-                    </group>
-                    <group>
                         <field name="website_id" invisible="1"/>
                         <field name="url" string="Page URL" widget="page_url" required="True"/>
                     </group>
@@ -46,20 +44,10 @@
                 <page string="Publish">
                     <group class="mt-4">
                         <field name="is_in_menu" string="Show in Top Menu" widget="boolean_toggle"/>
-                    </group>
-                    <group>
                         <field name="is_homepage" string="Use as Homepage" widget="boolean_toggle"/>
-                    </group>
-                    <group>
                         <field name="website_indexed" string="Indexed" widget="boolean_toggle" help="Hide this page from search results"/>
-                    </group>
-                    <group>
                         <field name="is_published" string="Published" widget="boolean_toggle"/>
-                    </group>
-                    <group>
                         <field name="date_publish" widget="datetime"/>
-                    </group>
-                    <group>
                         <field name="visibility"/>
                         <field name="visibility_password_display" attrs="{'invisible': [('visibility', '!=', 'password')], 'required': [('visibility', '=', 'password')]}" password="True" string="Password"/>
                         <field name="groups_id" attrs="{'invisible': [('visibility', '!=', 'restricted_group')]}" string="Authorized Groups" widget="many2many_tags"/>


### PR DESCRIPTION
Since [1] when the page properties dialog was converted to a backend view, its fields are not aligned anymore.

This commit fixes the layout of the page properties dialog by putting the fields of each page inside a single group.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506
