### PR TITLE
[FIX] tools, *: ignore the active field when updating assets

### DIFF
--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -21,6 +21,7 @@ from . import test_session
 from . import test_settings
 from . import test_snippet_background_video
 from . import test_systray
+from . import test_theme_ir_asset
 from . import test_views_during_module_operation
 from . import test_website_controller_page
 from . import test_website_field_sanitize

--- a/addons/test_website/tests/asset_tag.xml
+++ b/addons/test_website/tests/asset_tag.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<asset id="theme_default.test_asset_tag_aaa" name="Test asset tag (init active => keep active => update active)">
+    <bundle>test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+</asset>
+<asset id="theme_default.test_asset_tag_aii" name="Test asset tag (init active => make inactive => update inactive)">
+    <bundle>test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+</asset>
+<asset id="theme_default.test_asset_tag_aia" name="Test asset tag (init active => make inactive => update active)">
+    <bundle>test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+    <field name="active">True</field> <!-- Take into account during update -->
+</asset>
+<asset id="theme_default.test_asset_tag_iii" name="Test asset tag (init inactive => keep inactive => update inactive)" active="False">
+    <bundle>test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+</asset>
+<asset id="theme_default.test_asset_tag_iaa" name="Test asset tag (init inactive => make active => update active)" active="False">
+    <bundle>test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+</asset>
+<asset id="theme_default.test_asset_tag_prepend" name="Test asset tag with directive">
+    <bundle directive="prepend">test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+</asset>
+<asset id="theme_default.test_asset_tag_extra" name="Test asset tag with extra field">
+    <bundle>test_asset_bundle</bundle>
+    <path>theme_default/tests/something.scss</path>
+    <field name="sequence" eval="17"/>
+</asset>
+
+</odoo>

--- a/addons/test_website/tests/test_theme_ir_asset.py
+++ b/addons/test_website/tests/test_theme_ir_asset.py
@@ -1,0 +1,77 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tools import convert_file
+from odoo.tools.misc import file_path
+
+
+@tagged('-at_install', 'post_install')
+class TestThemeAsset(TransactionCase):
+
+    def test_theme_asset_tag(self):
+        """
+        Verify that assets defined with the <asset> tag are properly imported.
+        """
+        # Load new records
+        convert_file(
+            self.env, 'theme_default',
+            file_path('test_website/tests/asset_tag.xml'),
+            {}, 'init', False, 'test'
+        )
+        active_keep_asset = self.env.ref('theme_default.test_asset_tag_aaa')
+        inactive_keep_asset = self.env.ref('theme_default.test_asset_tag_iii')
+        active_switch_asset_reset = self.env.ref('theme_default.test_asset_tag_aia')
+        active_switch_asset_ignore = self.env.ref('theme_default.test_asset_tag_aii')
+        inactive_switch_asset = self.env.ref('theme_default.test_asset_tag_iaa')
+        prepend_asset = self.env.ref('theme_default.test_asset_tag_prepend')
+        asset_with_extra_field = self.env.ref('theme_default.test_asset_tag_extra')
+
+        # Verify initial load
+        self.assertEqual(prepend_asset._name, 'theme.ir.asset', 'Model should be theme.ir.asset')
+        self.assertEqual(prepend_asset.name, 'Test asset tag with directive', 'Name not loaded')
+        self.assertEqual(prepend_asset.directive, 'prepend', 'Directive not loaded')
+        self.assertEqual(prepend_asset.bundle, 'test_asset_bundle', 'Bundle not loaded')
+        self.assertEqual(prepend_asset.path, 'theme_default/tests/something.scss', 'Path not loaded')
+        self.assertEqual(asset_with_extra_field.sequence, 17, 'Sequence not loaded')
+        self.assertTrue(active_keep_asset.active, 'Should be active')
+        self.assertTrue(active_switch_asset_reset.active, 'Should be active')
+        self.assertTrue(active_switch_asset_ignore.active, 'Should be active')
+        self.assertFalse(inactive_keep_asset.active, 'Should be inactive')
+        self.assertFalse(inactive_switch_asset.active, 'Should be inactive')
+
+        # Patch records
+        prepend_asset.name = 'changed'
+        prepend_asset.directive = 'append'
+        prepend_asset.bundle = 'changed'
+        prepend_asset.path = 'theme_default/tests/changed.scss'
+        asset_with_extra_field.sequence = 3
+        active_switch_asset_reset.active = False
+        active_switch_asset_ignore.active = False
+        inactive_switch_asset.active = True
+
+        # Update records
+        convert_file(
+            self.env, 'theme_default',
+            file_path('test_website/tests/asset_tag.xml'),
+            {
+                'theme_default.test_asset_tag_aaa': active_keep_asset.id,
+                'theme_default.test_asset_tag_iii': inactive_keep_asset.id,
+                'theme_default.test_asset_tag_aia': active_switch_asset_reset.id,
+                'theme_default.test_asset_tag_aii': active_switch_asset_ignore.id,
+                'theme_default.test_asset_tag_iaa': inactive_switch_asset.id,
+                'theme_default.test_asset_tag_prepend': prepend_asset.id,
+                'theme_default.test_asset_tag_extra': asset_with_extra_field.id,
+            }, 'update', False, 'test'
+        )
+
+        # Verify updated load
+        self.assertEqual(prepend_asset.name, 'Test asset tag with directive', 'Name not restored')
+        self.assertEqual(prepend_asset.directive, 'prepend', 'Directive not restored')
+        self.assertEqual(prepend_asset.bundle, 'test_asset_bundle', 'Bundle not restored')
+        self.assertEqual(prepend_asset.path, 'theme_default/tests/something.scss', 'Path not restored')
+        self.assertEqual(asset_with_extra_field.sequence, 17, 'Sequence not restored')
+        self.assertTrue(active_keep_asset.active, 'Should be active')
+        self.assertTrue(active_switch_asset_reset.active, 'Should be reset to active')
+        self.assertFalse(active_switch_asset_ignore.active, 'Should be kept inactive')
+        self.assertFalse(inactive_keep_asset.active, 'Should be inactive')
+        self.assertTrue(inactive_switch_asset.active, 'Should be kept active')

--- a/addons/web_editor/data/editor_assets.xml
+++ b/addons/web_editor/data/editor_assets.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record id="web_editor.13_0_color_system_support_primary_variables_scss" model="ir.asset">
-            <field name="name">13 0 color system support primary variables SCSS</field>
-            <field name="bundle">web._assets_primary_variables</field>
-            <field name="path">web_editor/static/src/scss/13_0_color_system_support_primary_variables.scss</field>
-            <field name="active" eval="False"/>
-        </record>
+        <asset id="web_editor.13_0_color_system_support_primary_variables_scss" name="13 0 color system support primary variables SCSS" active="False">
+            <bundle>web._assets_primary_variables</bundle>
+            <path>web_editor/static/src/scss/13_0_color_system_support_primary_variables.scss</path>
+        </asset>
     </data>
 </odoo>

