### PR TITLE
[FIX] account: Fix duplicate payment terms and "Terms and condition" on invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -247,12 +247,6 @@
                             <strong class="text-center">Scan me with your banking app.</strong><br/><br/>
                             <img class="border border-dark rounded" t-att-src="qr_code_urls[o.id]"/>
                         </p>
-                        <p t-if="o.invoice_payment_term_id" name="payment_term">
-                            <span t-field="o.invoice_payment_term_id.note"/>
-                        </p>
-                        <div t-if="not is_html_empty(o.narration)" name="comment">
-                            <span t-field="o.narration"/>
-                        </div>
                         <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note">
                             <span t-field="o.fiscal_position_id.note"/>
                         </p>


### PR DESCRIPTION
Before this commit: When the QR code settings is activated and the payments terms have the option to display them on invoices is ticked, we have duplicate payments terms and "terms and conditions" on the invoice.

After this commit: The payments terms and "terms and conditions" appear only once in the invoice.

Issue: Duplicate field in the QR code part

Edit: Pr already exist for this issue #103878
