### PR TITLE
[FIX] sale, purchase, hr_timesheet: website overview text color

### DIFF
--- a/addons/hr_timesheet/views/project_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_portal_templates.xml
@@ -15,7 +15,7 @@
     </template>
 
     <template id="portal_timesheet_table" name="Portal Timesheet Table">
-        <table class="table table-sm">
+        <table class="table table-sm bg-white">
             <thead>
               <tr>
                 <th>Date</th>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -140,7 +140,7 @@
                   </div>
                 </div>
                 <h3 class="font-weight-normal">Pricing</h3>
-                <table class="table table-sm">
+                <table class="table table-sm bg-white">
                   <thead class="bg-100">
                     <tr>
                       <th>Products</th>
@@ -185,7 +185,7 @@
                 </table>
                 <div class="row" t-if="order.state in ['purchase', 'done']">
                   <div class="col-sm-7 col-md-5 ml-auto">
-                    <table class="table table-sm">
+                    <table class="table table-sm bg-white">
                       <tbody>
                         <tr>
                           <td>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -426,7 +426,7 @@
 
                 <t t-set="display_discount" t-value="True in [line.discount > 0 for line in sale_order.order_line]"/>
 
-                <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table table-sm" id="sales_order_table">
+                <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table table-sm bg-white" id="sales_order_table">
                     <thead class="bg-100">
                         <tr>
                             <th class="text-left">Products</th>
@@ -547,7 +547,7 @@
     </template>
 
     <template id="sale_order_portal_content_totals_table">
-        <table class="table table-sm">
+        <table class="table table-sm bg-white">
             <tr class="border-black">
                 <td><strong>Subtotal</strong></td>
                 <td class="text-right">


### PR DESCRIPTION
Steps to reproduce:

- Go to the website, edit, theme and set the background color as black
and the color as white.
- Go to sales, and select any quotation > Select the customer Overview

Or go to website and "My profile" most of the previews will have this
issue

Issue:

We can see that the portal tables inherit the white color from the theme
which makes them unreadable.

Solution:

So far the easiest solution I've found is to gave the tables that are
affected the class "bg-white" which will set the color as black.

I have also the same solution for subscriptions (enterprise) I'll create
the PR If these changes are a good solution.

This bug affects all versions from 14.0 until 16.0

opw-3048306
