### PR TITLE
[FIX] stock: include mandatory group dependent uom field

### DIFF
--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -51,6 +51,7 @@
                                 <div class="o_row">
                                     <field name="scrap_qty"/>
                                     <field name="product_uom_category_id" invisible="1"/>
+                                    <field name="product_uom_id" invisible="1" groups="!uom.group_uom"/>
                                     <field name="product_uom_id" groups="uom.group_uom" force_save="1"/>
                                 </div>
                             </group>
@@ -165,6 +166,7 @@
                                 <field name="scrap_qty"
                                     attrs="{'readonly': [('tracking', '=', 'serial')]}"/>
                                 <field name="product_uom_category_id" invisible="1"/>
+                                <field name="product_uom_id" invisible="1" groups="!uom.group_uom"/>
                                 <field name="product_uom_id" groups="uom.group_uom"/>
                             </div>
                         </group>


### PR DESCRIPTION
Steps to reproduce the bug:
- do not activate UoM in the settings
- create a scrap order for any product
- try to validate it

Problem:
An Error is triggered: "The operation cannot be completed: - Create/update: a mandatory field is not set."

The group unification done by https://github.com/odoo/odoo/pull/95729 missed adding the often mandatory `product_uom_id` into some views when `uom.group_uom` is False.

opw-3041155
