### PR TITLE
[FIX] survey: fix section title colspan

### DIFF
--- a/addons/survey/static/src/question_page/question_page_list_renderer.js
+++ b/addons/survey/static/src/question_page/question_page_list_renderer.js
@@ -67,6 +67,7 @@ export class QuestionPageListRenderer extends ListRenderer {
                 sectionColumns.push(col);
             }
         }
+        sectionColumns.push(columns[columns.length - 1]); // trash button
 
         const colspan = columns.length - sectionColumns.length;
         const titleCol = columns.find(


### PR DESCRIPTION
Probably due to always-edit mode transition, one too many column was used 
for the title, which resulted in random_questions_count title-value misalignment.

Task-3043371
