### PR TITLE
[FIX] mrp(_workorder): backorder should be create as per selected operation type

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -556,19 +556,22 @@ class MrpProduction(models.Model):
 
     @api.depends('state', 'move_raw_ids.state')
     def _compute_reservation_state(self):
-        self.reservation_state = False
+        processed_production = self.env['mrp.production']
         for production in self:
             if production.state in ('draft', 'done', 'cancel'):
                 continue
             relevant_move_state = production.move_raw_ids._get_relevant_state_among_moves()
             # Compute reservation state according to its component's moves.
             if relevant_move_state == 'partially_available':
+                processed_production += production
                 if production.workorder_ids.operation_id and production.bom_id.ready_to_produce == 'asap':
                     production.reservation_state = production._get_ready_to_produce_state()
                 else:
                     production.reservation_state = 'confirmed'
             elif relevant_move_state != 'draft':
+                processed_production += production
                 production.reservation_state = relevant_move_state
+        (self - processed_production).reservation_state = False
 
     @api.depends('move_raw_ids', 'state', 'move_raw_ids.product_uom_qty')
     def _compute_unreserve_visible(self):
@@ -1407,12 +1410,21 @@ class MrpProduction(models.Model):
     def _action_generate_backorder_wizard(self, quantity_issues):
         ctx = self.env.context.copy()
         lines = []
+        ask_create_backorder = always_create_backorder = self.env['mrp.production']
         for order in quantity_issues:
-            lines.append((0, 0, {
-                'mrp_production_id': order.id,
-                'to_backorder': True
-            }))
-        ctx.update({'default_mrp_production_ids': self.ids, 'default_mrp_production_backorder_line_ids': lines})
+            # For the production of serial numbers for the 'never' option : do not apply mechanism and ask instead
+            if order.picking_type_id.create_backorder == 'ask' or (order.picking_type_id.create_backorder == 'never' and order.product_id.tracking == 'serial'):
+                lines.append((0, 0, {
+                    'mrp_production_id': order.id,
+                    'to_backorder': True
+                }))
+                ask_create_backorder += order
+            if order.picking_type_id.create_backorder == 'always':
+                always_create_backorder += order
+        (self - ask_create_backorder).with_context(ctx, skip_backorder=True, mo_ids_to_backorder=always_create_backorder.ids).button_mark_done()
+        if not ask_create_backorder:
+            return True
+        ctx.update({'default_mrp_production_ids': ask_create_backorder.ids, 'default_mrp_production_backorder_line_ids': lines})
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.action_mrp_production_backorder")
         action['context'] = ctx
         return action
@@ -1797,6 +1809,11 @@ class MrpProduction(models.Model):
 
         for workorder in self.workorder_ids.filtered(lambda w: w.state not in ('done', 'cancel')):
             workorder.duration_expected = workorder._get_duration_expected()
+
+        # if create backorder is always then it's alrady create show add here to open form view or tree view
+        for production in self:
+            if production.mrp_production_backorder_count > 1 and production.picking_type_id.create_backorder == 'always':
+                backorders = self.procurement_group_id.mrp_production_ids.filtered(lambda p: p.state != 'done' and p.id not in self.ids)
 
         if not backorders:
             if self.env.context.get('from_workorder'):

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -228,3 +228,11 @@ class TestMrpCommon(common2.TestStockCommon):
             'tracking': 'none',
             'categ_id': cls.env.ref('product.product_category_all').id,
         })
+        domain = [
+            ('code', '=', 'mrp_operation'),
+            ('warehouse_id.company_id', 'in', cls.env.company.ids),
+        ]
+        cls.picking_type_always = cls.env['stock.picking.type'].search(domain, limit=1).copy({
+            'sequence_code': 'always',
+            'create_backorder': 'always',
+        })

--- a/addons/mrp/wizard/mrp_production_backorder.py
+++ b/addons/mrp/wizard/mrp_production_backorder.py
@@ -31,10 +31,18 @@ class MrpProductionBackorder(models.TransientModel):
             wizard.show_backorder_lines = len(wizard.mrp_production_backorder_line_ids) > 1
 
     def action_close_mo(self):
+        ctx = dict(self.env.context)
+        if ctx.get('workorder_id'):
+            workorder_id = self.env['mrp.workorder'].browse(ctx.get("workorder_id"))
+            return workorder_id.with_context(ctx, skip_backorder=True).record_production()
         return self.mrp_production_ids.with_context(skip_backorder=True).button_mark_done()
 
     def action_backorder(self):
         ctx = dict(self.env.context)
         ctx.pop('default_mrp_production_ids', None)
         mo_ids_to_backorder = self.mrp_production_backorder_line_ids.filtered(lambda l: l.to_backorder).mrp_production_id.ids
-        return self.mrp_production_ids.with_context(ctx, skip_backorder=True, mo_ids_to_backorder=mo_ids_to_backorder).button_mark_done()
+        if ctx.get('workorder_id'):
+            workorder_id = self.env['mrp.workorder'].browse(ctx.get("workorder_id"))
+            return workorder_id.with_context(ctx, skip_backorder=True, mo_ids_to_backorder=mo_ids_to_backorder).record_production()
+        res = self.mrp_production_ids.with_context(ctx, skip_backorder=True, mo_ids_to_backorder=mo_ids_to_backorder).button_mark_done()
+        return res


### PR DESCRIPTION
**Current behavior before PR:**

The option on the operation type to select the way in which backorders should be generated (never, always, ask) does not work for the Manufacturing Operation type.

**Desired behavior after PR is merged:**

The option on the operation type to select the way in which backorders should be generated will work for the Manufacturing Operation type.

**Task**-2918994


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
