### PR TITLE
[FIX] l10n_syscohada: currency rate on credit note

### DIFF
--- a/addons/l10n_syscohada/__init__.py
+++ b/addons/l10n_syscohada/__init__.py
@@ -3,3 +3,6 @@
 
 # Copyright (C) 2010-2011 BAAMTU SARL (<http://www.baamtu.sn>).
 # contact: leadsn@baamtu.com
+
+from . import models
+from . import wizard

--- a/addons/l10n_syscohada/models/__init__.py
+++ b/addons/l10n_syscohada/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move

--- a/addons/l10n_syscohada/models/account_move.py
+++ b/addons/l10n_syscohada/models/account_move.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _get_fields_onchange_subtotal(self, price_subtotal=None, move_type=None, currency=None, company=None, date=None):
+        self.ensure_one()
+        date = self.move_id.reversed_entry_id.date if self.env.context.get('origin_date') else date
+        return super()._get_fields_onchange_subtotal(
+            price_subtotal=self.price_subtotal if price_subtotal is None else price_subtotal,
+            move_type=self.move_id.move_type if move_type is None else move_type,
+            currency=self.currency_id if currency is None else currency,
+            company=self.move_id.company_id if company is None else company,
+            date=self.move_id.date if date is None else date,
+        )

--- a/addons/l10n_syscohada/wizard/__init__.py
+++ b/addons/l10n_syscohada/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move_reversal

--- a/addons/l10n_syscohada/wizard/account_move_reversal.py
+++ b/addons/l10n_syscohada/wizard/account_move_reversal.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+from odoo.addons.account import SYSCOHADA_LIST
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reversal"
+
+    def reverse_moves(self):
+        if self.country_code in SYSCOHADA_LIST and self.currency_id != self.env.company.currency_id:
+            return super(AccountMoveReversal, self.with_context(origin_date=True)).reverse_moves()
+        else:
+            return super().reverse_moves()


### PR DESCRIPTION
When making a credit note in foreign currency,
we use the rate of the credit note date.
In countries who use ohada accounting, we have
to use the same rate as the reversed move.

opw-2998367
