### PR TITLE
[FIX] web: unable to set default options on developer mode

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -236,9 +236,7 @@ class SetDefaultDialog extends Component {
                     fieldInfo.type === "one2many" ||
                     fieldInfo.type === "many2many" ||
                     fieldInfo.type === "binary" ||
-                    this.fieldsInfo[fieldName].options.isPassword ||
-                    fieldInfo.depends === undefined ||
-                    fieldInfo.depends.length !== 0
+                    this.fieldsInfo[fieldName].options.isPassword
                 ) {
                     return false;
                 }


### PR DESCRIPTION
Steps to reproduce:
    - enable debug mode;
    - go to the sales model;
    - try to set default options from the technical bug.

Issue:
    It does not show any options to set default value.

Cause:
    The condition that determines if the field is added to the list of default options takes into account a 'key' which does not exist.

opw-3031290