### PR TITLE
[IMP] web: add inplace transition

### DIFF
--- a/addons/web/static/src/core/transition.js
+++ b/addons/web/static/src/core/transition.js
@@ -128,10 +128,11 @@ export class Transition extends Component {
     }
 }
 
-Transition.template = xml`<t t-slot="default" t-if="transition.shouldMount" className="transition.className"/>`;
+Transition.template = xml`<t t-slot="default" t-if="this.props.alwaysMounted || transition.shouldMount" className="transition.className"/>`;
 Transition.props = {
     name: String,
     visible: { type: Boolean, optional: true },
+    alwaysMounted: { type: Boolean, optional: true },
     leaveDuration: { type: Number, optional: true },
     onLeave: { type: Function, optional: true },
     slots: Object,


### PR DESCRIPTION
Currently, the animated element is removed when the transition is over, with this commit it would be possible to leave the element in screen to add transition inplace, e.g. change color, rotate once, ...


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
