### PR TITLE
[IMP] point_of_sale: Adjust phone number in POS

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -107,6 +107,9 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
                 this.state.selectedClient = clients[0];
                 this.clickNext();
             } else {
+	            if (event.target.value[0] == 0) {
+                    this.state.query = event.target.value.slice(1)
+                }
                 this.render();
             }
         }


### PR DESCRIPTION
Current behavior before PR:
When searching for a customer by phone number in the POS, with the case:
Search 0935xxx not showing customer with phone number +84935xxx, +86935xxx, ....

Desired behavior after PR is merged:
Search 0935xxx showing customer with phone number +84935xxx, +86935xxx,  0935xxx, (+84)935xxx, ....

How fix: I will cut the 0 at the beginning of the phone number when users search, it won't affect other cases

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