--- a/addons/website/data/ir_asset.xml
+++ b/addons/website/data/ir_asset.xml
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-
-        <record id="website.user_custom_bootstrap_overridden_scss" model="ir.asset">
-            <field name="name">User custom bootstrap overridden SCSS</field>
-            <field name="bundle">web._assets_frontend_helpers</field>
-            <field name="directive">prepend</field>
-            <field name="path">website/static/src/scss/user_custom_bootstrap_overridden.scss</field>
+        <asset id="website.user_custom_bootstrap_overridden_scss" name="User custom bootstrap overridden SCSS">
+            <bundle directive="prepend">web._assets_frontend_helpers</bundle>
+            <path>website/static/src/scss/user_custom_bootstrap_overridden.scss</path>
             <field name="sequence" eval="99"/>
-        </record>
+        </asset>
 
-        <record id="website.user_custom_rules_scss" model="ir.asset">
-            <field name="name">User custom rules SCSS</field>
-            <field name="bundle">web.assets_frontend</field>
-            <field name="path">website/static/src/scss/user_custom_rules.scss</field>
+        <asset id="website.user_custom_rules_scss" name="User custom rules SCSS">
+            <bundle>web.assets_frontend</bundle>
+            <path>website/static/src/scss/user_custom_rules.scss</path>
             <field name="sequence" eval="99"/>
-        </record>
+        </asset>
 
-        <record id="website.configurator_tour" model="ir.asset">
+        <asset id="website.configurator_tour" name="Website Configurator Tour" active="False">
             <field name="key">website.configurator_tour</field>
-            <field name="name">Website Configurator Tour</field>
-            <field name="bundle">website.assets_editor</field>
-            <field name="path">website/static/src/js/tours/configurator_tour.js</field>
-            <field name="active" eval="False"/>
-        </record>
-
+            <bundle>website.assets_editor</bundle>
+            <path>website/static/src/js/tours/configurator_tour.js</path>
+        </asset>
     </data>
 </odoo>

--- a/addons/website/views/snippets/s_alert.xml
+++ b/addons/website/views/snippets/s_alert.xml
@@ -39,10 +39,9 @@
     </xpath>
 </template>
 
-<record id="website.s_alert_000_scss" model="ir.asset">
-    <field name="name">Alert 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_alert/000.scss</field>
-</record>
+<asset id="website.s_alert_000_scss" name="Alert 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_alert/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_badge.xml
+++ b/addons/website/views/snippets/s_badge.xml
@@ -18,16 +18,14 @@
     </xpath>
 </template>
 
-<record id="website.s_badge_000_variables_scss" model="ir.asset">
-    <field name="name">Badge 000 variables SCSS</field>
-    <field name="bundle">web._assets_primary_variables</field>
-    <field name="path">website/static/src/snippets/s_badge/000_variables.scss</field>
-</record>
+<asset id="website.s_badge_000_variables_scss" name="Badge 000 variables SCSS">
+    <bundle>web._assets_primary_variables</bundle>
+    <path>website/static/src/snippets/s_badge/000_variables.scss</path>
+</asset>
 
-<record id="website.s_badge_000_scss" model="ir.asset">
-    <field name="name">Badge 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_badge/000.scss</field>
-</record>
+<asset id="website.s_badge_000_scss" name="Badge 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_badge/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_blockquote.xml
+++ b/addons/website/views/snippets/s_blockquote.xml
@@ -53,10 +53,9 @@
     </xpath>
 </template>
 
-<record id="website.s_blockquote_000_scss" model="ir.asset">
-    <field name="name">Blockquote 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_blockquote/000.scss</field>
-</record>
+<asset id="website.s_blockquote_000_scss" name="Blockquote 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_blockquote/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_btn.xml
+++ b/addons/website/views/snippets/s_btn.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<record id="website.s_btn_000_scss" model="ir.asset">
-    <field name="name">Btn 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_btn/000.scss</field>
-</record>
+<asset id="website.s_btn_000_scss" name="Btn 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_btn/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_card.xml
+++ b/addons/website/views/snippets/s_card.xml
@@ -13,11 +13,10 @@
     </div>
 </template>
 
-<record id="website.s_card_000_scss" model="ir.asset">
-    <field name="name">Card 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_card/000.scss</field>
-</record>
+<asset id="website.s_card_000_scss" name="Card 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_card/000.scss</path>
+</asset>
 
 
 </odoo>

--- a/addons/website/views/snippets/s_chart.xml
+++ b/addons/website/views/snippets/s_chart.xml
@@ -68,10 +68,9 @@
     </xpath>
 </template>
 
-<record id="website.s_chart_000_js" model="ir.asset">
-    <field name="name">Chart 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_chart/000.js</field>
-</record>
+<asset id="website.s_chart_000_js" name="Chart 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_chart/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_color_blocks_2.xml
+++ b/addons/website/views/snippets/s_color_blocks_2.xml
@@ -22,10 +22,9 @@
     </section>
 </template>
 
-<record id="website.s_color_blocks_2_000_scss" model="ir.asset">
-    <field name="name">Color blocks 2 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_color_blocks_2/000.scss</field>
-</record>
+<asset id="website.s_color_blocks_2_000_scss" name="Color blocks 2 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_color_blocks_2/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_company_team.xml
+++ b/addons/website/views/snippets/s_company_team.xml
@@ -58,10 +58,9 @@
     </section>
 </template>
 
-<record id="website.s_company_team_000_scss" model="ir.asset">
-    <field name="name">Company team 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_company_team/000.scss</field>
-</record>
+<asset id="website.s_company_team_000_scss" name="Company team 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_company_team/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_comparisons.xml
+++ b/addons/website/views/snippets/s_comparisons.xml
@@ -79,10 +79,9 @@
     </section>
 </template>
 
-<record id="website.s_comparisons_000_scss" model="ir.asset">
-    <field name="name">Comparisons 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_comparisons/000.scss</field>
-</record>
+<asset id="website.s_comparisons_000_scss" name="Comparisons 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_comparisons/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -80,16 +80,14 @@
     </xpath>
 </template>
 
-<record id="website.s_countdown_000_js" model="ir.asset">
-    <field name="name">Countdown 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_countdown/000.js</field>
-</record>
+<asset id="website.s_countdown_000_js" name="Countdown 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_countdown/000.js</path>
+</asset>
 
-<record id="website.s_countdown_000_xml" model="ir.asset">
-    <field name="name">Countdown 000 XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_countdown/000.xml</field>
-</record>
+<asset id="website.s_countdown_000_xml" name="Countdown 000 XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_countdown/000.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -38,22 +38,19 @@
         </xpath>
     </template>
 
-<record id="website.s_dynamic_snippet_000_scss" model="ir.asset">
-    <field name="name">Dynamic snippet 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_dynamic_snippet/000.scss</field>
-</record>
+<asset id="website.s_dynamic_snippet_000_scss" name="Dynamic snippet 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_dynamic_snippet/000.scss</path>
+</asset>
 
-<record id="website.s_dynamic_snippet_000_js" model="ir.asset">
-    <field name="name">Dynamic snippet 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_dynamic_snippet/000.js</field>
-</record>
+<asset id="website.s_dynamic_snippet_000_js" name="Dynamic snippet 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_dynamic_snippet/000.js</path>
+</asset>
 
-<record id="website.s_dynamic_snippet_000_xml" model="ir.asset">
-    <field name="name">Dynamic snippet 000 XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_dynamic_snippet/000.xml</field>
-</record>
+<asset id="website.s_dynamic_snippet_000_xml" name="Dynamic snippet 000 XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_dynamic_snippet/000.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
@@ -24,22 +24,19 @@
         </xpath>
     </template>
 
-<record id="website.s_dynamic_snippet_carousel_000_scss" model="ir.asset">
-    <field name="name">Dynamic snippet carousel 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_dynamic_snippet_carousel/000.scss</field>
-</record>
+<asset id="website.s_dynamic_snippet_carousel_000_scss" name="Dynamic snippet carousel 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_dynamic_snippet_carousel/000.scss</path>
+</asset>
 
-<record id="website.s_dynamic_snippet_carousel_000_js" model="ir.asset">
-    <field name="name">Dynamic snippet carousel 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_dynamic_snippet_carousel/000.js</field>
-</record>
+<asset id="website.s_dynamic_snippet_carousel_000_js" name="Dynamic snippet carousel 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_dynamic_snippet_carousel/000.js</path>
+</asset>
 
-<record id="website.s_dynamic_snippet_carousel_000_xml" model="ir.asset">
-    <field name="name">Dynamic snippet carousel 000 XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_dynamic_snippet_carousel/000.xml</field>
-</record>
+<asset id="website.s_dynamic_snippet_carousel_000_xml" name="Dynamic snippet carousel 000 XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_dynamic_snippet_carousel/000.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_embed_code.xml
+++ b/addons/website/views/snippets/s_embed_code.xml
@@ -33,10 +33,9 @@
 <!-- Snippet assets -->
 <!-- TODO: create a new ir.asset for s_embed_code_000_js in master. -->
 
-<record id="website.s_embed_code_000_scss" model="ir.asset">
-    <field name="name">Embed Code 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_embed_code/000.scss</field>
-</record>
+<asset id="website.s_embed_code_000_scss" name="Embed Code 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_embed_code/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_facebook_page.xml
+++ b/addons/website/views/snippets/s_facebook_page.xml
@@ -23,10 +23,9 @@
 </template>
 
 <!-- Snippet assets -->
-<record id="website.s_facebook_page_000_js" model="ir.asset">
-    <field name="name">Facebook page 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_facebook_page/000.js</field>
-</record>
+<asset id="website.s_facebook_page_000_js" name="Facebook page 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_facebook_page/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_faq_collapse.xml
+++ b/addons/website/views/snippets/s_faq_collapse.xml
@@ -55,10 +55,9 @@
     </xpath>
 </template>
 
-<record id="website.s_faq_collapse_000_scss" model="ir.asset">
-    <field name="name">Faq collapse 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_faq_collapse/000.scss</field>
-</record>
+<asset id="website.s_faq_collapse_000_scss" name="Faq collapse 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_faq_collapse/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_features_grid.xml
+++ b/addons/website/views/snippets/s_features_grid.xml
@@ -68,10 +68,9 @@
     </section>
 </template>
 
-<record id="website.s_features_grid_000_scss" model="ir.asset">
-    <field name="name">Features grid 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_features_grid/000.scss</field>
-</record>
+<asset id="website.s_features_grid_000_scss" name="Features grid 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_features_grid/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_google_map.xml
+++ b/addons/website/views/snippets/s_google_map.xml
@@ -44,16 +44,14 @@
     </xpath>
 </template>
 
-<record id="website.s_google_map_000_scss" model="ir.asset">
-    <field name="name">Google map 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_google_map/000.scss</field>
-</record>
+<asset id="website.s_google_map_000_scss" name="Google map 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_google_map/000.scss</path>
+</asset>
 
-<record id="website.s_google_map_000_js" model="ir.asset">
-    <field name="name">Google map 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_google_map/000.js</field>
-</record>
+<asset id="website.s_google_map_000_js" name="Google map 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_google_map/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_hr.xml
+++ b/addons/website/views/snippets/s_hr.xml
@@ -29,10 +29,9 @@
     </xpath>
 </template>
 
-<record id="website.s_hr_000_scss" model="ir.asset">
-    <field name="name">Hr 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_hr/000.scss</field>
-</record>
+<asset id="website.s_hr_000_scss" name="Hr 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_hr/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -117,29 +117,24 @@
     </xpath>
 </template>
 
-<record id="website.s_image_gallery_000_js" model="ir.asset">
-    <field name="name">Image gallery 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_image_gallery/000.js</field>
-</record>
+<asset id="website.s_image_gallery_000_js" name="Image gallery 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_image_gallery/000.js</path>
+</asset>
 
-<record id="website.s_image_gallery_000_scss" model="ir.asset">
-    <field name="name">Image gallery 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_image_gallery/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_image_gallery_000_scss" name="Image gallery 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_image_gallery/000.scss</path>
+</asset>
 
-<record id="website.s_image_gallery_001_scss" model="ir.asset">
-    <field name="name">Image gallery 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_image_gallery/001.scss</field>
-</record>
+<asset id="website.s_image_gallery_001_scss" name="Image gallery 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_image_gallery/001.scss</path>
+</asset>
 
-<record id="website.s_image_gallery_000_xml" model="ir.asset">
-    <field name="name">Image gallery 000 XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_image_gallery/000.xml</field>
-</record>
+<asset id="website.s_image_gallery_000_xml" name="Image gallery 000 XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_image_gallery/000.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_instagram_page.xml
+++ b/addons/website/views/snippets/s_instagram_page.xml
@@ -25,16 +25,14 @@
     </xpath>
 </template>
 
-<record id="website.s_instagram_page_000_js" model="ir.asset">
-    <field name="name">Instagram Page 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_instagram_page/000.js</field>
-</record>
+<asset id="website.s_instagram_page_000_js" name="Instagram Page 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_instagram_page/000.js</path>
+</asset>
 
-<record id="website.s_instagram_page_000_scss" model="ir.asset">
-    <field name="name">Instagram Page 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_instagram_page/000.scss</field>
-</record>
+<asset id="website.s_instagram_page_000_scss" name="Instagram Page 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_instagram_page/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_map.xml
+++ b/addons/website/views/snippets/s_map.xml
@@ -53,16 +53,14 @@
     </xpath>
 </template>
 
-<record id="website.s_map_000_scss" model="ir.asset">
-    <field name="name">Map 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_map/000.scss</field>
-</record>
+<asset id="website.s_map_000_scss" name="Map 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_map/000.scss</path>
+</asset>
 
-<record id="website.s_map_000_js" model="ir.asset">
-    <field name="name">Map 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_map/000.js</field>
-</record>
+<asset id="website.s_map_000_js" name="Map 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_map/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_masonry_block.xml
+++ b/addons/website/views/snippets/s_masonry_block.xml
@@ -312,24 +312,19 @@
 </template>
 
 <!-- Assets -->
-<record id="website.s_masonry_block_000_scss" model="ir.asset">
-    <field name="name">Masonry block 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_masonry_block/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_masonry_block_000_scss" name="Masonry block 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_masonry_block/000.scss</path>
+</asset>
 
-<record id="website.s_masonry_block_001_scss" model="ir.asset">
-    <field name="name">Masonry block 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_masonry_block/001.scss</field>
-</record>
+<asset id="website.s_masonry_block_001_scss" name="Masonry block 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_masonry_block/001.scss</path>
+</asset>
 
