### PR TITLE
[FIX] web: nginx returning 503

### DIFF
--- a/addons/web/static/src/core/network/download.js
+++ b/addons/web/static/src/core/network/download.js
@@ -491,7 +491,7 @@ download._download = (options) => {
                 _download(xhr.response, filename, mimetype);
                 return resolve(filename);
 
-            } else if (xhr.status === 502) { // If Odoo is behind another server (nginx)
+            } else if (xhr.status === 502 || xhr.status === 503) { // If Odoo is behind another server (nginx)
                 reject(new ConnectionLostError());
             } else {
                 const decoder = new FileReader();

--- a/addons/web/static/src/core/network/http_service.js
+++ b/addons/web/static/src/core/network/http_service.js
@@ -3,7 +3,7 @@
 import { registry } from "../registry";
 
 function checkResponseStatus(response) {
-    if (response.status === 502) {
+    if (response.status === 502 || response.status === 503) {
         throw new Error("Failed to fetch");
     }
 }

--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -56,7 +56,7 @@ export function jsonrpc(env, rpcId, url, params, settings = {}) {
         }
         // handle success
         request.addEventListener("load", () => {
-            if (request.status === 502) {
+            if (request.status === 502 || request.status === 503) {
                 // If Odoo is behind another server (eg.: nginx)
                 if (!settings.silent) {
                     bus.trigger("RPC:RESPONSE", data.id);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If Odoo is running behind nginx and then for example the Odoo pod (Kubernetes) restarts nginx returns 503. The status code 502 is already handled by Odoo, but 503 should probably be handled the same way.

Current behavior before PR:

Odoo crashes when the response from the server has a 503 status code.

![InkedDownload](https://user-images.githubusercontent.com/4851083/197323946-7f130567-d070-4199-81b5-d1d5fac7044b.jpg)

Desired behavior after PR is merged:

Status code 503 is treated in the same way as status code 502.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
