### PR TITLE
[IMP] delivery: remove uom system param

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -46,7 +46,8 @@ class DeliveryCarrier(models.Model):
     debug_logging = fields.Boolean('Debug logging', help="Log requests in order to ease debugging")
     company_id = fields.Many2one('res.company', string='Company', related='product_id.company_id', store=True, readonly=False)
     product_id = fields.Many2one('product.product', string='Delivery Product', required=True, ondelete='restrict')
-
+    weight_uom_id = fields.Many2one('uom.uom', string='Weight UoM to convert to when sending weight to carrier', compute='_compute_weight_uom_id')
+    dimension_uom_id = fields.Many2one('uom.uom', string='Dimension UoM to convert to when sending dimensions to carrier', compute='_compute_dimension_uom_id')
     invoice_policy = fields.Selection([
         ('estimated', 'Estimated cost'),
         ('real', 'Real cost')
@@ -83,6 +84,16 @@ class DeliveryCarrier(models.Model):
         ('shipping_insurance_is_percentage', 'CHECK(shipping_insurance >= 0 AND shipping_insurance <= 100)', "The shipping insurance must be a percentage between 0 and 100."),
     ]
 
+    # override with each new carrier to set desired weight uom depending on delivery type
+    @api.depends('delivery_type')
+    def _compute_weight_uom_id(self):
+        self.weight_uom_id = self.env.ref('uom.product_uom_kgm')
+
+    # override with each new carrier to set desired dimension uom depending on delivery type
+    @api.depends('delivery_type')
+    def _compute_dimension_uom_id(self):
+        self.dimension_uom_id = self.env.ref('uom.product_uom_millimeter')
+
     @api.depends('delivery_type')
     def _compute_can_generate_return(self):
         for carrier in self:
@@ -92,6 +103,26 @@ class DeliveryCarrier(models.Model):
     def _compute_supports_shipping_insurance(self):
         for carrier in self:
             carrier.supports_shipping_insurance = False
+
+    def convert_weight(self, weight, weight_uom_id):
+        """Converts given weight in given uom to carrier uom
+
+        :param weight: weight to convert
+        :param weight_uom_id: uom to convert from
+        :return: converted weight in carrier uom
+        """
+        self.ensure_one()
+        return weight_uom_id._compute_quantity(weight, self.weight_uom_id, round=False)
+
+    def convert_dimension(self, dimension, dimension_uom_id):
+        """Converts given dimension in given uom to carrier uom
+
+        :param dimension: dimension to convert
+        :param dimension_uom_id: uom to convert from
+        :return: converted dimension in carrier uom
+        """
+        self.ensure_one()
+        return dimension_uom_id._compute_quantity(dimension, self.dimension_uom_id, round=False)
 
     def toggle_prod_environment(self):
         for c in self:
@@ -321,16 +352,14 @@ class DeliveryCarrier(models.Model):
     # -------------------------------- #
 
     def _get_packages_from_order(self, order, default_package_type):
+        self.ensure_one()
         packages = []
-
         total_cost = 0
         for line in order.order_line.filtered(lambda line: not line.is_delivery and not line.display_type):
             total_cost += self._product_price_to_company_currency(line.product_qty, line.product_id, order.company_id)
-
-        total_weight = order._get_estimated_weight() + default_package_type.base_weight
+        total_weight = order._get_estimated_weight(default_package_type.weight_uom_id) + default_package_type.base_weight
         if total_weight == 0.0:
-            weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-            raise UserError(_("The package cannot be created because the total weight of the products in the picking is 0.0 %s") % (weight_uom_name))
+            raise UserError(_("The package cannot be created because the total weight of the products in the picking is 0.0 %s") % (default_package_type.weight_uom_id.display_name))
         # If max weight == 0 => division by 0. If this happens, we want to have
         # more in the max weight than in the total weight, so that it only
         # creates ONE package with everything.
@@ -345,11 +374,12 @@ class DeliveryCarrier(models.Model):
         return packages
 
     def _get_packages_from_picking(self, picking, default_package_type):
+        self.ensure_one()
         packages = []
 
         if picking.is_return_picking:
             commodities = self._get_commodities_from_stock_move_lines(picking.move_line_ids)
-            weight = picking._get_estimated_weight() + default_package_type.base_weight
+            weight = picking._get_estimated_weight(default_package_type.weight_uom_id) + default_package_type.base_weight
             packages.append(DeliveryPackage(commodities, weight, default_package_type, currency=picking.company_id.currency_id, picking=picking))
             return packages
 
@@ -368,10 +398,10 @@ class DeliveryCarrier(models.Model):
             package_total_cost = 0.0
             for move_line in picking.move_line_ids:
                 package_total_cost += self._product_price_to_company_currency(move_line.qty_done, move_line.product_id, picking.company_id)
-            packages.append(DeliveryPackage(commodities, picking.weight_bulk, default_package_type, name='Bulk Content', total_cost=package_total_cost, currency=picking.company_id.currency_id, picking=picking))
+            weight = picking.weight_uom_id._compute_quantity(picking.weight_bulk, default_package_type.weight_uom_id) if default_package_type.weight_uom_id else picking.weight_bulk
+            packages.append(DeliveryPackage(commodities, weight, default_package_type, name='Bulk Content', total_cost=package_total_cost, currency=picking.company_id.currency_id, picking=picking))
         elif not packages:
-            raise UserError(_("The package cannot be created because the total weight of the products in the picking is 0.0 %s") % (picking.weight_uom_name))
-
+            raise UserError(_("The package cannot be created because the total weight of the products in the picking is 0.0 %s") % (picking.weight_uom_id.display_name))
         return packages
 
     def _get_commodities_from_order(self, order):

--- a/addons/delivery/models/delivery_request_objects.py
+++ b/addons/delivery/models/delivery_request_objects.py
@@ -10,7 +10,9 @@ class DeliveryPackage:
         self.order_id = order
         self.company_id = order and order.company_id or picking and picking.company_id
         self.commodities = commodities or []  # list of DeliveryCommodity objects
-        self.weight = weight
+        self.weight = weight  # weight is in package type weight uom
+        self.weight_uom_id = package_type.weight_uom_id
+        self.dimension_uom_id = package_type.dimension_uom_id
         self.dimension = {
             'length': package_type.packaging_length,
             'width': package_type.width,

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -8,6 +8,9 @@ from odoo.exceptions import UserError
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
+    def _get_default_weight_uom_id(self):
+        return self.env.company.default_weight_uom_id
+
     carrier_id = fields.Many2one('delivery.carrier', string="Delivery Method", domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="Fill this field if you plan to invoice the shipping based on picking.")
     delivery_message = fields.Char(readonly=True, copy=False)
     delivery_rating_success = fields.Boolean(copy=False)
@@ -15,6 +18,10 @@ class SaleOrder(models.Model):
     recompute_delivery_price = fields.Boolean('Delivery cost should be recomputed')
     is_all_service = fields.Boolean("Service Product", compute="_compute_is_service_products")
     shipping_weight = fields.Float("Shipping Weight", compute="_compute_shipping_weight", store=True, readonly=False)
+    weight_uom_id = fields.Many2one('uom.uom', string='Weight unit of measure', default=_get_default_weight_uom_id, compute='_compute_weight_uom_id')
+
+    def _compute_weight_uom_id(self):
+        self.weight_uom_id = self._get_default_weight_uom_id()
 
     @api.depends('order_line')
     def _compute_is_service_products(self):
@@ -155,14 +162,20 @@ class SaleOrder(models.Model):
         for order in self:
             order.shipping_weight = order._get_estimated_weight()
 
-    def _get_estimated_weight(self):
+    def _get_estimated_weight(self, target_weight_uom_id=False):
+        ''' Gets the total estimated weight of SO by getting weight for each orderline and converting
+            it to targert weight if given.
+            Returns the sum of order line converted weight
+        '''
         self.ensure_one()
         if self.delivery_set:
             return self.shipping_weight
-        weight = 0.0
+        total_weight = 0.0
         for order_line in self.order_line.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not l.is_delivery and not l.display_type):
-            weight += order_line.product_qty * order_line.product_id.weight
-        return weight
+            weight = order_line.product_qty * order_line.product_id.weight
+            total_weight += order_line.product_id.weight_uom_id._compute_quantity(weight, target_weight_uom_id or self.weight_uom_id)
+
+        return total_weight
 
 
 class SaleOrderLine(models.Model):

--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -26,10 +26,11 @@ class StockQuantPackage(models.Model):
             for res_group in res_groups:
                 product_id = self.env['product.product'].browse(res_group['product_id'][0])
                 product_uom_id = self.env['uom.uom'].browse(res_group['product_uom_id'][0])
-                package_weights[res_group['result_package_id'][0]] += (
+                package_id = self.env['stock.quant.package'].browse(res_group['result_package_id'][0])
+                package_weights[package_id.id] += (
                     res_group['__count']
                     * product_uom_id._compute_quantity(res_group['qty_done'], product_id.uom_id)
-                    * product_id.weight
+                    * product_id.weight_uom_id._compute_quantity(product_id.weight, package_id.weight_uom_id)
                 )
         for package in self:
             weight = package.package_type_id.base_weight or 0.0
@@ -37,27 +38,19 @@ class StockQuantPackage(models.Model):
                 package.weight = weight + package_weights[package.id]
             else:
                 for quant in package.quant_ids:
-                    weight += quant.quantity * quant.product_id.weight
+                    weight += quant.quantity * quant.product_id.weight_uom_id._compute_quantity(
+                        quant.product_id.weight, package.weight_uom_id)
                 package.weight = weight
-
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
-    def _compute_weight_uom_name(self):
-        for package in self:
-            package.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
 
     def _compute_weight_is_kg(self):
         self.weight_is_kg = False
-        uom_id = self.env['product.template']._get_weight_uom_id_from_ir_config_parameter()
-        if uom_id == self.env.ref('uom.product_uom_kgm'):
+        if self.weight_uom_id == self.env.ref('uom.product_uom_kgm'):
             self.weight_is_kg = True
-        self.weight_uom_rounding = uom_id.rounding
 
     weight = fields.Float(compute='_compute_weight', digits='Stock Weight', help="Total weight of all the products contained in the package.")
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
+    weight_uom_id = fields.Many2one(related='package_type_id.weight_uom_id', string='Weight unit of measure label', readonly=True)
     weight_is_kg = fields.Boolean("Technical field indicating whether weight uom is kg or not (i.e. lb)", compute="_compute_weight_is_kg")
-    weight_uom_rounding = fields.Float("Technical field indicating weight's number of decimal places", compute="_compute_weight_is_kg")
+    weight_uom_rounding = fields.Float("Technical field indicating weight's number of decimal places", related="weight_uom_id.rounding")
     shipping_weight = fields.Float(string='Shipping Weight', help="Total weight of the package.")
 
 
@@ -94,7 +87,7 @@ class StockPicking(models.Model):
                         packs.add(move_line.result_package_id.id)
             package.package_ids = list(packs)
 
-    @api.depends('move_line_ids', 'move_line_ids.result_package_id', 'move_line_ids.product_uom_id', 'move_line_ids.qty_done')
+    @api.depends('move_line_ids', 'move_line_ids.result_package_id', 'move_line_ids.product_uom_id', 'move_line_ids.qty_done', 'weight_uom_id')
     def _compute_bulk_weight(self):
         picking_weights = defaultdict(float)
         # Ordering by qty_done prevents the default ordering by groupby fields that can inject multiple Left Joins in the resulting query.
@@ -105,19 +98,20 @@ class StockPicking(models.Model):
             lazy=False, orderby='qty_done asc'
         )
         products_by_id = {
-            product_res['id']: (product_res['uom_id'][0], product_res['weight'])
+            product_res['id']: (product_res['uom_id'][0], product_res['weight'], product_res['weight_uom_id'][0])
             for product_res in
             self.env['product.product'].with_context(active_test=False).search_read(
-                [('id', 'in', list(set(grp["product_id"][0] for grp in res_groups)))], ['uom_id', 'weight'])
+                [('id', 'in', list(set(grp["product_id"][0] for grp in res_groups)))], ['uom_id', 'weight', 'weight_uom_id'])
         }
         for res_group in res_groups:
