### PR TITLE
[FIX] account: payment term visual improvement

### DIFF
--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -35,36 +35,28 @@
                     <sheet>
                         <field name="active" invisible="1"/>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <div class="oe_title">
+                            <label for="name"/>
+                            <h1><field name="name" nolabel="1" placeholder="e.g. 30 days"/></h1>
+                        </div>
                         <group>
-                            <group>
-                                <field name="name"/>
-                            </group>
-                            <group>
-                                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
-                            </group>
-                        </group>
-                        <group>
-                            <field name="note" placeholder="Payment term explanation for the customer..."/>
-                        </group>
-                        <label for="display_on_invoice"/>
-                        <field name="display_on_invoice"/>
-                        <separator string="Terms"/>
-                        <p class="text-muted">
-                            The last line's computation type should be "Balance" to ensure that the whole amount will be allocated.
-                        </p>
-                        <field name="line_ids">
-                            <tree string="Payment Terms" editable="top" no_open="True">
-                                <field name="value" string="Due Type"/>
-                                <field name="value_amount" attrs="{'invisible': [('value', '=', 'balance')]}" digits="[2, 2]"/>
-                                <field name="months"/>
-                                <field name="days"/>
-                                <field name="end_month" widget="boolean_toggle"/>
-                                <field name="days_after" attrs="{'invisible': [('end_month','=', False)]}"/>
-                                <field name="discount_percentage"/>
-                                <field name="discount_days"/>
-                            </tree>
-                        </field>
+                            <field name="company_id" options="{'no_create': True}" class="w-25" groups="base.group_multi_company"/>
+                            <field name="note" string="Payment Terms description on Invoice" placeholder="e.g. Payment terms: 30 days after invoice date"/>
+                            <field name="display_on_invoice" string="Display details"/>
 
+                            <field name="line_ids" nolabel="1" colspan="2">
+                                <tree string="Payment Terms" editable="top" no_open="True">
+                                    <field name="value" string="Due Type"/>
+                                    <field name="value_amount" attrs="{'invisible': [('value', '=', 'balance')]}" digits="[2, 2]"/>
+                                    <field name="months"/>
+                                    <field name="days"/>
+                                    <field name="end_month" widget="boolean_toggle"/>
+                                    <field name="days_after" attrs="{'invisible': [('end_month','=', False)]}"/>
+                                    <field name="discount_percentage"/>
+                                    <field name="discount_days"/>
+                                </tree>
+                            </field>
+                        </group>
                         <div class="oe_edit_only">
                             <separator string="Example"/>
                             <field name="example_invalid" invisible="1"/>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -207,29 +207,31 @@
                     <div t-field="o.invoice_payment_term_id.note" name="payment_term"/>
                     <t t-if="o.invoice_payment_term_id.display_on_invoice and payment_term_details">
                         <div t-if='o.show_payment_term_details' id="total_payment_term_details_table" class="row">
-                            <div t-attf-class="#{'col-7' if report_type != 'html' else 'col-sm-7 col-md-6'} mt-2 mb-2">
-                                <table class="table table-sm" style="page-break-inside: avoid;">
-                                    <th class="border-black text-start">
-                                        Due Date
-                                    </th>
-                                    <th class="border-black text-end">
-                                        Amount Due
-                                    </th>
-                                    <th t-if="o.show_discount_details" class="border-black text-end">
-                                        Discount
-                                    </th>
-                                    <t t-foreach="payment_term_details" t-as="term">
-                                        <tr>
-                                            <td t-esc="term.get('date')" class="text-start"/>
+                            <div t-attf-class="#{'col-12' if report_type != 'html' else 'col-sm-10 col-md-9'}">
+                                <t t-if="len(payment_term_details) == 1 and payment_term_details[0].get('discount_date')">
+                                    <td>
+                                        <span t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                              t-esc="payment_term_details[0].get('discount_amount_currency')"/> due if paid before
+                                        <span t-esc="payment_term_details[0].get('discount_date')"/>
+                                    </td>
+                                </t>
+
+                                <t t-set="i" t-value="1"/>
+                                <t t-if="len(payment_term_details) > 1" t-foreach="payment_term_details" t-as="term">
+                                    <tr>
+                                        <p> <span t-esc="i"/> - Installment of
                                             <td t-options='{"widget": "monetary", "display_currency": o.currency_id}' t-esc="term.get('amount')" class="text-end"/>
-                                            <td t-if="term.get('discount_date')" class="text-end">
+                                            <span> due on </span>
+                                            <td t-esc="term.get('date')" class="text-start"/>
+                                            <td t-if="term.get('discount_date')" class="text-end">(
                                                 <span t-options='{"widget": "monetary", "display_currency": o.currency_id}'
                                                       t-esc="term.get('discount_amount_currency')"/> if paid before
-                                                <span t-esc="term.get('discount_date')"/>
+                                                <span t-esc="term.get('discount_date')"/>)
                                             </td>
-                                        </tr>
-                                    </t>
-                                </table>
+                                        </p>
+                                    </tr>
+                                    <t t-set="i" t-value="i+1"/>
+                                </t>
                             </div>
                         </div>
                     </t>


### PR DESCRIPTION
The payment terms view needed a bit a change so this PR change a few things:

* Make the title of the payment terms bigger like the other view in odoo
* Group the company, note and display on invoice so that they are aligned
* removing the section Terms and the span

This PR also change the display of payment terms on invoice when printing or previewing them. Now :
* If there is one line (no cash discount) it's not displayed
* If there is one lone with cash discount) it's displayed
* If more than one line then displayed Before this PR it was presented with a table but now the line are displayed like a list.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
