### PR TITLE
[FIX] stock: differenciate model stock_forecasted

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -954,7 +954,7 @@ class ProductTemplate(models.Model):
 
     def action_product_tmpl_forecast_report(self):
         self.ensure_one()
-        action = self.env["ir.actions.actions"]._for_xml_id('stock.stock_replenishment_product_product_action')
+        action = self.env["ir.actions.actions"]._for_xml_id('stock.stock_replenishment_product_template_action')
         return action
 
 

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -3,7 +3,6 @@
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { View } from "@web/views/view";
-import { useSetupAction } from "@web/webclient/actions/action_hook";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 
 import { ForecastedButtons } from "./forecasted_buttons";
@@ -13,29 +12,31 @@ import { ForecastedWarehouseFilter } from "./forecasted_warehouse_filter";
 
 const { Component, onWillStart, useState, useSubEnv} = owl;
 
-class StockForecasted extends Component{
-    setup(){
-        useSetupAction();
+class StockForecasted extends Component {
+    setup() {
         useSubEnv({
             //ControlPanel trick : Allow the use of ControlPanel's bottom-right while disabling search to avoid errors
-            searchModel:{
-                searchMenuTypes : [],
+            searchModel: {
+                searchMenuTypes: [],
             },
+            //Cannot use 'control-panel-bottom-right' slot without the following, as viewSwitcherEntries doesn't exist in this.env.config here.
+            //Remove of the following lines leads to a "TypeError: Cannot read properties of undefined (reading 'length')" in ControlPanel
+            config: {
+                ...this.env.config,
+                viewSwitcherEntries: [],
+            }
         });
-        this.env.config.viewSwitcherEntries = [];
 
         this.orm = useService("orm");
         this.action = useService("action");
 
         this.context = useState(this.props.action.context);
         this.productId = this.context.active_id;
-        this.resModel = this.context.active_model || this.context.params.active_model || 'product.template';
+        this.resModel = this.context.active_model;
         const isTemplate = this.resModel === 'product.template';
         this.reportModelName = `report.stock.report_product_${isTemplate ? 'template' : 'product'}_replenishment`;
         this.title = this.props.action.name;
 
-        this.docs = useState({});
-        
         onWillStart(this._getReportValues);
     }
 

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -271,7 +271,7 @@
                             <button type="object"
                                 name="action_product_forecast_report"
                                 attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
-                                context="{'default_product_id': id}"
+                                context="{'default_product_id': id, 'context': 'product.template'}"
                                 class="oe_stat_button" icon="fa-cubes">
                                 <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value">

--- a/addons/stock/views/stock_forecasted.xml
+++ b/addons/stock/views/stock_forecasted.xml
@@ -4,6 +4,13 @@
     <record id="stock_replenishment_product_product_action" model="ir.actions.client">
         <field name="name">Forecasted Report</field>
         <field name="tag">replenish_report</field>
+        <field name="context" eval="{'active_model': 'product.product'}"/>
+    </record>
+
+    <record id="stock_replenishment_product_template_action" model="ir.actions.client">
+        <field name="name">Forecasted Report</field>
+        <field name="tag">replenish_report</field>
+        <field name="context" eval="{'active_model': 'product.template'}"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When using browser's "go back", active_model previously defined in context is lost and defaults to
'product.template', which can result in a bad request

Current behavior before PR:
When opening stock_forecasted with an '_active_model_' sets to '_product.product_' in the context, leaving the page for another one, then going back to the stock_forecasted page through browser's 'go back', the '_active_model_' is lost and defaults to '_product.template_' while the id is still the same. This can result in showing a totally unexpected product, which may not even be of type '_storable_'.

Desired behavior after PR is merged:
'_active_model_' is always defined through the action's id available in the URL, such that the model and the id used by stock_forecasted is always well-defined and its output is deterministic.

Enterprise : odoo/enterprise#32471


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