-            uom_id, weight = products_by_id[res_group['product_id'][0]]
+            uom_id, weight, weight_uom_id = products_by_id[res_group['product_id'][0]]
             uom = self.env['uom.uom'].browse(uom_id)
+            weight_uom_id = self.env['uom.uom'].browse(weight_uom_id)
             product_uom_id = self.env['uom.uom'].browse(res_group['product_uom_id'][0])
             picking_weights[res_group['picking_id'][0]] += (
                 res_group['__count']
                 * product_uom_id._compute_quantity(res_group['qty_done'], uom)
-                * weight
+                * weight_uom_id._compute_quantity(weight, self.weight_uom_id)
             )
         for picking in self:
             picking.weight_bulk = picking_weights[picking.id]
@@ -126,14 +120,11 @@ class StockPicking(models.Model):
     def _compute_shipping_weight(self):
         for picking in self:
             # if shipping weight is not assigned => default to calculated product weight
-            picking.shipping_weight = picking.weight_bulk + sum([pack.shipping_weight or pack.weight for pack in picking.package_ids])
+            picking.shipping_weight = picking.weight_bulk + sum([pack.weight_uom_id._compute_quantity(
+                                                                pack.shipping_weight or pack.weight, picking.weight_uom_id) for pack in picking.package_ids.with_context(picking_id=picking.id)])
 
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
-    def _compute_weight_uom_name(self):
-        for package in self:
-            package.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
+    def _compute_weight_uom_id(self):
+        self.weight_uom_id = self.env.company.default_weight_uom_id
 
     carrier_price = fields.Float(string="Shipping Cost")
     delivery_type = fields.Selection(related='carrier_id.delivery_type', readonly=True)