-<record id="website.s_masonry_block_000_variables_scss" model="ir.asset">
-    <field name="name">Masonry block 000 variables SCSS</field>
-    <field name="bundle">web._assets_primary_variables</field>
-    <field name="path">website/static/src/snippets/s_masonry_block/000_variables.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_masonry_block_000_variables_scss" name="Masonry block 000 variables SCSS" active="False">
+    <bundle>web._assets_primary_variables</bundle>
+    <path>website/static/src/snippets/s_masonry_block/000_variables.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_media_list.xml
+++ b/addons/website/views/snippets/s_media_list.xml
@@ -104,17 +104,14 @@
     </xpath>
 </template>
 
-<record id="website.s_media_list_000_scss" model="ir.asset">
-    <field name="name">Media list 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_media_list/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_media_list_000_scss" name="Media list 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_media_list/000.scss</path>
+</asset>
 
-<record id="website.s_media_list_001_scss" model="ir.asset">
-    <field name="name">Media list 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_media_list/001.scss</field>
-</record>
+<asset id="website.s_media_list_001_scss" name="Media list 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_media_list/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_cards.xml
+++ b/addons/website/views/snippets/s_mega_menu_cards.xml
@@ -63,10 +63,9 @@
     </div>
 </template>
 
-<record id="website.s_mega_menu_cards_000_scss" model="ir.asset">
-    <field name="name">Menu - Cards 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_mega_menu_cards/000.scss</field>
-</record>
+<asset id="website.s_mega_menu_cards_000_scss" name="Menu - Cards 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_mega_menu_cards/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
@@ -68,10 +68,9 @@
     </a>
 </template>
 
-<record id="website.s_mega_menu_images_subtitles_000_scss" model="ir.asset">
-    <field name="name">Menu - images &amp; subtitles 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_mega_menu_images_subtitles/000.scss</field>
-</record>
+<asset id="website.s_mega_menu_images_subtitles_000_scss" name="Menu - images &amp; subtitles 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_mega_menu_images_subtitles/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_little_icons.xml
+++ b/addons/website/views/snippets/s_mega_menu_little_icons.xml
@@ -65,10 +65,9 @@
     </section>
 </template>
 
-<record id="website.s_mega_menu_little_icons_000_scss" model="ir.asset">
-    <field name="name">Menu - Little icons 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_mega_menu_little_icons/000.scss</field>
-</record>
+<asset id="website.s_mega_menu_little_icons_000_scss" name="Menu - Little icons 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_mega_menu_little_icons/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_menus_logos.xml
+++ b/addons/website/views/snippets/s_mega_menu_menus_logos.xml
@@ -81,10 +81,9 @@
     </section>
 </template>
 
-<record id="website.s_mega_menu_menus_logos_000_scss" model="ir.asset">
-    <field name="name">Menus &amp; logos 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_mega_menu_menus_logos/000.scss</field>
-</record>
+<asset id="website.s_mega_menu_menus_logos_000_scss" name="Menus &amp; logos 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_mega_menu_menus_logos/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
@@ -90,10 +90,9 @@
     </section>
 </template>
 
-<record id="website.s_mega_menu_odoo_menu_000_scss" model="ir.asset">
-    <field name="name">Odoo Menu 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_mega_menu_odoo_menu/000.scss</field>
-</record>
+<asset id="website.s_mega_menu_odoo_menu_000_scss" name="Odoo Menu 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_mega_menu_odoo_menu/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_mega_menu_thumbnails.xml
+++ b/addons/website/views/snippets/s_mega_menu_thumbnails.xml
@@ -105,10 +105,9 @@
     </div>
 </template>
 
-<record id="website.s_mega_menu_thumbnails_000_scss" model="ir.asset">
-    <field name="name">Menu - Thumbnails 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_mega_menu_thumbnails/000.scss</field>
-</record>
+<asset id="website.s_mega_menu_thumbnails_000_scss" name="Menu - Thumbnails 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_mega_menu_thumbnails/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -76,23 +76,19 @@
     </xpath>
 </template>
 
-<record id="website.s_popup_000_scss" model="ir.asset">
-    <field name="name">Popup 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_popup/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_popup_000_scss" name="Popup 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_popup/000.scss</path>
+</asset>
 
-<record id="website.s_popup_000_js" model="ir.asset">
-    <field name="name">Popup 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_popup/000.js</field>
-</record>
+<asset id="website.s_popup_000_js" name="Popup 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_popup/000.js</path>
+</asset>
 
-<record id="website.s_popup_001_scss" model="ir.asset">
-    <field name="name">Popup 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_popup/001.scss</field>
-</record>
+<asset id="website.s_popup_001_scss" name="Popup 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_popup/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_process_steps.xml
+++ b/addons/website/views/snippets/s_process_steps.xml
@@ -86,17 +86,14 @@
     </xpath>
 </template>
 
-<record id="website.s_process_steps_000_scss" model="ir.asset">
-    <field name="name">Process steps 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_process_steps/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_process_steps_000_scss" name="Process steps 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_process_steps/000.scss</path>
+</asset>
 
-<record id="website.s_process_steps_001_scss" model="ir.asset">
-    <field name="name">Process steps 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_process_steps/001.scss</field>
-</record>
+<asset id="website.s_process_steps_001_scss" name="Process steps 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_process_steps/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -97,10 +97,9 @@
     </xpath>
 </template>
 
-<record id="website.s_product_catalog_001_scss" model="ir.asset">
-    <field name="name">Product catalog 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_product_catalog/001.scss</field>
-</record>
+<asset id="website.s_product_catalog_001_scss" name="Product catalog 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_product_catalog/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -59,16 +59,14 @@
     </section>
 </template>
 
-<record id="website.s_product_list_000_variables_scss" model="ir.asset">
-    <field name="name">Product list 000 variables SCSS</field>
-    <field name="bundle">web._assets_primary_variables</field>
-    <field name="path">website/static/src/snippets/s_product_list/000_variables.scss</field>
-</record>
+<asset id="website.s_product_list_000_variables_scss" name="Product list 000 variables SCSS">
+    <bundle>web._assets_primary_variables</bundle>
+    <path>website/static/src/snippets/s_product_list/000_variables.scss</path>
+</asset>
 
-<record id="website.s_product_list_000_scss" model="ir.asset">
-    <field name="name">Product list 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_product_list/000.scss</field>
-</record>
+<asset id="website.s_product_list_000_scss" name="Product list 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_product_list/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -72,17 +72,14 @@
     </section>
 </template>
 
-<record id="website.s_quotes_carousel_000_scss" model="ir.asset">
-    <field name="name">Quotes carousel 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_quotes_carousel/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_quotes_carousel_000_scss" name="Quotes carousel 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_quotes_carousel/000.scss</path>
+</asset>
 
-<record id="website.s_quotes_carousel_001_scss" model="ir.asset">
-    <field name="name">Quotes carousel 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_quotes_carousel/001.scss</field>
-</record>
+<asset id="website.s_quotes_carousel_001_scss" name="Quotes carousel 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_quotes_carousel/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_rating.xml
+++ b/addons/website/views/snippets/s_rating.xml
@@ -56,17 +56,14 @@
     </xpath>
 </template>
 
