### PR TITLE
[FIX] account: don't show address on partner search on vendor bills

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -13,6 +13,14 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
         this.partner_autocomplete = usePartnerAutocomplete();
     }
 
+    getNameSearchContext() {
+        const context = {
+            ...this.props.context,
+        }
+        delete context.show_address;
+        return context;
+    }
+
     validateSearchTerm(request) {
         return request && request.length > 2;
     }

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -189,6 +189,10 @@ export class Many2XAutocomplete extends Component {
         return this.props.activeActions || {};
     }
 
+    getNameSearchContext() {
+        return this.props.context;
+    }
+
     getCreationContext(value) {
         return makeContext([
             this.props.context,
@@ -218,7 +222,7 @@ export class Many2XAutocomplete extends Component {
             operator: "ilike",
             args: this.props.getDomain(),
             limit: this.props.searchLimit + 1,
-            context: this.props.context,
+            context: this.getNameSearchContext(),
         });
 
         const options = records.map((result) => ({


### PR DESCRIPTION
The old partner autocomplete widget wasn't showing the address when looking for a partner as it didn't take into account the context passed in the view.

After its Owl conversion (see odoo/odoo#101098), the context defined in the view is now taken into account when performing the `name_get` call, so the `show_address` key needs to be removed from the context.