### PR TITLE
[IMP] event_sale: add event on sale order

### DIFF
--- a/addons/event_booth_sale/__manifest__.py
+++ b/addons/event_booth_sale/__manifest__.py
@@ -20,6 +20,7 @@ Sell your event booths and track payments on sale orders.
         'views/event_booth_registration_views.xml',
         'views/event_booth_views.xml',
         'wizard/event_booth_configurator_views.xml',
+        'wizard/event_booth_batch_configurator_views.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/event_booth_sale/models/__init__.py
+++ b/addons/event_booth_sale/models/__init__.py
@@ -9,4 +9,3 @@ from . import event_booth_category
 from . import event_type_booth
 from . import sale_order
 from . import sale_order_line
-from . import sale_order_template_line

--- a/addons/event_booth_sale/models/sale_order.py
+++ b/addons/event_booth_sale/models/sale_order.py
@@ -24,6 +24,11 @@ class SaleOrder(models.Model):
             so.event_booth_count = slot_mapped.get(so.id, 0)
 
     def action_confirm(self):
+        for line in self.order_line:
+            if not line.event_id.id and line.product_type == 'event_booth':
+                return self.env['ir.actions.act_window'].with_context(
+                    default_sale_order_id=self.id
+                )._for_xml_id('event_booth_sale.event_booth_batch_configurator_action')
         res = super(SaleOrder, self).action_confirm()
         for so in self:
             so.order_line._update_event_booths()

--- a/addons/event_booth_sale/models/sale_order_template_line.py
+++ b/addons/event_booth_sale/models/sale_order_template_line.py
@@ -1,6 +1,0 @@
-from odoo import fields, models
-
-class SaleOrderTemplateLine(models.Model):
-    _inherit = "sale.order.template.line"
-
-    product_id = fields.Many2one(domain="[('sale_ok', '=', True), ('detailed_type', 'not in', ['event', 'event_booth']), ('company_id', 'in', [company_id, False])]")

--- a/addons/event_booth_sale/security/ir.model.access.csv
+++ b/addons/event_booth_sale/security/ir.model.access.csv
@@ -3,3 +3,5 @@ access_event_booth_registration_salesman,access.event.booth.registration.salesma
 access_event_booth_registration_event_desk,access.event.booth.registration.event.desk,model_event_booth_registration,event.group_event_registration_desk,1,0,0,0
 access_event_booth_registration_event_user,access.event.booth.registration.event.user,model_event_booth_registration,event.group_event_user,1,1,1,1
 access_event_booth_configurator_salesman,access.event.booth.configurator.salesman,model_event_booth_configurator,sales_team.group_sale_salesman,1,1,1,0
+access_event_event_booth_configurator_batch,access.event.event.booth.configurator.batch,model_event_event_booth_configurator_batch,sales_team.group_sale_salesman,1,1,1,0
+access_event_booth_editor_line,access.event.booth.editor.line,model_event_booth_editor_line,sales_team.group_sale_salesman,1,1,1,1

