### PR TITLE
[FIX] web: always show field borders in settings view

### DIFF
--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -47,3 +47,7 @@
 .o_kanban_quick_create .o_field_widget .o_input {
     border-color: var(--o-input-border-color);
 }
+
+.o_highlight_fields .o_field_widget:not(.o_legacy_field_widget) .o_input {
+    border-color: var(--o-input-border-color);
+}

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="web.SettingsFormView" t-inherit="web.FormView" t-inherit-mode="primary" owl="1">
         <xpath expr="./div[@t-ref='root']" position="attributes">
-            <attribute name="class">o-settings-form-view</attribute>
+            <attribute name="class">o-settings-form-view o_highlight_fields</attribute>
         </xpath>
         <xpath expr="//Layout" position="inside">
             <t t-set-slot="control-panel-top-right">


### PR DESCRIPTION
With the introduction of always edit, form views do not display fields like they are editable anymore unless you hover over them. For regular records, this is fine as basically all of the text is known to be editbale as part of a field (unless it is bold in which case it is a label). In the settings, there are lots of labels that do not refer directly to a field but instead refer to a section, as well as descriptive text for the settings that are not part of a field, which can cause a lot of confusion as to what is editable and what is not.

This commit makes all the fields in the settings display their usual "hover" border/underline so that it is clear they are editable.
