### PR TITLE
[FIX] Maintenance: Fix the issue on select of Team Members from team.

### DIFF
--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -786,6 +786,7 @@
         <field name="model">maintenance.team</field>
         <field name="arch" type="xml">
             <tree string="Maintenance Team" editable="bottom">
+                <field name="company_id" invisible="1"/>
                 <field name="name"/>
                 <field name="member_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True}" domain="[('share', '=', False)]"/>
                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fix the error raised when we select the Team Members on Maintenance team tree view.

**Impacted versions:**
- 16.0

**Steps to Reproduce :**
- Uncheck Multi Company Access rights if assign.
- Go to the Maintenance --> Configuration --> Maintenance Teams.   
- Click on the list view and try to select the Team Members of any record.
- see the error raised.

**Current behaviour before PR:**
System shows the error when we try to add/select the Team Members.

> UncaughtPromiseError > EvaluationError
Uncaught Promise > Name 'company_id' is not defined


**Desired behavior after PR is merged:**
After this PR merge, System will allow to select the Team Members.

![Odoo-Teams](https://user-images.githubusercontent.com/114251616/199604969-49bf5333-3fa5-4359-8bf5-8c7bbd385e97.png)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
