### PR TITLE
[FIX] account: fix din5008 and l10n_ch qr displays

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -14,12 +14,7 @@
 
         <template id="l10n_ch_swissqr_template">
             <t t-set="o" t-value="o.with_context(lang=lang)"/>
-            <t t-call="web.external_layout">
-                <!-- TODO master: remove this -->
-                <script t-if="0">document.body.className += " l10n_ch_qr";</script>
-                <!-- add default margin for header (matching A4 European margin) -->
-                <t t-set="report_header_style">padding-top:6.2mm; padding-left:8.2mm; padding-right:8.2mm;</t>
-
+            <div t-attf-class="header" t-att-style="report_header_style">
                 <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.amount_residual).replace(',','\xa0')"/>
 
                 <t t-set="is_qrr" t-value="o.partner_bank_id.l10n_ch_qr_iban"/>
@@ -214,7 +209,7 @@
 
                     </div>
                 </div>
-            </t>
+            </div>
         </template>
 
         <template id="l10n_ch.qr_report_main">
@@ -229,6 +224,6 @@
             <body position="attributes">
                 <attribute name="t-att-data-report-id">report_xml_id</attribute>
             </body>
-        </template> 
+        </template>
     </data>
 </odoo>

--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -35,7 +35,7 @@
         <template id="external_layout_din5008">
             <div>
                 <div t-attf-class="header din_page o_company_#{company.id}_layout">
-                        <table class="company_header" t-att-style="'height: %dmm;' % (din_header_spacing or 27)">
+                        <table class="company_header table-borderless" t-att-style="'height: %dmm;' % (din_header_spacing or 27)">
                             <tr>
                                 <td><h3 class="mt0" t-field="company.report_header"/></td>
                                 <td><img t-if="company.logo" t-att-src="image_data_uri(company.logo)" t-att-style="'max-height: %dmm;' % (din_header_spacing or 27)"/></td>
@@ -44,7 +44,7 @@
                 </div>
 
                 <div t-attf-class="din_page invoice_note article o_company_#{company.id}_layout" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id">
-                    <table>
+                    <table class="table-borderless">
                         <tr>
                             <td>
                                 <div class="address">
@@ -117,7 +117,7 @@
                         </div>
                     </div>
                     <div class="company_details">
-                        <table>
+                        <table class="table-borderless">
                             <tr>
                                 <td>
                                     <ul class="list-inline">


### PR DESCRIPTION
Since the Bootstrap update, the documents using the DIN5008 would not correctly print.

Some borders would be displayed when they shouldn't.

Adding the` table-borderless` class to the sections returned the display back to its original appearance.

The QR page of the l10n_ch QR Bill also had a display problem : the header from the first page would display on both pages.

Limited the usage of `web.external_layout` in order not to repeat the header when not intended.

Task-3037921