### PR TITLE
[FIX] website_sale : update taxcloud tax before payment transaction

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -905,6 +905,8 @@ class WebsiteSale(http.Controller):
 
         assert order.partner_id.id != request.website.partner_id.id
 
+        order.validate_taxes_on_sales_order()
+
         # Create transaction
         vals = {'acquirer_id': acquirer_id,
                 'return_url': '/shop/payment/validate'}


### PR DESCRIPTION
### Setup
- DB with main company on the US
- account_taxcloud, ecommerce, sales, and website_sale_coupon installed
- Full address (US) set on the company
- Taxcloud activated (with test credentials*)
- Taxcloud fiscal position set as “detect automatically”
- Have a product available in your eShop

### Steps to reproduce
- in a new incognito window, go to the shop, put a product in your shopping cart and process to check out
- Fill in an Americana address. It's important to have an address that makes sense and whose state is supported by taxcloud. You can use the following:
  - City: Gaylord
  - Postcode: 55334
  - Country: United States
  - State: Minnesota
- click next, and you'll be redirected to a payment page
- now open the shopping cart in a new tab

If you go to the sales app and look at the quotation associated with your session, you should see that the taxes have been removed.  However, since you already have a payment page open, you can complete the checkout without having to pay the taxes.

### Cause
In the `website_sale_coupon` module, `SaleOrder.recompute_coupon_lines()` is called when the user goes to the shopping cart. https://github.com/odoo/odoo/blob/a3d543d2ac266ea7db1e1c2c60617963d4005a5a/addons/website_sale_coupon/controllers/main.py#L25-L28
However, the following line in `SaleOrder.recompute_coupon_lines()` clears the tax. https://github.com/odoo/enterprise/blob/892e19ec2f805af6696008ddeb783d49770a54f8/sale_coupon_taxcloud/models/sale_order.py#L31 In most cases this is fine since the taxes are recomputed when the users go to the payment page.  But in this case, the user already has a payment page open, so the tax is never recomputed.



opw-2815397