### PR TITLE
[FIX] web_editor: remove dot in powerbox commands

### DIFF
--- a/addons/web_editor/i18n/ar.po
+++ b/addons/web_editor/i18n/ar.po
@@ -279,21 +279,21 @@ msgstr "إضافة رابط"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr "إضافة عمود إلى اليمين "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "تشغيل تلقائي"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr "الأسفل "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "ترويسة قسم كبير. "
 
 #. module: web_editor
@@ -750,21 +750,21 @@ msgstr "التناقض "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -804,21 +804,21 @@ msgstr "إنشاء"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "إنشاء قائمة مرقمة. "
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "إنشاء قائمة نقاط بسيطة. "
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1059,14 +1059,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1497,42 +1497,42 @@ msgstr "نص مضمن "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "إدراج جدول. "
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "إدراج فاصل قاعدة أفقي. "
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1560,7 +1560,7 @@ msgstr "إدراج جدول "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1738,7 +1738,7 @@ msgstr "متوسط "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "ترويسة قسم متوسط. "
 
 #. module: web_editor
@@ -1929,7 +1929,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "كتلة الفقرة. "
 
 #. module: web_editor
@@ -2492,7 +2492,7 @@ msgstr "التوقيع"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2544,7 +2544,7 @@ msgstr "صغير"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "ترويسة قسم صغير. "
 
 #. module: web_editor
@@ -2620,7 +2620,7 @@ msgstr "تبديل الاتجاه "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "تبديل اتجاه النص. "
 
 #. module: web_editor
@@ -2905,7 +2905,7 @@ msgstr "تلميح "
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "تتبع المهام باستخدام القائمة المرجعية. "
 
 #. module: web_editor

--- a/addons/web_editor/i18n/az.po
+++ b/addons/web_editor/i18n/az.po
@@ -271,21 +271,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -306,7 +306,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -483,7 +483,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -532,7 +532,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -742,21 +742,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -796,21 +796,21 @@ msgstr "Yaradın"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1056,14 +1056,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1488,42 +1488,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1558,7 +1558,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1743,7 +1743,7 @@ msgstr "Reklam Vasitəsi"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1934,7 +1934,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2497,7 +2497,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2549,7 +2549,7 @@ msgstr "Kiçik"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2625,7 +2625,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2910,7 +2910,7 @@ msgstr "Çıxan izah"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/ca.po
+++ b/addons/web_editor/i18n/ca.po
@@ -292,21 +292,21 @@ msgstr "Afegir enllaç"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -327,7 +327,7 @@ msgstr "Afegir una columna a la dreta"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -504,7 +504,7 @@ msgstr "Reproducció automàtica"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -553,7 +553,7 @@ msgstr "A baix"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -763,21 +763,21 @@ msgstr "Contrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -817,21 +817,21 @@ msgstr "Crear"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1077,14 +1077,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1511,42 +1511,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1581,7 +1581,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1766,7 +1766,7 @@ msgstr "Mitja"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1957,7 +1957,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2520,7 +2520,7 @@ msgstr "Signatura"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2572,7 +2572,7 @@ msgstr "Petit"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2648,7 +2648,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2933,7 +2933,7 @@ msgstr "Informació sobre eines"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/cs.po
+++ b/addons/web_editor/i18n/cs.po
@@ -281,21 +281,21 @@ msgstr "Přidat URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -316,7 +316,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -493,7 +493,7 @@ msgstr "Automatické přehrávání"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -542,7 +542,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr "Kontrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Vytvořit"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1068,14 +1068,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1506,42 +1506,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1576,7 +1576,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1761,7 +1761,7 @@ msgstr "Médium"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1952,7 +1952,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2515,7 +2515,7 @@ msgstr "Podpis"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2567,7 +2567,7 @@ msgstr "Malý"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2643,7 +2643,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2934,7 +2934,7 @@ msgstr "Kontextová nápověda"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/da.po
+++ b/addons/web_editor/i18n/da.po
@@ -278,21 +278,21 @@ msgstr "Tilføj URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -313,7 +313,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -490,7 +490,7 @@ msgstr "Autoafspilning"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -539,7 +539,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -749,21 +749,21 @@ msgstr "Kontrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -803,21 +803,21 @@ msgstr "Opret"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1066,14 +1066,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1505,42 +1505,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1575,7 +1575,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1760,7 +1760,7 @@ msgstr "Medium"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1951,7 +1951,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2514,7 +2514,7 @@ msgstr "Signatur"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2566,7 +2566,7 @@ msgstr "Lille"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2642,7 +2642,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2934,7 +2934,7 @@ msgstr "Værktøjstip"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/de.po
+++ b/addons/web_editor/i18n/de.po
@@ -279,21 +279,21 @@ msgstr "URL hinzufügen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Eine Schaltfläche hinzufügen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Einen Codeabschnitt hinzufügen."
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr "Spalte rechts hinzufügen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Einen Link hinzufügen."
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "Automatisch abspielen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Große Abschnittsüberschrift."
 
 #. module: web_editor
@@ -750,21 +750,21 @@ msgstr "Kontrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -804,21 +804,21 @@ msgstr "Anlegen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Eine Liste mit Nummerierung erstellen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Erstellen Sie eine einfache Aufzählungsliste."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "URL erstellen."
 
 #. module: web_editor
@@ -1061,14 +1061,14 @@ msgstr "Youtube Video einbetten"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "Bild in Dokument einbetten."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "Youtube-Video in Dokument einbetten."
 
 #. module: web_editor
@@ -1501,42 +1501,42 @@ msgstr "Inline Text"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Tabelle einfügen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "Video einfügen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Einfügen eines horizontalen Trennstrichs."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Ein Bild einfügen."
 
 #. module: web_editor
@@ -1564,7 +1564,7 @@ msgstr "Tabelle einfügen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1742,7 +1742,7 @@ msgstr "Mittel"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Mittelgroße Abschnittsüberschrift."
 
 #. module: web_editor
@@ -1933,7 +1933,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2498,7 +2498,7 @@ msgstr "Signatur"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "Einfachen Text einfügen."
 
 #. module: web_editor
@@ -2550,7 +2550,7 @@ msgstr "Sehr klein"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Kleine Abschnittsüberschrift."
 
 #. module: web_editor
@@ -2626,7 +2626,7 @@ msgstr "Richtung ändern"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Textrichtung ändern."
 
 #. module: web_editor
@@ -2916,7 +2916,7 @@ msgstr "Tooltip"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/es.po
+++ b/addons/web_editor/i18n/es.po
@@ -281,21 +281,21 @@ msgstr "Agregar URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Añadir una sección de citas en bloque."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Añadir un Botón"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Añadir una sección de código."
 
 #. module: web_editor
@@ -316,7 +316,7 @@ msgstr "Agregar una columna a la derecha"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Añadir un vínculo"
 
 #. module: web_editor
@@ -493,7 +493,7 @@ msgstr "Reproducción automática"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr "Volver a una columna."
 
 #. module: web_editor
