### PR TITLE
[FIX] web_editor: hide None column option for snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4559,8 +4559,11 @@ registry.layout_column = SnippetOptionWidget.extend({
         // Needs to be done manually for now because _computeWidgetVisibility
         // doesn't go through this option for buttons inside of a select.
         // TODO: improve this.
-        this.$el.find('we-button[data-name="zero_cols_opt"]')
-            .toggleClass('d-none', !this.$target.is('.s_allow_columns'));
+        let $row = this.$('> .row')[0];
+        let $el = this.$el.find('we-button[data-name="zero_cols_opt"]');
+        $row && $row.querySelectorAll('div.row').length !== 0
+            ? $el.hide()
+            : $el.toggleClass('d-none', !this.$target.is('.s_allow_columns'));
         return this._super(...arguments);
     },
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
-------
Changing the columns of the "Features Grid" snippet to `None` produced an unexpected result in the UI.

Current behavior before PR:
--------
While selecting the columns to `None`, it removes the parent `div.class=row` and the child element becomes the parent element, so the child elements `div.class=row` acts as a column, when setting the column to `None` for the first time snippet structure add **4 columns** instead of None.

Default arch with a number of columns 2 for "Features Grid" snippet:
```xml
    <div class="row"> <!-- parent element -->
        ...
            <div class="row"> <!-- child element -->
                <div class="col-lg-12">...<div>
                <div class="col-lg-12">...<div>
                <div class="col-lg-12">...<div>
                <div class="col-lg-12">...<div>
            <div>
    <div>
    <div class="row">
        ...
    <div>
```

By setting it to None for the first time it became:
```xml
    <div class="row"> <!-- child element became parent element-->
        <div class="col-lg-12">...<div>
        <div class="col-lg-12">...<div>
        <div class="col-lg-12">...<div>
        <div class="col-lg-12">...<div>
    <div>

```

Desired behavior after PR is merged:
--------
`None` option for Columns can be hidden where the snippet contains a column inside the column structure to avoid unexpected results.

PR [102841](https://github.com/odoo/odoo/pull/102841)
task-2955793

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