--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -21,7 +21,7 @@ patch(SaleOrderLineProductField.prototype, 'event_booth_sale', {
     },
 
     get isConfigurableLine() {
-        return this._super(...arguments) || Boolean(this.props.record.data.event_booth_category_id);
+        return this._super(...arguments) || Boolean(this.props.record.data.product_type === 'event_booth');
     },
 
     async _openEventBoothConfigurator(edit) {

--- a/addons/event_booth_sale/wizard/__init__.py
+++ b/addons/event_booth_sale/wizard/__init__.py
@@ -2,3 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import event_booth_configurator
+from . import event_booth_batch_configurator
+from . import event_booth_batch_configurator_line

--- a/addons/event_booth_sale/wizard/event_booth_batch_configurator.py
+++ b/addons/event_booth_sale/wizard/event_booth_batch_configurator.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+
+
+class BoothBatchEventConfigurator(models.TransientModel):
+    _name = 'event.event.booth.configurator.batch'
+    _description = 'Event booth batch Configurator'
+
+    configurable_booth_event_ids = fields.One2many('event.booth.editor.line', 'editor_id', string="Configurable Event ids")
+    sale_order_id = fields.Many2one('sale.order', 'Sales Order', required=True, ondelete='cascade')
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if not res.get('sale_order_id'):
+            sale_order_id = res.get('sale_order_id', self._context.get('active_id'))
+            res['sale_order_id'] = sale_order_id
+        sale_order = self.env['sale.order'].browse(res.get('sale_order_id'))
+        res['configurable_booth_event_ids'] = [
+            [0, 0, {
+                'event_id': so_line.event_id.id,
+                'event_booth_ids': so_line.event_booth_ids.ids,
+                'event_booth_category_id': so_line.event_booth_category_id.id,
+                'product_id': so_line.product_id,
+                'order_id': sale_order,
+                'sale_order_line_id':so_line,
+            }]
+            for so_line in sale_order.order_line
+            for __ in range(int(so_line.product_uom_qty))
+            if so_line.product_type == 'event_booth'
+        ]
+        return self._convert_to_write(res)
+
+    def action_configure(self):
+        self.ensure_one()
+        for configurable_booth_event_id in self.configurable_booth_event_ids:
+            configurable_booth_event_id._get_event_data()
+        return {'type': 'ir.actions.act_window_close'}

--- a/addons/event_booth_sale/wizard/event_booth_batch_configurator_line.py
+++ b/addons/event_booth_sale/wizard/event_booth_batch_configurator_line.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+
+
+class EventConfiguratorLine(models.TransientModel):
+    """Event Booth Configuration"""
+    _name = "event.booth.editor.line"
+    _description = 'Edit Event Booth values on Sales Confirmation'
+    _order = "id desc"
+
+    editor_id = fields.Many2one('event.event.booth.configurator.batch')
+    product_id = fields.Many2one('product.product', string="Product", readonly=True)
+    event_booth_category_id = fields.Many2one(
+        'event.booth.category', string='Booth Category', required=True,
+        compute='_compute_event_booth_category_id', readonly=False, store=True)
+    event_booth_ids = fields.Many2many(
+        'event.booth', string='Booth', required=True,
+        compute='_compute_event_booth_ids', readonly=False, store=True)
+    event_id = fields.Many2one('event.event', string='Event', required=True)
+    event_booth_category_available_ids = fields.Many2many(related='event_id.event_booth_category_available_ids', readonly=True)
+    order_id = fields.Many2many('sale.order', string="Sale order")
+    sale_order_line_id = fields.Many2many('sale.order.line', string="Sale Order Line")
+
+    @api.depends('event_id')
+    def _compute_event_booth_category_id(self):
+        # Once event is changed, booth category field should reset
+        self.event_booth_category_id = False
+
+    @api.depends('event_id', 'event_booth_category_id')
+    def _compute_event_booth_ids(self):
+        # Once event or booth category is changed, booth field should reset
+        self.event_booth_ids = False
+
+    def _get_event_data(self):
+        self.ensure_one()
+        lines = self.sale_order_line_id.filtered(
+             lambda line: line.product_type == 'event_booth' and not line.event_id.id)
+        lines.write({
+                'event_id': self.event_id.id,
+                'order_id': self.order_id.id,
+                'event_booth_ids': self.event_booth_ids.ids,
+                'event_booth_category_id': self.event_booth_category_id.id,
+            })

--- a/addons/event_booth_sale/wizard/event_booth_batch_configurator_views.xml
+++ b/addons/event_booth_sale/wizard/event_booth_batch_configurator_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_booth_batch_configurator_view_form" model="ir.ui.view">
+        <field name="name">event.batch.configurator.view.tree</field>
+        <field name="model">event.event.booth.configurator.batch</field>
+        <field name="arch" type="xml">
+            <form string="Booth">
+                <sheet>
+                    <field name="configurable_booth_event_ids">
+                        <tree string="Booth" editable="top" create="false" delete="false">
+                            <field name="product_id"/>
+                            <field name="event_id" options="{'no_open': True, 'no_create': True}"
+                                domain="[
+                                        ('event_booth_ids.product_id', '=', product_id),
+                                        ('is_finished', '=', False) 
+                                        ]"/> 
+                            <field name="event_booth_category_available_ids" invisible="1"/>
+                            <field name="event_booth_category_id" options="{'no_open': True, 'no_create': True}"
+                                domain="[('id', 'in', event_booth_category_available_ids)]"/> 
+                            <field name="event_booth_ids" widget="many2many_tags"
+                                domain="[
+                                        ('event_id', '=', event_id),
+                                        ('booth_category_id', '=', event_booth_category_id),
+                                        ('product_id', '=', product_id),
+                                        ('state', '=', 'available')
+                                ]"/> 
+                            <field name="order_id" invisible="1"/>
+                            <field name="sale_order_line_id" invisible="1"/>
+                        </tree>
+                    </field>
+                </sheet>
+                <footer>
+                    <button string="Save Configuration" name="action_configure"
+                                type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Skip" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="event_booth_batch_configurator_action" model="ir.actions.act_window">
+            <field name="name">Event Booth Configuration</field>
+            <field name="res_model">event.event.booth.configurator.batch</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="event_booth_batch_configurator_view_form"/>
+            <field name="target">new</field>
+            <field name="context">{}</field>
+    </record>
+</odoo>

