### PR TITLE
[IMP] base: writable address/commercial fields on contacts

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -221,10 +221,10 @@
                                 />
                             </group>
                             <group string="Accounting Entries" name="accounting_entries" groups="account.group_account_readonly">
-                                <p colspan="2" class="text-info" attrs="{'invisible': [('parent_id', '=', False), ('is_company', '=', False)]}">Accounting-related changes will also be applied on <a role="button" name="open_commercial_entity" type="object" string="the parent company" class="oe_link"/>.</p>
                                 <field name="currency_id" invisible="1"/>
                                 <field name="property_account_receivable_id"/>
                                 <field name="property_account_payable_id"/>
+                                <p colspan="2" class="text-info" attrs="{'invisible': ['!', '|', ('commercial_field_changed', 'ilike', 'property_account_receivable_id'), ('commercial_field_changed', 'ilike', 'property_account_payable_id')]}"><i class="fa fa-info-circle"/> Accounting-related changes will also be applied on <a role="button" name="open_commercial_entity" type="object" string="the parent company" class="oe_link"/>.</p>
                             </group>
                             <group string="Credit Limits"
                                    name="credit_limits"

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -199,7 +199,7 @@
                     </div>
                 </xpath>
                 <page name="sales_purchases" position="after">
-                    <page string="Invoicing" name="accounting" attrs="{'invisible': [('is_company','=',False),('parent_id','!=',False)]}" groups="account.group_account_invoice,account.group_account_readonly">
+                    <page string="Invoicing" name="accounting" groups="account.group_account_invoice,account.group_account_readonly">
                         <field name="duplicated_bank_account_partners_count" invisible="1"/>
                         <field name="show_credit_limit" invisible="1"/>
                         <group>
@@ -221,6 +221,7 @@
                                 />
                             </group>
                             <group string="Accounting Entries" name="accounting_entries" groups="account.group_account_readonly">
+                                <p colspan="2" class="text-info" attrs="{'invisible': [('parent_id', '=', False), ('is_company', '=', False)]}">Accounting-related changes will also be applied on <a role="button" name="open_commercial_entity" type="object" string="the parent company" class="oe_link"/>.</p>
                                 <field name="currency_id" invisible="1"/>
                                 <field name="property_account_receivable_id"/>
                                 <field name="property_account_payable_id"/>
@@ -237,11 +238,6 @@
                                 </div>
                             </group>
                         </group>
-                    </page>
-                    <page string="Invoicing" name="accounting_disabled" attrs="{'invisible': ['|',('is_company','=',True),('parent_id','=',False)]}" groups="account.group_account_invoice,account.group_account_readonly">
-                        <div>
-                            <p>Accounting-related settings are managed on <button name="open_commercial_entity" type="object" string="the parent company" class="oe_link"/></p>
-                        </div>
                     </page>
                 </page>
                 <xpath expr="//group[@name='misc']" position="before">

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -508,12 +508,6 @@ $o-form-label-margin-right: 0px;
         .o_priority > .o_priority_star {
             font-size: inherit;
         }
-        > h1 {
-            min-height: 55px;
-        }
-        > h2 {
-            min-height: 43px;
-        }
     }
 
     // Avatar

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -360,9 +360,6 @@
         .o_priority > .o_priority_star {
             font-size: inherit;
         }
-        > h1 {
-            min-height: 55px;
-        }
         > h2 {
             min-height: 42px;
         }

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -64,9 +64,9 @@
                     <field name="email" optional="show"/>
                     <field name="user_id" optional="show" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                     <field name="city" optional="show"/>
-                    <field name="state_id" optional="hide" readonly="1"/>
-                    <field name="country_id" optional="show" readonly="1"/>
-                    <field name="vat" optional="hide" readonly="1"/>
+                    <field name="state_id" optional="hide"/>
+                    <field name="country_id" optional="show"/>
+                    <field name="vat" optional="hide"/>
                     <field name="category_id" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="company_id" groups="base.group_multi_company" readonly="1"/>
                     <field name="is_company" invisible="1"/>
@@ -196,22 +196,16 @@
                                 <b attrs="{'invisible': [('is_company', '=', False)]}">Address</b>
                             </span>
                             <div class="o_address_format">
-                                <field name="street" placeholder="Street..." class="o_address_street"
-                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
-                                <field name="street2" placeholder="Street 2..." class="o_address_street"
-                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
-                                <field name="city" placeholder="City" class="o_address_city"
-                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
-                                <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}"
-                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
-                                <field name="zip" placeholder="ZIP" class="o_address_zip"
-                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                                <field name="street" placeholder="Street..." class="o_address_street"/>
+                                <field name="street2" placeholder="Street 2..." class="o_address_street"/>
+                                <field name="city" placeholder="City" class="o_address_city"/>
+                                <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                 <div name="partner_address_country" class="d-flex justify-content-between">
-                                    <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
-                                        attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                                    <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                 </div>
                             </div>
