### PR TITLE
[FIX] web_editor: add back `observerUnactive` in `_onDragAndDropStart`

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -970,6 +970,7 @@ var SnippetEditor = Widget.extend({
      * @private
      */
     _onDragAndDropStart: function () {
+        this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
         this.trigger_up('drag_and_drop_start');
         this.options.wysiwyg.odooEditor.automaticStepUnactive();
         var self = this;


### PR DESCRIPTION
In commit [1], the call to `observerUnactive` at the start of the
`_onDragAndDropStart` function has been removed because with it,
undoing a drag and drop in grid mode did not work properly (since the
style (like the `grid-area`) and the grid classes changes were not
observed, the grid items were broken).
However, this call was originally added in [2] (and modified in [3]) to
avoid recording mutations triggered by the `we-hook` changes, which
would create unnecessary views in the backend.
Therefore, this call should not have been removed.

This commit adds this call back.

[1]: https://github.com/odoo/odoo/commit/cc406afcea7bf5846233a9f97a4a8ac5f618f3ec
[2]: https://github.com/odoo/odoo/commit/1b80fe9b56acea09a6784691561df65fe6349f50
[3]: https://github.com/odoo/odoo/commit/f76ba944c516a0377cec324f564df604e52c2ffd

task-3074139