### PR TITLE
[16.0] type annotation ideas

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -8,6 +8,7 @@ import hashlib
 import pytz
 import threading
 import re
+from typing_extensions import Self
 import warnings
 
 import requests
@@ -738,7 +739,7 @@ class Partner(models.Model):
         return result
 
     @api.model_create_multi
-    def create(self, vals_list):
+    def create(self, vals_list) -> Self:
         if self.env.context.get('import_file'):
             self._check_import_consistency(vals_list)
         for vals in vals_list:

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from inspect import signature
 from pprint import pformat
 from weakref import WeakSet
+from typing import ParamSpec, TypeVar, Any, Callable
 
 try:
     from decorator import decoratorx as decorator
@@ -33,6 +34,10 @@ from .tools import classproperty, frozendict, lazy_property, OrderedSet, Query, 
 from .tools.translate import _
 
 _logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R", bound=Any)
+
 
 # The following attributes are used, and reflected on wrapping methods:
 #  - method._constrains: set by @constrains, specifies constraint dependencies
@@ -97,7 +102,7 @@ def propagate(method1, method2):
     return method2
 
 
-def constrains(*args):
+def constrains(*args: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorate a constraint checker.
 
     Each argument must be a field name used in the check::
@@ -243,7 +248,7 @@ def onchange(*args):
     return attrsetter('_onchange', args)
 
 
-def depends(*args):
+def depends(*args: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """ Return a decorator that specifies the field dependencies of a "compute"
         method (for new-style function fields). Each argument must be a string
         that consists in a dot-separated sequence of field names::

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -347,6 +347,14 @@ class Field(MetaField('DummyField', (object,), {}), Generic[_T]):
         self._sequence = next(_global_seq)
         self.args = self._args__ = {key: val for key, val in kwargs.items() if val is not Default}
 
+    def new(self, **kwargs):
+        """ Return a field of the same type as ``self``, with its own parameters. """
+        type_args = typing.get_args(getattr(self, "__orig_class__", None))
+        t = type(self)
+        if type_args:
+            t = t[type_args[0]]
+        return t(**kwargs)
+
     def __str__(self):
         if self.name is None:
             return "<%s.%s>" % (__name__, type(self).__name__)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4643,7 +4643,7 @@ class One2many(Generic[_T], _RelationalMulti[_T]):
         return records
 
 
-class Many2many(_RelationalMulti):
+class Many2many(Generic[_T], _RelationalMulti[_T]):
     """ Many2many field; the value of such a field is the recordset.
 
     :param comodel_name: name of the target model (string)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2717,8 +2717,7 @@ class BaseModel(metaclass=MetaModel):
                 # following specific properties:
                 #  - reading inherited fields should not bypass access rights
                 #  - copy inherited fields iff their original field is copied
-                Field = type(field)
-                self._add_field(name, Field(
+                self._add_field(name, field.new(
                     inherited=True,
                     inherited_field=field,
                     related=f"{parent_fname}.{name}",
@@ -2807,12 +2806,11 @@ class BaseModel(metaclass=MetaModel):
                 if not translate:
                     # patch the field definition by adding an override
                     _logger.debug("Patching %s.%s with translate=True", cls._name, name)
-                    fields_.append(type(fields_[0])(translate=True))
+                    fields_.append(fields_[0].new(translate=True))
             if len(fields_) == 1 and fields_[0]._direct and fields_[0].model_name == cls._name:
                 cls._fields[name] = fields_[0]
             else:
-                Field = type(fields_[-1])
-                self._add_field(name, Field(_base_fields=tuple(fields_)))
+                self._add_field(name, fields_[-1].new(_base_fields=tuple(fields_)))
 
         # 2. add manual fields
         if self.pool._init_modules:

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -42,6 +42,8 @@ from collections.abc import MutableMapping
 from contextlib import closing
 from inspect import getmembers, currentframe
 from operator import attrgetter, itemgetter
+from typing import Iterator, Union
+from typing_extensions import Self
 
 import babel.dates
 import dateutil.relativedelta
@@ -462,12 +464,12 @@ class BaseModel(metaclass=MetaModel):
     .. seealso:: :class:`TransientModel`
     """
 
-    _name = None                #: the model name (in dot-notation, module namespace)
-    _description = None         #: the model's informal name
+    _name: Union[str, None] = None                #: the model name (in dot-notation, module namespace)
+    _description: Union[str, None] = None         #: the model's informal name
     _module = None              #: the model's module (in the Odoo sense)
     _custom = False             #: should be True for custom models only
 
-    _inherit = ()
+    _inherit: Union[str, list[str]] = ()
     """Python-inherited models:
 
     :type: str or list(str)
@@ -1515,7 +1517,7 @@ class BaseModel(metaclass=MetaModel):
     @api.returns('self',
         upgrade=lambda self, value, domain, offset=0, limit=None, order=None, count=False: value if count else self.browse(value),
         downgrade=lambda self, value, domain, offset=0, limit=None, order=None, count=False: value if count else value.ids)
-    def search(self, domain, offset=0, limit=None, order=None, count=False):
+    def search(self, domain, offset=0, limit=None, order=None, count=False) -> Self:
         """ search(domain[, offset=0][, limit=None][, order=None][, count=False])
 
         Searches for records based on the ``domain``
@@ -3922,7 +3924,7 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model_create_multi
     @api.returns('self', lambda value: value.id)
-    def create(self, vals_list):
+    def create(self, vals_list) -> Self:
         """ create(vals_list) -> records
 
         Creates new records for the model.
@@ -5155,7 +5157,7 @@ class BaseModel(metaclass=MetaModel):
     #  - the global cache is only an index to "resolve" a record 'id'.
     #
 
-    def __init__(self, env, ids, prefetch_ids):
+    def __init__(self, env, ids=(), prefetch_ids=()):
         """ Create a recordset instance.
 
         :param env: an environment
@@ -5166,7 +5168,7 @@ class BaseModel(metaclass=MetaModel):
         self._ids = ids
         self._prefetch_ids = prefetch_ids
 
-    def browse(self, ids=None):
+    def browse(self, ids=None) -> Self:
         """ browse([ids]) -> records
 
         Returns a recordset for the ids provided as parameter in the current
@@ -5833,7 +5835,7 @@ class BaseModel(metaclass=MetaModel):
         """ Return the size of ``self``. """
         return len(self._ids)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Self]:
         """ Return an iterator over ``self``. """
         if len(self._ids) > PREFETCH_MAX and self._prefetch_ids is self._ids:
             for ids in self.env.cr.split_for_in_conditions(self._ids):
@@ -5843,7 +5845,7 @@ class BaseModel(metaclass=MetaModel):
             for id_ in self._ids:
                 yield self.__class__(self.env, (id_,), self._prefetch_ids)
 
-    def __reversed__(self):
+    def __reversed__(self) -> Iterator[Self]:
         """ Return an reversed iterator over ``self``. """
         if len(self._ids) > PREFETCH_MAX and self._prefetch_ids is self._ids:
             for ids in self.env.cr.split_for_in_conditions(reversed(self._ids)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel pac
 requests==2.25.1 ;  python_version < '3.12' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 requests==2.31.0 ; python_version >= '3.12' # (Noble) Compatibility with i
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
+typing_extensions==4.4.0
 urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
 vobject==0.9.6.1


### PR DESCRIPTION
This PR, which is not meant to be merged as is, goes along with my Odoo Experience 2022 talk "Towards Idiomatic Python with Types for the Odoo ORM" ([slides](https://docs.google.com/presentation/d/1A8UzGnw3TisUjajnPySiHk6E75tEpi7D3zxsHdtjIW4/edit?usp=sharing), [video](https://youtu.be/pAVGpEVORbY)).

It does not much more than the examples shown in the talk:
- annotate some core ORM methods
- annotate field descriptors

For the class instanciation and inheritance examples shown in the talk to work, you need to `pip install typodoo` ([repo](https://github.com/sbidoul/typodoo)), which monkey patches the metaclass.