### PR TITLE
[FIX] website_sale: base unit price not updated

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -205,7 +205,7 @@ class ProductTemplate(models.Model):
 
             combination_info.update(
                 base_unit_name=product.base_unit_name,
-                base_unit_price=product.base_unit_price,
+                base_unit_price=list_price / product.base_unit_count if product.base_unit_count != 0 else product.base_unit_count,
                 price=price,
                 list_price=list_price,
                 price_extra=price_extra,

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -587,7 +587,7 @@
     </template>
 
     <template id="base_unit_price" name="Product Bas eunit price">
-        (<span class="o_base_unit_price" t-field="product.base_unit_price" t-options="{'display_currency': website.currency_id}"/>
+        (<span class="o_base_unit_price" t-esc="round(combination_info['base_unit_price'],2)"/> <span t-esc="website.currency_id.symbol"/>
          / <span class="oe_custom_base_unit" t-field="product.base_unit_name"/>)
     </template>
 
@@ -655,7 +655,7 @@
                                 <div class="js_product js_main_product mb-3">
                                     <div>
                                         <t t-call="website_sale.product_price" />
-                                        <small class="ml-1 text-muted o_base_unit_price_wrapper d-none" groups="website_sale.group_show_uom_price">
+                                        <small class="ml-1 text-muted o_base_unit_price_wrapper" groups="website_sale.group_show_uom_price">
                                             <t t-call='website_sale.base_unit_price'/>
                                         </small>
                                     </div>


### PR DESCRIPTION
Steps to reproduce:
    - set a price on the product form;
    - set a base unit count on the product form;
    - define at least a pricelist with an other price;
    - go to website on the product page;
    - change the selected pricelist.

Issue:
    The base unit price is not updated even if the total price is different.

Cause:
    The base unit price is recomputed when the "list_price" field is changed.
    Unfortunately, this field is defined only in the product form.
    Change the pricelist does not change the "list_price" field of the model and therefore, the "base_unit_price" field is not updated.

Solution:
    Update the display of the base unit price taking into consideration that it is not possible to set the "base_unit_price" field (otherwise we risk an AccessError).

opw-2995474