### PR TITLE
[IMP] delivery: shipping fixed margin for carriers

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -61,6 +61,7 @@ class DeliveryCarrier(models.Model):
              "E.g. instructions for customers to follow.")
 
     margin = fields.Float(help='This percentage will be added to the shipping price.')
+    fixed_margin = fields.Float(help='This fixed amount will be added to the shipping price.')
     free_over = fields.Boolean('Free if order amount is above', help="If the order total amount (shipping excluded) is above or equal to this value, the customer benefits from a free shipping", default=False)
     amount = fields.Float(string='Amount', help="Amount of the order to benefit from a free shipping, expressed in the company currency")
 
@@ -184,7 +185,7 @@ class DeliveryCarrier(models.Model):
                 product_currency=company.currency_id
             )
             # apply margin on computed price
-            res['price'] = float(res['price']) * (1.0 + (self.margin / 100.0))
+            res['price'] = (float(res['price']) * (1.0 + (self.margin / 100.0))) + self.fixed_margin
             # save the real price in case a free_over rule overide it to 0
             res['carrier_price'] = res['price']
             # free when order is large enough

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -97,12 +97,13 @@
                             <group name="delivery_details">
                                 <field name="product_id" context="{'default_detailed_type': 'service', 'default_sale_ok': False, 'default_purchase_ok': False, 'default_invoice_policy': 'order'}" />
                                 <field name="invoice_policy" widget="radio" attrs="{'invisible': ['|', ('delivery_type', 'in', ('fixed', 'base_on_rule')), ('integration_level', '=', 'rate')]}"/>
-                                <label for="margin" string="Margin on Rate"/>
-                                <div>
-                                    <field name="margin" class="oe_inline"/>%
+                                <label for="margin" string="Margin on Rate" attrs="{'invisible': [ ('delivery_type', '=', 'fixed')]}"/>
+                                <div attrs="{'invisible': [ ('delivery_type', '=', 'fixed')]}">
+                                    <field name="margin" class="oe_inline" />%
                                 </div>
-                                <field name="free_over"/>
-                                <field name="amount" attrs="{'required':[('free_over','!=', False)], 'invisible':[('free_over','=', False)]}"/>
+                                <field name="fixed_margin" attrs="{'invisible': [ ('delivery_type', '=', 'fixed')]}"/>
+                                <field name="free_over" attrs="{'invisible': [ ('delivery_type', '=', ('base_on_rule'))]}"/>
+                                <field name="amount" attrs="{'required':[('free_over','!=', False)], 'invisible':['|',('free_over','=', False),('delivery_type', '=', ('base_on_rule'))]}"/>
                                 <field name="supports_shipping_insurance" invisible="1"/>
                                 <label for="shipping_insurance" String="Shipping Insurance" attrs="{'invisible': [('supports_shipping_insurance', '=', False)]}"/>
                                 <div attrs="{'invisible': [('supports_shipping_insurance', '=', False)]}">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Multiple fields were unused / redundant in the shipping methods :

"Margin on rate" with provider "Fixed Price"
"Margin on rate", "Free if order amount is above" and "Amount" with provider "Based on Rules" as we can put them in the rules

Add the field fixed margin for the other providers

Current behavior before PR:

removed "Margin on rate" for "Fixed Price" and "Based on Rules"
added "Fixed Margin" for all the other providers

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