@@ -542,7 +542,7 @@ msgstr "Debajo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Encabezado de sección grande"
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr "Contraste"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr "Convertir en 2 columnas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr "Convertir en 3 columnas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr "Convertir en 4 columnas."
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Crear"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Crear una lista con numeración."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Crear una lista simple de viñetas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "Crear una URL"
 
 #. module: web_editor
@@ -1069,14 +1069,14 @@ msgstr "Insertar vídeo de Youtube"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "Insertar la imagen en el documento."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "Insertar el vídeo de youtube en el documento."
 
 #. module: web_editor
@@ -1507,42 +1507,42 @@ msgstr "Texto en línea"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr "Insertar una calificación mayor a 3 estrellas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr "Insertar una calificación mayor a 5 estrellas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Insertar una tabla."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "Inserta un vídeo."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Insertar un separador de línea horizontal."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Insertar una imagen."
 
 #. module: web_editor
@@ -1577,7 +1577,7 @@ msgstr "Insertar tabla"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr "Insertar su firma."
 
 #. module: web_editor
@@ -1762,7 +1762,7 @@ msgstr "Media"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Encabezado de sección mediana."
 
 #. module: web_editor
@@ -1953,7 +1953,7 @@ msgstr "Opciones de página"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Bloque de párrafo."
 
 #. module: web_editor
@@ -2517,7 +2517,7 @@ msgstr "Firma"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "Pegar texto simple."
 
 #. module: web_editor
@@ -2569,7 +2569,7 @@ msgstr "Pequeño"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Encabezado de sección pequeña."
 
 #. module: web_editor
@@ -2647,7 +2647,7 @@ msgstr "Cambiar dirección"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Cambiar la dirección del texto."
 
 #. module: web_editor
@@ -2940,7 +2940,7 @@ msgstr "Cuadro de información"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Seguir tareas con una checklist."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/es_MX.po
+++ b/addons/web_editor/i18n/es_MX.po
@@ -279,21 +279,21 @@ msgstr "Agregar URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Agregar una sección de bloque de cita."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Agregar un botón."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Agregar una sección de código."
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr "Agregar una columna a la derecha"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Agregar un enlace."
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "Reproducción automática"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr "Volver a una columna."
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr "Debajo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Encabezado de sección grande."
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr "Contraste"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr "Convertir en 2 columnas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr "Convertir en 3 columnas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr "Convertir en 4 columnas."
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Crear"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Crear una lista numerada."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Crear una lista de viñetas sencilla."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "Crear un URL."
 
 #. module: web_editor
@@ -1070,14 +1070,14 @@ msgstr "Insertar video de YouTube"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "Insertar la imagen en el documento."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "Insertar el video de YouTube en el documento."
 
 #. module: web_editor
@@ -1508,42 +1508,42 @@ msgstr "Texto en línea"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr "Insertar una calificación mayor a 3 estrellas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr "Insertar una calificación mayor a 5 estrellas."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Insertar una tabla."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "Insertar un video."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Insertar un separador de regla horizontal."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Insertar una imagen."
 
 #. module: web_editor
@@ -1578,7 +1578,7 @@ msgstr "Insertar tabla"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr "Insertar su firma."
 
 #. module: web_editor
@@ -1763,7 +1763,7 @@ msgstr "Medio"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Encabezado de texto de sección mediana."
 
 #. module: web_editor
@@ -1954,7 +1954,7 @@ msgstr "Opciones de página"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Bloque de párrafo."
 
 #. module: web_editor
@@ -2518,7 +2518,7 @@ msgstr "Firma"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "Pegado de texto simple."
 
 #. module: web_editor
@@ -2570,7 +2570,7 @@ msgstr "Pequeño"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Encabezado de sección pequeña."
 
 #. module: web_editor
@@ -2648,7 +2648,7 @@ msgstr "Cambiar dirección"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Cambiar la dirección del texto."
 
 #. module: web_editor
@@ -2941,7 +2941,7 @@ msgstr "Información sobre herramientas"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Llevar el seguimiento de tareas con una lista de pendientes."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/et.po
+++ b/addons/web_editor/i18n/et.po
@@ -281,21 +281,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -316,7 +316,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -493,7 +493,7 @@ msgstr "Automaatne esitamine"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -542,7 +542,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Loo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1066,14 +1066,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1500,42 +1500,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1570,7 +1570,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1755,7 +1755,7 @@ msgstr "Levitamise vahend"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1946,7 +1946,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2513,7 +2513,7 @@ msgstr "Allkiri"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2565,7 +2565,7 @@ msgstr "Väike"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2641,7 +2641,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2926,7 +2926,7 @@ msgstr "Vihje"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/fi.po
+++ b/addons/web_editor/i18n/fi.po
@@ -281,21 +281,21 @@ msgstr "Lisää URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -316,7 +316,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -493,7 +493,7 @@ msgstr "Automaattinen toisto"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -542,7 +542,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Luo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1066,14 +1066,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1500,42 +1500,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1570,7 +1570,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1755,7 +1755,7 @@ msgstr "Media"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1946,7 +1946,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2509,7 +2509,7 @@ msgstr "Allekirjoitus"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2561,7 +2561,7 @@ msgstr "Pieni"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2637,7 +2637,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2922,7 +2922,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/fr.po
+++ b/addons/web_editor/i18n/fr.po
@@ -278,21 +278,21 @@ msgstr "Ajouter une URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Ajouter une section de citations."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Ajouter un bouton."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Ajouter une section de code."
 
 #. module: web_editor
@@ -313,7 +313,7 @@ msgstr "Ajouter une colonne à droite"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Ajouter un lien."
 
 #. module: web_editor
@@ -490,7 +490,7 @@ msgstr "Lecture automatique"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr "Retour à une colonne."
 
 #. module: web_editor
@@ -539,7 +539,7 @@ msgstr "En-dessous"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Titre d'une section importante."
 
 #. module: web_editor
@@ -749,21 +749,21 @@ msgstr "Contraste"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr "Convertir en 2 colonnes."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr "Convertir en 3 colonnes."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr "Convertir en 4 colonnes."
 
 #. module: web_editor
@@ -803,21 +803,21 @@ msgstr "Créer"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Créez une liste avec numérotation."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Créez une simple liste à puces."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "Créer une URL."
 
 #. module: web_editor
@@ -1068,14 +1068,14 @@ msgstr "Intégrer une vidéo Youtube"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "Intégrer l'image dans le document."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "Intégrer la vidéo Youtube dans le document."
 
 #. module: web_editor
@@ -1506,42 +1506,42 @@ msgstr "Texte inline"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr "Insérer une note sur 3 étoiles."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr "Insérer une note sur 5 étoiles."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Insérer un tableau."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "Insérez une vidéo."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Insérer une ligne horizontale de séparation."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Insérer une image"
 
 #. module: web_editor
@@ -1576,7 +1576,7 @@ msgstr "Insérer un tableau"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr "Insérez votre signature"
 
 #. module: web_editor
@@ -1761,7 +1761,7 @@ msgstr "Moyen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Titre d'une section moyenne."
 
 #. module: web_editor
