### PR TITLE
[FIX] account_edi: cancel payment through SAT

### DIFF
--- a/addons/account_edi/models/account_payment.py
+++ b/addons/account_edi/models/account_payment.py
@@ -7,5 +7,47 @@ from odoo import models, fields, api, _
 class AccountPayment(models.Model):
     _inherit = 'account.payment'
 
+    edi_show_cancel_button = fields.Boolean(
+        compute='_compute_edi_show_cancel_button')
+
+    @api.depends(
+        'state',
+        'move_id.edi_document_ids.state',
+        'move_id.edi_document_ids.attachment_id')
+    def _compute_edi_show_cancel_button(self):
+        for payment in self:
+            if payment.state != 'posted':
+                payment.edi_show_cancel_button = False
+                continue
+
+            payment.edi_show_cancel_button = any([doc.edi_format_id._needs_web_services()
+                                                  and doc.attachment_id
+                                                  and doc.state == 'sent'
+                                                  and payment.reconciled_invoice_ids.is_invoice(include_receipts=True)
+                                                  and doc.edi_format_id._is_required_for_invoice(payment.reconciled_invoice_ids)
+                                                  for doc in payment.edi_document_ids])
+
     def action_process_edi_web_services(self):
         return self.move_id.action_process_edi_web_services()
+
+    def button_cancel_posted_payments(self):
+        """
+        Mark the edi.document related to this payment to be canceled.
+        """
+        to_cancel_documents = self.env['account.edi.document']
+        for payment in self:
+            is_payment_marked = False
+            for doc in payment.edi_document_ids:
+                if doc.edi_format_id._needs_web_services() \
+                        and doc.attachment_id \
+                        and doc.state == 'sent' \
+                        and payment.reconciled_invoice_ids.is_invoice(include_receipts=True) \
+                        and doc.edi_format_id._is_required_for_invoice(payment.reconciled_invoice_ids):
+                    to_cancel_documents |= doc
+                    is_payment_marked = True
+            if is_payment_marked:
+                payment.message_post(body=_("A cancellation of the EDI has been requested."))
+            payment.move_id.line_ids.remove_move_reconcile()
+            payment.action_draft()
+            payment.action_cancel()
+        to_cancel_documents.write({'state': 'to_cancel', 'error': False, 'blocking_level': False})

--- a/addons/account_edi/views/account_payment_views.xml
+++ b/addons/account_edi/views/account_payment_views.xml
@@ -14,6 +14,14 @@
             <field name="model">account.payment</field>
             <field name="inherit_id" ref="account.view_account_payment_form" />
             <field name="arch" type="xml">
+                <xpath expr="//button[@name='action_cancel']" position="after">
+                    <field name="edi_show_cancel_button" invisible="1"/>
+                    <button name="button_cancel_posted_payments"
+                            string="Request EDI Cancellation"
+                            type="object"
+                            groups="account.group_account_invoice"
+                            attrs="{'invisible' : [('edi_show_cancel_button', '=', False)]}"/>
+                </xpath>
                 <xpath expr="//header" position="after">
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
                          attrs="{'invisible': ['|', ('edi_web_services_to_process', 'in', ['', False]), ('state', '=', 'draft')]}">


### PR DESCRIPTION
It is not possible to cancel a payment with EDI

Steps to reproduce:
1. Install l10n_mx_edi, l10n_mx_edi_extended and Accounting (set company
   to MX Company)
2. Go to Settings > Accounting > Electronic invoicing (MX), add a fiscal
   regime, an MX certificate (password 12345678a) and check MX PAC test
   environment
3. Give a VAT number to the company EKU9003173C9 and to customer Azure
   Interior
2. Create an invoice with customer Azure Interior, due date: 2 months,
   product: Large Cabinet (specify any UNSPSC on it)
3. Save and confirm the invoice and send it to edi (Send now) then
   register payment with payment way 'Transferencia electrónica de
   fondos'
6. Go to the payment (through the little "i" next to the total)
7. Send to edi (Send now), reset to draft, cancel and resend

Solution:
Add a way to cancel the payment through EDI

opw-2926261
