### PR TITLE
[FIX] payment: avoid showing processing when saving payment methods

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -820,6 +820,7 @@ class PaymentTransaction(models.Model):
         - `state_message`: The information message about the state.
         - `is_post_processed`: Whether the transaction has already been post-processed.
         - `landing_route`: The route the user is redirected to after the transaction.
+        - `operation`: The type of operation the transaction is.
         - Additional provider-specific entries.
 
         Note: `self.ensure_one()`
@@ -838,6 +839,7 @@ class PaymentTransaction(models.Model):
             'state_message': self.state_message,
             'is_post_processed': self.is_post_processed,
             'landing_route': self.landing_route,
+            'operation': self.operation,
         }
         _logger.debug(
             "post-processing values of transaction with reference %s for provider with id %s:\n%s",

--- a/addons/payment/static/src/js/post_processing.js
+++ b/addons/payment/static/src/js/post_processing.js
@@ -77,6 +77,15 @@ odoo.define('payment.post_processing', function (require) {
 
             // group the transaction according to their state
             display_values_list.forEach(function (display_values) {
+
+                // in case one of the tx is a validation operation (creation of a token)
+                // we immediately redirect to the landing route, no need of showing the
+                // payment status page
+                if (display_values.operation === 'validation') {
+                    window.location = display_values.landing_route;
+                    return;
+                }
+
                 var key = 'tx_' + display_values.state;
                 if(key in render_values) {
                     if (display_values["display_message"]) {
@@ -95,7 +104,7 @@ odoo.define('payment.post_processing', function (require) {
                 }
                 return nbTx;
             }
-                       
+
             /*
             * When the server sends the list of monitored transactions, it tries to post-process 
             * all the successful ones. If it succeeds or if the post-process has already been made, 


### PR DESCRIPTION
Transactions post processing information where showing during the creation of tokens flow.
After this commit we will be automatically redirected to the landing page whenever a save payment method flow is triggered. This does not affect the user experience for the providers that support tokenization.

Task - 3050181



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
