### PR TITLE
[FIX] web, sms: text area in sms template displayed correctly

### DIFF
--- a/addons/sms/views/sms_template_views.xml
+++ b/addons/sms/views/sms_template_views.xml
@@ -49,7 +49,7 @@
                     <notebook>
                         <page string="Content" name="content">
                             <group>
-                                <field name="body" widget="sms_widget" nolabel="1"/>
+                                <field name="body" widget="sms_widget" nolabel="1" colspan="2"/>
                             </group>
                         </page>
                     </notebook>

--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -94,7 +94,7 @@ export class TextField extends Component {
         });
         textarea.style.height = "auto";
         const height = Math.max(this.minimumHeight, textarea.scrollHeight + heightOffset);
-        Object.assign(textarea.style, previousStyle, { height: `${height}px` });
+        Object.assign(textarea.style, previousStyle, { height: `${height}px`, display: "inline-block" });
     }
 
     onInput() {


### PR DESCRIPTION
Steps to reproduce:

- Dev mode on.
- Go to sms templates.
- Open any template.

Issue:

See the very narrow adjustable column and the translation button placed incorrectly for the text area.

Solution:

For the text area view we just need to specify the colspan of it as 2, as it is set as 1 by default. And for the translation button, we need to give the text area widget the "display> "inline-block" in order to be displayed correctly, as it is for other fields.

opw-3032856
