### PR TITLE
[FIX] mass_mailing: correct 'total' value

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -199,7 +199,7 @@ class MassMailing(models.Model):
     def _compute_total(self):
         for mass_mailing in self:
             total = self.env[mass_mailing.mailing_model_real].search_count(mass_mailing._parse_mailing_domain())
-            if total and mass_mailing.ab_testing_pc < 100:
+            if total and mass_mailing.ab_testing_enabled and mass_mailing.ab_testing_pc < 100:
                 total = max(int(total / 100.0 * mass_mailing.ab_testing_pc), 1)
             mass_mailing.total = total
 


### PR DESCRIPTION
The percentage used for A/B test was applied even when A/B testing was disabled. As that value is 10% by default the 'total' was innacurate by 90% for most mailings.

task - 3008627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