@@ -1952,7 +1952,7 @@ msgstr "Options de la page"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Bloc paragraphe"
 
 #. module: web_editor
@@ -2515,7 +2515,7 @@ msgstr "Signature"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "Coller comme texte simple."
 
 #. module: web_editor
@@ -2567,7 +2567,7 @@ msgstr "Petit"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Titre d'une petite section."
 
 #. module: web_editor
@@ -2645,7 +2645,7 @@ msgstr "Changer de direction"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Changer la direction du texte"
 
 #. module: web_editor
@@ -2939,7 +2939,7 @@ msgstr "Info-bulle"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Suivre les tâches grâce à une check-list."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/he.po
+++ b/addons/web_editor/i18n/he.po
@@ -280,21 +280,21 @@ msgstr "הוסף כתובת אתר אינטרנט"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "הוסף קטע ציטוט."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "הוספת כפתור."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -315,7 +315,7 @@ msgstr "הוסף עמודה לימין"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "הוסף קישור."
 
 #. module: web_editor
@@ -492,7 +492,7 @@ msgstr "ניגון אוטומטי"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -541,7 +541,7 @@ msgstr "למטה"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "כותרת בגודל גדול"
 
 #. module: web_editor
@@ -751,21 +751,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -805,21 +805,21 @@ msgstr "צור"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "יצירת רשימה ממוספרת"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "יצירת רשימת תבליטים פשוטה."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1065,14 +1065,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1503,42 +1503,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "הכנס לטבלה."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "הכנס סרטון"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "הכנס קו מפריד אופקי."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "הכנס תמונה"
 
 #. module: web_editor
@@ -1573,7 +1573,7 @@ msgstr "הכנס טבלה"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr "הכנס את החתימה שלך."
 
 #. module: web_editor
@@ -1758,7 +1758,7 @@ msgstr "אמצעי תקשורת"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "כותרת בגודל בינוני"
 
 #. module: web_editor
@@ -1949,7 +1949,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "בלוק פסקה."
 
 #. module: web_editor
@@ -2512,7 +2512,7 @@ msgstr "חתימה"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2564,7 +2564,7 @@ msgstr "קטן"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "כותרת בגודל קטן"
 
 #. module: web_editor
@@ -2640,7 +2640,7 @@ msgstr "החלפת כיוון"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "החלף את כיוון הטקסט."
 
 #. module: web_editor
@@ -2925,7 +2925,7 @@ msgstr "הסבר"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "עקוב אחר משימות בעזרת צ'ק ליסט."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/hr.po
+++ b/addons/web_editor/i18n/hr.po
@@ -282,21 +282,21 @@ msgstr "Dodaj URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -317,7 +317,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -494,7 +494,7 @@ msgstr "Autopokretanje"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -543,7 +543,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -753,21 +753,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -807,21 +807,21 @@ msgstr "Kreiraj"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1067,14 +1067,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1499,42 +1499,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1569,7 +1569,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1754,7 +1754,7 @@ msgstr "Medij"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1945,7 +1945,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2508,7 +2508,7 @@ msgstr "Potpis"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2560,7 +2560,7 @@ msgstr "Malo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2636,7 +2636,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2921,7 +2921,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/id.po
+++ b/addons/web_editor/i18n/id.po
@@ -273,21 +273,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -308,7 +308,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -485,7 +485,7 @@ msgstr "Autoplay"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -534,7 +534,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -744,21 +744,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -798,21 +798,21 @@ msgstr "Buat"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1058,14 +1058,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1490,42 +1490,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1560,7 +1560,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1745,7 +1745,7 @@ msgstr "Media"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1936,7 +1936,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2499,7 +2499,7 @@ msgstr "Tanda Tangan"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2551,7 +2551,7 @@ msgstr "Kecil"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2627,7 +2627,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2912,7 +2912,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/is.po
+++ b/addons/web_editor/i18n/is.po
@@ -270,21 +270,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -305,7 +305,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -482,7 +482,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -531,7 +531,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -741,21 +741,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -795,21 +795,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1055,14 +1055,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1487,42 +1487,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1557,7 +1557,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1742,7 +1742,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1933,7 +1933,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2496,7 +2496,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2548,7 +2548,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2624,7 +2624,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2909,7 +2909,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/it.po
+++ b/addons/web_editor/i18n/it.po
@@ -277,21 +277,21 @@ msgstr "Aggiungi URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -312,7 +312,7 @@ msgstr "Aggiungi colonna a destra"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -489,7 +489,7 @@ msgstr "Riproduzione automatica"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -538,7 +538,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -748,21 +748,21 @@ msgstr "Contrasto"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -802,21 +802,21 @@ msgstr "Crea"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1064,14 +1064,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1502,42 +1502,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1572,7 +1572,7 @@ msgstr "Inserisci tabella"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1757,7 +1757,7 @@ msgstr "Medio"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1948,7 +1948,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2511,7 +2511,7 @@ msgstr "Firma"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2563,7 +2563,7 @@ msgstr "Piccolo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2639,7 +2639,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2930,7 +2930,7 @@ msgstr "Suggerimento"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/ja.po
+++ b/addons/web_editor/i18n/ja.po
@@ -273,21 +273,21 @@ msgstr "URL追加"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -308,7 +308,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -485,7 +485,7 @@ msgstr "自動再生"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -534,7 +534,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -744,21 +744,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -798,21 +798,21 @@ msgstr "作成"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1051,14 +1051,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1483,42 +1483,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1546,7 +1546,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1724,7 +1724,7 @@ msgstr "媒体"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1915,7 +1915,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2478,7 +2478,7 @@ msgstr "署名"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2530,7 +2530,7 @@ msgstr "小"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2606,7 +2606,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2885,7 +2885,7 @@ msgstr "ツールチップ"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/ko.po
+++ b/addons/web_editor/i18n/ko.po
@@ -272,21 +272,21 @@ msgstr "URL 추가"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -307,7 +307,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -484,7 +484,7 @@ msgstr "자동 재생"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -533,7 +533,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -743,21 +743,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -799,21 +799,21 @@ msgstr "작성"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1052,14 +1052,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1484,42 +1484,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1547,7 +1547,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1725,7 +1725,7 @@ msgstr "중간"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1916,7 +1916,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2479,7 +2479,7 @@ msgstr "서명"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2531,7 +2531,7 @@ msgstr "작게"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2607,7 +2607,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2886,7 +2886,7 @@ msgstr "툴팁"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/lt.po
+++ b/addons/web_editor/i18n/lt.po
@@ -287,21 +287,21 @@ msgstr "Pridėti nuorodą"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -322,7 +322,7 @@ msgstr "Pridėti stulpelį dešinėje"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -499,7 +499,7 @@ msgstr "Automatinis paleidimas"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -548,7 +548,7 @@ msgstr "Žemiau"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -758,21 +758,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -812,21 +812,21 @@ msgstr "Sukurti"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1072,14 +1072,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1506,42 +1506,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1576,7 +1576,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1761,7 +1761,7 @@ msgstr "Vidutinis"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1952,7 +1952,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2515,7 +2515,7 @@ msgstr "Parašas"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2567,7 +2567,7 @@ msgstr "Mažas"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2643,7 +2643,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2928,7 +2928,7 @@ msgstr "Paaiškinimas"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/lv.po
+++ b/addons/web_editor/i18n/lv.po
@@ -275,21 +275,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -310,7 +310,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -487,7 +487,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -536,7 +536,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -746,21 +746,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -800,21 +800,21 @@ msgstr "Izveidot"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1060,14 +1060,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1492,42 +1492,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1562,7 +1562,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1747,7 +1747,7 @@ msgstr "Vidējs"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1938,7 +1938,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2501,7 +2501,7 @@ msgstr "Signature"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2553,7 +2553,7 @@ msgstr "Small"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2629,7 +2629,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2914,7 +2914,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/mn.po
+++ b/addons/web_editor/i18n/mn.po
@@ -279,21 +279,21 @@ msgstr "URL нэмэх"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "Автомат тоглох"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -750,21 +750,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -804,21 +804,21 @@ msgstr "Үүсгэх"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1064,14 +1064,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1496,42 +1496,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1566,7 +1566,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1751,7 +1751,7 @@ msgstr "Дундаж"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1942,7 +1942,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2505,7 +2505,7 @@ msgstr "Гарын үсэг"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2557,7 +2557,7 @@ msgstr "Жижиг"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2633,7 +2633,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2918,7 +2918,7 @@ msgstr "Багажны зөвлөмж"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/ms.po
+++ b/addons/web_editor/i18n/ms.po
@@ -266,21 +266,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -301,7 +301,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -478,7 +478,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -527,7 +527,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -737,21 +737,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -791,21 +791,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1051,14 +1051,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1483,42 +1483,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1553,7 +1553,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1738,7 +1738,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1929,7 +1929,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2492,7 +2492,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2544,7 +2544,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2620,7 +2620,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2905,7 +2905,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/nb.po
+++ b/addons/web_editor/i18n/nb.po
@@ -281,21 +281,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -316,7 +316,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -493,7 +493,7 @@ msgstr "Automatisk avspilling"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -542,7 +542,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Opprett"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1066,14 +1066,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1500,42 +1500,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1570,7 +1570,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1755,7 +1755,7 @@ msgstr "Medium"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1946,7 +1946,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2509,7 +2509,7 @@ msgstr "Signatur"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2561,7 +2561,7 @@ msgstr "Liten"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2637,7 +2637,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2922,7 +2922,7 @@ msgstr "Hjelpetekst"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/nl.po
+++ b/addons/web_editor/i18n/nl.po
@@ -279,21 +279,21 @@ msgstr "URL Toevoegen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Voeg een blokcitaat sectie toe."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Voeg een knop toe."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Codesectie toevoegen."
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr "Een kolom rechts toevoegen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Voeg een link toe."
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "Automatisch afspelen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr "Terug naar één kolom."
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr "Onderstaand"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Grote sectiekop."
 
 #. module: web_editor
