### PR TITLE
[IMP] e-commerce : attributes not available in the selected category should not be displayed

### DIFF
--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -18,14 +18,14 @@
                 <field name="expense_policy" widget="radio" attrs="{'invisible': [('visible_expense_policy', '=', False)]}"/>
             </field>
             <field name="product_tooltip" position="after">
-                <!-- <label for="product_tooltip" string=""
-                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'order')]}"/> -->
+                <label for="product_tooltip" string=""
+                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'order')]}"/>
                 <div attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'order')]}"
                     class="fst-italic text-muted">
                     You can invoice them before they are delivered.
                 </div>
-                <!-- <label for="product_tooltip" string=""
-                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'delivery')]}"/> -->
+                <label for="product_tooltip" string=""
+                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'delivery')]}"/>
                 <div attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'delivery')]}"
                     class="fst-italic text-muted">
                     Invoice after delivery, based on quantities delivered, not ordered.

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -18,14 +18,14 @@
                 <field name="expense_policy" widget="radio" attrs="{'invisible': [('visible_expense_policy', '=', False)]}"/>
             </field>
             <field name="product_tooltip" position="after">
-                <label for="product_tooltip" string=""
-                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'order')]}"/>
+                <!-- <label for="product_tooltip" string=""
+                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'order')]}"/> -->
                 <div attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'order')]}"
                     class="fst-italic text-muted">
                     You can invoice them before they are delivered.
                 </div>
-                <label for="product_tooltip" string=""
-                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'delivery')]}"/>
+                <!-- <label for="product_tooltip" string=""
+                    attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'delivery')]}"/> -->
                 <div attrs="{'invisible': ['|', ('type', 'not in', ('product', 'consu')), ('invoice_policy', '!=', 'delivery')]}"
                     class="fst-italic text-muted">
                     Invoice after delivery, based on quantities delivered, not ordered.

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -438,6 +438,14 @@ class WebsiteSale(http.Controller):
         else:
             attributes = lazy(lambda: ProductAttribute.browse(attributes_ids))
 
+        ProductAttributeValue = request.env['product.attribute.value']
+        if products:
+            attributes_values = lazy(lambda: ProductAttributeValue.search([
+                ('pav_attribute_line_ids.product_tmpl_id', 'in', search_product.ids),
+            ]))
+        else:
+            attributes_values = lazy(lambda: ProductAttributeValue.browse(attrib_set))
+
         layout_mode = request.session.get('website_sale_shop_layout_mode')
         if not layout_mode:
             if website.viewref('website_sale.products_list_view').active:
@@ -465,6 +473,7 @@ class WebsiteSale(http.Controller):
             'ppr': ppr,
             'categories': categs,
             'attributes': attributes,
+            'attributes_values' : attributes_values,
             'keep': keep,
             'search_categories_ids': search_categories.ids,
             'layout_mode': layout_mode,

--- a/addons/website_sale/models/product_attribute.py
+++ b/addons/website_sale/models/product_attribute.py
@@ -30,3 +30,18 @@ class ProductTemplateAttributeLine(models.Model):
         for ptal in single_value_lines:
             single_value_attributes[ptal.attribute_id] |= ptal
         return single_value_attributes
+
+class ProductAttributeValue(models.Model):
+    _inherit = 'product.attribute.value'
+
+    def is_product_variant_in_category(self, category):
+        # All products category
+        if(not category.name):
+            return True
+        # Specific category
+        for child in category.child_id:
+            if(self.is_product_variant_in_category(child)):
+                return True
+        attributes_products = self.pav_attribute_line_ids.product_tmpl_id
+        # Check if at least one element of this attribute value is displayed in the selected category
+        return any(product in attributes_products for product in category.product_tmpl_ids)

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -816,25 +816,31 @@
                                     <select class="form-select css_attribute_select mb-2" name="attrib">
                                         <option value="" selected="true">-</option>
                                         <t t-foreach="a.value_ids" t-as="v">
-                                            <option t-att-value="'%s-%s' % (a.id,v.id)" t-esc="v.name" t-att-selected="v.id in attrib_set" />
+                                            <t t-if="v.is_product_variant_in_category(category) or v.id in attrib_set">
+                                                <option t-att-value="'%s-%s' % (a.id,v.id)" t-esc="v.name" t-att-selected="v.id in attrib_set" />
+                                            </t>
                                         </t>
                                     </select>
                                 </t>
                                 <t t-if="a.display_type == 'radio' or a.display_type == 'pills'">
                                     <div class="flex-column mb-3">
                                         <t t-foreach="a.value_ids" t-as="v">
