### PR TITLE
[IMP][15.0] mail: Add avatar when tagging name

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
@@ -21,6 +21,9 @@
                         hasBackground="false"
                         partnerLocalId="record.localId"
                     />
+                    <div class="o_user_menu">
+                        <img class="rounded-circle o_user_avatar " t-att-src="record.avatarUrl" />
+                    </div>
                     <span class="o_ComposerSuggestion_part1 text-truncate"><t t-esc="record.nameOrDisplayName"/></span>
                     <t t-if="record.email">
                         <span class="o_ComposerSuggestion_part2 text-truncate">(<t t-esc="record.email"/>)</span>


### PR DESCRIPTION
Current behavior before PR:

- Currently, when the username tag ('@') only shows the name, but in the case of multiple names that are the same, it is very easy to be mistakenly tagged.

    => Annoying unrelated people. People who need to know do not receive information

Desired behavior after PR is merged:

- Add avatar when tagging the person's name on the suggestion section

![image](https://user-images.githubusercontent.com/91303385/202619809-0dc871ef-b938-49f9-88b9-6a5602445a4b.png)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
