### PR TITLE
[FIX] pos_sale: correctly apply down payments that include taxes

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -47,7 +47,7 @@ class PosOrder(models.Model):
                 sale_line = self.env['sale.order.line'].create({
                     'order_id': line.sale_order_origin_id.id,
                     'product_id': line.product_id.id,
-                    'price_unit': line.price_unit,
+                    'price_unit': line.price_subtotal_incl,
                     'product_uom_qty': 0,
                     'tax_id': [(6, 0, line.tax_ids.ids)],
                     'is_downpayment': True,


### PR DESCRIPTION
Current behavior:
If the down payment product has a tax, the tax is not applied correctly to the order. Currently, if you pay a down payment of 100€ with a tax of 15%, you will pay the 115€, but the order will be paid with 100€.

Steps to reproduce:
- Edit the down payment product and add a tax of 15%
- Create a new order and add a product for 1000$
- Start a PoS session
- Apply a 10% down payment to the order you just created, you should pay 100$ + 15$ (tax) = 115$
- Pay the down payment
- Go back to the order, and create an invoice (make sure "Deduce down payment" is checked)
- The value of the down payment in the invoice is not correct (100$ instead of 115$)

opw-3013644
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
