### PR TITLE
[FIX] payment: use correct value for amount_paid of account.move

### DIFF
--- a/addons/payment/models/account_move.py
+++ b/addons/payment/models/account_move.py
@@ -28,16 +28,12 @@ class AccountMove(models.Model):
                 lambda tx: tx.state == 'authorized'
             )
 
-    @api.depends('transaction_ids')
+    @api.depends('amount_total', 'amount_residual')
     def _compute_amount_paid(self):
-        """ Sum all the transaction amount for which state is in 'authorized' or 'done'
+        """ Compute the amount already paid for this invoice based on the total amount and the residual amount.
         """
         for invoice in self:
-            invoice.amount_paid = sum(
-                invoice.transaction_ids.filtered(
-                    lambda tx: tx.state in ('authorized', 'done')
-                ).mapped('amount')
-            )
+            invoice.amount_paid = invoice.amount_total - invoice.amount_residual
 
     def get_portal_last_transaction(self):
         self.ensure_one()


### PR DESCRIPTION
The field `amount_paid` of account.move has no value

Steps to reproduce:
1. Install Invoicing and Studio
2. Go to Invoicing > Customers > Invoices
3. Toggle Studio
4. Add the field amount_paid to the list view and close Studio
5. Register the payment for any invoice and return to the list view
6. The field `amount_paid` still shows an amount of 0

Solution:
Compute `amount_paid` based on the difference between `amount_total` and `amount_residual`

opw-3034707