### PR TITLE
[15.0][imp] calendar reminder doesn't notify event author

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -179,6 +179,7 @@ class AlarmManager(models.AbstractModel):
         for alarm in alarms:
             alarm_attendees = attendees.filtered(lambda attendee: attendee.event_id.id in events_by_alarm[alarm.id])
             alarm_attendees.with_context(
+                mail_notify_author=True,
                 mail_notify_force_send=True,
                 calendar_template_ignore_recurrence=True
             )._send_mail_to_attendees(


### PR DESCRIPTION
Before this commit calendar reminder doesn't trigger email notification to the author of calendar.event.
This is odd because this person set this reminder.

After this commit reminder will send email notification to all attendees, including author.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
