### PR TITLE
[FIX] note: fix the export all xlsx report error.

### DIFF
--- a/addons/note/models/note.py
+++ b/addons/note/models/note.py
@@ -89,15 +89,20 @@ class Note(models.Model):
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
         if groupby and groupby[0] == "stage_id" and (len(groupby) == 1 or lazy):
             stages = self.env['note.stage'].search([('user_id', '=', self.env.uid)])
-            if stages:  # if the user has some stages
-                result = [{  # notes by stage for stages user
-                    '__context': {'group_by': groupby[1:]},
-                    '__domain': domain + [('stage_ids.id', '=', stage.id)],
-                    'stage_id': (stage.id, stage.name),
-                    'stage_id_count': self.search_count(domain + [('stage_ids', '=', stage.id)]),
-                    '__fold': stage.fold,
-                } for stage in stages]
-
+            if stages:
+                # if the user has some stages
+                result = []
+                for stage in stages:
+                    # notes by stage for stages user
+                    nb_stage_counts = self.search_count(domain + [('stage_ids', '=', stage.id)])
+                    result.append({
+                        '__context': {'group_by': groupby[1:]},
+                        '__domain': domain + [('stage_ids.id', '=', stage.id)],
+                        'stage_id': (stage.id, stage.name),
+                        'stage_id_count': nb_stage_counts,
+                        '__count': nb_stage_counts,
+                        '__fold': stage.fold,
+                    })
                 # note without user's stage
                 nb_notes_ws = self.search_count(domain + [('stage_ids', 'not in', stages.ids)])
                 if nb_notes_ws:
@@ -107,6 +112,7 @@ class Note(models.Model):
                         dom_in = result[0]['__domain'].pop()
                         result[0]['__domain'] = domain + ['|', dom_in, dom_not_in]
                         result[0]['stage_id_count'] += nb_notes_ws
+                        result[0]['__count'] += nb_notes_ws
                     else:
                         # add the first stage column
                         result = [{
@@ -114,6 +120,7 @@ class Note(models.Model):
                             '__domain': domain + [dom_not_in],
                             'stage_id': (stages[0].id, stages[0].name),
                             'stage_id_count': nb_notes_ws,
+                            '__count': nb_notes_ws,
                             '__fold': stages[0].name,
                         }] + result
             else:  # if stage_ids is empty, get note without user's stage
@@ -123,7 +130,8 @@ class Note(models.Model):
                         '__context': {'group_by': groupby[1:]},
                         '__domain': domain,
                         'stage_id': False,
-                        'stage_id_count': nb_notes_ws
+                        'stage_id_count': nb_notes_ws,
+                        '__count': nb_notes_ws
                     }]
                 else:
                     result = []

--- a/doc/cla/individual/malaycmkhamar.md
+++ b/doc/cla/individual/malaycmkhamar.md
@@ -1,0 +1,12 @@
+India, 2022-11-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Malay Khamar cmk.malay.khamar@gmail.com https://github.com/malaycmkhamar
+


### PR DESCRIPTION
[FIX] note: fix the export all xlsx report error

When the user exports the note records, an error is raised because the `__count` key does not exist in the result of the `read_group` method.

Steps to reproduce:
------------------
- Go to the Notes
- Click on the list view of notes and filter group by Stage.
- Click on the export all button to print the excel report and see the 
error.

Expected behavior:
-----------------
The data should be exported in `csv` file.

Current behavior:
----------------
An error is raised when the user wants to export the data.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
