### PR TITLE
[FIX] hr_expense: correctly cancel expense sheet when bill is cancelled

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1356,6 +1356,12 @@ msgid "Partially Paid"
 msgstr ""
 
 #. module: hr_expense
+#: code:addons/hr_expense/models/account_move.py:0
+#, python-format
+msgid "Payment Refused"
+msgstr ""
+
+#. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__payment_state
 msgid "Payment Status"
 msgstr ""

--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import models, fields, _
 
 
 class AccountMove(models.Model):
@@ -25,3 +25,7 @@ class AccountMove(models.Model):
         if self.line_ids.expense_id:
             return True
         return super()._payment_state_matters()
+
+    def button_cancel(self):
+        super(AccountMove, self).button_cancel()
+        self.line_ids.expense_id.refuse_expense(_('Payment Refused'))


### PR DESCRIPTION
Current behavior:
When you cancel a bill linked to an expense sheet, the expense sheet is not cancelled.

Steps to reproduce:
- Create an expense sheet
- Approve it and create the payment for it
- Go on the journal entry and cancel it
- Go back on the expense sheet and see that it is still in "Done" state

opw-3014289
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
