### PR TITLE
[FIX] website_blog, *: reduce new content dialog size

### DIFF
--- a/addons/website_blog/views/blog_post_add.xml
+++ b/addons/website_blog/views/blog_post_add.xml
@@ -21,6 +21,7 @@
     <field name="view_mode">form</field>
     <field name="target">new</field>
     <field name="view_id" ref="blog_post_view_form_add"/>
+    <field name="context">{'dialog_size': 'medium'}</field>
 </record>
 
 </odoo>

--- a/addons/website_event/views/event_event_add.xml
+++ b/addons/website_event/views/event_event_add.xml
@@ -28,7 +28,7 @@
     <field name="view_mode">form</field>
     <field name="target">new</field>
     <field name="view_id" ref="event_event_view_form_add"/>
-    <field name="context">{'default_address_id': False}</field>
+    <field name="context">{'default_address_id': False, 'dialog_size': 'medium'}</field>
 </record>
 
 </odoo>

--- a/addons/website_forum/views/forum_forum_add.xml
+++ b/addons/website_forum/views/forum_forum_add.xml
@@ -22,6 +22,7 @@
     <field name="view_mode">form</field>
     <field name="target">new</field>
     <field name="view_id" ref="forum_forum_view_form_add"/>
+    <field name="context">{'dialog_size': 'medium'}</field>
 </record>
 
 </odoo>

--- a/addons/website_livechat/views/im_livechat_channel_add.xml
+++ b/addons/website_livechat/views/im_livechat_channel_add.xml
@@ -20,6 +20,7 @@
     <field name="view_mode">form</field>
     <field name="target">new</field>
     <field name="view_id" ref="im_livechat_channel_view_form_add"/>
+    <field name="context">{'dialog_size': 'medium'}</field>
 </record>
 
 </odoo>

--- a/addons/website_sale/views/product_product_add.xml
+++ b/addons/website_sale/views/product_product_add.xml
@@ -20,6 +20,7 @@
     <field name="view_mode">form</field>
     <field name="target">new</field>
     <field name="view_id" ref="product_product_view_form_add"/>
+    <field name="context">{'dialog_size': 'medium'}</field>
 </record>
 
 </odoo>

--- a/addons/website_slides/views/slide_channel_add.xml
+++ b/addons/website_slides/views/slide_channel_add.xml
@@ -27,6 +27,7 @@
     <field name="view_mode">form</field>
     <field name="target">new</field>
     <field name="view_id" ref="slide_channel_view_form_add"/>
+    <field name="context">{'dialog_size': 'medium'}</field>
 </record>
 
 </odoo>


### PR DESCRIPTION
*: website_event, website_forum, website_livechat, website_sale, website_slides

Since [1], some fields have an auto width which leaves empty space on website "new content" dialogs.

The goal of this commit is to improve the layout on thoses dialogs by reducing their size.

[1]: https://github.com/odoo/odoo/commit/774213758c7ddf7b74a9b370457f017e09d9bbcf