### PR TITLE
[FIX] web_editor: should not crash on switching from codeview

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -308,7 +308,7 @@ export class HtmlField extends Component {
      *
      * @param {JQuery} $codeview
      */
-    toggleCodeView (el = this.codeViewRef.el) {
+    toggleCodeView () {
         this.state.showCodeView = !this.state.showCodeView;
 
         this.wysiwyg.odooEditor.observerUnactive('toggleCodeView');
@@ -318,7 +318,7 @@ export class HtmlField extends Component {
             this.props.update(value);
         } else {
             this.wysiwyg.odooEditor.observerActive('toggleCodeView');
-            const $codeview = $(el);
+            const $codeview = $(this.codeViewRef.el);
             const value = $codeview.val();
             this.props.update(value);
 


### PR DESCRIPTION
**Current behavior before PR:**

On switching from codeview there was a traceback.

**Desired behavior after PR is merged:**

The codeview panel should close when we click codeview button again.

**Task-3036994**