### PR TITLE
[IMP] assets: support optimized rjsmin JS minification

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -32,7 +32,7 @@ _logger = logging.getLogger(__name__)
 EXTENSIONS = (".js", ".css", ".scss", ".sass", ".less")
 
 class CompileError(RuntimeError): pass
-def rjsmin(script):
+def regex_jsmin(script):
     """ Minify js with a clever regex.
     Taken from http://opensource.perlig.de/rjsmin (version 1.1.0)
     Apache License, Version 2.0 """
@@ -91,6 +91,12 @@ def rjsmin(script):
         r'\011\013\014\016-\040]|(?:/\*[^*]*\*+(?:[^/*][^*]*\*+)*/))*)+', subber, '\n%s\n' % script
     ).strip()
     return result
+
+try:
+    import rjsmin as rjsminlib
+    rjsmin = rjsminlib.jsmin
+except ImportError:
+    rjsmin = regex_jsmin
 
 class AssetError(Exception):
     pass

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -131,6 +131,8 @@ def init_logger():
     warnings.filterwarnings('ignore', r'^invalid escape sequence \'?\\.', category=DeprecationWarning)
     # recordsets are both sequence and set so trigger warning despite no issue
     warnings.filterwarnings('ignore', r'^Sampling from a set', category=DeprecationWarning, module='odoo')
+    # rsjmin triggers this with Python 3.10+ (that warning comes from the C code and has no `module`)
+    warnings.filterwarnings('ignore', r'^PyUnicode_FromUnicode\(NULL, size\) is deprecated', category=DeprecationWarning)
     # ignore a bunch of warnings we can't really fix ourselves
     for module in [
         'babel.util', # deprecated parser module, no release yet


### PR DESCRIPTION
This backport of #104283 allows opt-in installation of rjsmin 1.1.0+ (`python3-rjsmin` package on Debian/Fedora/...) in order to speedup asset minification.

The C implementation of the JS minification gives speedups between 6 and 55 times faster than the regex-based Python port, depending on how compressed the input it (which is what our default implementation does).

This is measurable when generating compiled assets bundle from scratch, e.g. after installing/updating modules or source code.

As an illustration, the minification of a 2MB JS bundle can be 50x faster:

```py
import rjsmin
from odoo.addons.base.models.assetsbundle import regex_jsmin
js_source = open("web.assets_common_lazy.js").read() # 2MB JS
%timeit regex_jsmin(js_source)
 # -> 339 ms ± 495 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit rjsmin.jsmin(js_source)
 # -> 6.88 ms ± 213 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

It's also a drop-in replacement, as long as you rjsmin 1.1.0 or better is available (to support format strings properly, a.o.).

See also the documentation of rjsmin: http://opensource.perlig.de/rjsmin/