### PR TITLE
[IMP] analytic, account: order applicability

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -171,11 +171,13 @@ class AccountAnalyticPlan(models.Model):
             # For models for example, we want all plans to be visible, so we force the applicability
             return kwargs['applicability']
         else:
-            score = 0
+            # If an applicability is valid it should return with a score of 1+, so better than the default one
+            # In case of equality, the most recent one should prevail
+            score = 1
             applicability = self.default_applicability
             for applicability_rule in self.applicability_ids:
                 score_rule = applicability_rule._get_score(**kwargs)
-                if score_rule > score:
+                if score_rule >= score:
                     applicability = applicability_rule.applicability
                     score = score_rule
             return applicability

--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -165,3 +165,29 @@ class TestAnalyticAccount(TransactionCase):
         })
         self.assertEqual(distribution_json, distribution_4.analytic_distribution,
                          "Distribution 4 should be given, as the partner_category_id is better than the company_id")
+
+    def test_analytic_applicability(self):
+        """ Test the applicability returned from a plan """
+        self.assertEqual(self.analytic_plan_2._get_applicability(**{}), 'optional')
+
+        self.analytic_plan_2.write({
+            'applicability_ids': [Command.create({
+                'business_domain': 'general',
+                'applicability': 'unavailable',
+            })]
+        })
+
+        self.assertEqual(self.analytic_plan_2._get_applicability(**{}), 'optional')
+        self.assertEqual(self.analytic_plan_2._get_applicability(**{'business_domain': 'other'}), 'optional')
+        self.assertEqual(self.analytic_plan_2._get_applicability(**{'business_domain': 'general'}), 'unavailable')
+
+        self.analytic_plan_2.write({
+            'applicability_ids': [Command.create({
+                'business_domain': 'general',
+                'applicability': 'mandatory',
+            })]
+        })
+        self.assertEqual(self.analytic_plan_2._get_applicability(**{'business_domain': 'other'}), 'optional')
+
+        # In case of equality of applicability rules: take the last created
+        self.assertEqual(self.analytic_plan_2._get_applicability(**{'business_domain': 'general'}), 'mandatory')


### PR DESCRIPTION
When there is an equality between applicability rules, the oldest
one is taken.
It is counterintuitive, it should be the most recent one that
should be  chosen.

Also added tests in analytic and account to enforce it.

Fixed an issue found with task-3040919




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
