### PR TITLE
[IMP] web: add button in company switcher

### DIFF
--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -60,6 +60,9 @@ export const companyService = {
                 let nextCompanyIds;
                 if (mode === "toggle") {
                     nextCompanyIds = symmetricalDifference(allowedCompanyIds, companyIds);
+                } else if (mode === "set") {
+                    nextCompanyIds = companyIds
+                    nextCompanyIds = nextCompanyIds.length ? nextCompanyIds : [allowedCompanyIds[0]];
                 } else if (mode === "loginto") {
                     const companyId = companyIds[0];
                     if (allowedCompanyIds.length === 1) {
@@ -73,12 +76,12 @@ export const companyService = {
                         ];
                     }
                 }
-                nextCompanyIds = nextCompanyIds.length ? nextCompanyIds : [companyIds[0]];
-
-                // apply them
-                router.pushState({ cids: nextCompanyIds }, { lock: true });
-                cookie.setCookie("cids", nextCompanyIds);
-                browser.setTimeout(() => browser.location.reload()); // history.pushState is a little async
+                if (mode !== "toggle") {
+                     // apply them
+                    router.pushState({ cids: nextCompanyIds }, { lock: true });
+                    cookie.setCookie("cids", nextCompanyIds);
+                    browser.setTimeout(() => browser.location.reload()); // history.pushState is a little async
+                }
             },
         };
     },

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -19,15 +19,15 @@ export class SwitchCompanyMenu extends Component {
         this.state.companiesToToggle = symmetricalDifference(this.state.companiesToToggle, [
             companyId,
         ]);
-        browser.clearTimeout(this.toggleTimer);
-        this.toggleTimer = browser.setTimeout(() => {
-            this.companyService.setCompanies("toggle", ...this.state.companiesToToggle);
-        }, this.constructor.toggleDelay);
+        this.companyService.setCompanies("toggle", ...this.state.companiesToToggle);
     }
 
     logIntoCompany(companyId) {
-        browser.clearTimeout(this.toggleTimer);
         this.companyService.setCompanies("loginto", companyId);
+    }
+
+    setCompanies(companyIds) {
+        this.companyService.setCompanies("set", ...companyIds);
     }
 
     get selectedCompanies() {
@@ -38,7 +38,6 @@ export class SwitchCompanyMenu extends Component {
     }
 }
 SwitchCompanyMenu.template = "web.SwitchCompanyMenu";
-SwitchCompanyMenu.toggleDelay = 1000;
 
 export const systrayItem = {
     Component: SwitchCompanyMenu,

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -13,6 +13,7 @@
                 <t t-set="company" t-value="company" />
             </t>
         </t>
+        <button class="btn btn-sm btn-primary float-left set_company" style="margin-top:5px; margin-bottom:5px;" t-on-click="setCompanies(selectedCompanies)">Apply</button>
     </Dropdown>
 </t>
 


### PR DESCRIPTION
The toggleDelay feature was a bit mess. If you had several companies and you wanted to toggle several of them at once, sometimes the window was reloaded before you could select all the companies you wanted (maybe due to being too slow toggling).

With this commit, it becomes simpler: First select all the companies you want (without any reload), and then click on the new "Apply" button to set those companies and trigger the reload.

**Description of the issue/feature this PR addresses:**

It bothers a bit that when you are toggling the companies in the widget, the page is reloaded before you have finished the toggling. This PR avoids this problem by adding a button to apply the toggled companies.

**Current behavior before PR:**

![Peek 2022-10-19 00-10](https://user-images.githubusercontent.com/25005517/196557234-a1ee1434-057f-46b8-aa8c-48604f15c5a1.gif)


**Desired behavior after PR is merged:**

![Peek 2022-10-19 00-13](https://user-images.githubusercontent.com/25005517/196557271-7153945a-66df-40e3-b51f-33ba38bc05bd.gif)

NOTE 1: I suggested this to @ged-odoo at OXP.
NOTE 2: I know that the button needs some css styles to make it look better.
NOTE 3: If you like the idea, feel free to cherry-pick and finish it or to port to another branch.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr