### PR TITLE
[FIX] core: fix python-format flag

### DIFF
--- a/odoo/addons/test_translation_import/i18n/fr.po
+++ b/odoo/addons/test_translation_import/i18n/fr.po
@@ -143,27 +143,23 @@ msgstr ""
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "do export"
-msgstr ""
+msgstr "exporter"
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "slot"
-msgstr ""
+msgstr "emplacement"
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "slot 2"
-msgstr ""
+msgstr "emplacement 2"
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "text node"
-msgstr ""
+msgstr "nœud de texte"

--- a/odoo/addons/test_translation_import/i18n/fr.po
+++ b/odoo/addons/test_translation_import/i18n/fr.po
@@ -141,25 +141,26 @@ msgid "XML"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "do export"
 msgstr "exporter"
 
 #. module: test_translation_import
-#. openerp-web
+#: code:addons/test_translation_import/models/models.py:0
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, python-format, javascript-format
 msgid "slot"
 msgstr "emplacement"
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "slot 2"
 msgstr "emplacement 2"
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "text node"
 msgstr "nœud de texte"

--- a/odoo/addons/test_translation_import/i18n/fr_BE.po
+++ b/odoo/addons/test_translation_import/i18n/fr_BE.po
@@ -140,25 +140,26 @@ msgid "XML"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "do export"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
+#: code:addons/test_translation_import/models/models.py:0
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, python-format, javascript-format
 msgid "slot"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "slot 2"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "text node"
 msgstr ""

--- a/odoo/addons/test_translation_import/i18n/fr_BE.po
+++ b/odoo/addons/test_translation_import/i18n/fr_BE.po
@@ -142,27 +142,23 @@ msgstr ""
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "do export"
 msgstr ""
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "slot"
 msgstr ""
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "slot 2"
 msgstr ""
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "text node"
 msgstr ""

--- a/odoo/addons/test_translation_import/i18n/test_translation_import.pot
+++ b/odoo/addons/test_translation_import/i18n/test_translation_import.pot
@@ -15,6 +15,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "Bar chart title"
+msgstr ""
+
+#. module: test_translation_import
 #: code:addons/test_translation_import/models/models.py:0
 #, python-format
 msgid "Code Lazy, English"
@@ -94,6 +100,36 @@ msgid "Name"
 msgstr ""
 
 #. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "Opportunities"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "Pipeline"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "Pipeline Analysis"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "Scorecard chart"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "Scorecard description"
+msgstr ""
+
+#. module: test_translation_import
 #: model:ir.model.fields,field_description:test_translation_import.field_test_translation_import_model1__selection
 msgid "Selection"
 msgstr ""
@@ -140,25 +176,68 @@ msgid "XML"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "aa (\\\"inside\\\") bb"
+msgstr ""
+
+#. module: test_translation_import
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "do export"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "exported 1"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "exported 2"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "exported 3"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "hello \\\"world\\\""
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "link label"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/models/models.py:0
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, python-format, javascript-format
 msgid "slot"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "slot 2"
 msgstr ""
 
 #. module: test_translation_import
-#. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
+#, javascript-format
 msgid "text node"
+msgstr ""
+
+#. module: test_translation_import
+#: code:addons/test_translation_import/data/files/test_spreadsheet_dashboard.json:0
+#, javascript-format
+msgid "with spaces"
 msgstr ""

--- a/odoo/addons/test_translation_import/i18n/test_translation_import.pot
+++ b/odoo/addons/test_translation_import/i18n/test_translation_import.pot
@@ -142,27 +142,23 @@ msgstr ""
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "do export"
 msgstr ""
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "slot"
 msgstr ""
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "slot 2"
 msgstr ""
 
 #. module: test_translation_import
 #. openerp-web
 #: code:addons/test_translation_import/static/src/xml/js_templates.xml:0
-#, python-format
 msgid "text node"
 msgstr ""

--- a/odoo/addons/test_translation_import/models/models.py
+++ b/odoo/addons/test_translation_import/models/models.py
@@ -14,6 +14,7 @@ class TestTranslationImportModel1(models.Model):
     xml = fields.Text('XML', translate=xml_translate)
 
     def get_code_translation(self):
+        _('slot')  # a code translation for both python and js(static/src/xml/js_template.xml)
         return _('Code, English')
 
     def get_code_lazy_translation(self):

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -275,6 +275,13 @@ class TestTranslationFlow(common.TransactionCase):
                 for tran in new_web['messages']
             ), 'Python only translations should not be stored as webclient translations'
         )
+        self.assertIn('slot', new_python, 'translations for both python and webclient should be stored as python translations')
+        self.assertTrue(
+            any(
+                tran['id'] == 'slot'
+                for tran in new_web['messages']
+            ), 'translations for both python and webclient should be stored as webclient translations'
+        )
 
         # test model and model terms translations
         record = self.env.ref('test_translation_import.test_translation_import_model1_record1')