-<record id="website.s_rating_000_scss" model="ir.asset">
-    <field name="name">Rating 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_rating/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_rating_000_scss" name="Rating 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_rating/000.scss</path>
+</asset>
 
-<record id="website.s_rating_001_scss" model="ir.asset">
-    <field name="name">Rating 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_rating/001.scss</field>
-</record>
+<asset id="website.s_rating_001_scss" name="Rating 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_rating/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_references.xml
+++ b/addons/website/views/snippets/s_references.xml
@@ -30,10 +30,9 @@
     </section>
 </template>
 
-<record id="website.s_references_000_scss" model="ir.asset">
-    <field name="name">References 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_references/000.scss</field>
-</record>
+<asset id="website.s_references_000_scss" name="References 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_references/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_searchbar.xml
+++ b/addons/website/views/snippets/s_searchbar.xml
@@ -58,16 +58,14 @@
     <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside" t-translation="off">, .s_searchbar_input</xpath>
 </template>
 
-<record id="website.s_searchbar_000_js" model="ir.asset">
-    <field name="name">Searchbar 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_searchbar/000.js</field>
-</record>
+<asset id="website.s_searchbar_000_js" name="Searchbar 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_searchbar/000.js</path>
+</asset>
 
-<record id="website.s_searchbar_000_xml" model="ir.asset">
-    <field name="name">Searchbar 000 XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_searchbar/000.xml</field>
-</record>
+<asset id="website.s_searchbar_000_xml" name="Searchbar 000 XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_searchbar/000.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -25,16 +25,14 @@
     </div>
 </template>
 
-<record id="website.s_share_000_scss" model="ir.asset">
-    <field name="name">Share 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_share/000.scss</field>
-</record>
+<asset id="website.s_share_000_scss" name="Share 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_share/000.scss</path>
+</asset>
 
-<record id="website.s_share_000_js" model="ir.asset">
-    <field name="name">Share 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_share/000.js</field>
-</record>
+<asset id="website.s_share_000_js" name="Share 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_share/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_showcase.xml
+++ b/addons/website/views/snippets/s_showcase.xml
@@ -62,24 +62,19 @@
 </template>
 
 <!-- Assets -->
-<record id="website.s_showcase_000_scss" model="ir.asset">
-    <field name="name">Showcase 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_showcase/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_showcase_000_scss" name="Showcase 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_showcase/000.scss</path>
+</asset>
 
-<record id="website.s_showcase_001_scss" model="ir.asset">
-    <field name="name">Showcase 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_showcase/001.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_showcase_001_scss" name="Showcase 001 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_showcase/001.scss</path>
+</asset>
 
-<record id="website.s_showcase_002_scss" model="ir.asset">
-    <field name="name">Showcase 002 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_showcase/002.scss</field>
-</record>
+<asset id="website.s_showcase_002_scss" name="Showcase 002 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_showcase/002.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -45,10 +45,9 @@ title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
     </xpath>
 </template>
 
-<record id="website.s_social_media_000_scss" model="ir.asset">
-    <field name="name">SocialMedia 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_social_media/000.scss</field>
-</record>
+<asset id="website.s_social_media_000_scss" name="SocialMedia 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_social_media/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -75,16 +75,14 @@
     </xpath>
 </template>
 
-<record id="website.s_table_of_content_000_scss" model="ir.asset">
-    <field name="name">Table of content 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_table_of_content/000.scss</field>
-</record>
+<asset id="website.s_table_of_content_000_scss" name="Table of content 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_table_of_content/000.scss</path>
+</asset>
 
-<record id="website.s_table_of_content_000_js" model="ir.asset">
-    <field name="name">Table of content 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_table_of_content/000.js</field>
-</record>
+<asset id="website.s_table_of_content_000_js" name="Table of content 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_table_of_content/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_tabs.xml
+++ b/addons/website/views/snippets/s_tabs.xml
@@ -94,10 +94,9 @@
     </xpath>
 </template>
 
-<record id="website.s_tabs_001_scss" model="ir.asset">
-    <field name="name">Tabs 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_tabs/001.scss</field>
-</record>
+<asset id="website.s_tabs_001_scss" name="Tabs 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_tabs/001.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -16,10 +16,9 @@
     </section>
 </template>
 
-<record id="website.s_text_cover_000_scss" model="ir.asset">
-    <field name="name">Text cover 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_text_cover/000.scss</field>
-</record>
+<asset id="website.s_text_cover_000_scss" name="Text cover 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_text_cover/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_text_highlight.xml
+++ b/addons/website/views/snippets/s_text_highlight.xml
@@ -10,10 +10,9 @@
     </div>
 </template>
 
-<record id="website.s_text_highlight_000_scss" model="ir.asset">
-    <field name="name">Text highlight 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_text_highlight/000.scss</field>
-</record>
+<asset id="website.s_text_highlight_000_scss" name="Text highlight 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_text_highlight/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_three_columns.xml
+++ b/addons/website/views/snippets/s_three_columns.xml
@@ -37,11 +37,9 @@
     </section>
 </template>
 
-<record id="website.s_three_columns_000_scss" model="ir.asset">
-    <field name="name">Three columns 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_three_columns/000.scss</field>
-    <field name="active" eval="False"/>
-    </record>
+<asset id="website.s_three_columns_000_scss" name="Three columns 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_three_columns/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -80,10 +80,9 @@ actually removes because it judges them useless)
     </xpath>
 </template>
 
-<record id="website.s_timeline_000_scss" model="ir.asset">
-    <field name="name">Timeline 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_timeline/000.scss</field>
-</record>
+<asset id="website.s_timeline_000_scss" name="Timeline 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_timeline/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_title.xml
+++ b/addons/website/views/snippets/s_title.xml
@@ -9,11 +9,9 @@
     </section>
 </template>
 
-<record id="website.s_title_000_scss" model="ir.asset">
-    <field name="name">Title 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_title/000.scss</field>
-    <field name="active" eval="False"/>
-    </record>
+<asset id="website.s_title_000_scss" name="Title 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_title/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -316,29 +316,24 @@
 </template>
 
 
-<record id="website.s_website_form_000_scss" model="ir.asset">
-    <field name="name">Website form 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_website_form/000.scss</field>
-    <field name="active" eval="False"/>
-</record>
+<asset id="website.s_website_form_000_scss" name="Website form 000 SCSS" active="False">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_website_form/000.scss</path>
+</asset>
 
-<record id="website.s_website_form_001_scss" model="ir.asset">
-    <field name="name">Website form 001 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_website_form/001.scss</field>
-</record>
+<asset id="website.s_website_form_001_scss" name="Website form 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_website_form/001.scss</path>
+</asset>
 
-<record id="website.s_website_form_000_js" model="ir.asset">
-    <field name="name">Website form 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_website_form/000.js</field>
-</record>
+<asset id="website.s_website_form_000_js" name="Website form 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_website_form/000.js</path>
+</asset>
 
-<record id="website.s_website_form_xml" model="ir.asset">
-    <field name="name">Website form XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/xml/website_form.xml</field>
-</record>
+<asset id="website.s_website_form_xml" name="Website form XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/xml/website_form.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2311,21 +2311,17 @@
 </template>
 
 <!-- Effect options -->