@@ -750,21 +750,21 @@ msgstr "Contrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr "Converteren naar 2 kolommen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr "Converteren naar 3 kolommen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr "Converteren naar 4 kolommen."
 
 #. module: web_editor
@@ -804,21 +804,21 @@ msgstr "Aanmaken"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Maak een lijst met nummering."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Maak een lijst met opsommingstekens."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "Maak een url."
 
 #. module: web_editor
@@ -1067,14 +1067,14 @@ msgstr "Youtube video insluiten"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "Sluit de afbeelding in het document in."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "Sluit de youtube-video in het document in."
 
 #. module: web_editor
@@ -1506,42 +1506,42 @@ msgstr "Inline tekst"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr "Voeg een waardering van meer dan 3 sterren toe."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr "Voeg een waardering van meer dan 5 sterren toe."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Tabel invoegen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "Een video invoegen."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Voeg een horizontale lijn in."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Een afbeelding invoegen."
 
 #. module: web_editor
@@ -1576,7 +1576,7 @@ msgstr "Tabel invoegen"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr "Plaats je handtekening."
 
 #. module: web_editor
@@ -1761,7 +1761,7 @@ msgstr "Medium"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Medium sectiekop."
 
 #. module: web_editor
@@ -1952,7 +1952,7 @@ msgstr "Pagina-opties"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Paragraaf blok."
 
 #. module: web_editor
@@ -2515,7 +2515,7 @@ msgstr "Handtekening"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "Eenvoudige tekst plakken."
 
 #. module: web_editor
@@ -2567,7 +2567,7 @@ msgstr "Klein"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Kleine sectiekop."
 
 #. module: web_editor
@@ -2645,7 +2645,7 @@ msgstr "Richting omdraaien"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Draai de tekstrichting om."
 
 #. module: web_editor
@@ -2939,7 +2939,7 @@ msgstr "Tooltip"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Volg taken met een checklist."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/pl.po
+++ b/addons/web_editor/i18n/pl.po
@@ -294,21 +294,21 @@ msgstr "Dodaj link"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -329,7 +329,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -506,7 +506,7 @@ msgstr "Autoplay"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -555,7 +555,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -765,21 +765,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -819,21 +819,21 @@ msgstr "Utwórz"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1079,14 +1079,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1515,42 +1515,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1585,7 +1585,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1770,7 +1770,7 @@ msgstr "Medium"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1961,7 +1961,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2524,7 +2524,7 @@ msgstr "Podpis"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2576,7 +2576,7 @@ msgstr "Mały"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2652,7 +2652,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2937,7 +2937,7 @@ msgstr "Tooltip"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/pt.po
+++ b/addons/web_editor/i18n/pt.po
@@ -279,21 +279,21 @@ msgstr "Adicionar URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "Iniciar Automaticamente"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -750,21 +750,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -804,21 +804,21 @@ msgstr "Criar"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1064,14 +1064,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1496,42 +1496,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1566,7 +1566,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1751,7 +1751,7 @@ msgstr "Médio"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1942,7 +1942,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2505,7 +2505,7 @@ msgstr "Assinatura"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2557,7 +2557,7 @@ msgstr "Pequeno"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2633,7 +2633,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2921,7 +2921,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/pt_BR.po
+++ b/addons/web_editor/i18n/pt_BR.po
@@ -280,21 +280,21 @@ msgstr "Adicionar URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -315,7 +315,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -492,7 +492,7 @@ msgstr "Reprodução Automática"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -541,7 +541,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -751,21 +751,21 @@ msgstr "Contraste"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -805,21 +805,21 @@ msgstr "Criar"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1070,14 +1070,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1508,42 +1508,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1578,7 +1578,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1763,7 +1763,7 @@ msgstr "Médio"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1954,7 +1954,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2517,7 +2517,7 @@ msgstr "Assinatura"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2569,7 +2569,7 @@ msgstr "Pequeno"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2645,7 +2645,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2936,7 +2936,7 @@ msgstr "Dica"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/ro.po
+++ b/addons/web_editor/i18n/ro.po
@@ -281,21 +281,21 @@ msgstr "Adăugare URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -316,7 +316,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -493,7 +493,7 @@ msgstr "Autoplay"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -542,7 +542,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -752,21 +752,21 @@ msgstr "Contrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -806,21 +806,21 @@ msgstr "Creează"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1069,14 +1069,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1507,42 +1507,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1577,7 +1577,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1762,7 +1762,7 @@ msgstr "Mediu"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1953,7 +1953,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2516,7 +2516,7 @@ msgstr "Semnătură"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2568,7 +2568,7 @@ msgstr "Mic"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2644,7 +2644,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2932,7 +2932,7 @@ msgstr "Sfat"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/ru.po
+++ b/addons/web_editor/i18n/ru.po
@@ -288,21 +288,21 @@ msgstr "Добавить через URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Добавить абзац с цитатой."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Добавить кнопку."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Добавить абзац с кодом."
 
 #. module: web_editor
