### PR TITLE
[IMP] web: Add property list view

### DIFF
--- a/addons/sale_timesheet/static/src/components/so_line_field/so_line_field.js
+++ b/addons/sale_timesheet/static/src/components/so_line_field/so_line_field.js
@@ -3,6 +3,10 @@
 import { registry } from "@web/core/registry";
 import { Many2OneField } from "@web/views/fields/many2one/many2one_field";
 
+// ensure load order
+// TODO Remove me when the gantt view is converted in OWL
+import "@web/views/fields/x2many/x2many_field";
+
 export class SoLineField extends Many2OneField {
     setup() {
         super.setup();

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -53,7 +53,7 @@
                                     <i class="o_optional_columns_dropdown_toggle oi oi-fw oi-settings-adjust"/>
                                 </t>
 
-                                <t t-foreach="getOptionalFields" t-as="field" t-key="field_index">
+                                <t t-foreach="getOptionalFields(getNonPropertyColumns(allColumns))" t-as="field" t-key="field_index">
                                     <DropdownItem parentClosingMode="'none'" onSelected="() => this.toggleOptionalField(field.name)">
                                         <CheckBox
                                             onChange="() => this.toggleOptionalField(field.name)"
@@ -63,6 +63,37 @@
                                             <t t-esc="field.label"/> <t t-if="env.debug" t-esc="' (' + field.name + ')'" />
                                         </CheckBox>
                                     </DropdownItem>
+                                </t>
+                                <!--Display dynamic properties at the end, if any-->
+                                <t t-set="propertyColumnGroups" t-value="getPropertyColumnGroups(allColumns)"/>
+                                <t t-foreach="propertyColumnGroups" t-as="definitionGroup" t-key="definitionGroup.definitionModel">
+                                    <t t-if="propertyColumnGroups.length > 1">
+                                        <div class="dropdown-divider border-dark"/>
+                                        <DropdownItem>
+                                            <div class="w-100 text-center fw-bold">Defined on <t t-out="definitionGroup.definitionModel"/></div>
+                                        </DropdownItem>
+                                    </t>
+                                    <t t-set="propertyColumnGroup" t-value="definitionGroup.group"/>
+                                    <t t-foreach="propertyColumnGroup" t-as="columnGroup" t-key="columnGroup.parentId">
+                                        <div class="dropdown-divider"/>
+                                        <t t-if="propertyColumnGroup.length > 1">
+                                            <DropdownItem>
+                                                <div class="w-100 text-center" t-out="columnGroup.parentName"/>
+                                            </DropdownItem>
+                                            <div class="dropdown-divider"/>
+                                        </t>
+                                        <t t-foreach="getOptionalFields(columnGroup.columns)" t-as="field" t-key="field.name">
+                                            <DropdownItem parentClosingMode="'none'" onSelected="() => this.toggleOptionalField(field.name)">
+                                                <CheckBox
+                                                    onChange="() => this.toggleOptionalField(field.name)"
+                                                    value="field.value"
+                                                    name="field.name"
+                                                >
+                                                    <t t-esc="field.label"/> <t t-if="env.debug" t-esc="' (' + field.name + ')'" />
+                                                </CheckBox>
+                                            </DropdownItem>
+                                        </t>
+                                    </t>
                                 </t>
                             </Dropdown>
                         </th>
@@ -232,6 +263,22 @@
                         t-on-click="(ev) => this.onCellClicked(record, column, ev)" tabindex="-1">
                         <t t-if="!evalModifier(column.modifiers.invisible, record)">
                             <t t-if="canUseFormatter(column, record)" t-out="getFormattedValue(column, record)"/>
+                            <t t-elif="column.propertyType">
+                                <PropertyValue t-if="record.data[column.name] and record.data[column.name].value"
+                                    canChangeDefinition="false"
+                                    context="record.context"
+                                    comodel="record.data[column.name].comodel || ''"
+                                    domain="record.data[column.name].domain || '[]'"
+                                    readonly="true"
+                                    selection="record.data[column.name].selection"
+                                    string="column.string"
+                                    tags="record.data[column.name].tags"
+                                    type="column.propertyType"
+                                    value="record.data[column.name].value"
+                                    onChange.bind="() => {}"
+                                    onTagsChange.bind="() => {}"
+                                />
+                            </t>
                             <Field t-else="" name="column.name" record="record" type="column.widget" class="getFieldClass(column)" fieldInfo="props.archInfo.fieldNodes[column.name]" setDirty="(isDirty) => this.setDirty(isDirty)"/>
                         </t>
                     </td>

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -703,10 +703,14 @@ export class Record extends DataPoint {
         const changes = { ...(allFields ? this.data : this._changes) };
         for (const fieldName in changes) {
             if (
+                !this.fields[fieldName]
+                ||
+                (
                 !allFields &&
                 fieldName in this.activeFields &&
                 !this.activeFields[fieldName].forceSave &&
                 this.isReadonly(fieldName)
+                )
             ) {
                 delete changes[fieldName];
                 continue;

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3224,6 +3224,7 @@ class Properties(Field):
 
     _description_definition_record = property(attrgetter('definition_record'))
     _description_definition_record_field = property(attrgetter('definition_record_field'))
+    _description_sortable = False
 
     ALLOWED_TYPES = (
         'boolean', 'integer', 'float', 'char', 'date',


### PR DESCRIPTION
Adds columns in the list view for properties.

Dynamically create 'fields' for list views
that copy the characteristics of their 'properties' field. Allows for seamless display of property values in the list view.

## Notes

These columns cannot be sorted (requires python ORM modifications)

These columns cannot be edited (not easily achievable)

task #2980121

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