-<record id="website.ripple_effect_scss" model="ir.asset">
+<asset id="website.ripple_effect_scss" name="Ripple effect SCSS" active="False">
     <field name="key">website.ripple_effect_scss</field>
-    <field name="name">Ripple effect SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">/website/static/src/scss/options/ripple_effect.scss</field>
-    <field name="active" eval="False"/>
-</record>
+    <bundle>web.assets_frontend</bundle>
+    <path>/website/static/src/scss/options/ripple_effect.scss</path>
+</asset>
 
-<record id="website.ripple_effect_js" model="ir.asset">
+<asset id="website.ripple_effect_js" name="Ripple effect JS" active="False">
     <field name="key">website.ripple_effect_js</field>
-    <field name="name">Ripple effect JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">/website/static/src/js/content/ripple_effect.js</field>
-    <field name="active" eval="False"/>
-</record>
+    <bundle>web.assets_frontend</bundle>
+    <path>/website/static/src/js/content/ripple_effect.js</path>
+</asset>
 
 <!-- Error and special pages -->
 <template id="website_info" name="Odoo Information">

--- a/addons/website_blog/data/ir_asset.xml
+++ b/addons/website_blog/data/ir_asset.xml
@@ -2,12 +2,10 @@
 <odoo>
     <data>
 
-            <record id="website_blog.s_latest_posts_000_scss" model="ir.asset">
-                <field name="name">Latest posts 000 SCSS</field>
-                <field name="bundle">web.assets_frontend</field>
-                <field name="path">website_blog/static/src/snippets/s_latest_posts/000.scss</field>
-                <field name="active" eval="False"/>
-                </record>
+        <asset id="website_blog.s_latest_posts_000_scss" name="Latest posts 000 SCSS" active="False">
+            <bundle>web.assets_frontend</bundle>
+            <path>website_blog/static/src/snippets/s_latest_posts/000.scss</path>
+        </asset>
 
     </data>
 </odoo>

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -134,16 +134,14 @@
 </template>
 
 <!-- Assets -->
-<record id="website_blog.s_blog_posts_000_scss" model="ir.asset">
-    <field name="name">Blog posts 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_blog/static/src/snippets/s_blog_posts/000.scss</field>
-</record>
+<asset id="website_blog.s_blog_posts_000_scss" name="Blog posts 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_blog/static/src/snippets/s_blog_posts/000.scss</path>
+</asset>
 
-<record id="website_blog.s_blog_posts_000_js" model="ir.asset">
-    <field name="name">Blog posts 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_blog/static/src/snippets/s_blog_posts/000.js</field>
-</record>
+<asset id="website_blog.s_blog_posts_000_js" name="Blog posts 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_blog/static/src/snippets/s_blog_posts/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -104,16 +104,14 @@
 
 <!--ASSETS-->
 
-<record id="website_event.s_events_000_scss" model="ir.asset">
-    <field name="name">Event 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_event/static/src/snippets/s_events/000.scss</field>
-</record>
+<asset id="website_event.s_events_000_scss" name="Event 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_event/static/src/snippets/s_events/000.scss</path>
+</asset>
 
-<record id="website_event.s_events_000_js" model="ir.asset">
-    <field name="name">Event 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_event/static/src/snippets/s_events/000.js</field>
-</record>
+<asset id="website_event.s_events_000_js" name="Event 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_event/static/src/snippets/s_events/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -77,16 +77,14 @@
     </xpath>
 </template>
 
-<record id="website_event.s_searchbar_000_js" model="ir.asset">
-    <field name="name">Searchbar 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_event/static/src/snippets/s_searchbar/000.js</field>
-</record>
+<asset id="website_event.s_searchbar_000_js" name="Searchbar 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_event/static/src/snippets/s_searchbar/000.js</path>
+</asset>
 
-<record id="website_event.s_searchbar_000_xml" model="ir.asset">
-    <field name="name">Searchbar 000 XML</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_event/static/src/snippets/s_searchbar/000.xml</field>
-</record>
+<asset id="website_event.s_searchbar_000_xml" name="Searchbar 000 XML">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_event/static/src/snippets/s_searchbar/000.xml</path>
+</asset>
 
 </odoo>

--- a/addons/website_mail_group/views/snippets/s_group.xml
+++ b/addons/website_mail_group/views/snippets/s_group.xml
@@ -24,9 +24,8 @@
             </div>
         </xpath>
     </template>
-    <record id="website_mail_group.s_group_000_js" model="ir.asset">
-        <field name="name">Group 000 JS</field>
-        <field name="bundle">web.assets_frontend</field>
-        <field name="path">website_mail_group/static/src/snippets/s_group/000.js</field>
-    </record>
+    <asset id="website_mail_group.s_group_000_js" name="Group 000 JS">
+        <bundle>web.assets_frontend</bundle>
+        <path>website_mail_group/static/src/snippets/s_group/000.js</path>
+    </asset>
 </odoo>

--- a/addons/website_mass_mailing/views/snippets/s_popup.xml
+++ b/addons/website_mass_mailing/views/snippets/s_popup.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<record id="website_mass_mailing.s_popup_000_js" model="ir.asset">
-    <field name="name">Popup 000 JS Website Mass Mailing Override</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_mass_mailing/static/src/snippets/s_popup/000.js</field>
-</record>
+<asset id="website_mass_mailing.s_popup_000_js" name="Popup 000 JS Website Mass Mailing Override">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_mass_mailing/static/src/snippets/s_popup/000.js</path>
+</asset>
 
 </odoo>

--- a/addons/website_payment/views/snippets/s_donation.xml
+++ b/addons/website_payment/views/snippets/s_donation.xml
@@ -84,16 +84,14 @@
     </xpath>
 </template>
 
-<record id="website_payment.s_donation_000_js" model="ir.asset">
-    <field name="name">Donation 000 JS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_payment/static/src/snippets/s_donation/000.js</field>
-</record>
+<asset id="website_payment.s_donation_000_js" name="Donation 000 JS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_payment/static/src/snippets/s_donation/000.js</path>
+</asset>
 
-<record id="website_payment.s_donation_000_scss" model="ir.asset">
-    <field name="name">Donation 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_payment/static/src/snippets/s_donation/000.scss</field>
-</record>
+<asset id="website_payment.s_donation_000_scss" name="Donation 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_payment/static/src/snippets/s_donation/000.scss</path>
+</asset>
 
 </odoo>

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -397,10 +397,9 @@
         </template>
 
         <!-- Assets -->
-        <record id="website_sale.s_dynamic_snippet_products_000_scss" model="ir.asset">
-            <field name="name">Dynamic snippet products 000 SCSS</field>
-            <field name="bundle">web.assets_frontend</field>
-            <field name="path">website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss</field>
-        </record>
+        <asset id="website_sale.s_dynamic_snippet_products_000_scss" name="Dynamic snippet products 000 SCSS">
+            <bundle>web.assets_frontend</bundle>
+            <path>website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss</path>
+        </asset>
     </data>
 </odoo>

--- a/addons/website_sale/views/snippets/s_add_to_cart.xml
+++ b/addons/website_sale/views/snippets/s_add_to_cart.xml
@@ -42,9 +42,8 @@
             </div>
         </xpath>
     </template>
