### PR TITLE
[FIX] account: disable tax deletion

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1047,7 +1047,7 @@
                                            'kanban_view_ref': 'account.account_move_line_view_kanban_mobile',
                                        }"
                                        attrs="{'invisible': [('payment_state', '=', 'invoicing_legacy'), ('move_type', '!=', 'entry')]}">
-                                    <tree editable="bottom" string="Journal Items" decoration-muted="display_type in ('line_section', 'line_note')" default_order="sequence, id">
+                                    <tree editable="bottom" string="Journal Items" decoration-muted="display_type in ('line_section', 'line_note')" default_order="sequence, id" delete="0">
                                         <!-- Displayed fields -->
                                         <field name="account_id"
                                                attrs="{


### PR DESCRIPTION
When in a Journal Entry, if we try to delete a generated tax line, an error will be raised, obligating the user to discard current changes, without any other alternative.

Now the tax line cannot manually be deleted (the user should remove the tax on the baseline instead): an error still pops up but the line stays, and previous changes are kept.