### PR TITLE
[FIX] product_expiry: make expiration date editable when existing lots

### DIFF
--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -19,9 +19,10 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_name']" position="after" >
                 <field name="picking_type_use_existing_lots" invisible="1"/>
+                <field name="picking_type_use_create_lots" invisible="1"/>
                 <field name="expiration_date" force_save="1" attrs="{
                     'column_invisible': ['|', ('parent.use_expiration_date', '!=', True), ('parent.picking_code', '!=', 'incoming')],
-                    'readonly': [('picking_type_use_existing_lots', '=', True)],
+                    'readonly': [('picking_type_use_existing_lots', '=', True), ('picking_type_use_create_lots', '=', False)],
                 }"/>
             </xpath>
         </field>
@@ -34,9 +35,10 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_name']" position="after">
                 <field name="picking_type_use_existing_lots" invisible="1"/>
+                <field name="picking_type_use_create_lots" invisible="1"/>
                 <field name="expiration_date" force_save="1" attrs="{
                     'column_invisible': [('parent.picking_type_code', '!=', 'incoming')],
-                    'readonly': [('picking_type_use_existing_lots', '=', True)],
+                    'readonly': [('picking_type_use_existing_lots', '=', True), ('picking_type_use_create_lots', '=', False)],
                 }"/>
             </xpath>
         </field>


### PR DESCRIPTION
Current behavior:
When "Use existing lots" and "Create new lots" are both checked (in the receipt configuration), the expiration date is not editable on the picking. But it should be because the user should ba able to choose another expiration date if the lot is a new lot.

Steps to reproduce:
- Activate "Use existing lots" and "Create new lots" in the picking receipt configuration
- Create a new product with expiration date checked, and tracked by lot
- Create a new picking receipt with the product, and create a new lot
- The expiration is not editable

opw-2965753
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
