### PR TITLE
[FIX] web_editor, website: fix documents upload

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/document_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/document_selector.js
@@ -49,7 +49,7 @@ export class DocumentSelector extends FileSelector {
     static async createElements(selectedMedia, { orm }) {
         return Promise.all(selectedMedia.map(async attachment => {
             const linkEl = document.createElement('a');
-            let href = `/web/content/${attachment.id}?unique=${attachment.checksum}&download=true`;
+            let href = `/web/content/${attachment.id}?unique=${attachment.checksum}`;
             if (!attachment.public) {
                 let accessToken = attachment.access_token;
                 if (!accessToken) {
@@ -64,11 +64,16 @@ export class DocumentSelector extends FileSelector {
             linkEl.href = href;
             linkEl.title = attachment.name;
             linkEl.dataset.mimetype = attachment.mimetype;
+            linkEl.dataset.fileName = attachment.name;
+            linkEl.textContent = attachment.name;
+            // The document behaviour is by default set to open in a new tab.
+            // This behaviour is configurable with an option in the Link Tools.
+            linkEl.target = '_blank';
             return linkEl;
         }));
     }
 }
-DocumentSelector.mediaSpecificClasses = ['o_image'];
+DocumentSelector.mediaSpecificClasses = [];
 DocumentSelector.mediaSpecificStyles = [];
 DocumentSelector.mediaExtraClasses = [];
 DocumentSelector.tagNames = ['A'];

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -198,6 +198,9 @@ export class MediaDialog extends Component {
                 element.classList.remove(...this.initialIconClasses);
                 element.classList.remove('o_modified_image_to_save');
                 element.classList.remove('oe_edited_link');
+                // The o_image class is not used anymore but it still needs to
+                // be removed for documents uploaded before 16.0.
+                element.classList.remove('o_image');
                 element.classList.add(...TABS[this.state.activeTab].Component.mediaSpecificClasses);
             });
             if (this.props.multiImages) {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -40,6 +40,7 @@ const LinkTools = Link.extend({
         this.customColors = {};
         this.colorpickers = {};
         this.colorpickersPromises = {};
+        this.fileName = this.linkEl.dataset.fileName;
     },
     /**
      * @override

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -54,6 +54,11 @@ weWidgets.LinkTools.include({
         const isFromWebsite = urlInputValue[0] === '/';
         const $selectMenu = this.$('we-selection-items[name="link_anchor"]');
 
+        if (this.fileName) {
+            $pageAnchor[0].classList.add('d-none');
+            return;
+        }
+
         if ($selectMenu.data("anchor-for") !== urlInputValue) { // avoid useless query
             $pageAnchor.toggleClass('d-none', !isFromWebsite);
             $selectMenu.empty();


### PR DESCRIPTION
Before this commit, a document uploaded from the Media Dialog was
inserted as a "document" icon link (using the o_image class), without
text.
After that, it was not possible to modify it with the SnippetsMenu link
tools (clicking on it in edit mode had no effect, and the document was
downloaded automatically in normal mode).

Now, the document will be inserted as a regular link, whose content will
be the title of the document. The o_image class is no longer used in
this case.

After, the user can modify the link with the link tools:
- open in the current/new window for documents viewable in the
browser (e.g. pdf documents), downloaded otherwise (pptx, ...),
- change the link style and content.

task-2172311


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
