### PR TITLE
[FIX]base: correct handling for empty Thousands Separator

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -217,7 +217,7 @@ class IrHttp(models.AbstractModel):
                 "time_format": langs.time_format,
                 "grouping": langs.grouping,
                 "decimal_point": langs.decimal_point,
-                "thousands_sep": langs.thousands_sep,
+                "thousands_sep": langs.thousands_sep or '',
                 "week_start": langs.week_start,
             }
             lang_params['week_start'] = int(lang_params['week_start'])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Activate language Portuguese / Português
- change users language as above
- try updating product's price

Current behavior before PR:
- Field is invalid

Desired behavior after PR is merged:
- updates the amount correctly


Opw-3024548


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
