### PR TITLE
[FIX] account: do not approximate rates

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -189,7 +189,7 @@ class AccountMove(models.Model):
 
     # used by cash basis taxes, telling the lines of the move are always
     # exigible. This happens if the move contains no payable or receivable line.
-    always_tax_exigible = fields.Boolean(compute='_compute_always_tax_exigible', store=True, readonly=False)
+    always_tax_exigible = fields.Boolean(compute='_compute_always_tax_exigible', store=True)
 
     # === Misc fields === #
     auto_post = fields.Selection(

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -938,7 +938,17 @@ class AccountMoveLine(models.Model):
                 include_caba_tags=line.move_id.always_tax_exigible,
                 fixed_multiplicator=sign,
             )
-            rate = line.amount_currency / line.balance if line.balance else 1
+            compute_all = line.tax_ids.compute_all(
+                amount,
+                currency=line.company_id.currency_id,
+                quantity=quantity,
+                product=line.product_id,
+                partner=line.move_id.partner_id or line.partner_id,
+                is_refund=line.is_refund,
+                handle_price_include=handle_price_include,
+                include_caba_tags=line.move_id.always_tax_exigible,
+                fixed_multiplicator=sign/line.currency_rate,
+            )
             line.compute_all_tax_dirty = True
             line.compute_all_tax = {
                 frozendict({
@@ -953,16 +963,16 @@ class AccountMoveLine(models.Model):
                     'move_id': line.move_id.id,
                 }): {
                     'name': tax['name'],
-                    'balance': tax['amount'] / rate,
-                    'amount_currency': tax['amount'],
-                    'tax_base_amount': tax['base'] / rate * (-1 if line.tax_tag_invert else 1),
+                    'balance': tax['amount'],
+                    'amount_currency': tax_currency['amount'],
+                    'tax_base_amount': tax['base'] * (-1 if line.tax_tag_invert else 1),
                 }
-                for tax in compute_all_currency['taxes']
-                if tax['amount']
+                for tax, tax_currency in zip(compute_all['taxes'], compute_all_currency['taxes'])
+                if tax['amount'] or tax_currency['amount']
             }
             if not line.tax_repartition_line_id:
                 line.compute_all_tax[frozendict({'id': line.id})] = {
-                    'tax_tag_ids': [(6, 0, compute_all_currency['base_tags'])],
+                    'tax_tag_ids': [(6, 0, compute_all['base_tags'])],
                 }
 
     @api.depends('tax_ids', 'account_id', 'company_id')

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1933,7 +1933,6 @@ class AccountMoveLine(models.Model):
             'date': max(exchange_date or date.min, company._get_user_fiscal_lock_date() + timedelta(days=1)),
             'journal_id': journal.id,
             'line_ids': [],
