### PR TITLE
[FIX] account: import notification

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -335,7 +335,11 @@ class AccountBankStatementLine(models.Model):
         for i, st_line in enumerate(st_lines):
             counterpart_account_id = counterpart_account_ids[i]
 
-            to_write = {'statement_line_id': st_line.id, 'narration': st_line.narration}
+            to_write = {
+                'statement_line_id': st_line.id,
+                'narration': st_line.narration,
+                'state': st_line.state or 'draft',
+            }
             if 'line_ids' not in vals_list[i]:
                 to_write['line_ids'] = [(0, 0, line_vals) for line_vals in st_line._prepare_move_line_default_vals(
                     counterpart_account_id=counterpart_account_id)]
@@ -346,7 +350,7 @@ class AccountBankStatementLine(models.Model):
             self.env.remove_to_compute(st_line.move_id._fields['narration'], st_line.move_id)
 
         # No need for the user to manage their status (from 'Draft' to 'Posted')
-        st_lines.move_id.action_post()
+        st_lines.move_id.filtered(lambda m: m.state == 'draft').action_post()
         return st_lines
 
     def write(self, vals):

--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -20,6 +20,7 @@ export class AccountFileUploader extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
+        this.notification = useService("notification");
         this.attachmentIdsToProcess = [];
         const rec = this.props.record ? this.props.record.data : false;
         this.extraContext = rec ? {
@@ -45,6 +46,29 @@ export class AccountFileUploader extends Component {
             context: { ...this.extraContext, ...this.env.searchModel.context },
         });
         this.attachmentIdsToProcess = [];
+        if (action.context && action.context.notifications) {
+            const actionService = this.action;
+            for (let [key, notif] of Object.entries(action.context.notifications)) {
+                const popupCloseFn = this.notification.add(
+                    notif.message,
+                    {
+                        title: key,
+                        type: "info",
+                        sticky: true,
+                        buttons: [
+                            {
+                                name: _lt("View"),
+                                primary: true,
+                                onClick: () => {
+                                    actionService.doAction(notif.action);
+                                    popupCloseFn();
+                                },
+                            },
+                        ],
+                    });
+            }
+            delete action.context.notifications;
+        }
         this.action.doAction(action);
     }
 }


### PR DESCRIPTION
Since mail.thread was removed from the account.bank.statement, the message_post code was causing a crash. This commit retrieves the messages from the returned action and displays them using the notification service.
Task-3044636