@@ -323,7 +323,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Добавить ссылку."
 
 #. module: web_editor
@@ -500,7 +500,7 @@ msgstr "Автозапуск"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -549,7 +549,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Большой заголовок раздела."
 
 #. module: web_editor
@@ -759,21 +759,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -813,21 +813,21 @@ msgstr "Создать"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Создать список с нумерацией."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Создать простой маркированный список."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1073,14 +1073,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1511,42 +1511,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Вставить таблицу."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Вставить горизонтальную линию."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Вставить картинку."
 
 #. module: web_editor
@@ -1581,7 +1581,7 @@ msgstr "Вставить таблицу"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1766,7 +1766,7 @@ msgstr "Тип трафика"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Средний заголовок раздела."
 
 #. module: web_editor
@@ -1957,7 +1957,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Простой абзац."
 
 #. module: web_editor
@@ -2520,7 +2520,7 @@ msgstr "Подпись"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2572,7 +2572,7 @@ msgstr "Маленький"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Малый заголовок раздела."
 
 #. module: web_editor
@@ -2648,7 +2648,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2933,7 +2933,7 @@ msgstr "Подсказка"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Отслеживать задачи при помощи чеклиста."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/sv.po
+++ b/addons/web_editor/i18n/sv.po
@@ -286,21 +286,21 @@ msgstr "Infoga URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -321,7 +321,7 @@ msgstr "Lägg till kolumn till höger"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -498,7 +498,7 @@ msgstr "Spela automatiskt"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -547,7 +547,7 @@ msgstr "Nedan"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -757,21 +757,21 @@ msgstr "Kontrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -811,21 +811,21 @@ msgstr "Skapa"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1071,14 +1071,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1505,42 +1505,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1575,7 +1575,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1760,7 +1760,7 @@ msgstr "Medium"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1951,7 +1951,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2514,7 +2514,7 @@ msgstr "Signatur"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2566,7 +2566,7 @@ msgstr "Liten"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2642,7 +2642,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2927,7 +2927,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/th.po
+++ b/addons/web_editor/i18n/th.po
@@ -278,21 +278,21 @@ msgstr "เพิ่ม URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -313,7 +313,7 @@ msgstr "เพิ่มคอลัมน์ขวา"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -490,7 +490,7 @@ msgstr "เล่นอัตโนมัติ"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -539,7 +539,7 @@ msgstr "ด้านล่าง"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -749,21 +749,21 @@ msgstr "เปรียบต่าง"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -803,21 +803,21 @@ msgstr "สร้าง"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1058,14 +1058,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1495,42 +1495,42 @@ msgstr "ข้อความแบบอินไลน์"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1558,7 +1558,7 @@ msgstr "แทรกตาราง"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1736,7 +1736,7 @@ msgstr "สื่อกลาง"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1927,7 +1927,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2490,7 +2490,7 @@ msgstr "ลายเซ็น"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2542,7 +2542,7 @@ msgstr "เล็ก"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2618,7 +2618,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2901,7 +2901,7 @@ msgstr "ทูลทิป"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/tr.po
+++ b/addons/web_editor/i18n/tr.po
@@ -295,21 +295,21 @@ msgstr "URL Ekle"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -330,7 +330,7 @@ msgstr "Sağ sütun ekleme"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -507,7 +507,7 @@ msgstr "Otomatik oynat"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -556,7 +556,7 @@ msgstr "Altında"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Büyük bölüm başlığı."
 
 #. module: web_editor
@@ -766,21 +766,21 @@ msgstr "Kontrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -820,21 +820,21 @@ msgstr "Oluştur"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Numaralandırma içeren bir liste oluşturun."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Basit bir madde işaretli liste oluşturun."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1083,14 +1083,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1521,42 +1521,42 @@ msgstr "Satır İçi Metin"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Tablo ekleyin."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Yatay kural ayırıcısı ekleyin."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1591,7 +1591,7 @@ msgstr "Tablo ekle"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1776,7 +1776,7 @@ msgstr "Orta"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Orta bölüm başlığı."
 
 #. module: web_editor
@@ -1967,7 +1967,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Paragraf bloğu."
 
 #. module: web_editor
@@ -2530,7 +2530,7 @@ msgstr "İmza"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2582,7 +2582,7 @@ msgstr "Küçük"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Küçük bölüm başlığı."
 
 #. module: web_editor
@@ -2658,7 +2658,7 @@ msgstr "Yön değiştir"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Metnin yönünü değiştirin."
 
 #. module: web_editor
@@ -2951,7 +2951,7 @@ msgstr "Bilgi Çubuğu"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Bir denetim listesiyle görevleri izleyin."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/uk.po
+++ b/addons/web_editor/i18n/uk.po
@@ -277,21 +277,21 @@ msgstr "Додати URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Додайте блок цитати."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Додайте кнопку."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Додайте блок коду."
 
 #. module: web_editor
@@ -312,7 +312,7 @@ msgstr "Додати колонку справа"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Додайте посилання."
 
 #. module: web_editor
@@ -489,7 +489,7 @@ msgstr "Автопрогравання"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -538,7 +538,7 @@ msgstr "Нижче"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "Великий заголовок розділу."
 
 #. module: web_editor
@@ -748,21 +748,21 @@ msgstr "Контраст"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -802,21 +802,21 @@ msgstr "Створити"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "Створіть пронумерований список."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "Створіть простий список з пунктами."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "Створити URL."
 
 #. module: web_editor
@@ -1067,14 +1067,14 @@ msgstr "Вставте Youtube відео"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "Вставте зображення в документ."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "Вставте youtube відео в документ."
 
 #. module: web_editor
@@ -1505,42 +1505,42 @@ msgstr "Вбудований текст"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "Вставте таблицю."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "Вставте відео."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "Вставте горизонтальний роздільник."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "Вставте зображення."
 
 #. module: web_editor
@@ -1575,7 +1575,7 @@ msgstr "Вставити таблицю"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1760,7 +1760,7 @@ msgstr "Канал"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "Середній заголовок розділу."
 
 #. module: web_editor
@@ -1951,7 +1951,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "Блок абзацу."
 
 #. module: web_editor
@@ -2514,7 +2514,7 @@ msgstr "Підпис"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "Просте текстове вставлення."
 
 #. module: web_editor