-            'always_tax_exigible': True,
         }
         to_reconcile = []
 

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -2668,8 +2668,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'debit': 12.5,     'credit': 0.0,      'amount_currency': 25.0,    'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
             {'debit': 0.0,      'credit': 12.5,     'amount_currency': -25.0,   'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
             # tax_1:
-            {'debit': 4.17,     'credit': 0.0,      'amount_currency': 8.333,   'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
-            {'debit': 0.0,      'credit': 4.17,     'amount_currency': -8.333,  'currency_id': currency_id,     'account_id': self.tax_account_1.id},
+            {'debit': 4.16,     'credit': 0.0,      'amount_currency': 8.333,   'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
+            {'debit': 0.0,      'credit': 4.16,     'amount_currency': -8.333,  'currency_id': currency_id,     'account_id': self.tax_account_1.id},
             # tax_2:
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': 0.003,   'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': -0.003,  'currency_id': currency_id,     'account_id': self.tax_account_2.id},
@@ -2688,8 +2688,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         self.assertAmountsGroupByAccount([
             # Account                               Balance     Amount Currency
-            (self.cash_basis_transfer_account,      -5.54,      -22.226),
-            (self.tax_account_1,                    -5.57,      -11.11),
+            (self.cash_basis_transfer_account,      -5.55,      -22.226),
+            (self.tax_account_1,                    -5.56,      -11.11),
             (self.tax_account_2,                    0.0,        -0.004),
         ])
 
@@ -2709,8 +2709,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'debit': 16.67,    'credit': 0.0,      'amount_currency': 33.331,  'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
             {'debit': 0.0,      'credit': 16.67,    'amount_currency': -33.331, 'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
             # tax_1:
-            {'debit': 5.56,     'credit': 0.0,      'amount_currency': 11.109,  'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
-            {'debit': 0.0,      'credit': 5.56,     'amount_currency': -11.109, 'currency_id': currency_id,     'account_id': self.tax_account_1.id},
+            {'debit': 5.55,     'credit': 0.0,      'amount_currency': 11.109,  'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
+            {'debit': 0.0,      'credit': 5.55,     'amount_currency': -11.109, 'currency_id': currency_id,     'account_id': self.tax_account_1.id},
             # tax_2:
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': 0.003,   'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': -0.003,  'currency_id': currency_id,     'account_id': self.tax_account_2.id},
@@ -2740,8 +2740,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         self.assertAmountsGroupByAccount([
             # Account                               Balance     Amount Currency
-            (self.cash_basis_transfer_account,      5.57,       -0.002),
-            (self.tax_account_1,                    -16.68,     -33.328),
+            (self.cash_basis_transfer_account,      5.55,       -0.002),
+            (self.tax_account_1,                    -16.66,     -33.328),
             (self.tax_account_2,                    0.0,        -0.01),
         ])
 
@@ -2756,8 +2756,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.assertEqual(len(res.get('tax_cash_basis_moves', [])), 1)
         self.assertRecordValues(res['tax_cash_basis_moves'].line_ids, [
             # Base amount of tax_1 & tax_2:
-            {'debit': 0.01,     'credit': 0.0,      'amount_currency': 0.007,   'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
-            {'debit': 0.0,      'credit': 0.01,     'amount_currency': -0.007,  'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
+            {'debit': 0.0,     'credit': 0.0,       'amount_currency': 0.007,   'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
+            {'debit': 0.0,      'credit': 0.0,      'amount_currency': -0.007,  'currency_id': currency_id,     'account_id': self.cash_basis_base_account.id},
             # tax_1:
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': 0.002,   'currency_id': currency_id,     'account_id': self.cash_basis_transfer_account.id},
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': -0.002,  'currency_id': currency_id,     'account_id': self.tax_account_1.id},
@@ -2767,10 +2767,10 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         ])
 
         self.assertRecordValues(res['full_reconcile'].exchange_move_id.line_ids, [
-            {'account_id': self.cash_basis_base_account.id,     'debit': 16.71, 'credit': 0.0,      'tax_ids': taxes.ids,   'tax_line_id': False},
-            {'account_id': self.cash_basis_base_account.id,     'debit': 0.0,   'credit': 16.71,    'tax_ids': [],          'tax_line_id': False},
-            {'account_id': self.tax_account_1.id,               'debit': 5.58,  'credit': 0.0,      'tax_ids': [],          'tax_line_id': self.cash_basis_tax_a_third_amount.id},
-            {'account_id': self.cash_basis_transfer_account.id, 'debit': 0.0,   'credit': 5.58,     'tax_ids': [],          'tax_line_id': False},
+            {'account_id': self.cash_basis_base_account.id,     'debit': 16.7,  'credit': 0.0,      'tax_ids': taxes.ids,   'tax_line_id': False},
+            {'account_id': self.cash_basis_base_account.id,     'debit': 0.0,   'credit': 16.7,     'tax_ids': [],          'tax_line_id': False},
+            {'account_id': self.tax_account_1.id,               'debit': 5.56,  'credit': 0.0,      'tax_ids': [],          'tax_line_id': self.cash_basis_tax_a_third_amount.id},
+            {'account_id': self.cash_basis_transfer_account.id, 'debit': 0.0,   'credit': 5.56,     'tax_ids': [],          'tax_line_id': False},
             {'account_id': self.tax_account_2.id,               'debit': 0.0,   'credit': 0.01,     'tax_ids': [],          'tax_line_id': self.cash_basis_tax_tiny_amount.id},
             {'account_id': self.cash_basis_transfer_account.id, 'debit': 0.01,  'credit': 0.0,      'tax_ids': [],          'tax_line_id': False},
         ])
@@ -3272,7 +3272,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     'tax_tag_ids': self.tax_tags[0].ids,
                 },
                 {
-                    'debit': 66.66,
+                    'debit': 66.67,
                     'credit': 0,
                     'amount_currency': 33.33,
                     'currency_id': rates_data['currency'].id,
@@ -3282,7 +3282,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                 },
                 {
                     'debit': 0,
-                    'credit': 66.66,
+                    'credit': 66.67,
                     'amount_currency': -33.33,
                     'currency_id': rates_data['currency'].id,
                     'tax_ids': [],
@@ -3315,7 +3315,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                 },
                 {
                     'debit': 0,
-                    'credit': 99.99,
+                    'credit': 100,
                     'amount_currency': -33.33,
                     'currency_id': rates_data['currency'].id,
                     'tax_ids': [],
@@ -3323,7 +3323,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     'tax_tag_ids': [],
                 },
                 {
-                    'debit': 99.99,
+                    'debit': 100,
                     'credit': 0,
                     'amount_currency': 33.33,
                     'currency_id': rates_data['currency'].id,

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -681,11 +681,11 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
 
         self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [{
             'tax_base_amount': 567.38,      # 155.32 * 1 / (1 / 0.273748)
-            'balance': -119.16,             # tax_base_amount * 0.21
+            'balance': -119.15,             # tax_base_amount * 0.21
         }])
 
         self.assertRecordValues(invoice.line_ids.filtered(lambda l: not l.name), [{
-            'balance': 686.54,
+            'balance': 686.53,
         }])
 
         with Form(invoice) as invoice_form:
@@ -693,9 +693,9 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
 
         self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [{
             'tax_base_amount': 567.38,
-            'balance': -119.16,
+            'balance': -119.15,
         }])
 
         self.assertRecordValues(invoice.line_ids.filtered(lambda l: l.account_id.account_type == 'asset_receivable'), [{
-            'balance': 686.54,
+            'balance': 686.53
         }])


### PR DESCRIPTION
### [REV] account: primarily compute taxes in currency

This reverts commit 68fe20f612b8da003415a061b18bb0464329dba9.

The comment on the changed test speaks for itself.

_____________________
### [REV] account: fix exigibility of cash basis rounding corrections in exchange move

This reverts commit https://github.com/odoo/odoo/commit/cc924d5c91ccbb05f0f076faf5da8fbd739660b2.

Don't over complicate the logic of computed fields without any reason.

_____________________
### [FIX] account: do not use approximated rates in cash basis taxes

Trying to compute the rate from the balance and the amount currency
cannot work since those are rounded values.
