### PR TITLE
[FIX] purchase{,_requisition} : Fix purchase order form visuals

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -193,12 +193,12 @@
                                 <field name="mail_reminder_confirmed" invisible="1"/>
                                 <span class="text-muted" attrs="{'invisible': [('mail_reminder_confirmed', '=', False)]}">(confirmed by vendor)</span>
                             </div>
-                            <label for="receipt_reminder_email" invisible='1'/>
+                            <label for="receipt_reminder_email" class="d-none"/>
                             <div name="reminder" class="o_row" groups='purchase.group_send_reminder' title="Automatically send a confirmation email to the vendor X days before the expected receipt date, asking him to confirm the exact date.">
                                 <field name="receipt_reminder_email"/>
                                 <span>Ask confirmation</span>
                                 <div class="o_row oe_inline" attrs="{'invisible': [('receipt_reminder_email', '=', False)]}">
-                                    <field name="reminder_date_before_receipt" class="oe_inline"/>
+                                    <field name="reminder_date_before_receipt"/>
                                     day(s) before
                                     <widget name='toaster_button' button_name="send_reminder_preview" title="Preview the reminder email by sending it to yourself." attrs="{'invisible': [('id', '=', False)]}"/>
                                 </div>

--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -17,12 +17,12 @@
                 <page string="Alternatives" name="alternative_pos">
                     <group>
                         <group>
-                            <p>Create a call for tender by adding alternative request for quotations to different vendors.
+                            <p colspan="2">Create a call for tender by adding alternative request for quotations to different vendors.
                             Make your choice by selecting the best combination of lead time, OTD and/or total amount.
                             By comparing product lines you can also decide to order some products from one vendor and others from another vendor.</p>
                         </group>
                         <group>
-                            <p>
+                            <p colspan="2">
                                 <button name="action_create_alternative" type="object" class="btn-link d-block" string="Create Alternative" icon="fa-copy" attrs="{'invisible': [('id', '=', False)]}" />
                                 <button name="action_compare_alternative_lines" type="object" class="btn-link d-block" string="Compare Product Lines" icon="fa-bar-chart" attrs="{'invisible': [('alternative_po_ids', '=', [])]}"/>
                             </p>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A few fixes of the visuals of the Purchase Order form.

Current behavior before PR:
Alternatives RFQ:
![2022-10-04_09-54-07](https://user-images.githubusercontent.com/18055894/194296728-849e9693-c4d5-42d9-83b5-576de54eecf2.png)

Confirmation before arrival:
![image](https://user-images.githubusercontent.com/18055894/194297447-328d640f-387a-43e6-b59d-cb8ab707be82.png)


Desired behavior after PR is merged:
Alternatives RFQ:
![image](https://user-images.githubusercontent.com/18055894/194297724-e93654e5-b8ac-4e00-b1ca-569b35bc6337.png)

Confirmation before arrival:
![image](https://user-images.githubusercontent.com/18055894/194297503-d846d7c6-8bfb-41d7-92fd-14552a9bdc17.png)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