--- a/addons/event_sale/__manifest__.py
+++ b/addons/event_sale/__manifest__.py
@@ -33,6 +33,7 @@ this event.
         'security/event_security.xml',
         'wizard/event_edit_registration.xml',
         'wizard/event_configurator_views.xml',
+        'wizard/event_batch_configurator_views.xml',
     ],
     'demo': [
         'data/event_sale_demo.xml',

--- a/addons/event_sale/models/__init__.py
+++ b/addons/event_sale/models/__init__.py
@@ -6,4 +6,3 @@ from . import event_registration
 from . import event_ticket
 from . import sale_order
 from . import product
-from . import sale_order_template_line

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -19,6 +19,11 @@ class SaleOrder(models.Model):
         return result
 
     def action_confirm(self):
+        for line in self.order_line:
+            if not line.event_id.id and line.product_type == 'event':
+                return self.env['ir.actions.act_window'].with_context(
+                    default_sale_order_id=self.id
+                )._for_xml_id('event_sale.event_batch_configurator_action')
         res = super(SaleOrder, self).action_confirm()
         for so in self:
             if not any(line.product_type == 'event' for line in so.order_line):

--- a/addons/event_sale/models/sale_order_template_line.py
+++ b/addons/event_sale/models/sale_order_template_line.py
@@ -1,6 +1,0 @@
-from odoo import fields, models
-
-class SaleOrderTemplateLine(models.Model):
-    _inherit = "sale.order.template.line"
-
-    product_id = fields.Many2one(domain="[('sale_ok', '=', True), ('detailed_type', '!=', 'event'), ('company_id', 'in', [company_id, False])]")

--- a/addons/event_sale/security/ir.model.access.csv
+++ b/addons/event_sale/security/ir.model.access.csv
@@ -5,3 +5,5 @@ access_registration_editor,access.registration.editor,model_registration_editor,
 access_registration_editor_line,access.registration.editor.line,model_registration_editor_line,sales_team.group_sale_salesman,1,1,1,1
 access_event_event_configurator,access.event.event.configurator,model_event_event_configurator,sales_team.group_sale_salesman,1,1,1,0
 access_event_sale_report_manager,access.event.sale.report.manager,model_event_sale_report,event.group_event_manager,1,1,1,1
+access_event_event_configurator_batch,access.event.event.configurator.batch,model_event_event_configurator_batch,sales_team.group_sale_salesman,1,1,1,0
+access_event_editor_line,access.event.editor.line,model_event_editor_line,sales_team.group_sale_salesman,1,1,1,1

--- a/addons/event_sale/static/src/js/sale_product_field.js
+++ b/addons/event_sale/static/src/js/sale_product_field.js
@@ -21,7 +21,7 @@ patch(SaleOrderLineProductField.prototype, 'event_sale', {
     },
 
     get isConfigurableLine() {
-        return this._super(...arguments) || Boolean(this.props.record.data.event_ticket_id);
+        return this._super(...arguments) || Boolean(this.props.record.data.product_type === 'event');
     },
 
     async _openEventConfigurator() {

--- a/addons/event_sale/wizard/__init__.py
+++ b/addons/event_sale/wizard/__init__.py
@@ -1,2 +1,5 @@
 from . import event_edit_registration
+from . import event_edit_registration_line
 from . import event_configurator
+from . import event_batch_configurator
+from . import event_batch_configurator_line

--- a/addons/event_sale/wizard/event_batch_configurator.py
+++ b/addons/event_sale/wizard/event_batch_configurator.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+
+
+class BatchEventConfigurator(models.TransientModel):
+    _name = 'event.event.configurator.batch'
+    _description = 'Event batch Configurator'
+
+    configurable_event_ids = fields.One2many('event.editor.line', 'editor_id', string='Configurable Event ids')
+    sale_order_id = fields.Many2one('sale.order', 'Sales Order', required=True, ondelete='cascade')
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if not res.get('sale_order_id'):
+            sale_order_id = res.get('sale_order_id', self._context.get('active_id'))
+            res['sale_order_id'] = sale_order_id
+        sale_order = self.env['sale.order'].browse(res.get('sale_order_id'))
+        res['configurable_event_ids'] = [
+            [0, 0, {
+                    'event_id': so_line.event_id.id,
+                    'event_ticket_id': so_line.event_ticket_id.id,
+                    'product_id': so_line.product_id,
+                    'order_id': sale_order,
+                    'sale_order_line_id':so_line,
+                }]
+            for so_line in sale_order.order_line
+            for __ in range(int(so_line.product_uom_qty))
+            if so_line.product_type == "event"
+        ]
+        return self._convert_to_write(res)
+
+    def action_configure(self):
+        self.ensure_one()
+        for configurable_event_id in self.configurable_event_ids:
+            configurable_event_id._get_event_data()
+        return {'type': 'ir.actions.act_window_close'}

--- a/addons/event_sale/wizard/event_batch_configurator_line.py
+++ b/addons/event_sale/wizard/event_batch_configurator_line.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+
+
+class EventConfiguratorLine(models.TransientModel):
+    """Event Configuration"""
+    _name = "event.editor.line"
+    _description = 'Edit Event Lines on Sales Confirmation'
+    _order = "id desc"
+
+    editor_id = fields.Many2one('event.event.configurator.batch', string="Editor")
+    product_id = fields.Many2one('product.product', string="Product", readonly=True)
+    event_ticket_id = fields.Many2one('event.event.ticket', string="Event Ticket",
+        compute='_compute_event_ticket_ids', readonly=False, store=True)
+    event_id = fields.Many2one('event.event', string="Event")
+    order_id = fields.Many2many('sale.order', string="Sale order")
+    sale_order_line_id = fields.Many2many('sale.order.line', string="Sale Order Line")
+
+    @api.depends('event_id')
+    def _compute_event_ticket_ids(self):
+        # Once event is changed, ticket category should reset
+        self.event_ticket_id = False
+
+    def _get_event_data(self):
+        self.ensure_one()
+        lines = self.sale_order_line_id.filtered(
+            lambda line: line.product_type == 'event' and not line.event_id.id)
+        lines.write({
+                'event_id': self.event_id.id,
+                'event_ticket_id': self.event_ticket_id.id,
+                'order_id': self.order_id.id,
+            })

--- a/addons/event_sale/wizard/event_batch_configurator_views.xml
+++ b/addons/event_sale/wizard/event_batch_configurator_views.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_batch_configurator_view_form" model="ir.ui.view">
+        <field name="name">event.batch.configurator.view.tree</field>
+        <field name="model">event.event.configurator.batch</field>
+        <field name="arch" type="xml">
+            <form string="event">
+                <sheet>
+                    <field name="configurable_event_ids">
+                        <tree string="event" editable="top" create="false" delete="false">
+                            <field name="product_id" />
+                            <field
+                                name="event_id"
+                                domain="[
+                                    ('event_ticket_ids.product_id','=', product_id),
+                                    ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00'))
+                                ]"
+                                required="1"
+                                context="{'name_with_seats_availability': True}"
+                                options="{'no_open': True, 'no_create': True}"
+                            />
+                            <field
+                                name="event_ticket_id"
+                                domain="[('event_id', '=', event_id), ('product_id', '=', product_id)]"
+                                attrs="{
+                                    'required': [('event_id', '!=', False)],
+                                }"
+                                context="{'name_with_seats_availability': True}"
+                                options="{'no_open': True, 'no_create': True}"
+                            />
+                            <field name="order_id" invisible="1" />
+                            <field name="sale_order_line_id" invisible="1"/>
+                        </tree>
+                    </field>
+                </sheet>
+                <footer>
+                    <button string="Save Configuration" name="action_configure"
+                             type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Skip" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="event_batch_configurator_action" model="ir.actions.act_window">
+            <field name="name">Event Configuration</field>
+            <field name="res_model">event.event.configurator.batch</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="event_batch_configurator_view_form"/>
+            <field name="target">new</field>
+            <field name="context">{}</field>
+    </record>
+</odoo>

--- a/addons/event_sale/wizard/event_edit_registration.py
+++ b/addons/event_sale/wizard/event_edit_registration.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import Counter, defaultdict
 
@@ -81,14 +82,13 @@ class RegistrationEditor(models.TransientModel):
                     'mobile': so_line.order_partner_id.mobile,
                 }])
         res['event_registration_ids'] = attendee_list
