### PR TITLE
[FIX] web_editor: fix gap between sections with shapes

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -57,6 +57,10 @@
             }
         }
     }
+    // Hack to fix an issue in Chrome where CSS backgrounds with SVG are
+    // sometimes positioned a few pixels too high or too low (due to a
+    // roundness handling issue) leaving a thin space between two sections.
+    margin: -2px 0px;
 }
 @include media-breakpoint-down(sm) {
     .o_we_shape {


### PR DESCRIPTION
This commit fixes an issue in Chrome with shapes, with certain screen resolutions a space of a few pixels goes between two sections when one of them contains a shape.

This can be tested by changing the zoom of the page and then changing the width of the window, at some point the gap appears.

It is due to a roundness handling issue in Chrome with CSS backgrounds with SVG.

task-2824607