### PR TITLE
Master dnd block nby

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -25,7 +25,6 @@ Odoo Web Editor widget.
         'web_editor.assets_legacy_wysiwyg': [
             'web_editor/static/src/js/editor/snippets.editor.js',
             'web_editor/static/src/js/editor/snippets.options.js',
-            'web_editor/static/src/js/editor/smooth_scroll_on_drag.js',
         ],
         'web_editor.wysiwyg_iframe_editor_assets': [
             ('include', 'web._assets_helpers'),
@@ -144,6 +143,7 @@ Odoo Web Editor widget.
             'web_editor/static/src/js/editor/odoo-editor/src/commands/toggleList.js',
 
             # utils
+            'web_editor/static/src/js/editor/smooth_scroll_on_drag.js',
             'web_editor/static/src/js/wysiwyg/linkDialogCommand.js',
             'web_editor/static/src/js/wysiwyg/PeerToPeer.js',
             'web_editor/static/src/js/wysiwyg/conflict_dialog.js',

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -145,6 +145,7 @@ Odoo Web Editor widget.
             # utils
             'web_editor/static/src/js/editor/smooth_scroll_on_drag.js',
             'web_editor/static/src/js/wysiwyg/linkDialogCommand.js',
+            'web_editor/static/src/js/wysiwyg/MoveNodePlugin.js',
             'web_editor/static/src/js/wysiwyg/PeerToPeer.js',
             'web_editor/static/src/js/wysiwyg/conflict_dialog.js',
             'web_editor/static/src/js/wysiwyg/conflict_dialog.xml',

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -4,6 +4,7 @@ import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { QWebPlugin } from '@web_editor/js/backend/QWebPlugin';
+import { MoveNodePlugin } from '@web_editor/js/wysiwyg/MoveNodePlugin';
 import { TranslationButton } from "@web/views/fields/translation_button";
 import { useDynamicPlaceholder } from "@web/views/fields/dynamic_placeholder_hook";
 import {
@@ -671,7 +672,7 @@ export const htmlField = {
             minHeight: options.minHeight,
             maxHeight: options.maxHeight,
             resizable: 'resizable' in options ? options.resizable : false,
-            editorPlugins: [QWebPlugin],
+            editorPlugins: [QWebPlugin, MoveNodePlugin],
         };
         if ('collaborative' in options) {
             wysiwygOptions.collaborative = options.collaborative;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -97,6 +97,8 @@ const HISTORY_SNAPSHOT_BUFFER_TIME = 1000 * 10;
 
 const KEYBOARD_TYPES = { VIRTUAL: 'VIRTUAL', PHYSICAL: 'PHYSICAL', UNKNOWN: 'UKNOWN' };
 
+export const AVATAR_SIZE = 25;
+
 const IS_KEYBOARD_EVENT_UNDO = ev => ev.key === 'z' && (ev.ctrlKey || ev.metaKey);
 const IS_KEYBOARD_EVENT_REDO = ev => ev.key === 'y' && (ev.ctrlKey || ev.metaKey);
 const IS_KEYBOARD_EVENT_BOLD = ev => ev.key === 'b' && (ev.ctrlKey || ev.metaKey);
@@ -334,9 +336,22 @@ export class OdooEditor extends EventTarget {
         // Collaborator selection and caret display.
         this._collabSelectionInfos = new Map();
         this._collabSelectionColor = `hsl(${(Math.random() * 360).toFixed(0)}, 75%, 50%)`;
-        this._collabSelectionsContainer = this.document.createElement('div');
-        this._collabSelectionsContainer.classList.add('oe-collaboration-selections-container');
-        this.editable.before(this._collabSelectionsContainer);
+        this._avatarsOverlaps = {}
+
+        // This main container is used to contain a tree of sub containers.
+        // By having one parent that contains a tree of containers, it is easy
+        // to change the z-index of any container by changing their place in the
+        // tree rather than tweaking a z-index number.
+        this._mainAbsoluteContainer = this.document.createElement('div');
+        this._mainAbsoluteContainer.classList.add('oe-absolute-container');
+        this.editable.before(this._mainAbsoluteContainer);
+
+        // This container contains the users selections.
+        this._selectionsContainer = this.makeAbsoluteContainer('oe-selections-container');
+        // This container contains the users avatars.
+        this._avatarsContainer = this.makeAbsoluteContainer('oe-avatars-container');
+        // This container contains the users counter that overlap the users avatars.
+        this._avatarsCountersContainer = this.makeAbsoluteContainer('oe-avatars-counters-container');
 
         // Promise for extra rendering, collaborative external steps will be
         // buffered (delayed) until it is resolved.
@@ -669,7 +684,7 @@ export class OdooEditor extends EventTarget {
         this._removeDomListener();
         this.powerbox.destroy();
         this.powerboxTablePicker.el.remove();
-        this._collabSelectionsContainer.remove();
+        this._mainAbsoluteContainer.remove();
         this._resizeObserver.disconnect();
         clearInterval(this._snapshotInterval);
         this._pluginCall('destroy', []);
@@ -818,6 +833,22 @@ export class OdooEditor extends EventTarget {
         const boundCallback = callback.bind(this);
         this._domListeners.push([element, eventName, boundCallback]);
         element.addEventListener(eventName, boundCallback);
+    }
+
+    /**
+     * Make an absolute container to organise floating elements inside it's own
+     * box and z-index isolation.
+     *
+     * @param {string} containerId An id to add to the container in order to make
+     *              the container more visible in the devtool and potentially
+     *              add css rules for the container and it's children.
+     */
+    makeAbsoluteContainer(containerId) {
+        const container = this.document.createElement('div');
+        container.className = `oe-absolute-container`;
+        container.setAttribute('data-oe-absolute-container-id', containerId);
+        this.mainAbsoluteContainer.append(container);
+        return container;
     }
 
     _generateId() {
@@ -1685,30 +1716,27 @@ export class OdooEditor extends EventTarget {
     // -------------------------------------------------------------------------
 
     onExternalMultiselectionUpdate(selection) {
-        this._multiselectionDisplayClient(selection);
         const { clientId } = selection;
-        if (this._collabSelectionInfos.has(clientId)) {
-            this._collabSelectionInfos.get(clientId).selection = selection;
+        const currentInfo = this._collabSelectionInfos.get(clientId);
+        if (currentInfo) {
+            currentInfo.selection = selection;
         } else {
             this._collabSelectionInfos.set(clientId, { selection });
         }
+        this._drawClientSelection(selection);
+        this._drawClientAvatar(selection);
+        this._updateAvatarCounters();
     }
 
     multiselectionRefresh() {
-        // Refresh the selection but keep the relevant images to avoid flickering.
-        const avatars = [...this._collabSelectionInfos.values()].map(info => info.avatarElement);
-        for (const element of this._collabSelectionsContainer.childNodes) {
-            const isAvatarElement = element.classList && element.classList.contains('oe-collaboration-caret-avatar');
-            if (!(isAvatarElement && avatars.includes(element))) {
-                element.remove();
-            }
-        }
         for (const { selection } of this._collabSelectionInfos.values()) {
-            this._multiselectionDisplayClient(selection);
+            this._drawClientSelection(selection);
+            this._drawClientAvatar(selection);
         }
+        this._updateAvatarCounters();
     }
 
-    _multiselectionDisplayClient({ selection, color, clientId, clientAvatarUrl = '', clientName = this.options._t('Anonymous') }) {
+    _drawClientSelection({ selection, color, clientId, clientName = this.options._t('Anonymous') }) {
         let clientRects;
 
         let anchorNode = this.idFind(selection.anchorNodeOid);
@@ -1753,7 +1781,7 @@ export class OdooEditor extends EventTarget {
         }
 
         // Draw rects (in case the selection is not collapsed).
-        const containerRect = this._collabSelectionsContainer.getBoundingClientRect();
+        const containerRect = this._selectionsContainer.getBoundingClientRect();
         const indicators = clientRects.map(({ x, y, width, height }) => {
             const rectElement = this.document.createElement('div');
             rectElement.style = `
@@ -1783,69 +1811,6 @@ export class OdooEditor extends EventTarget {
         caretTopSquare.setAttribute('data-client-name', clientName);
         caretElement.append(caretTopSquare);
 
-        // Draw user avatar.
-        const selectionInfo = this._collabSelectionInfos.get(clientId);
-        let caretAvatar = selectionInfo && selectionInfo.avatarElement;
-        if (!caretAvatar) {
-            caretAvatar = this.document.createElement('div');
-            caretAvatar.className = 'oe-collaboration-caret-avatar';
-            caretAvatar.style.display = 'none';
-            const image = this.document.createElement('img');
-            caretAvatar.append(image);
-            image.onload = () => caretAvatar.style.removeProperty('display');
-            image.setAttribute('src', clientAvatarUrl);
-            caretAvatar.setAttribute('data-selection-client-id', clientId);
-            this._collabSelectionsContainer.append(caretAvatar);
-        }
-        // Make sure data is up to date.
-        if (selectionInfo) {
-            selectionInfo.avatarElement = caretAvatar;
-            selectionInfo.clientName = clientName;
-        } else {
-            this._collabSelectionInfos.set(clientId, { avatarElement: caretAvatar, clientName: clientName });
-        }
-
-        const anchorBlockRect = closestBlock(anchorNode).getBoundingClientRect();
-        const previousTop = caretAvatar.style.top;
-        const top = anchorBlockRect.y - containerRect.y + 'px';
-        caretAvatar.style.top = top;
-        const closestList = closestElement(anchorNode, 'ul, ol'); // Prevent overlap bullets.
-        const anchorX = closestList ? closestList.getBoundingClientRect().x : anchorBlockRect.x;
-        const previousLeft = caretAvatar.style.left;
-        const left = anchorX - containerRect.x - 25 + 'px';
-        caretAvatar.style.left = left;
-
-        // Handle overlapping avatars.
-        if (previousTop !== top || previousLeft !== left) {
-            const allAvatarsInDom = [...this._collabSelectionsContainer.children].filter(child => child.classList.contains('oe-collaboration-caret-avatar'));
-            for (const position of [[previousTop, previousLeft], [top, left]]) {
-                // Filter clients at that position.
-                const [currentTop, currentLeft] = position;
-                const clients = new Map([...this._collabSelectionInfos.entries()].filter(([key, value]) => {
-                    const avatarTop = value.avatarElement && value.avatarElement.style.top;
-                    const avatarLeft = value.avatarElement && value.avatarElement.style.left;
-                    return value.avatarElement && avatarTop === currentTop && avatarLeft === currentLeft;
-                }));
-                // Update avatar values for that position.
-                const avatars = [...clients.values()].map(client => client.avatarElement);
-                const lastInDom = allAvatarsInDom.find(avatar => avatars.includes(avatar));
-                const newTitle = [...clients.values()].map(client => client.clientName).join('\n');
-                for (const client of clients.values()) {
-                    const avatar = client.avatarElement;
-                    // Only show the number of overlapping avatars on the z-top
-                    // element, and then only if there are indeed more than one
-                    // at the same position.
-                    if (clients.size > 1 && avatar === lastInDom) {
-                        avatar.setAttribute('data-overlapping-avatars', clients.size);
-                    } else {
-                        avatar.removeAttribute('data-overlapping-avatars');
-                    }
-                    if (avatar.firstElementChild.getAttribute('title') !== newTitle) {
-                        avatar.firstElementChild.setAttribute('title', newTitle);
-                    }
-                };
-            }
-        }
         if (direction === DIRECTIONS.LEFT) {
             const rect = clientRects[0];
             caretElement.style.height = `${rect.height * 1.2}px`;
@@ -1858,24 +1823,89 @@ export class OdooEditor extends EventTarget {
             caretElement.style.left = `${rect.right - containerRect.x}px`;
         }
         this._multiselectionRemoveClient(clientId);
-        this._collabSelectionsContainer.append(caretElement, ...indicators);
+        this._selectionsContainer.append(caretElement, ...indicators);
     }
 
-    multiselectionRemove(clientId) {
-        this._collabSelectionInfos.delete(clientId);
-        this._multiselectionRemoveClient(clientId);
-        const avatars = [...this._collabSelectionsContainer.children].filter(child => (
-            child.classList.contains('oe-collaboration-caret-avatar') &&
-            child.getAttribute('data-selection-client-id') === clientId
-        ));
-        for (const avatar of avatars) {
-            avatar.remove();
+    _drawClientAvatar({ selection, clientId, clientAvatarUrl = '', clientName = this.options._t('Anonymous') }) {
+        const anchorNode = this.idFind(selection.anchorNodeOid);
+        const focusNode = this.idFind(selection.focusNodeOid);
+        if (!anchorNode || !focusNode) {
+            return;
+        }
+        const anchorBlock = closestBlock(anchorNode);
+        if (!anchorBlock) return;
+
+        const containerRect = this._avatarsContainer.getBoundingClientRect();
+
+        // Draw user avatar.
+        const selectionInfo = this._collabSelectionInfos.get(clientId) || {};
+        let avatarElement = selectionInfo.avatarElement;
+        if (!avatarElement) {
+            avatarElement = this.document.createElement('div');
+            avatarElement.className = 'oe-collaboration-caret-avatar';
+            avatarElement.style.display = 'none';
+            const image = this.document.createElement('img');
+            avatarElement.append(image);
+            image.onload = () => avatarElement.style.removeProperty('display');
+            image.setAttribute('src', clientAvatarUrl);
+        }
+        // Avoid re-appending the element in the dom.
+        if (!avatarElement.parentElement) {
+            this._avatarsContainer.append(avatarElement);
+        }
+        // Make sure data is up to date.
+        selectionInfo.avatarElement = avatarElement;
+        selectionInfo.clientName = clientName;
+        selectionInfo.avatarTargetElement = anchorBlock;
+        this._collabSelectionInfos.set(clientId, selectionInfo);
+
+        const anchorBlockRect = anchorBlock.getBoundingClientRect();
+        const top = anchorBlockRect.y - containerRect.y;
+        avatarElement.style.top = top + 'px';
+        const closestList = closestElement(anchorNode, 'ul, ol'); // Prevent overlap bullets.
+        const anchorX = closestList ? closestList.getBoundingClientRect().x : anchorBlockRect.x;
+        const left = anchorX - containerRect.x - AVATAR_SIZE;
+        avatarElement.style.left = left + 'px';
+        selectionInfo.avatarPositionKey = `${left}|${top}`;
+    }
+
+    _updateAvatarCounters() {
+        this._avatarsOverlaps = {};
+        for (const info of this._collabSelectionInfos.values()) {
+            const key =  info.avatarPositionKey;
+            this._avatarsOverlaps[key] = this._avatarsOverlaps[key] || new Set();
+            this._avatarsOverlaps[key].add(info);
+        }
+
+        // Render avatars overlap.
+        this._avatarsCountersContainer.replaceChildren();
+        for (const [overlapKey, infos] of Object.entries(this._avatarsOverlaps)) {
+            const size = infos.size;
+            if (size > 1) {
+                const [left, top] = overlapKey.split('|').map((n) => parseInt(n, 10));
+                const div = document.createElement('div');
+                div.className = 'oe-overlapping-counter';
+                div.style.left = left + 10 + 'px';
+                div.style.top = top + 10 + 'px';
+                div.innerText = size;
+                this._avatarsCountersContainer.append(div);
+            }
         }
     }
 
+    multiselectionRemove(clientId) {
+        const selectionInfo = this._collabSelectionInfos.get(clientId);
+        if (selectionInfo && selectionInfo.avatarElement) {
+            selectionInfo.avatarElement.remove();
+        }
+        this._multiselectionRemoveClient(clientId)
+        this._collabSelectionInfos.delete(clientId);
+        this._updateAvatarCounters();
+    }
+
     _multiselectionRemoveClient(clientId) {
-        const elements = this._collabSelectionsContainer.querySelectorAll(
-            `[data-selection-client-id="${clientId}"]:not(.oe-collaboration-caret-avatar)`,
+        const elements = this._selectionsContainer.querySelectorAll(
+            `[data-selection-client-id="${clientId}"]`,
         );
         for (const element of elements) {
             element.remove();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -342,9 +342,9 @@ export class OdooEditor extends EventTarget {
         // By having one parent that contains a tree of containers, it is easy
         // to change the z-index of any container by changing their place in the
         // tree rather than tweaking a z-index number.
-        this._mainAbsoluteContainer = this.document.createElement('div');
-        this._mainAbsoluteContainer.classList.add('oe-absolute-container');
-        this.editable.before(this._mainAbsoluteContainer);
+        this.mainAbsoluteContainer = this.document.createElement('div');
+        this.mainAbsoluteContainer.classList.add('oe-absolute-container');
+        this.editable.before(this.mainAbsoluteContainer);
 
         // This container contains the users selections.
         this._selectionsContainer = this.makeAbsoluteContainer('oe-selections-container');
@@ -365,6 +365,7 @@ export class OdooEditor extends EventTarget {
             this.historySetInitialId(this.options.initialHistoryId);
         }
 
+        this._pluginCall('start', [editable]);
         this._pluginCall('sanitizeElement', [editable]);
 
         // ------
@@ -684,7 +685,7 @@ export class OdooEditor extends EventTarget {
         this._removeDomListener();
         this.powerbox.destroy();
         this.powerboxTablePicker.el.remove();
-        this._mainAbsoluteContainer.remove();
+        this.mainAbsoluteContainer.remove();
         this._resizeObserver.disconnect();
         clearInterval(this._snapshotInterval);
         this._pluginCall('destroy', []);
@@ -3386,6 +3387,22 @@ export class OdooEditor extends EventTarget {
         this.observer.takeRecords();
     }
 
+    disableAvatarForElement(element) {
+        this.enableAvatars();
+        for (const info of this._collabSelectionInfos.values()) {
+            if (info.avatarTargetElement === element) {
+                if (!info.avatarElement.classList.contains('opacity-0')) {
+                    info.avatarElement.classList.add('opacity-0');
+                }
+            }
+        }
+    }
+    enableAvatars() {
+        for (const element of this._avatarsContainer.querySelectorAll('.oe-collaboration-caret-avatar.opacity-0')) {
+            element.classList.remove('opacity-0');
+        }
+    }
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -5024,7 +5041,7 @@ export class OdooEditor extends EventTarget {
     _pluginAdd(Plugin) {
         this._plugins.push(new Plugin({ editor: this }));
     }
-    _pluginCall(method, args) {
+    _pluginCall(method, args = []) {
         for (const plugin of this._plugins) {
             if (plugin[method]) {
                 plugin[method](...args);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2988,8 +2988,8 @@ export class OdooEditor extends EventTarget {
             }
         }
         if (sel.rangeCount) {
-            const closestStartContainer = closestElement(sel.getRangeAt(0).startContainer, '*');
-            const selectionStartStyle = getComputedStyle(closestStartContainer);
+            const closestStartContainer = closestElement(sel.getRangeAt(0).startContainer);
+            const selectionStartStyle = closestStartContainer && getComputedStyle(closestStartContainer);
 
             // queryCommandState does not take stylesheets into account
             for (const format of ['bold', 'italic', 'underline', 'strikeThrough', 'switchDirection']) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -48,6 +48,7 @@ import {
     isWhitespace,
     isVisibleTextNode,
     getCursorDirection,
+    resetOuids,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/g;
@@ -764,10 +765,7 @@ export const editorCommands = {
                 for (const column of columns) {
                     const columnContents = unwrapContents(column);
                     for (const node of columnContents) {
-                        node.ouid = undefined; // Allow move out of unbreakable
-                        for (const descendant of descendants(node)) {
-                            descendant.ouid = undefined; // Allow move out of unbreakable
-                        }
+                        resetOuids(node);
                     }
                 }
             }
@@ -784,10 +782,7 @@ export const editorCommands = {
             row.classList.add('row');
             container.append(row);
             const block = closestBlock(anchor);
-            block.ouid = undefined; // Allow move out of unbreakable
-            for (const descendant of descendants(block)) {
-                descendant.ouid = undefined; // Allow move out of unbreakable
-            }
+            resetOuids(block);
             const columnSize = Math.floor(12 / numberOfColumns);
             const columns = [];
             for (let i = 0; i < numberOfColumns; i++) {
@@ -846,10 +841,7 @@ export const editorCommands = {
                     const column = columns.pop();
                     const columnContents = unwrapContents(column);
                     for (const node of columnContents) {
-                        node.ouid = undefined; // Allow move out of unbreakable
-                        for (const descendant of descendants(node)) {
-                            descendant.ouid = undefined; // Allow move out of unbreakable
-                        }
+                        resetOuids(node);
                     }
                     contents.unshift(...columnContents);
                 }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -387,8 +387,90 @@ i.oe-powerbox-commandImg {
     }
 }
 
+/* Element widget */
+.oe-sidewidget-move {
+    position: absolute;
+    opacity: 0.6;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: white;
+    color: #6e727a;
+    border-radius: 3px;
+    padding: 2px 3px;
+    cursor: move; /* fallback if grab cursor is unsupported */
+    cursor: grab;
+    right: 5px;
+    top: 0px;
+}
+.oe-sidewidget-move:hover {
+    opacity: 1;
+}
+
+/* Element widget drag & drop zone */
+.oe-dropzone-box {
+    position: absolute;
+}
+$oe-dropzone-size-inside: 2px;
+$oe-dropzone-size-outside: 1px;
+$oe-dropzone-size: $oe-dropzone-size-outside + $oe-dropzone-size-inside;
+.oe-dropzone-box-side {
+    position: absolute;
+
+    &.oe-dropzone-box-side-north {
+        width: 100%;
+        height: 50%;
+        top: -($oe-dropzone-size-outside);
+    }
+    &.oe-dropzone-box-side-south {
+        width: 100%;
+        height: 50%;
+        bottom: -($oe-dropzone-size-outside);
+    }
+    &.oe-dropzone-box-side-east {
+        height: 100%;
+        width: ($oe-dropzone-size);
+        right: -($oe-dropzone-size-outside);
+    }
+    &.oe-dropzone-box-side-west {
+        height: 100%;
+        width: ($oe-dropzone-size);
+        left: -($oe-dropzone-size-outside);
+    }
+}
+.debug {
+    .oe-dropzone-box {
+        background: rgba(255, 0, 0, 0.3);
+    }
+    .oe-dropzone-box-side {
+        background: rgb(255, 166, 0);
+    }
+    .oe-dropzone-hook {
+        background: rgba(255, 0, 132, 0.2);
+    }
+}
+.oe-dropzone-hook {
+    position: absolute;
+}
+[data-oe-absolute-container-id=oe-dropzones-container] {
+    opacity: 0.3;
+}
+[data-oe-absolute-container-id=oe-widget-hooks-container] {
+    opacity: 0.3;
+}
+[data-oe-absolute-container-id=oe-dropzone-hint-container] {
+    pointer-events: none;
+}
+.oe-current-drop-hint {
+    position: absolute;
+    background: rgba(0, 136, 255, 0.508);
+}
+.oe-editor-dragging {
+    pointer-events: none;
+}
+
 /* Collaboration cursor */
-.oe-collaboration-selections-container {
+.oe-absolute-container {
     position: absolute;
     isolation: isolate;
     height: 0;
@@ -419,9 +501,11 @@ i.oe-powerbox-commandImg {
     height: 1.5rem;
     width: 1.5rem;
     border-radius: 50%;
-    transition: top 0.5s, left 0.5s;
+    transition: top 0.5s, left 0.5s, opacity 0.2s;
 
     > img {
+        position: absolute;
+        opacity: 1;
         height: 100%;
         width: 100%;
         border-radius: 50%;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -426,19 +426,17 @@ i.oe-powerbox-commandImg {
         width: 100%;
         border-radius: 50%;
     }
-
-    &[data-overlapping-avatars]::after {
-        content: attr(data-overlapping-avatars);
-        background-color: green;
-        color: white;
-        border-radius: 50%;
-        font-size: 9px;
-        padding: 0 4px;
-        position: absolute;
-        top: 11px;
-        right: -5px;
-        z-index: 1;
-    }
+}
+.oe-avatars-counters-container {
+    pointer-events: none;
+}
+.oe-overlapping-counter {
+    position: absolute;
+    background-color: green;
+    color: white;
+    border-radius: 50%;
+    font-size: 9px;
+    padding: 0 4px;
 }
 code.o_inline_code {
     background-color: #c5c5c5;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -285,22 +285,27 @@ export function getFurthestUneditableParent(node, parentLimit) {
     return nonEditableElement;
 }
 /**
- * Returns the closest HTMLElement of the provided Node
- * if a 'selector' is provided, Returns the closest HTMLElement that match the selector
+ * Returns the closest HTMLElement of the provided Node. If the predicate is a
+ * string, returns the closest HTMLElement that match the predicate selector. If
+ * the predicate is a function, returns the closest element that matches the
+ * predicate. Any returned element will be contained within the editable.
  *
  * @param {Node} node
- * @param {string} [selector=undefined]
- * @returns {HTMLElement}
+ * @param {string | Function} [predicate='*']
+ * @returns {HTMLElement|null}
  */
-export function closestElement(node, selector) {
-    let element = node;
-    while (element && element.nodeType !== Node.ELEMENT_NODE) {
-        element = element.parentNode;
+export function closestElement(node, predicate = "*") {
+    if (!node) return null;
+    let element = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+    if (typeof predicate === 'function') {
+        while (element && !predicate(element)) {
+            element = element.parentElement;
+        }
+    } else {
+        element = element?.closest(predicate);
     }
-    if (element && selector) {
-        element = element.closest(selector);
-    }
-    return element && element.querySelector('.odoo-editor-editable') ? null : element;
+
+    return element?.closest('.odoo-editor-editable') && element;
 }
 
 /**

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -2056,6 +2056,16 @@ export function moveNodes(
     const firstNode = nodes.find(node => !!node.parentNode);
     return firstNode ? leftPos(firstNode) : [destinationEl, destinationOffset];
 }
+/**
+ * Remove ouid of a node and it's descendants in order to allow that tree
+ * to be moved into another parent.
+ */
+export function resetOuids(node) {
+    node.ouid = undefined;
+    for (const descendant of descendants(node)) {
+        descendant.ouid = undefined;
+    }
+}
 
 //------------------------------------------------------------------------------
 // Prepare / Save / Restore state utilities

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/powerbox.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/powerbox.test.js
@@ -64,6 +64,7 @@ describe('Powerbox', () => {
     describe('class', () => {
         it('should properly order default commands and categories', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             const powerbox = new Powerbox({
                 categories: [
@@ -97,6 +98,7 @@ describe('Powerbox', () => {
         });
         it('should navigate through commands with arrow keys', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             const powerbox = new Powerbox({
                 categories: [],
@@ -122,6 +124,7 @@ describe('Powerbox', () => {
         });
         it('should execute command on press Enter', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             const powerbox = new Powerbox({
                 categories: [],
@@ -144,6 +147,7 @@ describe('Powerbox', () => {
         });
         it('should filter commands with `commandFilters`', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             const powerbox = new Powerbox({
                 categories: [],
@@ -169,6 +173,7 @@ describe('Powerbox', () => {
         });
         it('should filter commands with `isDisabled`', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             let disableCommands = false;
             const powerbox = new Powerbox({
@@ -198,6 +203,7 @@ describe('Powerbox', () => {
         });
         it('should filter commands with filter text', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             editable.append(document.createTextNode('original text'));
             setSelection(editable.firstChild, 13);
@@ -236,6 +242,7 @@ describe('Powerbox', () => {
         });
         it('should close the Powerbox on remove last filter text with Backspace', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             editable.append(document.createTextNode('1'));
             setSelection(editable.firstChild, 13);
@@ -277,6 +284,7 @@ describe('Powerbox', () => {
         });
         it('should close the Powerbox on press Escape', async () => {
             const editable = document.createElement('div');
+            editable.classList.add('odoo-editor-editable');
             document.body.append(editable);
             const powerbox = new Powerbox({
                 categories: [],

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
@@ -55,6 +55,7 @@ const cleanTestHtml = () => {
 const insertTestHtml = innerHtml => {
     cleanTestHtml();
     const container = document.createElement('DIV');
+    container.classList.add('odoo-editor-editable');
     container.setAttribute('contenteditable', true);
     container.innerHTML = innerHtml;
     document.body.appendChild(container);

--- a/addons/web_editor/static/src/js/editor/smooth_scroll_on_drag.js
+++ b/addons/web_editor/static/src/js/editor/smooth_scroll_on_drag.js
@@ -1,13 +1,9 @@
 /** @odoo-module **/
 
-import Class from "@web/legacy/js/core/class";
-import mixins from "@web/legacy/js/core/mixins";
-
 /**
  * Provides a helper for SmoothScrollOnDrag options.offsetElements
  */
-const OffsetElementsHelper = Class.extend({
-
+class OffsetElementsHelper {
     /**
      * @constructor
      * @param {Object} offsetElements
@@ -16,39 +12,39 @@ const OffsetElementsHelper = Class.extend({
      * @param {jQuery} [offsetElements.$bottom] bottom offset element
      * @param {jQuery} [offsetElements.$left] left offset element
      */
-    init: function (offsetElements) {
+    constructor(offsetElements) {
         this.offsetElements = offsetElements;
-    },
-    top: function () {
+    }
+    top () {
         if (!this.offsetElements.$top || !this.offsetElements.$top.length) {
             return 0;
         }
         return this.offsetElements.$top.get(0).getBoundingClientRect().bottom;
-    },
-    right: function () {
+    }
+    right () {
         if (!this.offsetElements.$right || !this.offsetElements.$right.length) {
             return 0;
         }
         return this.offsetElements.$right.get(0).getBoundingClientRect().left;
-    },
-    bottom: function () {
+    }
+    bottom () {
         if (!this.offsetElements.$bottom || !this.offsetElements.$bottom.length) {
             return 0;
         }
         return this.offsetElements.$bottom.get(0).getBoundingClientRect().top;
-    },
-    left: function () {
+    }
+    left () {
         if (!this.offsetElements.$left || !this.offsetElements.$left.length) {
             return 0;
         }
         return this.offsetElements.$left.get(0).getBoundingClientRect().right;
-    },
-});
+    }
+}
 
 /**
  * Provides smooth scroll behaviour on drag.
  */
-const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
+export class SmoothScrollOnDrag {
 
     /**
      * @constructor
@@ -91,10 +87,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
      *        $scrollTarget.
      * @param {boolean} [options.disableHorizontalScroll = false] Disable horizontal scroll if not needed.
      */
-    init(parent, $element, $scrollTarget, options = {}) {
-        mixins.ParentedMixin.init.call(this);
-        this.setParent(parent);
-
+    constructor($element, $scrollTarget, options = {}) {
         this.$element = $element;
         this.$scrollTarget = $scrollTarget;
         this.options = options;
@@ -146,15 +139,14 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
             }
         });
         this.$element.draggable(draggableOptions);
-    },
+    }
     /**
      * @override
      */
-    destroy: function () {
-        mixins.ParentedMixin.destroy.call(this);
+    destroy() {
         this.$element.off('.smooth_scroll');
         this._stopSmoothScroll();
-    },
+    }
 
     //--------------------------------------------------------------------------
     // Private
@@ -230,7 +222,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
             },
             this.options.scrollTimerInterval
         );
-    },
+    }
     /**
      * Stops the scroll process if any is running.
      *
@@ -240,7 +232,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
         clearInterval(this.autoScrollHandler);
 
         this.$scrollTarget[0].style.scrollBehavior = this._initialScrollBehavior || '';
-    },
+    }
     /**
      * Updates the options depending on the offset position of the draggable
      * helper. In the same time options are used by an interval to trigger
@@ -343,7 +335,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
         this.horizontalDelta = Math.ceil(scrollStepDirection.horizontal *
             this.options.scrollStep *
             (1 - Math.sqrt(scrollDecelerator.horizontal)));
-    },
+    }
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -362,7 +354,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
             top: ev.pageY - elementOffset.top,
             left: ev.pageX - elementOffset.left,
         };
-    },
+    }
     /**
      * Called when dragging the element.
      * Updates the position options and call the provided callback if any.
@@ -377,7 +369,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
         if (typeof onDragCallback === 'function') {
             onDragCallback.call(ui.helper, ev, ui);
         }
-    },
+    }
     /**
      * Called when starting to drag the element.
      * Updates the position params, starts smooth scrolling process and call the
@@ -397,7 +389,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
         if (typeof onDragStartCallBack === 'function') {
             onDragStartCallBack.call(ui.helper, ev, ui);
         }
-    },
+    }
     /**
      * Called when stopping to drag the element.
      * Stops the smooth scrolling process and call the provided callback if any.
@@ -412,7 +404,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
         if (typeof onDragEndCallBack === 'function') {
             onDragEndCallBack.call(ui.helper, ev, ui);
         }
-    },
+    }
     /**
      * Called when the mouse is released outside the page iframe (e.g. the
      * editor panel in Website). This is only useful in Chrome, where the 'stop'
@@ -423,7 +415,6 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
      */
     _onParentWindowMouseup() {
         this.targetWindow.document.dispatchEvent(new Event('mouseup'));
-    },
-});
+    }
+}
 
-export default SmoothScrollOnDrag;

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -7,7 +7,7 @@ import dom from "@web/legacy/js/core/dom";
 import { Markup, confine } from "@web/legacy/js/core/utils";
 import Widget from "@web/legacy/js/core/widget";
 import options from "@web_editor/js/editor/snippets.options";
-import SmoothScrollOnDrag from "@web_editor/js/editor/smooth_scroll_on_drag";
+import { SmoothScrollOnDrag } from "@web_editor/js/editor/smooth_scroll_on_drag";
 import weUtils from "@web_editor/js/common/utils";
 import * as gridUtils from "@web_editor/js/common/grid_layout_utils";
 import { escape } from "@web/core/utils/strings";
@@ -142,7 +142,7 @@ var SnippetEditor = Widget.extend({
                 || (this.options.wysiwyg.snippetsMenu && this.options.wysiwyg.snippetsMenu.$scrollable)
                 || (this.$scrollingElement.length && this.$scrollingElement)
                 || $().getScrollingElement(this.ownerDocument);
-            this.draggableComponent = new SmoothScrollOnDrag(this, this.$el, $scrollable, smoothScrollOptions);
+            this.draggableComponent = new SmoothScrollOnDrag(this.$el, $scrollable, smoothScrollOptions);
         } else {
             this.$('.o_overlay_move_options').addClass('d-none');
             $customize.find('.oe_snippet_clone').addClass('d-none');
@@ -192,6 +192,7 @@ var SnippetEditor = Widget.extend({
         // Before actually destroying a snippet editor, notify the parent
         // about it so that it can update its list of alived snippet editors.
         this.trigger_up('snippet_editor_destroyed');
+        this.draggableComponent && this.draggableComponent.destroy();
         if (this.$optionsSection) {
             this.$optionsSection.remove();
         }
@@ -2008,6 +2009,7 @@ var SnippetsMenu = Widget.extend({
         document.removeEventListener("touchstart", this.__onTouchEvent, true);
         document.removeEventListener("touchmove", this.__onTouchEvent, true);
         document.removeEventListener("touchend", this.__onTouchEvent, true);
+        this.draggableComponent && this.draggableComponent.destroy();
         if (this.$window) {
             if (this.$snippetEditorArea) {
                 this.$snippetEditorArea.remove();
@@ -3424,7 +3426,7 @@ var SnippetsMenu = Widget.extend({
                 },
             },
         });
-        this.draggableComponent = new SmoothScrollOnDrag(this, $snippets, $scrollingElement, smoothScrollOptions);
+        this.draggableComponent = new SmoothScrollOnDrag($snippets, $scrollingElement, smoothScrollOptions);
     },
     /**
      * Adds the 'o_default_snippet_text' class on nodes which contain only

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -43,8 +43,8 @@ import {
 import { renderToElement } from "@web/core/utils/render";
 
 const preserveCursor = OdooEditorLib.preserveCursor;
-const descendants = OdooEditorLib.descendants;
 const { DateTime } = luxon;
+const resetOuids = OdooEditorLib.resetOuids;
 
 /**
  * @param {HTMLElement} el
@@ -5059,9 +5059,7 @@ registry.layout_column = SnippetOptionWidget.extend({
         let $row = this.$('> .row');
         if (!$row.length) {
             const restoreCursor = preserveCursor(this.$target[0].ownerDocument);
-            for (const node of descendants(this.$target[0])) {
-                node.ouid = undefined;
-            }
+            resetOuids(this.$target[0]);
             $row = this.$target.contents().wrapAll($('<div class="row"><div class="col-lg-12"/></div>')).parent().parent();
             restoreCursor();
         }
@@ -5074,9 +5072,7 @@ registry.layout_column = SnippetOptionWidget.extend({
         await new Promise(resolve => setTimeout(resolve));
         if (nbColumns === 0) {
             const restoreCursor = preserveCursor(this.$target[0].ownerDocument);
-            for (const node of descendants($row[0])) {
-                node.ouid = undefined;
-            }
+            resetOuids($row[0]);
             $row.contents().unwrap().contents().unwrap();
             restoreCursor();
             this.trigger_up('activate_snippet', {$snippet: this.$target});

--- a/addons/web_editor/static/src/js/wysiwyg/MoveNodePlugin.js
+++ b/addons/web_editor/static/src/js/wysiwyg/MoveNodePlugin.js
@@ -1,0 +1,415 @@
+/** @odoo-module */
+
+import {
+    ancestors,
+    closestElement,
+    resetOuids,
+    setSelection,
+} from '@web_editor/js/editor/odoo-editor/src/OdooEditor';
+import { SmoothScrollOnDrag } from "@web_editor/js/editor/smooth_scroll_on_drag";
+
+const WIDGET_CONTAINER_WIDTH = 25;
+const WIDGET_MOVE_SIZE = 20;
+
+const ALLOWED_ELEMENTS = 'h1, h2, h3, p, hr, pre, blockquote, ul, ol, table, .o_knowledge_behavior_anchor, .o_text_columns';
+
+export class MoveNodePlugin {
+    constructor(options = {}) {
+        this._options = options;
+
+        this._intersectionObserver = new IntersectionObserver(
+            this._intersectionObserverCallback.bind(this),
+            {
+                root: document,
+            }
+        );
+        this._visibleMovableElements = new Set();
+    }
+
+    start() {
+        this._editor = this._options.editor;
+        this._editable = this._options.editor.editable;
+        this._document = this._options.editor.document;
+        this._elementHookMap = new Map();
+
+        this._editor.addDomListener(this._editable, 'mousemove', this._onMousemove.bind(this), true);
+        this._editor.addDomListener(this._editor.document, 'keydown', this._onDocumentKeydown.bind(this), true);
+        this._editor.addDomListener(this._editor.document, 'mousemove', this._onDocumentMousemove.bind(this), true);
+
+        const avatarContainer = this._editor.mainAbsoluteContainer.querySelector('[data-oe-absolute-container-id="oe-avatars-counters-container"]');
+
+        // This container help to add zone into which the mouse can activate the move widget.
+        this._widgetHookContainer = this._editor.makeAbsoluteContainer('oe-widget-hooks-container');
+        avatarContainer.before(this._widgetHookContainer);
+        // This container contains the differents widgets.
+        this._widgetContainer = this._editor.makeAbsoluteContainer('oe-widgets-container');
+        avatarContainer.before(this._widgetContainer);
+        // This container contains the jquery helper element.
+        this._dragHelperContainer = this._editor.makeAbsoluteContainer('oe-movenode-helper-container');
+        avatarContainer.before(this._dragHelperContainer);
+        // This container contains drop zones. They are the zones that handle where the drop should happen.
+        this._dropzonesContainer = this._editor.makeAbsoluteContainer('oe-dropzones-container');
+        avatarContainer.before(this._dropzonesContainer);
+        // This container contains drop hint. The final rectangle showed to the user.
+        this._dropzoneHintContainer = this._editor.makeAbsoluteContainer('oe-dropzone-hint-container');
+        avatarContainer.before(this._dropzoneHintContainer);
+
+        // Uncomment line for debugging tranparent zones
+        // this._widgetHookContainer.classList.add('debug');
+        // this._dropzonesContainer.classList.add('debug');
+
+        this._scrollableElement = closestElement(this._editable.parentElement);
+        while (this._scrollableElement && getComputedStyle(this._scrollableElement).overflowY !== 'auto') {
+            this._scrollableElement = this._scrollableElement.parentElement;
+        }
+        this._scrollableElement = this._scrollableElement || this._editable;
+
+        this._resetHooksNextMousemove = true;
+        this.mutationObserver = new MutationObserver(() => {
+            this._resetHooksNextMousemove = true;
+            this._removeMoveWidget();
+        });
+        this.mutationObserver.observe(this._editable, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+            characterDataOldValue: true,
+        });
+        this._editor.addDomListener(window, 'resize', this._updateHooks.bind(this));
+        if (this._editor.document.defaultView !== window) {
+            this._editor.addDomListener(this._editor.document.defaultView, 'resize', this._updateHooks.bind(this));
+        }
+    }
+    destroy() {
+        this._intersectionObserver.disconnect();
+        this.mutationObserver.disconnect();
+        this.smoothScrollOnDrag && this.smoothScrollOnDrag.destroy();
+    }
+    _intersectionObserverCallback(entries) {
+        for (const entry of entries) {
+            const element = entry.target;
+            if (entry.isIntersecting) {
+                this._visibleMovableElements.add(element);
+                this._resetHooksNextMousemove = true;
+            } else {
+                this._visibleMovableElements.delete(element);
+                this._elementHookMap.get(element).style.display = `none`;
+            }
+        }
+    }
+    _updateHooks() {
+        const editableStyles = getComputedStyle(this._editable);
+        this._editableRect = this._editable.getBoundingClientRect();
+        const paddingLeft = parseInt(editableStyles.paddingLeft, 10) || 0;
+        this._editableRect.x = this._editableRect.x + paddingLeft - (WIDGET_CONTAINER_WIDTH + 5);
+        this._editableRect.width = this._editableRect.width - paddingLeft + (WIDGET_CONTAINER_WIDTH + 5);
+        const containerRect = this._widgetHookContainer.getBoundingClientRect();
+        const elements = this._getMovableElements();
+
+        const elementsToGarbageCollect = new Set(this._elementHookMap.keys());
+        for (const index in elements) {
+            const element = elements[index];
+            elementsToGarbageCollect.delete(element);
+            let hookElement = this._elementHookMap.get(element);
+            if (!hookElement) {
+                hookElement = document.createElement('div');
+                this._elementHookMap.set(element, hookElement);
+                hookElement.classList.add('oe-dropzone-hook');
+                hookElement.addEventListener('mouseenter', () => {
+                    if (element !== this._currentMovableElement) {
+                        this._setMovableElement(element);
+                    }
+                });
+                this._widgetHookContainer.append(hookElement);
+                hookElement.style.display = `none`;
+
+                this._intersectionObserver.observe(element);
+            }
+            hookElement.style.zIndex = index;
+        }
+        // For all the elements that are not in the dom, remove their
+        // corresponding hook.
+        for (const element of elementsToGarbageCollect) {
+            this._visibleMovableElements.delete(element);
+            this._elementHookMap.get(element).remove();
+            this._intersectionObserver.unobserve(element);
+            this._elementHookMap.delete(element);
+        }
+
+        const visibleElements = [...this._visibleMovableElements];
+        // Prevent layout thrashing by computing all the rects in advance.
+        const elementRects = visibleElements.map((element) => element.getBoundingClientRect());
+        for (const index in visibleElements) {
+            const element = visibleElements[index];
+            const elementRect = elementRects[index];
+            const hookElement = this._elementHookMap.get(element);
+
+            const style = getComputedStyle(element);
+            const marginTop = parseInt(style.marginTop, 10) || 0;
+            const marginBottom = parseInt(style.marginBottom, 10) || 0;
+            let hookBox;
+            if (element.tagName === 'HR') {
+                hookBox = new DOMRect(
+                    elementRect.x - containerRect.left - WIDGET_CONTAINER_WIDTH,
+                    elementRect.y - containerRect.top - marginTop,
+                    elementRect.width + WIDGET_CONTAINER_WIDTH,
+                    elementRect.height + marginTop + marginBottom,
+                );
+            } else {
+                hookBox = new DOMRect(
+                    elementRect.x - containerRect.left - WIDGET_CONTAINER_WIDTH,
+                    elementRect.y - containerRect.top - marginTop,
+                    WIDGET_CONTAINER_WIDTH,
+                    elementRect.height + marginTop + marginBottom,
+                );
+            }
+
+            hookElement.style.left = `${hookBox.x}px`;
+            hookElement.style.top = `${hookBox.y}px`;
+            hookElement.style.width = `${hookBox.width}px`;
+            hookElement.style.height = `${hookBox.height}px`;
+            hookElement.style.display = `block`;
+        }
+    }
+    _updateAnchorWidgets(newAnchorWidget) {
+        let movableElement = newAnchorWidget && closestElement(newAnchorWidget, (node) => {
+            return isNodeMovable(node) && node.matches(ALLOWED_ELEMENTS);
+        });
+        // Retrive the first list container from the ancestors.
+        const listContainer = movableElement && ancestors(movableElement, this._editable)
+            .reverse()
+            .find(n => ['UL', 'OL'].includes(n.tagName));
+        movableElement = listContainer || movableElement;
+        if (movableElement && (movableElement !== this._currentMovableElement)) {
+            this._setMovableElement(movableElement);
+        }
+    }
+    _getMovableElements() {
+        return [...new Set([...this._editable.querySelectorAll(ALLOWED_ELEMENTS)])]
+            .filter((node) =>
+                node.parentElement && node.parentElement.isContentEditable &&
+                isNodeMovable(node)
+            );
+    }
+    _getDroppableElements(draggableNode) {
+        return this._getMovableElements().filter((node) =>
+            !closestElement(node.parentElement, (n) => n === draggableNode)
+        );
+    }
+    _setMovableElement(movableElement) {
+        this._removeMoveWidget();
+        this._currentMovableElement = movableElement;
+        this._editor.disableAvatarForElement(movableElement);
+
+        const containerRect = this._widgetContainer.getBoundingClientRect();
+        const anchorBlockRect = this._currentMovableElement.getBoundingClientRect();
+        const closestList = closestElement(this._currentMovableElement, 'ul, ol'); // Prevent overlap bullets.
+        const anchorX = closestList ? closestList.getBoundingClientRect().x : anchorBlockRect.x;
+        let anchorY = anchorBlockRect.y;
+        if (this._currentMovableElement.tagName.match(/H[1-6]/)) {
+            anchorY += (anchorBlockRect.height - WIDGET_MOVE_SIZE) / 2;
+        }
+
+        this._moveWidget = this._document.createElement('div');
+        this._moveWidget.className = 'oe-sidewidget-move fa fa-sort';
+        this._widgetContainer.append(this._moveWidget);
+
+        let moveWidgetOffsetTop = 0;
+        if (movableElement.tagName === 'HR') {
+            const style = getComputedStyle(movableElement);
+            moveWidgetOffsetTop = parseInt(style.marginTop, 10) || 0;
+        }
+
+        this._moveWidget.style.width = `${WIDGET_MOVE_SIZE}px`;
+        this._moveWidget.style.height = `${WIDGET_MOVE_SIZE}px`;
+        this._moveWidget.style.top = `${anchorY - containerRect.y - moveWidgetOffsetTop}px`;
+        this._moveWidget.style.left = `${anchorX - containerRect.x - WIDGET_CONTAINER_WIDTH}px`;
+
+        if (this._scrollableElement) {
+            this.smoothScrollOnDrag && this.smoothScrollOnDrag.destroy();
+            this.smoothScrollOnDrag = new SmoothScrollOnDrag($(this._moveWidget), $(this._scrollableElement), {
+                scrollBoundaries: {
+                    right: false,
+                },
+                jQueryDraggableOptions: {
+                    start: () => this._startDropzones(movableElement, containerRect),
+                    stop: () => this._stopDropzones(movableElement),
+                    helper: () => {
+                        const container = document.createElement('div');
+                        container.append(movableElement.cloneNode(true))
+                        const style = getComputedStyle(movableElement);
+                        container.style.height = style.height;
+                        container.style.width = style.width;
+                        container.style.paddingLeft = '25px';
+                        container.style.opacity = '0.4';
+                        return $(container);
+                    },
+                    appendTo: this._dragHelperContainer,
+                    cursor: 'move',
+                    scroll: false,
+                },
+                disableHorizontalScroll: true,
+            });
+        }
+    }
+    _removeMoveWidget() {
+        this._editor.enableAvatars();
+        this._moveWidget?.remove();
+        this._moveWidget = undefined;
+        this._currentMovableElement = undefined;
+    }
+    _startDropzones(movableElement, containerRect, directions = ['north', 'south']) {
+        this._removeMoveWidget();
+        const elements = this._getDroppableElements(movableElement);
+
+        this._dropzonesContainer.replaceChildren();
+        this._editable.classList.add('oe-editor-dragging');
+
+        for (const element of elements) {
+            const originalRect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            const marginTop = parseInt(style.marginTop, 10);
+            const marginBottom = parseInt(style.marginBottom, 10);
+            const marginLeft = parseInt(style.marginLeft, 10);
+            const marginRight = parseInt(style.marginRight, 10);
+
+            const dropzoneRect = new DOMRect(
+                originalRect.left - marginLeft - WIDGET_CONTAINER_WIDTH,
+                originalRect.top - marginTop,
+                originalRect.width + marginLeft + marginRight + WIDGET_CONTAINER_WIDTH,
+                originalRect.height + marginTop + marginBottom,
+            );
+            const dropzoneHintRect = new DOMRect(
+                originalRect.left - marginLeft,
+                originalRect.top - marginTop,
+                originalRect.width + marginLeft + marginRight,
+                originalRect.height + marginTop + marginBottom,
+            );
+
+            const dropzoneBox = document.createElement('div');
+            dropzoneBox.className = `oe-dropzone-box`;
+            dropzoneBox.style.top = `${dropzoneRect.top - containerRect.top}px`;
+            dropzoneBox.style.left = `${dropzoneRect.left - containerRect.left}px`;
+            dropzoneBox.style.width = `${dropzoneRect.width}px`;
+            dropzoneBox.style.height = `${dropzoneRect.height}px`;
+
+            const dropzoneHintBox = document.createElement('div');
+            dropzoneHintBox.className = `oe-dropzone-box`;
+            dropzoneHintBox.style.top = `${dropzoneHintRect.top - containerRect.top}px`;
+            dropzoneHintBox.style.left = `${dropzoneHintRect.left - containerRect.left}px`;
+            dropzoneHintBox.style.width = `${dropzoneHintRect.width}px`;
+            dropzoneHintBox.style.height = `${dropzoneHintRect.height}px`;
+
+            const sideElements = {};
+            for (const direction of directions) {
+                const sideElement = document.createElement('div');
+                sideElement.className = `oe-dropzone-box-side oe-dropzone-box-side-${direction}`;
+                sideElements[direction] = sideElement;
+                dropzoneBox.append(sideElement);
+                sideElement.addEventListener('mouseenter', () => {
+                    this._currentZone = [direction];
+
+                    removeDropHint();
+                    this._currentDropHint = document.createElement('div');
+                    this._currentDropHint.className = `oe-current-drop-hint`;
+                    const currentDropHintSize = 4;
+                    const currentDropHintSizeHalf = currentDropHintSize / 2;
+
+                    if (direction === 'north') {
+                        this._currentDropHint.style['top'] = `-${currentDropHintSizeHalf}px`;
+                        this._currentDropHint.style['width'] = `100%`;
+                        this._currentDropHint.style['height'] = `${currentDropHintSize}px`;
+                        dropzoneHintBox.append(this._currentDropHint);
+                        this._currentDropHintElementPosition = ['top', element];
+                    } else if (direction === 'south') {
+                        this._currentDropHint.style['bottom'] = `-${currentDropHintSizeHalf}px`;
+                        this._currentDropHint.style['width'] = `100%`;
+                        this._currentDropHint.style['height'] = `${currentDropHintSize}px`;
+                        dropzoneHintBox.append(this._currentDropHint);
+                        this._currentDropHintElementPosition = ['bottom', element];
+                    } else if (direction === 'west') {
+                        this._currentDropHint.style['left'] = `-${currentDropHintSizeHalf}px`;
+                        this._currentDropHint.style['height'] = `100%`;
+                        this._currentDropHint.style['width'] = `${currentDropHintSize}px`;
+                        dropzoneHintBox.append(this._currentDropHint);
+                        this._currentDropHintElementPosition = ['left', element];
+                    } else if (direction === 'east') {
+                        this._currentDropHint.style['right'] = `-${currentDropHintSizeHalf}px`;
+                        this._currentDropHint.style['height'] = `100%`;
+                        this._currentDropHint.style['width'] = `${currentDropHintSize}px`;
+                        dropzoneHintBox.append(this._currentDropHint);
+                        this._currentDropHintElementPosition = ['right', element];
+                    }
+                });
+                const removeDropHint = () => {
+                    if (this._currentDropHint) {
+                        this._currentDropHint.remove();
+                        this._currentDropHint = null;
+                    }
+                    this._currentDropHintCommand = null;
+                }
+                dropzoneBox.addEventListener('mouseleave', removeDropHint);
+            }
+
+            this._dropzonesContainer.append(dropzoneBox);
+            this._dropzoneHintContainer.append(dropzoneHintBox);
+        }
+    }
+    _stopDropzones(movableElement) {
+        this._editable.classList.remove('oe-editor-dragging');
+        this._dropzonesContainer.replaceChildren();
+        this._dropzoneHintContainer.replaceChildren();
+
+        if (this._currentDropHintElementPosition) {
+            const [position, focusElelement] = this._currentDropHintElementPosition;
+            this._currentDropHintElementPosition = undefined;
+            const previousParent = movableElement.parentElement;
+            if (position === 'top') {
+                focusElelement.before(movableElement);
+            } else if (position === 'bottom') {
+                focusElelement.after(movableElement);
+            }
+            if (previousParent.innerHTML.trim() === '') {
+                const p = document.createElement('p');
+                const br = document.createElement('br');
+                p.append(br);
+                previousParent.append(p);
+            }
+            setSelection(
+                movableElement,
+                movableElement.childNodes.length
+            );
+            resetOuids(movableElement);
+            this._editor.historyStep();
+        }
+    }
+    _onMousemove(e) {
+        this._updateAnchorWidgets(e.target);
+    }
+    _onDocumentKeydown() {
+        // Hide the move widget upon keystroke for visual clarity and provide
+        // visibility to a collaborative avatar.
+        this._removeMoveWidget();
+    }
+    _onDocumentMousemove(e) {
+        if(this._resetHooksNextMousemove) {
+            this._resetHooksNextMousemove = false;
+            this._removeMoveWidget();
+            this._updateHooks();
+        }
+        if (this._editableRect && !isPointInside(this._editableRect, e.clientX, e.clientY)) {
+            this._removeMoveWidget();
+        }
+    }
+}
+
+function isNodeMovable(node) {
+    return node.parentElement?.getAttribute('contentEditable') === 'true';
+}
+
+function isPointInside(rect, x, y) {
+    return rect.left <= x &&
+        rect.right >= x &&
+        rect.top <= y &&
+        rect.bottom >= y;
+};


### PR DESCRIPTION
- [REF] web_editor,mass_mailing,website: make `closestElement` support `predicate`
- [REF] web_editor: prepare absolute containers for the movable node 
- [IMP] web_editor: drag and drop nodes within the editable

PURPOSE
The main reason is that when there are two block side by side that are
not editable (eg. the `HR` tag, the `/template` block), it is impossible
to set the cursor in between to add more content.

task-2984709

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
