### PR TITLE
[FIX] website: fix the website LinkPopoverWidget on Firefox

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -283,7 +283,11 @@ LinkPopoverWidget.createFor = async function (parent, targetEl, options) {
     if (wysiwyg) {
         wysiwyg.odooEditor.observerUnactive('LinkPopoverWidget');
     }
-    await popoverWidget.appendTo(targetEl)
+    // The LinkPopoverWidget element does not need to be inserted in the DOM,
+    // it just needs to be rendered so that it can be used as a content option
+    // for the Bootstrap popover.
+    const template = document.createElement('template');
+    await popoverWidget.appendTo(template);
     if (wysiwyg) {
         wysiwyg.odooEditor.observerActive('LinkPopoverWidget');
     }


### PR DESCRIPTION
On Firefox, from the website builder:
- Drop a snippet,
- Create a link,
- Click on it,
=> There is a traceback when the link popover is created.

Until now, the LinkPopoverWidget element was appended to the target.
This was done to render the HTMLElement so that it can be used as the
content for the Bootstrap popover.

In the case of the website builder, the LinkPopoverWidget's target is
inside the iframe, introduced in [1]. Therefore, the javascript class
was instantiated outside of the iframe, with a ClipboardJS class defined
in the top window, and its HTMLElement was appended and started inside
the iframe.

On Firefox, instantiating a ClipboardJS class with an element that is
not defined in the same window as the class will throw an error: it
compares the HTMLElement class of the iframe's contentWindow from the
target, with the HTMLElement class from the top window that is in the
scope of ClipboardJS.

To fix that, the LinkPopoverWidget element is not inserted in the DOM
anymore, as it is only used as the popover's content. It is now rendered
in a template element.

[1]: https://github.com/odoo/odoo/commit/931d488af0d4dce529e4ea4ab3c8b827bda0d699

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
