### PR TITLE
[FIX] account: handle writing just tax_ids on an aml

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2103,9 +2103,9 @@ class AccountMove(models.Model):
                 ))
                 stack.enter_context(self._sync_invoice(invoice_container))
                 line_container = {'records': self.line_ids}
-                with self.line_ids._sync_invoice(line_container):
+                with container['records'].line_ids._sync_invoice(line_container):
                     yield
-                    line_container['records'] = self.line_ids
+                    line_container['records'] = container['records'].line_ids
                 tax_container['records'] = container['records'].filtered(tax_filter)
                 invoice_container['records'] = container['records'].filtered(invoice_filter)
                 misc_container['records'] = container['records'].filtered(misc_filter)

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -115,6 +115,23 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             vals['invoice_payment_term_id'] = invoice_payment_term_id.id
         return self.env['account.move'].create(vals)
 
+    def test_setting_tax_separately(self):
+        ''' Test:
+        price_unit | Taxes
+        ------------------
+        100        | 21%
+
+        Expected:
+        Tax         | Taxes     | Base      | Amount
+        --------------------------------------------
+        21%         | /         | 100       | 21
+        '''
+        invoice = self._create_invoice([(100, self.env['account.tax'])])
+        invoice.invoice_line_ids[0].tax_ids = self.percent_tax_1
+        self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [
+            {'name': self.percent_tax_1.name, 'tax_base_amount': 100, 'balance': -21, 'tax_ids': []},
+        ])
+
     def test_one_tax_per_line(self):
         ''' Test:
         price_unit | Taxes


### PR DESCRIPTION
account_avatax sets tax_ids in account.move's _compute_avalara_taxes() function:
```
line.tax_ids = detail['tax_ids']
```
In certain cases tax lines (lines with tax_line_id) were not generated. This resulted in errors about the journal entry being unbalanced.

The tax line is supposed to be generated by account.move's _sync_dynamic_line() as follows:

Before the yield dirty lines (lines with a True compute_all_tax_dirty field) are recorded and are then marked as not being dirty. During the yield tax_ids is updated. This is a dependency of _compute_all_tax() which will cause compute_all_tax_dirty to be set to True again. When the yield in the _sync_dynamic_line() contextmanager returns we again search for dirty lines, if dirty lines exist this early return is bypassed and tax lines are generated:
```
if dirty_recs_before and not dirty_recs_after:
   return
```
However, when writing tax_ids on a single line we end up with following nested _sync_dynamic_line() contextmanagers:
```
1. old taxes and wrote false on compute_all_tax_dirty
   ...
2.   new taxes and wrote false on compute_all_tax_dirty
3. taxes changed and compute_all_tax_dirty is [False, False]
```
The contextmanager on line 1 is supposed to generate the tax line. Line 1 shows that before the yield it sees the original tax_ids (before the write), It sets the dirty field of the lines to False and yields. The problem occurs on line 2: a _sync_dynamic_line() call has occurred via the self.line_ids._sync_invoice() call in _sync_dynamic_lines(), it does:
```
line.balance = amount_currency
```
This write on account.move.line calls _sync_dynamic_lines() again. When _sync_dynamic_lines() calls a new _sync_dynamic_line() the dirty field is True, because the write on tax_ids has now happened. It sets it to False. When the yield of the line 1 contextmanager returns the dirty field remains False and the if statement early returns, causing no tax line to be generated.

No existing tests fail because the issue doesn't occur when writing on multiple lines at the same time. This also explains why the issue can not be reproduced manually in the webclient by setting a tax_ids on a line; the webclient will always send the tax_ids of all the lines, even when just changing one:
```
...
[
  [1, 967, {"tax_ids": [[6, false, [1]]]}]
  [4, 968, false]
]
...
```
test_setting_tax_separately() was added to cover this case.

The _disable_recursion() contextmanager will prevent nested calls like the one on line 2, but it did not work because it sets context on the container, not self. To fix the issue stop using self and instead use the records in the container.

opw-3016530

PR note: some random runbot failures but passed CI before.