### PR TITLE
[FIX] web: grid cell of a field should take the full width

### DIFF
--- a/addons/web/static/src/views/form/form_group/form_group.js
+++ b/addons/web/static/src/views/form/form_group/form_group.js
@@ -84,29 +84,6 @@ export class InnerGroup extends Group {
             currentRow.isVisible = currentRow.isVisible || isVisible;
         }
         rows.push(currentRow);
-
-        // Compute the relative size of non-label cells
-        // The aim is for cells containing business data to occupy as much space as possible
-        rows.forEach((row) => {
-            let labelCount = 0;
-            const dataCells = [];
-            for (const c of row) {
-                if (c.subType === "label") {
-                    labelCount++;
-                } else if (c.subType === "item_component") {
-                    labelCount++;
-                    dataCells.push(c);
-                } else {
-                    dataCells.push(c);
-                }
-            }
-
-            const sizeOfDataCell = 100 / (maxCols - labelCount);
-            dataCells.forEach((c) => {
-                const itemSpan = c.subType === "item_component" ? c.itemSpan - 1 : c.itemSpan;
-                c.width = (itemSpan || 1) * sizeOfDataCell;
-            });
-        });
         return rows;
     }
 }

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -26,7 +26,7 @@
                 <t t-else="">
                     <div
                         class="o_cell flex-grow-1 flex-sm-grow-0"
-                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}{{ cell.width ? 'width: ' + cell.width + '%' + ';' : '' }}"
+                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}"
                         t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label w-100 text-break text-900' : null }}"
                         t-if="cell.isVisible">
                         <t t-slot="{{ cell.name }}" />
@@ -44,7 +44,7 @@
     </div>
     <div
         class="o_cell o_wrap_input flex-grow-1 flex-sm-grow-0"
-        t-attf-style="{{ cell.itemSpan -1 > 1 ? 'grid-column: span ' + (cell.itemSpan -1) + ';' : '' }}{{ cell.width ? 'width: ' + cell.width + '%' + ';' : '' }}"
+        t-attf-style="{{ cell.itemSpan -1 > 1 ? 'grid-column: span ' + (cell.itemSpan -1) + ';' : '' }}"
     >
         <t t-slot="{{ cell.name }}" />
     </div>


### PR DESCRIPTION
When a field has multiple labels (but only one shows at a time),
the labeled field only takes 50% of the width of its container.
It should take the full width as nothing is taking the other
half.

This proposed solution is a regression where we remove the forcing
of grid cell's width inside an InnerGroup component. Instead of
using `<group>` and play with col and colspan attributes for making a
complicated layout, users should just make there own layout inside
flex/grid elements outside a `<group>`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
