### PR TITLE
[FIX] core: deploy command broken in multi-db

### DIFF
--- a/odoo/cli/deploy.py
+++ b/odoo/cli/deploy.py
@@ -26,6 +26,7 @@ class Deploy(Command):
 
     def login_upload_module(self, module_file, url, login, password, db, force=False):
         print("Uploading module file...")
+        self.session.get(f'{url}/web/login?db={db}', allow_redirects=False)  # this set the db in the session
         endpoint = url + '/base_import_module/login_upload'
         post_data = {
             'login': login,


### PR DESCRIPTION
Start a server without a -d and with a --dbfilter that allows for multiple database. Make sure one of the database has the `base_import_module` addon installed. Create an empty module using scaffold and deploy it to the server, make sure to provide the `--db` argument to the deploy command.

It zips the file and attempt to upload it but it fails for a 404 page not found error.

The problem is that the controllers of base_import_module are only accessible when the client is connected to a database. It must first connect to a database (to have a db in his session) and then access the controller.

The /web/login route is an example of a rather cheap route to get that is both accessible without being connected to a database and that takes a `?db=` argument to connect to one. Using that route, we can ensure that we are connected to a database prior to uploading a module.

Closes #104589

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
