### PR TITLE
[FIX] sale_mrp: avoid failing average price test

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2273,6 +2273,6 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         with so_form.order_line.new() as line:
             line.product_id = super_kit
         so = so_form.save()
-        self.assertEqual(so.order_line.purchase_price, 60)
+        self.assertEqual(super_kit.standard_price, 60)
         so.action_confirm()
-        self.assertEqual(so.order_line.purchase_price, 60)
+        self.assertEqual(super_kit.standard_price, 60)


### PR DESCRIPTION
The `test_kit_cost_calculation` test added in this [commit] will fail if the `sale_margin` module is not installed. This happens because an assertion in the test uses the `purchase_price` field defined in the `sale_margin` module.

As the test is testing the average costing method on kit products, it does not actually need this field. The average cost can simply be checked on the product itself.

opw-3041718

[commit]: https://github.com/odoo/odoo/commit/ea9fdac32111e4747453dee1e336b34e934cbc4d