### PR TITLE
[FIX] core: fix read_group in en_US

### DIFF
--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -614,6 +614,19 @@ class TestBase(TransactionCase):
         self.assertEqual([g['title_count'] for g in groups_data], [2, 4], 'Incorrect number of results')
         self.assertEqual([g['color'] for g in groups_data], [-1, 10], 'Incorrect aggregation of int column')
 
+    def test_62_en_US_read_group(self):
+        self.env['res.lang'].with_context(active_test=False).search([('code', '=', 'fr_FR')]).active = True
+        self.env['res.users'].search([('lang', '=', 'en_US')]).lang = 'fr_FR'
+        self.env['res.partner'].search([('lang', '=', 'en_US')]).lang = 'fr_FR'
+        self.env['res.lang'].search([('code', '=', 'en_US')]).active = False
+        self.env['res.partner'].create({'name': 'test_read_group'})._write({'create_date': '2022-10-12'})
+        result = self.env['res.partner'].with_context(lang='en_US')._read_group(
+            [('create_date', '>', '2022-10-10'), ('create_date', '<', '2022-10-14')],
+            fields=['create_date'],
+            groupby=['create_date:month']
+        )
+        self.assertEqual(result[0]['create_date:month'], 'October 2022')
+
     def test_70_archive_internal_partners(self):
         test_partner = self.env['res.partner'].create({'name':'test partner'})
         test_user = self.env['res.users'].create({

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2376,7 +2376,7 @@ class BaseModel(metaclass=MetaModel):
                 if ftype in ['many2one', 'many2many']:
                     value = value[0]
                 elif ftype in ('date', 'datetime'):
-                    locale = get_lang(self.env).code
+                    locale = 'en_US' if self.env.context.get('lang') == 'en_US' else get_lang(self.env).code
                     fmt = DEFAULT_SERVER_DATETIME_FORMAT if ftype == 'datetime' else DEFAULT_SERVER_DATE_FORMAT
                     tzinfo = None
                     range_start = value


### PR DESCRIPTION
from saas-15.3 code like
https://github.com/odoo/enterprise/blob/2df8476a4eb9c3ebe201781a83b632d7e17bddc7/hr_payroll/models/hr_payslip.py#L1013
tries to use `with_context(lang='en_US')._read_group` to get `en_US` value
however if 'en_US' is not activated, the non-en_US date will trigger error in the following `datetime.strptime`

this commit allows `with_context(lang='en_US')._read_group` to be a hack and returns English locale value even if `en_US` is not activated.


To be discussed:
If we should do it for `locale` or ask functional teams to change the code
