### PR TITLE
[FIX] web_editor: open documents from URL in a new tab

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/document_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/document_selector.js
@@ -64,6 +64,9 @@ export class DocumentSelector extends FileSelector {
             linkEl.href = href;
             linkEl.title = attachment.name;
             linkEl.dataset.mimetype = attachment.mimetype;
+            if (attachment.type === 'url') {
+                linkEl.target = '_blank';
+            }
             return linkEl;
         }));
     }


### PR DESCRIPTION
Since [1] when the edited website page has been moved inside an iframe, when a document is uploaded from a URL, its link cannot be browsed within the iframe because of cross-origin restrictions.

This commit makes URL document links open in a new tab - also for visitors. For uploaded document files, the link is unchanged and triggers a download.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

task-2687506
