### PR TITLE
[FIX] web: remove value modified from the list of invalid fields

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -539,7 +539,7 @@ export class Record extends DataPoint {
             const fieldNames = await prom;
             this._removeInvalidFields(fieldNames);
             for (const fieldName of fieldNames) {
-                if (["one2many", "many2many"].includes(this.fields[fieldName].type)) {
+                if (!this.fields[fieldName] || (["one2many", "many2many"].includes(this.fields[fieldName].type))) {
                     const { editedRecord } = this.data[fieldName];
                     if (editedRecord) {
                         editedRecord._removeAllInvalidFields();


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable “Work orders” in the manufacturing settings
- Create a bill of materials:
    - Add an operation:
        - select "Compute based on tracked time"

Problem:
Traceback is triggered: `Cannot read properties of undefined (reading 'type')`

The field that has been modified and its new value are added to the list of fieldNames, then we do a loop to get each field but since value is not a valid field, we cannot find it, and without checking the result we try to access its type.

opw-3055772
