### PR TITLE
[FIX] mrp: access structure & cost BOM's of archived products

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -115,7 +115,7 @@ class ReportBomStructure(models.AbstractModel):
         if product_id:
             product = self.env['product.product'].browse(int(product_id))
         else:
-            product = bom.product_id or bom.product_tmpl_id.product_variant_id
+            product = bom.product_id or bom.product_tmpl_id.with_context(active_test=False).product_variant_id
         if product:
             price = product.uom_id._compute_price(product.with_company(company).standard_price, bom.product_uom_id) * bom_quantity
             attachments = self.env['mrp.document'].search(['|', '&', ('res_model', '=', 'product.product'),


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product and add a BOM
- Archive the product
- Click on Bill of material widget button
- on Filters, select “Archived’ → Click on the archived BOM
- try to access “Structure & cost”

Problem:
Traceback is triggered,`ValueError: Expected singleton:product.product()`

The `_match_all_variant_values` function is called but without the product, while it takes at least one:
https://github.com/odoo/odoo/blob/15.0/addons/mrp/models/mrp_bom.py#L456 https://github.com/odoo/odoo/blob/15.0/addons/mrp/models/product.py#L286

The product must be set in the `_get_bom` function, in our case, the function does not receive it as an argument, so we have to get it from the BOM, but as the `product variant` field has not been set in the BOM, we should get it from the product_template:

https://github.com/odoo/odoo/blob/48c9babaae54fd8fc4db25761688a53f38a0cef0/addons/mrp/report/mrp_report_bom_structure.py#L118

The `product_variant_id` field is a non-stored compute field: https://github.com/odoo/odoo/blob/34a2948d3d6e0f597c1b5d65f9f118e891c07cc4/addons/product/models/product_template.py#L133

And in the compute function, we use the first element of the `product_variant_ids`:
https://github.com/odoo/odoo/blob/34a2948d3d6e0f597c1b5d65f9f118e891c07cc4/addons/product/models/product_template.py#L177-L179

But it is a `Many2one` field, and for this type of field we have to add `with_context(active_test=False)` to the ORM returns all records, active or archived.

opw-3010170




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
