### PR TITLE
[IMP] web: add isAvailable in options command

### DIFF
--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -21,6 +21,7 @@ import { Component, xml, EventBus } from "@odoo/owl";
 /**
  * @typedef {import("../hotkeys/hotkey_service").HotkeyOptions & {
  *  category?: string;
+ *  isAvailable: ()=>(boolean);
  * }} CommandOptions
  */
 

--- a/addons/web/static/src/core/commands/default_providers.js
+++ b/addons/web/static/src/core/commands/default_providers.js
@@ -38,12 +38,15 @@ const commandCategoryRegistry = registry.category("command_categories");
 const commandProviderRegistry = registry.category("command_provider");
 commandProviderRegistry.add("command", {
     provide: (env, options = {}) => {
-        const commands = env.services.command.getCommands(options.activeElement).map((cmd) => {
-            cmd.category = commandCategoryRegistry.contains(cmd.category)
-                ? cmd.category
-                : "default";
-            return cmd;
-        });
+        const commands = env.services.command
+            .getCommands(options.activeElement)
+            .map((cmd) => {
+                cmd.category = commandCategoryRegistry.contains(cmd.category)
+                    ? cmd.category
+                    : "default";
+                return cmd;
+            })
+            .filter((command) => command.isAvailable === undefined || command.isAvailable());
 
         return commands.map((command) => ({
             Component: command.hotkey ? HotkeyCommandItem : DefaultCommandItem,

--- a/addons/web/static/tests/core/commands/command_service_tests.js
+++ b/addons/web/static/tests/core/commands/command_service_tests.js
@@ -169,6 +169,33 @@ QUnit.test("useCommand hook when the activeElement change", async (assert) => {
     );
 });
 
+QUnit.test("useCommand hook with isAvailable", async (assert) => {
+    let available = false;
+    class MyComponent extends TestComponent {
+        setup() {
+            useCommand("Take the throne", () => {}, {
+                isAvailable: () => {
+                    return available;
+                },
+            });
+        }
+    }
+    await mount(MyComponent, target, { env });
+
+    triggerHotkey("control+k");
+    await nextTick();
+    assert.containsOnce(target, ".o_command_palette");
+    assert.containsNone(target, ".o_command");
+
+    triggerHotkey("escape");
+    await nextTick();
+    available = true;
+    triggerHotkey("control+k");
+    await nextTick();
+    assert.containsOnce(target, ".o_command_palette");
+    assert.containsOnce(target, ".o_command");
+});
+
 QUnit.test("command with hotkey", async (assert) => {
     assert.expect(2);
 


### PR DESCRIPTION
This commit adds the isAvailable option to the command. If you set this option, then it determines if the command should be displayed or not in the command palette.

Why add this option?
We want to allow a component to define a command that will be displayed according to the internal state of the component

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
