### PR TITLE
[FIX] mail: re-allign composer fields

### DIFF
--- a/addons/mail/static/src/scss/composer.scss
+++ b/addons/mail/static/src/scss/composer.scss
@@ -62,8 +62,11 @@
 }
 
 .o_mail_composer_form {
-    .oe-bordered-editor[name=body] .o_readonly {
+    .oe-bordered-editor[name=body] {
         border: 1px solid $o-gray-300;
         padding: 4px;
+    }
+    .o_field_widget {
+        width: 100%;
     }
 }

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -25,8 +25,8 @@
                         <field name="email_from"
                             attrs="{'invisible':[('composition_mode', '!=', 'mass_mail')]}"/>
                         <label for="partner_ids" string="Recipients" attrs="{'invisible': ['|', ('is_log', '=', True), ('composition_mode', '!=', 'comment')]}"/>
-                        <div groups="base.group_user" attrs="{'invisible': [('is_log', '=', True)]}">
-                            <span name="document_followers_text" attrs="{'invisible':['|', ('model', '=', False), ('composition_mode', '=', 'mass_mail')]}">Followers of the document and</span>
+                        <div groups="base.group_user" attrs="{'invisible': ['|', ('is_log', '=', True), ('composition_mode', '!=', 'comment')]}">
+                            <span name="document_followers_text" attrs="{'invisible':['|', ('model', '=', False), ('composition_mode', '=', 'mass_mail')]}">Followers of the document and </span>
                             <field name="partner_ids" widget="many2many_tags_email" placeholder="Add contacts to notify..."
                                 context="{'force_email':True, 'show_email':True}"
                                 attrs="{'invisible': [('composition_mode', '!=', 'comment')]}"/>

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -45,16 +45,18 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" class="oe-bordered-editor" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
-                        <group>
+                        <div>
+                            <field name="body" class="oe-bordered-editor" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                             <group>
-                                <field name="attachment_ids" widget="many2many_binary"/>
+                                <group>
+                                    <field name="attachment_ids" widget="many2many_binary"/>
+                                </group>
+                                <group>
+                                    <field name="deadline"/>
+                                    <field name="template_id" label="Use template"/>
+                                </group>
                             </group>
-                            <group>
-                                <field name="deadline"/>
-                                <field name="template_id" label="Use template"/>
-                            </group>
-                        </group>
+                        </div>
                     </group>
                     <footer>
                         <button string="Send" name="action_invite" type="object" class="btn-primary" data-hotkey="q"/>

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -20,15 +20,17 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" class="oe-bordered-editor" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
-                        <group>
+                        <div>
+                            <field name="body" class="oe-bordered-editor" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                             <group>
-                                <field name="attachment_ids" widget="many2many_binary"/>
+                                <group>
+                                    <field name="attachment_ids" widget="many2many_binary"/>
+                                </group>
+                                <group>
+                                    <field name="template_id" label="Use template" context="{'default_model': 'slide.channel.partner'}"/>
+                                </group>
                             </group>
-                            <group>
-                                <field name="template_id" label="Use template" context="{'default_model': 'slide.channel.partner'}"/>
-                            </group>
-                        </group>
+                        </div>
                     </group>
                     <footer>
                         <button string="Send" name="action_invite" type="object" class="btn-primary" data-hotkey="q"/>


### PR DESCRIPTION
## Issues

The group displaying the recipients was not
made invisible when it is empty.
This added an empty div which broke the
``label: [field]`` ordering inside the flex-wrap.

The email_from field was too small
to display the default address.

## Changes

The visibility condition was updated
to reflect the visibility of the field.

The email_from field was given 
a sensible minimum width.

task #3007478
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
