### PR TITLE
[FIX] account/l10n_ch: remove qr codes option from settings

### DIFF
--- a/addons/l10n_ch/views/res_config_settings_views.xml
+++ b/addons/l10n_ch/views/res_config_settings_views.xml
@@ -6,6 +6,9 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="account.res_config_settings_view_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//div[@id='qr_code_invoices']" position="replace">
+                    <div id="qr_code_invoices" invisible="1"/>
+                </xpath>
                 <xpath expr="//div[@id='invoicing_settings']" position="inside">
                     <div class="col-12 col-lg-6 o_setting_box" id="l10n_ch-isr_print_bank" attrs="{'invisible': [('country_code', '!=', 'CH')]}">
                         <div class="o_setting_left_pane">


### PR DESCRIPTION

In Switzerland, adding an extra page containing a QR Bill is mandatory in many cases, mainly when the customer is also from Switzerland (although there are other conditions).

However, activating the option 'QR Codes' in the settings (which is not linked to the QR Bill) can cause problem.

For instance, the Swiss QR code will be repeated multiple times accross the pages, or it will be impossible to bill a foreign customer.

This option is misleading for the Swiss user, and it is best not to display it at all.

task-3062570