@@ -2566,7 +2566,7 @@ msgstr "Малий"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "Заголовок невеликого розділу."
 
 #. module: web_editor
@@ -2642,7 +2642,7 @@ msgstr "Змінити напрямок"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "Змінити напрямок тексту."
 
 #. module: web_editor
@@ -2937,7 +2937,7 @@ msgstr "Підказка"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "Відстежуйте завдання за допомогою чеклисту."
 
 #. module: web_editor

--- a/addons/web_editor/i18n/vi.po
+++ b/addons/web_editor/i18n/vi.po
@@ -279,21 +279,21 @@ msgstr "Thêm URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "Thêm một blockquote section."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "Thêm một nút."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "Thêm một code section."
 
 #. module: web_editor
@@ -314,7 +314,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "Thêm một liên kết."
 
 #. module: web_editor
@@ -491,7 +491,7 @@ msgstr "Chơi tự động"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -540,7 +540,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -750,21 +750,21 @@ msgstr "Contrast"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -804,21 +804,21 @@ msgstr "Tạo"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "Tạo một URL."
 
 #. module: web_editor
@@ -1059,14 +1059,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1495,42 +1495,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1558,7 +1558,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1736,7 +1736,7 @@ msgstr "Kênh trung gian"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1927,7 +1927,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2490,7 +2490,7 @@ msgstr "Chữ ký"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2542,7 +2542,7 @@ msgstr "Nhỏ"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2618,7 +2618,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2901,7 +2901,7 @@ msgstr "Tooltip"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -266,21 +266,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -301,7 +301,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -478,7 +478,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -527,7 +527,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -737,21 +737,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -791,21 +791,21 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1051,14 +1051,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1483,42 +1483,42 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1553,7 +1553,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1738,7 +1738,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1929,7 +1929,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2492,7 +2492,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2544,7 +2544,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2620,7 +2620,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2905,7 +2905,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/i18n/zh_CN.po
+++ b/addons/web_editor/i18n/zh_CN.po
@@ -273,21 +273,21 @@ msgstr "添加URL"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr "添加引用章节."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr "添加按钮."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr "添加代码部分."
 
 #. module: web_editor
@@ -308,7 +308,7 @@ msgstr "在右侧添加一栏"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr "添加一个链接."
 
 #. module: web_editor
@@ -485,7 +485,7 @@ msgstr "自动播放"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr "回到一栏"
 
 #. module: web_editor
@@ -534,7 +534,7 @@ msgstr "下面"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr "大型章节标题。"
 
 #. module: web_editor
@@ -744,21 +744,21 @@ msgstr "对比度"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr "转换为2栏"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr "转换为3栏"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr "转换为4栏"
 
 #. module: web_editor
@@ -798,21 +798,21 @@ msgstr "创建"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr "创建一个带编号的列表."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr "创建一个简单的编号列表."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr "创建一个网址."
 
 #. module: web_editor
@@ -1058,14 +1058,14 @@ msgstr "嵌入油管视频"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr "在文档中嵌入图像."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr "在文档中嵌入油管视频."
 
 #. module: web_editor
@@ -1490,42 +1490,42 @@ msgstr "内联文本"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr "插入3星以上的评级。"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr "插入3星以上的评级。"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr "插入表格。"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr "插入视频."
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr "插入水平线尺规分隔。"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr "插入图像."
 
 #. module: web_editor
@@ -1560,7 +1560,7 @@ msgstr "插入表格"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr "插入你的签名。"
 
 #. module: web_editor
@@ -1745,7 +1745,7 @@ msgstr "媒介"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr "中等章节标题。"
 
 #. module: web_editor
@@ -1936,7 +1936,7 @@ msgstr "页面选项"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr "段落组件。"
 
 #. module: web_editor
@@ -2499,7 +2499,7 @@ msgstr "签名"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr "简单的文本粘贴."
 
 #. module: web_editor
@@ -2551,7 +2551,7 @@ msgstr "小"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr "小型章节标题。"
 
 #. module: web_editor
@@ -2627,7 +2627,7 @@ msgstr "切换方向"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr "切换文本的方向."
 
 #. module: web_editor
@@ -2914,7 +2914,7 @@ msgstr "提示框"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr "使用清单跟踪任务。"
 
 #. module: web_editor

--- a/addons/web_editor/i18n/zh_TW.po
+++ b/addons/web_editor/i18n/zh_TW.po
@@ -270,21 +270,21 @@ msgstr "添加網址"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a blockquote section."
+msgid "Add a blockquote section"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a button."
+msgid "Add a button"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a code section."
+msgid "Add a code section"
 msgstr ""
 
 #. module: web_editor
@@ -305,7 +305,7 @@ msgstr "右側添加一列"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Add a link."
+msgid "Add a link"
 msgstr ""
 
 #. module: web_editor
@@ -482,7 +482,7 @@ msgstr "自動播放"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Back to one column."
+msgid "Back to one column"
 msgstr ""
 
 #. module: web_editor
@@ -531,7 +531,7 @@ msgstr "下方"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Big section heading."
+msgid "Big section heading"
 msgstr ""
 
 #. module: web_editor
@@ -741,21 +741,21 @@ msgstr "對比"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 2 columns."
+msgid "Convert into 2 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 3 columns."
+msgid "Convert into 3 columns"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Convert into 4 columns."
+msgid "Convert into 4 columns"
 msgstr ""
 
 #. module: web_editor
@@ -795,21 +795,21 @@ msgstr "建立"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a list with numbering."
+msgid "Create a list with numbering"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create a simple bulleted list."
+msgid "Create a simple bulleted list"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Create an URL."
+msgid "Create an URL"
 msgstr ""
 
 #. module: web_editor
@@ -1048,14 +1048,14 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the image in the document."
+msgid "Embed the image in the document"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Embed the youtube video in the document."
+msgid "Embed the youtube video in the document"
 msgstr ""
 
 #. module: web_editor
@@ -1480,42 +1480,42 @@ msgstr "內嵌文本"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 3 stars."
+msgid "Insert a rating over 3 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a rating over 5 stars."
+msgid "Insert a rating over 5 stars"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert a table."
+msgid "Insert a table"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert a video."
+msgid "Insert a video"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Insert an horizontal rule separator."
+msgid "Insert an horizontal rule separator"
 msgstr ""
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert an image."
+msgid "Insert an image"
 msgstr ""
 
 #. module: web_editor
@@ -1543,7 +1543,7 @@ msgstr "插入表格"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/wysiwyg/wysiwyg.js:0
 #, python-format
-msgid "Insert your signature."
+msgid "Insert your signature"
 msgstr ""
 
 #. module: web_editor
@@ -1721,7 +1721,7 @@ msgstr "媒體"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Medium section heading."
+msgid "Medium section heading"
 msgstr ""
 
 #. module: web_editor
@@ -1912,7 +1912,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Paragraph block."
+msgid "Paragraph block"
 msgstr ""
 
 #. module: web_editor
