### PR TITLE
[FIX] web,web_editor,sms : remove legacy DPH

### DIFF
--- a/addons/sms/static/src/components/sms_widget/fields_sms_widget.js
+++ b/addons/sms/static/src/components/sms_widget/fields_sms_widget.js
@@ -6,7 +6,6 @@ import { EmojisTextField} from '@mail/views/fields/emojis_text_field/emojis_text
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 
-const DynamicPlaceholderFieldMixin = basic_fields.DynamicPlaceholderFieldMixin;
 /**
  * SmsWidget is a widget to display a textarea (the body) and a text representing
  * the number of SMS and the number of characters. This text is computed every
@@ -27,21 +26,6 @@ export class SmsWidget extends EmojisTextField {
     }
     get nbrSMS() {
         return this._countSMS(this.nbrChar, this.encoding);
-    }
-
-    /**
-     * Open a Model Field Selector in order to select fields
-     * and create a dynamic placeholder string with or without
-     * a default text value.
-     *
-     * @public
-     * @param {String} baseModel
-     * @param {Array} chain
-     *
-     */
-    async openDynamicPlaceholder(baseModel, chain = []) {
-        const modelSelector = await this._openNewModelSelector(baseModel, chain);
-        modelSelector.$el.css('margin-top', 4);
     }
 
     //--------------------------------------------------------------------------
@@ -108,16 +92,8 @@ export class SmsWidget extends EmojisTextField {
     async onInput(ev) {
         await this.props.update(this.targetEditElement.el.value);
         super.onInput(...arguments);
-        const key = ev.originalEvent ? ev.originalEvent.data : '';
-        if (this.props.dynamicPlaceholder && key === this.DYNAMIC_PLACEHOLDER_TRIGGER_KEY) {
-            const baseModel = this.recordData && this.recordData.mailing_model_real ? this.recordData.mailing_model_real : undefined;
-            if (baseModel) {
-                this.openDynamicPlaceholder(baseModel);
-            }
-        }
     }
-};
+}
 SmsWidget.template = 'sms.SmsWidget';
 SmsWidget.additionalClasses = [...(EmojisTextField.additionalClasses || []), 'o_field_text'];
-patch(SmsWidget.prototype, 'sms_widget_dynamic_placeholder_field_mixin', DynamicPlaceholderFieldMixin);
 registry.category("fields").add("sms_widget", SmsWidget);

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -17,7 +17,6 @@ var dom = require('web.dom');
 var Domain = require('web.Domain');
 var DomainSelector = require('web.DomainSelector');
 var DomainSelectorDialog = require('web.DomainSelectorDialog');
-var ModelFieldSelectorPopover = require("web.ModelFieldSelectorPopover");
 var framework = require('web.framework');
 var py_utils = require('web.py_utils');
 var session = require('web.session');
@@ -71,100 +70,6 @@ var TranslatableFieldMixin = {
             id: this.dataPointID,
             isComingFromTranslationAlert: false,
         });
-    },
-};
-
-var DynamicPlaceholderFieldMixin = {
-    DYNAMIC_PLACEHOLDER_TRIGGER_KEY: '#',
-    /**
-     * Overridable method that ensure the modelSelectorPopover is
-     * positioned properly.
-     *
-     * @public
-     * @param {ModelFieldSelectorPopover} modelSelector
-     */
-    positionModelSelector: function (modelSelector) {
-        let relativeParent = this.el.closest('div.modal-content');
-        if (!relativeParent) {
-            relativeParent = this.el;
-            while(!relativeParent || !['absolute', 'relative'].includes(getComputedStyle(relativeParent).position)) {
-                relativeParent = relativeParent.offsetParent;
-            }
-        }
-
-        const relatedElementPosition = this.el.getBoundingClientRect();
-        const relativeParentPosition = relativeParent.getBoundingClientRect();
-
-        let topPosition = relatedElementPosition.top + relatedElementPosition.height - relativeParentPosition.top
-        let leftPosition = relatedElementPosition.left - relativeParentPosition.left;
-
-        modelSelector.el.style.top = topPosition + 'px';
-        modelSelector.el.style.left = leftPosition + 'px';
-    },
-    /**
-     * Open and return new Model Field Selector with the provided options
-     *
-     * @private
-     * @param {String} baseModel
-     * @param {Array} chain
-     * @param {Function} onFieldChanged
-     * @param {Function} onFieldCancel
-     *
-     * @returns {ModelFieldSelectorPopover}
-     */
-    _openNewModelSelector: async function (baseModel, chain, onFieldChanged = null, onFieldCancel = null) {
-        const triggerKeyReplaceRegex = new RegExp(`${this.DYNAMIC_PLACEHOLDER_TRIGGER_KEY}$`);
-
-        const modelSelector = new ModelFieldSelectorPopover(
-            this,
-            baseModel,
-            [],
-            {
-                readonly: false,
-                needDefaultValue: true,
-                cancelOnEscape: true,
-                chainedTitle: true,
-                filter: (model) => !["one2many", "boolean", "many2many"].includes(model.type)
-            }
-        );
-        if (!onFieldChanged) {
-            onFieldChanged = (ev) => {
-                this.$el.focus();
-                if (ev.data.chain.length) {
-                    let dynamicPlaceholder = "{{object." + ev.data.chain.join('.');
-                    const defaultValue = ev.data.defaultValue;
-                    dynamicPlaceholder += defaultValue && defaultValue !== '' ? ` or '''${defaultValue}'''}}` : '}}';
-                    this.el.value =
-                        this.el.value.replace(triggerKeyReplaceRegex, '') + dynamicPlaceholder;
-                }
-                modelSelector.destroy();
-            };
-        }
-
-        if (onFieldCancel === null) {
-            onFieldCancel = () => {
-                this.$el.focus();
-                modelSelector.destroy();
-            };
-
-        }
-
-        modelSelector.on("field_chain_changed", undefined, onFieldChanged);
-        modelSelector.on("field_chain_cancel", undefined, onFieldCancel);
-
-        // If we are inside a modal environment,
-        // we need to append the ModelFieldSelectorPopover outside the
-        // modal body, to be sure the overflow will be visible.
-        const modalParent = this.el.closest('div.modal-content');
-        if (modalParent) {
-            await modelSelector.appendTo(modalParent);
-        } else {
-            await modelSelector.insertAfter(this.el);
-        }
-        this.positionModelSelector(modelSelector);
-
-        modelSelector.open(chain, true);
-        return modelSelector;
     },
 };
 
