### PR TITLE
[FIX] base: prevent blocking module upgrade on model renaming

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1415,6 +1415,10 @@ class IrModelSelection(models.Model):
                 records.invalidate_cache([fname])
 
         for selection in self:
+            if selection.field_id.model not in self.env:
+                _logger.warning('Selection field "%s" references to non-existing model "%s". You may need to add migration script', selection.field_id.name, selection.field_id.model)
+                continue
+
             Model = self.env[selection.field_id.model]
             # The field may exist in database but not in registry. In this case
             # we allow the field to be skipped, but for production this should


### PR DESCRIPTION
On model renaming (or removing), ORM does a clean up for `ir.model.fields.selection` record. However, it doesn't work because the record references to old model (if there are no migration scripts).

This commit adds warning and ignores such case.
It makes sense, because the whole table is deleted anyway (if there are no migration scripts).

STEPS

* install following module
* rename model
* upgrade the module via Apps menu

```py

from odoo import models, fields

class Test(models.Model):
    _name = 'test_install'
    _description = 'Test'
    sel = fields.Selection([('ok', 'OK')])

```

opw-3024537

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
