### PR TITLE
[FIX] base: added missing countries to sepa countries

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1618,9 +1618,10 @@
                 ref('gr'),ref('hr'),ref('hu'),ref('ie'),ref('im'),
                 ref('is'),ref('it'),ref('je'),ref('li'),ref('lt'),
                 ref('lu'),ref('lv'),ref('mc'),ref('mf'),ref('mq'),
-                ref('mt'),ref('nl'),ref('no'),ref('pl'),ref('pm'),
-                ref('pt'),ref('re'),ref('ro'),ref('se'),ref('si'),
-                ref('sk'),ref('sm'),ref('va'),ref('yt')])]"/>
+                ref('mt'),ref('nc'),ref('nl'),ref('no'),ref('pf'),
+                ref('pl'),ref('pm'),ref('pt'),ref('re'),ref('ro'),
+                ref('se'),ref('si'),ref('sk'),ref('sm'),ref('va'),
+                ref('wf'),ref('yt')])]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
Issue: The SEPA Direct Debit is not possible for some countries but it should be possible. Countries missing: New Caledonia, Wallis and Futuna and French Polynesia.

Solution: Added this three countries to the SEPA Countries, Country group.

The fix will only wotk for new created databases, for the existing ones will require to manually add these countries through:

Contacts > Configuration > Country Group > SEPA Countries, and edit.

This fix affects all versions.

opw-3045577