### PR TITLE
[FIX] payment: reset custom_mode when removing providers

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -603,6 +603,7 @@ class PaymentProvider(models.Model):
         return {
             'code': 'none',
             'state': 'disabled',
+            'custom_mode': False,
             'is_published': False,
             'redirect_form_view_id': None,
             'inline_form_view_id': None,


### PR DESCRIPTION
When resetting payment providers to strip them from payment method specific data, the `custom_mode` should also be reset. This avoids constraint violations on the `payment_provider_custom_providers_setup` constraint.