### PR TITLE
[IMP] web_editor: set default values for repeat-pattern background size

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4296,7 +4296,7 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
     backgroundType: function (previewMode, widgetValue, params) {
         this.$target.toggleClass('o_bg_img_opt_repeat', widgetValue === 'repeat-pattern');
         this.$target.css('background-position', '');
-        this.$target.css('background-size', '');
+        this.$target.css('background-size', widgetValue !== 'repeat-pattern' ? '' : '100px');
     },
     /**
      * Saves current background position and enables overlay.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
---

When a user chooses "Repeat Pattern" as the background image position, nothing happens.

Current behavior before PR:
---

As the background size is set to auto, for background-position `repeat-pattern` no effect[1] can be seen in the
background size.

[1]: https://bit.ly/3MM31Ac

Desired behavior after PR is merged:
---
Not a bug but can be considered an improvement in features by setting some default[2] width or height for a repeat-pattern option for all relevant snippets.

[2]: https://bit.ly/3GbGIBo

PR: [106143](https://github.com/odoo/odoo/pull/106143)
task- 2862510