@@ -141,7 +132,7 @@ class StockPicking(models.Model):
     weight = fields.Float(compute='_cal_weight', digits='Stock Weight', store=True, help="Total weight of the products in the picking.", compute_sudo=True)
     carrier_tracking_ref = fields.Char(string='Tracking Reference', copy=False)
     carrier_tracking_url = fields.Char(string='Tracking URL', compute='_compute_carrier_tracking_url')
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
+    weight_uom_id = fields.Many2one('uom.uom', string='Weight unit of measure', compute='_compute_weight_uom_id')
     package_ids = fields.Many2many('stock.quant.package', compute='_compute_packages', string='Packages')
     weight_bulk = fields.Float('Bulk Weight', compute='_compute_bulk_weight', help="Total weight of products which are not in a package.")
     shipping_weight = fields.Float("Weight for Shipping", compute='_compute_shipping_weight',
@@ -177,10 +168,12 @@ class StockPicking(models.Model):
         except (ValueError, TypeError):
             return False
 
-    @api.depends('move_ids')
+    @api.depends('move_ids', 'weight_uom_id')
     def _cal_weight(self):
         for picking in self:
-            picking.weight = sum(move.weight for move in picking.move_ids if move.state != 'cancel')
+            # move weight is in product weight uom, need to convert it to picking weight uom
+            picking.weight = sum(move.product_id.weight_uom_id._compute_quantity(move.weight, picking.weight_uom_id)
+                                 for move in picking.move_ids if move.state != 'cancel')
 
     def _send_confirmation_email(self):
         for pick in self:
@@ -309,12 +302,17 @@ class StockPicking(models.Model):
             picking.message_post(body=msg)
             picking.carrier_tracking_ref = False
 
-    def _get_estimated_weight(self):
+    def _get_estimated_weight(self, target_weight_uom_id=False):
+        ''' Gets the total estimated weight of picking by getting weight for each move and converting
+            it to targert weight if given.
+            Returns the sum of each move converted weight
+        '''
         self.ensure_one()
-        weight = 0.0
+        total_weight = 0.0
         for move in self.move_ids:
-            weight += move.product_qty * move.product_id.weight
-        return weight
+            weight = move.product_qty * move.product_id.weight
+            total_weight = move.product_id.weight_uom_id._compute_quantity(weight, target_weight_uom_id or self.weight_uom_id)
+        return total_weight
 
     def _should_generate_commercial_invoice(self):
         self.ensure_one()

--- a/addons/delivery/tests/__init__.py
+++ b/addons/delivery/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import test_delivery_cost, test_delivery_stock_move
 from . import test_packing_delivery
 from . import test_carrier_propagation
+from . import test_delivery_weight

--- a/addons/delivery/tests/test_delivery_weight.py
+++ b/addons/delivery/tests/test_delivery_weight.py
@@ -1,0 +1,92 @@
+from odoo.tests import common
+from odoo.tools import float_round
+
+
+@common.tagged('post_install', '-at_install')
+class TestDeliveryWeight(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_kg = cls.env['product.product'].create({
+            'name': 'Product in kg',
+            'type': 'product',
+            'weight': 4,
+            'weight_uom_id': cls.env.ref('uom.product_uom_kgm').id
+        })
+
+        cls.product_lb = cls.env['product.product'].create({
+            'name': 'Product in lb',
+            'type': 'product',
+            'weight': 4,
+            'weight_uom_id': cls.env.ref('uom.product_uom_lb').id
+        })
+
+        cls.product_delivery = cls.env['product.product'].create({
+            'name': 'Normal Delivery Charges',
+            'invoice_policy': 'order',
+            'type': 'service',
+            'list_price': 10.0,
+            'categ_id': cls.env.ref('delivery.product_category_deliveries').id,
+        })
+
+        cls.delivery_pack_type = cls.env['stock.package.type'].create({
+            'name': "My Package",
+            'base_weight': 1,
+            'max_weight': 20,
+            'weight_uom_id': cls.env.ref('uom.product_uom_lb').id
+        })
+        # carrier weight uom is kg and dimension uom is mm by default
+        cls.carrier = cls.env['delivery.carrier'].create({
+            'name': 'Delivery Carrier',
+            'fixed_price': 10,
+            'delivery_type': 'fixed',
+            'product_id': cls.product_delivery.id,
+        })
+        cls.partner = cls.env['res.partner'].create({'name': 'Customer'})
+        cls.warehouse = cls.env['stock.warehouse'].search([('company_id', '=', cls.env.company.id)], limit=1)
+        cls.env['stock.quant']._update_available_quantity(cls.product_kg, cls.warehouse.lot_stock_id, 20)
+        cls.env['stock.quant']._update_available_quantity(cls.product_lb, cls.warehouse.lot_stock_id, 20)
+
+    def test_delivery_weight_conversions(self):
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'order_line': [(0, 0, {
+                'name': 'kg product',
+                'product_id': self.product_kg.id,
+                'product_uom_qty': 2,
+                'price_unit': 10,
+            }), (0, 0, {
+                'name': 'lb product',
+                'product_id': self.product_lb.id,
+                'product_uom_qty': 2,
+                'price_unit': 10,
+            })],
+        })
+        weight_kg = sale_order._get_estimated_weight()
+        self.assertEqual(float_round(weight_kg, 2), 11.63)
+        packages = self.carrier._get_packages_from_order(sale_order, self.delivery_pack_type)
+        self.assertEqual(len(packages), 2)
+        self.assertEqual(packages[0].weight, 20)
+        self.assertEqual(packages[0].weight_uom_id, self.env.ref('uom.product_uom_lb'))
+        total_package_weight = sum(pack.weight for pack in packages)
+        order_weight_in_pounds = sale_order._get_estimated_weight(self.delivery_pack_type.weight_uom_id) + self.delivery_pack_type.base_weight
+        self.assertEqual(total_package_weight, order_weight_in_pounds)
+        delivery_wizard = self.env['choose.delivery.carrier'].with_context({
+            'order_id': sale_order.id,
+            'carrier_id': self.carrier.id
+        })
+        delivery_wizard.button_confirm()
+        sale_order.action_confirm()
+        # Ship
+        for ml in sale_order.picking_ids.move_ids.move_line_ids:
+            ml.qty_done = 2
+        picking_id = sale_order.picking_ids
+        picking_id.button_validate()
+        packages = self.carrier._get_packages_from_picking(picking_id, self.delivery_pack_type)
+        total_package_weight = sum(pack.weight for pack in packages)
+        # TODO: fix pricision errors, should be 11.63
+        self.assertEqual(picking_id.shipping_weight, 11.64)
+        self.assertEqual(picking_id.weight_bulk, 11.64)

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -241,12 +241,12 @@
                         <label for="weight" string="Weight"/>
                         <div>
                             <field name="weight" class="oe_inline"/>
