### PR TITLE
[FIX] web: fix label compiler in form settings compiler

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_compiler.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_compiler.js
@@ -177,7 +177,7 @@ export class SettingsFormCompiler extends FormCompiler {
             { selector: "h2", fn: compileSettingsGroupTitle },
             { selector: "h3.o_setting_tip", fn: compileSettingsGroupTip },
             // search terms and highlight :
-            { selector: "label", fn: compileLabel },
+            { selector: "label", fn: compileLabel, doNotCopyAttributes: true },
             { selector: "span.o_form_label", fn: compileGenericLabel },
             { selector: "div.text-muted", fn: compileGenericLabel },
             { selector: "field", fn: compileField }

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -91,7 +91,7 @@ QUnit.module("SettingsFormView", (hooks) => {
                                             <field name="bar"/>
                                         </div>
                                         <div class="o_setting_right_pane">
-                                            <label for="bar"/>
+                                            <label for="bar" class="my_custom_class"/>
                                             <div class="text-muted">this is bar</div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Before this commit when compiling a label with an existing class
parameter it didn't pass the validation props since class isn't
expected. This commit fix this by adding the doNotCopyAttributes.
We add a custom class in the test that will crash without this fix.

Task-3044750



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
