### PR TITLE
[IMP] core: add indomain operator

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -142,7 +142,7 @@ DOMAIN_OPERATORS = (NOT_OPERATOR, OR_OPERATOR, AND_OPERATOR)
 # operators are also used. In this case its right operand has the form (subselect, params).
 TERM_OPERATORS = ('=', '!=', '<=', '<', '>', '>=', '=?', '=like', '=ilike',
                   'like', 'not like', 'ilike', 'not ilike', 'in', 'not in',
-                  'child_of', 'parent_of')
+                  'child_of', 'parent_of', 'indomain')
 
 # A subset of the above operators, with a 'negative' semantic. When the
 # expressions 'in NEGATIVE_TERM_OPERATORS' or 'not in NEGATIVE_TERM_OPERATORS' are used in the code
@@ -738,6 +738,9 @@ class expression(object):
             # -------------------------------------------------
             # RELATIONAL FIELDS
             # -------------------------------------------------
+
+            elif operator == 'indomain' and field.type in ['one2many', 'many2one', 'many2many']:
+                push((left, 'in', comodel._search(right, order='id')), model, alias)
 
             # Applying recursivity on field(one2many)
             elif field.type == 'one2many' and operator in HIERARCHY_FUNCS:


### PR DESCRIPTION
[IMP] core: add indomain operator

Purpose:
When a relational field is used multiple times in different leaves,
the query has bad performance for sake of multi sub SELECT queries
check query test in this commit for

`self.Partner.search([('company_id.name', 'like', self.company.name), ('company_id.active', '=', True)])`

I want to merge the two sub SELECTs in the query into one.
The best implementation should support the old domain, while it is very hard to
know which leaves can be merged.
The suboptimal implementation in this commit is to introduce a new operator
'indomain'. And as a result, the domain becomes nested for relational fields

A POC for 'indomain' operator
('relational_field.relational_field', 'indomain', domain)
'auto_join' should be rechecked later

Advantage
1. Performance: when the many2one is used multiple times in different leaves,
the indomain is much faster than the &
`Model.search([('product_id', 'indomain', [('price', '>', 100), ('price', '<', 200)])])`
is faster than
`Model.search([('product_id.price', '>', 100), ('product_id.price', '<', 200)])`
In one of my test, the query for indomain is 3x faster
And the time complexity for parsing the domain is not increased

2. Readability?: group up leaves for the relational fields

4. Implementation: simple code with only 3 lines

Disadvantage
1. the 'indomain' is hard to be used by the searchbar from UI
2. needs developers to optimize their existing code to improve performance