@@ -349,7 +356,7 @@ class TestTranslationFlow(common.TransactionCase):
         trans_static = []
         po_reader = TranslationModuleReader(self.env.cr, ['test_translation_import'])
         for line in po_reader:
-            module, ttype, name, res_id, source, value, comments = line
+            module, ttype, name, res_id, source, value, comments, flags = line
             if name == "addons/test_translation_import/static/src/xml/js_templates.xml":
                 trans_static.append(source)
 
@@ -363,7 +370,7 @@ class TestTranslationFlow(common.TransactionCase):
         terms = []
         po_reader = TranslationModuleReader(self.env.cr, ['test_translation_import'])
         for line in po_reader:
-            _module, _ttype, name, _res_id, source, _value, _comments = line
+            _module, _ttype, name, _res_id, source, _value, _comments, _flags = line
             if name == "addons/test_translation_import/data/files/test_spreadsheet_dashboard.json":
                 terms.append(source)
         self.assertEqual(set(terms), {

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -7,10 +7,9 @@ import io
 import odoo
 from odoo.tests import common, tagged
 from odoo.tools.misc import file_open, mute_logger
-from odoo.tools.translate import _, _lt, TranslationFileReader, TranslationModuleReader
+from odoo.tools.translate import TranslationModuleReader, code_translations, CodeTranslations
 from odoo import Command
 from odoo.addons.base.models.ir_fields import BOOLEAN_TRANSLATIONS
-
 
 class TestImport(common.TransactionCase):
 
@@ -232,7 +231,6 @@ class TestTranslationFlow(common.TransactionCase):
 
     def test_export_import(self):
         """ Ensure export+import gives the same result as loading a language """
-        # load language and generate missing terms to create missing empty terms
         self.env["base.language.install"].create({
             'overwrite': True,
             'lang_ids': [(6, 0, [self.env.ref('base.lang_fr').id])],
@@ -245,9 +243,40 @@ class TestTranslationFlow(common.TransactionCase):
             'modules': [Command.set([module.id])]
         })
         export.act_getfile()
-        po_file = export.data
-        self.assertIsNotNone(po_file)
+        po_file_data = export.data
+        self.assertIsNotNone(po_file_data)
 
+        # test code translations
+        new_code_translations = CodeTranslations()
+        # a hack to load code translations for new_code_translations
+        with io.BytesIO(base64.b64decode(po_file_data)) as po_file:
+            po_file.name = 'fr_FR.po'
+            new_code_translations.python_translations[('test_translation_import', 'fr_FR')] = \
+                new_code_translations._trans_load_code_python(po_file, 'po', 'fr_FR')
+            new_code_translations.web_translations[('test_translation_import', 'fr_FR')] = {
+                "messages": [
+                    {"id": src, "string": value}
+                    for src, value in new_code_translations._trans_load_code_webclient(po_file, 'po', 'fr_FR').items()
+                ]
+            }
+
+        old_python = code_translations.get_python_translations('test_translation_import', 'fr_FR')
+        new_python = new_code_translations.get_python_translations('test_translation_import', 'fr_FR')
+        self.assertEqual(old_python, new_python, 'python code translations are not exported/imported correctly')
+
+        old_web = code_translations.get_web_translations('test_translation_import', 'fr_FR')
+        new_web = new_code_translations.get_web_translations('test_translation_import', 'fr_FR')
+        self.assertEqual(old_web, new_web, 'web client code translations are not exported/imported correctly')
+
+        self.assertNotIn('text node', new_python, 'web client only translations should not be stored as python translations')
+        self.assertFalse(
+            any(
+                tran['id'] == 'Code Lazy, English'
+                for tran in new_web['messages']
+            ), 'Python only translations should not be stored as webclient translations'
+        )
+
+        # test model and model terms translations
         record = self.env.ref('test_translation_import.test_translation_import_model1_record1')
         record.invalidate_recordset()
         self.assertEqual(

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1133,6 +1133,7 @@ class TranslationModuleReader:
             translations = code_translations.get_python_translations(module, self._lang)
         else:
             translations = code_translations.get_web_translations(module, self._lang)
+            translations = {tran['id']: tran['string'] for tran in translations['messages']}
         try:
             for extracted in extract.extract(extract_method, src_file, keywords=extract_keywords, options=options):
                 # Babel 0.9.6 yields lineno, message, comments


### PR DESCRIPTION
Before this comment the flag 'python-format' marked all code translations even
if the translation is only for web client (with comment openerp-web).

From Odoo 16, code translations are stored in RAM on demand. And web client only
translations have to be unnecessarily stored with other python translations.

This commit won't set flag 'python-format' for those translations who don't
contain python code translations.