### PR TITLE
[FIX] stock: include mandatory group dependent warehouse_id field

### DIFF
--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -88,6 +88,7 @@
                             <field name="sequence_id" groups="base.group_no_one"/>
                             <field name="sequence_code"/>
                             <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
+                            <field name="warehouse_id" invisible="1" groups="!stock.group_stock_multi_warehouses"/>
                             <field name="reservation_method" attrs="{'invisible': [('hide_reservation_method', '=', True)]}" widget="radio"/>
                             <field name="auto_show_reception_report" attrs="{'invisible': [('code', 'not in', ['incoming', 'internal'])]}" groups="stock.group_reception_report"/>
                             <label for="reservation_days_before" string="Reserve before scheduled date" attrs="{'invisible': ['|', ('code', '=', 'incoming'), ('reservation_method', '!=', 'by_date')]}"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- make sure `Storage Locations` option is not enabled in the settings
- Create an operation type
- try to save

Problem:
Traceback is triggered because the `warehouse_id` field is not sent in the create vals:
https://github.com/odoo/odoo/blob/18952cdc76070f2a70789f2fa25e4fa0d546d470/addons/stock/models/stock_picking.py#L95

The group unification done by https://github.com/odoo/odoo/pull/95729 missed adding the field `warehouse_id` into this view when `stock.group_stock_multi_warehouses` is False.

opw-3068182
