### PR TITLE
[FIX] hr: phone number employee private information set to readonly

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -136,7 +136,7 @@
                                                     'form_view_ref': 'base.res_partner_view_form_private'}"
                                                 options='{"always_reload": True, "highlight_first_line": True}'/>
                                             <field name="private_email" string="Email"/>
-                                            <field name="phone" class="o_force_ltr" groups="hr.group_hr_user" string="Phone" readonly="True"/>
+                                            <field name="phone" class="o_force_ltr" string="Phone" readonly="True"/>
                                             <field name="bank_account_id" context="{'default_partner_id': address_home_id}"/>
                                         </group>
                                         <group col="4" colspan="2">


### PR DESCRIPTION
Steps to reproduce:

Go to employee app, and select any employee, inside the employee you go to the "Private Information" page. See the "Phone" field.

Issue:

The field "Phone" is editable and should be set as readonly.

Solution:

Removing the `groups="hr.group_hr_user"` from the "Phone" field will make the attrs to be taken into account and set the field to readonly.

I've already spoke to the PO and not being able to modify this field is the expected behavior.

opw-3071803
