### PR TITLE
[FIX] point_of_sale: reset number buffer when the select order line

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -16,6 +16,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
         setup() {
             super.setup();
             useListener('update-selected-orderline', this._updateSelectedOrderline);
+            useListener('select-line', this._selectLine);
             useListener('set-numpad-mode', this._setNumpadMode);
             useListener('click-product', this._clickProduct);
             useListener('click-partner', this.onClickPartner);
@@ -160,6 +161,9 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             NumberBuffer.capture();
             NumberBuffer.reset();
             this.env.pos.numpadMode = mode;
+        }
+        _selectLine() {
+            NumberBuffer.reset();
         }
         async _updateSelectedOrderline(event) {
             if (this.env.pos.numpadMode === 'quantity' && this.env.pos.disallowLineQuantityChange()) {

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -67,6 +67,26 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
     ProductScreen.check.productIsDisplayed('Letter Tray');
     ProductScreen.do.clickHomeCategory();
 
+    // Add two orderlines and update quantity
+    ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+    ProductScreen.do.clickDisplayedProduct('Wall Shelf Unit');
+    ProductScreen.do.clickOrderline('Whiteboard Pen', '1.0');
+    ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '1.0');
+    ProductScreen.do.pressNumpad('2');
+    ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '2.0');
+    ProductScreen.do.clickOrderline('Wall Shelf Unit', '1.0');
+    ProductScreen.check.selectedOrderlineHas('Wall Shelf Unit', '1.0');
+    ProductScreen.do.pressNumpad('2');
+    ProductScreen.check.selectedOrderlineHas('Wall Shelf Unit', '2.0');
+    ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Wall Shelf Unit', '0.0');
+    ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '2.0');
+    ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '0.0');
+    ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.orderIsEmpty();
+
     // Add multiple orderlines then delete each of them until empty
     ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
     ProductScreen.do.clickDisplayedProduct('Wall Shelf Unit');


### PR DESCRIPTION
Before this commit: if you add two products in PoS and try to change the quantity
for the first one, it works fine, but when you click on the other order line and try to
update the quantity, it uses the previous number buffer.

The solution is to reset the number buffer after selecting the order line.

issue: https://github.com/odoo/odoo/issues/103230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
