### PR TITLE
[FIX] crm: Only send email to accessible leads

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1788,6 +1788,10 @@ class Lead(models.Model):
             res.update(super(Lead, leftover)._notify_get_reply_to(default=default, records=None, company=company, doc_names=doc_names))
         return res
 
+    def _mailing_get_default_domain(self, mailing):
+        return ['|', ('company_id', '=', self.env.company.id), ('company_id', '=', False)]
+
+
     def _message_get_default_recipients(self):
         return {r.id: {
             'partner_ids': [],


### PR DESCRIPTION
Steps to reproduce:

- create a new company in the database with its own leads
- create new user who can only access the new company
- have user create email marketing campaign and change the recipients
line from mailing list to leads. It will show X amount of records
from said company

The email marketing campaign is targeted to leads from the current
company and leads without a company.

Issue:
When you send the email, it will actually send to all leads from the
database, not just from the new company (it will send more than X emails).

Sending the emails creates a separate cron job which will send the emails
at the specified time. The issue happens because while deploying the cron
job, `sudo()` is called, which loses the `env.company` context variable.

Solution:
Before sending the email, include the current company into the default
domain for the lead/opportunity model.

This solution introduces a visual change in the mailing creation form,
specifically the domain widget.

opw-[3023589](https://www.odoo.com/web#id=3023589&view_type=form&model=project.task)