### PR TITLE
[FIX] rating: hide internal messages from review tab

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -394,6 +394,16 @@ class ProductTemplate(models.Model):
             if product.id:
                 product.website_url = "/shop/%s" % slug(product)
 
+    @api.returns('mail.message', lambda value: value.id)
+    def message_post(self, **kwargs):
+        self.ensure_one()
+        # messages posted from the backend by an internal user with no rating
+        # should have their state as "Employees Only" (eCommerce)
+        author_user = self.env["res.users"].browse(kwargs.get("author_id", None)) or self.env.user
+        if author_user and author_user.has_group("base.group_user") and not kwargs.get("rating_value", False):
+            kwargs["is_internal"] = True
+        return super(ProductTemplate, self).message_post(**kwargs)
+
     # ---------------------------------------------------------
     # Rating Mixin API
     # ---------------------------------------------------------

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -459,6 +459,11 @@ class Channel(models.Model):
             parent_message = self.env['mail.message'].sudo().browse(parent_id)
             if parent_message.subtype_id and parent_message.subtype_id == self.env.ref('website_slides.mt_channel_slide_published'):
                 subtype_id = self.env.ref('mail.mt_note').id
+        # messages posted from the backend by an internal user with no rating
+        # should have their state as "Employees Only" (eLearning)
+        author_user = self.env["res.users"].browse(kwargs.get("author_id", None)) or self.env.user
+        if author_user and author_user.has_group("base.group_user") and not kwargs.get("rating_value", False):
+            kwargs["is_internal"] = True
         return super(Channel, self).message_post(parent_id=parent_id, subtype_id=subtype_id, **kwargs)
 
     # ---------------------------------------------------------


### PR DESCRIPTION
# Current behaviour
The internal message thread from the backend for reviews (eLearning and eCommerce) is currently publicly visible to public users by default.

# Expected behaviour
Internal message threads on reviews should be "Employees Only" by default. Hiding them by hand in the frontend is done by clicking a button one-by-one, which is tedious.

# Steps to reproduce
- Install eLearning and eCommerce
- Login as the admin, and activate "Discussion and Rating" for the eCom.
- Go to the backend, choose a course and a website product, for each of them "Send Message".
- Logout and go on the review tab of the respective course and product
- Observe you can see the message you've just posted.

# Reason for the problem
Message visibility state is the same as frontend reviews.

# Fix
Add the `is_internal` keyword when posting a message from the backend.
Message from the backend don't have a rating value, and if they are
posted by an internal user, we set it as `is_internal`.

# Affected versions
- 14.0
- 15.0
- saas-15.2
- saas-15.3
- 16.0
- master
---
opw-3033074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