-    <record id="website_sale.s_add_to_cart_000_js" model="ir.asset">
-        <field name="name">Add to Cart 000 JS</field>
-        <field name="bundle">web.assets_frontend</field>
-        <field name="path">website_sale/static/src/snippets/s_add_to_cart/000.js</field>
-    </record>
+    <asset id="website_sale.s_add_to_cart_000_js" name="Add to Cart 000 JS">
+        <bundle>web.assets_frontend</bundle>
+        <path>website_sale/static/src/snippets/s_add_to_cart/000.js</path>
+    </asset>
 </odoo>

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -35,10 +35,9 @@
         </xpath>
     </template>
 
-    <record id="website_sale.s_dynamic_snippet_products_000_js" model="ir.asset">
-        <field name="name">Dynamic snippet products 000 JS</field>
-        <field name="bundle">web.assets_frontend</field>
-        <field name="path">website_sale/static/src/snippets/s_dynamic_snippet_products/000.js</field>
-    </record>
+    <asset id="website_sale.s_dynamic_snippet_products_000_js" name="Dynamic snippet products 000 JS">
+        <bundle>web.assets_frontend</bundle>
+        <path>website_sale/static/src/snippets/s_dynamic_snippet_products/000.js</path>
+    </asset>
 
 </odoo>

--- a/addons/website_sale/views/snippets/s_popup.xml
+++ b/addons/website_sale/views/snippets/s_popup.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<record id="website_sale.s_popup_000_js" model="ir.asset">
-    <field name="name">Popup 000 JS Website Sale Override</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website_sale/static/src/snippets/s_popup/000.js</field>
-</record>
+<asset id="website_sale.s_popup_000_js" name="Popup 000 JS Website Sale Override">
+    <bundle>web.assets_frontend</bundle>
+    <path>website_sale/static/src/snippets/s_popup/000.js</path>
+</asset>
 
 </odoo>

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -19,6 +19,7 @@ from . import test_http_case
 from . import test_image
 from . import test_avatar_mixin
 from . import test_ir_actions
+from . import test_ir_asset
 from . import test_ir_attachment
 from . import test_ir_cron
 from . import test_ir_filters

--- a/odoo/addons/base/tests/asset_tag.xml
+++ b/odoo/addons/base/tests/asset_tag.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<asset id="base.test_asset_tag_aaa" name="Test asset tag (init active => keep active => update active)">
+    <bundle>test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+</asset>
+<asset id="base.test_asset_tag_aii" name="Test asset tag (init active => make inactive => update inactive)">
+    <bundle>test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+</asset>
+<asset id="base.test_asset_tag_aia" name="Test asset tag (init active => make inactive => update active)">
+    <bundle>test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+    <field name="active">True</field> <!-- Take into account during update -->
+</asset>
+<asset id="base.test_asset_tag_iii" name="Test asset tag (init inactive => keep inactive => update inactive)" active="False">
+    <bundle>test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+</asset>
+<asset id="base.test_asset_tag_iaa" name="Test asset tag (init inactive => make active => update active)" active="False">
+    <bundle>test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+</asset>
+<asset id="base.test_asset_tag_prepend" name="Test asset tag with directive">
+    <bundle directive="prepend">test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+</asset>
+<asset id="base.test_asset_tag_extra" name="Test asset tag with extra field">
+    <bundle>test_asset_bundle</bundle>
+    <path>base/tests/something.scss</path>
+    <field name="sequence" eval="17"/>
+</asset>
+
+</odoo>

--- a/odoo/addons/base/tests/test_ir_asset.py
+++ b/odoo/addons/base/tests/test_ir_asset.py
@@ -1,0 +1,77 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tools import convert_file
+from odoo.tools.misc import file_path
+
+
+@tagged('-at_install', 'post_install')
+class TestAsset(TransactionCase):
+
+    def test_asset_tag(self):
+        """
+        Verify that assets defined with the <asset> tag are properly imported.
+        """
+        # Load new records
+        convert_file(
+            self.env, 'base',
+            file_path('base/tests/asset_tag.xml'),
+            {}, 'init', False, 'test'
+        )
+        active_keep_asset = self.env.ref('base.test_asset_tag_aaa')
+        inactive_keep_asset = self.env.ref('base.test_asset_tag_iii')
+        active_switch_asset_reset = self.env.ref('base.test_asset_tag_aia')
+        active_switch_asset_ignore = self.env.ref('base.test_asset_tag_aii')
+        inactive_switch_asset = self.env.ref('base.test_asset_tag_iaa')
+        prepend_asset = self.env.ref('base.test_asset_tag_prepend')
+        asset_with_extra_field = self.env.ref('base.test_asset_tag_extra')
+
+        # Verify initial load
+        self.assertEqual(prepend_asset._name, 'ir.asset', 'Model should be ir.asset')
+        self.assertEqual(prepend_asset.name, 'Test asset tag with directive', 'Name not loaded')
+        self.assertEqual(prepend_asset.directive, 'prepend', 'Directive not loaded')
+        self.assertEqual(prepend_asset.bundle, 'test_asset_bundle', 'Bundle not loaded')
+        self.assertEqual(prepend_asset.path, 'base/tests/something.scss', 'Path not loaded')
+        self.assertEqual(asset_with_extra_field.sequence, 17, 'Sequence not loaded')
+        self.assertTrue(active_keep_asset.active, 'Should be active')
+        self.assertTrue(active_switch_asset_reset.active, 'Should be active')
+        self.assertTrue(active_switch_asset_ignore.active, 'Should be active')
+        self.assertFalse(inactive_keep_asset.active, 'Should be inactive')
+        self.assertFalse(inactive_switch_asset.active, 'Should be inactive')
+
+        # Patch records
+        prepend_asset.name = 'changed'
+        prepend_asset.directive = 'append'
+        prepend_asset.bundle = 'changed'
+        prepend_asset.path = 'base/tests/changed.scss'
+        asset_with_extra_field.sequence = 3
+        active_switch_asset_reset.active = False
+        active_switch_asset_ignore.active = False
+        inactive_switch_asset.active = True
+
+        # Update records
+        convert_file(
+            self.env, 'base',
+            file_path('base/tests/asset_tag.xml'),
+            {
+                'base.test_asset_tag_aaa': active_keep_asset.id,
+                'base.test_asset_tag_iii': inactive_keep_asset.id,
+                'base.test_asset_tag_aia': active_switch_asset_reset.id,
+                'base.test_asset_tag_aii': active_switch_asset_ignore.id,
+                'base.test_asset_tag_iaa': inactive_switch_asset.id,
+                'base.test_asset_tag_prepend': prepend_asset.id,
+                'base.test_asset_tag_extra': asset_with_extra_field.id,
+            }, 'update', False, 'test'
+        )
+
+        # Verify updated load
+        self.assertEqual(prepend_asset.name, 'Test asset tag with directive', 'Name not restored')
+        self.assertEqual(prepend_asset.directive, 'prepend', 'Directive not restored')
+        self.assertEqual(prepend_asset.bundle, 'test_asset_bundle', 'Bundle not restored')
+        self.assertEqual(prepend_asset.path, 'base/tests/something.scss', 'Path not restored')
+        self.assertEqual(asset_with_extra_field.sequence, 17, 'Sequence not restored')
+        self.assertTrue(active_keep_asset.active, 'Should be active')
+        self.assertTrue(active_switch_asset_reset.active, 'Should be reset to active')
+        self.assertFalse(active_switch_asset_ignore.active, 'Should be kept inactive')
+        self.assertFalse(inactive_keep_asset.active, 'Should be inactive')
+        self.assertTrue(inactive_switch_asset.active, 'Should be kept active')

