### PR TITLE
[FIX] web: correctly mock read_group day format

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -781,7 +781,7 @@ export class MockServer {
             if (type === "date") {
                 const date = DateTime.fromSQL(val);
                 if (aggregateFunction === "day") {
-                    return date.toFormat("yyyy-MM-dd");
+                    return date.toFormat("dd MMM yyyy");
                 } else if (aggregateFunction === "week") {
                     return `W${date.toFormat("WW kkkk")}`;
                 } else if (aggregateFunction === "quarter") {
@@ -796,7 +796,7 @@ export class MockServer {
                 if (aggregateFunction === "hour") {
                     return date.toFormat("HH:00 dd MMM");
                 } else if (aggregateFunction === "day") {
-                    return date.toFormat("yyyy-MM-dd");
+                    return date.toFormat("dd MMM yyyy");
                 } else if (aggregateFunction === "week") {
                     return `W${date.toFormat("WW kkkk")}`;
                 } else if (aggregateFunction === "quarter") {
@@ -895,7 +895,7 @@ export class MockServer {
                                 break;
                             }
                             case "day": {
-                                startDate = parseDateTime(value, { format: "yyyy-MM-dd" });
+                                startDate = parseDateTime(value, { format: "dd MMM yyyy" });
                                 endDate = startDate.plus({ days: 1 });
                                 break;
                             }

--- a/addons/web/static/tests/legacy/views/pivot_tests.js
+++ b/addons/web/static/tests/legacy/views/pivot_tests.js
@@ -3128,10 +3128,10 @@ QUnit.module('Views', {
             pivot.$('th').slice(8).text(),
             [
                 'Total',
-                    '2016-12-15',
-                    '2016-12-17',
-                    '2016-11-22',
-                    '2016-11-03'
+                    '15 Dec 2016',
+                    '17 Dec 2016',
+                    '22 Nov 2016',
+                    '03 Nov 2016'
             ].join(''),
             "The row headers should be as expected"
         );
@@ -3143,7 +3143,7 @@ QUnit.module('Views', {
             pivot.$('th').slice(0, 7).text(),
             [
                 '', 'Total',                                                '',
-                    '2016-12-15', '2016-12-17', '2016-11-22', '2016-11-03',
+                    '15 Dec 2016', '17 Dec 2016', '22 Nov 2016', '03 Nov 2016',
             ].join(''),
             "The col headers should be as expected"
         );
@@ -3171,7 +3171,7 @@ QUnit.module('Views', {
             pivot.$('th').slice(0, 7).text(),
             [
                 '', 'Total',                                                '',
-                    '2016-11-22', '2016-11-03', '2016-12-15', '2016-12-17',
+                    '22 Nov 2016', '03 Nov 2016', '15 Dec 2016', '17 Dec 2016',
             ].join(''),
             "The col headers should be as expected"
         );

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -171,7 +171,7 @@ QUnit.test("performRPC: read_group, group by date", async function (assert) {
     });
     assert.deepEqual(
         result.map((x) => x["date:day"]),
-        ["2016-12-14", "2016-10-26", "2016-12-15", "2016-04-11", "2019-12-30"]
+        ["14 Dec 2016", "26 Oct 2016", "15 Dec 2016", "11 Apr 2016", "30 Dec 2019"]
     );
     assert.deepEqual(
         result.map((x) => x.date_count),
@@ -288,7 +288,7 @@ QUnit.test("performRPC: read_group, group by datetime", async function (assert) 
     });
     assert.deepEqual(
         result.map((x) => x["datetime:day"]),
-        ["2016-12-14", "2016-10-26", "2016-12-15", "2016-04-11", "2019-12-30"]
+        ["14 Dec 2016", "26 Oct 2016", "15 Dec 2016", "11 Apr 2016", "30 Dec 2019"]
     );
     assert.deepEqual(
         result.map((x) => x.datetime_count),


### PR DESCRIPTION
The read_group mock implementation doesn't return groups aggretated by day with the correct format.

The python server returns "14 Dec 2016" but the mock server returns "2016-12-14"

https://github.com/odoo/odoo/blob/ca5b49deef4093e91461d709b2a4cce158bf4138/odoo/models.py#L2282


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
