### PR TITLE
[FIX] l10n_nz: fix the tax report

### DIFF
--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -47,7 +47,7 @@
                     <record id="tax_report_box8" model="account.report.line">
                         <field name="name">[BOX 8] Multiply the amount in Box 7 by 3 and then divide by 23</field>
                         <field name="code">NZBOX8</field>
-                        <field name="aggregation_formula">(NZBOX7.balance * 3).balance/23.balance</field>
+                        <field name="aggregation_formula">(NZBOX7.balance * 3)/23</field>
                     </record>
                     <record id="tax_report_box9" model="account.report.line">
                         <field name="name">[BOX 9] Enter any adjustments from your calculation sheet</field>
@@ -85,7 +85,7 @@
                     <record id="tax_report_box12" model="account.report.line">
                         <field name="name">[BOX 12] Multiply BOX11 by 3 and then divide by 23</field>
                         <field name="code">NZBOX12</field>
-                        <field name="aggregation_formula">(NZBOX11.balance * 3).balance/23.balance</field>
+                        <field name="aggregation_formula">(NZBOX11.balance * 3)/23</field>
                     </record>
                     <record id="tax_report_box13" model="account.report.line">
                         <field name="name">[BOX 13] Credit adjustments from your calculation sheet</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: The New Zealender tax report couldn't be opened because of an error in aggregation formula

Current behavior before PR: the tax report can't be opened

Desired behavior after PR is merged: the tax report is fixed, can be opened and is correct




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
