### PR TITLE
[FIX] hr_holidays selection field treated as boolean

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -148,7 +148,7 @@ class HolidaysType(models.Model):
         date_from = self._context.get('default_date_from', fields.Datetime.today())
         employee_id = self._context.get('default_employee_id', self._context.get('employee_id', self.env.user.employee_id.id))
         for holiday_type in self:
-            if holiday_type.requires_allocation:
+            if holiday_type.requires_allocation == 'yes':
                 allocation = self.env['hr.leave.allocation'].search([
                     ('holiday_status_id', '=', holiday_type.id),
                     ('employee_id', '=', employee_id),


### PR DESCRIPTION
`requires_allocation` is a "yes"/"no" Selection field, one line incorrectly treats it as a boolean.

Current behavior before PR:
`has_valid_allocation` may be False on a record even if `requires_allocation` is `"no"`.

Desired behavior after PR is merged:
`has_valid_allocation` is always True on records where `requires_allocation` is `"no"`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
