### PR TITLE
[IMP] mail: adapt mail compose wizard to grid & always edit

### DIFF
--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -39,20 +39,24 @@
                     <field name="can_edit_body" invisible="1"/>
                     <div attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">
                         <field name="body" class="oe-bordered-editor" placeholder="Write your message here..." options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
-                        <group col="4">
+                        <group>
+                            <group>
+                                <field name="template_id" string="Load template" options="{'no_create': True}"
+                                    context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
+                            </group>
                             <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
-                            <field name="template_id" string="Load template" options="{'no_create': True}"
-                                context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
                         </group>
                     </div>
                     <notebook attrs="{'invisible': [('composition_mode', '!=', 'mass_mail')]}">
                         <page string="Content">
                             <div>
                                 <field name="body" class="oe-bordered-editor" placeholder="Write your message here..." options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
-                                <group col="4">
-                                    <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
-                                    <field name="template_id" string="Load template" options="{'no_create': True}"
+                                <group>
+                                    <group>
+                                        <field name="template_id" string="Load template" options="{'no_create': True}"
                                         context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
+                                    </group>
+                                    <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                                 </group>
                             </div>
                         </page>


### PR DESCRIPTION
- move the "load template" field to the left (otherwise it's a bit too floating)
- fix attachment field