### PR TITLE
[FIX] web: add String type to resId props validator

### DIFF
--- a/addons/web/static/src/views/standard_view_props.js
+++ b/addons/web/static/src/views/standard_view_props.js
@@ -33,7 +33,7 @@ export const standardViewProps = {
     noBreadcrumbs: { type: Boolean, optional: true },
     orderBy: { type: Array, elements: String },
     relatedModels: { type: Object, elements: Object, optional: true },
-    resId: { type: [Number, Boolean], optional: true },
+    resId: { type: [Number, Boolean, String], optional: true },
     resIds: { type: Array, optional: true },
     searchMenuTypes: { type: Array, elements: String },
     selectRecord: { type: Function, optional: true },

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -81,7 +81,7 @@ FormViewDialog.props = {
     },
     onRecordSaved: { type: Function, optional: true },
     removeRecord: { type: Function, optional: true },
-    resId: { type: [Number, Boolean], optional: true },
+    resId: { type: [Number, Boolean, String], optional: true },
     title: { type: String, optional: true },
     viewId: { type: [Number, Boolean], optional: true },
     preventCreate: { type: Boolean, optional: true },


### PR DESCRIPTION
# Current behaviour
In debug mode, when clicking on a pill in a gantt view with multiple items vertically present in the view in the Rental app, we get a stacktrace that the resId is not a Number or Boolean.

# Expected behaviour
Should open the FormDialogView for the selected pill, just like in debug=0 mode.

# Steps to reproduce
- Install Inventory and Rental
- Go to Rental > Schedule
- Click on a pill in the gantt view

# Reason for the problem
When having multiple items (on multiple tracks) in a gantt view (Rental), the data-id of the rendered html elements are of the form `"((\d+)?\(\d+\))*\d+"` (for ex: `(57)56` or `5(54)53`, I presume more tracks adds a larger prefix). Those are not parsable integers, therefor in dev mode, when the props validator is active (only active in dev since it is an expensive op), we get the stacktrace from the failed validation.

# Fix
Add the String type to the resId in the validators that is impacting this ticket. There are lot of places where pure strings are used for the data-id, even some are just words. You can search with `data-id="[a-zA-Z\-_]+?"` to find a few examples.

# Affected versions
- 16.0
- master
---
opw-3072339

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
