### PR TITLE
[FIX] web_editor: fix save a page with an open popup

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1610,13 +1610,12 @@ var SnippetsMenu = Widget.extend({
                 }
 
                 // First disable all editors...
-                for (let i = this.snippetEditors.length; i--;) {
-                    const editor = this.snippetEditors[i];
+                this.snippetEditors.map(async editor => {
                     editor.toggleOverlay(false, previewMode);
                     if (!previewMode) {
                         await editor.toggleOptions(false);
                     }
-                }
+                });
                 // ... if no editors are to be enabled, look if any have been
                 // enabled previously by a click
                 if (!editorToEnable) {


### PR DESCRIPTION
The bug was introduced by this commit: [1].

Steps to reproduce the bug:

    - Enter edit mode.
    - Drag and drop a popup in the page.
    - Drag and drop a media list snippet in the popup.
    - Save the page => traceback.

The issue comes from when the page is saved, there is a race condition between all the existing editors which are destroyed on "save" and the popup closing which destroys the popup editors.

Because of this, the loop that iterates over the editors in the '_activateSnippet' function and which is based on the number of editors caused an error when the number of editors was changed and the loop did not complete. To fix this, we removed this loop and used the "map" js function instead. This avoids any side effects caused by modifying the editors array in parallel.

The fix in this commit [1] is no longer needed but we're leaving it because it wouldn't change much to remove it.

[1]: https://github.com/odoo/odoo/commit/686e011f9b54bcfe93cc22db24435d2ca9213664

task-3068995