-                            <field name="weight_uom_name" nolabel="1" class="oe_inline" style="margin-left:5px"/>
+                            <field name="weight_uom_id" nolabel="1" class="oe_inline" style="margin-left:5px"/>
                         </div>
                         <label for="shipping_weight" string="Weight for shipping"/>
                         <div>
                             <field name="shipping_weight" class="oe_inline"/>
-                            <field name="weight_uom_name" nolabel="1" class="oe_inline" style="margin-left:5px"/>
+                            <field name="weight_uom_id" nolabel="1" class="oe_inline" style="margin-left:5px"/>
                         </div>
                     </group>
                 </xpath>
@@ -299,8 +299,8 @@
                     <label for="shipping_weight"/>
                     <div class="o_row" name="Shipping Weight">
                         <field name="shipping_weight" class="oe_inline"/>
-                        <span><field name="weight_uom_name"/></span>
-                        <span class="text-muted">(computed: <field name="weight" class="oe_inline" nolabel="1"/></span><span class="text-muted"><field name="weight_uom_name" nolabel="1" class="oe_inline"/>)</span>
+                        <span><field name="weight_uom_id"/></span>
+                        <span class="text-muted">(computed: <field name="weight" class="oe_inline" nolabel="1"/></span><span class="text-muted"><field name="weight_uom_id" nolabel="1" class="oe_inline"/>)</span>
                     </div>
                 </field>
             </field>
@@ -354,7 +354,11 @@
                         <attribute name="decoration-warning">recompute_delivery_price and is_delivery</attribute>
                     </xpath>
                     <field name="picking_policy" position="after">
-                        <field name="shipping_weight" readonly="True"/>
+                        <label for="shipping_weight"/>
+                        <div class="o_row" name="shipping_weight">
+                            <field name="shipping_weight" class="oe_inline" readonly="True"/>
+                            <field name="weight_uom_id" readonly="True"/>
+                        </div>
                     </field>
                 </data>
                 

--- a/addons/delivery/views/report_deliveryslip.xml
+++ b/addons/delivery/views/report_deliveryslip.xml
@@ -9,7 +9,7 @@
                 <strong>Total Weight:</strong>
                 <br/>
                 <span t-field="o.shipping_weight"/>
-                <span t-field="o.weight_uom_name"/>
+                <span t-field="o.weight_uom_id"/>
             </div>
             <div t-if="o.carrier_tracking_ref" class="col-auto">
                 <strong>Tracking Number:</strong>
@@ -44,13 +44,13 @@
                 <t t-if="package.shipping_weight">
                     <span> - Weight: </span>
                     <span t-field="package.shipping_weight"/>
-                    <span t-field="package.weight_uom_name"/>
+                    <span t-field="package.weight_uom_id"/>
                 </t>
                 <!-- otherwise default to calculated value -->
                 <t t-else="">
                     <span> - Weight (estimated): </span>
                     <span t-field="package.weight"/>
-                    <span t-field="package.weight_uom_name"/>
+                    <span t-field="package.weight_uom_id"/>
                 </t>
             </t>
         </xpath>
@@ -61,7 +61,7 @@
             <t t-if="o.weight_bulk">
                 <span> - Weight: </span>
                 <span t-field="o.weight_bulk"/>
-                <span t-field="o.weight_uom_name"/>
+                <span t-field="o.weight_uom_id"/>
             </t>
         </xpath>
     </template>

--- a/addons/delivery/views/report_package_barcode.xml
+++ b/addons/delivery/views/report_package_barcode.xml
@@ -12,10 +12,10 @@
                 </t>
 ^FO310,200
                 <t t-if="package.shipping_weight">
-^A0N,44,33^FDShipping Weight: <t t-out="package.shipping_weight"/> <t t-out="package.weight_uom_name"/>^FS
+^A0N,44,33^FDShipping Weight: <t t-out="package.shipping_weight"/> <t t-out="package.weight_uom_id.display_name"/>^FS
                 </t>
                 <t t-else="">
