### PR TITLE
[IMP] phone_validation: phone_is_mobile

### DIFF
--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -59,6 +59,10 @@ try:
             phone_fmt = phonenumbers.PhoneNumberFormat.NATIONAL
         return phonenumbers.format_number(phone_nbr, phone_fmt)
 
+    def phone_is_mobile(number, country_code=None):
+        phone_nbr = phone_parse(number, country_code)
+        return phonenumbers.number_type(phone_nbr) == phonenumbers.PhoneNumberType.MOBILE
+
 except ImportError:
 
     def phone_parse(number, country_code):
@@ -74,6 +78,8 @@ except ImportError:
             _phonenumbers_lib_warning = True
         return number
 
+    def phone_is_mobile(number, country_code=None):
+        return False
 
 def phone_sanitize_numbers(numbers, country_code, country_phone_code, force_format='E164'):
     """ Given a list of numbers, return parsezd and sanitized information


### PR DESCRIPTION
Add a function to detect if the given phone number is a mobile number or not.

This function uses the number_type function from the phonenumbers library, which returns the value MOBILE from the enum PhoneNumberType.

If the phonenumbers library is not available, the number is assumed as not being a mobile number.

task-2972937

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
