### PR TITLE
[FIX] web: active striped row should have white background

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -140,15 +140,7 @@
         }
 
         .o_selected_row {
-            th:focus-within, td:focus-within {
-                --table-accent-bg: none;
-
-                background-color: $o-view-background-color;
-            }
-        }
-
-        .o_keyboard_navigation {
-            th:focus-within, td:focus-within {
+            th, td {
                 --table-accent-bg: none;
 
                 background-color: $o-view-background-color;


### PR DESCRIPTION
This is a follow up to: https://github.com/odoo/odoo/pull/102268

With the requirement (white background for active row), the styling for the `.o_keyboard_navigation` is no longer necessary.

**Before:**

<img width="1150" alt="Screenshot 2022-10-06 at 12 39 47" src="https://user-images.githubusercontent.com/3245568/194294137-62c691fb-60a7-4266-9ebc-a2f31c03a415.png">

**After:**

<img width="1149" alt="Screenshot 2022-10-06 at 12 32 33" src="https://user-images.githubusercontent.com/3245568/194293409-922b7858-5dfc-48c5-8af6-1241c4920123.png">




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
