### PR TITLE
[FIX] web: Allow users to edit float field

### DIFF
--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -37,7 +37,7 @@ FloatField.props = {
     ...standardFieldProps,
     inputType: { type: String, optional: true },
     step: { type: Number, optional: true },
-    digits: { type: Array, optional: true },
+    digits: { type: [Array, Number], optional: true },
     placeholder: { type: String, optional: true },
 };
 FloatField.defaultProps = {


### PR DESCRIPTION
Steps:
- Open studio in product form
- Add a related field
- Select currency -> inverse rate
- Traceback

In the float_field components the `digits` key is typed as Array, but it can be a Number too

opw-3039648