### PR TITLE
[FIX] project: duplicating project with analytic account

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -568,7 +568,6 @@ class Project(models.Model):
                 for res in projects_read_group
                 if res['analytic_account_id'] and res['analytic_account_id_count'] == 1
             ])
-            analytic_account_to_update.write({'name': self.name})
         return res
 
     def action_unlink(self):


### PR DESCRIPTION
Steps to reproduce:
    - create a project;
    - duplicate the project;
    - change the name of new project and analytic account;
    - save the project.

Issue:
    The analytic account name is automatically change to default (which is the project name)

Solution:
	When writing the project, if there is an analytic account linked to the project, use the name of the analytic account.

opw-3042923