### PR TITLE
[FIX] mail: email correctly sent with full composer

### DIFF
--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import users
+from odoo.tests import Form, users
 from odoo.addons.mail.tests.common import MailCommon
 
 
@@ -72,3 +72,22 @@ class TestMailComposer(MailCommon):
         self.assertIn(self.body_html,
             values[self.partner_employee.id]['body_html'],
             'We must preserve (mso) comments in email html')
+
+    def test_default_recipient_with_private_partner(self):
+        #Create a private partner
+        partner_private = self.env['res.partner'].create({
+            'name': 'Private',
+            'email': 'private@gmail.com',
+            'type': 'private',
+        })
+
+        form = Form(self.env['mail.compose.message'].with_context({
+            'default_partner_ids': partner_private.ids,
+            'active_ids': [self.test_record.id],
+            'active_model': self.test_record._name,
+            'active_id': self.test_record.id
+            }))
+        #assert partner_private is in the partner_ids
+        self.assertIn(partner_private, form.partner_ids)
+        saved_form = form.save()
+        self.assertIn(partner_private, saved_form.partner_ids)

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -82,6 +82,9 @@ class MailComposer(models.TransientModel):
         filtered_result = dict((fname, result[fname]) for fname in result if fname in fields)
         return filtered_result
 
+    def _partner_ids_domain(self):
+        return ['|', ('type', '!=', 'private'), ('id', 'in', self.env.context.get('default_partner_ids', []))]
+
     # content
     subject = fields.Char('Subject', compute=False)
     body = fields.Html('Contents', render_engine='qweb', compute=False, default='', sanitize_style=True)
@@ -139,7 +142,7 @@ class MailComposer(models.TransientModel):
     partner_ids = fields.Many2many(
         'res.partner', 'mail_compose_message_res_partner_rel',
         'wizard_id', 'partner_id', 'Additional Contacts',
-        domain=[('type', '!=', 'private')])
+        domain=_partner_ids_domain)
     # mass mode options
     notify = fields.Boolean('Notify followers', help='Notify followers of the document (mass post only)')
     auto_delete = fields.Boolean('Delete Emails',


### PR DESCRIPTION
Current behavior:
In the recruitement module, if you set an email template for the first step of the a job recruitement process. You couldn't send any other email using the full composer. This happen because the partner type is 'private' and this use type cannot be set as recipient in the full composer.

Steps to reproduce:
- Go to any job recruitement and set an email template for the first step
- Go on the website and apply for this job
- Go back to the job application and send an email using the full composer, the email is not sent to the applicant. And the applicant is not added to the followers.

opw-3010308
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
