### PR TITLE
[FIX] hr_holidays: use basic date when request_half_unit

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -275,9 +275,16 @@
                                         </span>
                                         <field name="request_date_from" class="oe_inline" nolabel="1"
                                             attrs="{'readonly': [('state', 'not in', ('draft', 'confirm'))],
+                                                    'invisible': ['|', ('request_unit_half', '=', True), ('request_unit_hours', '=', True)],
                                                     'required': ['|', ('date_from', '=', False), ('date_to', '=', False)]
                                                     }"
                                             widget="daterange" options="{'related_end_date': 'request_date_to'}"/>
+                                        <field name="request_date_from" class="oe_inline" nolabel="1"
+                                            attrs="{'readonly': [('state', 'not in', ('draft', 'confirm'))],
+                                                    'invisible': ['&amp;', ('request_unit_half', '=', False), ('request_unit_hours', '=', False)],
+                                                    'required': ['|', ('date_from', '=', False), ('date_to', '=', False)]
+                                                    }"
+                                        />
                                     </div>
                                     <div>
                                         <span class="oe_inline"


### PR DESCRIPTION
When user asks for half unit or custom hours, it makes more sense for
the `request_date_from` to use a basic date field than a daterange field
because the `related_end_date` field is invisible.

This also prevents having a traceback in the ui
as shown in the following clip:

https://www.awesomescreenshot.com/video/11576430?key=bd17e4189edc2b754c7c73e46e60799f

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