-                                            <div class="form-check mb-1">
-                                                <input type="checkbox" name="attrib" class="form-check-input" t-att-id="'%s-%s' % (a.id,v.id)" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None"/>
-                                                <label class="form-check-label fw-normal" t-att-for="'%s-%s' % (a.id,v.id)" t-field="v.name"/>
-                                            </div>
+                                            <t t-if="v.is_product_variant_in_category(category) or v.id in attrib_set">
+                                                <div class="form-check mb-1">
+                                                    <input type="checkbox" name="attrib" class="form-check-input" t-att-id="'%s-%s' % (a.id,v.id)" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None"/>
+                                                    <label class="form-check-label fw-normal" t-att-for="'%s-%s' % (a.id,v.id)" t-field="v.name"/>
+                                                </div>
+                                            </t>
                                         </t>
                                     </div>
                                 </t>
                                 <div t-if="a.display_type == 'color'" class="mb-3">
                                     <t t-foreach="a.value_ids" t-as="v">
-                                        <label t-attf-style="background-color:#{v.html_color or v.name}" t-attf-class="css_attribute_color mb-1 #{'active' if v.id in attrib_set else ''}">
-                                            <input type="checkbox" name="attrib" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None" t-att-title="v.name" />
-                                        </label>
+                                        <t t-if="v.is_product_variant_in_category(category) or v.id in attrib_set">
+                                            <label t-attf-style="background-color:#{v.html_color or v.name}" t-attf-class="css_attribute_color mb-1 #{'active' if v.id in attrib_set else ''}">
+                                                <input type="checkbox" name="attrib" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None" t-att-title="v.name" />
+                                            </label>
+                                        </t>
                                     </t>
                                 </div>
                             </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -815,8 +815,8 @@
                                 <t t-if="a.display_type == 'select'">
                                     <select class="form-select css_attribute_select mb-2" name="attrib">
                                         <option value="" selected="true">-</option>
-                                        <t t-foreach="a.value_ids" t-as="v">
-                                            <t t-if="v.is_product_variant_in_category(category) or v.id in attrib_set">
+                                        <t t-foreach="attributes_values" t-as="v">
+                                            <t t-if="v in a.value_ids or v in attrib_set">
                                                 <option t-att-value="'%s-%s' % (a.id,v.id)" t-esc="v.name" t-att-selected="v.id in attrib_set" />
                                             </t>
                                         </t>
@@ -824,8 +824,8 @@
                                 </t>
                                 <t t-if="a.display_type == 'radio' or a.display_type == 'pills'">
                                     <div class="flex-column mb-3">
-                                        <t t-foreach="a.value_ids" t-as="v">
-                                            <t t-if="v.is_product_variant_in_category(category) or v.id in attrib_set">
+                                        <t t-foreach="attributes_values" t-as="v">
+                                            <t t-if="v in a.value_ids or v in attrib_set">
                                                 <div class="form-check mb-1">
                                                     <input type="checkbox" name="attrib" class="form-check-input" t-att-id="'%s-%s' % (a.id,v.id)" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None"/>
                                                     <label class="form-check-label fw-normal" t-att-for="'%s-%s' % (a.id,v.id)" t-field="v.name"/>
@@ -835,8 +835,8 @@
                                     </div>
                                 </t>
                                 <div t-if="a.display_type == 'color'" class="mb-3">
-                                    <t t-foreach="a.value_ids" t-as="v">
-                                        <t t-if="v.is_product_variant_in_category(category) or v.id in attrib_set">
+                                    <t t-foreach="attributes_values" t-as="v">
+                                        <t t-if="v in a.value_ids or v in attrib_set">
                                             <label t-attf-style="background-color:#{v.html_color or v.name}" t-attf-class="css_attribute_color mb-1 #{'active' if v.id in attrib_set else ''}">
                                                 <input type="checkbox" name="attrib" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None" t-att-title="v.name" />
                                             </label>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Whenever a category was selected and the products linked to that category were displayed, it was possible to select attributes that were not even available among the category products, leading to a "no product defined" message.

Current behavior before PR:
All the attributes values are displayed, no filter is perfomed

Desired behavior after PR is merged:
Only the attributes leading to actual available products are displayed.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
