### PR TITLE
[FIX] knowledge,web_editor: prevent destroyed component value update

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -361,7 +361,9 @@ export class HtmlField extends Component {
                 }
                 this.wysiwyg.odooEditor.observerActive('commitChanges');
             }
-            await this.updateValue();
+            if (owl.status(this) !== 'destroyed') {
+                await this.updateValue();
+            }
         }
     }
     _isDirty() {


### PR DESCRIPTION
[FIX] knowledge,web_editor: prevent destroyed component value update

https://github.com/odoo/odoo/pull/102662 Highlighted the fact that in some
cases, an rpc call can be done on a destroyed component.

There is such a case in Knowledge, which now causes a traceback.

Impacted Versions

- 16.0 and higher

Steps to reproduce:

- create a new article in Knowledge

- type the space character: [ ] in the article body

- switch to another article

Current Behavior:

- traceback

Expected Behavior:

- no traceback

Contents of the fix:

Do not try to update the value of the html_field if the component is already
destroyed. This could happen when an urgent commitChanges was requested (i.e.
when leaving an article to open another).

Task-3069197
