### PR TITLE
[FIX] stock: print labels for empty ready pickings as in other states

### DIFF
--- a/addons/stock/wizard/product_label_layout.py
+++ b/addons/stock/wizard/product_label_layout.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 from odoo import fields, models
+from odoo.tools import float_is_zero
 
 
 class ProductLabelLayout(models.TransientModel):
@@ -23,7 +24,7 @@ class ProductLabelLayout(models.TransientModel):
         if 'zpl' in self.print_format:
             xml_id = 'stock.label_product_product'
 
-        if self.picking_quantity == 'picking' and self.move_line_ids:
+        if self.picking_quantity == 'picking' and any(not float_is_zero(ml.qty_done, precision_rounding=ml.product_uom_id.rounding) for ml in self.move_line_ids):
             qties = defaultdict(int)
             custom_barcodes = defaultdict(list)
             uom_unit = self.env.ref('uom.product_uom_categ_unit', raise_if_not_found=False)


### PR DESCRIPTION
When printing the labels of a picking, the results varies depending on the state of the picking.
- draft/waiting/confirmed/cancel: 1 label per line
- assigned/done: 1 label per qty_done per line

The issue is that when a picking is set in the `ready` state, when printing labels it now prints an empty sheet. Indeed, at that point the picking still has no `qty_done` set on its move_lines.

So here we display 1 label per line as long as no `qty_done` is set on any line. But as soon as one quantity is set, the printing acts as it used to (i.e. printing only the right quantities).

Part of task-2985735

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
