### PR TITLE
[IMP] mass_mailing(_sms): make form fields take full width

### DIFF
--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -112,7 +112,7 @@
                     <div class="oe_title">
                         <label for="name" string="Contact Name"/>
                         <h1>
-                            <field class="text-break" name="name" placeholder="e.g. John Smith"/>
+                            <field class="text-break w-100" name="name" placeholder="e.g. John Smith"/>
                         </h1>
                         <div>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%"/>
@@ -129,9 +129,9 @@
                                 <field name="email" widget="email"/>
                                 <field name="is_blacklisted" invisible="1"/>
                             </div>
-                            <field name="title_id"/>
-                            <field name="company_name"/>
-                            <field name="country_id" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="title_id" class="w-100"/>
+                            <field name="company_name" class="w-100"/>
+                            <field name="country_id" class="w-100" options="{'no_open': True, 'no_create': True}"/>
                         </group>
                         <group>
                             <field name="create_date" attrs="{'invisible': [('id', '=', False)]}" readonly="1"/>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -266,9 +266,9 @@
                                                     attrs="{'readonly': [('state', '!=', 'draft')]}"/> %
                                             </span>
                                         </span>
-                                        <field name="ab_testing_winner_selection"
+                                        <field name="ab_testing_winner_selection" class="w-100"
                                             attrs="{'required': [('ab_testing_enabled', '=', True), ('mailing_type', '=', 'mail')], 'invisible': ['|', ('ab_testing_enabled', '=', False), ('mailing_type', '!=', 'mail')], 'readonly': [('state', '!=', 'draft')]}"/>
-                                        <field name="ab_testing_schedule_datetime"
+                                        <field name="ab_testing_schedule_datetime" class="w-100"
                                             attrs="{'required': [('ab_testing_enabled', '=', True), ('ab_testing_winner_selection', '!=', 'manual')], 'readonly': ['|', ('ab_testing_enabled', '=', False), ('state', '!=', 'draft')], 'invisible': ['|', ('ab_testing_enabled', '=', False), ('ab_testing_winner_selection', '=', 'manual')]}"/>
                                     </group>
                                     <div>
@@ -308,7 +308,8 @@
                                             options="{'dynamic_placeholder': true}"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"
                                             widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
-                                        <field name="email_from" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                        <field name="email_from" class="w-100"
+                                               attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <label for="reply_to"/>
                                         <div name="reply_to_details">
                                             <field name="reply_to_mode" widget="radio"
@@ -316,7 +317,7 @@
                                                     'invisible': [('mailing_model_name', 'in', ['mailing.contact', 'res.partner', 'mailing.list'])],
                                                     'readonly': [('state', 'in', ('sending', 'done'))]
                                             }"/>
-                                            <field name="reply_to"
+                                            <field name="reply_to" class="w-100"
                                                 attrs="{
                                                     'required': [('reply_to_mode', '=', 'new')],
                                                     'invisible': [('reply_to_mode', '=', 'update')],
@@ -338,6 +339,7 @@
                                     </group>
                                     <group string="Tracking">
                                         <field name="campaign_id"
+                                            class="w-100"
                                             string="Campaign"
                                             groups="mass_mailing.group_mass_mailing_campaign"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
@@ -345,6 +347,7 @@
                                              string="Medium"
                                              required="True"
                                              groups="base.group_no_one"
+                                             class="w-100"
                                              attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <field name="source_id"
                                             string="Source"
@@ -353,12 +356,13 @@
                                             class="o_text_overflow"
                                             groups="base.group_no_one"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
-                                        <field name="user_id" widget="many2one_avatar_user"
+                                        <field name="user_id" widget="many2one_avatar_user" class="w-100"
                                             domain="[('share', '=', False)]"/>
                                     </group>
                                     <group string="Advanced" groups="base.group_no_one">
                                         <field name="mail_server_available" invisible="1"/>
-                                        <field name="name" required="False" string="Name" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                        <field name="name" required="False" string="Name" class="w-100"
+                                               attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <field name="mail_server_id" attrs="{'readonly': [('state', 'in', ('sending', 'done'))],
                                          'invisible': [('mail_server_available', '=', False)]}"/>
                                         <field name="keep_archives" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -49,8 +49,9 @@
                 <group name="ab_test_group" groups="mass_mailing.group_mass_mailing_campaign" attrs="{'invisible': [('ab_testing_mailings_count', '=', 0)]}">
                     <group string="A/B Test">
                         <field name="ab_testing_completed" invisible="1"/>
-                        <field name="ab_testing_winner_selection" attrs="{'readonly': [('ab_testing_completed', '=', True)]}"/>
-                        <field name="ab_testing_schedule_datetime"
+                        <field name="ab_testing_winner_selection" class="w-100"
+                               attrs="{'readonly': [('ab_testing_completed', '=', True)]}"/>
+                        <field name="ab_testing_schedule_datetime" class="w-100"
                             attrs="{'invisible': [('ab_testing_winner_selection', '=', 'manual')], 'readonly': [('ab_testing_completed', '=', True)]}"/>
                     </group>
                 </group>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -102,7 +102,7 @@
                     For an SMS Text Message, internal Title of the Message.</attribute>
             </xpath>
             <xpath expr="//field[@name='subject']" position="after">
-                <field class="text-break" name="sms_subject" string="Title" placeholder="e.g. Black Friday SMS coupon" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))], 'required': [('mailing_type', '=', 'sms')]}"/>
+                <field class="text-break w-100" name="sms_subject" string="Title" placeholder="e.g. Black Friday SMS coupon" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))], 'required': [('mailing_type', '=', 'sms')]}"/>
             </xpath>
             <xpath expr="//button[@name='action_set_favorite']" position="attributes">
                 <attribute name="attrs">{'invisible': ['|', ('mailing_type', '!=', 'mail'), ('favorite', '=', True)]}</attribute>
@@ -162,11 +162,11 @@
             <xpath expr="//field[@name='ab_testing_winner_selection']" position="after">
                 <label for="ab_testing_sms_winner_selection" string="Winner Selection"
                     attrs="{'invisible': ['|', ('ab_testing_enabled', '=', False), ('mailing_type', '!=', 'sms')]}"/>
-                <field name="ab_testing_sms_winner_selection" nolabel="1"
+                <field name="ab_testing_sms_winner_selection" nolabel="1" class="w-100"
                     attrs="{'required': [('ab_testing_enabled', '=', True), ('mailing_type', '=', 'sms')], 'invisible': ['|', ('ab_testing_enabled', '=', False), ('mailing_type', '!=', 'sms')], 'readonly': [('state', '!=', 'draft')]}"/>
             </xpath>
             <xpath expr="//field[@name='ab_testing_schedule_datetime']" position="replace">
-                 <field name="ab_testing_schedule_datetime"
+                 <field name="ab_testing_schedule_datetime" class="w-100"
                         attrs="{'required': [('ab_testing_enabled', '=', True), ('ab_testing_winner_selection', '!=', 'manual'), ('ab_testing_sms_winner_selection', '!=', 'manual')], 'readonly': ['|', ('ab_testing_enabled', '=', False), ('state', '!=', 'draft')], 'invisible': ['|', '|', ('ab_testing_enabled', '=', False), ('ab_testing_winner_selection', '=', 'manual'), ('ab_testing_sms_winner_selection', '=', 'manual')]}"/>
             </xpath>
             <xpath expr="//span[@name='ab_test_manual']" position="attributes">


### PR DESCRIPTION
Purpose:
--------
Add "w-100" class to several fields in the form views so that they are no more truncated "too early", hiding content.