@@ -2475,7 +2475,7 @@ msgstr "簽名"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Simple text paste."
+msgid "Simple text paste"
 msgstr ""
 
 #. module: web_editor
@@ -2527,7 +2527,7 @@ msgstr "小"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Small section heading."
+msgid "Small section heading"
 msgstr ""
 
 #. module: web_editor
@@ -2603,7 +2603,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Switch the text's direction."
+msgid "Switch the text's direction"
 msgstr ""
 
 #. module: web_editor
@@ -2882,7 +2882,7 @@ msgstr "工具提示"
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #, python-format
-msgid "Track tasks with a checklist."
+msgid "Track tasks with a checklist"
 msgstr ""
 
 #. module: web_editor

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -444,7 +444,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Structure'),
                     name: this.options._t('Bulleted list'),
                     priority: 110,
-                    description: this.options._t('Create a simple bulleted list.'),
+                    description: this.options._t('Create a simple bulleted list'),
                     fontawesome: 'fa-list-ul',
                     callback: () => {
                         this.execCommand('toggleList', 'UL');
@@ -454,7 +454,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Structure'),
                     name: this.options._t('Numbered list'),
                     priority: 100,
-                    description: this.options._t('Create a list with numbering.'),
+                    description: this.options._t('Create a list with numbering'),
                     fontawesome: 'fa-list-ol',
                     callback: () => {
                         this.execCommand('toggleList', 'OL');
@@ -464,7 +464,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Structure'),
                     name: this.options._t('Checklist'),
                     priority: 90,
-                    description: this.options._t('Track tasks with a checklist.'),
+                    description: this.options._t('Track tasks with a checklist'),
                     fontawesome: 'fa-check-square-o',
                     callback: () => {
                         this.execCommand('toggleList', 'CL');
@@ -474,7 +474,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Structure'),
                     name: this.options._t('Table'),
                     priority: 80,
-                    description: this.options._t('Insert a table.'),
+                    description: this.options._t('Insert a table'),
                     fontawesome: 'fa-table',
                     callback: () => {
                         this.powerboxTablePicker.show();
@@ -484,7 +484,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Structure'),
                     name: this.options._t('Separator'),
                     priority: 40,
-                    description: this.options._t('Insert an horizontal rule separator.'),
+                    description: this.options._t('Insert an horizontal rule separator'),
                     fontawesome: 'fa-minus',
                     callback: () => {
                         this.execCommand('insertHorizontalRule');
@@ -494,7 +494,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Format'),
                     name: this.options._t('Heading 1'),
                     priority: 50,
-                    description: this.options._t('Big section heading.'),
+                    description: this.options._t('Big section heading'),
                     fontawesome: 'fa-header',
                     callback: () => {
                         this.execCommand('setTag', 'H1');
@@ -504,7 +504,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Format'),
                     name: this.options._t('Heading 2'),
                     priority: 40,
-                    description: this.options._t('Medium section heading.'),
+                    description: this.options._t('Medium section heading'),
                     fontawesome: 'fa-header',
                     callback: () => {
                         this.execCommand('setTag', 'H2');
@@ -514,7 +514,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Format'),
                     name: this.options._t('Heading 3'),
                     priority: 30,
-                    description: this.options._t('Small section heading.'),
+                    description: this.options._t('Small section heading'),
                     fontawesome: 'fa-header',
                     callback: () => {
                         this.execCommand('setTag', 'H3');
@@ -524,7 +524,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Format'),
                     name: this.options._t('Switch direction'),
                     priority: 20,
-                    description: this.options._t('Switch the text\'s direction.'),
+                    description: this.options._t('Switch the text\'s direction'),
                     fontawesome: 'fa-exchange',
                     callback: () => {
                         this.execCommand('switchDirection');
@@ -534,7 +534,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Format'),
                     name: this.options._t('Text'),
                     priority: 10,
-                    description: this.options._t('Paragraph block.'),
+                    description: this.options._t('Paragraph block'),
                     fontawesome: 'fa-paragraph',
                     callback: () => {
                         this.execCommand('setTag', 'P');
@@ -544,7 +544,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Widgets'),
                     name: this.options._t('3 Stars'),
                     priority: 20,
-                    description: this.options._t('Insert a rating over 3 stars.'),
+                    description: this.options._t('Insert a rating over 3 stars'),
                     fontawesome: 'fa-star-o',
                     callback: () => {
                         let html = '\u200B<span contenteditable="false" class="o_stars o_three_stars">';
@@ -557,7 +557,7 @@ export class OdooEditor extends EventTarget {
                     category: this.options._t('Widgets'),
                     name: this.options._t('5 Stars'),
                     priority: 10,
-                    description: this.options._t('Insert a rating over 5 stars.'),
+                    description: this.options._t('Insert a rating over 5 stars'),
                     fontawesome: 'fa-star',
                     callback: () => {
                         let html = '\u200B<span contenteditable="false" class="o_stars o_five_stars">';
@@ -4043,7 +4043,7 @@ export class OdooEditor extends EventTarget {
                         {
                             category: this.options._t('Paste'),
                             name: this.options._t('Paste as URL'),
-                            description: this.options._t('Create an URL.'),
+                            description: this.options._t('Create an URL'),
                             fontawesome: 'fa-link',
                             callback: () => {
                                 this.historyUndo();
@@ -4066,7 +4066,7 @@ export class OdooEditor extends EventTarget {
                         {
                             category: this.options._t('Paste'),
                             name: this.options._t('Paste as text'),
-                            description: this.options._t('Simple text paste.'),
+                            description: this.options._t('Simple text paste'),
                             fontawesome: 'fa-font',
                             callback: () => {},
                         },
@@ -4089,7 +4089,7 @@ export class OdooEditor extends EventTarget {
                             {
                                 category: this.options._t('Embed'),
                                 name: this.options._t('Embed Image'),
-                                description: this.options._t('Embed the image in the document.'),
+                                description: this.options._t('Embed the image in the document'),
                                 fontawesome: 'fa-image',
                                 callback: () => {
                                     execCommandAtStepIndex(stepIndexBeforeInsert, () => {
@@ -4115,7 +4115,7 @@ export class OdooEditor extends EventTarget {
                             {
                                 category: this.options._t('Embed'),
                                 name: this.options._t('Embed Youtube Video'),
-                                description: this.options._t('Embed the youtube video in the document.'),
+                                description: this.options._t('Embed the youtube video in the document'),
                                 fontawesome: 'fa-youtube-play',
                                 callback: async () => {
                                     let videoElement;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2011,7 +2011,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Structure'),
                 name: _t('Quote'),
                 priority: 30,
-                description: _t('Add a blockquote section.'),
+                description: _t('Add a blockquote section'),
                 fontawesome: 'fa-quote-right',
                 callback: () => {
                     this.odooEditor.execCommand('setTag', 'blockquote');
@@ -2021,7 +2021,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Structure'),
                 name: _t('Code'),
                 priority: 20,
-                description: _t('Add a code section.'),
+                description: _t('Add a code section'),
                 fontawesome: 'fa-code',
                 callback: () => {
                     this.odooEditor.execCommand('setTag', 'pre');
@@ -2030,7 +2030,7 @@ const Wysiwyg = Widget.extend({
             {
                 category: _t('Basic blocks'),
                 name: _t('Signature'),
-                description: _t('Insert your signature.'),
+                description: _t('Insert your signature'),
                 fontawesome: 'fa-pencil-square-o',
                 callback: async () => {
                     const res = await this._rpc({
@@ -2047,7 +2047,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Structure'),
                 name: _t('2 columns'),
                 priority: 13,
-                description: _t('Convert into 2 columns.'),
+                description: _t('Convert into 2 columns'),
                 fontawesome: 'fa-columns',
                 callback: () => this.odooEditor.execCommand('columnize', 2, editorOptions.insertParagraphAfterColumns),
                 isDisabled: () => {
@@ -2060,7 +2060,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Structure'),
                 name: _t('3 columns'),
                 priority: 12,
-                description: _t('Convert into 3 columns.'),
+                description: _t('Convert into 3 columns'),
                 fontawesome: 'fa-columns',
                 callback: () => this.odooEditor.execCommand('columnize', 3, editorOptions.insertParagraphAfterColumns),
                 isDisabled: () => {
@@ -2073,7 +2073,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Structure'),
                 name: _t('4 columns'),
                 priority: 11,
-                description: _t('Convert into 4 columns.'),
+                description: _t('Convert into 4 columns'),
                 fontawesome: 'fa-columns',
                 callback: () => this.odooEditor.execCommand('columnize', 4, editorOptions.insertParagraphAfterColumns),
                 isDisabled: () => {
@@ -2086,7 +2086,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Structure'),
                 name: _t('Remove columns'),
                 priority: 10,
-                description: _t('Back to one column.'),
+                description: _t('Back to one column'),
                 fontawesome: 'fa-columns',
                 callback: () => this.odooEditor.execCommand('columnize', 0),
                 isDisabled: () => {
@@ -2103,7 +2103,7 @@ const Wysiwyg = Widget.extend({
                     category: _t('Navigation'),
                     name: _t('Link'),
                     priority: 40,
-                    description: _t('Add a link.'),
+                    description: _t('Add a link'),
                     fontawesome: 'fa-link',
                     callback: () => {
                         this.toggleLinkTools({forceDialog: true});
@@ -2113,7 +2113,7 @@ const Wysiwyg = Widget.extend({
                     category: _t('Navigation'),
                     name: _t('Button'),
                     priority: 30,
-                    description: _t('Add a button.'),
+                    description: _t('Add a button'),
                     fontawesome: 'fa-link',
                     callback: () => {
                         this.toggleLinkTools({forceDialog: true});
@@ -2133,7 +2133,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Media'),
                 name: _t('Image'),
                 priority: 40,
-                description: _t('Insert an image.'),
+                description: _t('Insert an image'),
                 fontawesome: 'fa-file-image-o',
                 callback: () => {
                     this.openMediaDialog();
@@ -2145,7 +2145,7 @@ const Wysiwyg = Widget.extend({
                 category: _t('Media'),
                 name: _t('Video'),
                 priority: 30,
-                description: _t('Insert a video.'),
+                description: _t('Insert a video'),
                 fontawesome: 'fa-file-video-o',
                 callback: () => {
                     this.openMediaDialog({noVideos: false, noImages: true, noIcons: true, noDocuments: true});

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -5287,70 +5287,70 @@ msgstr ""
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a badge snippet."
+msgid "Insert a badge snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a blockquote snippet."
+msgid "Insert a blockquote snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a card snippet."
+msgid "Insert a card snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a chart snippet."
+msgid "Insert a chart snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a progress bar snippet."
+msgid "Insert a progress bar snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a rating snippet."
+msgid "Insert a rating snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a share snippet."
+msgid "Insert a share snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert a text Highlight snippet."
+msgid "Insert a text Highlight snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert an alert snippet."
+msgid "Insert an alert snippet"
 msgstr ""
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/menu/edit.js:0
 #, python-format
-msgid "Insert an horizontal separator sippet."
+msgid "Insert an horizontal separator snippet"
 msgstr ""
 
 #. module: website

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -519,7 +519,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Alert'),
                 priority: 100,
-                description: this.env._t('Insert an alert snippet.'),
+                description: this.env._t('Insert an alert snippet'),
                 fontawesome: 'fa-info',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_alert"]');
@@ -529,7 +529,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Rating'),
                 priority: 90,
-                description: this.env._t('Insert a rating snippet.'),
+                description: this.env._t('Insert a rating snippet'),
                 fontawesome: 'fa-star-half-o',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_rating"]');
@@ -539,7 +539,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Card'),
                 priority: 80,
-                description: this.env._t('Insert a card snippet.'),
+                description: this.env._t('Insert a card snippet'),
                 fontawesome: 'fa-sticky-note',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_card"]');
@@ -549,7 +549,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Share'),
                 priority: 70,
-                description: this.env._t('Insert a share snippet.'),
+                description: this.env._t('Insert a share snippet'),
                 fontawesome: 'fa-share-square-o',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_share"]');
@@ -559,7 +559,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Text Highlight'),
                 priority: 60,
-                description: this.env._t('Insert a text Highlight snippet.'),
+                description: this.env._t('Insert a text Highlight snippet'),
                 fontawesome: 'fa-sticky-note',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_text_highlight"]');
@@ -569,7 +569,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Chart'),
                 priority: 50,
-                description: this.env._t('Insert a chart snippet.'),
+                description: this.env._t('Insert a chart snippet'),
                 fontawesome: 'fa-bar-chart',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_chart"]');
@@ -579,7 +579,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Progress Bar'),
                 priority: 40,
-                description: this.env._t('Insert a progress bar snippet.'),
+                description: this.env._t('Insert a progress bar snippet'),
                 fontawesome: 'fa-spinner',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_progress_bar"]');
@@ -589,7 +589,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Badge'),
                 priority: 30,
-                description: this.env._t('Insert a badge snippet.'),
+                description: this.env._t('Insert a badge snippet'),
                 fontawesome: 'fa-tags',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_badge"]');
@@ -599,7 +599,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Blockquote'),
                 priority: 20,
-                description: this.env._t('Insert a blockquote snippet.'),
+                description: this.env._t('Insert a blockquote snippet'),
                 fontawesome: 'fa-quote-left',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_blockquote"]');
@@ -609,7 +609,7 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
                 category: this.env._t('Website'),
                 name: this.env._t('Separator'),
                 priority: 10,
-                description: this.env._t('Insert an horizontal separator sippet.'),
+                description: this.env._t('Insert an horizontal separator snippet'),
                 fontawesome: 'fa-minus',
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_hr"]');


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Removal of dot (period) at the end of Powerbox commands' descriptions.

Current behavior before PR:
There were dots. Example: "Create a simple bulleted list."

Desired behavior after PR is merged:
No more dots. Example: "Create a simple bulleted list"

task-2901665
Enterprise PR: https://github.com/odoo/enterprise/pull/33052
