### PR TITLE
[FIX] sale_project: Can't get invoices related to a project

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -155,6 +155,7 @@ class Project(models.Model):
         query = self.env['account.move.line']._search([('move_id.move_type', '=', 'out_invoice')])
         query.add_where('analytic_distribution ? %s', [str(self.analytic_account_id.id)])
         query_string, query_param = query.select('DISTINCT move_id')
+        query_string = query_string.split('ORDER BY')[0]
         self._cr.execute(query_string, query_param)
         invoice_ids = [line.get('move_id') for line in self._cr.dictfetchall()]
         action = {


### PR DESCRIPTION
Steps to reproduce the issue:
- Enable "Analytics Accounting", "Margin Analysis" and "Budget Management" in accounting settings.
- Create a product as a service, with the "Create on order" option set to Project.
- Create a quotation with the product and create the invoice from it.
- Go to the settings of the created project and enable "Billable".
- Confirm the invoice.
- Go to Project -> Project update from the new project, try to get the invoices related to it.

Problem:
The ```_search()``` methods of the models generate a sql query with the ORDER BY clause of all the attributes present in the ```_order``` field of the model. The problem is that if we use a SELECT DISTINCT clause all fields present in the ORDER BY must be present in the SELECT (limitation of postgresql).

As we can't remove the ORDER BY clause in the query generated by the _search() method, I removed the DISTINCT from the query  and remove the duplicates from the python list result.

opw-3022798
