### PR TITLE
[FIX] sale: Recording of expense reports on a sale order

### DIFF
--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -22,6 +22,17 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             groups='base.group_user',
             company_ids=[(6, 0, cls.env.companies.ids)],
         )
+
+        cls.expense_user_employee_a = mail_new_test_user(
+            cls.env,
+            name='expense_user_employee_a',
+            login='expense_user_employee_a',
+            email='expense_user_employee_a@example.com',
+            notification_type='email',
+            groups='base.group_user',
+            company_ids=[(6, 0, cls.env.companies.ids)],
+        )
+
         cls.expense_user_manager = mail_new_test_user(
             cls.env,
             name='Expense manager',
@@ -37,6 +48,13 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             'user_id': cls.expense_user_employee.id,
             'address_home_id': cls.expense_user_employee.partner_id.id,
             'address_id': cls.expense_user_employee.partner_id.id,
+        })
+
+        cls.expense_employee_a = cls.env['hr.employee'].create({
+            'name': 'expense_employee_a',
+            'user_id': cls.expense_user_employee_a.id,
+            'address_home_id': cls.expense_user_employee_a.partner_id.id,
+            'address_id': cls.expense_user_employee_a.partner_id.id,
         })
 
         # Allow the current accounting user to access the expenses.

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -122,6 +122,7 @@ class AccountMoveLine(models.Model):
                         ('order_id', '=', sale_order.id),
                         ('price_unit', '=', price),
                         ('product_id', '=', move_line.product_id.id),
+                        ('name', 'like', move_line.name),
                         ('is_expense', '=', True),
                     ], limit=1)
                     if sale_line:  # found existing one, so keep the browse record


### PR DESCRIPTION
## Steps to reproduce:

 - Install Sales,Account,Expenses
 - Select analytic Account in Settings
 - Create a Sales Order, linking it to an Analytic Account(Other Info)
 - Confirm the Sales order
 - Have an existing Expense Product with invoicing policy delivered quantities, Re-invoice Policy at Sales Price
 - Create an expense with Product the previously created product, at X price, Customer to Reinvoice (previously created SO, same analytic account), by Employee A.
 - Create Report->Submit to manager->Approve->Post journal Entries
 - Repeat expense creation, this time with Employee B (A!=B)
 - Verify sale order line truncates the two different sales order to the first (same product, X price) employee expense, described with delivery quantities updated (correct).

## Issue:

 Expenses from different Employees get truncated to existing similar
 sales order line. No explicit discrimination between (different lines)
 in Sale order, Order Lines panel exists. Entries created can have
 incorrect description (first user that created a expense on the SO,
 with same product, price linked to it's analytic account).

## Cause:

 DB queried by same sale order, price, product if expense,
 thus returning an existing sale order line. In this case the existing
 sale order line has the delivered quantity updated and no new sale order
 line is created.

## Solution:

 Forcing a search for sale order with additional Employee information
 from move_line name in it's description. Each move line name created
 this way is of the form "Employee name: product". New query has
 an additional conditional expression i.e (Employee Name in
 sale order line description). This results in distinguishing
 expenses made by different Employees, while updating qty_delivered
 only in same Employee, product, product price expenses.

opw-2993240