### PR TITLE
[FIX] mail: rtc settings blank labels

### DIFF
--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
@@ -2,10 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-import { browser } from "@web/core/browser/browser";
-
 const { Component } = owl;
-const { useState } = owl.hooks;
 
 export class RtcConfigurationMenu extends Component {
 
@@ -14,13 +11,10 @@ export class RtcConfigurationMenu extends Component {
      */
     setup() {
         super.setup();
-        this.state = useState({
-            userDevices: undefined,
-        });
     }
 
-    async willStart() {
-        this.state.userDevices = await browser.navigator.mediaDevices.enumerateDevices();
+    async onWillStart() {
+        return this.messaging.rtc.updateAudioDevices();
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
@@ -9,7 +9,7 @@
                     <div>
                         <select name="inputDevice" class="o_RtcConfigurationMenu_optionDeviceSelect" t-att-value="messaging.userSetting.audioInputDeviceId" t-on-change="_onChangeSelectAudioInput">
                             <option value="">Browser default</option>
-                            <t t-if="state.userDevices" t-foreach="state.userDevices" t-as="device">
+                            <t t-foreach="messaging.rtc.audioDevices" t-as="device">
                                 <t t-if="device.kind === 'audioinput'">
                                     <option t-att-value="device.deviceId"><t t-esc="device.label"/></option>
                                 </t>


### PR DESCRIPTION
Before this PR, the rtc settings input select would have contained blank options. This is due to the fact that `enumerateDevices` returns every single available input, even if the autorisation has not been given by the user. In this case, the inputs are returned without any deviceId/label.

This PR fixes the issue by only keeping available input having a deviceId/label since they can't be used without it.

task-3058594