### PR TITLE
[FIX] payment_authorize: authorize_currency_id not defined

### DIFF
--- a/addons/payment_authorize/i18n/payment_authorize.pot
+++ b/addons/payment_authorize/i18n/payment_authorize.pot
@@ -313,3 +313,9 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:payment_authorize.inline_form
 msgid "YY"
 msgstr ""
+
+#. module: payment_authorize
+#: code:addons/payment_authorize/models/payment_acquirer.py:0
+#, python-format
+msgid "You must set a Currency to enable this payment acquirer."
+msgstr ""

--- a/addons/payment_authorize/models/payment_acquirer.py
+++ b/addons/payment_authorize/models/payment_acquirer.py
@@ -65,6 +65,11 @@ class PaymentAcquirer(models.Model):
                 'payment.payment_icon_cc_visa',
             )])]
 
+    @api.onchange('authorize_currency_id', 'state')
+    def _onchange_state(self):
+        if not self.authorize_currency_id and self.state in ['enabled', 'test']:
+            raise UserError(_("You must set a Currency to enable this payment acquirer."))
+
     def action_update_merchant_details(self):
         """ Fetch the merchant details to update the client key and the account currency. """
         self.ensure_one()


### PR DESCRIPTION
Steps to reproduce the issue:

1. Go to Payment Acquirer and disable all the payment acquirer, if any enabled.
2. Enable Authorize.net.
3. Go to your e-commerce site and reach the final stage of checkout where you can see:

No suitable payment option could be found

Reference: https://github.com/odoo/odoo/blob/15.0/addons/payment_authorize/models/payment_acquirer.py#L101

The authorize_currency_id must be defined otherwise it won't be considered as a compatible acquirer

opw:2854113