### PR TITLE
[FIX] mail: access right issues on read-only documents

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -6663,6 +6663,13 @@ msgid ""
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/composer_text_input/composer_text_input.js:0
+#, python-format
+msgid "You cannot post on this Document..."
+msgstr ""
+
+#. module: mail
 #: code:addons/mail/models/mail_alias.py:0
 #, python-format
 msgid ""

--- a/addons/mail/static/src/components/attachment_box/attachment_box.xml
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.xml
@@ -29,7 +29,7 @@
                         t-on-o-attachment-removed="_onAttachmentRemoved"
                     />
                 </t>
-                <button class="o_AttachmentBox_buttonAdd btn btn-link" type="button" t-on-click="_onClickAdd">
+                <button class="o_AttachmentBox_buttonAdd btn btn-link" t-att-disabled="thread and !thread.hasWriteAccess" type="button" t-on-click="_onClickAdd">
                     <i class="fa fa-plus-square"/>
                     Add attachments
                 </button>

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -12,7 +12,7 @@
                                 'o-active': chatter.isComposerVisible and chatter.composer and !chatter.composer.isLog,
                                 'o-bordered': chatter.hasExternalBorder,
                             }"
-                            t-att-disabled="chatter.isDisabled"
+                            t-att-disabled="chatter.isDisabled or !(chatter.thread.hasWriteAccess or (chatter.thread.hasReadAccess and chatter.thread.canPostOnReadOnly))"
                             t-on-click="_onClickSendMessage"
                         >
                             Send message
@@ -23,14 +23,14 @@
                                 'o-active': chatter.isComposerVisible and chatter.composer and chatter.composer.isLog,
                                 'o-bordered': chatter.hasExternalBorder,
                             }"
-                            t-att-disabled="chatter.isDisabled"
+                            t-att-disabled="chatter.isDisabled or !(chatter.thread.hasWriteAccess or (chatter.thread.hasReadAccess and chatter.thread.canPostOnReadOnly))"
                             t-on-click="_onClickLogNote"
                         >
                             Log note
                         </button>
                     </t>
                     <t t-if="chatter.hasActivities">
-                        <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity" type="button" t-att-disabled="chatter.isDisabled" t-on-click="_onClickScheduleActivity">
+                        <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity" type="button" t-att-disabled="chatter.isDisabled or !chatter.thread.hasWriteAccess" t-on-click="_onClickScheduleActivity">
                             <i class="fa fa-clock-o"/>
                             Schedule activity
                         </button>
@@ -50,7 +50,7 @@
                                 <t t-if="chatter.thread.channel_type !== 'chat'">
                                     <FollowButton
                                         class="o_ChatterTopbar_button o_ChatterTopbar_followButton"
-                                        isDisabled="chatter.isDisabled"
+                                        isDisabled="chatter.isDisabled or !chatter.thread.hasReadAccess"
                                         threadLocalId="chatter.thread.localId"
                                     />
                                 </t>

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -86,7 +86,7 @@
                         t-key="composer.localId"
                         t-ref="textInput"
                     />
-                    <div class="o_Composer_buttons" t-att-class="{ 'o-composer-is-compact': props.isCompact, 'o-mobile': env.messaging.device.isMobile }">
+                    <div class="o_Composer_buttons" t-if="!composer.thread or composer.thread.hasWriteAccess or (composer.thread.hasReadAccess and composer.thread.canPostOnReadOnly)" t-att-class="{ 'o-composer-is-compact': props.isCompact, 'o-mobile': env.messaging.device.isMobile }">
                         <div class="o_Composer_toolButtons"
                             t-att-class="{
                                 'o-composer-has-current-partner-avatar': props.hasCurrentPartnerAvatar,

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -82,6 +82,9 @@ class ComposerTextInput extends Component {
         }
         if (this.composer.thread && this.composer.thread.model !== 'mail.channel') {
             if (this.composer.isLog) {
+                if (!(this.composer.thread.hasWriteAccess || (this.composer.thread.hasReadAccess && this.composer.thread.canPostOnReadOnly))) {
+                    return this.env._t("You cannot post on this Document...");
+                }
                 return this.env._t("Log an internal note...");
             }
             return this.env._t("Send a message to followers...");

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -10,7 +10,7 @@
                         isBelow="props.hasMentionSuggestionsBelowPosition"
                     />
                 </t>
-                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': props.isCompact }" t-esc="composer.textInputContent" t-att-placeholder="textareaPlaceholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
+                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': props.isCompact }" t-esc="composer.textInputContent" t-att-disabled="composer.thread and !(composer.thread.hasWriteAccess or (composer.thread.hasReadAccess and composer.thread.canPostOnReadOnly))" t-att-placeholder="textareaPlaceholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
                 <!--
                      This is an invisible textarea used to compute the composer
                      height based on the text content. We need it to downsize

--- a/addons/mail/static/src/components/follower/follower.xml
+++ b/addons/mail/static/src/components/follower/follower.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Follower" owl="1">
         <div class="o_Follower">
             <t t-if="follower">
-                <a class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" role="menuitem" t-on-click="_onClickDetails">
+                <a class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive, 'py-1': !follower.isEditable }" href="#" role="menuitem" t-on-click="_onClickDetails">
                     <img class="o_Follower_avatar" t-attf-src="/web/image/{{ follower.resModel }}/{{ follower.resId }}/image_128" alt=""/>
                     <span class="o_Follower_name" t-esc="follower.name or follower.displayName"/>
                 </a>

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -12,11 +12,11 @@
                 <t t-if="state.isDropdownOpen">
                     <div class="o_FollowerListMenu_dropdown dropdown-menu dropdown-menu-right" role="menu">
                         <t t-if="thread.channel_type !== 'chat'">
