### PR TITLE
[FIX] web: impossible to delete subtask without saving

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -324,7 +324,6 @@ export class FormController extends Component {
                 key: "delete",
                 description: this.env._t("Delete"),
                 callback: () => this.deleteRecord(),
-                skipSave: true,
             });
         }
         return Object.assign({}, this.props.info.actionMenus, { other: otherActionItems });


### PR DESCRIPTION
**Current behavior before PR:**

When we try to delete subtask with unsaved changes then subtask is not deleted.

**Desired behavior after PR is merged:**

- When we try to delete subtask with unsaved changes then it call delete action and in delete action there is a parameter "skipSave: true" because of that it skip the saving process and directly try to delete it.

- Hence,If we remove skipSave or set it "skipSave: false" then it  wait for changes to be saved and after that it will delete subtask.

Task-3063834




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