-        res = self._convert_to_write(res)
-        return res
+        return self._convert_to_write(res)
 
     def action_make_registration(self):
         self.ensure_one()
         registrations_to_create = []
         for registration_line in self.event_registration_ids:
-            values = registration_line.get_registration_data()
+            values = registration_line._get_registration_data()
             if registration_line.registration_id:
                 registration_line.registration_id.write(values)
             else:

--- a/addons/event_sale/wizard/event_edit_registration.py
+++ b/addons/event_sale/wizard/event_edit_registration.py
@@ -99,34 +99,3 @@ class RegistrationEditor(models.TransientModel):
             confirm=self.sale_order_id.amount_total == 0 and not self.seats_available_insufficient)
 
         return {'type': 'ir.actions.act_window_close'}
-
-
-class RegistrationEditorLine(models.TransientModel):
-    """Event Registration"""
-    _name = "registration.editor.line"
-    _description = 'Edit Attendee Line on Sales Confirmation'
-    _order = "id desc"
-
-    editor_id = fields.Many2one('registration.editor')
-    sale_order_line_id = fields.Many2one('sale.order.line', string='Sales Order Line')
-    event_id = fields.Many2one('event.event', string='Event', required=True)
-    registration_id = fields.Many2one('event.registration', 'Original Registration')
-    event_ticket_id = fields.Many2one('event.event.ticket', string='Event Ticket')
-    email = fields.Char(string='Email')
-    phone = fields.Char(string='Phone')
-    mobile = fields.Char(string='Mobile')
-    name = fields.Char(string='Name')
-
-    def get_registration_data(self):
-        self.ensure_one()
-        return {
-            'event_id': self.event_id.id,
-            'event_ticket_id': self.event_ticket_id.id,
-            'partner_id': self.editor_id.sale_order_id.partner_id.id,
-            'name': self.name or self.editor_id.sale_order_id.partner_id.name,
-            'phone': self.phone or self.editor_id.sale_order_id.partner_id.phone,
-            'mobile': self.mobile or self.editor_id.sale_order_id.partner_id.mobile,
-            'email': self.email or self.editor_id.sale_order_id.partner_id.email,
-            'sale_order_id': self.editor_id.sale_order_id.id,
-            'sale_order_line_id': self.sale_order_line_id.id,
-        }

