### PR TITLE
[FIX] snailmail: dont resend without credits

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -114,6 +114,10 @@ class SnailmailLetter(models.Model):
 
         return letters
 
+    def action_reset_to_pending(self):
+        for rec in self:
+            rec.write({'state': 'pending'})
+
     def _fetch_attachment(self):
         """
         This method will check if we have any existent attachement matching the model
@@ -413,7 +417,7 @@ class SnailmailLetter(models.Model):
             ('state', '=', 'pending'),
             '&',
             ('state', '=', 'error'),
-            ('error_code', 'in', ['TRIAL_ERROR', 'CREDIT_ERROR', 'ATTACHMENT_ERROR', 'MISSING_REQUIRED_FIELDS'])
+            ('error_code', 'in', ['TRIAL_ERROR', 'ATTACHMENT_ERROR', 'MISSING_REQUIRED_FIELDS'])
         ])
         for letter in letters_send:
             letter._snailmail_print()

--- a/addons/snailmail/views/snailmail_views.xml
+++ b/addons/snailmail/views/snailmail_views.xml
@@ -56,6 +56,14 @@
         <field name="view_id" ref="snailmail_letter_list" />
     </record>
 
+    <record id="action_reset_to_pending" model="ir.actions.server">
+      <field name="name">Reset to pending</field>
+      <field name="model_id" ref="snailmail.model_snailmail_letter"/>
+      <field name="binding_model_id" ref="snailmail.model_snailmail_letter"/>
+      <field name="state">code</field>
+      <field name="code">records.action_reset_to_pending()</field>
+    </record>
+
     <menuitem id="menu_snailmail_letters" parent="base.menu_email" action="action_mail_letters"
               sequence="50"/>
 </odoo>


### PR DESCRIPTION
We are spammed by some accounts that don't have credits anymore.

With this commit, the snailmail `cron` does not take their messages into account anymore.

There is a new server action (action_reset_to_pending) callable from the list view, for bulk updates on the snailmail_letter records. This action allows the user to reset the state of chosen letters, making those elligible again to the cron.

__Pros & Cons__

Some drawbacks of this approach are:
 - Since the server action is in the views, the snailmail module needs to be upgraded.
 - The user needs to act (before it was in the background => less ui friendly, but probably rare enough).
 - Risk of abuse.

Some upsides are:
 - Allows bulk and fine tuning reset (maybe some of the letters dont need to be sent anymore)
 - Fixes our issue, which is spam.

task-2930455

![image](https://user-images.githubusercontent.com/51679926/196122339-0167cb22-c202-40b3-813b-7094a0da12b7.png)