### PR TITLE
[FIX] account: fix auto-reconciliation with bank statements and multicurrency

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1073,7 +1073,7 @@ class AccountBankStatementLine(models.Model):
         reconciliation_overview = []
 
         total_balance = liquidity_lines.balance
-        total_amount_currency = liquidity_lines.amount_currency
+        total_amount_currency = -self._prepare_move_line_default_vals()[1]['amount_currency']
         sign = 1 if liquidity_lines.balance > 0.0 else -1
 
         # Step 1: Split 'lines_vals_list' into two batches:


### PR DESCRIPTION
### Steps to reproduce
- activate *auto-validate* on the *Invoices/Bills Perfect Match* reconciliation model
- make sure you have a secondary currency that's weaker than your company's currency. Here, we'll call the main and secondary currency C1 and C2 respectively. Let's assume 1 C2 = 0.8 C1 
(i.e, 1 C1 = 1.25 C2).
- create a new vendor bill whose currency is C2. Make sure to give that bill a reference, and confirm. Let's assume the total of that bill is 100 C2 (i.e, 80 C1).
- create a new bank statement and add a line whose values match the vendor bill you created:
  - Partner  = same as the vendor bill
  - Label = same as the vendor bill's reference
  - Amount Currency  = -100
  - Foreign Currency = C2
  - Amount = -80
- post and reconcile that bank statement

The vendor bill and the bank statement will be automatically reconciled. Furthermore, we expect the bill to be fully paid. 
However, if you go to the vendor bill, it will be marked as partially paid and 20 C2 will be missing. The currencies are being mixed up.

opw-2991183