-^A0N,44,33^FDWeight: <t t-out="package.weight"/> <t t-out="package.weight_uom_name"/>^FS
+^A0N,44,33^FDWeight: <t t-out="package.weight"/> <t t-out="package.weight_uom_id.display_name"/>^FS
                 </t>
             </t>
         </xpath>
@@ -37,15 +37,15 @@
         <xpath expr="//div[hasclass('o_packaging_type')]" position="after">
             <t t-if="o.valid_sscc">
                 <!-- SSCC uses weight if necessary/available, standard barcode will not -->
-                <div t-if="o.shipping_weight" class="col-auto"><strong>Shipping Weight: </strong><span t-field="o.shipping_weight"/> <t t-out="o.weight_uom_name"/></div>
-                <div t-elif="o.weight" class="col-auto"><strong>Weight: </strong><span t-field="o.weight"/> <t t-out="o.weight_uom_name"/></div>
+                <div t-if="o.shipping_weight" class="col-auto"><strong>Shipping Weight: </strong><span t-field="o.shipping_weight"/> <span t-field="o.weight_uom_id"/></div>
+                <div t-elif="o.weight" class="col-auto"><strong>Weight: </strong><span t-field="o.weight"/> <span t-field="o.weight_uom_id"/></div>
             </t>
             <t t-else="">
                 <div t-if="o.shipping_weight" class="col-auto">
                     <strong>Shipping Weight:</strong>
                     <br/>
                     <span t-field="o.shipping_weight"/>
-                    <span t-out="env['product.template']._get_weight_uom_id_from_ir_config_parameter().display_name"/>
+                    <span t-field="o.weight_uom_id"/>
                 </div>
             </t>
         </xpath>
@@ -65,12 +65,12 @@
             </t>
         </xpath>
         <xpath expr="//div[@name='datamatrix_pack_type']" position="after">
-            <div t-if="o.shipping_weight" class="row">Shipping Weight: <span t-field="o.shipping_weight"/> <t t-out="o.weight_uom_name"/></div>
-            <div t-elif="o.weight" class="row">Weight: <span t-field="o.weight"/> <t t-out="o.weight_uom_name"/></div>
+            <div t-if="o.shipping_weight" class="row">Shipping Weight: <span t-field="o.shipping_weight"/> <span t-field="o.weight_uom_id"/></div>
+            <div t-elif="o.weight" class="row">Weight: <span t-field="o.weight"/> <span t-field="o.weight_uom_id"/></div>
         </xpath>
         <xpath expr="//div[hasclass('o_packaging_type')]" position="after">
             <div class="row o_package_shipping_weight" t-if="o.shipping_weight">
-                <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Shipping Weight: </span><span t-field="o.shipping_weight"/> <t t-out="o.weight_uom_name"/></div>
+                <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Shipping Weight: </span><span t-field="o.shipping_weight"/> <span t-field="o.weight_uom_id"/></div>
             </div>
         </xpath>
     </template>

--- a/addons/delivery/views/report_shipping.xml
+++ b/addons/delivery/views/report_shipping.xml
@@ -9,7 +9,7 @@
                 <strong>Weight:</strong>
                 <br/>
                 <span t-field="o.weight"/>
-                <span t-field="o.weight_uom_name"/>
+                <span t-field="o.weight_uom_id"/>
             </div>
         </xpath>
     </template>

