### PR TITLE
[FIX] Repair order tax alignment

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -162,12 +162,8 @@
                         <group class="oe_subtotal_footer oe_right">
                             <field name="amount_untaxed" sum="Untaxed amount"/>
                             <field name="amount_tax"/>
-                            <div class="oe_subtotal_footer_separator oe_inline">
-                                <label for="amount_total" />
-                                <button name="button_dummy"
-                                    states="draft" string="(update)" type="object" class="oe_edit_only oe_link"/>
-                            </div>
-                            <field name="amount_total" nolabel="1" sum="Total amount" class="oe_subtotal_footer_separator"/>
+                            <label for="amount_total" />
+                            <field name="amount_total" nolabel="1" sum="Total amount" class="o_footer_tax_separator" />
                         </group>
                         <div class="clearfix"/>
                     </page>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1197,3 +1197,11 @@
     clear: both;
     justify-content: space-between;
 }
+
+.o_footer_tax_separator{
+    width: 100%;
+    text-align: right;
+    border-top: 1px solid $border-color;
+    font-weight: $font-weight-bold;
+    font-size: 1.3em;
+}


### PR DESCRIPTION
Visual fix for the repair order computed total
Usage of the widget TaxTotalsComponent

Based on the tax total from CRM quotations

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
