### PR TITLE
[IMP] website: test that no COW view is created on save without change

### DIFF
--- a/addons/website/static/tests/tours/website_edit_footer_only.js
+++ b/addons/website/static/tests/tours/website_edit_footer_only.js
@@ -1,0 +1,24 @@
+odoo.define("website.tour.website_edit_footer_only", function (require) {
+"use strict";
+
+const tour = require("web_tour.tour");
+
+tour.register("test_edit_footer_only", {
+    test: true,
+    url: "/contactus",
+}, [{
+    content: "Enter edit mode",
+    trigger: "a[data-action=edit]",
+}, {
+    content: "Drag separator into footer",
+    trigger: "#oe_snippets .oe_snippet[name=Separator] .oe_snippet_thumbnail",
+    run: "drag_and_drop footer div.col-lg-5:has(h5:contains(About)) p",
+}, {
+    content: "Save",
+    trigger: "[data-action=save]",
+    extra_trigger: "footer .s_hr",
+}, {
+    content: "Wait until saved",
+    trigger: "[data-action=edit]",
+}]);
+});

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1115,6 +1115,19 @@ class TestCowViewSaving(TestViewSavingCommon):
 
 
 @tagged('-at_install', 'post_install')
+class TestViewSavingTour(HttpCase):
+    """ Ensure no COW view is generated on save if no change was made
+        in the page content.
+    """
+    def test_view_no_cow(self):
+        self.assertEqual(self.env['website.page'].search_count([('url', '=', '/contactus')]), 1)
+        self.assertEqual(self.env['ir.ui.view'].search_count([('key', '=', 'website.footer_custom')]), 1)
+        self.start_tour('/contactus', 'test_edit_footer_only', login='admin')
+        self.assertEqual(self.env['website.page'].search_count([('url', '=', '/contactus')]), 1)
+        self.assertEqual(self.env['ir.ui.view'].search_count([('key', '=', 'website.footer_custom')]), 2)
+
+
+@tagged('-at_install', 'post_install')
 class Crawler(HttpCase):
     def setUp(self):
         super(Crawler, self).setUp()


### PR DESCRIPTION
This commit adds a test that verifies that no copy-on-write view is
created if a website page is saved without any change within its
content while there is a change in the footer.

task-2078924
