### PR TITLE
[IMP] *: unify module category for better grouping result

### DIFF
--- a/addons/auth_password_policy_portal/__manifest__.py
+++ b/addons/auth_password_policy_portal/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': "Password Policy support for Signup",
     'depends': ['auth_password_policy', 'portal'],
-    'category': 'Tools',
+    'category': 'Hidden/Tools',
     'auto_install': True,
     'data': ['views/templates.xml'],
     'assets': {

--- a/addons/base_automation/__manifest__.py
+++ b/addons/base_automation/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Automated Action Rules',
     'version': '1.0',
-    'category': 'Sales/Sales',
+    'category': 'Hidden/Tools',
     'description': """
 This module allows to implement action rules for any object.
 ============================================================

--- a/addons/l10n_ae_pos/__manifest__.py
+++ b/addons/l10n_ae_pos/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'United Arab Emirates - Point of Sale',
     'author': 'Odoo PS',
-    'category': 'Accounting/Localizations/Point of Sale',
+    'category': 'Sales/Point of Sale',
     'description': """
 United Arab Emirates POS Localization
 =======================================================

--- a/addons/l10n_ar_website_sale/__manifest__.py
+++ b/addons/l10n_ar_website_sale/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': 'Argentinean eCommerce',
     'version': '1.0',
-    'category': 'Accounting/Localizations/Website',
+    'category': 'Website/Website',
     'sequence': 14,
     'author': 'Odoo S.A., ADHOC SA',
     'description': """Be able to see Identification Type and AFIP Responsibility in ecommerce checkout form.""",

--- a/addons/l10n_co_pos/__manifest__.py
+++ b/addons/l10n_co_pos/__manifest__.py
@@ -6,7 +6,7 @@
     'icon': '/l10n_co/static/description/icon.png',
     'version': '1.0',
     'description': """Colombian - Point of Sale""",
-    'category': 'Accounting/Localizations/Point of Sale',
+    'category': 'Sales/Point of Sale',
     'auto_install': True,
     'depends': [
         'l10n_co',

--- a/addons/l10n_eg_edi_eta/__manifest__.py
+++ b/addons/l10n_eg_edi_eta/__manifest__.py
@@ -9,7 +9,7 @@
        Special thanks to Plementus <info@plementus.com> for their help in developing this module.
     """,
     'website': 'https://www.odoo.com',
-    'category': 'account',
+    'category': 'Accounting/Localizations/EDI',
     'version': '0.1',
     'license': 'LGPL-3',
     'depends': ['account_edi', 'l10n_eg'],

--- a/addons/l10n_fr_fec/__manifest__.py
+++ b/addons/l10n_fr_fec/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': 'France - FEC Export',
     'icon': '/l10n_fr/static/description/icon.png',
-    'category': 'Accounting/Localizations/Reporting',
+    'category': 'Accounting/Localizations',
     'summary': "Fichier d'Échange Informatisé (FEC) for France",
     'author': "Akretion,Odoo Community Association (OCA)",
     'depends': ['l10n_fr', 'account'],

--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'France - VAT Anti-Fraud Certification for Point of Sale (CGI 286 I-3 bis)',
     'icon': '/l10n_fr/static/description/icon.png',
     'version': '1.0',
-    'category': 'Accounting/Localizations/Point of Sale',
+    'category': 'Sales/Point of Sale',
     'description': """
 This add-on brings the technical requirements of the French regulation CGI art. 286, I. 3° bis that stipulates certain criteria concerning the inalterability, security, storage and archiving of data related to sales to private individuals (B2C).
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -6,7 +6,7 @@
     'icon': '/l10n_in/static/description/icon.png',
     'version': '1.0',
     'description': """GST Point of Sale""",
-    'category': 'Accounting/Localizations/Point of Sale',
+    'category': 'Sales/Point of Sale',
     'depends': [
         'l10n_in',
         'point_of_sale'

--- a/addons/l10n_in_purchase/__manifest__.py
+++ b/addons/l10n_in_purchase/__manifest__.py
@@ -6,7 +6,7 @@
     'icon': '/l10n_in/static/description/icon.png',
     'version': '1.0',
     'description': """GST Purchase Report""",
-    'category': 'Accounting/Localizations/Purchase',
+    'category': 'Inventory/Purchase',
     'depends': [
         'l10n_in',
         'purchase',

--- a/addons/l10n_in_purchase_stock/__manifest__.py
+++ b/addons/l10n_in_purchase_stock/__manifest__.py
@@ -16,7 +16,7 @@
     """,
 
     'website': "https://www.odoo.com",
-    'category': 'Accounting/Localizations/Purchase',
+    'category': 'Inventory/Purchase',
     'version': '1.0',
 
     'depends': ['l10n_in_purchase', 'l10n_in_stock'],

--- a/addons/l10n_in_sale/__manifest__.py
+++ b/addons/l10n_in_sale/__manifest__.py
@@ -6,7 +6,7 @@
     'icon': '/l10n_in/static/description/icon.png',
     'version': '1.0',
     'description': """GST Sale Report""",
-    'category': 'Accounting/Localizations/Sale',
+    'category': 'Sales/Sales',
     'depends': [
         'l10n_in',
         'sale',

--- a/addons/l10n_in_sale_stock/__manifest__.py
+++ b/addons/l10n_in_sale_stock/__manifest__.py
@@ -16,7 +16,7 @@
     """,
 
     'website': "https://www.odoo.com",
-    'category': 'Accounting/Localizations/Sale',
+    'category': 'Sales/Sales',
     'version': '0.1',
 
     'depends': ['l10n_in_sale', 'l10n_in_stock'],

--- a/addons/loyalty/__manifest__.py
+++ b/addons/loyalty/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Coupons & Loyalty',
     'summary': "Use discounts, gift card, eWallets and loyalty programs in different sales channels",
-    'category': 'Sales',
+    'category': 'Sales/Sales',
     'version': '1.0',
     'depends': ['product'],
     'data': [

--- a/addons/loyalty_delivery/__manifest__.py
+++ b/addons/loyalty_delivery/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Coupons & Loyalty - Delivery',
     'summary': "Add a free shipping option to your rewards",
-    'category': 'Sales',
+    'category': 'Sales/Sales',
     'version': '1.0',
     'depends': ['loyalty', 'delivery'],
     'data': [

--- a/addons/mail_group/__manifest__.py
+++ b/addons/mail_group/__manifest__.py
@@ -8,6 +8,7 @@
         Manage your mailing lists from Odoo.
     """,
     'version': '1.0',
+    'category': 'Productivity/Discuss',
     'depends': [
         'mail',
         'portal',

--- a/addons/mrp_subcontracting_purchase/__manifest__.py
+++ b/addons/mrp_subcontracting_purchase/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Purchase and Subcontracting Management',
     'version': '0.1',
-    'category': 'Manufacturing/Purchase',
+    'category': 'Inventory/Purchase',
     'description': """
         This bridge module adds some smart buttons between Purchase and Subcontracting
     """,

--- a/addons/pos_restaurant_adyen/__manifest__.py
+++ b/addons/pos_restaurant_adyen/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'POS Restaurant Adyen',
     'version': '1.0',
-    'category': 'Point of Sale',
+    'category': 'Sales/Point of Sale',
     'sequence': 6,
     'summary': 'Adds American style tipping to Adyen',
     'depends': ['pos_adyen', 'pos_restaurant', 'payment_adyen'],

--- a/addons/pos_restaurant_stripe/__manifest__.py
+++ b/addons/pos_restaurant_stripe/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'POS Restaurant Stripe',
     'version': '1.0',
-    'category': 'Point of Sale',
+    'category': 'Sales/Point of Sale',
     'sequence': 6,
     'summary': 'Adds American style tipping to Stripe',
     'depends': ['pos_stripe', 'pos_restaurant', 'payment_stripe'],

--- a/addons/product_images/__manifest__.py
+++ b/addons/product_images/__manifest__.py
@@ -11,7 +11,7 @@ This module integrates with the Google Custom Search API to set images on produc
 barcode.
     """,
     'license': 'LGPL-3',
-    'category': 'Technical',
+    'category': 'Hidden',
     'depends': ['product'],
     'data': [
         'data/ir_cron_data.xml',

--- a/addons/project_hr_expense/__manifest__.py
+++ b/addons/project_hr_expense/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Project Expenses',
     'version': '1.0',
-    'category': 'Services/expenses',
+    'category': 'Services/Expenses',
     'summary': 'Project expenses',
     'description': 'Bridge created to add the number of expenses linked to an AA to a project form',
     'depends': ['project', 'hr_expense'],

--- a/addons/sale_project_stock/__manifest__.py
+++ b/addons/sale_project_stock/__manifest__.py
@@ -7,7 +7,7 @@
     'description': 'Adds a full traceability of inventory operations on the profitability report.',
     'summary': 'Adds a full traceability of inventory operations on the profitability report.',
     'license': 'LGPL-3',
-    'category': 'Sales',
+    'category': 'Sales/Sales',
     'depends': ['sale_project', 'sale_stock'],
     'data': [
         'views/stock_move_views.xml',

--- a/addons/spreadsheet_account/__manifest__.py
+++ b/addons/spreadsheet_account/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': "Spreadsheet Accounting Formulas",
     'version': '1.0',
-    'category': 'Accounting',
+    'category': 'Accounting/Accounting',
     'summary': 'Spreadsheet Accounting formulas',
     'description': 'Spreadsheet Accounting formulas',
     'depends': ['spreadsheet', 'account'],

--- a/addons/test_base_automation/__manifest__.py
+++ b/addons/test_base_automation/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Test - Base Automation',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9877,
     'summary': 'Base Automation Tests: Ensure Flow Robustness',
     'description': """This module contains tests related to base automation. Those are

--- a/addons/test_discuss_full/__manifest__.py
+++ b/addons/test_discuss_full/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Test Discuss (full)',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9877,
     'summary': 'Test of Discuss with all possible overrides installed.',
     'description': """Test of Discuss with all possible overrides installed, including feature and performance tests.""",

--- a/addons/test_mail/__manifest__.py
+++ b/addons/test_mail/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Mail Tests',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9876,
     'summary': 'Mail Tests: performances and tests specific to mail',
     'description': """This module contains tests related to mail. Those are

--- a/addons/test_mail_full/__manifest__.py
+++ b/addons/test_mail_full/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Mail Tests (Full)',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9876,
     'summary': 'Mail Tests: performances and tests specific to mail with all sub-modules',
     'description': """This module contains tests related to various mail features

--- a/addons/test_mail_sms/__manifest__.py
+++ b/addons/test_mail_sms/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'SMS Tests',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9876,
     'summary': 'SMS Tests: performances and tests specific to SMS',
     'description': """This module contains tests related to SMS. Those are

--- a/addons/test_mass_mailing/__manifest__.py
+++ b/addons/test_mass_mailing/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Mass Mail Tests',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 8765,
     'summary': 'Mass Mail Tests: feature and performance tests for mass mailing',
     'description': """This module contains tests related to mass mailing. Those

--- a/addons/test_resource/__manifest__.py
+++ b/addons/test_resource/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Test - Resource',
     'version': '1.1',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'depends': ['resource'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/test_sale_product_configurators/__manifest__.py
+++ b/addons/test_sale_product_configurators/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Sale Product Configurators Tests",
     'summary': "Test Suite for Sale Product Configurator",
-    'category': "Hidden",
+    'category': 'Hidden/Tests',
     'depends': [
         'event_sale',
         'sale_management',

--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Website Test',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9876,
     'summary': 'Website Test, mainly for module install/uninstall tests',
     'description': """This module contains tests related to website. Those are

--- a/addons/test_website_modules/__manifest__.py
+++ b/addons/test_website_modules/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Website Modules Test',
     'version': '1.0',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'sequence': 9876,
     'description': """This module contains tests related to website modules.
 It allows to test website business code when another website module is

--- a/addons/website_mail_group/__manifest__.py
+++ b/addons/website_mail_group/__manifest__.py
@@ -5,6 +5,7 @@
     'name': "Website Mail Group",
     'summary': "Add a website snippet for the mail groups.",
     'version': '1.0',
+    'category': 'Productivity/Discuss',
     'depends': ['mail_group', 'website'],
     'auto_install': True,
     'data': [

--- a/odoo/addons/test_apikeys/__manifest__.py
+++ b/odoo/addons/test_apikeys/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Tests flow of API keys',
-    'category': 'Tools',
+    'category': 'Hidden/Tests',
     'depends': ['web_tour'],
     'assets': {
         'web.assets_tests': [

--- a/odoo/addons/test_auth_custom/__manifest__.py
+++ b/odoo/addons/test_auth_custom/__manifest__.py
@@ -2,6 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Tests that custom auth works & is not impaired by CORS',
-    'category': 'Hidden',
+    'category': 'Hidden/Tests',
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_performance/__manifest__.py
+++ b/odoo/addons/test_performance/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': "Test Performance",
     'version': "1.0",
-    'category': "Hidden",
+    'category': 'Hidden/Tests',
     'depends': ['base'],
     'data': [
         'security/ir.model.access.csv',

--- a/odoo/addons/test_populate/__manifest__.py
+++ b/odoo/addons/test_populate/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': 'test-populate',
     'version': '0.1',
-    'category': 'Tests',
+    'category': 'Hidden/Tests',
     'description': """A module to test populate.""",
     'depends': ['base'],
     'data': [


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

*:  auth_password_policy_portal, base_automation , hr_hourly_cost,  l10n_ae_pos, l10n_ar_website_sale, l10n_co_pos, l10n_eg_edi_eta, l10n_fi_sale, l10n_fr_fec, l10n_fr_pos_cert, l10n_fr_pos_cert, l10n_gcc_pos, l10n_in_pos, l10n_in_purchase,  l10n_in_purchase_stock, l10n_in_sale, l10n_in_sale_stock, l10n_sa_pos, loyalty, loyalty_delivery, mail_group,mrp_subcontracting_purchase, pos_restaurant_adyen ..

currently there are lot of duplicated module categories and for some modules wrong category is given. also if we group by category from apps menu, we can see duplication of category names.

![Screenshot from 2022-12-09 21-59-39](https://user-images.githubusercontent.com/27989791/206776094-ac7fc01e-8db7-414f-add6-29e1f4d763c5.png)



**Current behavior before PR:**
duplicated and wrong module category. for example base_automation module is currently under sales category

**Desired behavior after PR is merged:**
better result on grouping by category for the modules


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
