### PR TITLE
[REF] tools: provide compatibility with PyPDF2 > 2.x

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -4,7 +4,6 @@ import re
 import base64
 import io
 
-from PyPDF2 import PdfFileReader, PdfFileMerger, PdfFileWriter
 from reportlab.platypus import Frame, Paragraph, KeepInFrame
 from reportlab.lib.units import mm
 from reportlab.lib.pagesizes import A4
@@ -14,6 +13,7 @@ from reportlab.pdfgen.canvas import Canvas
 from odoo import fields, models, api, _
 from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import AccessError, UserError
+from odoo.tools.pdf import OdooPdfFileReader, OdooPdfFileWriter, PdfMerger
 from odoo.tools.safe_eval import safe_eval
 
 DEFAULT_ENDPOINT = 'https://iap-snailmail.odoo.com'
@@ -461,10 +461,10 @@ class SnailmailLetter(models.Model):
         canvas.save()
         cover_buf.seek(0)
 
-        invoice = PdfFileReader(io.BytesIO(invoice_bin))
+        invoice = OdooPdfFileReader(io.BytesIO(invoice_bin))
         cover_bin = io.BytesIO(cover_buf.getvalue())
-        cover_file = PdfFileReader(cover_bin)
-        merger = PdfFileMerger()
+        cover_file = OdooPdfFileReader(cover_bin)
+        merger = PdfMerger()
 
         merger.append(cover_file, import_bookmarks=False)
         merger.append(invoice, import_bookmarks=False)
@@ -507,9 +507,9 @@ class SnailmailLetter(models.Model):
         canvas.save()
         pdf_buf.seek(0)
 
-        new_pdf = PdfFileReader(pdf_buf)
-        curr_pdf = PdfFileReader(io.BytesIO(invoice_bin))
-        out = PdfFileWriter()
+        new_pdf = OdooPdfFileReader(pdf_buf)
+        curr_pdf = OdooPdfFileReader(io.BytesIO(invoice_bin))
+        out = OdooPdfFileWriter()
         for page in curr_pdf.pages:
             page.mergePage(new_pdf.getPage(0))
             out.addPage(page)

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -7,7 +7,6 @@ import io
 import logging
 import re
 import requests
-import PyPDF2
 
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
@@ -18,6 +17,7 @@ from odoo.addons.http_routing.models.ir_http import slug, url_for
 from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
 from odoo.tools import html2plaintext, sql
+from odoo.tools.pdf import OdooPdfFileReader
 
 _logger = logging.getLogger(__name__)
 
@@ -1310,7 +1310,7 @@ class Slide(models.Model):
 
         if data_bytes.startswith(b'%PDF-'):
             try:
-                pdf = PyPDF2.PdfFileReader(io.BytesIO(data_bytes), overwriteWarnings=False)
+                pdf = OdooPdfFileReader(io.BytesIO(data_bytes), overwriteWarnings=False)
                 return (5 * len(pdf.pages)) / 60
             except Exception:
                 pass  # as this is a nice to have, fail silently

--- a/odoo/addons/base/tests/test_pdf.py
+++ b/odoo/addons/base/tests/test_pdf.py
@@ -21,7 +21,7 @@ class TestPdf(TransactionCase):
         attachments = list(self.minimal_pdf_reader.getAttachments())
         self.assertEqual(len(attachments), 0)
 
-        pdf_writer = pdf.PdfFileWriter()
+        pdf_writer = pdf.PdfWriter()
         pdf_writer.cloneReaderDocumentRoot(self.minimal_pdf_reader)
         pdf_writer.addAttachment('test_attachment.txt', b'My awesome attachment')
 
@@ -74,7 +74,7 @@ class TestPdf(TransactionCase):
 
     def test_branded_file_writer(self):
         # It's not easy to create a PDF with PyPDF2, so instead we copy minimal.pdf with our custom pdf writer
-        pdf_writer = pdf.PdfFileWriter()  # BrandedFileWriter
+        pdf_writer = pdf.PdfWriter()  # BrandedFileWriter
         pdf_writer.cloneReaderDocumentRoot(self.minimal_pdf_reader)
         writer_buffer = io.BytesIO()
         pdf_writer.write(writer_buffer)
@@ -83,7 +83,7 @@ class TestPdf(TransactionCase):
 
         # Read the metadata of the newly created pdf.
         reader_buffer = io.BytesIO(branded_content)
-        pdf_reader = pdf.PdfFileReader(reader_buffer)
+        pdf_reader = pdf.OdooPdfFileReader(reader_buffer)
         pdf_info = pdf_reader.getDocumentInfo()
         self.assertEqual(pdf_info['/Producer'], 'Odoo')
         self.assertEqual(pdf_info['/Creator'], 'Odoo')


### PR DESCRIPTION
The next Debian [0] and Ubuntu [1] releases will provide PyPDF2 2.x. As Odoo 16.0 should be packaged for the next Debian but should also work with the current stable reeleases, this commit is an attempt to do the splits.

As explained in the migration documentation [2], most changes are simple naming adjustments. For this reason, the current adapt the code to already use the new naming convention and patch the old PyPDF2 to provide the new naming.

The patch is done in odoo.tools.pdf in order to import PyPDF2 from this place when needed.

[0] https://packages.debian.org/bookworm/python3-pypdf2
[1] https://packages.ubuntu.com/kinetic/python3-pypdf2
[2] https://pypdf2.readthedocs.io/en/latest/user/migration-1-to-2.html

