### PR TITLE
[FIX] account: round sale orders' taxlines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -875,6 +875,7 @@ class AccountTax(models.Model):
         for grouping_key, tax_values in base_line_map.items():
             if tax_values['currency_id']:
                 currency = self.env['res.currency'].browse(tax_values['currency_id'])
+                tax_values['tax_amount'] = currency.round(tax_values['tax_amount'])
                 res['totals'][currency]['amount_tax'] += currency.round(tax_values['tax_amount'])
 
             if grouping_key in existing_tax_line_map:


### PR DESCRIPTION
### Steps to reproduce
* create two 17% sales taxes. We'll call those taxes `17a` and `17b`.
* set rounding method to global
* set product price's decimal accuracy to 5
* create a SO with the following 2 lines:
  * Quantity = `1`, Price = `50.4`, Taxes = `17a`
  * Quantity = `1`, Price = `47.208`, Taxes = `17b`
* note that the total tax amount on the SO is `16.59`
* confirm and invoice the SO.

You should see that the total tax amount on the invoice is `16.60`. The invoice and SO should have the same tax amount.

opw-3014755