--- a/odoo/addons/test_assetsbundle/data/ir_asset.xml
+++ b/odoo/addons/test_assetsbundle/data/ir_asset.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record id="test_assetsbundle.test_jsfile[!4]_js" model="ir.asset">
-            <field name="name">Test jsfile[!4] JS</field>
-            <field name="bundle">test_assetsbundle.bundle1</field>
-            <field name="path">test_assetsbundle/static/src/js/test_jsfile[!4].js</field>
-        </record>
+        <asset id="test_assetsbundle.test_jsfile[!4]_js" name="Test jsfile[!4] JS">
+            <bundle>test_assetsbundle.bundle1</bundle>
+            <path>test_assetsbundle/static/src/js/test_jsfile[!4].js</path>
+        </asset>
     </data>
 </odoo>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -217,6 +217,26 @@
         </rng:element>
     </rng:define>
 
+    <rng:define name="asset">
+        <rng:element name="asset">
+            <rng:attribute name="id" />
+            <rng:attribute name="name" />
+            <rng:optional><rng:attribute name="active" /></rng:optional>
+            <rng:interleave>
+                <rng:element name="bundle">
+                    <rng:optional><rng:attribute name="directive" /></rng:optional>
+                    <rng:text/>
+                </rng:element>
+                <rng:element name="path">
+                    <rng:text/>
+                </rng:element>
+                <rng:zeroOrMore>
+                    <rng:ref name="field" />
+                </rng:zeroOrMore>
+            </rng:interleave>
+        </rng:element>
+    </rng:define>
+
     <rng:define name="delete">
         <rng:element name="delete">
             <rng:attribute name="model" />
@@ -323,6 +343,7 @@
                     <rng:ref name="menuitem" />
                     <rng:ref name="record" />
                     <rng:ref name="template" />
+                    <rng:ref name="asset" />
                     <rng:ref name="delete" />
                     <rng:ref name="act_window" />
                     <rng:ref name="report" />

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -514,10 +514,16 @@ form: module.record_id""" % (xml_id,)
             record.append(Field(name='website_id', ref=el.get('website_id')))
         if 'key' in el.attrib:
             record.append(Field(el.get('key'), name='key'))
+
+        # If the "active" value is set on the root node (instead of an inner
+        # <field>), it is treated as the value for the "active" field but only
+        # when *not updating*. This allows to update the record in a more recent
+        # version without changing its active state (compatibility).
         if el.get('active') in ("True", "False"):
             view_id = self.id_get(tpl_id, raise_if_not_found=False)
             if self.mode != "update" or not view_id:
                 record.append(Field(name='active', eval=el.get('active')))
+
         if el.get('customize_show') in ("True", "False"):
             record.append(Field(name='customize_show', eval=el.get('customize_show')))
         groups = el.attrib.pop('groups', None)
@@ -537,6 +543,46 @@ form: module.record_id""" % (xml_id,)
         # inject complete <template> element (after changing node name) into
         # the ``arch`` field
         record.append(Field(el, name="arch", type="xml"))
+
+        return self._tag_record(record)
+
+    def _tag_asset(self, el):
+        """
+        Transforms an <asset> element into a <record> and forwards it.
+        """
+        asset_id = el.get('id')
+        Field = builder.E.field
+
+        record = etree.Element('record', attrib={
+            'id': asset_id,
+            'model': 'theme.ir.asset' if self.module.startswith('theme_') else 'ir.asset',
+        })
+
+        name = el.get('name', asset_id)
+        record.append(Field(name, name='name'))
+
+        # E.g. <bundle directive="prepend">web.assets_frontend</bundle>
+        # (directive is optional)
+        bundle_el = el.find('bundle')
+        record.append(Field(bundle_el.text, name='bundle'))
+        if 'directive' in bundle_el.attrib:
+            record.append(Field(bundle_el.get('directive'), name='directive'))
+
+        # E.g. <path>website/static/src/snippets/s_share/000.scss</path>
+        record.append(Field(el.find('path').text, name='path'))
+
+        # Same as <template> for ir.ui.view:
+        # If the "active" value is set on the root node (instead of an inner
+        # <field>), it is treated as the value for the "active" field but only
+        # when *not updating*. This allows to update the record in a more recent
+        # version without changing its active state (compatibility).
+        if el.get('active') in ("True", "False"):
+            record_id = self.id_get(asset_id, raise_if_not_found=False)
+            if self.mode != "update" or not record_id:
+                record.append(Field(name='active', eval=el.get('active')))
+
+        for child in el.iterchildren('field'):
+            record.append(child)
 
         return self._tag_record(record)
 
@@ -612,6 +658,7 @@ form: module.record_id""" % (xml_id,)
             'function': self._tag_function,
             'menuitem': self._tag_menuitem,
             'template': self._tag_template,
+            'asset': self._tag_asset,
 
             **dict.fromkeys(self.DATA_ROOTS, self._tag_root)
         }


### PR DESCRIPTION
Before this commit when a module was updated all ir.asset records were
reset to their defined `active` state, if defined.
This causes assets related to old snippet versions to be made inactive
even if those old snippet versions are used inside existing pages.

It used to work when the activation of assets was made through view
inheritance because when views are defined through a `<template>` tag,
the `active` attribute is in fact ignored during updates since [1],
except for new records since [2].

This commit introduces an `<asset>` tag in the XML import format.
It is an alias of `<record ... model="ir.asset">` with the additional
feature that it avoids taking the `active` field into account during
updates for existing `ir_asset` records, just like `<template>` if the
`active` field is mentioned as attribute of the tag.
We then rely on the `website_disable_unused_snippets_assets` cron to
properly disable any unused asset at a later stage (note that the bug
being fixed here was mitigated by the fact that cron also re-enabled
assets which were disabled by mistake... but that might happen only a
few days later).

Another approach was to overload `_load_records_write` in `base`'s
`ir_asset.py` to avoid taking the `active` field into account when
updating records:
```py
    def _load_records_write(self, values):
        values.pop('active', None)
        super()._load_records_write(values)
```
But this is not as stable because it changes the way `ir.asset` records
are imported when the `<record>` tag is used. In the end we chose to be
consistent and do exactly the same as `<template>`, as this also allows
more and should be entirely stable.

[1]: https://github.com/odoo/odoo/commit/2d296cb77922d33be2dc45b900191fac34bda429#diff-175c28787c272a219b9275f79262a48af9aa029e718f45077fd609737559e84eR803-R804
[2]: https://github.com/odoo/odoo/commit/f1c70d4cc943ac4eb81a85a9dc005de34cd2060a#diff-175c28787c272a219b9275f79262a48af9aa029e718f45077fd609737559e84eR801-R804

task-2963840

(Follow-up of https://github.com/odoo/upgrade/pull/3829)