-                            <a class="o_FollowerListMenu_addFollowersButton dropdown-item" href="#" role="menuitem" t-on-click="_onClickAddFollowers">
+                            <a class="o_FollowerListMenu_addFollowersButton dropdown-item btn" t-att-class="{'disabled': !thread.hasWriteAccess}" href="#" role="menuitem" t-on-click="_onClickAddFollowers">
                                 Add Followers
                             </a>
                         </t>
-                        <a class="o_FollowerListMenu_addChannelsButton dropdown-item" href="#" role="menuitem" t-on-click="_onClickAddChannels">
+                        <a class="o_FollowerListMenu_addChannelsButton dropdown-item btn" t-att-class="{'disabled': !thread.hasWriteAccess}" href="#" role="menuitem" t-on-click="_onClickAddChannels">
                             Add Channels
                         </a>
                         <t t-if="thread.followers.length > 0">

--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -106,7 +106,7 @@ function factory(dependencies) {
          * @param {boolean} [param1.notifyServer]
          * @param {boolean} [param1.replaceNewMessage=false]
          */
-        openThread(thread, {
+        async openThread(thread, {
             isFolded = false,
             makeActive = false,
             notifyServer,
@@ -124,6 +124,16 @@ function factory(dependencies) {
                     manager: [['link', this]],
                     thread: [['link', thread]],
                 });
+                if (thread.model !== 'mail.channel') {
+                    const { canPostOnReadOnly, hasReadAccess, hasWriteAccess } = await this.env.services.rpc({
+                        route: '/mail/thread/check_message_post_access',
+                        params: {
+                            thread_id: thread.id,
+                            thread_model: thread.model,
+                        },
+                    }, { shadow: true });
+                    thread.update({ canPostOnReadOnly, hasReadAccess, hasWriteAccess });
+                }
             } else {
                 chatWindow.update({ isFolded });
             }

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -688,6 +688,9 @@ function factory(dependencies) {
             }
             const {
                 attachments: attachmentsData,
+                canPostOnReadOnly,
+                hasWriteAccess,
+                hasReadAccess,
             } = await this.env.services.rpc({
                 route: '/mail/thread/data',
                 params: {
@@ -699,7 +702,7 @@ function factory(dependencies) {
             if (!this.exists()) {
                 return;
             }
-            const values = {};
+            const values = { canPostOnReadOnly, hasReadAccess, hasWriteAccess };
             if (attachmentsData) {
                 Object.assign(values, {
                     areAttachmentsLoaded: true,
@@ -1832,6 +1835,7 @@ function factory(dependencies) {
             inverse: 'thread',
             isCausal: true,
         }),
+        canPostOnReadOnly: attr({ default: true }),
         channel_type: attr(),
         /**
          * States the `mail.chat_window` related to `this`. Serves as compute
@@ -1912,6 +1916,7 @@ function factory(dependencies) {
         hasActivities: attr({
             default: false,
         }),
+        hasReadAccess: attr({ default: true }),
         /**
          * Determine whether this thread has the seen indicators (V and VV)
          * enabled or not.
@@ -1925,6 +1930,7 @@ function factory(dependencies) {
                 'model',
             ],
         }),
+        hasWriteAccess: attr({ default: true }),
         id: attr(),
         /**
          * States whether this thread is a `mail.channel` qualified as chat.


### PR DESCRIPTION
**Current behavior before PR:**

`Access Right Error` raises on a read-only document when a user tries to
post a message, update followers in the follower's menu or upload an attachment.

**Desired behavior after PR is merged:**

Disabled messaging buttons which would cause an `Access Right Error`
for such cases.

Task-3062266

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
