### PR TITLE
[FIX] mrp: avoid traceback when configuring a BoM operation

### DIFF
--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -101,6 +101,7 @@
                             </group><group name="workorder">
                                 <field name="workorder_count" invisible="1"/>
                                 <field name="time_mode" widget="radio"/>
+                                <field name="time_computed_on" invisible="1"/>
                                 <label for="time_mode_batch" attrs="{'invisible': [('time_mode', '=', 'manual')]}"/>
                                 <div attrs="{'invisible': [('time_mode', '=', 'manual')]}">
                                     last


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Enable “Work orders” in the manufacturing settings
- Create a bill of materials:
    - Add an operation:
        - select "Compute based on tracked time"

**Problem:**
Traceback is triggered: `Cannot read properties of undefined (reading 'type')`

The `time_computed_on` is a computed field and depends on the `time_mode`:
https://github.com/odoo/odoo/blob/38ac9ccbc1921e4860de4885e8a79b1303632095/addons/mrp/models/mrp_routing.py#L46-L47

So as we changed the `time_mode`, the `update` function in js will be triggered, and then the fields that have changed will be retrieved to remove them from the list of invalid fields, see:
https://github.com/odoo/odoo/commit/46074244798d2e447f4e5cf174244ea263563b1d

The type of each field is checked if is a `"one2many" or "many2many"` but since `time_computed_on` is not in the view, it won't be found:
https://github.com/odoo/odoo/blob/46074244798d2e447f4e5cf174244ea263563b1d/addons/web/static/src/views/basic_relational_model.js#L682-L683

and without checking the result, its type is accessed while it is undefined

opw-3055772
