### PR TITLE
Fix context_today in py_builtin.js

### DIFF
--- a/addons/web/static/src/core/py_js/py_builtin.js
+++ b/addons/web/static/src/core/py_js/py_builtin.js
@@ -34,7 +34,10 @@ export const BUILTINS = {
     },
 
     context_today() {
-        return PyDate.today();
+        const d = new Date();
+        // include getTimezoneOffset so tests can set timezone by patch getTimezoneOffset
+        const t = PyDateTime.now().add(PyTimeDelta.create({minutes: -d.getTimezoneOffset()}));
+        return new PyDate(t.year, t.month, t.day);
     },
 
     get current_date() {

--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -166,14 +166,14 @@ function applyBinaryOp(ast, context) {
                 if (right instanceof PyDate || right instanceof PyDateTime) {
                     return right.add(left);
                 } else {
-                    throw NotSupportedError();
+                    throw new NotSupportedError();
                 }
             }
             if (timeDeltaOnRight) {
                 if (left instanceof PyDate || left instanceof PyDateTime) {
                     return left.add(right);
                 } else {
-                    throw NotSupportedError();
+                    throw new NotSupportedError();
                 }
             }
 
@@ -192,7 +192,7 @@ function applyBinaryOp(ast, context) {
                 } else if (left instanceof PyDate || left instanceof PyDateTime) {
                     return left.substract(right);
                 } else {
-                    throw NotSupportedError();
+                    throw new NotSupportedError();
                 }
             }
 

--- a/addons/web/static/tests/core/domain_tests.js
+++ b/addons/web/static/tests/core/domain_tests.js
@@ -282,9 +282,9 @@ QUnit.module("domain", {}, () => {
             },
         });
         let domainStr =
-            "[('date','>=', (context_today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]";
+            "[('date','>=', (datetime.date.today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]";
         assert.deepEqual(new Domain(domainStr).toList(), [["date", ">=", "2013-03-25"]]);
-        domainStr = "[('date', '>=', context_today() - relativedelta(days=30))]";
+        domainStr = "[('date', '>=', datetime.date.today() - relativedelta(days=30))]";
         const domainList = new Domain(domainStr).toList(); // domain creation using `parseExpr` function since the parameter is a string.
         assert.deepEqual(
             domainList[0][2],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
`context_today` should not be same as `date.today()`,  instead it should be localized

Current behavior before PR:
`context_today` is equal to `date.today()`

Desired behavior after PR is merged:
`context_today` should be localized date

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
