### PR TITLE
[FIX] delivery: raise user error while getting shipping rate

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -154,7 +154,7 @@ class SaleOrder(models.Model):
     def _get_estimated_weight(self):
         self.ensure_one()
         weight = 0.0
-        for order_line in self.order_line.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not l.is_delivery and not l.display_type):
+        for order_line in self.order_line.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not l.is_delivery and not l.display_type and l.product_uom_qty > 0):
             weight += order_line.product_qty * order_line.product_id.weight
         return weight
 


### PR DESCRIPTION
Steps to produce an error:
-If any user makes SO which has 2 products with the same weight, Both product's quantity is the same but one of the product quantity is negative, Then we try to get the shipping rate then it raises user error

After this commit:
-In this commit, I ignore the rate of shipping in negative quantity in the SO line.

TaskId=3028023