### PR TITLE
[IMP] product: enable Imperial units at install when required

### DIFF
--- a/addons/product/__init__.py
+++ b/addons/product/__init__.py
@@ -6,3 +6,11 @@ from . import models
 from . import report
 from . import populate
 from . import wizard
+
+def _post_init_hook(env):
+    companies = env['res.company'].search([])
+    country_codes = ['US', 'MM', 'LR']
+
+    if all(c.country_id.code in country_codes for c in companies):
+        env['ir.config_parameter'].sudo().set_param('product.weight_in_lbs', '1')
+        env['ir.config_parameter'].sudo().set_param('product.volume_in_cubic_feet', '1')

--- a/addons/product/__manifest__.py
+++ b/addons/product/__manifest__.py
@@ -73,4 +73,5 @@ Print product labels with barcode.
         ],
     },
     'license': 'LGPL-3',
+    'post_init_hook': '_post_init_hook',
 }


### PR DESCRIPTION
The imperial units are now automatically enabled at the module installation if *all* the companies use imperial units (USA, Myanmar, and Liberia).

task-2951823

