### PR TITLE
[FIX] web_editor: check selection in editable in contenteditable true

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2663,8 +2663,9 @@ export class OdooEditor extends EventTarget {
      */
     isSelectionInEditable(selection) {
         selection = selection || this.document.getSelection()
-        return selection && selection.anchorNode && this.editable.contains(selection.anchorNode) &&
-            this.editable.contains(selection.focusNode);
+        return selection && selection.anchorNode &&
+            closestElement(selection.anchorNode).isContentEditable && closestElement(selection.focusNode).isContentEditable &&
+            this.editable.contains(selection.anchorNode) && this.editable.contains(selection.focusNode);
     }
 
     /**


### PR DESCRIPTION
The function that checks if the current selection is in an editable area only checked if it was in a descendant of the editor's editable element, failing to account for sub-zones that might be set to `contenteditable=false`.

task-2962912

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
