### PR TITLE
[FIX] mail: fix chat window ctrl-c

### DIFF
--- a/addons/mail/static/src/webclient/home_menu/home_menu.js
+++ b/addons/mail/static/src/webclient/home_menu/home_menu.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { HomeMenu } from "@web_enterprise/webclient/home_menu/home_menu";
+import { patch } from "@web/core/utils/patch";
+
+
+patch(HomeMenu.prototype, 'mail.home_menu_focus', {
+    /**
+     * @override
+     */
+    _onKeydownFocusInput(ev) {
+        const isOnchatWindow = document.activeElement && document.activeElement.classList.contains('o_ChatWindow');
+        const isCopyCmd = ev.key === 'c' && (ev.ctrlKey || ev.metaKey);
+        // prevent focusing the home menu hence loosing the selected
+        // text when copying a message on a chat window.
+        if (isOnchatWindow && (['Control', 'Meta'].includes(ev.key) || isCopyCmd)) {
+            return;
+        }
+        this._super(ev);
+    },
+});


### PR DESCRIPTION
Since [[1]](https://github.com/odoo/enterprise/pull/24356), pressing any key within a focused chat window would
focus the home menu. This is an issue when trying to copy a message
from a chat window.

This commit fixes this issue by preventing the home menu focus when
the event is triggered inside the chat window and is related to either:
- The Ctrl/Meta key.
- The c key with one of the above pressed.