### PR TITLE
[FIX] account, crm, web: remove references to `session.company_currency_id`

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -4,7 +4,6 @@ import { formatFloat, formatMonetary } from "@web/views/fields/formatters";
 import { parseFloat } from "@web/views/fields/parsers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { registry } from "@web/core/registry";
-import { session } from "@web/session";
 
 const { Component, onPatched, onWillUpdateProps, useRef, useState } = owl;
 
@@ -17,8 +16,8 @@ class TaxGroupComponent extends Component {
         this.state = useState({ value: "readonly" });
         onPatched(() => {
             if (this.state.value === "edit") {
-                const { taxGroup, currency } = this.props;
-                const newVal = formatFloat(taxGroup.tax_group_amount, { digits: currency.digits });
+                const { taxGroup } = this.props;
+                const newVal = formatFloat(taxGroup.tax_group_amount);
                 this.inputTax.el.value = newVal;
                 this.inputTax.el.focus(); // Focus the input
             }
@@ -89,7 +88,6 @@ class TaxGroupComponent extends Component {
 }
 
 TaxGroupComponent.props = {
-    currency: {},
     taxGroup: { optional: true },
     onChangeTaxGroup: { optional: true },
     isReadonly: Boolean,
@@ -118,12 +116,7 @@ export class TaxTotalsComponent extends Component {
     }
 
     get currencyId() {
-        const recordCurrency = this.props.record.data.currency_id;
-        return recordCurrency ? recordCurrency[0] : session.company_currency_id;
-    }
-
-    get currency() {
-        return session.currencies[this.currencyId];
+        return this.props.record.data.currency_id;
     }
 
     invalidate() {
@@ -145,7 +138,8 @@ export class TaxTotalsComponent extends Component {
     }
 
     _format(amount) {
-        return formatMonetary(amount, { currencyId: this.currencyId });
+        const options = this.currencyId ? { currencyId: this.currencyId } : {};
+        return formatMonetary(amount, options);
     }
 
     _computeTotalsFormat() {

--- a/addons/account/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/account/static/src/components/tax_totals/tax_totals.xml
@@ -55,7 +55,6 @@
 
                     <t t-foreach="totals.groups_by_subtotal[subtotal['name']]" t-as="taxGroup" t-key="taxGroup.group_key">
                         <TaxGroupComponent
-                            currency="currency"
                             taxGroup="taxGroup"
                             isReadonly="readonly"
                             onChangeTaxGroup.bind="_onChangeTaxValueByTaxGroup"

--- a/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
-import { session } from "@web/session";
 import { useService } from "@web/core/utils/hooks";
 
 const { onWillStart } = owl;
@@ -24,8 +23,8 @@ export class CrmKanbanRenderer extends KanbanRenderer {
         const value = group.getAggregates(rrField.name);
         const title = rrField.string || this.env._t("Count");
         let currency = false;
-        if (value && rrField.currency_field) {
-            currency = session.currencies[session.company_currency_id];
+        if (value && rrField.currency_field && group.list.records.length) {
+            currency = group.list.records[0].data[rrField.currency_field];
         }
         return { value, currency, title };
     }

--- a/addons/web/static/src/legacy/js/views/sample_server.js
+++ b/addons/web/static/src/legacy/js/views/sample_server.js
@@ -1,6 +1,5 @@
 /** @odoo-module alias=web.SampleServer **/
 
-    import session from 'web.session';
     import utils from 'web.utils';
     import Registry from 'web.Registry';
     import viewUtils from 'web.viewUtils';
@@ -249,7 +248,7 @@
                     return this._getRandomInt(SampleServer.MAX_MONETARY);
                 case "many2one":
                     if (field.relation === 'res.currency') {
-                        return session.company_currency_id;
+                        return 1;
                     }
                     if (field.relation === 'ir.attachment') {
                         return false;

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -9,7 +9,6 @@ import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { useSortable } from "@web/core/utils/sortable";
 import { sprintf } from "@web/core/utils/strings";
-import { session } from "@web/session";
 import { isAllowedDateField } from "@web/views/relational_model";
 import { isNull, isRelational } from "@web/views/utils";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
@@ -284,8 +283,8 @@ export class KanbanRenderer extends Component {
         const value = group.getAggregates(sumField && sumField.name);
         const title = sumField ? sumField.string : this.env._t("Count");
         let currency = false;
-        if (sumField && value && sumField.currency_field) {
-            currency = session.currencies[session.company_currency_id];
+        if (sumField && value && sumField.currency_field && group.list.records.length) {
+            currency = group.list.records[0].data[sumField.currency_field];
         }
         return { value, currency, title };
     }

--- a/addons/web/static/tests/legacy/views/sample_server_tests.js
+++ b/addons/web/static/tests/legacy/views/sample_server_tests.js
@@ -2,8 +2,6 @@ odoo.define('web.sample_server_tests', function (require) {
     "use strict";
 
     const SampleServer = require('web.SampleServer');
-    const session = require('web.session');
-    const { mock } = require('web.test_utils');
 
     const {
         MAIN_RECORDSET_SIZE, SEARCH_READ_LIMIT, // Limits
@@ -83,10 +81,6 @@ odoo.define('web.sample_server_tests', function (require) {
         QUnit.test("Sample data: people type + all field names", async function (assert) {
             assert.expect(26);
 
-            mock.patch(session, {
-                company_currency_id: 4,
-            });
-
             const allFieldNames = Object.keys(this.fields['res.users']);
             const server = new DeterministicSampleServer('res.users', this.fields['res.users']);
             const { records } = await server.mockRpc({
@@ -145,7 +139,7 @@ odoo.define('web.sample_server_tests', function (require) {
             assert.ok(selectionValues.includes(rec.type));
 
             // Relational fields
-            assert.strictEqual(rec.currency[0], 4);
+            assert.strictEqual(rec.currency[0], 1);
             // Currently we expect the currency name to be a latin string, which
             // is not important; in most case we only need the ID. The following
             // assertion can be removed if needed.
@@ -166,7 +160,6 @@ odoo.define('web.sample_server_tests', function (require) {
                 (id) => typeof id === 'number')
             );
 
-            mock.unpatch(session);
         });
 
         QUnit.test("Sample data: country type", async function (assert) {


### PR DESCRIPTION
### Steps to reproduce
* install Sales
* create a new product
* activate debug mode
* create a new quotation and add the product you just made (without setting a customer or a pricelist)

You will be met with a traceback.

### Cause

The issue occurs because  `session.company_currency_id` referenced on the following line, is never defined.
https://github.com/odoo/odoo/blob/48c068a2d76c302fdddda7125b7244c670b4a77c/addons/account/static/src/components/tax_totals/tax_totals.js#L122

This means that `currency`, defined just below that, will also be undefined. However, since `TaxGroupComponent.currency` is a required prop, a traceback appears when `owl.validateProps` is called. (For performance reasons, `owl.validateProps` is only called when debug is active. That's why the issue only happens when debug mode is active.)
https://github.com/odoo/odoo/blob/be996cf423ce09be4e4661c0b42a97d92a4dcdb4/addons/web/static/lib/owl/owl.js#L3046

### Note
This could fix some other potential issues as well because `session.company_currency_id` is used in a few other files without being defined. For example:
https://github.com/odoo/odoo/blob/42237c0ddc78dada8662277c80ca7424287f9af2/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js#L28

Moreover, `session.company_currency_id` used to be defined in `web_dashboard`, a module that does not exist anymore.
https://github.com/odoo/enterprise/blob/3d351aa3f8e4943df81bc09640ae16380e9a89f7/web_dashboard/models/ir_http.py#L14

opw-3033656