--- a/addons/event_sale/wizard/event_edit_registration_line.py
+++ b/addons/event_sale/wizard/event_edit_registration_line.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
 
@@ -18,7 +19,7 @@ class RegistrationEditorLine(models.TransientModel):
     mobile = fields.Char(string='Mobile')
     name = fields.Char(string='Name')
 
-    def get_registration_data(self):
+    def _get_registration_data(self):
         self.ensure_one()
         return {
             'event_id': self.event_id.id,

--- a/addons/event_sale/wizard/event_edit_registration_line.py
+++ b/addons/event_sale/wizard/event_edit_registration_line.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields
+
+class RegistrationEditorLine(models.TransientModel):
+    """Event Registration"""
+    _name = "registration.editor.line"
+    _description = 'Edit Attendee Line on Sales Confirmation'
+    _order = "id desc"
+
+    editor_id = fields.Many2one('registration.editor')
+    sale_order_line_id = fields.Many2one('sale.order.line', string='Sales Order Line')
+    event_id = fields.Many2one('event.event', string='Event', required=True)
+    registration_id = fields.Many2one('event.registration', 'Original Registration')
+    event_ticket_id = fields.Many2one('event.event.ticket', string='Event Ticket')
+    email = fields.Char(string='Email')
+    phone = fields.Char(string='Phone')
+    mobile = fields.Char(string='Mobile')
+    name = fields.Char(string='Name')
+
+    def get_registration_data(self):
+        self.ensure_one()
+        return {
+            'event_id': self.event_id.id,
+            'event_ticket_id': self.event_ticket_id.id,
+            'partner_id': self.editor_id.sale_order_id.partner_id.id,
+            'name': self.name or self.editor_id.sale_order_id.partner_id.name,
+            'phone': self.phone or self.editor_id.sale_order_id.partner_id.phone,
+            'mobile': self.mobile or self.editor_id.sale_order_id.partner_id.mobile,
+            'email': self.email or self.editor_id.sale_order_id.partner_id.email,
+            'sale_order_id': self.editor_id.sale_order_id.id,
+            'sale_order_line_id': self.sale_order_line_id.id,
+        }


### PR DESCRIPTION
[IMP] event_sale: add event on sale order

This commit allows us to add event on sale order in an order line, as well as adding events via template.

Ticket-2988003




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
