### PR TITLE
[IMP] mail, *: remove unused is_notification field

### DIFF
--- a/addons/im_livechat/static/src/legacy/models/public_livechat_message.js
+++ b/addons/im_livechat/static/src/legacy/models/public_livechat_message.js
@@ -26,7 +26,6 @@ const PublicLivechatMessage = Class.extend({
      *   If not provided, use current date time for this message.
      * @param {integer} data.id
      * @param {boolean} [data.is_discussion = false]
-     * @param {boolean} [data.is_notification = false]
      * @param {string} [data.message_type = undefined]
      */
     init(parent, messaging, data) {
@@ -36,7 +35,6 @@ const PublicLivechatMessage = Class.extend({
         this._date = data.date ? moment(time.str_to_datetime(data.date)) : moment();
         this._id = data.id;
         this._isDiscussion = data.is_discussion;
-        this._isNotification = data.is_notification;
         this._serverAuthor = data.author;
         this._type = data.message_type || undefined;
 
@@ -196,22 +194,6 @@ const PublicLivechatMessage = Class.extend({
      */
     isNote() {
         return this._isNote;
-    },
-    /**
-     * State whether this message is a notification
-     *
-     * User notifications are defined as either
-     *      - notes
-     *      - pushed to user Inbox or email through classic notification process
-     *      - not linked to any document, meaning model and res_id are void
-     *
-     * This is useful in order to display white background for user
-     * notifications in chatter
-     *
-     * @returns {boolean}
-     */
-    isNotification() {
-        return this._isNotification;
     },
     setChatbotStepAnswerId(chatbotStepAnswerId) {
         this._chatbotStepAnswerId = chatbotStepAnswerId;

--- a/addons/im_livechat/static/src/legacy/widgets/public_livechat_view/public_livechat_view.xml
+++ b/addons/im_livechat/static/src/legacy/widgets/public_livechat_view/public_livechat_view.xml
@@ -133,7 +133,7 @@
         @param {integer} [options.selectedMessageID]
     -->
     <t t-name="im_livechat.legacy.mail.widget.Thread.Message">
-        <div t-if="!message.isEmpty()" t-att-class="'o_thread_message o_PublicLivechatMessage ' + (message.getID() === options.selectedMessageID ? 'o_thread_selected_message ' : ' ') + (message.isDiscussion() or message.isNotification() ? ' o_mail_discussion ' : ' o_mail_not_discussion ') + (message.isVisitorTheAuthor() ? 'o-isVisitorTheAuthor' : '')">
+        <div t-if="!message.isEmpty()" t-att-class="'o_thread_message o_PublicLivechatMessage ' + (message.getID() === options.selectedMessageID ? 'o_thread_selected_message ' : ' ') + (message.isDiscussion() ? ' o_mail_discussion ' : ' o_mail_not_discussion ') + (message.isVisitorTheAuthor() ? 'o-isVisitorTheAuthor' : '')">
             <div t-if="options.displayAvatars" class="o_thread_message_sidebar">
                 <t t-if="message.hasAuthor()">
                     <div t-if="displayAuthorMessages[message.getID()]" class="o_thread_message_sidebar_image">

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -6,12 +6,12 @@
             t-att-class="{
                 'o_MessageView_active': isActive,
                 'o-clicked': messagingAsClickedMessageView,
-                'o-discussion': message.isDiscussionOrNotification,
+                'o-discussion': message.isDisplayedInChatBubble,
                 'o-has-message-selection': messageListViewItemOwner and messageListViewItemOwner.messageListViewOwner.threadViewOwner.replyingToMessageView,
                 'o-highlighted': message.isHighlighted or isHighlighted,
                 'o-isReplyHighlighted bg-view shadow-lg': isHighlighted,
                 'o-isDeviceSmall': messaging.device.isSmall,
-                'o-not-discussion': !message.isDiscussionOrNotification,
+                'o-not-discussion': !message.isDisplayedInChatBubble,
                 'o-notification': message.message_type === 'notification',
                 'o-selected': isSelected,
                 'o-squashed pt-1': isSquashed,
@@ -86,7 +86,7 @@
                         </div>
                     </div>
                     <div
-                        class="o_MessageView_bubbleWrap position-relative d-flex align-items-start"
+                        class="position-relative d-flex align-items-start"
                         t-att-class="{
                             'd-flex justify-content-end': isInChatWindowAndIsAlignedRight,
                             'pe-4': isInChatWindowAndIsAlignedLeft and !composerViewInEditing,
@@ -96,27 +96,27 @@
                         }"
                     >
                         <div
-                            class="o_MessageView_bubble position-relative"
+                            class="position-relative"
                             t-att-class="{
                                 'flex-grow-1': composerViewInEditing,
-                                'w-100': !(message.isDiscussionOrNotification or message.message_type === 'sms') and !isInChatWindow,
+                                'w-100': !message.isDisplayedInChatBubble and !isInChatWindow,
                                 'me-2': isInChatWindowAndIsAlignedLeft and !composerViewInEditing,
                                 'ms-2': isInChatWindowAndIsAlignedRight and !composerViewInEditing,
-                                'p-3': message.prettyBody !== '' and !composerViewInEditing and (message.isDiscussionOrNotification or message.message_type === 'sms'),
+                                'p-3': message.prettyBody !== '' and !composerViewInEditing and message.isDisplayedInChatBubble,
                                 'p-2': composerViewInEditing,
-                                'text-muted': message.is_note and message.message_type !== 'sms',
+                                'text-muted': message.hasTextMuted,
                             }"
                         >
                             <div
                                 t-if="message.prettyBody !== '' || composerViewInEditing"
                                 class="o_MessageView_background position-absolute start-0 top-0 w-100 h-100"
                                 t-att-class="{
-                                    'rounded-end-3': !isInChatWindowAndIsAlignedRight and (message.isDiscussionOrNotification or message.message_type === 'sms'),
-                                    'rounded-start-3': isInChatWindowAndIsAlignedRight and (message.isDiscussionOrNotification or message.message_type === 'sms'),
-                                    'rounded-bottom-3 border': message.isDiscussionOrNotification or message.message_type === 'sms',
-                                    'o-isAuthorNotCurrentUserOrGuest border-info bg-info-light': !message.isCurrentUserOrGuestAuthor and !message.isHighlighted and (message.isDiscussionOrNotification or message.message_type === 'sms'),
-                                    'border-success bg-success-light opacity-25': message.isCurrentUserOrGuestAuthor and !message.isHighlighted and (message.isDiscussionOrNotification or message.message_type === 'sms'),
-                                    'border-warning bg-warning-light opacity-50': message.isHighlighted and (message.isDiscussionOrNotification or message.message_type === 'sms'),
+                                    'rounded-end-3': !isInChatWindowAndIsAlignedRight and message.isDisplayedInChatBubble,
+                                    'rounded-start-3': isInChatWindowAndIsAlignedRight and message.isDisplayedInChatBubble,
+                                    'rounded-bottom-3 border': message.isDisplayedInChatBubble,
+                                    'o-isAuthorNotCurrentUserOrGuest border-info bg-info-light': !message.isCurrentUserOrGuestAuthor and !message.isHighlighted and message.isDisplayedInChatBubble,
+                                    'border-success bg-success-light opacity-25': message.isCurrentUserOrGuestAuthor and !message.isHighlighted and message.isDisplayedInChatBubble,
+                                    'border-warning bg-warning-light opacity-50': message.isHighlighted and message.isDisplayedInChatBubble,
                                 }"
                             />
                             <em t-if="message.subject and !message.isSubjectSimilarToOriginThreadName" class="o_MessageView_subject position-relative mb-1 me-2">Subject: <t t-esc="message.subject"/></em>
@@ -142,21 +142,21 @@
                                 'position-absolute top-0': !isInDiscuss,
                                 'start-0 ms-3': isInChatWindowAndIsAlignedRight,
                                 'end-0 me-3': isInChatWindowAndIsAlignedLeft || isInChatter,
-                                'mt-n4': isInChatter and (message.isDiscussionOrNotification or message.message_type === 'sms'),
-                                'mt-n5': isInChatter and !(message.isDiscussionOrNotification or message.message_type === 'sms'),
-                                'mt-2': isInDiscuss and (message.isDiscussionOrNotification or message.message_type === 'sms'),
+                                'mt-n4': isInChatter and message.isDisplayedInChatBubble,
+                                'mt-n5': isInChatter and !message.isDisplayedInChatBubble,
+                                'mt-2': isInDiscuss and message.isDisplayedInChatBubble,
                                 'mt-n3': isInChatWindow,
                                 'ms-2': isInDiscuss,
                             }"
                             t-attf-class="{{ isActive ? 'visible' : 'invisible' }}"
                         >
-                            <MessageActionList record="messageActionList" classNameObj="{ 'mt-3': isInChatter and !(message.isDiscussionOrNotification or message.message_type === 'sms') }"/>
+                            <MessageActionList record="messageActionList" classNameObj="{ 'mt-3': isInChatter and !message.isDisplayedInChatBubble }"/>
                         </div>
                     </div>
                     <AttachmentList t-if="attachmentList" record="attachmentList" className="'position-relative'"/>
                     <LinkPreviewListView t-if="linkPreviewListView" record="linkPreviewListView"/>
                     <div t-if="message.messageReactionGroups.length > 0" class="position-relative d-flex flex-wrap"
-                    t-att-class="{ 'flex-row-reverse me-3': isInChatWindowAndIsAlignedRight, 'ms-3': !isInChatWindowAndIsAlignedRight and (message.isDiscussionOrNotification or message.message_type === 'sms')}" t-attf-class="{{ message.isDiscussionOrNotification or message.message_type === 'sms' ? 'mt-n2' : 'mt-1' }}">
+                    t-att-class="{ 'flex-row-reverse me-3': isInChatWindowAndIsAlignedRight, 'ms-3': !isInChatWindowAndIsAlignedRight and message.isDisplayedInChatBubble }" t-attf-class="{{ message.isDisplayedInChatBubble ? 'mt-n2' : 'mt-1' }}">
                         <MessageReactionGroup t-foreach="message.messageReactionGroups" t-as="messageReactionGroup" t-key="messageReactionGroup.localId" className="'mb-1'" classNameObj="{ 'ms-1': isInChatWindowAndIsAlignedRight, 'me-1': !(isInChatWindowAndIsAlignedRight) }" record="messageReactionGroup"/>
                     </div>
                 </div>

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -46,9 +46,6 @@ Model({
             if ('is_note' in data) {
                 data2.is_note = data.is_note;
             }
-            if ('is_notification' in data) {
-                data2.is_notification = data.is_notification;
-            }
             data2.linkPreviews = data.linkPreviews;
             if ('messageReactionGroups' in data) {
                 data2.messageReactionGroups = data.messageReactionGroups;
@@ -412,6 +409,14 @@ Model({
                 return !this.isTemporary && !this.isTransient;
             },
         }),
+        hasTextMuted: attr({ default: false,
+            compute() {
+                if (this.is_note) {
+                    return true;
+                }
+                return clear();
+            },
+        }),
         id: attr({ identifying: true }),
         isCurrentUserOrGuestAuthor: attr({ default: false,
             compute() {
@@ -473,9 +478,9 @@ Model({
                 return inlineBody.toLowerCase() === this.subtype_description.toLowerCase();
             },
         }),
-        isDiscussionOrNotification: attr({ default: false,
+        isDisplayedInChatBubble: attr({ default: false,
             compute() {
-                if (this.is_discussion || this.is_notification) {
+                if (this.is_discussion) {
                     return true;
                 }
                 return clear();
@@ -561,7 +566,6 @@ Model({
          */
         isNeedaction: attr({ default: false }),
         is_note: attr({ default: false }),
-        is_notification: attr({ default: false }),
         /**
          * Determine whether the current partner is mentioned.
          */
@@ -613,7 +617,10 @@ Model({
                 if (this.message_type === 'notification') {
                     return this.env._t("System notification");
                 }
-                if (!this.is_discussion && !this.is_notification) {
+                if (this.message_type === 'user_notification') {
+                    return this.env._t("User notification");
+                }
+                if (!this.is_discussion) {
                     return this.env._t("Note");
                 }
                 return this.env._t("Message");

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -263,7 +263,7 @@ Model({
             }
             this.message.originThread.update({
                 composer: {
-                    isLog: !this.message.is_discussion && !this.message.is_notification,
+                    isLog: !this.message.is_discussion,
                 },
             });
             this.messageListViewItemOwner.messageListViewOwner.threadViewOwner.update({

--- a/addons/mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/mail/static/tests/helpers/model_definitions_setup.js
@@ -69,7 +69,6 @@ insertModelFields('mail.message', {
     history_partner_ids: { relation: 'res.partner', string: "Partners with History", type: 'many2many' },
     is_discussion: { string: 'Discussion', type: 'boolean' },
     is_note: { string: "Discussion", type: 'boolean' },
-    is_notification: { string: "Note", type: 'boolean' },
     needaction_partner_ids: { relation: 'res.partner', string: "Partners with Need Action", type: 'many2many' },
     res_model_name: { string: "Res Model Name", type: 'char' },
 });

--- a/addons/sms/static/src/models/message.js
+++ b/addons/sms/static/src/models/message.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { Patch } from '@mail/model';
+import { clear } from '@mail/model/model_field_command';
 
 Patch({
     name: 'Message',
@@ -21,6 +22,24 @@ Patch({
             } else {
                 this._super(...arguments);
             }
+        },
+    },
+    fields: {
+        hasTextMuted: {
+            compute() {
+                if (this.message_type !== 'sms') {
+                    return clear();
+                }
+                return this._super();
+            }
+        },
+        isDisplayedInChatBubble: {
+            compute() {
+                if (this.message_type === 'sms') {
+                    return true;
+                }
+                return this._super();
+            },
         },
     },
 });


### PR DESCRIPTION
*: im_livechat, sms.

The `is_notification` message field is misleading: the `notification`
message type exists, but the value of this field relies on the message
type to be `user_notification`. Moreover, this field is not required
anymore.

Besides, the `mail.message` template has condition referencing the `sms`
message type while it does not exist in the mail module.

This PR removes the `is_notification` field and moves the `sms` message
type condition to the `sms` module.