### PR TITLE
[IMP][15.0] maintenance: form maintenance request simple extend

### DIFF
--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -64,6 +64,7 @@
                     <div attrs="{'invisible': [('archive', '=', False)]}">
                         <span class="badge badge-warning float-right">Canceled</span>
                     </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <div class="oe_right">
                         <field name="kanban_state" class="oe_inline" widget="state_selection"/>
                     </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Current behavior before PR:**
There isn't HTML tag containing buttons on the maintenance request form. Currently on the maintenance request form there is no place to contain other model link buttons.
**Desired behavior after PR is merged:**
Add div tag with class 'button_box' to the maintenance request form view for others to inherit and inject buttons inside
**Example image:**
![image](https://user-images.githubusercontent.com/106485602/198184201-0c4930e8-c446-4a78-a1e5-6e42e80145eb.png)






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