@@ -663,7 +568,7 @@ var NumericField = InputField.extend({
     },
 });
 
-var FieldChar = InputField.extend(TranslatableFieldMixin, DynamicPlaceholderFieldMixin, {
+var FieldChar = InputField.extend(TranslatableFieldMixin, {
     description: _lt("Text"),
     className: 'o_field_char',
     tagName: 'span',
@@ -674,38 +579,6 @@ var FieldChar = InputField.extend(TranslatableFieldMixin, DynamicPlaceholderFiel
     // Private
     //--------------------------------------------------------------------------
 
-
-    /**
-     * @override
-     */
-    init: function () {
-        this._super(...arguments);
-        if (this.nodeOptions && this.nodeOptions.dynamic_placeholder) {
-            // When the dynamic placeholder is active, the recordData
-            // need to be updated when `mailing_model_real` change
-            this.resetOnAnyFieldChange = true;
-        }
-    },
-    /**
-     * Open the dynamic placeholder if trigger key match
-     *
-     * @private
-     * @override
-     * @param {KeyboardEvent} ev
-     */
-    async _onKeydown(ev) {
-        this._super(...arguments);
-        if (this.nodeOptions &&
-            this.nodeOptions.dynamic_placeholder &&
-            ev.key === this.DYNAMIC_PLACEHOLDER_TRIGGER_KEY) {
-            ev.preventDefault();
-            const baseModel = this.recordData && this.recordData.mailing_model_real ? this.recordData.mailing_model_real : undefined;
-            if (baseModel) {
-                await this._openNewModelSelector(baseModel);
-            }
-            this.el.value += ev.key;
-        }
-    },
     /**
      * Add translation button
      *
@@ -4295,7 +4168,6 @@ var FieldColorPicker = FieldInteger.extend({
 
 return {
     TranslatableFieldMixin: TranslatableFieldMixin,
-    DynamicPlaceholderFieldMixin: DynamicPlaceholderFieldMixin,
     DebouncedField: DebouncedField,
     FieldEmail: FieldEmail,
     FieldBinaryFile: FieldBinaryFile,

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -21,7 +21,6 @@ import "@web/views/fields/html/html_field"; // make sure the html field file has
 var _lt = core._lt;
 var _t = core._t;
 var TranslatableFieldMixin = basic_fields.TranslatableFieldMixin;
-var DynamicPlaceholderFieldMixin = basic_fields.DynamicPlaceholderFieldMixin;
 var QWeb = core.qweb;
 
 /**
@@ -39,7 +38,7 @@ var QWeb = core.qweb;
  *  - resizable
  *  - codeview
  */
-var FieldHtml = basic_fields.DebouncedField.extend(DynamicPlaceholderFieldMixin).extend(TranslatableFieldMixin, {
+var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
     description: _lt("Html"),
     className: 'oe_form_field oe_form_field_html',
     supportedFieldTypes: ['html'],
@@ -85,45 +84,6 @@ var FieldHtml = basic_fields.DebouncedField.extend(DynamicPlaceholderFieldMixin)
         modelSelector.el.style.top = topPosition + 'px';
         modelSelector.el.style.left = leftPosition + 'px';
     },
-    /**
-     * Open a Model Field Selector which can select fields
-     * to create a dynamic placeholder <t-out> Element in the field HTML
-     * with or without a default text value.
-     *
-     * @override
-     * @public
-     * @param {String} baseModel
-     * @param {Array} chain
-     *
-     */
-    openDynamicPlaceholder: async function (baseModel, chain = []) {
-        let modelSelector;
-        const onFieldChanged = (ev) => {
-            this.wysiwyg.odooEditor.editable.focus();
-            if (ev.data.chain.length) {
-                let dynamicPlaceholder = "object." + ev.data.chain.join('.');
-                const defaultValue = ev.data.defaultValue;
-                dynamicPlaceholder += defaultValue && defaultValue !== '' ? ` or '''${defaultValue}'''` : '';
-
-                const t = document.createElement('T');
-                t.setAttribute('t-out', dynamicPlaceholder);
-                this.wysiwyg.odooEditor.execCommand('insert', t);
-                setSelection(...rightPos(t));
-                this.wysiwyg.odooEditor.editable.focus();
-            }
-            modelSelector.destroy();
-        };
-
-        const onFieldCancel = () => {
-            this.wysiwyg.odooEditor.editable.focus();
-            modelSelector.destroy();
-        };
-
-        modelSelector = await this._openNewModelSelector(
-            baseModel, chain, onFieldChanged, onFieldCancel
-        );
-    },
-
     /**
      * @override
      */


### PR DESCRIPTION
Remove the Dynamic Placeholder from the legacy Odoo field.

Introduce in 308f639e295fce07e4f34d6c76b35aab259e21ad And migrate to be OWL compatible in #101768

Therefore the old code targeting legacy odoo field is unnecessary and need to be cleaned.

task-3071417

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
