### PR TITLE
[IMP] profiler: profiling database from an env variable

### DIFF
--- a/addons/web/static/src/legacy/scss/base_frontend.scss
+++ b/addons/web/static/src/legacy/scss/base_frontend.scss
@@ -1,4 +1,5 @@
 // Frontend general
+
 html, body, #wrapwrap {
     width: 100%;
     height: 100%;

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -683,7 +683,7 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
             self.profile_session = profiler.make_session(test_method)
         return profiler.Profiler(
             description='%s uid:%s %s %s' % (test_method, self.env.user.id, 'warm' if self.warm else 'cold', description),
-            db=self.env.cr.dbname,
+            db=os.environ.get('ODOO_PROFILER_DATABASE', self.env.cr.dbname),
             profile_session=self.profile_session,
             **kwargs)
 

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import gc
 import json
 import logging
+import os
 import sys
 import time
 import threading
@@ -483,7 +484,9 @@ class Profiler:
 
         if db is ...:
             # determine database from current thread
-            db = getattr(threading.current_thread(), 'dbname', None)
+            db = os.environ.get('ODOO_PROFILER_DATABASE')
+            if not db:
+                db = getattr(threading.current_thread(), 'dbname', None)
             if not db:
                 # only raise if path is not given and db is not explicitely disabled
                 raise Exception('Database name cannot be defined automaticaly. \n Please provide a valid/falsy dbname or path parameter')
@@ -548,7 +551,7 @@ class Profiler:
                     )
                     cr.execute(query, [tuple(values.values())])
                     self.profile_id = cr.fetchone()[0]
-                    _logger.info('ir_profile %s (%s) created', self.profile_id, self.profile_session)
+                    _logger.info('ir_profile %s (%s) created in database %s', self.profile_id, self.profile_session, self.db)
         finally:
             if self.disable_gc:
                 gc.enable()


### PR DESCRIPTION
The profiling must be enabled on the database to consult the result. Moreover when profiling multiple database, the profiler result are lost or spread in different database

This commit allows to define a database where to log the result, similar to the log-db parameter for ir_logging.