### PR TITLE
[FIX] account_edi_ubl_cii: taxes computed incorrectly on upload

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import _, models
-from odoo.tools import float_repr
+from odoo.tools import float_repr, float_compare
 from odoo.tests.common import Form
 from odoo.exceptions import UserError
 
@@ -531,6 +531,9 @@ class AccountEdiCommon(models.AbstractModel):
         # respected, and the result will not be correct, so we just follow the simple rule below:
         if net_price_unit == 0 and price_subtotal != net_price_unit * (billed_qty / basis_qty) - allow_charge_amount:
             invoice_line_form.price_unit = price_subtotal / billed_qty
+
+        return float_compare(gross_price_unit, net_price_unit,
+                             precision_rounding=self.env.company.currency_id.rounding) != 0
 
     # -------------------------------------------------------------------------
     # Check xml using the free API from Ph. Helger, don't abuse it !

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -333,7 +333,7 @@ class AccountEdiXmlCII(models.AbstractModel):
             'allowance_charge_amount': './{*}ActualAmount',  # below allowance_charge node
             'line_total_amount': './{*}SpecifiedLineTradeSettlement/{*}SpecifiedTradeSettlementLineMonetarySummation/{*}LineTotalAmount',
         }
-        self._import_fill_invoice_line_values(tree, xpath_dict, invoice_line_form, qty_factor)
+        tax_included = self._import_fill_invoice_line_values(tree, xpath_dict, invoice_line_form, qty_factor)
 
         if not invoice_line_form.product_uom_id:
             logs.append(
@@ -349,6 +349,7 @@ class AccountEdiXmlCII(models.AbstractModel):
                 ('amount', '=', float(tax_node.text)),
                 ('amount_type', '=', 'percent'),
                 ('type_tax_use', '=', journal.type),
+                ('price_include', '=', tax_included),
             ], limit=1)
             if tax:
                 taxes.append(tax)
@@ -356,6 +357,7 @@ class AccountEdiXmlCII(models.AbstractModel):
                 logs.append(_("Could not retrieve the tax: %s %% for line '%s'.", float(tax_node.text), invoice_line_form.name))
 
         invoice_line_form.tax_ids.clear()
+        invoice_line_form.discount = 0.0
         for tax in taxes:
             invoice_line_form.tax_ids.add(tax)
         return logs

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -587,7 +587,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'allowance_charge_amount': './{*}Amount',  # below allowance_charge node
             'line_total_amount': './{*}LineExtensionAmount',
         }
-        self._import_fill_invoice_line_values(tree, xpath_dict, invoice_line_form, qty_factor)
+        tax_included = self._import_fill_invoice_line_values(tree, xpath_dict, invoice_line_form, qty_factor)
 
         if not invoice_line_form.product_uom_id:
             logs.append(
@@ -608,6 +608,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 ('amount', '=', float(tax_node.text)),
                 ('amount_type', '=', 'percent'),
                 ('type_tax_use', '=', journal.type),
+                ('price_included', '=', tax_included)
             ], limit=1)
             if tax:
                 taxes.append(tax)
@@ -615,6 +616,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 logs.append(_("Could not retrieve the tax: %s %% for line '%s'.", float(tax_node.text), invoice_line_form.name))
 
         invoice_line_form.tax_ids.clear()
+        invoice_line_form.discount = 0.0
         for tax in taxes:
             invoice_line_form.tax_ids.add(tax)
         return logs


### PR DESCRIPTION
Steps to reproduce:

- Install Switzerland localization, Accounting
- Create new invoice, select Swiss customer, add a product, set taxes to 7.7% sales
- Save > Confirm > Print invoices
- Dashboard > Vendor Bills > Upload, select the file

Issue:
After the file is imported, you can see that the tax on the uploaded
invoice product is not the same as the one in the database.

This happens because the factur-x XML does not make a distinction between
added taxes and included taxes when applying them to invoice lines.

Solution:
When looking for a suitable tax, consider if the tax is included or
added, based on the gross and net price of the line.

Limitation:
If an invoice line has multiple taxes and one of them is included, then
all of the other taxes on the line will also be considered as included.

opw-3032382