### PR TITLE
[FIX] sale: keep different delivery address when creating invoices

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -641,7 +641,7 @@ class SaleOrder(models.Model):
         return action
 
     def _get_invoice_grouping_keys(self):
-        return ['company_id', 'partner_id', 'currency_id']
+        return ['company_id', 'partner_id', 'currency_id', 'partner_shipping_id']
 
     @api.model
     def _nothing_to_invoice_error(self):


### PR DESCRIPTION
Steps to reproduce:

- Go to Sales app.
- Create 2 Quotations with the same customer, same invoice address but with different delivery address for each one.
- Then select the 2 Quotations from the list view > Action > Create invoices.
- In the popup window click on "Create and view invoice".
- This will create just one invoice, keeping only one of the 2 delivery addresses.
- If we go to print > Invoices, we can see same behaviour, just one of the 2 addresses is displayed.

Issue:

The 2 Quotations with different delivery address (for the same customer) are merged together when creating the invoices together, which makes one of the 2 delivery addresses to get lost.

Fix:

Added the delivery address (partner_shipping_id) to the invoice grouping keys will make the sales app to split the invoice in 2 also when the delivery address is different.

opw-3020941