### PR TITLE
[FIX] web: fix fields math formulas with different localization

### DIFF
--- a/addons/web/static/src/views/fields/parsers.js
+++ b/addons/web/static/src/views/fields/parsers.js
@@ -18,6 +18,7 @@ function evaluateMathematicalExpression(expr, context = {}) {
     for (let v of val.split(new RegExp(/([-+*/()^])/g))) {
         if (!["+", "-", "*", "/", "(", ")", "^"].includes(v) && v.length) {
             // check if this is a float and take into account user delimiter preference
+
             v = parseFloat(v);
         }
         if (v === "^") {
@@ -38,10 +39,12 @@ function evaluateMathematicalExpression(expr, context = {}) {
  * @returns {number}
  */
 function parseNumber(value, options = {}) {
+    if (!value.startsWith("=")) {
     // a number can have the thousand separator multiple times. ex: 1,000,000.00
     value = value.replaceAll(new RegExp(escapeRegExp(options.thousandsSep), "g") || ",", "");
     // a number only have one decimal separator
     value = value.replace(new RegExp(escapeRegExp(options.decimalPoint), "g") || ".", ".");
+    }
 
     if (value.startsWith("=")) {
         value = evaluateMathematicalExpression(value.substring(1));

--- a/addons/web/static/tests/views/fields/parsers_tests.js
+++ b/addons/web/static/tests/views/fields/parsers_tests.js
@@ -143,4 +143,13 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(parseInteger("1,000,000"), 1000000);
         assert.strictEqual(parseFloat("1,000,000.50"), 1000000.5);
     });
+
+    QUnit.test("parseWithMathFormula", function (assert) {
+        patchWithCleanup(localization, {
+            decimalPoint: ",",
+            thousandsSep: ".",
+        });
+        assert.strictEqual(parseFloat("=2,5*2"), 5);
+        assert.strictEqual(parseFloat("=2.500*2"), 5000);
+    });
 });


### PR DESCRIPTION
Current behavior:
If you use a localization that uses a different decimal separator than the default one, the field math formulas are not working correctly. For example, if you use the localization for France, the decimal separator is a comma and not a dot. So if you have a field with "= 1,5 * 2" the value will be 30 instead of 3.

Steps to reproduce:
- Change language to French
- Go to any numeric field (e.g. Unit Price on a SO line)
- Enter "= 1,5 * 2" in the field
- The result will be 30 instead of 3

This happens because it will first parse the entire formula and transform "1,5*2" into "1.5*2" and then it will parse the different values in the formula, so the "1.5" will be parsed as 15 instead of 1.5.

opw-3051593
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