-                            <field name="vat" placeholder="e.g. BE0477472701" attrs="{'readonly': [('parent_id','!=',False)]}"/>
+                            <field name="vat" placeholder="e.g. BE0477472701"/>
                         </group>
                         <group>
                             <field name="function" placeholder="e.g. Sales Director"
@@ -348,7 +342,7 @@
                                 <group string="Purchase" name="purchase" priority="2">
                                 </group>
                                 <group name="misc" string="Misc">
-                                    <field name="company_registry" attrs="{'invisible': [('parent_id','!=',False)]}"/>
+                                    <field name="company_registry"/>
                                     <field name="ref" string="Reference"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('parent_id', '!=', False)]}" force_save="1"/>
                                     <field name="industry_id" attrs="{'invisible': [('is_company', '=', False)]}" options="{'no_create': True}"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -176,7 +176,7 @@
                             <field id="company" class="text-break" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact'),('is_company', '=', True)], 'invisible': [('is_company','=', False)]}"/>
                             <field id="individual" class="text-break" name="name" default_focus="1" placeholder="e.g. Brandom Freeman" attrs="{'required' : [('type', '=', 'contact'), ('is_company', '=', False)], 'invisible': [('is_company','=', True)]}"/>
                         </h1>
-                        <div class="o_row">
+                        <h2 class="o_row">
                             <field name="parent_id"
                                 widget="res_partner_many2one"
                                 placeholder="Company Name..."
@@ -186,7 +186,7 @@
                                 <button name="create_company" icon="fa-plus-square" string="Create company"
                                     type="object" class="oe_edit_only btn-link"
                                     attrs="{'invisible': ['|', '|', ('is_company','=', True), ('company_name', '=', ''), ('company_name', '=', False)]}"/>
-                        </div>
+                        </h2>
                     </div>
 
                     <group>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -171,6 +171,8 @@
                         <field name="active" invisible="1"/>
                         <field name="company_id" invisible="1"/>
                         <field name="country_code" invisible="1"/>
+                        <field name="address_field_changed" invisible="1"/>
+                        <field name="commercial_field_changed" invisible="1"/>
                         <field name="company_type" widget="radio" options="{'horizontal': true}"/>
                         <h1>
                             <field id="company" class="text-break" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact'),('is_company', '=', True)], 'invisible': [('is_company','=', False)]}"/>
@@ -196,7 +198,16 @@
                                 <b attrs="{'invisible': [('is_company', '=', False)]}">Address</b>
                             </span>
                             <div class="o_address_format">
-                                <field name="street" placeholder="Street..." class="o_address_street"/>
+                                <div class="o_row">
+                                    <field name="street" placeholder="Street..." class="o_address_street"/>
+                                    <span class="text-info"
+                                          data-tooltip="By saving this change, the address of this contact's parent will also be updated."
+                                          aria-label="By saving this change, the address of this contact's parent will also be updated."
+                                          attrs="{'invisible': [('address_field_changed', '=', '')]}">
+                                        <i class="fa fa-info-circle" />
+                                        Address updated
+                                    </span>
+                                </div>
                                 <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                 <field name="city" placeholder="City" class="o_address_city"/>
                                 <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
@@ -205,7 +216,17 @@
                                     <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                 </div>
                             </div>
-                            <field name="vat" placeholder="e.g. BE0477472701"/>
+                            <label for="vat"/>
+                            <div class="o_row o_row_readonly">
+                                <field name="vat" placeholder="e.g. BE0477472701" nolabel="1"/>
+                                <span class="text-info"
+                                      data-tooltip="Tax ID changes will be applied on the parent company."
+                                      aria-label="Tax ID changes will be applied on the parent company."
+                                      attrs="{'invisible': ['!', ('commercial_field_changed', 'ilike', 'vat')]}">
+                                    <i class="fa fa-info-circle" />
+                                    Tax ID Updated
+                                </span>
+                            </div>
                         </group>
                         <group>
                             <field name="function" placeholder="e.g. Sales Director"


### PR DESCRIPTION
Before this revision (and AFAIK ever since the great res.partner
address debate of the early 2010s), some fields on contacts behaved
like readonly related stored fields. By that, I mean that
the hiearchy between a parent and its children  of type `contact`
would influence the propagation of data: address fields and commercial
fields would be propagated from the parent to the children upon edition,
but the reverse was not true. This only happened for children of the
contact type - invoicing, delivery, private etc. addresses would be
editable and not propagate or be propagated upon.

But having readonly fields on contacts is very unintuitive, especially
since no justification is provided with regards to this limitation.

This revision removes this readonly limitation altogether and allow
users to write on address and commercial fields of contacts - the
modification will be propagated upward (and to siblings as well).

This is akin to an inversable stored related fields, though it still
only happens for contact<->parent hierarchy and not other types
of addresses.

We also introduce several "warnings" in the UI to make it clear to
users that parent records will be impacted.



Task-2992695