### PR TITLE
[FIX] stock: stock move line reservation

### DIFF
--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -3473,9 +3473,8 @@ class StockMove(TransactionCase):
     def test_edit_reserved_move_line_9(self):
         """
         When writing on the reserved quantity on the SML, a process tries to
-        reserve the quants with that new quantity. If it fails (for instance
-        because the written quantity is more than actually available), this
-        quantity should be reset to 0.
+        reserve the quants with that new quantity. If the written quantity is
+        more than actually available, this quantity should be set to the available quantity.
         """
         self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 1.0)
 
@@ -3494,7 +3493,7 @@ class StockMove(TransactionCase):
         out_move.move_line_ids.reserved_uom_qty = 2
 
         self.assertTrue(out_move.move_line_ids)
-        self.assertEqual(out_move.move_line_ids.reserved_uom_qty, 0, "The reserved quantity should be cancelled")
+        self.assertEqual(out_move.move_line_ids.reserved_uom_qty, 1, "The reserved quantity should be what is available")
 
     def test_edit_done_move_line_1(self):
         """ Test that editing a done stock move line linked to an untracked product correctly and

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -85,7 +85,7 @@
                         <group>
                             <label for="reserved_uom_qty" string="Quantity Reserved" attrs="{'invisible': [('state', '=', 'done')]}"/>
                             <div class="o_row" attrs="{'invisible': [('state', '=', 'done')]}">
-                                <field name="reserved_uom_qty" readonly="1"/>
+                                <field name="reserved_uom_qty"/>
                                 <field name="product_uom_id" options="{'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                             </div>
                             <label for="qty_done" string="Quantity Done"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -248,7 +248,7 @@
                     <field name="package_id" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_package')" groups="stock.group_tracking_lot"/>
                     <field name="result_package_id" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" groups="stock.group_tracking_lot" context="{'picking_id': picking_id}"/>
                     <field name="owner_id" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_owner')" groups="stock.group_tracking_owner"/>
-                    <field name="reserved_uom_qty" invisible="not context.get('show_reserved_quantity')" readonly="1"/>
+                    <field name="reserved_uom_qty" invisible="not context.get('show_reserved_quantity')"/>
                     <field name="state" invisible="1"/>
                     <field name="is_locked" invisible="1"/>
                     <field name="picking_code" invisible="1"/>
@@ -286,7 +286,7 @@
                     <field name="lot_id" groups="stock.group_production_lot" attrs="{'column_invisible': [('parent.show_lots_text', '=', True)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
                     <field name="lot_name" groups="stock.group_production_lot" attrs="{'column_invisible': [('parent.show_lots_text', '=', False)], 'invisible': [('lots_visible', '=', False)]}" context="{'default_product_id': product_id}"/>
                     <field name="is_initial_demand_editable" invisible="1"/>
-                    <field name="reserved_uom_qty" readonly="1" attrs="{'column_invisible': ['|',('parent.immediate_transfer', '=', True),('parent.picking_type_code','=','incoming')]}" optional="show"/>
+                    <field name="reserved_uom_qty" attrs="{'column_invisible': ['|',('parent.immediate_transfer', '=', True),('parent.picking_type_code','=','incoming')]}" optional="show"/>
                     <field name="is_locked" invisible="1"/>
                     <field name="qty_done" attrs="{'readonly': [('state', 'in', ('done', 'cancel')), ('is_locked', '=', True)]}" force_save="1"/>
                     <field name="product_uom_id" force_save="1" attrs="{'readonly': [('state', '!=', 'draft'), ('id', '!=', False)]}" groups="uom.group_uom"/>


### PR DESCRIPTION
Before this commit, changing the `reserved_uom_qty` would reserve the new qty from quants only if available, if not the `reserved_uom_qty` would be set to zero, moving the sml state to 'confirmed' and breaking quant sync with any future edits on the line `reserved_uom_qty`

This commit avoids this by trying to reserve what is available in quants.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