--- a/addons/delivery/wizard/choose_delivery_carrier.py
+++ b/addons/delivery/wizard/choose_delivery_carrier.py
@@ -9,9 +9,6 @@ class ChooseDeliveryCarrier(models.TransientModel):
     _name = 'choose.delivery.carrier'
     _description = 'Delivery Carrier Selection Wizard'
 
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
     order_id = fields.Many2one('sale.order', required=True, ondelete="cascade")
     partner_id = fields.Many2one('res.partner', related='order_id.partner_id', required=True)
     carrier_id = fields.Many2one(
@@ -28,7 +25,7 @@ class ChooseDeliveryCarrier(models.TransientModel):
     invoicing_message = fields.Text(compute='_compute_invoicing_message')
     delivery_message = fields.Text(readonly=True)
     total_weight = fields.Float(string='Total Order Weight', related='order_id.shipping_weight', readonly=False)
-    weight_uom_name = fields.Char(readonly=True, default=_get_default_weight_uom)
+    weight_uom_name = fields.Char(related='order_id.weight_uom_id.display_name', string='Weight unit of measure')
 
     @api.onchange('carrier_id', 'total_weight')
     def _onchange_carrier_id(self):

--- a/addons/delivery/wizard/choose_delivery_package_views.xml
+++ b/addons/delivery/wizard/choose_delivery_package_views.xml
@@ -12,7 +12,7 @@
                     <label for="shipping_weight" attrs="{'invisible': [('delivery_package_type_id', '=', False)]}"/>
                     <div class="o_row" attrs="{'invisible': [('delivery_package_type_id', '=', False)]}" name="package_weight">
                         <field name="shipping_weight"/>
-                        <field name="weight_uom_name"/>
+                        <field name="weight_uom_id"/>
                     </div>
                 </group>
                 <footer>

--- a/addons/delivery_stock_picking_batch/models/stock_picking.py
+++ b/addons/delivery_stock_picking_batch/models/stock_picking.py
@@ -8,18 +8,14 @@ from odoo.osv import expression
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
     batch_group_by_carrier = fields.Boolean('Carrier', help="Automatically group batches by carriers")
     batch_max_weight = fields.Integer("Maximum weight per batch",
                                       help="A transfer will not be automatically added to batches that will exceed this weight if the transfer is added to it.\n"
                                            "Leave this value as '0' if no weight limit.")
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
+    weight_uom_id = fields.Many2one('uom.uom', string='Weight unit of measure', compute='_compute_weight_uom_id')
 
-    def _compute_weight_uom_name(self):
-        for picking_type in self:
-            picking_type.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
+    def _compute_weight_uom_id(self):
+        self.weight_uom_id = self.env.company.default_weight_uom_id
 
     @api.model
     def _get_batch_group_by_keys(self):

--- a/addons/delivery_stock_picking_batch/views/stock_picking_type_views.xml
+++ b/addons/delivery_stock_picking_batch/views/stock_picking_type_views.xml
@@ -16,7 +16,7 @@
                 <label for="batch_max_weight" attrs="{'invisible': [('auto_batch', '=', False)]}"/>
                 <div class="o_row" name="batch_max_weight" attrs="{'invisible': [('auto_batch', '=', False)]}">
                     <field name="batch_max_weight"/>
-                    <span><field name="weight_uom_name"/></span>
+                    <field name="weight_uom_id"/>
                 </div>
             </field>
         </field>

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -55,7 +55,11 @@ class ProductProduct(models.Model):
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
         Used to compute margins on sale orders.""")
     volume = fields.Float('Volume', digits='Volume')
+    volume_uom_id = fields.Many2one('uom.uom', default=lambda self: self.env.ref('uom.product_uom_cubic_meter'), string='Volume Unit of Measure',
+                                    domain=lambda self: [('category_id', '=', self.env.ref('uom.product_uom_categ_vol').id)])
     weight = fields.Float('Weight', digits='Stock Weight')
+    weight_uom_id = fields.Many2one('uom.uom', default=lambda self: self.env.ref('uom.product_uom_kgm'), string='Weight Unit of Measure',
+                                    domain=lambda self: [('category_id', '=', self.env.ref('uom.product_uom_categ_kgm').id)])
 
     pricelist_item_count = fields.Integer("Number of price rules", compute="_compute_variant_item_count")
 

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -34,6 +34,12 @@ class ProductTemplate(models.Model):
             category_ids = categories._search([], order=order, access_rights_uid=SUPERUSER_ID)
         return categories.browse(category_ids)
 
+    def _get_default_product_weight_uom_id(self):
+        return self.env.company.default_weight_uom_id
+
+    def _get_default_product_volume_uom_id(self):
+        return self.env.company.default_volume_uom_id
+
     name = fields.Char('Name', index='trigram', required=True, translate=True)
     sequence = fields.Integer('Sequence', default=1, help='Gives the sequence order when displaying a product list')
     description = fields.Html(
@@ -80,11 +86,16 @@ class ProductTemplate(models.Model):
 
     volume = fields.Float(
         'Volume', compute='_compute_volume', inverse='_set_volume', digits='Volume', store=True)
-    volume_uom_name = fields.Char(string='Volume unit of measure label', compute='_compute_volume_uom_name')
+    volume_uom_id = fields.Many2one('uom.uom', string='Volume unit of measure', compute='_compute_volume_uom_id',
+                                    default=_get_default_product_volume_uom_id, inverse='_set_volume_uom_id', store=True,
+                                    domain=lambda self: [('category_id', '=', self.env.ref('uom.product_uom_categ_vol').id)])
     weight = fields.Float(
         'Weight', compute='_compute_weight', digits='Stock Weight',
         inverse='_set_weight', store=True)
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name')
+    weight_uom_id = fields.Many2one('uom.uom', string='Weight unit of measure', compute='_compute_weight_uom_id',
+                                    inverse='_set_weight_uom_id', default=_get_default_product_weight_uom_id, store=True,
+                                    domain=lambda self: [('category_id', '=', self.env.ref('uom.product_uom_categ_kgm').id)])
+    weight_uom_name = fields.Char(string='Weight unit of measure label', related='weight_uom_id.display_name')
 
     sale_ok = fields.Boolean('Can be Sold', default=True)
     purchase_ok = fields.Boolean('Can be Purchased', default=True)
@@ -140,6 +151,11 @@ class ProductTemplate(models.Model):
     ], default='0', string="Favorite")
 
     product_tag_ids = fields.Many2many('product.tag', 'product_tag_product_template_rel', string='Product Tags')
+
+    _sql_constraints = [
+        ('weight_uom_check', 'CHECK(weight_uom_id IS NOT NULL OR weight = 0)', 'Weight Unit of measure must be provided with product weight.'),
+        ('volume_uom_check', 'CHECK(volume_uom_id IS NOT NULL OR volume = 0)', 'Volume Unit of measure must be provided with product volume.')
+    ]
 
     def _compute_item_count(self):
         for template in self:
@@ -237,15 +253,29 @@ class ProductTemplate(models.Model):
     def _compute_volume(self):
         self._compute_template_field_from_variant_field('volume')
 
+    @api.depends('product_variant_ids.volume_uom_id')
+    def _compute_volume_uom_id(self):
+        self._compute_template_field_from_variant_field('volume_uom_id', default=self._get_default_product_volume_uom_id())
+
     def _set_volume(self):
         self._set_product_variant_field('volume')
+
+    def _set_volume_uom_id(self):
+        self._set_product_variant_field('volume_uom_id')
 
     @api.depends('product_variant_ids.weight')
     def _compute_weight(self):
         self._compute_template_field_from_variant_field('weight')
 
+    @api.depends('product_variant_ids.weight_uom_id')
+    def _compute_weight_uom_id(self):
+        self._compute_template_field_from_variant_field('weight_uom_id', default=self._get_default_product_weight_uom_id())
+
     def _set_weight(self):
         self._set_product_variant_field('weight')
+
+    def _set_weight_uom_id(self):
+        self._set_product_variant_field('weight_uom_id')
 
     def _compute_is_product_variant(self):
         self.is_product_variant = False
@@ -262,63 +292,6 @@ class ProductTemplate(models.Model):
 
     def _set_barcode(self):
         self._set_product_variant_field('barcode')
-
-    @api.model
-    def _get_weight_uom_id_from_ir_config_parameter(self):
-        """ Get the unit of measure to interpret the `weight` field. By default, we considerer
-        that weights are expressed in kilograms. Users can configure to express them in pounds
-        by adding an ir.config_parameter record with "product.product_weight_in_lbs" as key
-        and "1" as value.
-        """
-        product_weight_in_lbs_param = self.env['ir.config_parameter'].sudo().get_param('product.weight_in_lbs')
-        if product_weight_in_lbs_param == '1':
-            return self.env.ref('uom.product_uom_lb')
-        else:
-            return self.env.ref('uom.product_uom_kgm')
-
-    @api.model
-    def _get_length_uom_id_from_ir_config_parameter(self):
-        """ Get the unit of measure to interpret the `length`, 'width', 'height' field.
-        By default, we considerer that length are expressed in millimeters. Users can configure
-        to express them in feet by adding an ir.config_parameter record with "product.volume_in_cubic_feet"
-        as key and "1" as value.
-        """
-        product_length_in_feet_param = self.env['ir.config_parameter'].sudo().get_param('product.volume_in_cubic_feet')
-        if product_length_in_feet_param == '1':
-            return self.env.ref('uom.product_uom_foot')
-        else:
-            return self.env.ref('uom.product_uom_millimeter')
-
-    @api.model
-    def _get_volume_uom_id_from_ir_config_parameter(self):
-        """ Get the unit of measure to interpret the `volume` field. By default, we consider
-        that volumes are expressed in cubic meters. Users can configure to express them in cubic feet
-        by adding an ir.config_parameter record with "product.volume_in_cubic_feet" as key
-        and "1" as value.
-        """
-        product_length_in_feet_param = self.env['ir.config_parameter'].sudo().get_param('product.volume_in_cubic_feet')
-        if product_length_in_feet_param == '1':
-            return self.env.ref('uom.product_uom_cubic_foot')
-        else:
-            return self.env.ref('uom.product_uom_cubic_meter')
-
-    @api.model
-    def _get_weight_uom_name_from_ir_config_parameter(self):
-        return self._get_weight_uom_id_from_ir_config_parameter().display_name
-
-    @api.model
-    def _get_length_uom_name_from_ir_config_parameter(self):
-        return self._get_length_uom_id_from_ir_config_parameter().display_name
-
-    @api.model
-    def _get_volume_uom_name_from_ir_config_parameter(self):
-        return self._get_volume_uom_id_from_ir_config_parameter().display_name
-
-    def _compute_weight_uom_name(self):
-        self.weight_uom_name = self._get_weight_uom_name_from_ir_config_parameter()
-
-    def _compute_volume_uom_name(self):
-        self.volume_uom_name = self._get_volume_uom_name_from_ir_config_parameter()
 
     @api.depends('product_variant_ids.product_tmpl_id')
     def _compute_product_variant_count(self):

--- a/addons/product/models/res_company.py
+++ b/addons/product/models/res_company.py
@@ -1,10 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, models
+from odoo import api, fields, models, _
 
 
 class ResCompany(models.Model):
     _inherit = "res.company"
+
+    default_weight_uom_id = fields.Many2one('uom.uom', string='Weight unit of measure', domain=lambda self: [('category_id', '=', self.env.ref('uom.product_uom_categ_kgm').id)],
+                                            default=lambda self: self.env.ref('uom.product_uom_kgm'))
+    default_volume_uom_id = fields.Many2one('uom.uom', string='Volume unit of measure', domain=lambda self: [('category_id', '=', self.env.ref('uom.product_uom_categ_vol').id)],
+                                            default=lambda self: self.env.ref('uom.product_uom_cubic_meter'))
+    default_dimension_uom_id = fields.Many2one('uom.uom', string='Dimension unit of measure', domain=lambda self: [('category_id', '=', self.env.ref('uom.uom_categ_length').id)],
+                                               default=lambda self: self.env.ref('uom.product_uom_millimeter'))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/product/models/res_config_settings.py
+++ b/addons/product/models/res_config_settings.py
@@ -25,14 +25,9 @@ class ResConfigSettings(models.TransientModel):
             ('advanced', 'Advanced price rules (discounts, formulas)')
             ], default='basic', string="Pricelists Method", config_parameter='product.product_pricelist_setting',
             help="Multiple prices: Pricelists with fixed price rules by product,\nAdvanced rules: enables advanced price rules for pricelists.")
-    product_weight_in_lbs = fields.Selection([
-        ('0', 'Kilograms'),
-        ('1', 'Pounds'),
-    ], 'Weight unit of measure', config_parameter='product.weight_in_lbs', default='0')
-    product_volume_volume_in_cubic_feet = fields.Selection([
-        ('0', 'Cubic Meters'),
-        ('1', 'Cubic Feet'),
-    ], 'Volume unit of measure', config_parameter='product.volume_in_cubic_feet', default='0')
+    company_weight_uom_id = fields.Many2one('uom.uom', string='Weight unit of measure', related='company_id.default_weight_uom_id', readonly=False)
+    company_volume_uom_id = fields.Many2one('uom.uom', string='Volume unit of measure', related='company_id.default_volume_uom_id', readonly=False)
+    company_dimension_uom_id = fields.Many2one('uom.uom', string='Dimension unit of measure', related='company_id.default_dimension_uom_id', readonly=False)
 
     @api.onchange('group_product_variant')
     def _onchange_group_product_variant(self):

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -121,12 +121,12 @@
                                     <label for="weight" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"/>
                                     <div class="o_row" name="weight" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}">
                                         <field name="weight" class="oe_inline"/>
-                                        <field name="weight_uom_name"/>
+                                        <field name="weight_uom_id"/>
                                     </div>
                                     <label for="volume" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"/>
                                     <div class="o_row" name="volume" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}">
                                         <field name="volume" string="Volume" class="oe_inline"/>
-                                        <field name="volume_uom_name"/>
+                                        <field name="volume_uom_id"/>
                                     </div>
                                 </group>
                             </group>
@@ -279,12 +279,12 @@
                                 <label for="volume"/>
                                 <div class="o_row">
                                     <field name="volume"/>
-                                    <span><field name="volume_uom_name"/></span>
+                                    <span><field name="volume_uom_id"/></span>
                                 </div>
                                 <label for="weight"/>
                                 <div class="o_row">
                                     <field name="weight"/>
-                                    <span><field name="weight_uom_name"/></span>
+                                    <span><field name="weight_uom_id"/></span>
                                 </div>
                             </group>
                             <group name="packaging" string="Packaging" groups="product.group_stock_packaging">

--- a/addons/product/views/res_config_settings_views.xml
+++ b/addons/product/views/res_config_settings_views.xml
@@ -6,14 +6,50 @@
             <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@id='companies']" position="after">
-                    <block title="Units of Measure" id="product_general_settings">
-                        <setting id="weight_uom_setting" string="Weight" help="Define your weight unit of measure">
-                            <field name="product_weight_in_lbs" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
-                        </setting>
-                        <setting id="manage_volume_uom_setting" string="Volume" help="Define your volume unit of measure">
-                            <field name="product_volume_volume_in_cubic_feet" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
-                        </setting>
-                    </block>
+                    <h2>Units of Measure</h2>
+                    <div class="row mt16 o_settings_container" id="product_general_settings">
+                        <div class="col-12 col-lg-6 o_setting_box" id="weight_uom_setting">
+                            <div class="o_setting_left_pane">
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="company_weight_uom_id" string="Weight"/>
+                                <div class="text-muted">
+                                    Define your default weight unit of measure
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="company_weight_uom_id" class="o_light_label"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="manage_volume_uom_setting">
+                            <div class="o_setting_right_pane">
+                                <label for="company_volume_uom_id" string="Volume"/>
+                                <div class="text-muted">
+                                    Define your default volume unit of measure
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="company_volume_uom_id" class="o_light_label"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="manage_dimension_uom_setting">
+                            <div class="o_setting_right_pane">
+                                <label for="company_dimension_uom_id" string="Dimension"/>
+                                <div class="text-muted">
+                                    Define your default dimension unit of measure
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="company_dimension_uom_id" class="o_light_label"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </xpath>
                  <xpath expr="//div[@id='product_get_pic_setting']" position="replace">
                     <setting id="product_get_pic_setting" string="Google Images" help="Get product pictures using Barcode" documentation="/applications/sales/sales/products_prices/products/product_images.html">

--- a/addons/stock/models/stock_package_type.py
+++ b/addons/stock/models/stock_package_type.py
@@ -8,12 +8,6 @@ class PackageType(models.Model):
     _name = 'stock.package.type'
     _description = "Stock package type"
 
-    def _get_default_length_uom(self):
-        return self.env['product.template']._get_length_uom_name_from_ir_config_parameter()
-
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
     name = fields.Char('Package Type', required=True)
     sequence = fields.Integer('Sequence', default=1, help="The first in the sequence is the default one.")
     height = fields.Float('Height', help="Packaging Height")
@@ -22,8 +16,8 @@ class PackageType(models.Model):
     base_weight = fields.Float(string='Weight', help='Weight of the package type')
     max_weight = fields.Float('Max Weight', help='Maximum weight shippable in this packaging')
     barcode = fields.Char('Barcode', copy=False)
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', default=_get_default_weight_uom)
-    length_uom_name = fields.Char(string='Length unit of measure label', compute='_compute_length_uom_name', default=_get_default_length_uom)
+    weight_uom_id = fields.Many2one('uom.uom', default=lambda self: self.env.company.default_weight_uom_id, string='Weight unit of measure')
+    dimension_uom_id = fields.Many2one('uom.uom', default=lambda self: self.env.company.default_dimension_uom_id, string='Dimensions unit of measure')
     company_id = fields.Many2one('res.company', 'Company', index=True)
     storage_category_capacity_ids = fields.One2many('stock.storage.category.capacity', 'package_type_id', 'Storage Category Capacity', copy=True)
 
@@ -33,15 +27,9 @@ class PackageType(models.Model):
         ('positive_width', 'CHECK(width>=0.0)', 'Width must be positive'),
         ('positive_length', 'CHECK(packaging_length>=0.0)', 'Length must be positive'),
         ('positive_max_weight', 'CHECK(max_weight>=0.0)', 'Max Weight must be positive'),
+        ('weight_uom_check', 'CHECK(weight_uom_id IS NOT NULL OR (base_weight = 0 AND max_weight = 0))', 'Weight Unit of measure must be provided with package weight.'),
+        ('dimension_uom_check', 'CHECK(dimension_uom_id IS NOT NULL OR (height = 0 AND width = 0 AND packaging_length = 0))', 'Length Unit of measure must be provided with package dimensions.')
     ]
-
-    def _compute_length_uom_name(self):
-        for package_type in self:
-            package_type.length_uom_name = self.env['product.template']._get_length_uom_name_from_ir_config_parameter()
-
-    def _compute_weight_uom_name(self):
-        for package_type in self:
-            package_type.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
 
     def copy(self, default=None):
         default = dict(default or {})

--- a/addons/stock/views/stock_package_type_view.xml
+++ b/addons/stock/views/stock_package_type_view.xml
@@ -14,24 +14,25 @@
                 </h1>
                 <group name="delivery">
                     <group>
-                        <label for="length_uom_name" string="Size"/>
+                        <label for="dimension_uom_id" string="Size"/>
                         <div class="o_row" name="size">
                             <field name="packaging_length" placeholder="Length"/>
                             <span>&#215;</span>
                             <field name="width" placeholder="Width"/>
                             <span>&#215;</span>
                             <field name="height" placeholder="Height"/>
-                            <span><field name="length_uom_name" help="Size: Length &#215; Width &#215; Height"/></span>
+                            <span><field name="dimension_uom_id" help="Size: Length &#215; Width &#215; Height"
+                                    attrs="{'required':['|', '|', ('width','>', 0), ('height', '>', 0), ('packaging_length', '>', 0)]}"/></span>
                         </div>
                         <label for="base_weight"/>
                         <div class="o_row" name="base_weight">
                             <field name="base_weight"/>
-                            <span><field name="weight_uom_name"/></span>
+                            <span><field name="weight_uom_id" attrs="{'required':['|', ('base_weight','>', 0), ('max_weight', '>', 0)]}"/></span>
                         </div>
                         <label for="max_weight"/>
                         <div class="o_row" name="max_weight">
                             <field name="max_weight"/>
-                            <span><field name="weight_uom_name"/></span>
+                            <span><field name="weight_uom_id" attrs="{'required':['|', ('base_weight','>', 0), ('max_weight', '>', 0)]}"/></span>
                         </div>
                         <field name="barcode"/>
                         <field name="company_id" groups="base.group_multi_company"/>


### PR DESCRIPTION
This commit removes the system paramter for weight and volume
that is used for product and package uom, instead, it adds following
to make things more flexible

1- Weight and Volume UoM fields on product
2- Weight and dimension UoM fields on packages, conversions are done when putting
product in pack
3- a configuration is added to set a weight UoM to use for picking shipping
weight since there is no longer a system paramter.
4- Weight and dimension UoM fields on carrier to be computed depending on
each type of carrier. These fields define the UoM to convert to when
sending products to carrier API, see enterprise PR.

Task Id: 3069715
ENT PR: https://github.com/odoo/enterprise/pull/35102


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
