### PR TITLE
[FIX] core: keeps translations for inherited modules when upgrade

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -483,6 +483,16 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
                     ['to install'], force, status, report,
                     loaded_modules, update_module, models_to_check)
 
+        if update_module:
+            # remove backup column for translations
+            cr.execute(r"""
+                SELECT table_name, quote_ident(column_name)
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                AND column_name LIKE '\_%_odoo_translation_backup'""")
+            for tablename, columnname in cr.fetchall():
+                cr.execute(f'ALTER TABLE "{tablename}" DROP COLUMN "{columnname}"')
+
         # check that all installed modules have been loaded by the registry after a migration/upgrade
         cr.execute("SELECT name from ir_module_module WHERE state = 'installed' and name != 'studio_customization'")
         module_list = [name for (name,) in cr.fetchall() if name not in graph]


### PR DESCRIPTION
when the 'translate' attribute for a field is changed for sake of inheritance its translations will be lost when upgrade.

this commit backup the jsonb column (translations) of a field before the end of upgrade and revert it in case the column type changes because of inheritance

relevant branch
https://github.com/odoo-dev/odoo/tree/16.0-translateininherit-nse

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
