### PR TITLE
[IMP] web, *: simplification and standardization of the settings arch

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -18,687 +18,312 @@
             <field name="priority" eval="40"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
+                <xpath expr="//form" position="inside">
                     <field name="country_code" invisible="1" groups="account.group_account_manager"/>
-                    <div class="app_settings_block" data-string="Invoicing" string="Invoicing" data-key="account" groups="account.group_account_manager">
+                    <app data-string="Invoicing" string="Invoicing" name="account" groups="account.group_account_manager">
                         <field name="has_chart_of_accounts" invisible="1"/>
                         <field name="has_accounting_entries" invisible="1"/>
-                        <h2 attrs="{'invisible': [('has_accounting_entries','!=',False)]}">Fiscal Localization</h2>
-                        <div class="row mt16 o_settings_container" name="fiscal_localization_setting_container" attrs="{'invisible': [('has_accounting_entries','!=',False)]}">
-                            <div class="col-12 o_setting_box">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Fiscal Localization</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Taxes, fiscal positions, chart of accounts &amp; legal statements for your country
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="row mt16">
-                                            <label for="chart_template_id" string="Package" class="col-2 o_light_label"/>
-                                            <field name="chart_template_id" options="{'no_open': True, 'no_create': True}"/>
-                                        </div>
-                                        <div class="mt8">
-                                            <button name="%(account.open_account_charts_modules)d" icon="fa-arrow-right" type="action" string="Install More Packages" discard="0" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Taxes</h2>
-                        <div class="row mt16 o_settings_container" name="default_taxes_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="default_taxes"
-                                title="These taxes are set in any new product created.">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Default Taxes</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Default taxes applied to local transactions
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="row mt16">
-                                            <label string="Sales Tax" for="sale_tax_id" class="col-lg-3 o_light_label"/>
-                                            <field name="sale_tax_id" domain="[('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company_id)]"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Purchase Tax" for="purchase_tax_id" class="col-lg-3 o_light_label"/>
-                                            <field name="purchase_tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all')), ('company_id', '=', company_id)]"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="rounding_method" title="A rounding per line is advised if your prices are tax-included. That way, the sum of line subtotals equals the total with taxes.">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Rounding Method</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        How total tax amount is computed in orders and invoices
-                                    </div>
-                                     <div class="content-group">
-                                        <field name="tax_calculation_rounding_method" class="o_light_label mt16" widget="radio"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Cash Discount Tax Reduction</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        When will the tax be reduced when offering a cash discount
-                                    </div>
-                                    <div class="content-group">
-                                        <field name="early_pay_discount_computation"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="taxcloud_settings">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_taxcloud" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="account_taxcloud_right_pane">
-                                    <label for="module_account_taxcloud" string="TaxCloud"/>
-                                    <div class="text-muted">
-                                        Compute tax rates based on U.S. ZIP codes
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="eu_service" title="If you sell goods and services to customers in a foreign EU country, you must charge VAT based on the delivery address. This rule applies regardless of where you are located.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_l10n_eu_oss"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="l10n_eu_oss_right_pane">
-                                    <label for="module_l10n_eu_oss"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/finance/accounting/taxation/taxes/eu_distance_selling.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Apply VAT of the EU country to which goods and services are delivered.
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="tax_exigibility"
-                                title="Select this if the taxes should use cash basis, which will create an entry for such taxes on a given account during reconciliation."
-                                groups="account.group_account_user">
-                                <div class="o_setting_left_pane">
-                                    <field name="tax_exigibility"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="tax_exigibility"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Allow to configure taxes using cash basis
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('tax_exigibility', '=', False)]}">
-                                        <div class="row mt16">
-                                            <label for="tax_cash_basis_journal_id" class="col-lg-3 o_light_label"/>
-                                            <field name="tax_cash_basis_journal_id"/>
-                                        </div>
-                                        <div class="row mt16">
-                                            <label for="account_cash_basis_base_account_id" class="col-lg-3 o_light_label"/>
-                                            <field name="account_cash_basis_base_account_id"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="tax_fiscal_country_234">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Fiscal Country</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Domestic country of your accounting
-                                    </div>
-                                    <div class="text-muted">
-                                        <field name="account_fiscal_country_id" options="{'no_create': True, 'no_open': True}"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Currencies</h2>
-                        <div class="row mt16 o_settings_container" name="main_currency_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="main_currency">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Main Currency</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Main currency of your company
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="row mt16">
-                                            <label for="currency_id" class="col-lg-3 o_light_label"/>
-                                            <field name="currency_id" options="{'no_create_edit': True, 'no_open': True}" context="{'active_test': False}"/>
-                                            <field name="group_multi_currency" invisible="1"/>
-                                        </div>
-                                        <div class="mt8">
-                                            <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="fa-arrow-right"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="update_exchange_rates"
-                                attrs="{'invisible': [('group_multi_currency', '=', False)]}">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_currency_rate_live" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_currency_rate_live"/>
-                                    <div class="text-muted" id="update_currency_live">
-                                        Update exchange rates automatically
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Customer Invoices</h2>
-                        <div class="row mt16 o_settings_container" id="invoicing_settings">
-                            <div class="col-12 col-lg-6 o_setting_box" id="default_setting_options">
-                                <div class="o_setting_left_pane">
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Default Sending Options</span>
-                                    <div class="text-muted">
-                                        Those options will be selected by default when clicking "Send &amp; Print" on invoices
-                                    </div>
-                                    <div class="mt16">
-                                        <div class="content-group" id="send_default">
-                                            <div>
-                                                <field name="invoice_is_print"/>
-                                                <label for="invoice_is_print"/>
-                                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                                            </div>
-                                            <div>
-                                                <field name="invoice_is_email"/>
-                                                <label for="invoice_is_email"/>
-                                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="send_invoices_followups">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_snailmail_account"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="snailmail_settings">
-                                    <label for="module_snailmail_account"/>
-                                    <div class="text-muted">
-                                        Send invoices and payment follow-ups by post
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="invoice_delivery_addresses">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_sale_delivery_address"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_sale_delivery_address"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/sales/sales/send_quotations/different_addresses.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Select specific invoice and delivery addresses
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="line_subtotals">
-                                <div class="o_setting_left_pane">
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="show_line_subtotals_tax_selection"/>
-                                    <div class="text-muted">
-                                        Line subtotals tax display
-                                    </div>
-                                    <div class="mt16">
-                                        <field name="show_line_subtotals_tax_selection" class="o_light_label" widget="radio"/>
-                                        <field name="group_show_line_subtotals_tax_excluded" invisible="1"/>
-                                        <field name="group_show_line_subtotals_tax_included" invisible="1"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="get_invoice_warnings">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_warning_account"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_warning_account" string="Warnings"/>
-                                    <div class="text-muted">
-                                        Get warnings when invoicing specific customers
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="smallest_coinage_currency">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_cash_rounding"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_cash_rounding"/>
-                                    <div class="text-muted">
-                                        Define the smallest coinage of the currency used to pay by cash
+                        <block title="Fiscal Localization" name="fiscal_localization_setting_container" attrs="{'invisible': [('has_accounting_entries','!=',False)]}">
+                            <setting string="Fiscal Localization" company_dependent="1" help="Taxes, fiscal positions, chart of accounts &amp; legal statements for your country">
+                                <div class="content-group">
+                                    <div class="row mt16">
+                                        <label for="chart_template_id" string="Package" class="col-2 o_light_label"/>
+                                        <field name="chart_template_id" options="{'no_open': True, 'no_create': True}"/>
                                     </div>
                                     <div class="mt8">
-                                        <button name="%(account.rounding_list_action)d" icon="fa-arrow-right"
-                                                type="action" string="Cash Roundings" class="btn-link"
-                                                attrs="{'invisible': [('group_cash_rounding', '=', False)]}"/>
+                                        <button name="%(account.open_account_charts_modules)d" icon="fa-arrow-right" type="action" string="Install More Packages" discard="0" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" id="intrastat_statistics">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_intrastat" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="intrastat_right_pane">
-                                    <label for="module_account_intrastat"/>
-                                    <div class="text-muted">
-                                        Collect information and produce statistics on the trade in goods in Europe with intrastat
+                            </setting>
+                        </block>
+                        <block title="Taxes" name="default_taxes_setting_container">
+                            <setting id="default_taxes" string="Default Taxes" company_dependent="1" help="Default taxes applied to local transactions" title="These taxes are set in any new product created.">
+                                <div class="content-group">
+                                    <div class="row mt16">
+                                        <label string="Sales Tax" for="sale_tax_id" class="col-lg-3 o_light_label"/>
+                                        <field name="sale_tax_id" domain="[('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company_id)]"/>
+                                    </div>
+                                    <div class="row">
+                                        <label string="Purchase Tax" for="purchase_tax_id" class="col-lg-3 o_light_label"/>
+                                        <field name="purchase_tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all')), ('company_id', '=', company_id)]"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="default_incoterm">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Default Incoterm</span>
-                                    <div class="text-muted">
-                                        Default Incoterm of your company
+                            </setting>
+                            <setting id="rounding_method" company_dependent="1" string="Rounding Method" help="How total tax amount is computed in orders and invoices" title="A rounding per line is advised if your prices are tax-included. That way, the sum of line subtotals equals the total with taxes.">
+                                <field name="tax_calculation_rounding_method" class="o_light_label mt16" widget="radio"/>
+                            </setting>
+                            <setting string="Cash Discount Tax Reduction" company_dependent="1" help="When will the tax be reduced when offering a cash discount">
+                                <field name="early_pay_discount_computation"/>
+                            </setting>
+                            <setting id="taxcloud_settings" string="TaxCloud" help="Compute tax rates based on U.S. ZIP codes">
+                                <field name="module_account_taxcloud" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="eu_service" title="If you sell goods and services to customers in a foreign EU country, you must charge VAT based on the delivery address. This rule applies regardless of where you are located." documentation="/applications/finance/accounting/taxation/taxes/eu_distance_selling.html" help="Apply VAT of the EU country to which goods and services are delivered.">
+                                <field name="module_l10n_eu_oss"/>
+                            </setting>
+                            <setting id="tax_exigibility" company_dependent="1" help="Allow to configure taxes using cash basis" title="Select this if the taxes should use cash basis, which will create an entry for such taxes on a given account during reconciliation." groups="account.group_account_user">
+                                <field name="tax_exigibility"/>
+                                <div class="content-group" attrs="{'invisible': [('tax_exigibility', '=', False)]}">
+                                    <div class="row mt16">
+                                        <label for="tax_cash_basis_journal_id" class="col-lg-3 o_light_label"/>
+                                        <field name="tax_cash_basis_journal_id"/>
                                     </div>
-                                    <div class="text-muted">
-                                        <field name="incoterm_id"/>
+                                    <div class="row mt16">
+                                        <label for="account_cash_basis_base_account_id" class="col-lg-3 o_light_label"/>
+                                        <field name="account_cash_basis_base_account_id"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" id="show_sale_receipts">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_show_sale_receipts" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="show_sale_receipts_right_pane">
-                                    <label for="group_show_sale_receipts"/>
-                                    <div class="text-muted">
-                                        Activate to create sale receipt
+                            </setting>
+                            <setting id="tax_fiscal_country_234" string="Fiscal Country" company_dependent="1" help="Domestic country of your accounting">
+                                <field name="account_fiscal_country_id" options="{'no_create': True, 'no_open': True}"/>
+                            </setting>
+                        </block>
+                        <block title="Currencies" name="main_currency_setting_container">
+                            <setting id="main_currency" string="Main Currency" company_dependent="1" help="Main currency of your company">
+                                <div class="content-group">
+                                    <div class="row mt16">
+                                        <label for="currency_id" class="col-lg-3 o_light_label"/>
+                                        <field name="currency_id" options="{'no_create_edit': True, 'no_open': True}" context="{'active_test': False}"/>
+                                        <field name="group_multi_currency" invisible="1"/>
+                                    </div>
+                                    <div class="mt8">
+                                        <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="fa-arrow-right"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="use_invoice_terms">
-                                <div class="o_setting_left_pane">
-                                    <field name="use_invoice_terms"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="use_invoice_terms"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Add your terms &amp; conditions at the bottom of invoices/orders/quotations
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('use_invoice_terms','=',False)]}">
-                                        <div class="mt16">
-                                            <field name="terms_type" class="o_light_label" widget="radio"/>
-                                            <div>
-                                                <field name="invoice_terms"
-                                                       attrs="{'invisible': [('terms_type', '=', 'html')]}"
-                                                       class="oe_account_terms mt-5 w-100"
-                                                       placeholder="Insert your terms &amp; conditions here..."/>
-                                            </div>
-                                            <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
-                                                <button name="action_update_terms" icon="fa-arrow-right" type="object" string="Update Terms" class="btn-link"/>
-                                            </div>
-                                            <field name="preview_ready" invisible="1"/>
-                                            <div class="mt4 ms-1" attrs="{'invisible': [('preview_ready', '=', False)]}">
-                                                <a class="btn-link" href="/terms" role="button">
-                                                    <i class="fa fa-arrow-right"></i>
-                                                    Preview
-                                                </a>
-                                            </div>
+                            </setting>
+                            <setting id="update_exchange_rates" attrs="{'invisible': [('group_multi_currency', '=', False)]}" help="Update exchange rates automatically">
+                                <field name="module_currency_rate_live" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                        <h2></h2>
+                        <block title="Customer Invoices" id="invoicing_settings">
+                            <setting id="default_setting_options" string="Default Sending Options" help="Those options will be selected by default when clicking &quot;Send &amp; Print&quot; on invoices">
+                                <div class="mt16">
+                                    <div class="content-group" id="send_default">
+                                        <div>
+                                            <field name="invoice_is_print"/>
+                                            <label for="invoice_is_print"/>
+                                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
+                                        </div>
+                                        <div>
+                                            <field name="invoice_is_email"/>
+                                            <label for="invoice_is_email"/>
+                                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="account_use_credit_limit"/>
+                            </setting>
+                            <setting id="send_invoices_followups" help="Send invoices and payment follow-ups by post">
+                                <field name="module_snailmail_account"/>
+                            </setting>
+                            <setting id="invoice_delivery_addresses" documentation="/applications/sales/sales/send_quotations/different_addresses.html" help="Select specific invoice and delivery addresses">
+                                <field name="group_sale_delivery_address"/>
+                            </setting>
+                            <setting id="line_subtotals" help="Line subtotals tax display">
+                                <field name="show_line_subtotals_tax_selection" class="o_light_label" widget="radio"/>
+                                <field name="group_show_line_subtotals_tax_excluded" invisible="1"/>
+                                <field name="group_show_line_subtotals_tax_included" invisible="1"/>
+                            </setting>
+                            <setting id="get_invoice_warnings" string="Warnings" help="Get warnings when invoicing specific customers">
+                                <field name="group_warning_account"/>
+                            </setting>
+                            <setting id="smallest_coinage_currency" help="Define the smallest coinage of the currency used to pay by cash">
+                                <field name="group_cash_rounding"/>
+                                <div class="mt8">
+                                    <button name="%(account.rounding_list_action)d" icon="fa-arrow-right"
+                                            type="action" string="Cash Roundings" class="btn-link"
+                                            attrs="{'invisible': [('group_cash_rounding', '=', False)]}"/>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="account_use_credit_limit"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." role="img"/>
-                                    <div class="text-muted">
-                                        Trigger alerts when creating Invoices and Sales Orders for Partners with a Total Receivable amount exceeding a limit.
-                                    </div>
-                                    <div class="content-group mt-2" attrs="{'invisible': [('account_use_credit_limit', '=', False)]}">
-                                        <div class="row">
-                                            <label for="account_default_credit_limit" class="col-lg-4 o_light_label"/>
-                                            <field name="account_default_credit_limit"/>
+                            </setting>
+                            <setting id="intrastat_statistics" help="Collect information and produce statistics on the trade in goods in Europe with intrastat">
+                                <field name="module_account_intrastat" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="default_incoterm" string="Default Incoterm" help="Default Incoterm of your company">
+                                <field name="incoterm_id"/>
+                            </setting>
+                            <setting id="show_sale_receipts" help="Activate to create sale receipt">
+                                <field name="group_show_sale_receipts" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="use_invoice_terms" company_dependent="1" help="Add your terms &amp; conditions at the bottom of invoices/orders/quotations">
+                                <field name="use_invoice_terms"/>
+                                <div class="content-group" attrs="{'invisible': [('use_invoice_terms','=',False)]}">
+                                    <div class="mt16">
+                                        <field name="terms_type" class="o_light_label" widget="radio"/>
+                                        <div>
+                                            <field name="invoice_terms"
+                                                    attrs="{'invisible': [('terms_type', '=', 'html')]}"
+                                                    class="oe_account_terms mt-5 w-100"
+                                                    placeholder="Insert your terms &amp; conditions here..."/>
+                                        </div>
+                                        <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
+                                            <button name="action_update_terms" icon="fa-arrow-right" type="object" string="Update Terms" class="btn-link"/>
+                                        </div>
+                                        <field name="preview_ready" invisible="1"/>
+                                        <div class="mt4 ms-1" attrs="{'invisible': [('preview_ready', '=', False)]}">
+                                            <a class="btn-link" href="/terms" role="button">
+                                                <i class="fa fa-arrow-right"></i>
+                                                Preview
+                                            </a>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                        <h2>Customer Payments</h2>
-                        <div class="row mt16 o_settings_container" id="pay_invoice_online_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_payment"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_account_payment"/>
-                                    <div class="text-muted">
-                                        Let your customers pay their invoices online
+                            </setting>
+                            <setting company_dependent="1" help="Trigger alerts when creating Invoices and Sales Orders for Partners with a Total Receivable amount exceeding a limit.">
+                                <field name="account_use_credit_limit"/>
+                                <div class="content-group mt-2" attrs="{'invisible': [('account_use_credit_limit', '=', False)]}">
+                                    <div class="row">
+                                        <label for="account_default_credit_limit" class="col-lg-4 o_light_label"/>
+                                        <field name="account_default_credit_limit"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="account_batch_payment">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_batch_payment" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_account_batch_payment" string="Batch Payments"/>
-                                    <div class="text-muted">
-                                        Group payments into a single batch to ease the reconciliation process
+                            </setting>
+                        </block>
+                        <block title="Customer Payments" id="pay_invoice_online_setting_container">
+                            <setting help="Let your customers pay their invoices online">
+                                <field name="module_account_payment"/>
+                            </setting>
+                            <setting id="account_batch_payment" string="Batch Payments" help="Group payments into a single batch to ease the reconciliation process">
+                                <field name="module_account_batch_payment" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="collect_customer_payment" title="If you check this box, you will be able to collect payments using SEPA Direct Debit mandates." string="SEPA Direct Debit (SDD)" company_dependent="1" help="Collect customer payments in one-click using Euro SEPA Service">
+                                <field name="module_account_sepa_direct_debit" class="oe_inline" widget="upgrade_boolean"/>
+                                <div class="content-group" attrs="{'invisible': [('module_account_sepa_direct_debit', '=', False)]}">
+                                    <div class="text-warning mt16 mb4">
+                                        Save this page and come back here to set up the feature.
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="collect_customer_payment"
-                                title="If you check this box, you will be able to collect payments using SEPA Direct Debit mandates.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_sepa_direct_debit" class="oe_inline" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="sepa_direct_debit_right_pane">
-                                    <label string="SEPA Direct Debit (SDD)" for="module_account_sepa_direct_debit"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Collect customer payments in one-click using Euro SEPA Service
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_account_sepa_direct_debit', '=', False)]}">
-                                        <div class="text-warning mt16 mb4">
-                                            Save this page and come back here to set up the feature.
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box"
-                                id="qr_code_invoices"
-                                title="Add a QR-code to your invoices so that your customers can pay instantly with their mobile banking application.">
-                                <div class="o_setting_left_pane">
-                                    <field name="qr_code" class="oe_inline"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="qr_code_right_pane">
-                                    <label string="QR Codes" for="qr_code"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Add a payment QR-code to your invoices
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Vendor Bills</h2>
-                        <div class="row mt16 o_settings_container" id="account_vendor_bills">
-                            <div class="col-xs-12 col-md-6 o_setting_box" id="show_purchase_receipts">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_show_purchase_receipts" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="show_purchase_receipts_right_pane">
-                                    <label for="group_show_purchase_receipts"/>
-                                    <div class="text-muted">
-                                        Activate to create purchase receipt
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Vendor Payments</h2>
-                        <div class="row mt16 o_settings_container" id="print_vendor_checks_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="print_checks" groups="account.group_account_user">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_check_printing"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Checks" for="module_account_check_printing"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted" id="print_bills_payment">
-                                        Print checks to pay your vendors
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="sepa_payments"
-                                title="If you check this box, you will be able to register your payment using SEPA.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_sepa" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" name="sepa_right_pane">
-                                    <label for="module_account_sepa"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Pay your bills in one-click using Euro SEPA Service
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </setting>
+                            <setting id="qr_code_invoices" title="Add a QR-code to your invoices so that your customers can pay instantly with their mobile banking application." string="QR Codes" company_dependent="1" help="Add a payment QR-code to your invoices">
+                                <field name="qr_code" class="oe_inline"/>
+                            </setting>
+                        </block>
+                        <block title="Vendor Bills" id="account_vendor_bills">
+                            <setting id="show_purchase_receipts" help="Activate to create purchase receipt">
+                                <field name="group_show_purchase_receipts" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                        <block title="Vendor Payments" id="print_vendor_checks_setting_container">
+                            <setting id="print_checks" groups="account.group_account_user" string="Checks" company_dependent="1" help="Print checks to pay your vendors">
+                                <field name="module_account_check_printing"/>
+                            </setting>
+                            <setting id="sepa_payments" title="If you check this box, you will be able to register your payment using SEPA." company_dependent="1" help="Pay your bills in one-click using Euro SEPA Service">
+                                <field name="module_account_sepa" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
 
-                        <h2>Digitization</h2>
-                        <div class="row mt16 o_settings_container" id="account_digitalization">
-                            <div class="col-12 col-lg-6 o_setting_box" id="account_ocr_settings">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_invoice_extract" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="digitalizeocr">
-                                    <label for="module_account_invoice_extract"/>
-                                    <div class="text-muted">
-                                        Digitize your PDF or scanned documents with OCR and Artificial Intelligence
-                                    </div>
-                                    <div id="msg_invoice_extract" class="content-group" attrs="{'invisible': [('module_account_invoice_extract', '=', False)]}">
-                                        <div class="text-warning mt16 mb4">
-                                            Save this page and come back here to set up the feature.
-                                        </div>
+                        <block title="Digitization" id="account_digitalization">
+                            <setting id="account_ocr_settings" help="Digitize your PDF or scanned documents with OCR and Artificial Intelligence">
+                                <field name="module_account_invoice_extract" widget="upgrade_boolean"/>
+                                <div id="msg_invoice_extract" class="content-group" attrs="{'invisible': [('module_account_invoice_extract', '=', False)]}">
+                                    <div class="text-warning mt16 mb4">
+                                        Save this page and come back here to set up the feature.
                                     </div>
                                 </div>
-                            </div>
-                        </div>
+                            </setting>
+                        </block>
 
                         <t groups="account.group_account_user">
-                            <h2>Default Accounts</h2>
-                            <div class="row mt16 o_settings_container" id="default_accounts">
-                                <div class="col-12 col-lg-6 o_setting_box"
-                                    attrs="{'invisible': [('group_multi_currency', '=', False)]}">
-                                    <div class="o_setting_left_pane"></div>
-                                    <div class="o_setting_right_pane">
-                                        <div class="content-group">
-                                            <div>
-                                                <span class="o_form_label">Post Exchange difference entries in:</span>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="currency_exchange_journal_id" class="col-lg-4 o_light_label" string="Journal" />
-                                                <field name="currency_exchange_journal_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="income_currency_exchange_account_id" class="col-lg-4 o_light_label"/>
-                                                <field name="income_currency_exchange_account_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="expense_currency_exchange_account_id" class="col-lg-4 o_light_label"/>
-                                                <field name="expense_currency_exchange_account_id"/>
-                                            </div>
+                            <block title="Default Accounts" id="default_accounts">
+                                <setting attrs="{'invisible': [('group_multi_currency', '=', False)]}" string="Post Exchange difference entries in:">
+                                    <div class="content-group">
+                                        <div class="row mt8">
+                                            <label for="currency_exchange_journal_id" class="col-lg-4 o_light_label" string="Journal" />
+                                            <field name="currency_exchange_journal_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="income_currency_exchange_account_id" class="col-lg-4 o_light_label"/>
+                                            <field name="income_currency_exchange_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="expense_currency_exchange_account_id" class="col-lg-4 o_light_label"/>
+                                            <field name="expense_currency_exchange_account_id"/>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box">
-                                    <div class="o_setting_left_panel"></div>
-                                    <div class="o_setting_right_pane">
-                                        <span class="o_form_label">The following default accounts are used with certain features.</span>
-                                        <div class="content-group">
-                                            <div class="row mt8">
-                                                <label for="account_journal_suspense_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="account_journal_suspense_account_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="account_journal_payment_debit_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="account_journal_payment_debit_account_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="account_journal_payment_credit_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="account_journal_payment_credit_account_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="transfer_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="transfer_account_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="account_journal_early_pay_discount_gain_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="account_journal_early_pay_discount_gain_account_id"/>
-                                            </div>
-                                            <div class="row mt8">
-                                                <label for="account_journal_early_pay_discount_loss_account_id" class="col-lg-5 o_light_label"/>
-                                                <field name="account_journal_early_pay_discount_loss_account_id"/>
-                                            </div>
+                                </setting>
+                                <setting string="The following default accounts are used with certain features.">
+                                    <div class="content-group">
+                                        <div class="row mt8">
+                                            <label for="account_journal_suspense_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_suspense_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="account_journal_payment_debit_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_payment_debit_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="account_journal_payment_credit_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_payment_credit_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="transfer_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="transfer_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="account_journal_early_pay_discount_gain_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_early_pay_discount_gain_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="account_journal_early_pay_discount_loss_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_early_pay_discount_loss_account_id"/>
                                         </div>
                                     </div>
-                                </div>
-                            </div>
+                                </setting>
+                            </block>
                         </t>
 
                         <t groups="account.group_account_user">
-                            <h2>Bank &amp; Cash</h2>
-                            <div class="row mt16 o_settings_container" id="bank_cash">
-                                <div class="col-12 col-lg-6 o_setting_box"
-                                    id="import_bank_statements_csv"
-                                    title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard.">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_account_bank_statement_import_csv" widget="upgrade_boolean"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label for="module_account_bank_statement_import_csv" string="CSV Import"/>
-                                        <div class="text-muted">
-                                            Import your bank statements in CSV
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box" title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard.">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_account_bank_statement_import_qif" widget="upgrade_boolean"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label for="module_account_bank_statement_import_qif" string="QIF Import"/>
-                                        <div class="text-muted">
-                                            Import your bank statements in QIF
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box" title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard.">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_account_bank_statement_import_ofx" widget="upgrade_boolean"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label for="module_account_bank_statement_import_ofx" string="OFX Import"/>
-                                        <div class="text-muted">
-                                            Import your bank statements in OFX
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box"
-                                    id="import_bank_statement_camt"
-                                    title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard.">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_account_bank_statement_import_camt" widget="upgrade_boolean"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label for="module_account_bank_statement_import_camt" string="CAMT Import"/>
-                                        <div class="text-muted">
-                                            Import your bank statements in CAMT.053
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <block title="Bank &amp; Cash" id="bank_cash">
+                                <setting id="import_bank_statements_csv" title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard." string="CSV Import" help="Import your bank statements in CSV">
+                                    <field name="module_account_bank_statement_import_csv" widget="upgrade_boolean"/>
+                                </setting>
+                                <setting title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard." string="QIF Import" help="Import your bank statements in QIF">
+                                    <field name="module_account_bank_statement_import_qif" widget="upgrade_boolean"/>
+                                </setting>
+                                <setting title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard." string="OFX Import" help="Import your bank statements in OFX">
+                                    <field name="module_account_bank_statement_import_ofx" widget="upgrade_boolean"/>
+                                </setting>
+                                <setting id="import_bank_statement_camt" title="Once installed, set 'Bank Feeds' to 'File Import' in bank account settings.This adds a button to import from the Accounting dashboard." string="CAMT Import" help="Import your bank statements in CAMT.053">
+                                    <field name="module_account_bank_statement_import_camt" widget="upgrade_boolean"/>
+                                </setting>
+                            </block>
                         </t>
 
                         <t groups="account.group_account_user">
-                            <h2>Fiscal Periods</h2>
-                            <div class="row mt16 o_settings_container" id="accounting_reports">
-                                <div class="col-12 col-lg-6 o_setting_box" id="fiscalyear" invisible="1" groups="account.group_account_user"/>
-                                <div class="col-12 col-lg-6 o_setting_box" id="dynamic_report" invisible="1" groups="account.group_account_user">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_account_reports" widget="upgrade_boolean"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label for="module_account_reports"/>
-                                        <div class="text-muted" id="account_reports">
-                                            Navigate easily through reports and see what is behind the numbers
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <block title="Fiscal Periods" id="accounting_reports">
+                                <setting id="fiscalyear" invisible="1" groups="account.group_account_user"/>
+                                <setting id="dynamic_report" invisible="1" groups="account.group_account_user" help="Navigate easily through reports and see what is behind the numbers">
+                                    <field name="module_account_reports" widget="upgrade_boolean"/>
+                                </setting>
+                            </block>
                         </t>
-                        <h2>Analytics</h2>
-                        <div class="row mt16 o_settings_container" id="analytic">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="track_costs_revenues"
-                                title="Allows you to use the analytic accounting."
-                                groups="account.group_account_user">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_analytic_accounting"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_analytic_accounting"/>
-                                    <div class="text-muted">
-                                        Track costs &amp; revenues by project, department, etc
-                                    </div>
-                                </div>
+                        <block title="Analytics" id="analytic">
+                            <setting id="track_costs_revenues" title="Allows you to use the analytic accounting." groups="account.group_account_user" help="Track costs &amp; revenues by project, department, etc">
+                                <field name="group_analytic_accounting"/>
+                            </setting>
+                            <setting id="account_budget" title="This allows accountants to manage analytic and crossovered budgets. Once the master budgets and the budgets are defined, the project managers can set the planned amount on each analytic account." groups="account.group_account_user" help="Use budgets to compare actual with expected revenues and costs">
+                                <field name="module_account_budget" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="monitor_product_margins" string="Margin Analysis" help="Monitor your product margins from invoices">
+                                <field name="module_product_margin"/>
+                            </setting>
+                        </block>
+                        <block title="Storno Accounting" id="storno">
+                            <setting id="enable_storno_accounting" company_dependent="1" help="Use Storno accounting" title="Allows you to use Storno accounting.">
+                                <field name="account_storno"/>
+                            </setting>
+                        </block>
+                        <block title="Accounting Firms mode" id="quick_edit_mode">
+                            <div class="text-muted">
+                                <p style="margin-bottom: 0">Accounting firm mode will change invoice/bill encoding:</p>
+                                <p style="margin-bottom: 0"> - The document's sequence becomes editable on all documents.</p>
+                                <p style="margin-bottom: 0"> - A new field « Total (tax inc.) » to speed up and control the encoding by automating line creation with the right account &amp; tax.</p>
+                                <p style="margin-bottom: 0"> - A default Customer Invoice / Vendor Bill date will be suggested.</p>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="account_budget" title="This allows accountants to manage analytic and crossovered budgets. Once the master budgets and the budgets are defined, the project managers can set the planned amount on each analytic account." groups="account.group_account_user">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_account_budget" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="budget_management">
-                                    <label for="module_account_budget"/>
-                                    <div class="text-muted">
-                                        Use budgets to compare actual with expected revenues and costs
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="monitor_product_margins">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_product_margin"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_product_margin" string="Margin Analysis"/>
-                                    <div class="text-muted">
-                                        Monitor your product margins from invoices
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Storno Accounting</h2>
-                        <div class="row mt16 o_settings_container" id="storno">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="enable_storno_accounting"
-                                title="Allows you to use Storno accounting.">
-                                <div class="o_setting_left_pane">
-                                    <field name="account_storno"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="account_storno"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div class="text-muted">
-                                        Use Storno accounting
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Accounting Firms mode</h2>
-                        <div class="row mt16 o_settings_container" id="quick_edit_mode">
-                            <div class="col-12 col-lg-12 o_setting_box">
-                                <div class="text-muted">
-                                    <p style="margin-bottom: 0">Accounting firm mode will change invoice/bill encoding:</p>
-                                    <p style="margin-bottom: 0"> - The document's sequence becomes editable on all documents.</p>
-                                    <p style="margin-bottom: 0"> - A new field « Total (tax inc.) » to speed up and control the encoding by automating line creation with the right account &amp; tax.</p>
-                                    <p style="margin-bottom: 0"> - A default Customer Invoice / Vendor Bill date will be suggested.</p>
-                                </div>
-                                <div class="o_setting_right_pane mt16">
-                                    <label for="quick_edit_mode"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                    <div>
-                                        <field name="quick_edit_mode" placeholder="Disabled"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                            <setting company_dependent="1">
+                                <field name="quick_edit_mode" placeholder="Disabled"/>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/account_check_printing/views/res_config_settings_views.xml
+++ b/addons/account_check_printing/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="print_bills_payment" position="after">
+            <setting id="print_checks" position="inside">
                 <div class="content-group">
                     <div class="row mt16">
                         <label for="account_check_printing_layout" class="col-lg-4 o_light_label"/>
@@ -32,7 +32,7 @@
                       <field name="account_check_printing_date_label"/>
                     </div>
                 </div>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/auth_oauth/views/res_config_settings_views.xml
+++ b/addons/auth_oauth/views/res_config_settings_views.xml
@@ -12,29 +12,18 @@
                         </div>
                     </div>
                 </div>
-                <div id="module_auth_oauth" position="after">
-                    <div class="col-12 col-lg-6 o_setting_box"
-                        id="signin_google_setting"
-                        attrs="{'invisible': [('module_auth_oauth','=',False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="auth_oauth_google_enabled"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="Google Authentication" for="auth_oauth_google_enabled"/>
-                            <a href="https://www.odoo.com/documentation/master/applications/general/auth/google.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                            <div class="text-muted">
-                                Allow users to sign in with their Google account
+                <setting id="module_auth_oauth" position="after">
+                    <setting id="signin_google_setting" string="Google Authentication" help="Allow users to sign in with their Google account" documentation="/applications/general/auth/google.html" attrs="{'invisible': [('module_auth_oauth','=',False)]}">
+                        <field name="auth_oauth_google_enabled"/>
+                        <div class="content-group" attrs="{'invisible': [('auth_oauth_google_enabled','=',False)]}">
+                            <div class="row mt16">
+                                <label for="auth_oauth_google_client_id" string="Client ID:" class="col-lg-3 o_light_label"/>
+                                <field name="auth_oauth_google_client_id" placeholder="e.g. 1234-xyz.apps.googleusercontent.com"/>
                             </div>
-                            <div class="content-group" attrs="{'invisible': [('auth_oauth_google_enabled','=',False)]}">
-                                <div class="row mt16">
-                                    <label for="auth_oauth_google_client_id" string="Client ID:" class="col-lg-3 o_light_label"/>
-                                    <field name="auth_oauth_google_client_id" placeholder="e.g. 1234-xyz.apps.googleusercontent.com"/>
-                                </div>
-                                <a href="https://www.odoo.com/documentation/master/applications/general/auth/google.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
-                            </div>
+                            <a href="https://www.odoo.com/documentation/master/applications/general/auth/google.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
                         </div>
-                    </div>
-                </div>
+                    </setting>
+                </setting>
             </field>
         </record>
 </odoo>

--- a/addons/auth_password_policy/views/res_config_settings_views.xml
+++ b/addons/auth_password_policy/views/res_config_settings_views.xml
@@ -6,14 +6,10 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <!-- add before the Access Rights section -->
-            <xpath expr="//div[@id='allow_import']" position="before">
-                <div class="col-12 col-lg-6 o_setting_box">
-                    <div class="o_setting_left_pane"/>
-                    <div class="o_setting_right_pane">
-                        <label for="minlength"/>
-                        <field name="minlength"/>
-                    </div>
-                </div>
+            <xpath expr="//setting[@id='allow_import']" position="before">
+                <setting>
+                    <field name="minlength"/>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/auth_signup/views/res_config_settings_views.xml
+++ b/addons/auth_signup/views/res_config_settings_views.xml
@@ -6,38 +6,18 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[@id='access_rights']" position="before">
-                    <div class="col-12 col-lg-6 o_setting_box"
-                        id="login_documents"
-                        title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*.">
-                        <div class="o_setting_left_pane">
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="auth_signup_uninvited"/>
-                            <div class="text-muted">
-                                Let your customers log in to see their documents
-                            </div>
+                <xpath expr="//setting[@id='access_rights']" position="before">
+                    <setting id="login_documents" title="To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*." help="Let your customers log in to see their documents">
+                        <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
+                        <div class="content-group" attrs="{'invisible': [('auth_signup_uninvited','=','b2b')]}">
                             <div class="mt8">
-                                <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
-                            </div>
-                            <div class="content-group" attrs="{'invisible': [('auth_signup_uninvited','=','b2b')]}">
-                                <div class="mt8">
-                                    <button type="object" name="action_open_template_user" string="Default Access Rights" icon="fa-arrow-right" class="btn-link"/>
-                                </div>
+                                <button type="object" name="action_open_template_user" string="Default Access Rights" icon="fa-arrow-right" class="btn-link"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="enable_password_reset">
-                        <div class="o_setting_left_pane">
-                            <field name="auth_signup_reset_password"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="Password Reset" for="auth_signup_reset_password"/>
-                            <div class="text-muted">
-                                Enable password reset from Login page
-                            </div>
-                        </div>
-                    </div>
+                    </setting>
+                    <setting string="Password Reset" help="Enable password reset from Login page" id="enable_password_reset">
+                        <field name="auth_signup_reset_password"/>
+                    </setting>
                 </xpath>
             </field>
         </record>

--- a/addons/auth_totp_mail_enforce/views/res_config_settings_views.xml
+++ b/addons/auth_totp_mail_enforce/views/res_config_settings_views.xml
@@ -8,23 +8,13 @@
             <field name="priority" eval="40"/>
             <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[@id='allow_import']" position="before">
-                    <div class="col-12 col-lg-6 o_setting_box" id="auth_totp_policy">
-                        <div class="o_setting_left_pane">
-                            <field name="auth_totp_enforce" />
+                <xpath expr="//setting[@id='allow_import']" position="before">
+                    <setting id="auth_totp_policy" help="Enforce the two-factor authentication by email for employees or for all users (including portal users) if they didn't enable any other two-factor authentication method.">
+                        <field name="auth_totp_enforce" />
+                        <div class="mt16" attrs="{'invisible': [('auth_totp_enforce', '=', False)]}">
+                            <field name="auth_totp_policy" class="o_light_label" widget="radio"/>
                         </div>
-                        <div class="o_setting_right_pane">
-                            <label for="auth_totp_policy"/>
-                            <div class="text-muted">
-                                Enforce the two-factor authentication by email for employees or for all users
-                                (including portal users) if they didn't enable any other two-factor authentication
-                                method.
-                            </div>
-                            <div class="mt16" attrs="{'invisible': [('auth_totp_enforce', '=', False)]}">
-                                <field name="auth_totp_policy" class="o_light_label" widget="radio"/>
-                            </div>
-                        </div>
-                    </div>
+                    </setting>
                 </xpath>
             </field>
         </record>

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -6,344 +6,190 @@
             <field name="priority" eval="0"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="General Settings" string="General Settings" data-key="general_settings">
+                <xpath expr="//form" position="inside">
+                    <app data-string="General Settings" string="General Settings" name="general_settings" logo="/base/static/description/settings.png">
 
                         <div id="invite_users">
-                            <h2>Users</h2>
-                            <div class="row mt16 o_settings_container" name="users_setting_container">
-                                <div class="col-12 col-lg-6 o_setting_box" id="invite_users_setting">
-                                    <div class="o_setting_right_pane">
-                                        <widget name='res_config_invite_users'/>
-                                    </div>
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box" id="active_user_setting">
-                                    <div class="o_setting_right_pane">
-                                        <span class="fa fa-lg fa-users" aria-label="Number of active users"/>
-                                        <field name='active_user_count' class="w-auto ps-3 fw-bold"/>
-                                        <span class='o_form_label' attrs="{'invisible':[('active_user_count', '&gt;', '1')]}">
-                                            Active User
-                                        </span>
-                                        <span class='o_form_label' attrs="{'invisible':[('active_user_count', '&lt;=', '1')]}">
-                                            Active Users
-                                        </span>
-                                        <a href="https://www.odoo.com/documentation/master/applications/general/users.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                        <br/>
-                                        <button name="%(base.action_res_users)d" icon="fa-arrow-right" type="action" string="Manage Users" class="btn-link o_web_settings_access_rights"/>
-                                    </div>
-                                </div>
-                            </div>
+                            <block title="Users" name="users_setting_container">
+                                <setting id="invite_users_setting">
+                                    <widget name='res_config_invite_users'/>
+                                </setting>
+                                <setting id="active_user_setting">
+                                    <span class="fa fa-lg fa-users" aria-label="Number of active users"/>
+                                    <field name='active_user_count' class="w-auto ps-3 fw-bold"/>
+                                    <span class='o_form_label' attrs="{'invisible':[('active_user_count', '&gt;', '1')]}">
+                                        Active User
+                                    </span>
+                                    <span class='o_form_label' attrs="{'invisible':[('active_user_count', '&lt;=', '1')]}">
+                                        Active Users
+                                    </span>
+                                    <a href="https://www.odoo.com/documentation/master/applications/general/users.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                    <br/>
+                                    <button name="%(base.action_res_users)d" icon="fa-arrow-right" type="action" string="Manage Users" class="btn-link o_web_settings_access_rights"/>
+                                </setting>
+                            </block>
                         </div>
 
                         <div id="languages">
-                            <h2>Languages</h2>
-                            <div class='row mt16 o_settings_container' name="languages_setting_container">
-                                <div class='col-xs-12 col-md-6 o_setting_box' id="languages_setting">
-                                    <div class='o_setting_right_pane'>
-                                        <!-- TODO This is not an ideal solution but it looks ok on the interface -->
-                                        <div class="w-50">
-                                            <field name="language_count" class="w-auto ps-1 fw-bold"/>
-                                            <span class='o_form_label' attrs="{'invisible':[('language_count', '&gt;', '1')]}">
-                                                Language
-                                            </span>
-                                            <span class='o_form_label' attrs="{'invisible':[('language_count', '&lt;=', '1')]}">
-                                                Languages
-                                            </span>
-                                        </div>
-                                        <div class="mt8">
-                                            <button name="%(base.action_view_base_language_install)d" icon="fa-arrow-right" type="action" string="Add Languages" class="btn-link"/>
-                                        </div>
-                                        <div class="mt8" groups="base.group_no_one">
-                                            <button name="%(base.res_lang_act_window)d" icon="fa-arrow-right" type="action" string="Manage Languages" class="btn-link"/>
-                                        </div>
+                            <block title="Languages" name="languages_setting_container">
+                                <setting id="languages_setting">
+                                    <!-- TODO This is not an ideal solution but it looks ok on the interface -->
+                                    <div class="w-50">
+                                        <field name="language_count" class="w-auto ps-1 fw-bold"/>
+                                        <span class='o_form_label' attrs="{'invisible':[('language_count', '&gt;', '1')]}">
+                                            Language
+                                        </span>
+                                        <span class='o_form_label' attrs="{'invisible':[('language_count', '&lt;=', '1')]}">
+                                            Languages
+                                        </span>
                                     </div>
-                                </div>
-                            </div>
+                                    <div class="mt8">
+                                        <button name="%(base.action_view_base_language_install)d" icon="fa-arrow-right" type="action" string="Add Languages" class="btn-link"/>
+                                    </div>
+                                    <div class="mt8" groups="base.group_no_one">
+                                        <button name="%(base.res_lang_act_window)d" icon="fa-arrow-right" type="action" string="Manage Languages" class="btn-link"/>
+                                    </div>
+                                </setting>
+                            </block>
                         </div>
 
                         <div id="companies">
-                            <h2>Companies</h2>
-                            <div class="row mt16 o_settings_container" name="companies_setting_container">
-                                <div class="col-12 col-lg-6 o_setting_box" id="company_details_settings">
-                                    <field name="company_id" invisible="1"/>
-                                    <div class="o_setting_right_pane">
-                                        <field name="company_name" class="fw-bold"/>
-                                        <br/>
-                                        <field name="company_informations" class="text-muted" style="width: 90%;"/>
-                                        <br/>
-                                        <button name="open_company" icon="fa-arrow-right" type="object" string="Update Info" class="btn-link"/>
-                                    </div>
+                            <block title="Companies" name="companies_setting_container">
+                                <field name="company_id" invisible="1"/>
+                                <setting id="company_details_settings">
+                                    <field name="company_name" nolabel="1" class="fw-bold"/>
                                     <br/>
-                                    <div class="o_setting_right_pane">
-                                        <span class="o_form_label">Document Layout</span>
-                                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                        <div class="text-muted">
-                                            Choose the layout of your documents
-                                        </div>
-                                        <div class="content-group">
-                                            <div class="mt16" groups="base.group_no_one">
-                                                <label for="external_report_layout_id" string="Layout" class="col-3 col-lg-3 o_light_label"/>
-                                                <field name="external_report_layout_id" domain="[('type','=', 'qweb')]" class="oe_inline"/>
-                                            </div>
-                                            <div class="mt8">
-                                                <button name="%(web.action_base_document_layout_configurator)d" string="Configure Document Layout" type="action" class="oe_link" icon="fa-arrow-right"/>
-                                                <button name="edit_external_header" string="Edit Layout" type="object" class="oe_link" groups="base.group_no_one"/>
-                                                <button name="%(web.action_report_externalpreview)d" string="Preview Document" type="action" class="oe_link" groups="base.group_no_one"/>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <field name="company_informations" class="text-muted" style="width: 90%;"/>
                                     <br/>
-                                </div>
-                                <div class="col-12 col-lg-6 o_setting_box" id="companies_setting">
-                                    <div class="o_setting_right_pane">
-                                        <field name='company_count' class="w-auto ps-1 fw-bold"/>
-                                        <span class='o_form_label' attrs="{'invisible':[('company_count', '&gt;', '1')]}">
-                                            Company
-                                        </span>
-                                        <span class='o_form_label' attrs="{'invisible':[('company_count', '&lt;=', '1')]}">
-                                            Companies
-                                        </span>
-                                        <br/>
-                                        <div class="mt8">
-                                            <button name="%(base.action_res_company_form)d" icon="fa-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
-                                        </div>
+                                    <button name="open_company" icon="fa-arrow-right" type="object" string="Update Info" class="btn-link"/>
+                                </setting>
+                                <setting id="companies_setting">
+                                    <field name='company_count' nolabel="1" class="w-auto ps-1 fw-bold"/>
+                                    <span class='o_form_label' attrs="{'invisible':[('company_count', '&gt;', '1')]}">
+                                        Company
+                                    </span>
+                                    <span class='o_form_label' attrs="{'invisible':[('company_count', '&lt;=', '1')]}">
+                                        Companies
+                                    </span>
+                                    <br/>
+                                    <div class="mt8">
+                                        <button name="%(base.action_res_company_form)d" icon="fa-arrow-right" type="action" string="Manage Companies" class="btn-link"/>
                                     </div>
-                                </div>
-                                <div id="inter_company" class="col-12 col-lg-6 o_setting_box" groups="base.group_multi_company" title="Configure company rules to automatically create SO/PO when one of your company sells/buys to another of your company.">
-                                    <field name="company_id" invisible="1"/>
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_account_inter_company_rules" widget="upgrade_boolean"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label string="Inter-Company Transactions" for="module_account_inter_company_rules"/>
-                                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                        <div class="text-muted">
-                                            Automatically generate counterpart documents for orders/invoices between companies
+                                </setting>
+                                <setting id="document_layout_setting" string="Document Layout" help="Choose the layout of your documents" company_dependent="1">
+                                    <div class="content-group">
+                                        <div class="mt16" groups="base.group_no_one">
+                                            <label for="external_report_layout_id" string="Layout" class="col-3 col-lg-3 o_light_label"/>
+                                            <field name="external_report_layout_id" domain="[('type','=', 'qweb')]" class="oe_inline"/>
                                         </div>
-                                        <div class="content-group" attrs="{'invisible': [('module_account_inter_company_rules','=',False)]}" id="inter_companies_rules">
-                                            <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                        </div>
+                                            <button name="%(web.action_base_document_layout_configurator)d" string="Configure Document Layout" type="action" class="oe_link" icon="fa-arrow-right"/>
+                                            <br groups="base.group_no_one"/>
+                                            <button name="edit_external_header" string="Edit Layout" type="object" class="oe_link" groups="base.group_no_one" icon="fa-arrow-right"/>
+                                            <br groups="base.group_no_one"/>
+                                            <button name="%(web.action_report_externalpreview)d" string="Preview Document" type="action" class="oe_link" groups="base.group_no_one" icon="fa-arrow-right"/>
                                     </div>
-                                </div>
-                            </div>
+                                </setting>
+                                <field name="company_id" invisible="1"/>
+                                <setting id="inter_company" string="Inter-Company Transactions" company_dependent="1" help="Automatically generate counterpart documents for orders/invoices between companies" groups="base.group_multi_company" title="Configure company rules to automatically create SO/PO when one of your company sells/buys to another of your company.">
+                                    <field name="module_account_inter_company_rules" widget="upgrade_boolean"/>
+                                    <div class="content-group" attrs="{'invisible': [('module_account_inter_company_rules','=',False)]}" id="inter_companies_rules">
+                                        <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
+                                    </div>
+                                </setting>
+                            </block>
                         </div>
                         <div id="emails"/>
 
                         <div id="contacts_settings">
-                            <h2>Contacts</h2>
-                            <div class="row mt16 o_settings_container" name="contacts_setting_container">
-                                <div class="col-xs-12 col-md-6 o_setting_box" id="sms">
-                                        <div class="o_setting_right_pane" id="sms_settings">
-                                            <div class="o_form_label">
-                                            Send SMS
-                                            <a href="https://www.odoo.com/documentation/master/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" title="Documentation" class="ms-1 o_doc_link" target="_blank"></a>
-                                            </div>
-                                            <div class="text-muted">
-                                                Send texts to your contacts
-                                            </div>
-                                        </div>
-                                </div>
-                                <div class="col-xs-12 col-md-6 o_setting_box" title="When populating your address book, Odoo provides a list of matching companies. When selecting one item, the company data and logo are auto-filled." id="partner_autocomplete">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_partner_autocomplete"/>
-                                    </div>
-                                    <div class="o_setting_right_pane" id="partner_autocomplete_settings">
-                                        <label for="module_partner_autocomplete"/>
-                                        <div class="text-muted">
-                                            Automatically enrich your contact base with company data
-                                        </div>
-                                    </div>
-                                </div>
-                        </div>
+                            <block title="Contacts" name="contacts_setting_container">
+                                <setting id="sms" string="Send SMS" documentation="/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" help="Send texts to your contacts" />
+                                <setting help="Automatically enrich your contact base with company data" title="When populating your address book, Odoo provides a list of matching companies. When selecting one item, the company data and logo are auto-filled." id="partner_autocomplete">
+                                    <field name="module_partner_autocomplete"/>
+                                </setting>
+                        </block>
                     </div>
 
-                    <h2>Permissions</h2>
-                    <div class="row mt16 o_settings_container" id="user_default_rights">
-                        <div class="col-12 col-lg-6 o_setting_box"  title="By default, new users get highest access rights for all installed apps." id="access_rights">
-                            <div class="o_setting_left_pane">
-                                <field name="user_default_rights"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label string="Default Access Rights" for="user_default_rights"/>
-                                <div class="text-muted">
-                                    Set custom access rights for new users
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('user_default_rights','=',False)]}">
-                                    <div class="mt8">
-                                        <button type="object" name="open_default_user" string="Default Access Rights" icon="fa-arrow-right" class="btn-link"/>
-                                    </div>
+                    <block title="Permissions" id="user_default_rights">
+                        <setting string="Default Access Rights" help="Set custom access rights for new users" title="By default, new users get highest access rights for all installed apps." id="access_rights">
+                            <field name="user_default_rights"/>
+                            <div class="content-group" attrs="{'invisible': [('user_default_rights','=',False)]}">
+                                <div class="mt8">
+                                    <button type="object" name="open_default_user" string="Default Access Rights" icon="fa-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                             groups="base.group_system">
-                            <div class="o_setting_left_pane"/>
-                            <div class="o_setting_right_pane">
-                                <button type="action" name="%(base.action_apikeys_admin)d" string="Manage API Keys" icon="fa-arrow-right" class="btn-link"/>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" groups="base.group_no_one" id="allow_import">
-                            <div class="o_setting_left_pane">
-                                <field name="module_base_import" />
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label string="Import &amp; Export" for="module_base_import"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/general/export_import_data.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Allow users to import data from CSV/XLS/XLSX/ODS files
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="feedback_motivate_setting" groups="base.group_no_one">
-                            <div class="o_setting_left_pane">
-                                <field name="show_effect"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="show_effect"/>
-                                <div class="text-muted">
-                                    Add fun feedback and motivate your employees
-                                </div>
-                            </div>
-                        </div>
-                        </div>
+                        </setting>
+                        <setting string="API Keys" help="API Keys allow your users to access Odoo with external tools when multi-factor authentication is enabled." groups="base.group_system">
+                            <button type="action" name="%(base.action_apikeys_admin)d" string="Manage API Keys" icon="fa-arrow-right" class="btn-link"/>
+                        </setting>
+                        <setting string="Import &amp; Export" help="Allow users to import data from CSV/XLS/XLSX/ODS files" documentation="/applications/general/export_import_data.html" groups="base.group_no_one" id="allow_import">
+                            <field name="module_base_import" />
+                        </setting>
+                        <setting id="feedback_motivate_setting" help="Add fun feedback and motivate your employees" groups="base.group_no_one">
+                            <field name="show_effect"/>
+                        </setting>
+                    </block>
 
-                        <h2>Integrations</h2>
-                        <div class="row mt16 o_settings_container" name="integration">
-                            <div class="col-12 col-lg-6 o_setting_box" id="mail_pluggin_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_mail_plugin" />
+                        <block title="Integrations" name="integration">
+                            <setting string="Mail Plugin" documentation="/applications/productivity/mail_plugins.html" help="Integrate with mail client plugins" id="mail_pluggin_setting">
+                                <field name="module_mail_plugin" />
+                            </setting>
+                            <setting string="Outlook Calendar" documentation="/applications/general/calendars/outlook/outlook_calendar.html" help="Synchronize your calendar with Outlook" id="sync_outlook_calendar_setting">
+                                <field name="module_microsoft_calendar" />
+                                <div class="content-group" attrs="{'invisible': [('module_microsoft_calendar', '=', False)]}" id="msg_module_microsoft_calendar">
+                                    <div class="text-warning mt16"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Mail Plugin" for="module_mail_plugin"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/productivity/mail_plugins.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Integrate with mail client plugins
-                                    </div>
+                            </setting>
+                            <setting string="Google Calendar" documentation="/applications/general/calendars/google/google_calendar_credentials.html" help="Synchronize your calendar with Google Calendar" id="sync_google_calendar_setting">
+                                <field name="module_google_calendar"/>
+                                <div class="content-group" attrs="{'invisible': [('module_google_calendar','=',False)]}" id="msg_module_google_calendar">
+                                    <div class="text-warning mt16"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="sync_outlook_calendar_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_microsoft_calendar" />
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Outlook Calendar" for="module_microsoft_calendar"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/general/calendars/outlook/outlook_calendar.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Synchronize your calendar with Outlook
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_microsoft_calendar', '=', False)]}" id="msg_module_microsoft_calendar">
-                                        <div class="text-warning mt16"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="sync_google_calendar_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_google_calendar" />
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Google Calendar" for="module_google_calendar"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/general/calendars/google/google_calendar_credentials.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Synchronize your calendar with Google Calendar
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_google_calendar','=',False)]}" id="msg_module_google_calendar">
-                                        <div class="text-warning mt16"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                    </div>
-                                </div>
-                            </div>
+                            </setting>
                             <div id="product_get_pic_setting"/>
-                            <div class="col-12 col-lg-6 o_setting_box" id="module_auth_oauth">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_auth_oauth" />
+                            <setting string="OAuth Authentication" help="Use external accounts to log in (Google, Facebook, etc.)" id="module_auth_oauth">
+                                <field name="module_auth_oauth" />
+                                <div class="content-group mt16" attrs="{'invisible': [('module_auth_oauth','=',False)]}" id="msg_module_auth_oauth">
+                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="OAuth Authentication" for="module_auth_oauth"/>
-                                    <div class="text-muted">
-                                       Use external accounts to log in (Google, Facebook, etc.)
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('module_auth_oauth','=',False)]}" id="msg_module_auth_oauth">
-                                        <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                    </div>
+                            </setting>
+                            <setting string="LDAP Authentication" help="Use LDAP credentials to log in" documentation="/applications/general/auth/ldap.html" id="oauth">
+                                <field name="module_auth_ldap"/>
+                                <div class="content-group" attrs="{'invisible': [('module_auth_ldap','=',False)]}" id="auth_ldap_warning">
+                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="oauth">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_auth_ldap"/>
+                            </setting>
+                            <setting documentation="/websites/website/optimize/unsplash.html" help="Find free high-resolution images from Unsplash" id="unsplash">
+                                <field name="module_web_unsplash"/>
+                                <div class="content-group" attrs="{'invisible': [('module_web_unsplash', '=', False)]}" id="web_unsplash_warning">
+                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                 </div>
-                                <div class="o_setting_right_pane" name="auth_ldap_right_pane">
-                                    <label string="LDAP Authentication" for="module_auth_ldap"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/general/auth/ldap.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                       Use LDAP credentials to log in
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_auth_ldap','=',False)]}" id="auth_ldap_warning">
-                                        <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                    </div>
+                            </setting>
+                            <setting string="Geo Localization" help="GeoLocalize your partners" id="base_geolocalize">
+                                <field name="module_base_geolocalize"/>
+                                <div class="content-group" attrs="{'invisible': [('module_base_geolocalize','=', False)]}" name="base_geolocalize_warning">
+                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to choose your Geo Provider.</div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="unsplash">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_web_unsplash"/>
+                            </setting>
+                            <setting help="Protect your forms from spam and abuse." id="recaptcha">
+                                <field name="module_google_recaptcha"/>
+                                <div class="content-group" attrs="{'invisible': [('module_google_recaptcha', '=', False)]}" id="recaptcha_warning">
+                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up reCaptcha.</div>
                                 </div>
-                                <div class="o_setting_right_pane" id="web_unsplash_settings">
-                                    <label for="module_web_unsplash"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/unsplash.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Find free high-resolution images from Unsplash
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_web_unsplash', '=', False)]}" id="web_unsplash_warning">
-                                        <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="base_geolocalize">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_base_geolocalize"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="web_geolocalize_settings">
-                                    <label string="Geo Localization" for="module_base_geolocalize"/>
-                                    <div class="text-muted">
-                                       GeoLocalize your partners
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_base_geolocalize','=', False)]}" name="base_geolocalize_warning">
-                                        <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to choose your Geo Provider.</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="recaptcha">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_google_recaptcha"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="website_recaptcha_settings">
-                                    <label for="module_google_recaptcha"/>
-                                    <div class="text-muted">
-                                        Protect your forms from spam and abuse.
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_google_recaptcha', '=', False)]}" id="recaptcha_warning">
-                                        <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up reCaptcha.</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </setting>
+                        </block>
 
-                        <h2 groups="base.group_no_one">Performance</h2>
-                        <div groups="base.group_no_one" class="row mt16 o_settings_container" name="performance">
-                            <div class="col-12 col-lg-6 o_setting_box" id="profiling_enabled_until">
-                            <label for="profiling_enabled_until"/>
-                            <field name="profiling_enabled_until"/>
-                            <div class="text-muted">
-                                Enable the profiling tool. Profiling may impact performance while being active.
-                            </div>
-                            </div>
-                        </div>
+                        <block title="Performance" groups="base.group_no_one" name="performance">
+                            <setting id="profiling_enabled_until" help="Enable the profiling tool. Profiling may impact performance while being active.">
+                                <field name="profiling_enabled_until"/>
+                            </setting>
+                        </block>
 
                         <widget name='res_config_dev_tool'/>
                         <div id='about'>
-                            <h2>About</h2>
-                            <div class="row mt16 o_settings_container" name="about_setting_container">
-                                <div class='col-12 col-lg-6 o_setting_box' id='appstore'>
+                            <block title="About" name="about_setting_container">
+                                <setting id='appstore'>
                                     <div class="d-flex">
-                                        <div class="o_setting_right_pane">
+                                        <div>
                                             <!-- FIXME Those links are defined directly in the template which means that we will have to
                                             update the template code is the link ever changes -->
                                             <a class="d-block mx-auto" href="https://play.google.com/store/apps/details?id=com.odoo.mobile" target="blank">
@@ -356,11 +202,11 @@
                                             </a>
                                         </div>
                                     </div>
-                                </div>
+                                </setting>
                                 <widget name='res_config_edition'/>
-                            </div>
+                            </block>
                         </div>
-                    </div>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/base_vat/views/res_config_settings_views.xml
+++ b/addons/base_vat/views/res_config_settings_views.xml
@@ -6,22 +6,11 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="eu_service" position="after">
-                <div class="col-12 col-lg-6 o_setting_box"
-                    id="vies_service_setting"
-                    title="If this checkbox is ticked, you will not be able to save a contact if its VAT number cannot be verified by the European VIES service.">
-                    <div class="o_setting_left_pane">
-                        <field name="vat_check_vies"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="vat_check_vies"/>
-                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                        <div class="text-muted">
-                           Verify VAT numbers using the European VIES service
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <setting id="eu_service" position="after">
+                <setting id="vies_service_setting" help="Verify VAT numbers using the European VIES service" company_dependent="1" title="If this checkbox is ticked, you will not be able to save a contact if its VAT number cannot be verified by the European VIES service.">
+                    <field name="vat_check_vies"/>
+                </setting>
+            </setting>
         </field>
     </record>
 

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -7,164 +7,94 @@
         <field name="priority" eval="5"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="CRM" string="CRM" data-key="crm" groups="sales_team.group_sale_manager">
-                    <h2>CRM</h2>
-                    <div class="row mt16 o_settings_container">
-                        <div class="col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="group_use_recurring_revenues"/>
+            <xpath expr="//form" position="inside">
+                <app data-string="CRM" string="CRM" name="crm" groups="sales_team.group_sale_manager">
+                    <block title="CRM">
+                        <setting help="Define recurring plans and revenues on Opportunities">
+                            <field name="group_use_recurring_revenues"/>
+                            <div attrs="{'invisible': [('group_use_recurring_revenues', '=', False)]}">
+                                <button type="action" name="crm.crm_recurring_plan_action"
+                                        string="Manage Recurring Plans" icon="fa-arrow-right" class="oe_link"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_use_recurring_revenues"/>
-                                <div class="text-muted">
-                                    Define recurring plans and revenues on Opportunities
+                        </setting>
+                        <setting id="crm_lead" title="Use leads if you need a qualification step before creating an opportunity or a customer. It can be a business card you received, a contact form filled in your website, or a file of unqualified prospects you import, etc. Once qualified, the lead can be converted into a business opportunity and/or a new customer in your address book." help="Add a qualification step before the creation of an opportunity">
+                            <field name="group_use_lead"/>
+                        </setting>
+                    </block>
+                    <block>
+                        <setting help="Assign salespersons into multiple Sales Teams.">
+                            <field name="is_membership_multi"/>
+                        </setting>
+                    </block>
+                    <block>
+                        <field name="predictive_lead_scoring_fields_str" invisible="1"/>
+                        <field name="predictive_lead_scoring_start_date_str" invisible="1"/>
+                        <setting title="This can be used to compute statistical probability to close a lead" name="predictive_lead_setting_container" string="Predictive Lead Scoring">
+                            <div class="text-muted">
+                                The success rate is computed based on <b>
+                                    <field name="predictive_lead_scoring_field_labels" class="d-inline"/>
+                                </b>
+                                for the leads created as of the
+                                <b><field name="predictive_lead_scoring_start_date" class="oe_inline" readonly="1"/></b>.
                                 </div>
-                                <div attrs="{'invisible': [('group_use_recurring_revenues', '=', False)]}">
-                                    <button type="action" name="crm.crm_recurring_plan_action"
-                                            string="Manage Recurring Plans" icon="fa-arrow-right" class="oe_link"/>
-                                </div>
+                            <div class="mt16" groups="base.group_erp_manager">
+                                <button name="%(crm_lead_pls_update_action)d" type="action"
+                                    string="Update Probabilities"
+                                    class="btn-primary"/>
                             </div>
-                        </div>
-                        <div class="col-lg-6 o_setting_box" id="crm_lead"
-                            title="Use leads if you need a qualification step before creating an opportunity or a customer. It can be a business card you received, a contact form filled in your website, or a file of unqualified prospects you import, etc. Once qualified, the lead can be converted into a business opportunity and/or a new customer in your address book.">
-                            <div class="o_setting_left_pane">
-                                <field name="group_use_lead"/>
+                        </setting>
+                        <setting title="This can be used to automatically assign leads to sales persons based on rules" documentation="/applications/sales/crm/track_leads/lead_scoring.html#assign-leads">
+                            <field name="crm_use_auto_assignment"/>
+                            <div class="text-muted">
+                                <span>Periodically assign leads based on rules</span><br />
+                                <span attrs="{'invisible': [('crm_use_auto_assignment', '=', False)]}">
+                                    All sales teams will use this setting by default unless
+                                    specified otherwise.
+                                </span>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_use_lead"/>
-                                <div class="text-muted">
-                                    Add a qualification step before the creation of an opportunity
-                                </div>
+                            <div class="row flex-row flex-nowrap mt16" attrs="{'invisible': [('crm_use_auto_assignment', '=', False)]}">
+                                <label string="Running" for="crm_auto_assignment_action" class="col-lg-3 o_light_label"/>
+                                <field name="crm_auto_assignment_action"
+                                    attrs="{'required': [('crm_use_auto_assignment', '=', True)]}"/>
+                                <button name="action_crm_assign_leads" type="object" class="btn-link w-auto">
+                                    <i title="Update now" role="img" aria-label="Update now" class="fa fa-fw fa-refresh"></i>
+                                </button>
                             </div>
-                        </div>
-                    </div>
-                    <div class="row mt16 o_settings_container">
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="is_membership_multi"/>
+                            <div class="row mt16" attrs="{'invisible': ['|', ('crm_use_auto_assignment', '=', False), ('crm_auto_assignment_action', '=', 'manual')]}">
+                                <label string="Repeat every" for="crm_auto_assignment_interval_type" class="col-lg-3 o_light_label"/>
+                                <field name="crm_auto_assignment_interval_number"
+                                    class="oe_inline me-2"
+                                    attrs="{'required': [('crm_use_auto_assignment', '=', True), ('crm_auto_assignment_action', '=', 'auto')]}"/>
+                                <field name="crm_auto_assignment_interval_type"
+                                    class="oe_inline"
+                                    attrs="{'required': [('crm_use_auto_assignment', '=', True), ('crm_auto_assignment_action', '=', 'auto')]}"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="is_membership_multi"/>
-                                <div class="text-muted">
-                                    Assign salespersons into multiple Sales Teams.
-                                </div>
+                            <div class="row" attrs="{'invisible': ['|', ('crm_use_auto_assignment', '=', False), ('crm_auto_assignment_action', '=', 'manual')]}">
+                                <label string="Next Run" for="crm_auto_assignment_run_datetime" class="col-lg-3 o_light_label"/>
+                                <field name="crm_auto_assignment_run_datetime"/>
                             </div>
-                        </div>
-                    </div>
-                    <div class="row mt16 o_settings_container">
-                        <div class="col-lg-6 o_setting_box"
-                            title="This can be used to compute statistical probability to close a lead"
-                            name="predictive_lead_setting_container">
-                            <field name="predictive_lead_scoring_fields_str" invisible="1"/>
-                            <field name="predictive_lead_scoring_start_date_str" invisible="1"/>
-                            <div class="o_setting_left_pane"></div>
-                            <div class="o_setting_right_pane">
-                                <b>Predictive Lead Scoring</b>
-                                <div class="text-muted">
-                                    The success rate is computed based on <b>
-                                        <field name="predictive_lead_scoring_field_labels" class="d-inline"/>
-                                    </b>
-                                    for the leads created as of the
-                                    <b><field name="predictive_lead_scoring_start_date" class="oe_inline" readonly="1"/></b>.
-                                 </div>
-                                <div class="mt16" groups="base.group_erp_manager">
-                                    <button name="%(crm_lead_pls_update_action)d" type="action"
-                                        string="Update Probabilities"
-                                        class="btn-primary"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            title="This can be used to automatically assign leads to sales persons based on rules">
-                            <div class="o_setting_left_pane">
-                                <field name="crm_use_auto_assignment"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="crm_use_auto_assignment"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/crm/track_leads/lead_scoring.html#assign-leads"
-                                    title="Assign Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    <span>Periodically assign leads based on rules</span><br />
-                                    <span attrs="{'invisible': [('crm_use_auto_assignment', '=', False)]}">
-                                        All sales teams will use this setting by default unless
-                                        specified otherwise.
-                                    </span>
-                                </div>
-                                <div class="row flex-row flex-nowrap mt16" attrs="{'invisible': [('crm_use_auto_assignment', '=', False)]}">
-                                    <label string="Running" for="crm_auto_assignment_action" class="col-lg-3 o_light_label"/>
-                                    <field name="crm_auto_assignment_action"
-                                        attrs="{'required': [('crm_use_auto_assignment', '=', True)]}"/>
-                                    <button name="action_crm_assign_leads" type="object" class="btn-link w-auto">
-                                        <i title="Update now" role="img" aria-label="Update now" class="fa fa-fw fa-refresh"></i>
-                                    </button>
-                                </div>
-                                <div class="row mt16" attrs="{'invisible': ['|', ('crm_use_auto_assignment', '=', False), ('crm_auto_assignment_action', '=', 'manual')]}">
-                                    <label string="Repeat every" for="crm_auto_assignment_interval_type" class="col-lg-3 o_light_label"/>
-                                    <field name="crm_auto_assignment_interval_number"
-                                        class="oe_inline me-2"
-                                        attrs="{'required': [('crm_use_auto_assignment', '=', True), ('crm_auto_assignment_action', '=', 'auto')]}"/>
-                                    <field name="crm_auto_assignment_interval_type"
-                                        class="oe_inline"
-                                        attrs="{'required': [('crm_use_auto_assignment', '=', True), ('crm_auto_assignment_action', '=', 'auto')]}"/>
-                                </div>
-                                <div class="row" attrs="{'invisible': ['|', ('crm_use_auto_assignment', '=', False), ('crm_auto_assignment_action', '=', 'manual')]}">
-                                    <label string="Next Run" for="crm_auto_assignment_run_datetime" class="col-lg-3 o_light_label"/>
-                                    <field name="crm_auto_assignment_run_datetime"/>
-                                </div>
+                        </setting>
+                    </block>
 
+                    <block title="Lead Generation" name="convert_visitor_setting_container">
+                        <setting string="Lead Enrichment" help="Enrich your leads with company data based on their email addresses">
+                            <field name="module_crm_iap_enrich"/>
+                            <div class="mt8" attrs="{'invisible': [('module_crm_iap_enrich','=',False)]}">
+                                <field name="lead_enrich_auto" class="o_light_label" widget="radio" required="True"/>
                             </div>
-                        </div>
-                    </div>
+                        </setting>
 
-                    <h2>Lead Generation</h2>
-                    <div class="row mt16 o_settings_container" name="convert_visitor_setting_container">
-                        <div class="col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="module_crm_iap_enrich"/>
-                            </div>
+                        <setting id="crm_iap_mine_settings" string="Lead Mining" documentation="/applications/sales/crm/acquire_leads/lead_mining.html" help="Generate new leads based on their country, industry, size, etc.">
+                            <field name="module_crm_iap_mine"/>
+                        </setting>
 
-                            <div class="o_setting_right_pane" id="crm_iap_enrich_settings">
-                                <label string="Lead Enrichment" for="module_crm_iap_enrich"/>
-                                <div class="text-muted">
-                                    Enrich your leads with company data based on their email addresses
-                                </div>
-                                <div class="mt8" attrs="{'invisible': [('module_crm_iap_enrich','=',False)]}">
-                                    <field name="lead_enrich_auto" class="o_light_label" widget="radio" required="True"/>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="module_crm_iap_mine"/>
-                            </div>
-
-                            <div class="o_setting_right_pane" id="crm_iap_mine_settings">
-                                <label string="Lead Mining" for="module_crm_iap_mine"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/crm/acquire_leads/lead_mining.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Generate new leads based on their country, industry, size, etc.
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
-                    <div class="row mt16 o_settings_container" name="generate_lead_setting_container">
-                        <div class="col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="module_website_crm_iap_reveal"/>
-                            </div>
-
-                            <div class="o_setting_right_pane" id="website_crm_iap_reveal_settings">
-                                <label string="Visits to Leads" for="module_website_crm_iap_reveal"/>
-                                <div class="text-muted">
-                                    Convert visitors of your website into leads and perform data enrichment based on their IP address
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                    </block>
+                    <block name="generate_lead_setting_container">
+                        <setting id="website_crm_iap_reveal_settings" string="Visits to Leads" help="Convert visitors of your website into leads and perform data enrichment based on their IP address">
+                            <field name="module_website_crm_iap_reveal"/>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/crm_iap_mine/views/res_config_settings_views.xml
+++ b/addons/crm_iap_mine/views/res_config_settings_views.xml
@@ -5,9 +5,9 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="crm.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="crm_iap_mine_settings" position="inside">
+            <setting id="crm_iap_mine_settings" position="inside">
                 <widget name="iap_buy_more_credits" service_name="reveal"/>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/delivery/views/res_config_settings_views.xml
+++ b/addons/delivery/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='delivery_carrier']" position="after">
+            <xpath expr="//setting[@id='delivery']" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery','=',False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="Shipping Methods" class="btn-link"/>

--- a/addons/digest/views/res_config_settings_views.xml
+++ b/addons/digest/views/res_config_settings_views.xml
@@ -7,32 +7,20 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='contacts_settings']" position="before">
                 <div id="statistics" >
-                    <h2>Statistics</h2>
-                    <div class='row mt16 o_settings_container' id='statistics_div'>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            title="New users are automatically added as recipient of the following digest email."
-                            name="digest_email_setting_container">
-                            <div class="o_setting_left_pane">
-                                <field name="digest_emails"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label string="Digest Email" for="digest_emails"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/general/digest_emails.html" title="Documentation" class="ms-1 o_doc_link" target="_blank"></a>
-                                <div class="text-muted" id="msg_module_digest">
-                                    Add new users as recipient of a periodic email with key metrics
+                    <block title="Statistics" id='statistics_div'>
+                        <setting string="Digest Email" help="Add new users as recipient of a periodic email with key metrics" documentation="/applications/general/digest_emails.html" title="New users are automatically added as recipient of the following digest email." name="digest_email_setting_container">
+                            <field name="digest_emails"/>
+                            <div class="content-group" attrs="{'invisible': [('digest_emails','=',False)]}">
+                                <div class="mt16">
+                                    <label for="digest_id" class="o_light_label"/>
+                                    <field name="digest_id" class="oe_inline"/>
                                 </div>
-                                <div class="content-group" attrs="{'invisible': [('digest_emails','=',False)]}">
-                                    <div class="mt16">
-                                        <label for="digest_id" class="o_light_label"/>
-                                        <field name="digest_id" class="oe_inline"/>
-                                    </div>
-                                    <div class="mt8">
-                                        <button type="action" name="%(digest.digest_digest_action)d" string="Configure Digest Emails" icon="fa-arrow-right" class="btn-link"/>
-                                    </div>
+                                <div class="mt8">
+                                    <button type="action" name="%(digest.digest_digest_action)d" string="Configure Digest Emails" icon="fa-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                    </div>
+                        </setting>
+                    </block>
                 </div>
             </xpath>
         </field>

--- a/addons/event/views/res_config_settings_views.xml
+++ b/addons/event/views/res_config_settings_views.xml
@@ -7,114 +7,50 @@
             <field name="priority" eval="65"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="Events" string="Events" data-key="event" groups="event.group_event_manager">
-                        <h2>Events</h2>
-                        <div class="row mt16 o_settings_container" name="events_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="manage_tracks"
-                                title="Add a navigation menu to your event web pages with schedule, tracks, a track proposal form, etc.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_event_track"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Schedule &amp; Tracks" for="module_website_event_track"/>
-                                    <div class="text-muted">
-                                        Manage &amp; publish a schedule with tracks
-                                    </div>
-                                    <div class="mt-3 d-flex" attrs="{'invisible': [('module_website_event_track', '=', False)]}">
-                                        <field name="module_website_event_track_live" class="w-auto"/>
-                                        <div>
-                                            <label string="Live Broadcast" for="module_website_event_track_live"/><br/>
-                                            <span class="text-muted">Air your tracks online through a Youtube integration</span>
-                                        </div>
-                                    </div>
-                                    <div class="mt-3 d-flex" attrs="{'invisible': [('module_website_event_track', '=', False)]}">
-                                        <field name="module_website_event_track_quiz" class="w-auto"/>
-                                        <div>
-                                            <label string="Event Gamification" for="module_website_event_track_quiz"/><br/>
-                                            <span class="text-muted">Share a quiz to your attendees once a track is over</span>
-                                        </div>
+                <xpath expr="//form" position="inside">
+                    <app data-string="Events" string="Events" name="event" groups="event.group_event_manager">
+                        <block title="Events" name="events_setting_container">
+                            <setting id="manage_tracks" title="Add a navigation menu to your event web pages with schedule, tracks, a track proposal form, etc." string="Schedule &amp; Tracks" help="Manage &amp; publish a schedule with tracks">
+                                <field name="module_website_event_track"/>
+                                <div class="mt-3 d-flex" attrs="{'invisible': [('module_website_event_track', '=', False)]}">
+                                    <field name="module_website_event_track_live" class="w-auto"/>
+                                    <div>
+                                        <label string="Live Broadcast" for="module_website_event_track_live"/><br/>
+                                        <span class="text-muted">Air your tracks online through a Youtube integration</span>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div>
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_website_event_meet"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label string="Community Chat Rooms" for="module_website_event_meet"/>
-                                        <div class="text-muted">
-                                            Foster interactions between attendees by creating virtual conference rooms
-                                        </div>
+                                <div class="mt-3 d-flex" attrs="{'invisible': [('module_website_event_track', '=', False)]}">
+                                    <field name="module_website_event_track_quiz" class="w-auto"/>
+                                    <div>
+                                        <label string="Event Gamification" for="module_website_event_track_quiz"/><br/>
+                                        <span class="text-muted">Share a quiz to your attendees once a track is over</span>
                                     </div>
                                 </div>
-                                <div class="mt-3">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_website_event_exhibitor"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label string="Online Exhibitors" for="module_website_event_exhibitor"/>
-                                        <div class="text-muted">
-                                            Display Sponsors and Exhibitors on your event pages
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="mt-3">
-                                    <div class="o_setting_left_pane">
-                                        <field name="module_event_booth"/>
-                                    </div>
-                                    <div class="o_setting_right_pane">
-                                        <label string="Booth Management" for="module_event_booth"/>
-                                        <div class="text-muted">
-                                            Create Booths and manage their reservations
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Registration</h2>
-                        <div class="row mt16 o_settings_container" name="registration_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="sell_tickets">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_event_sale"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_event_sale"/>
-                                    <div class="text-muted">
-                                        Sell tickets with sales orders
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" name="event_settings_website">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_event_sale"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_website_event_sale"/>
-                                    <div class="text-muted">
-                                        Sell tickets on your website
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Attendance</h2>
-                        <div class="row mt16 o_settings_container" name="attendance_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="event_barcode">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_event_barcode" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_event_barcode"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted" name="event_barcode">
-                                        Scan badges to confirm attendances
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                            <setting string="Community Chat Rooms" help="Foster interactions between attendees by creating virtual conference rooms">
+                                <field name="module_website_event_meet"/>
+                            </setting>
+                            <setting string="Online Exhibitors" help="Display Sponsors and Exhibitors on your event pages">
+                                <field name="module_website_event_exhibitor"/>
+                            </setting>
+                            <setting string="Booth Management" help="Create Booths and manage their reservations">
+                                <field name="module_event_booth"/>
+                            </setting>
+                        </block>
+                        <block title="Registration" name="registration_setting_container">
+                            <setting id="sell_tickets" help="Sell tickets with sales orders">
+                                <field name="module_event_sale"/>
+                            </setting>
+                            <setting name="event_settings_website" help="Sell tickets on your website">
+                                <field name="module_website_event_sale"/>
+                            </setting>
+                        </block>
+                        <block title="Attendance" name="attendance_setting_container">
+                            <setting id="event_barcode" company_dependent="1" help="Scan badges to confirm attendances">
+                                <field name="module_event_barcode" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/fleet/views/res_config_settings_views.xml
+++ b/addons/fleet/views/res_config_settings_views.xml
@@ -7,23 +7,18 @@
             <field name="priority" eval="90"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="Fleet" id="fleet" string="Fleet" data-key="fleet" groups="fleet.fleet_group_manager">
-                        <h2>Fleet Management</h2>
-                        <div class="row mt16 o_settings_container" id="end_contract_setting">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">End Date Contract Alert</span>
-                                    <div class="text-muted content-group mt16">
-                                        <span>Send an alert </span>
-                                        <field name="delay_alert_contract" class="text-center" style="width: 10%; min-width: 4rem;" />
-                                        <span> days before the end date</span>
-                                    </div>
+                <xpath expr="//form" position="inside">
+                    <app data-string="Fleet" id="fleet" string="Fleet" name="fleet" groups="fleet.fleet_group_manager">
+                        <block title="Fleet Management" id="end_contract_setting">
+                            <setting string="End Date Contract Alert">
+                                <div class="text-muted content-group mt16">
+                                    <span>Send an alert </span>
+                                    <field name="delay_alert_contract" class="text-center" style="width: 10%; min-width: 4rem;" />
+                                    <span> days before the end date</span>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/google_recaptcha/views/res_config_settings_view.xml
+++ b/addons/google_recaptcha/views/res_config_settings_view.xml
@@ -5,8 +5,8 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='website_recaptcha_settings']/div[hasclass('text-muted')]" position="inside">
-                <p>If no keys are provided, no checks will be done.</p>
+            <xpath expr="//setting[@id='recaptcha']" position="attributes">
+                <attribute name="help" add="If no keys are provided, no checks will be done." separator=" " />
             </xpath>
             <div id="recaptcha_warning" position="replace">
                 <div class="content-group" id="reacaptcha_configuration_settings" attrs="{'invisible': [('module_google_recaptcha', '=', False)]}">

--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -6,103 +6,55 @@
         <field name="priority" eval="70"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Employees" string="Employees" data-key="hr" groups="hr.group_hr_manager">
-                    <h2>Employees</h2>
-                    <div class="row mt16 o_settings_container" name="employees_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="presence_control_setting" title="Presence of employees">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Presence Control</span>
-                                <div class="content-group" name="hr_presence_options">
-                                    <div class="d-flex">
-                                        <field name="module_hr_attendance" class="ml16"/>
-                                        <label for="module_hr_attendance" class="o_light_label"/>
-                                    </div>
-                                    <div class="d-flex">
-                                        <field name="hr_presence_control_login" class="ml16"/>
-                                        <label for="hr_presence_control_login" class="o_light_label"/>
-                                    </div>
+            <xpath expr="//form" position="inside">
+                <app data-string="Employees" string="Employees" name="hr" groups="hr.group_hr_manager">
+                    <block title="Employees" name="employees_setting_container">
+                        <setting id="presence_control_setting" title="Presence of employees" string="Presence Control">
+                            <div class="content-group" name="hr_presence_options">
+                                <div class="d-flex">
+                                    <field name="module_hr_attendance" class="ml16"/>
+                                    <label for="module_hr_attendance" class="o_light_label"/>
+                                </div>
+                                <div class="d-flex">
+                                    <field name="hr_presence_control_login" class="ml16"/>
+                                    <label for="hr_presence_control_login" class="o_light_label"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="presence_reporting_setting"
-                            title="Advanced presence of employees">
-                            <div class="o_setting_left_pane">
-                                <field name="module_hr_presence"/>
+                        </setting>
+                        <setting id="presence_reporting_setting" help="Presence reporting screen, email and IP address control." title="Advanced presence of employees">
+                            <field name="module_hr_presence"/>
+                            <div class="d-flex mt-1" attrs="{'invisible': [('module_hr_presence', '=', False)]}">
+                                <field name="hr_presence_control_email" class="ml16"/>
+                                <label for="hr_presence_control_email" class="o_light_label"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_hr_presence"/>
-                                <div class="text-muted" name="hr_presence_options_advanced">
-                                    Presence reporting screen, email and IP address control.
-                                </div>
-                                <div class="d-flex mt-1" attrs="{'invisible': [('module_hr_presence', '=', False)]}">
-                                    <field name="hr_presence_control_email" class="ml16"/>
-                                    <label for="hr_presence_control_email" class="o_light_label"/>
-                                </div>
-                                <div class="d-flex ml32" attrs="{'invisible': ['|', ('module_hr_presence', '=', False), ('hr_presence_control_email', '=', False)]}">
-                                    <span class="flex-shrink-0 ml8 me-2">Minimum number of emails to send</span>
-                                    <field name="hr_presence_control_email_amount" class="ms-2 oe_inline"/>
-                                </div>
-                                <div class="d-flex" attrs="{'invisible': [('module_hr_presence', '=', False)]}">
-                                    <field name="hr_presence_control_ip" class="ml16"/>
-                                    <label for="hr_presence_control_ip" class="o_light_label"/>
-                                </div>
-                                <div class="d-flex ml32" attrs="{'invisible': ['|', ('module_hr_presence', '=', False), ('hr_presence_control_ip', '=', False)]}">
-                                    <span class="flex-shrink-0 ml8 me-2">IP Addresses (comma-separated)</span>
-                                    <field name="hr_presence_control_ip_list" class="ms-2 oe_inline"/>
-                                </div>
+                            <div class="d-flex ml32" attrs="{'invisible': ['|', ('module_hr_presence', '=', False), ('hr_presence_control_email', '=', False)]}">
+                                <span class="flex-shrink-0 ml8 me-2">Minimum number of emails to send</span>
+                                <field name="hr_presence_control_email_amount" class="ms-2 oe_inline"/>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="enrich_employee_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="module_hr_skills"/>
+                            <div class="d-flex" attrs="{'invisible': [('module_hr_presence', '=', False)]}">
+                                <field name="hr_presence_control_ip" class="ml16"/>
+                                <label for="hr_presence_control_ip" class="o_light_label"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_hr_skills"/>
-                                <div class="text-muted">
-                                        Enrich employee profiles with skills and resumes
-                                </div>
+                            <div class="d-flex ml32" attrs="{'invisible': ['|', ('module_hr_presence', '=', False), ('hr_presence_control_ip', '=', False)]}">
+                                <span class="flex-shrink-0 ml8 me-2">IP Addresses (comma-separated)</span>
+                                <field name="hr_presence_control_ip_list" class="ms-2 oe_inline"/>
                             </div>
-                        </div>
-                    </div>
-                    <h2>Work Organization</h2>
-                    <div class="row mt16 o_settings_container" name="work_organization_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="default_company_schedule_setting">
-                            <div class="o_setting_right_pane">
-                                <label for="resource_calendar_id"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="row">
-                                    <div class="text-muted col-lg-8">
-                                        Set default company schedule to manage your employees working time
-                                    </div>
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="resource_calendar_id" required="1"
-                                            class="o_light_label"
-                                            domain="[('company_id', '=', company_id)]"
-                                            context="{'default_company_id': company_id}"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Employee Update Rights</h2>
-                    <div class="row mt16 o_settings_container" name="employee_rights_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" title="Allow employees to update their own data.">
-                            <div class="o_setting_left_pane">
-                                <field name="hr_employee_self_edit"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="hr_employee_self_edit"/>
-                                <div class="text-muted">
-                                    Allow employees to update their own data
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                        </setting>
+                        <setting help="Enrich employee profiles with skills and resumes" id="enrich_employee_setting">
+                            <field name="module_hr_skills"/>
+                        </setting>
+                    </block>
+                    <block title="Work Organization" name="work_organization_setting_container">
+                        <setting company_dependent="1" help="Set default company schedule to manage your employees working time" id="default_company_schedule_setting">
+                            <field name="resource_calendar_id" required="1" class="o_light_label" domain="[('company_id', '=', company_id)]" context="{'default_company_id': company_id}"/>
+                        </setting>
+                    </block>
+                    <block title="Employee Update Rights" name="employee_rights_setting_container">
+                        <setting help="Allow employees to update their own data" title="Allow employees to update their own data.">
+                            <field name="hr_employee_self_edit"/>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -6,114 +6,56 @@
         <field name="priority" eval="80"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Attendances" string="Attendances" data-key="hr_attendance" groups="hr_attendance.group_hr_attendance_manager">
-                    <h2>Check-In/Out in Kiosk Mode</h2>
-                    <div class="row mt16 o_settings_container" name="kiosk_mode_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_right_pane">
-                                <label for="attendance_kiosk_mode"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="row">
-                                    <div class="text-muted col-lg-10">
-                                        Define the way the user will be identified by the application.
-                                    </div>
+            <xpath expr="//form" position="inside">
+                <app data-string="Attendances" string="Attendances" name="hr_attendance" groups="hr_attendance.group_hr_attendance_manager">
+                    <block title="Check-In/Out in Kiosk Mode" name="kiosk_mode_setting_container">
+                        <setting company_dependent="1" help="Define the way the user will be identified by the application.">
+                            <field name="attendance_kiosk_mode" required="1" class="w-75"/>
+                        </setting>
+                        <setting string="Display Time" company_dependent="1" help="Choose how long the greeting message will be displayed.">
+                            <field name="attendance_kiosk_delay" required="1" class="text-center" style="width: 10%; min-width: 4rem;"/><span> seconds</span>
+                        </setting>
+                    </block>
+                    <block name="pincode_setting_container">
+                        <setting attrs="{'invisible': [('attendance_kiosk_mode', '=', 'manual')]}" company_dependent="1" help="Define the camera used for the barcode scan.">
+                            <field name="attendance_barcode_source" required="1"/>
+                        </setting>
+                        <setting title="Set PIN codes in the employee detail form (in HR Settings tab)." attrs="{'invisible': [('attendance_kiosk_mode', '=', 'barcode')]}" help="Use PIN codes (defined on the Employee's profile) to check-in.">
+                            <field name="group_attendance_use_pin"/>
+                        </setting>
+                    </block>
+                    <block title="Extra Hours" name="overtime_settings">
+                        <setting title="Activate the count of employees' extra hours." string="Count of Extra Hours" company_dependent="1" help="Compare attendance with working hours set on employee.">
+                            <field name="hr_attendance_overtime"/>
+                            <div class="mt16" attrs="{'invisible': [('hr_attendance_overtime', '=', False)],
+                                                        'required': [('hr_attendance_overtime', '=', True)]}">
+                                <div class="mt16 row" title="Count of extra hours is considered from this date. Potential extra hours prior to this date are not considered.">
+                                    <label for="overtime_start_date" string="Start from" class="col-3 col-lg-3 o_light_label"/>
+                                    <field name="overtime_start_date" class="col-lg-3 p-0" attrs="{'required': [('hr_attendance_overtime', '=', True)]}" />
                                 </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="attendance_kiosk_mode" required="1" class="w-75"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_right_pane">
-                                <label for="attendance_kiosk_delay" string="Display Time"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="row">
-                                    <div class="text-muted col-lg-10">
-                                        Choose how long the greeting message will be displayed.
-                                    </div>
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="attendance_kiosk_delay" required="1" class="text-center" style="width: 10%; min-width: 4rem;"/> seconds
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row mt16 o_settings_container" name="pincode_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('attendance_kiosk_mode', '=', 'manual')]}">
-                            <div class="o_setting_right_pane">
-                                <label for="attendance_barcode_source"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="row">
-                                    <div class="text-muted col-lg-10">
-                                        Define the camera used for the barcode scan.
-                                    </div>
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="attendance_barcode_source" required="1"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" title="Set PIN codes in the employee detail form (in HR Settings tab)." attrs="{'invisible': [('attendance_kiosk_mode', '=', 'barcode')]}">
-                            <div class="o_setting_left_pane">
-                                <field name="group_attendance_use_pin"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_attendance_use_pin"/>
-                                <div class="text-muted col-lg-10">
-                                    Use PIN codes (defined on the Employee's profile) to check-in.
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Extra Hours</h2>
-                    <div class="row mt16 o_settings_container" name="overtime_settings">
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane" title="Activate the count of employees' extra hours.">
-                                <field name="hr_attendance_overtime"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="hr_attendance_overtime" class="o_form_label">Count of Extra Hours</label>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                <br/>
+                                <label for="overtime_company_threshold" class="o_form_label">
+                                    Tolerance Time In Favor Of Company
+                                </label>
                                 <div class="text-muted">
-                                    Compare attendance with working hours set on employee.
+                                    Allow a period of time (around working hours) where extra time will not be counted, in benefit of the company
                                 </div>
-                                <div class="mt16" attrs="{'invisible': [('hr_attendance_overtime', '=', False)],
-                                                          'required': [('hr_attendance_overtime', '=', True)]}">
-                                    <div class="mt16 row" title="Count of extra hours is considered from this date. Potential extra hours prior to this date are not considered.">
-                                        <label for="overtime_start_date" string="Start from" class="col-3 col-lg-3 o_light_label"/>
-                                        <field name="overtime_start_date" class="col-lg-3 p-0" attrs="{'required': [('hr_attendance_overtime', '=', True)]}" />
-                                    </div>
-                                    <br/>
-                                    <label for="overtime_company_threshold" class="o_form_label">
-                                        Tolerance Time In Favor Of Company
-                                    </label>
-                                    <div class="text-muted">
-                                        Allow a period of time (around working hours) where extra time will not be counted, in benefit of the company
-                                    </div>
-                                    <span>Time Period </span><field name="overtime_company_threshold" class="text-center"
-                                        attrs="{'required': [('hr_attendance_overtime', '=', True)]}" style="width: 10%; min-width: 4rem;"/><span> Minutes</span>
-                                    <br/>
-                                    <br/>
-                                    <label for="overtime_employee_threshold" class="o_form_label">
-                                        Tolerance Time In Favor Of Employee
-                                    </label>
-                                    <div class="text-muted">
-                                        Allow a period of time (around working hours) where extra time will not be deducted, in benefit of the employee
-                                    </div>
-                                    <span>Time Period </span><field name="overtime_employee_threshold" class="text-center"
-                                        attrs="{'required': [('hr_attendance_overtime', '=', True)]}" style="width: 10%; min-width: 4rem;"/><span> Minutes</span>
+                                <span>Time Period </span><field name="overtime_company_threshold" class="text-center"
+                                    attrs="{'required': [('hr_attendance_overtime', '=', True)]}" style="width: 10%; min-width: 4rem;"/><span> Minutes</span>
+                                <br/>
+                                <br/>
+                                <label for="overtime_employee_threshold" class="o_form_label">
+                                    Tolerance Time In Favor Of Employee
+                                </label>
+                                <div class="text-muted">
+                                    Allow a period of time (around working hours) where extra time will not be deducted, in benefit of the employee
                                 </div>
+                                <span>Time Period </span><field name="overtime_employee_threshold" class="text-center"
+                                    attrs="{'required': [('hr_attendance_overtime', '=', True)]}" style="width: 10%; min-width: 4rem;"/><span> Minutes</span>
                             </div>
-                        </div>
-                    </div>
-                </div>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -7,90 +7,41 @@
             <field name="priority" eval="85"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="Expenses" string="Expenses" data-key="hr_expense" groups="hr_expense.group_hr_expense_manager">
-                        <h2>Expenses</h2>
-                        <div class="row mt16 o_settings_container" name="expenses_setting_container">
-                            <div class="col-xs-12 col-md-6 o_setting_box"
-                                id="create_expense_setting"
-                                title="Send an email to this email alias with the receipt in attachment to create an expense in one click. If the first word of the mail subject contains the category's internal reference or the category name, the corresponding category will automatically be set. Type the expense amount in the mail subject to set it on the expense too.">
-                                <div class="o_setting_left_pane">
-                                    <field name="hr_expense_use_mailgateway"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Incoming Emails" for="hr_expense_use_mailgateway"/>
-                                    <div class="text-muted">
-                                        Create expenses from incoming emails
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': ['|', ('hr_expense_use_mailgateway', '=',  False), ('alias_domain', 'in', ['localhost', '', False])]}">
-                                        <div class="mt16">
-                                            <label for="hr_expense_alias_prefix" string="Alias" class="o_light_label"/>
-                                            <field name="hr_expense_alias_prefix" class="oe_inline"/>
-                                            <span>@</span>
-                                            <field name="alias_domain" class="oe_inline" readonly="1"/>
-                                        </div>
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': ['|', ('hr_expense_use_mailgateway', '=',  False), ('alias_domain', 'not in', ['localhost', '', False])]}">
-                                        <div class="mt16">
-                                            <button type="action" name="base_setup.action_general_configuration" icon="fa-arrow-right" string="Setup your domain alias" class="btn-link"/>
-                                        </div>
+                <xpath expr="//form" position="inside">
+                    <app data-string="Expenses" string="Expenses" name="hr_expense" groups="hr_expense.group_hr_expense_manager">
+                        <block title="Expenses" name="expenses_setting_container">
+                            <setting id="create_expense_setting" string="Incoming Emails" help="Create expenses from incoming emails" title="Send an email to this email alias with the receipt in attachment to create an expense in one click. If the first word of the mail subject contains the category's internal reference or the category name, the corresponding category will automatically be set. Type the expense amount in the mail subject to set it on the expense too.">
+                                <field name="hr_expense_use_mailgateway"/>
+                                <div class="content-group" attrs="{'invisible': ['|', ('hr_expense_use_mailgateway', '=',  False), ('alias_domain', 'in', ['localhost', '', False])]}">
+                                    <div class="mt16">
+                                        <label for="hr_expense_alias_prefix" string="Alias" class="o_light_label"/>
+                                        <field name="hr_expense_alias_prefix" class="oe_inline"/>
+                                        <span>@</span>
+                                        <field name="alias_domain" class="oe_inline" readonly="1"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-lg-6 col-12 o_setting_box" id="hr_payroll_accountant">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_hr_payroll_expense" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_hr_payroll_expense" string="Reimburse in Payslip"/>
-                                    <div class="text-muted">
-                                        Reimburse expenses in payslips
+                                <div class="content-group" attrs="{'invisible': ['|', ('hr_expense_use_mailgateway', '=',  False), ('alias_domain', 'not in', ['localhost', '', False])]}">
+                                    <div class="mt16">
+                                        <button type="action" name="base_setup.action_general_configuration" icon="fa-arrow-right" string="Setup your domain alias" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" title="use OCR to fill data from a picture of the bill">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_hr_expense_extract" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="expense_extract_settings">
-                                    <label string="Expense Digitalization (OCR)" for="module_hr_expense_extract"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                                    <div class="text-muted">
-                                        Digitalize your receipts with OCR and Artificial Intelligence
-                                    </div>
-                                </div>   
-                            </div>
-                        </div>
-                        <h2>Default Journals</h2>
-                        <div class="row mt16 o_settings_container">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane"></div>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Employee Expense Journal</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Default accounting journal for expenses paid by employees.
-                                    </div>
-                                    <div class="row mt8">
-                                        <field name="expense_journal_id"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane"></div>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Company Expense Journal</span>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Default accounting journal for expenses paid by the company.
-                                    </div>
-                                    <div class="row mt8">
-                                        <field name="company_expense_journal_id"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                            <setting string="Reimburse in Payslip" help="Reimburse expenses in payslips" id="hr_payroll_accountant">
+                                <field name="module_hr_payroll_expense" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="expense_extract_settings" string="Expense Digitalization (OCR)" company_dependent="1" help="Digitalize your receipts with OCR and Artificial Intelligence" title="use OCR to fill data from a picture of the bill">
+                                <field name="module_hr_expense_extract" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                        <block title="Default Journals">
+                            <setting company_dependent="1" help="Default accounting journal for expenses paid by employees." string="Employee Expense Journal">
+                                <field name="expense_journal_id"/>
+                            </setting>
+                            <setting company_dependent="1" string="Company Expense Journal" help="Default accounting journal for expenses paid by the company.">
+                                <field name="company_expense_journal_id"/>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/hr_recruitment/views/res_config_settings_views.xml
+++ b/addons/hr_recruitment/views/res_config_settings_views.xml
@@ -7,76 +7,28 @@
             <field name="priority" eval="75"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="Recruitment" string="Recruitment" data-key="hr_recruitment" groups="hr_recruitment.group_hr_recruitment_manager">
-                        <h2>Job Posting</h2>
-                        <div class="row mt16 o_settings_container" name="online_posting_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="publish_available_jobs_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_hr_recruitment"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_website_hr_recruitment" string="Online Posting"/>
-                                    <div class="text-muted">
-                                        Publish available jobs on your website
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Recruitment Process</h2>
-                        <div class="row mt16 o_settings_container" name="recruitment_process_div">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="interview_forms_setting"
-                                title="Use interview forms tailored to each job position during the recruitment process. Select the form to use in the job position detail form. This relies on the Survey app.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_hr_recruitment_survey"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_hr_recruitment_survey" string="Send Interview Survey"/>
-                                    <div class="text-muted">
-                                        Send an Interview Survey to the applicant during
-                                        the recruitment process
-                                    </div>
-                                    <div class="content-group" id="interview_forms"/>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" id="sms">
-                                <div class="o_setting_right_pane" id="sms_settings">
-                                    <div class="o_form_label">
-                                        Send SMS
-                                        <a href="https://www.odoo.com/documentation/master/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" title="Documentation" class="ms-1 o_doc_link" target="_blank"></a>
-                                    </div>
-                                    <div class="text-muted">
-                                        Send texts to your contacts
-                                    </div>
-                                    <widget name="iap_buy_more_credits" service_name="sms" hide_service="1"/>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" id="display_cv">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_applicant_cv_display"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_applicant_cv_display" string="CV Display"/>
-                                    <div class="text-muted">
-                                        Display CV on application form
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" title="Use OCR to fill data from a picture of the CV or the file itself">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_hr_recruitment_extract" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="recruitment_extract_settings">
-                                    <label string="CV Digitization (OCR)" for="module_hr_recruitment_extract"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                                    <div class="text-muted">
-                                        Digitize your CV to extract name and email automatically.
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <xpath expr="//form" position="inside">
+                    <app data-string="Recruitment" string="Recruitment" name="hr_recruitment" groups="hr_recruitment.group_hr_recruitment_manager">
+                        <block title="Job Posting" name="online_posting_setting_container">
+                            <setting id="publish_available_jobs_setting" string="Online Posting" help="Publish available jobs on your website">
+                                <field name="module_website_hr_recruitment"/>
+                            </setting>
+                        </block>
+                        <block title="Recruitment Process" name="recruitment_process_div">
+                            <setting id="interview_forms_setting" string="Send Interview Survey" help="Send an Interview Survey to the applicant during the recruitment process" title="Use interview forms tailored to each job position during the recruitment process. Select the form to use in the job position detail form. This relies on the Survey app.">
+                                <field name="module_hr_recruitment_survey"/>
+                            </setting>
+                            <setting id="sms" string="Send SMS" documentation="/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" help="Send texts to your contacts">
+                                <widget name="iap_buy_more_credits" service_name="sms" hide_service="1"/>
+                            </setting>
+                            <setting string="CV Display" help="Display CV on application form" id="display_cv">
+                                <field name="group_applicant_cv_display"/>
+                            </setting>
+                            <setting id="recruitment_extract_settings" string="CV Digitization (OCR)" company_dependent="1" help="Digitize your CV to extract name and email automatically." title="Use OCR to fill data from a picture of the CV or the file itself">
+                                <field name="module_hr_recruitment_extract" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/hr_recruitment_survey/views/res_config_setting_views.xml
+++ b/addons/hr_recruitment_survey/views/res_config_setting_views.xml
@@ -5,13 +5,13 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="hr_recruitment.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="interview_forms" position="replace">
+            <setting id="interview_forms_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8">
                         <button name="%(survey.action_survey_form)d" icon="fa-arrow-right" type="action" string="Interview Survey" class="btn-link"/>
                     </div>
                 </div>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo> 

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -6,121 +6,55 @@
         <field name="priority" eval="55"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Timesheets" string="Timesheets" data-key="hr_timesheet" groups="hr_timesheet.group_timesheet_manager" id="timesheets">
-                    <h2>Time Encoding</h2>
-                    <div class="row mt16 o_settings_container" name="time_encoding_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="time_mode_setting"
-                            attrs="{'invisible':[('project_time_mode_id', '!=', False)]}">
-                            <div class="o_setting_right_pane">
-                                <label for="project_time_mode_id"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="project_time_mode_id" options="{'no_create': True, 'no_open': True}"/>
+            <xpath expr="//form" position="inside">
+                <app data-string="Timesheets" string="Timesheets" name="hr_timesheet" groups="hr_timesheet.group_timesheet_manager" id="timesheets">
+                    <block title="Time Encoding" name="time_encoding_setting_container">
+                        <setting id="time_mode_setting" company_dependent="1" attrs="{'invisible':[('project_time_mode_id', '!=', False)]}">
+                            <field name="project_time_mode_id" options="{'no_create': True, 'no_open': True}"/>
+                        </setting>
+                        <setting company_dependent="1" help="Time unit used to record your timesheets" id="time_unit_timesheets_setting">
+                            <field name="timesheet_encode_uom_id" options="{'no_create': True, 'no_open': True}" required="1" class="col-lg-5 ps-0"/>
+                            <field name="is_encode_uom_days" invisible="1"/>
+                        </setting>
+                        <setting help="Track your time from anywhere, even offline, with our web/mobile apps" id="synchronize_web_mobile_setting">
+                            <field name="module_project_timesheet_synchro" widget="upgrade_boolean"/>
+                            <div class="content-group">
+                                <div class="row mt16 oe_center">
+                                    <div class="col-lg-3 pe-0 o_chrome_store_link d-none d-sm-inline-block">
+                                        <a href="http://www.odoo.com/app/timesheet?platform=chrome" class="align-middle" target="_blank">
+                                            <img alt="Google Chrome Store" class="img img-fluid align-middle mt-1" style="height: 85% !important;" src="project/static/src/img/chrome_store.png"/>
+                                        </a>
+                                    </div>
+                                    <div class="col-lg-3 pe-0">
+                                        <a href="https://apps.apple.com/be/app/awesome-timesheet/id1078657549" class="align-middle" target="_blank">
+                                            <img alt="Apple App Store" class="img img-fluid h-100 o_config_app_store" src="project/static/src/img/app_store.png"/>
+                                        </a>
+                                    </div>
+                                    <div class="col-lg-3 pe-0">
+                                        <a href="https://play.google.com/store/apps/details?id=com.odoo.OdooTimesheets" class="align-middle" target="_blank">
+                                            <img alt="Google Play Store" class="img img-fluid h-100 o_config_play_store" src="project/static/src/img/play_store.png"/>
+                                        </a>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="time_unit_timesheets_setting">
-                            <div class="o_setting_right_pane">
-                                <label for="timesheet_encode_uom_id"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="row">
-                                    <div class="text-muted col-md-12">
-                                        Time unit used to record your timesheets
-                                    </div>
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="timesheet_encode_uom_id" options="{'no_create': True, 'no_open': True}" required="1" class="col-lg-5 ps-0"/>
-                                        <field name="is_encode_uom_days" invisible="1"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="synchronize_web_mobile_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="module_project_timesheet_synchro" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_project_timesheet_synchro"/>
-                                <div class="text-muted">
-                                    Track your time from anywhere, even offline, with our web/mobile apps
-                                </div>
-                                <div class="content-group">
-                                    <div class="row mt16 oe_center">
-                                        <div class="col-lg-3 pe-0 o_chrome_store_link d-none d-sm-inline-block">
-                                            <a href="http://www.odoo.com/app/timesheet?platform=chrome" class="align-middle" target="_blank">
-                                                <img alt="Google Chrome Store" class="img img-fluid align-middle mt-1" style="height: 85% !important;" src="project/static/src/img/chrome_store.png"/>
-                                            </a>
-                                        </div>
-                                        <div class="col-lg-3 pe-0">
-                                            <a href="https://apps.apple.com/be/app/awesome-timesheet/id1078657549" class="align-middle" target="_blank">
-                                                <img alt="Apple App Store" class="img img-fluid h-100 o_config_app_store" src="project/static/src/img/app_store.png"/>
-                                            </a>
-                                        </div>
-                                        <div class="col-lg-3 pe-0">
-                                            <a href="https://play.google.com/store/apps/details?id=com.odoo.OdooTimesheets" class="align-middle" target="_blank">
-                                                <img alt="Google Play Store" class="img img-fluid h-100 o_config_play_store" src="project/static/src/img/play_store.png"/>
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Timesheets Control</h2>
-                    <div class="row mt16 o_settings_container">
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="reminder_user_allow" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane" id="reminder_user_allow">
-                                <label for="reminder_user_allow"/>
-                                <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="text-muted">
-                                    Send a periodical email reminder to timesheets users<br/>
-                                    that still have timesheets to encode
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="reminder_allow" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane" id="reminder_allow">
-                                <label for="reminder_allow"/>
-                                <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="text-muted">
-                                    Send a periodical email reminder to timesheets approvers<br/>
-                                    that still have timesheets to validate
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                        </setting>
+                    </block>
+                    <block title="Timesheets Control">
+                        <setting id="reminder_user_allow" company_dependent="1" help="Send a periodical email reminder to timesheets users that still have timesheets to encode">
+                            <field name="reminder_user_allow" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="reminder_allow" company_dependent="1" help="Send a periodical email reminder to timesheets approvers that still have timesheets to validate">
+                            <field name="reminder_allow" widget="upgrade_boolean"/>
+                        </setting>
+                    </block>
                     <div name="section_leaves">
-                        <h2>Time Off</h2>
-                        <div class="row mt16 o_settings_container" name="timesheet_control">
-                            <div class="col-12 col-lg-6 o_setting_box" id="timesheet_off_validation_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_project_timesheet_holidays"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_project_timesheet_holidays"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Generate timesheets upon time off validation
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="module_project_timesheet_holidays"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <block title="Time Off" name="timesheet_control">
+                            <setting company_dependent="1" help="Generate timesheets upon time off validation" id="timesheet_off_validation_setting">
+                                <field name="module_project_timesheet_holidays"/>
+                            </setting>
+                        </block>
                     </div>
-                </div>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/iap/static/src/action_buttons_widget/action_buttons_widget.js
+++ b/addons/iap/static/src/action_buttons_widget/action_buttons_widget.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 const { Component } = owl;
 
@@ -28,6 +29,11 @@ class IAPActionButtonsWidget extends Component {
     }
 }
 IAPActionButtonsWidget.template = "iap.ActionButtonsWidget";
+IAPActionButtonsWidget.props = {
+    ...standardWidgetProps,
+    serviceName: String,
+    showServiceButtons: Boolean,
+};
 IAPActionButtonsWidget.extractProps = ({ attrs }) => {
     return {
         serviceName: attrs.service_name,

--- a/addons/iap/views/res_config_settings.xml
+++ b/addons/iap/views/res_config_settings.xml
@@ -18,23 +18,11 @@ if records:
         <field name="arch" type="xml">
             <xpath expr="//div[@id='contacts_settings']" position="inside">
                 <div id="iap_portal">
-                    <div class='row mt16 o_settings_container iap_portal' name="iap_purchases_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="iap_credits_setting">
-                            <div class='o_setting_right_pane'>
-                                <div class="o_form_label">
-                                Odoo IAP
-                                <a href="https://www.odoo.com/documentation/master/applications/general/in_app_purchase.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <a href="https://www.odoo.com/documentation/master/developer/misc/api/iap.html" title="Documentation" class="ms-1 o_doc_link" target="_blank"></a>
-                                </div>
-                                <div class="text-muted">
-                                    View your IAP Services and recharge your credits
-                                </div>
-                                <div class='mt8'>
-                                    <button name="%(iap.open_iap_account)d" icon="fa-arrow-right" type="action" string="View My Services" class="btn-link"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <block class='iap_portal' name="iap_purchases_setting_container">
+                        <setting id="iap_credits_setting" string="Odoo IAP" help ="View your IAP Services and recharge your credits" documentation="/applications/general/in_app_purchase.html">
+                            <button name="%(iap.open_iap_account)d" icon="fa-arrow-right" type="action" string="View My Services" class="btn-link"/>
+                        </setting>
+                    </block>
                 </div>
             </xpath>
         </field>

--- a/addons/l10n_ar/views/res_config_settings_view.xml
+++ b/addons/l10n_ar/views/res_config_settings_view.xml
@@ -6,11 +6,10 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@data-key='account']/div" position="after">
+            <xpath expr="//div[@name='account']/div" position="after">
                 <div  id="argentina_localization_section" invisible="1">
-                    <h2 attrs="{'invisible':[('country_code', '!=', 'AR')]}">Argentinean Localization</h2>
-                    <div class="row mt16 o_settings_container" id="argentina_localization" attrs="{'invisible':[('country_code', '!=', 'AR')]}">
-                    </div>
+                    <block title="Argentinean Localization" id="argentina_localization" attrs="{'invisible':[('country_code', '!=', 'AR')]}">
+                    </block>
                 </div>
             </xpath>
         </field>

--- a/addons/l10n_ch/views/res_config_settings_views.xml
+++ b/addons/l10n_ch/views/res_config_settings_views.xml
@@ -6,48 +6,32 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="account.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[@id='invoicing_settings']" position="inside">
-                    <div class="col-12 col-lg-6 o_setting_box" id="l10n_ch-isr_print_bank" attrs="{'invisible': [('country_code', '!=', 'CH')]}">
-                        <div class="o_setting_left_pane">
-                            <field name="l10n_ch_isr_print_bank_location"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="l10n_ch_isr_print_bank_location"/>
-                            <div class="text-muted">
-                                Print the coordinates of your bank under the &apos;Payment for&apos; title of the ISR.
-                                Your address will be moved to the &apos;in favour of&apos; section.
+                <xpath expr="//block[@id='invoicing_settings']" position="inside">
+                    <setting id="l10n_ch-isr_print_bank" help="Print the coordinates of your bank under the &apos;Payment for&apos; title of the ISR. Your address will be moved to the &apos;in favour of&apos; section." attrs="{'invisible': [('country_code', '!=', 'CH')]}">
+                        <field name="l10n_ch_isr_print_bank_location"/>
+                        <div class="content-group" attrs="{'invisible': [('l10n_ch_isr_print_bank_location', '=', False)]}">
+                            <div class="row mt16">
+                                <label for="l10n_ch_isr_preprinted_bank" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_ch_isr_preprinted_bank"/>
                             </div>
-                            <div class="content-group" attrs="{'invisible': [('l10n_ch_isr_print_bank_location', '=', False)]}">
-                                <div class="row mt16">
-                                    <label for="l10n_ch_isr_preprinted_bank" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_ch_isr_preprinted_bank"/>
-                                </div>
-                                <div class="row">
-                                    <label for="l10n_ch_isr_preprinted_account" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_ch_isr_preprinted_account"/>
-                                </div>
+                            <div class="row">
+                                <label for="l10n_ch_isr_preprinted_account" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_ch_isr_preprinted_account"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="l10n_ch-isr_print_scanline_offset" attrs="{'invisible': [('country_code', '!=', 'CH')]}">
-                        <div class="o_setting_left_pane"/>
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">ISR scan line offset</span>
-                            <div class="text-muted">
-                                Offset to move the scan line in mm
+                    </setting>
+                    <setting id="l10n_ch-isr_print_scanline_offset" string="ISR scan line offset" help="Offset to move the scan line in mm" attrs="{'invisible': [('country_code', '!=', 'CH')]}">
+                        <div class="content-group">
+                            <div class="row mt16">
+                                <label for="l10n_ch_isr_scan_line_top" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_ch_isr_scan_line_top"/>
                             </div>
-                            <div class="content-group">
-                                <div class="row mt16">
-                                    <label for="l10n_ch_isr_scan_line_top" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_ch_isr_scan_line_top"/>
-                                </div>
-                                <div class="row">
-                                    <label for="l10n_ch_isr_scan_line_left" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_ch_isr_scan_line_left"/>
-                                </div>
+                            <div class="row">
+                                <label for="l10n_ch_isr_scan_line_left" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_ch_isr_scan_line_left"/>
                             </div>
                         </div>
-                    </div>
+                    </setting>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_cl/views/res_config_settings_view.xml
+++ b/addons/l10n_cl/views/res_config_settings_view.xml
@@ -6,13 +6,10 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='invoicing_settings']" position="after">
-                <div id="l10n_cl_title" attrs="{'invisible': True}">
-                    <h2>Chilean Localization</h2>
-                </div>
-                <div id="l10n_cl_section" class="row mt16 o_settings_container" attrs="{'invisible': [('country_code', '!=', 'CL')]}">
+            <xpath expr="//block[@id='invoicing_settings']" position="after">
+                <block title="Chilean Localization" id="l10n_cl_section" attrs="{'invisible': [('country_code', '!=', 'CL')]}">
                     <!-- inside empty to add configuration of tags -->
-                </div>
+                </block>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_eg_edi_eta/views/res_config_settings_view.xml
+++ b/addons/l10n_eg_edi_eta/views/res_config_settings_view.xml
@@ -6,39 +6,30 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@data-key='account']/div" position="after">
-                <h2 attrs="{'invisible':[('country_code', '!=', 'EG')]}">ETA E-Invoicing Settings</h2>
-                <div class="row mt16 o_settings_container" name="egyption_eta_edi" attrs="{'invisible':[('country_code', '!=', 'EG')]}">
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-                        <div class="o_setting_left_pane"/>
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">ETA API Integration</span>
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                            <div class="text-muted">
-                                    Enter your API credentials to enable ETA E-Invoicing.
-                                    <field name="country_code" invisible="1"/>
+            <xpath expr="//app[@name='account']/block" position="after">
+                <block title="ETA E-Invoicing Settings" name="egyption_eta_edi" attrs="{'invisible':[('country_code', '!=', 'EG')]}">
+                    <field name="country_code" invisible="1"/>
+                    <setting string="ETA API Integration" help="Enter your API credentials to enable ETA E-Invoicing." company_dependent="1">
+                        <div class="content-group">
+                            <div class="row mt16">
+                                <label for="l10n_eg_production_env" class="col-lg-6 o_light_label"/>
+                                <field name="l10n_eg_production_env" help="Check to start sending invoices to your e-invoicing production environment"/>
                             </div>
-                            <div class="content-group">
-                                <div class="row mt16">
-                                    <label for="l10n_eg_production_env" class="col-lg-6 o_light_label"/>
-                                    <field name="l10n_eg_production_env" help="Check to start sending invoices to your e-invoicing production environment"/>
-                                </div>
-                                <div class="row">
-                                    <label for="l10n_eg_client_identifier" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_eg_client_identifier" help="The client ID retrieved from the ETA e-invoicing portal"/>
-                                </div>
-                                <div class="row">
-                                    <label for="l10n_eg_client_secret" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_eg_client_secret" password="True" help="The secret key provided by the ETA. You can input client secret 1 or 2"/>
-                                </div>
-                                <div class="row">
-                                    <label for="l10n_eg_invoicing_threshold" class="col-lg-4 o_light_label"/>
-                                    <field name="l10n_eg_invoicing_threshold" help="Set the threshold amount for invoices that won't require the VAT ID of individuals when invoicing"/>
-                                </div>
+                            <div class="row">
+                                <label for="l10n_eg_client_identifier" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_eg_client_identifier" help="The client ID retrieved from the ETA e-invoicing portal"/>
+                            </div>
+                            <div class="row">
+                                <label for="l10n_eg_client_secret" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_eg_client_secret" password="True" help="The secret key provided by the ETA. You can input client secret 1 or 2"/>
+                            </div>
+                            <div class="row">
+                                <label for="l10n_eg_invoicing_threshold" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_eg_invoicing_threshold" help="Set the threshold amount for invoices that won't require the VAT ID of individuals when invoicing"/>
                             </div>
                         </div>
-                    </div>
-                </div>
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_es_edi_sii/views/res_config_settings_views.xml
+++ b/addons/l10n_es_edi_sii/views/res_config_settings_views.xml
@@ -5,53 +5,40 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@data-key='account']/div" position="after">
-                <h2 attrs="{'invisible': [('country_code', '!=', 'ES')]}">Spain Localization</h2>
-                <div class="row mt16 o_settings_container"
-                     name="spain_localization"
-                     attrs="{'invisible': [('country_code', '!=', 'ES')]}">
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-
-                        <!-- Invisible fields -->
-                        <field name="l10n_es_edi_certificate_ids" invisible="1"/>
-
-                        <div class="o_setting_left_pane"/>
-
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">Registro de Libros connection SII</span>
-                            <span class="fa fa-lg fa-building-o"
-                                  title="Values set here are company-specific."
-                                  groups="base.group_multi_company"/>
-                            <div class="content-group">
-                                <div class="mt16">
-                                    <label for="l10n_es_edi_tax_agency" class="o_light_label"/>
-                                    <field name="l10n_es_edi_tax_agency"/>
-                                    <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_tax_agency', '!=', False)]}">
-                                        No tax agency selected: SII not activated.
-                                    </div>
-                                    <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_tax_agency', '=', False)]}">
-                                        Tax agency selected: invoices will be sent by SII for journals where it is activated.
-                                    </div>
-                                    <br/>
-                                    <div class="o_row">
-                                        <label for="l10n_es_edi_test_env" class="o_light_label"/>
-                                        <field name="l10n_es_edi_test_env"/>
-                                    </div>
-                                    <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_test_env', '=', False)]}">
-                                        Test mode: EDI data is sent to separate test servers and is not considered official.
-                                    </div>
-                                    <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_test_env', '!=', False)]}">
-                                        Production mode: EDI data is sent to the official agency servers.
-                                    </div>
-                                    <br/>
-                                    <div>
-                                        <button name="%(l10n_es_edi_certificate_action)d" type="action" class="oe_link">Manage certificates (SII/TicketBAI)</button>
-                                    </div>
+            <xpath expr="//app[@name='account']/block" position="after">
+                <block title="Spain Localization" name="spain_localization" attrs="{'invisible': [('country_code', '!=', 'ES')]}">
+                    <!-- Invisible fields -->
+                    <field name="l10n_es_edi_certificate_ids" invisible="1"/>
+                    <setting string="Registro de Libros connection SII" company_dependent="1">
+                        <div class="content-group">
+                            <div class="mt16">
+                                <label for="l10n_es_edi_tax_agency" class="o_light_label"/>
+                                <field name="l10n_es_edi_tax_agency"/>
+                                <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_tax_agency', '!=', False)]}">
+                                    No tax agency selected: SII not activated.
+                                </div>
+                                <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_tax_agency', '=', False)]}">
+                                    Tax agency selected: invoices will be sent by SII for journals where it is activated.
+                                </div>
+                                <br/>
+                                <div class="o_row">
+                                    <label for="l10n_es_edi_test_env" class="o_light_label"/>
+                                    <field name="l10n_es_edi_test_env"/>
+                                </div>
+                                <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_test_env', '=', False)]}">
+                                    Test mode: EDI data is sent to separate test servers and is not considered official.
+                                </div>
+                                <div class="text-muted" attrs="{'invisible': [('l10n_es_edi_test_env', '!=', False)]}">
+                                    Production mode: EDI data is sent to the official agency servers.
+                                </div>
+                                <br/>
+                                <div>
+                                    <button name="%(l10n_es_edi_certificate_action)d" type="action" class="oe_link">Manage certificates (SII/TicketBAI)</button>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
+                    </setting>
+                </block>
             </xpath>
 
         </field>

--- a/addons/l10n_id_efaktur/views/res_config_settings_views.xml
+++ b/addons/l10n_id_efaktur/views/res_config_settings_views.xml
@@ -6,28 +6,21 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='invoicing_settings']" position="after">
-                <div id="l10n_cl_title">
-                    <h2>Indonesian Localization</h2>
-                </div>
-                <div id="l10n_cl_section" class="row mt16 o_settings_container">
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane"/>
-                        <div class="o_setting_right_pane">
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                            <div class="content-group">
-                                <div class="row mt16">
-                                    <label for="l10n_id_tax_address" class="col-lg-3"/>
-                                    <field name="l10n_id_tax_address"/>
-                                </div>
-                                <div class="row mt16">
-                                    <label for="l10n_id_tax_name" class="col-lg-3"/>
-                                    <field name="l10n_id_tax_name"/>
-                                </div>
+            <xpath expr="//block[@id='invoicing_settings']" position="after">
+                <block title="Indonesian Localization" id="l10n_cl_section">
+                    <setting company_dependent="1">
+                        <div class="content-group">
+                            <div class="row mt16">
+                                <label for="l10n_id_tax_address" class="col-lg-3"/>
+                                <field name="l10n_id_tax_address"/>
+                            </div>
+                            <div class="row mt16">
+                                <label for="l10n_id_tax_name" class="col-lg-3"/>
+                                <field name="l10n_id_tax_name"/>
                             </div>
                         </div>
-                    </div>
-                </div>
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -5,22 +5,11 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="invoicing_settings" position="inside">
-                <div class="col-xs-12 col-md-6 o_setting_box"
-                    name="ecommerce_reseller_setting"
-                    title="Manage Reseller(E-Commerce)"
-                    attrs="{'invisible': [('country_code', '!=', 'IN')]}">
-                    <div class="o_setting_left_pane">
-                        <field name="group_l10n_in_reseller"/>
-                    </div>
-                    <div class="o_setting_right_pane" name="l10n_eu_service_right_pane">
-                        <label for="group_l10n_in_reseller"/>
-                        <div class="text-muted">
-                            Use this if setup with Reseller(E-Commerce).
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <block id="invoicing_settings" position="inside">
+                <setting help="Use this if setup with Reseller(E-Commerce)." name="ecommerce_reseller_setting" title="Manage Reseller(E-Commerce)" attrs="{'invisible': [('country_code', '!=', 'IN')]}">
+                    <field name="group_l10n_in_reseller"/>
+                </setting>
+            </block>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_in_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi/views/res_config_settings_views.xml
@@ -5,36 +5,28 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div data-key="account" position="inside">
-                <h2 attrs="{'invisible': [('country_code', '!=', 'IN')]}">Indian Electronic Invoicing</h2>
-                <div class='row mt16 o_settings_container' name="l10n_in_edi_iap" attrs="{'invisible': [('country_code', '!=', 'IN')]}">
-                    <div class="col-12 col-lg-6 o_setting_box" id="gsp_setting">
-                        <div class="o_setting_right_pane">
-                            <t class="o_form_label">Setup E-invoice</t>
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                            <div class="text-muted">
-                                Setup E-invoice Service for this company
-                            </div>
-                            <div class="content-group">
-                                <div class="mt16 row">
-                                    <label for="l10n_in_edi_username" string="Username" class="col-3 col-lg-3 o_light_label"/>
-                                    <field name="l10n_in_edi_username"  nolabel="1"/>
-                                    <label for="l10n_in_edi_password" string="Password" class="col-3 col-lg-3 o_light_label" />
-                                    <field name="l10n_in_edi_password" password="True" nolabel="1"/>
-                                    <label for="l10n_in_edi_production_env" string="Production Environment" class="col-3 col-lg-3 o_light_label"/>
-                                    <field name="l10n_in_edi_production_env" nolabel="1"/>
-                                    <div class="text-muted">
-                                        Only check if you are in production.
-                                    </div>
+            <app name="account" position="inside">
+                <block title="Indian Electronic Invoicing" name="l10n_in_edi_iap" attrs="{'invisible': [('country_code', '!=', 'IN')]}">
+                    <setting id="gsp_setting" string="Setup E-invoice" help="Setup E-invoice Service for this company" company_dependent="1">
+                        <div class="content-group">
+                            <div class="mt16 row">
+                                <label for="l10n_in_edi_username" string="Username" class="col-3 col-lg-3 o_light_label"/>
+                                <field name="l10n_in_edi_username"  nolabel="1"/>
+                                <label for="l10n_in_edi_password" string="Password" class="col-3 col-lg-3 o_light_label" />
+                                <field name="l10n_in_edi_password" password="True" nolabel="1"/>
+                                <label for="l10n_in_edi_production_env" string="Production Environment" class="col-3 col-lg-3 o_light_label"/>
+                                <field name="l10n_in_edi_production_env" nolabel="1"/>
+                                <div class="text-muted">
+                                    Only check if you are in production.
                                 </div>
                             </div>
-                            <div class='mt8'>
-                                <button name="l10n_in_edi_test" icon="fa-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
-                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
+                        <div class='mt8'>
+                            <button name="l10n_in_edi_test" icon="fa-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
+                        </div>
+                    </setting>
+                </block>
+            </app>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -6,47 +6,42 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='account_vendor_bills']" position="after">
-                <div attrs="{'invisible':[('country_code', '!=', 'IT')]}">
-                    <h2>Electronic Document Invoicing</h2>
-                    <div class="row mt16 o_settings_container" id='account_edi'>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_right_pane">
-                                <div class="group-content">
-                                    <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
-                                    <span class="o_form_label">
-                                        Fattura Elettronica mode
-                                    </span>
-                                    <div class="text-muted">
-                                        In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
-                                        In test mode (experimental) Odoo will send the invoices to a non-production service.
-                                        Saving this change will direct all companies on this database to this use this configuration.
-                                        Once registered for testing or official, the mode cannot be changed.
-                                    </div>
-                                    <field name="l10n_it_edi_sdicoop_demo_mode"
-                                           widget="radio"
-                                           options="{'horizontal': true}"/>
-                                </div>
-                                <div class="mt8 content-group" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','=','active'), '&amp;', ('l10n_it_edi_proxy_current_state','=','demo'), ('l10n_it_edi_sdicoop_demo_mode','=','demo')]}">
-                                    <span class="o_form_label">Allow Odoo to process invoices</span>
-                                    <div class="text-muted">
-                                        By checking this box, I accept that Odoo may process my invoices.
-                                    </div>
-                                    <div class="content-group">
-                                        <field name="l10n_it_edi_sdicoop_register"/>
-                                    </div>
-
-                                </div>
-                                <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_proxy_current_state','in', ['inactive', 'demo'])]}">
-                                    An Official or Test service has been registered.
-                                </div>
-                                <div class="text-success mt8" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','!=', 'demo'), ('l10n_it_edi_sdicoop_demo_mode', '!=', 'demo')]}">
-                                    A Demo service is in use.
-                                </div>
+            <xpath expr="//block[@id='account_vendor_bills']" position="after">
+                <block title="Electronic Document Invoicing" attrs="{'invisible':[('country_code', '!=', 'IT')]}" id='account_edi'>
+                    <setting>
+                        <div class="group-content">
+                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
+                            <span class="o_form_label">
+                                Fattura Elettronica mode
+                            </span>
+                            <div class="text-muted">
+                                In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
+                                In test mode (experimental) Odoo will send the invoices to a non-production service.
+                                Saving this change will direct all companies on this database to this use this configuration.
+                                Once registered for testing or official, the mode cannot be changed.
                             </div>
+                            <field name="l10n_it_edi_sdicoop_demo_mode"
+                                    widget="radio"
+                                    options="{'horizontal': true}"/>
                         </div>
-                    </div>
-                </div>
+                        <div class="mt8 content-group" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','=','active'), '&amp;', ('l10n_it_edi_proxy_current_state','=','demo'), ('l10n_it_edi_sdicoop_demo_mode','=','demo')]}">
+                            <span class="o_form_label">Allow Odoo to process invoices</span>
+                            <div class="text-muted">
+                                By checking this box, I accept that Odoo may process my invoices.
+                            </div>
+                            <div class="content-group">
+                                <field name="l10n_it_edi_sdicoop_register"/>
+                            </div>
+
+                        </div>
+                        <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_proxy_current_state','in', ['inactive', 'demo'])]}">
+                            An Official or Test service has been registered.
+                        </div>
+                        <div class="text-success mt8" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','!=', 'demo'), ('l10n_it_edi_sdicoop_demo_mode', '!=', 'demo')]}">
+                            A Demo service is in use.
+                        </div>
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_mx/views/res_config_settings_views.xml
+++ b/addons/l10n_mx/views/res_config_settings_views.xml
@@ -5,18 +5,10 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr=".//div[@id='invoicing_settings']" position="inside">
-                <div class="col-12 col-lg-6 o_setting_box" id="electronic_invoices_mx" attrs="{'invisible': [('country_code', '!=', 'MX')]}">
-                    <div class="o_setting_left_pane">
-                        <field name="module_l10n_mx_edi" class="oe_inline" widget="upgrade_boolean"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="module_l10n_mx_edi"/>
-                        <div class="text-muted">
-                            Create your electronic invoices automatically (CFDI format)
-                        </div>
-                    </div>
-                </div>
+            <xpath expr=".//block[@id='invoicing_settings']" position="inside">
+                <setting id="electronic_invoices_mx" help="Create your electronic invoices automatically (CFDI format)" attrs="{'invisible': [('country_code', '!=', 'MX')]}">
+                    <field name="module_l10n_mx_edi" class="oe_inline" widget="upgrade_boolean"/>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/lunch/views/res_config_settings.xml
+++ b/addons/lunch/views/res_config_settings.xml
@@ -6,45 +6,25 @@
         <field name="priority" eval="90"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Lunch" string="Lunch" data-key="lunch" groups="lunch.group_lunch_manager">
+            <xpath expr="//form" position="inside">
+                <app data-string="Lunch" string="Lunch" name="lunch" groups="lunch.group_lunch_manager">
                     <field name="currency_id" invisible="1"/>
-                    <h2>Lunch</h2>
-                    <div class="row mt16 o_settings_container" name="lunch_overdraft_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="lunch_minimum_threshold"
-                            title="None">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Lunch Overdraft</span>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                <div class="text-muted">
-                                    Maximum overdraft that your employees can reach
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16 row">
-                                        <label for="company_lunch_minimum_threshold" string="Overdraft" class="col-3 col-lg-3 o_light_label"/>
-                                        <field name="company_lunch_minimum_threshold" widget="monetary"/>
-                                    </div>
+                    <block title="Lunch" name="lunch_overdraft_setting_container">
+                        <setting id="lunch_minimum_threshold" string="Lunch Overdraft" help="Maximum overdraft that your employees can reach" company_dependent="1">
+                            <div class="content-group">
+                                <div class="mt16 row">
+                                    <label for="company_lunch_minimum_threshold" string="Overdraft" class="col-3 col-lg-3 o_light_label"/>
+                                    <field name="company_lunch_minimum_threshold" widget="monetary"/>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div class="row mt16 o_settings_container" name="lunch_notification_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="lunch_notification">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Reception notification</span>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                <div class="text-mutex">
-                                    Send this message to your users when their order has been delivered.
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16 row">
-                                        <field name="company_lunch_notify_message" widget="html" class="col col-lg w-100"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                        </setting>
+                    </block>
+                    <block name="lunch_notification_setting_container">
+                        <setting string="Reception notification" company_dependent="1" help="Send this message to your users when their order has been delivered." id="lunch_notification">
+                            <field name="company_lunch_notify_message" widget="html" class="col col-lg w-100"/>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -8,145 +8,76 @@
             <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
                 <div id="emails" position='replace'>
-                    <h2>Discuss</h2>
-                    <div class="row mt16 o_settings_container" id="emails">
-                        <div class="col-12 col-lg-6 o_setting_box" id="activities_setting">
-                            <div class="o_setting_left_pane"/>
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Activities</span>
-                                <div class="text-muted">
-                                    Configure your activity types
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt8">
-                                        <button name="%(mail.mail_activity_type_action)d" string="Activity Types" type="action" class="oe_link" icon="fa-arrow-right"/>
-                                    </div>
+                    <block title="Discuss" id="emails">
+                        <setting id="activities_setting" string="Activities" help="Configure your activity types">
+                            <div class="content-group">
+                                <div class="mt8">
+                                    <button name="%(mail.mail_activity_type_action)d" string="Activity Types" type="action" class="oe_link" icon="fa-arrow-right"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="email_servers_setting"
-                            title="Using your own email server is required to send/receive emails in Community and Enterprise versions. Online users already benefit from a ready-to-use email server (@mycompany.odoo.com).">
-                            <div class="o_setting_left_pane">
-                                <field name="external_email_server_default"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="external_email_server_default"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/general/email_communication/email_servers.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted" id="external_email_server_default">
-                                    Configure your own email servers
+                        </setting>
+                        <setting id="email_servers_setting" title="Using your own email server is required to send/receive emails in Community and Enterprise versions. Online users already benefit from a ready-to-use email server (@mycompany.odoo.com)." documentation="/applications/general/email_communication/email_servers.html" help="Configure your own email servers">
+                            <field name="external_email_server_default"/>
+                            <div class="content-group mb-3"  attrs="{'invisible': [('external_email_server_default', '=', False)]}">
+                                <div class="mt16" id="mail_alias_domain">
+                                    <label for="alias_domain" class="o_light_label"/>
+                                    <span>@</span>
+                                    <field name="alias_domain" placeholder='e.g. "mycompany.com"'/>
                                 </div>
-                                <div class="content-group mb-3"  attrs="{'invisible': [('external_email_server_default', '=', False)]}">
-                                    <div class="mt16" id="mail_alias_domain">
-                                        <label for="alias_domain" class="o_light_label"/>
-                                        <span>@</span>
-                                        <field name="alias_domain" placeholder='e.g. "mycompany.com"'/>
-                                    </div>
-                                    <div class="mt8">
-                                        <button type="action"
-                                        name="%(action_email_server_tree)d"
-                                        string="Incoming Email Servers" icon="fa-arrow-right" class="btn-link"/>
-                                    </div>
-                                    <div class="mt8">
-                                        <button type="action"
-                                        name="%(base.action_ir_mail_server_list)d"
-                                        string="Outgoing Email Servers" icon="fa-arrow-right" class="btn-link"/>
-                                    </div>
+                                <div class="mt8">
+                                    <button type="action"
+                                    name="%(action_email_server_tree)d"
+                                    string="Incoming Email Servers" icon="fa-arrow-right" class="btn-link"/>
+                                </div>
+                                <div class="mt8">
+                                    <button type="action"
+                                    name="%(base.action_ir_mail_server_list)d"
+                                    string="Outgoing Email Servers" icon="fa-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('external_email_server_default', '=', False)]}">
-                            <div class="o_setting_left_pane">
-                                <field name="module_google_gmail"/>
+                        </setting>
+                        <setting string="Use a Gmail Server" help="Send and receive emails through your Gmail account." documentation="https://console.developers.google.com/" attrs="{'invisible': [('external_email_server_default', '=', False)]}">
+                            <field name="module_google_gmail"/>
+                            <div class="content-group" attrs="{'invisible': [('module_google_gmail','=',False)]}" id="msg_module_google_gmail">
+                                <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label string="Use a Gmail Server" for="module_google_gmail"/>
-                                <a href="https://console.developers.google.com/" title="Get Gmail API credentials" class="o_doc_link" target="_blank"/>
-                                <div class="text-muted">
-                                    Send and receive emails through your Gmail account.
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('module_google_gmail','=',False)]}" id="msg_module_google_gmail">
-                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('external_email_server_default', '=', False)]}">
-                            <div class="o_setting_left_pane">
-                                <field name="module_microsoft_outlook"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label string="Use an Outlook Server" for="module_microsoft_outlook"/>
-                                <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app"
-                                    title="Get Outlook API credentials" class="o_doc_link" target="_blank"/>
-                                <div class="text-muted">
-                                    Send and receive emails through your Outlook account.
-                                </div>
-                                <div class="content-group" id="msg_module_microsoft_outlook"
-                                    attrs="{'invisible': [('module_microsoft_outlook','=',False)]}">
-                                    <div class="mt16 text-warning">
-                                        <strong>Save</strong> this page and come back here to set up the feature.
-                                    </div>
+                        </setting>
+                        <setting string="Use an Outlook Server" help="Send and receive emails through your Outlook account." documentation="https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app" attrs="{'invisible': [('external_email_server_default', '=', False)]}">
+                            <field name="module_microsoft_outlook"/>
+                            <div class="content-group" id="msg_module_microsoft_outlook"
+                                attrs="{'invisible': [('module_microsoft_outlook','=',False)]}">
+                                <div class="mt16 text-warning">
+                                    <strong>Save</strong> this page and come back here to set up the feature.
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="use_twilio_rtc_servers"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="use_twilio_rtc_servers"/>
-                                <div class="text-muted col-md-12">
-                                    Add your twilio credentials for ICE servers
+                        </setting>
+                        <setting help="Add your twilio credentials for ICE servers">
+                            <field name="use_twilio_rtc_servers"/>
+                            <div class="content-group"  attrs="{'invisible': [('use_twilio_rtc_servers', '=', False)]}">
+                                <div class="row mt16" id="mail_twilio_sid">
+                                    <label for="twilio_account_sid" class="col-lg-3"/>
+                                    <field name="twilio_account_sid" placeholder="e.g. ACd5543a0b450ar4c7t95f1b6e8a39t543"/>
                                 </div>
-                                <div class="content-group"  attrs="{'invisible': [('use_twilio_rtc_servers', '=', False)]}">
-                                    <div class="row mt16" id="mail_twilio_sid">
-                                        <label for="twilio_account_sid" class="col-lg-3"/>
-                                        <field name="twilio_account_sid" placeholder="e.g. ACd5543a0b450ar4c7t95f1b6e8a39t543"/>
-                                    </div>
-                                    <div class="row mt16" id="mail_twilio_auth_token">
-                                        <label for="twilio_account_token" class="col-lg-3"/>
-                                        <field name="twilio_account_token" placeholder="e.g. 65ea4f9e948b693N5156F350256bd152"/>
-                                    </div>
+                                <div class="row mt16" id="mail_twilio_auth_token">
+                                    <label for="twilio_account_token" class="col-lg-3"/>
+                                    <field name="twilio_account_token" placeholder="e.g. 65ea4f9e948b693N5156F350256bd152"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Custom ICE server list</span>
-                                <div class="row">
-                                    <div class="text-muted col-md-12">
-                                        Configure your ICE server list for webRTC
-                                    </div>
-                                </div>
-                                <div class="content-group">
-                                    <div class="row col-lg-4">
-                                        <button type="action" name="%(mail.action_ice_servers)d" string="ICE Servers" icon="fa-arrow-right" class="btn-link"/>
-                                    </div>
+                        </setting>
+                        <setting string="Custom ICE server list" help="Configure your ICE server list for webRTC">
+                            <div class="content-group">
+                                <div class="row col-lg-4">
+                                    <button type="action" name="%(mail.action_ice_servers)d" string="ICE Servers" icon="fa-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="restrict_template_rendering_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="restrict_template_rendering"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="restrict_template_rendering"/>
-                                <div class="text-muted" id="restrict_template_rendering">
-                                    Restrict mail templates edition and QWEB placeholders usage.
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                        </setting>
+                        <setting id="restrict_template_rendering_setting" help="Restrict mail templates edition and QWEB placeholders usage.">
+                            <field name="restrict_template_rendering"/>
+                        </setting>
+                    </block>
                 </div>
-                <div id="companies_setting" position="inside">
-                    <br/>
-                    <div class="o_setting_right_pane" id="mail_templates_setting"
-                        groups="mail.group_mail_template_editor,base.group_system">
-                        <span class="o_form_label">Email Templates</span>
-                        <div class="text-muted">
-                            Customize the look and feel of automated emails
-                        </div>
+                <setting id="document_layout_setting" position="after">
+                    <setting string="Email Templates" help="Customize the look and feel of automated emails" id="mail_templates_setting" groups="mail.group_mail_template_editor,base.group_system">
                         <div class="w-50 row">
                             <span class="d-block w-75 py-2">Header Color</span>
                             <field name="primary_color" class="d-block w-25 p-0 m-0" widget="color"/>
@@ -160,8 +91,8 @@
                             groups="base.group_no_one" class="btn-link"/>
                         <br groups="base.group_no_one"/>
                         <button name="open_mail_templates" icon="fa-arrow-right" type="object" string="Review All Templates" class="btn-link"/>
-                    </div>
-                </div>
+                    </setting>
+                </setting>
             </field>
         </record>
     </data>

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -6,67 +6,32 @@
             <field name="priority" eval="60"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="Email Marketing" string="Email Marketing" data-key="mass_mailing" groups="mass_mailing.group_mass_mailing_user">
-                      <h2>Email Marketing</h2>
-                        <div class="row mt16 o_settings_container" name="managa_mail_campaigns_setting_container">
-                            <div class="col-lg-6 o_setting_box col-12" title="This tool is advised if your marketing campaign is composed of several emails.">
-                                <div class="o_setting_left_pane" title="This is useful if your marketing campaigns are composed of several emails.">
-                                    <field name="group_mass_mailing_campaign"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_mass_mailing_campaign"/>
-                                    <div class="text-muted">
-                                        Manage mass mailing campaigns
+                <xpath expr="//form" position="inside">
+                    <app data-string="Email Marketing" string="Email Marketing" name="mass_mailing" groups="mass_mailing.group_mass_mailing_user">
+                        <block title="Email Marketing" name="managa_mail_campaigns_setting_container">
+                            <setting title="This tool is advised if your marketing campaign is composed of several emails." help="Manage mass mailing campaigns">
+                                <field name="group_mass_mailing_campaign"/>
+                            </setting>
+                            <setting name="dedicated_server_setting_container" title="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails." help="Pick a dedicated outgoing mail server for your mass mailings">
+                                <field name="mass_mailing_outgoing_mail_server"/>
+                                <div class="content-group" attrs="{'invisible': [('mass_mailing_outgoing_mail_server', '=', False)]}">
+                                    <div class="mt16">
+                                        <field name="mass_mailing_mail_server_id" options="{'no_create': True, 'no_open': True}"
+                                                placeholder="Default Server"/>
+                                    </div>
+                                    <div class="mt8">
+                                        <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="fa-arrow-right" class="oe_link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-lg-6 o_setting_box col-12" name="dedicated_server_setting_container">
-                                <div class="o_setting_left_pane" title="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails.">
-                                    <field name="mass_mailing_outgoing_mail_server"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="mass_mailing_outgoing_mail_server"/>
-                                    <div class="text-muted">
-                                        Pick a dedicated outgoing mail server for your mass mailings
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('mass_mailing_outgoing_mail_server', '=', False)]}">
-                                        <div class="mt16">
-                                            <field name="mass_mailing_mail_server_id" options="{'no_create': True, 'no_open': True}"
-                                                   placeholder="Default Server"/>
-                                        </div>
-                                        <div class="mt8">
-                                            <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="fa-arrow-right" class="oe_link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-6 o_setting_box col-xs-12" name="allow_blacklist_setting_container">
-                                <div class="o_setting_left_pane" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page.
-                                If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page.
-                                The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe.">
-                                    <field name="show_blacklist_buttons"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="show_blacklist_buttons"/>
-                                    <div class="text-muted">
-                                        Allow recipients to blacklist themselves
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-6 o_setting_box col-xs-12" name="mass_mailing_reports_setting_container">
-                                <div class="o_setting_left_pane" title="Send a report to the mailing responsible one day after the mailing has been sent.">
-                                    <field name="mass_mailing_reports"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="mass_mailing_reports"/>
-                                    <div class="text-muted">
-                                        Check how well your mailing is doing a day after it has been sent
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
+                                <field name="show_blacklist_buttons"/>
+                            </setting>
+                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
+                                <field name="mass_mailing_reports"/>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -7,140 +7,68 @@
             <field name="priority" eval="35"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form" />
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside">
-                    <div class="app_settings_block" data-string="Manufacturing" string="Manufacturing" data-key="mrp" groups="mrp.group_mrp_manager">
-                        <h2>Operations</h2>
-                        <div class="row mt16 o_settings_container" name="process_operations_setting_container">
-                            <div class="col-lg-6 col-12 o_setting_box" id="work_order" title="Work Order Operations allow you to create and manage the manufacturing operations that should be followed within your work centers in order to produce a product. They are attached to bills of materials that will define the required components.">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_mrp_routings"/>
-                                    <field name="module_mrp_workorder" invisible="1"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="workorder_settings">
-                                    <label for="group_mrp_routings" string="Work Orders"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/manufacturing/management/bill_configuration.html#adding-a-routing" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Process operations at specific work centers
-                                    </div>
-                                    <div id="workorder_settings_workcenters" class="content-group" attrs="{'invisible': [('group_mrp_routings','=',False)]}">
-                                        <div class="mt8">
-                                            <div>
-                                                <button name="%(mrp.mrp_workcenter_action)d" icon="fa-arrow-right" type="action" string="Work Centers" class="btn-link"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div id="workorder_settings_dependencies" class="row mt-2" attrs="{'invisible': [('group_mrp_routings','=',False)]}">
-                                        <field name="group_mrp_workorder_dependencies" class="col-lg-1 mr0"/>
-                                        <div class="col ps-0">
-                                            <label for="group_mrp_workorder_dependencies"/>
-                                            <div class="text-muted">
-                                                Set the order that work orders should be processed in. Activate the feature within each BoM's Miscellaneous tab
-                                            </div>
+                <xpath expr="//form" position="inside">
+                    <app data-string="Manufacturing" string="Manufacturing" name="mrp" groups="mrp.group_mrp_manager">
+                        <block title="Operations" name="process_operations_setting_container">
+                            <setting id="work_order" string="Work Orders" help="Process operations at specific work centers" documentation="/applications/inventory_and_mrp/manufacturing/management/bill_configuration.html#adding-a-routing" title="Work Order Operations allow you to create and manage the manufacturing operations that should be followed within your work centers in order to produce a product. They are attached to bills of materials that will define the required components.">
+                                <field name="group_mrp_routings"/>
+                                <field name="module_mrp_workorder" invisible="1"/>
+                                <div id="workorder_settings_workcenters" class="content-group" attrs="{'invisible': [('group_mrp_routings','=',False)]}">
+                                    <div class="mt8">
+                                        <div>
+                                            <button name="%(mrp.mrp_workcenter_action)d" icon="fa-arrow-right" type="action" string="Work Centers" class="btn-link"/>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-lg-6 col-12 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_mrp_subcontracting"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_mrp_subcontracting"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/manufacturing/management/subcontracting.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Subcontract the production of some products
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-lg-6 col-12 o_setting_box" id="quality_control_mrp">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_quality_control" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_quality_control"/>
-                                    <div class="text-muted">
-                                        Add quality checks to your work orders
-                                    </div>
-                                    <div class="row mt-2" attrs="{'invisible': [('module_quality_control','=',False)]}">
-                                        <field name="module_quality_control_worksheet" widget="upgrade_boolean" class="col-lg-1 ml16 mr0"/>
-                                        <div class="col ps-0">
-                                            <label for="module_quality_control_worksheet"/>
-                                            <div class="text-muted">
-                                                Create customizable worksheets for your quality checks
-                                            </div>
+                                <div id="workorder_settings_dependencies" class="row mt-2" attrs="{'invisible': [('group_mrp_routings','=',False)]}">
+                                    <field name="group_mrp_workorder_dependencies" class="col-lg-1 mr0"/>
+                                    <div class="col ps-0">
+                                        <label for="group_mrp_workorder_dependencies"/>
+                                        <div class="text-muted">
+                                            Set the order that work orders should be processed in. Activate the feature within each BoM's Miscellaneous tab
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-lg-6 col-12 o_setting_box" id="mrp_lock">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_unlocked_by_default"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_unlocked_by_default"/>
-                                    <div class="text-muted">
-                                        Allow manufacturing users to modify quantities to consume, without the need for prior approval
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-lg-6 col-12 o_setting_box" id="mrp_byproduct" title="Add by-products to bills of materials. This can be used to get several finished products as well. Without this option you only do: A + B = C. With the option: A + B = C + D.">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_mrp_byproducts"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_mrp_byproducts"/>
-                                    <div class="text-muted">
-                                        Produce residual products (A + B -> C + D)
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="mrp_reception_report">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_mrp_reception_report"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_mrp_reception_report"/>
-                                    <div class="text-muted">
-                                        View and allocate manufactured quantities
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Planning</h2>
-                        <div class="row mt16 o_settings_container">
-                            <div class="col-lg-6 col-12 o_setting_box" id="mrp_mps" title="Using a MPS report to schedule your reordering and manufacturing operations is useful if you have long lead time and if you produce based on sales forecasts.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_mrp_mps" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_mrp_mps"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/manufacturing/management/use_mps.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Plan manufacturing or purchase orders based on forecasts
-                                    </div>
-                                    <div class="content-group" id="content_mrp_mps"/>
-                                </div>
-                            </div>
-                            <div class="col-lg-6 col-12 o_setting_box" id="security_lead_time">
-                                <div class="o_setting_left_pane">
-                                    <field name="use_manufacturing_lead"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Security Lead Time" for="use_manufacturing_lead"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Documentation" class="me-2 o_doc_link" target="_blank"></a>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Schedule manufacturing orders earlier to avoid delays
-                                     </div>
-                                     <div class="content-group" attrs="{'invisible': [('use_manufacturing_lead','=',False)]}">
-                                        <div class="mt16" >
-                                            <field name="manufacturing_lead" class="oe_inline"/> days
+                            </setting>
+                            <setting help="Subcontract the production of some products" documentation="/applications/inventory_and_mrp/manufacturing/management/subcontracting.html">
+                                <field name="module_mrp_subcontracting"/>
+                            </setting>
+                            <setting id="quality_control_mrp" help="Add quality checks to your work orders">
+                                <field name="module_quality_control" widget="upgrade_boolean"/>
+                                <div class="row mt-2" attrs="{'invisible': [('module_quality_control','=',False)]}">
+                                    <field name="module_quality_control_worksheet" widget="upgrade_boolean" class="col-lg-1 ml16 mr0"/>
+                                    <div class="col ps-0">
+                                        <label for="module_quality_control_worksheet"/>
+                                        <div class="text-muted">
+                                            Create customizable worksheets for your quality checks
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                            <setting help="Allow manufacturing users to modify quantities to consume, without the need for prior approval" id="mrp_lock">
+                                <field name="group_unlocked_by_default"/>
+                            </setting>
+                            <setting id="mrp_byproduct" help="Produce residual products (A + B -> C + D)" title="Add by-products to bills of materials. This can be used to get several finished products as well. Without this option you only do: A + B = C. With the option: A + B = C + D.">
+                                <field name="group_mrp_byproducts"/>
+                            </setting>
+                            <setting id="mrp_reception_report" help="View and allocate manufactured quantities">
+                                <field name="group_mrp_reception_report"/>
+                            </setting>
+                        </block>
+                        <block title="Planning">
+                            <setting id="mrp_mps" help="Plan manufacturing or purchase orders based on forecasts" documentation="/applications/inventory_and_mrp/manufacturing/management/use_mps.html" title="Using a MPS report to schedule your reordering and manufacturing operations is useful if you have long lead time and if you produce based on sales forecasts.">
+                                <field name="module_mrp_mps" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="security_lead_time" string="Security Lead Time" company_dependent="1" help="Schedule manufacturing orders earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html">
+                                <field name="use_manufacturing_lead"/>
+                                <div class="content-group" attrs="{'invisible': [('use_manufacturing_lead','=',False)]}">
+                                    <div class="mt16" >
+                                        <field name="manufacturing_lead" class="oe_inline"/> days
+                                    </div>
+                                </div>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/partner_autocomplete/views/res_config_settings_views.xml
+++ b/addons/partner_autocomplete/views/res_config_settings_views.xml
@@ -5,9 +5,9 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="partner_autocomplete_settings" position="inside">
+            <setting id="partner_autocomplete" position="inside">
                 <widget name="iap_buy_more_credits" service_name="partner_autocomplete" hide_service="1"/>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="priority" eval="95"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
+            <xpath expr="//form" position="inside">
                 <t groups="point_of_sale.group_pos_manager">
                     <field name="pos_selectable_categ_ids" invisible="1"/>
                     <field name="pos_has_active_session" invisible="1"/>
@@ -18,20 +18,11 @@
                     <field name="group_cash_rounding" invisible="1"/>
                 </t>
 
-                <div class="app_settings_block" data-string="Point of sale" string="Point of Sale" data-key="point_of_sale" groups="point_of_sale.group_pos_manager">
-                    <div class="app_settings_header pt-1 pb-1 bg-warning bg-opacity-25">
-                        <div class="col-xs-12 col-md-6 ms-0 o_setting_box">
-                            <div class="o_setting_right_pane border-start-0 ms-0 ps-0">
-                                <div class="content-group">
-                                    <div class="row flex-row flex-nowrap mt8 align-items-center">
-                                        <label class="col text-nowrap ml8 flex-nowrap" string="Point of Sale" for="pos_config_id"/>
-                                        <field name="pos_config_id" class="col" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this point of sale."/>
-                                        <button name="action_pos_config_create_new" type="object" string="+ New Shop" class="col btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <app data-string="Point of sale" string="Point of Sale" name="point_of_sale" groups="point_of_sale.group_pos_manager">
+                    <setting type="header" string="Point of Sale">
+                        <field name="pos_config_id" class="col" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this point of sale."/>
+                        <button name="action_pos_config_create_new" type="object" string="+ New Shop" class="col btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
+                    </setting>
 
                     <div class="o_view_nocontent" attrs="{'invisible': [('pos_config_id', '!=', False)]}">
                         <div class="o_nocontent_help">
@@ -41,690 +32,361 @@
                     </div>
 
                     <div attrs="{'invisible': [('pos_config_id', '=', False)]}">
-                        <h2 name="pos_interface">PoS Interface</h2>
-                        <div class="row mt16 o_settings_container" id="pos_interface_section">
-                            <div class="o_setting_box">
-                                <!-- Wrap the warnings in an o_setting_box so that it doesn't show in the search. -->
-                                <div class="o_notification_alert alert alert-warning" attrs="{'invisible':[('pos_has_active_session','=', False)]}" role="alert">
-                                    A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
-                                    <button class="btn-link" style="padding:0" name="pos_open_ui" type="object" context="{'pos_config_id': pos_config_id}">Click here to close the session</button>
-                                </div>
-                                <div class="o_notification_alert alert alert-warning" attrs="{'invisible': [('pos_company_has_template','=',True)]}" role="alert">
-                                    There is no Chart of Accounts configured on the company. Please go to the invoicing settings to install a Chart of Accounts.
-                                </div>
+                        <block title="PoS Interface" id="pos_interface_section">
+                            <!-- Wrap the warnings in an o_setting_box so that it doesn't show in the search. -->
+                            <div class="o_notification_alert alert alert-warning" attrs="{'invisible':[('pos_has_active_session','=', False)]}" role="alert">
+                                A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
+                                <button class="btn-link" style="padding:0" name="pos_open_ui" type="object" context="{'pos_config_id': pos_config_id}">Click here to close the session</button>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_module_pos_restaurant" attrs="{'readonly': [('pos_has_active_session', '=', True)]}"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_module_pos_restaurant"/>
-                                    <div class="content-group" id="warning_text_pos_restaurant" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                                        <div class="text-warning mt16 mb4">
-                                            Save this page and come back here to set up the feature.
-                                        </div>
+                            <div class="o_notification_alert alert alert-warning" attrs="{'invisible': [('pos_company_has_template','=',True)]}" role="alert">
+                                There is no Chart of Accounts configured on the company. Please go to the invoicing settings to install a Chart of Accounts.
+                            </div>
+                            <setting>
+                                <field name="pos_module_pos_restaurant" attrs="{'readonly': [('pos_has_active_session', '=', True)]}"/>
+                                <div class="content-group" id="warning_text_pos_restaurant" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                                    <div class="text-warning mt16 mb4">
+                                        Save this page and come back here to set up the feature.
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_start_category"/>
+                            </setting>
+                            <setting help="Start selling from a default product category">
+                                <field name="pos_start_category"/>
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_start_category', '=', False)]}">
+                                    <field name="pos_iface_start_categ_id" domain="[('id', 'in', pos_selectable_categ_ids)]"/>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_start_category"/>
-                                    <div class="text-muted">
-                                        Start selling from a default product category
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_start_category', '=', False)]}">
-                                        <field name="pos_iface_start_categ_id" domain="[('id', 'in', pos_selectable_categ_ids)]"/>
-                                    </div>
-                                </div>
-                            </div>
+                            </setting>
 
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                title="Employees can scan their badge or enter a PIN to log in to a PoS session. These credentials are configurable in the *HR Settings* tab of the employee form.">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_module_pos_hr" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Multi Employees per Session</span>
-                                    <div class="text-muted">
-                                        Allow to log and switch between selected Employees
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_module_pos_hr','=',False)]}">
-                                        <div class="text-warning" id="warning_text_employees">
-                                            Save this page and come back here to set up the feature.
-                                        </div>
+                            <setting title="Employees can scan their badge or enter a PIN to log in to a PoS session. These credentials are configurable in the *HR Settings* tab of the employee form." string="Multi Employees per Session" help="Allow to log and switch between selected Employees">
+                                <field name="pos_module_pos_hr" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_module_pos_hr','=',False)]}">
+                                    <div class="text-warning" id="warning_text_employees">
+                                        Save this page and come back here to set up the feature.
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_limit_categories" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                            </setting>
+                            <setting help="Pick which product categories are available">
+                                <field name="pos_limit_categories" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_limit_categories', '=', False)]}">
+                                    <field name="pos_iface_available_categ_ids" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_limit_categories"/>
-                                    <div class="text-muted">
-                                        Pick which product categories are available
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_limit_categories', '=', False)]}">
-                                        <field name="pos_iface_available_categ_ids" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_limit_categories', '=', False)]}">
-                                        <button name="%(product_pos_category_action)d" icon="fa-arrow-right" type="action" string="PoS Product Categories" class="btn-link"/>
-                                    </div>
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_limit_categories', '=', False)]}">
+                                    <button name="%(product_pos_category_action)d" icon="fa-arrow-right" type="action" string="PoS Product Categories" class="btn-link"/>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_iface_big_scrollbars"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_iface_big_scrollbars"/>
-                                    <div class="text-muted">
-                                        Improve navigation for imprecise industrial touchscreens
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_is_margins_costs_accessible_to_every_user"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_is_margins_costs_accessible_to_every_user" string="Margins &amp; Costs"/>
-                                    <div class="text-muted">
-                                        Show margins &amp; costs on product information
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </setting>
+                            <setting help="Improve navigation for imprecise industrial touchscreens">
+                                <field name="pos_iface_big_scrollbars"/>
+                            </setting>
+                            <setting string="Margins &amp; Costs" help="Show margins &amp; costs on product information">
+                                <field name="pos_is_margins_costs_accessible_to_every_user"/>
+                            </setting>
+                        </block>
 
-                        <h2>Accounting</h2>
-                        <div class="row mt16 o_settings_container" id="pos_accounting_section">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="default_sales_tax_setting"
-                                title="This tax is applied to any new product created in the catalog.">
-                                <div class="o_setting_right_pane">
+                        <block title="Accounting" id="pos_accounting_section">
+                            <setting id="default_sales_tax_setting" title="This tax is applied to any new product created in the catalog.">
+                                <label string="Default Sales Tax" for="sale_tax_id"/>
+                                <i class="fa fa-info-circle me-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
+                                <div class="text-muted">
+                                    Default sales tax for products
+                                </div>
+                                <div class="content-group mt16">
+                                    <field name="sale_tax_id" colspan="4" nolabel="1" domain="[('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company_id)]"/>
+                                </div>
+                                <div class="mt8">
+                                    <button name="%(account.action_tax_form)d" icon="fa-arrow-right" type="action" string="Taxes" class="btn-link"/>
+                                </div>
+                            </setting>
+                            <setting groups="account.group_account_readonly">
+                                <label string="Default Temporary Account" for="account_default_pos_receivable_account_id"/>
+                                <i class="fa fa-info-circle me-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
+                                <div class="text-muted">
+                                    Intermediary account used for unidentified customers.
+                                </div>
+                                <field name="account_default_pos_receivable_account_id" colspan="4" nolabel="1" domain="[('reconcile', '=', True), ('account_type', '=', 'asset_receivable'), ('company_id', '=', company_id)]"/>
+                            </setting>
+                            <setting title="Choose a specific fiscal position at the order depending on the kind of customer (tax exempt, onsite vs. takeaway, etc.)." string="Flexible Taxes" help="Use fiscal positions to get different taxes by order">
+                                <field name="pos_tax_regime_selection"/>
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_tax_regime_selection', '=', False)]}">
+                                    <div class="row">
+                                        <label string="Default" for="pos_default_fiscal_position_id" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_default_fiscal_position_id" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]"/>
+                                    </div>
+                                    <div class="row">
+                                        <label string="Allowed" for="pos_fiscal_position_ids" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_fiscal_position_ids" widget="many2many_tags" options="{'no_create': True}" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]"/>
+                                    </div>
                                     <div>
-                                        <label string="Default Sales Tax" for="sale_tax_id"/>
-                                        <i class="fa fa-info-circle me-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
-                                        <div class="text-muted">
-                                            Default sales tax for products
-                                        </div>
-                                        <div class="content-group mt16">
-                                            <field name="sale_tax_id" colspan="4" nolabel="1" domain="[('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company_id)]"/>
-                                        </div>
+                                        <button name="%(account.action_account_fiscal_position_form)d" icon="fa-arrow-right" type="action" string="Fiscal Positions" class="btn-link"/>
+                                    </div>
+                                </div>
+                            </setting>
+                            <setting string="Default Journals" help="Default journals for orders and invoices">
+                                <div class="content-group mt16">
+                                    <div class="row" title="Whenever you close a session, one entry is generated in the following accounting journal for all the orders not invoiced. Invoices are recorded in accounting separately.">
+                                        <label string="Orders" for="pos_journal_id" class="col-lg-3 o_light_label" options="{'no_open': True, 'no_create': True}"/>
+                                        <field name="pos_journal_id" domain="[('company_id', '=', company_id), ('type', 'in', ('general', 'sale'))]" context="{'default_company_id': company_id, 'default_type': 'general'}" attrs="{'required': [('pos_company_has_template', '=', True)]}"/>
+                                    </div>
+                                    <div class="row">
+                                        <label string="Invoices" for="pos_invoice_journal_id" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_invoice_journal_id"
+                                            domain="[('company_id', '=', company_id), ('type', '=', 'sale')]"
+                                            attrs="{'required': [('pos_company_has_template', '=', True)]}"
+                                            context="{'default_company_id': company_id, 'default_type': 'sale'}"/>
+                                    </div>
+                                </div>
+                            </setting>
+                        </block>
+
+                        <block title="Pricing" id="pos_pricing_section">
+                            <setting id="multiple_prices_setting" string="Flexible Pricelists" help="Set multiple prices per product, automated discounts, etc.">
+                                <field name="pos_use_pricelist" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                                <div class="content-group" attrs="{'invisible': [('pos_use_pricelist' ,'=', False)]}">
+                                    <div class="mt16">
+                                        <field name="group_sale_pricelist" invisible="1"/>
+                                        <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
+                                    </div>
+                                    <div class="row mt16">
+                                        <label string="Available" for="pos_available_pricelist_ids" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_available_pricelist_ids" widget="many2many_tags" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                                    </div>
+                                    <div class="row mt16" attrs="{'invisible': [('is_default_pricelist_displayed', '=', False)]}">
+                                        <label string="Default" for="pos_pricelist_id" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_pricelist_id" domain="[('id', 'in', pos_allowed_pricelist_ids)]" options="{'no_create': True}"/>
                                     </div>
                                     <div class="mt8">
-                                        <button name="%(account.action_tax_form)d" icon="fa-arrow-right" type="action" string="Taxes" class="btn-link"/>
+                                        <button name="%(product.product_pricelist_action2)d" icon="fa-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                groups="account.group_account_readonly">
-                                <div class="o_setting_right_pane">
+                            </setting>
+                            <setting class="price_control" title="Only users with Manager access rights for PoS app can modify the product prices on orders." string="Price Control" help="Restrict price modification to managers">
+                                <field name="pos_restrict_price_control"/>
+                            </setting>
+                            <setting id="product_prices" string="Product Prices" help="Product prices on receipts">
+                                <field name="pos_iface_tax_included" class="o_light_label" widget="radio"/>
+                                <div class="content-group">
+                                    <a attrs="{'invisible': [('pos_iface_tax_included', '!=', 'total')]}"
+                                        href="https://www.odoo.com/documentation/master/applications/finance/accounting/taxation/taxes/B2B_B2C.html"
+                                        target="_blank" class="oe-link"><i class="fa fa-fw fa-arrow-right"/>How to manage tax-included prices</a>
+                                </div>
+                            </setting>
+                            <setting help="Allow cashiers to set a discount per line">
+                                <field name="pos_manual_discount"/>
+                            </setting>
+                            <setting help="Adds a button to set a global discount">
+                                <field name="pos_module_pos_discount" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                                <div class="content-group mt16" attrs="{'invisible':[('pos_module_pos_discount','=',False)]}">
+                                    <div class="text-warning mb4" id="warning_text_pos_discount" >
+                                        Save this page and come back here to set up the feature.
+                                    </div>
+                                </div>
+                            </setting>
+                            <setting id="pos-loyalty" title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products." string="Promotions, Coupons, Gift Card &amp; Loyalty Program" help="Manage promotion that will grant customers discounts or gifts">
+                                <field name="module_loyalty" nolabel="1"/>
+                            </setting>
+                        </block>
+
+                        <block title="Bills &amp; Receipts" id="pos_bills_and_receipts_section">
+                            <setting help="Add a custom message to header and footer">
+                                <field name="pos_is_header_or_footer"/>
+                                <div class="content-group mt16" attrs="{'invisible' : [('pos_is_header_or_footer', '=', False)]}">
                                     <div>
-                                        <label string="Default Temporary Account" for="account_default_pos_receivable_account_id"/>
-                                        <i class="fa fa-info-circle me-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
-                                        <div class="text-muted">
-                                            Intermediary account used for unidentified customers.
-                                        </div>
-                                        <div class="content-group mt16">
-                                            <field name="account_default_pos_receivable_account_id" colspan="4" nolabel="1" domain="[('reconcile', '=', True), ('account_type', '=', 'asset_receivable'), ('company_id', '=', company_id)]"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" title="Choose a specific fiscal position at the order depending on the kind of customer (tax exempt, onsite vs. takeaway, etc.).">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_tax_regime_selection"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_tax_regime_selection" string="Flexible Taxes"/>
-                                    <div class="text-muted">
-                                        Use fiscal positions to get different taxes by order
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_tax_regime_selection', '=', False)]}">
-                                        <div class="row">
-                                            <label string="Default" for="pos_default_fiscal_position_id" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_default_fiscal_position_id" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Allowed" for="pos_fiscal_position_ids" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_fiscal_position_ids" widget="many2many_tags" options="{'no_create': True}" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]"/>
-                                        </div>
-                                        <div>
-                                            <button name="%(account.action_account_fiscal_position_form)d" icon="fa-arrow-right" type="action" string="Fiscal Positions" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Default Journals</span>
-                                    <div class="text-muted">
-                                        Default journals for orders and invoices
-                                    </div>
-                                    <div class="content-group mt16">
-                                        <div class="row" title="Whenever you close a session, one entry is generated in the following accounting journal for all the orders not invoiced. Invoices are recorded in accounting separately.">
-                                            <label string="Orders" for="pos_journal_id" class="col-lg-3 o_light_label" options="{'no_open': True, 'no_create': True}"/>
-                                            <field name="pos_journal_id" domain="[('company_id', '=', company_id), ('type', 'in', ('general', 'sale'))]" context="{'default_company_id': company_id, 'default_type': 'general'}" attrs="{'required': [('pos_company_has_template', '=', True)]}"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Invoices" for="pos_invoice_journal_id" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_invoice_journal_id"
-                                                domain="[('company_id', '=', company_id), ('type', '=', 'sale')]"
-                                                attrs="{'required': [('pos_company_has_template', '=', True)]}"
-                                                context="{'default_company_id': company_id, 'default_type': 'sale'}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <h2>Pricing</h2>
-                        <div class="row mt16 o_settings_container" id="pos_pricing_section">
-                            <div class="col-12 col-lg-6 o_setting_box" id="multiple_prices_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_use_pricelist" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_use_pricelist" string="Flexible Pricelists" />
-                                    <div class="text-muted">
-                                        Set multiple prices per product, automated discounts, etc.
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('pos_use_pricelist' ,'=', False)]}">
-                                        <div class="mt16">
-                                            <field name="group_sale_pricelist" invisible="1"/>
-                                            <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
-                                        </div>
-                                        <div class="row mt16">
-                                            <label string="Available" for="pos_available_pricelist_ids" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_available_pricelist_ids" widget="many2many_tags" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                                        </div>
-                                        <div class="row mt16" attrs="{'invisible': [('is_default_pricelist_displayed', '=', False)]}">
-                                            <label string="Default" for="pos_pricelist_id" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_pricelist_id" domain="[('id', 'in', pos_allowed_pricelist_ids)]" options="{'no_create': True}"/>
-                                        </div>
-                                        <div class="mt8">
-                                            <button name="%(product.product_pricelist_action2)d" icon="fa-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box price_control" title="Only users with Manager access rights for PoS app can modify the product prices on orders.">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_restrict_price_control"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_restrict_price_control" string="Price Control"/>
-                                    <div class="text-muted">
-                                        Restrict price modification to managers
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-lg-6 o_setting_box" id="product_prices">
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_iface_tax_included" string="Product Prices"/>
-                                    <div class="text-muted">
-                                        Product prices on receipts
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt16">
-                                            <field name="pos_iface_tax_included" class="o_light_label" widget="radio"/>
-                                        </div>
-                                        <a attrs="{'invisible': [('pos_iface_tax_included', '!=', 'total')]}"
-                                            href="https://www.odoo.com/documentation/master/applications/finance/accounting/taxation/taxes/B2B_B2C.html"
-                                            target="_blank" class="oe-link"><i class="fa fa-fw fa-arrow-right"/>How to manage tax-included prices</a>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-lg-6 o_setting_box" >
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_manual_discount"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_manual_discount"/>
-                                    <div class="text-muted">
-                                        Allow cashiers to set a discount per line
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-xs-12 col-lg-6 o_setting_box" >
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_module_pos_discount" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_module_pos_discount"/>
-                                    <div class="text-muted">
-                                        Adds a button to set a global discount
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible':[('pos_module_pos_discount','=',False)]}">
-                                        <div class="text-warning mb4" id="warning_text_pos_discount" >
-                                            Save this page and come back here to set up the feature.
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="pos-loyalty"
-                                title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_loyalty" nolabel="1"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_loyalty" string="Promotions, Coupons, Gift Card &amp; Loyalty Program"/>
-                                    <div class="text-muted" id="loyalty_program_text" >
-                                        Manage promotion that will grant customers discounts or gifts
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <h2>Bills &amp; Receipts</h2>
-                        <div class="row mt16 o_settings_container" id="pos_bills_and_receipts_section">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_is_header_or_footer"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_is_header_or_footer"/>
-                                    <div class="text-muted">
-                                        Add a custom message to header and footer
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible' : [('pos_is_header_or_footer', '=', False)]}">
-                                        <div>
-                                            <label string="Header" for="pos_receipt_header" class="col-lg-2 o_light_label"/>
-                                            <field name="pos_receipt_header" placeholder="e.g. Company Address, Website"/>
-                                        </div>
-                                        <div>
-                                            <label string="Footer" for="pos_receipt_footer" class="col-lg-2 o_light_label"/>
-                                            <field name="pos_receipt_footer" placeholder="e.g. Return Policy, Thanks for shopping with us!"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="auto_printing">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_iface_print_auto"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_iface_print_auto"/>
-                                    <div class="text-muted">
-                                        Print receipts automatically once the payment is registered
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible' : ['|', ('pos_iface_print_auto', '=', False), '&amp;', ('pos_is_posbox', '=', False), ('pos_other_devices', '=', False)]}">
-                                        <div>
-                                            <field name="pos_iface_print_skip_screen" class="oe_inline"/><span class="oe_inline"><b>Skip Preview Screen</b></span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="o_setting_left_pane mt-4">
-                                    <field name="point_of_sale_use_ticket_qr_code"/>
-                                </div>
-                                <div class="o_setting_right_pane mt-4">
-                                    <label for="point_of_sale_use_ticket_qr_code"/>
-                                    <div class="text-muted">
-                                        Print a QR code on the receipt to allow the user to easily request the invoice for an order.
-                                    </div>
-                                </div>
-                            </div>
-                            <div id="order_reference" class="col-12 col-lg-6 o_setting_box" groups="base.group_no_one">
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Order Reference</span>
-                                    <div class="text-muted">
-                                        Generation of your order references
-                                    </div>
-                                    <div class="content-group mt16">
-                                        <field name="pos_sequence_id" readonly="1"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <h2>Payment</h2>
-                        <div class="row mt16 o_settings_container" id="pos_payment_section">
-                            <div class="col-12 col-lg-6 o_setting_box" id="payment_methods_new">
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Payment Methods</span>
-                                    <div class="text-muted">
-                                        Payment methods available
-                                    </div>
-                                    <div class="content-group mt16">
-                                        <field name="pos_payment_method_ids" colspan="4" nolabel="1" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)], 'required': [('pos_company_has_template', '=', True)]}" options="{'no_create': True}" />
+                                        <label string="Header" for="pos_receipt_header" class="col-lg-2 o_light_label"/>
+                                        <field name="pos_receipt_header" placeholder="e.g. Company Address, Website"/>
                                     </div>
                                     <div>
-                                        <button name="%(action_payment_methods_tree)d" icon="fa-arrow-right" type="action" string="Payment Methods" class="btn-link"/>
+                                        <label string="Footer" for="pos_receipt_footer" class="col-lg-2 o_light_label"/>
+                                        <field name="pos_receipt_footer" placeholder="e.g. Return Policy, Thanks for shopping with us!"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_auto_validate_terminal_payment"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_auto_validate_terminal_payment" string="Automatically validate order" />
-                                    <div class="text-muted">
-                                        Automatically validates orders paid with a payment terminal.
+                            </setting>
+                            <setting id="auto_printing" help="Print receipts automatically once the payment is registered">
+                                <field name="pos_iface_print_auto"/>
+                                <div class="content-group mt16" attrs="{'invisible' : ['|', ('pos_iface_print_auto', '=', False), '&amp;', ('pos_is_posbox', '=', False), ('pos_other_devices', '=', False)]}">
+                                    <div>
+                                        <field name="pos_iface_print_skip_screen" class="oe_inline"/><span class="oe_inline"><b>Skip Preview Screen</b></span>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_cash_rounding"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_cash_rounding" string="Cash Rounding" />
-                                    <a href="https://www.odoo.com/documentation/master/applications/sales/point_of_sale/shop/cash_rounding.html"
-                                        title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Define the smallest coinage of the currency used to pay by cash
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_cash_rounding', '=', False)]}">
-                                        <div class="row mt16">
-                                            <label string="Rounding Method" for="pos_rounding_method" class="col-lg-3 o_light_label" />
-                                            <field name="pos_rounding_method" attrs="{'required' : [('pos_cash_rounding', '=', True)]}" domain="[('company_id', '=', company_id)]"/>
-                                        </div>
-                                        <div class="row mt16">
-                                            <label string="Only on cash methods" for="pos_only_round_cash_method" class="col-lg-3 o_light_label" />
-                                            <field name="pos_only_round_cash_method"/>
-                                        </div>
-                                    </div>
-                                    <div class="mt8">
-                                        <button name="%(account.rounding_list_action)d" icon="fa-arrow-right"
-                                                type="action" string="Cash Roundings" class="btn-link"
-                                                attrs="{'invisible': [('group_cash_rounding', '=', False)]}"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_set_maximum_difference" />
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_set_maximum_difference" />
-                                    <div class="text-muted">
-                                        Set a maximum difference allowed between the expected and counted money during the closing of the session
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible': [('pos_set_maximum_difference', '=', False)]}">
-                                        <label for="pos_amount_authorized_diff" string="Authorized Difference" class="fw-normal"/>
-                                        <field name="pos_amount_authorized_diff"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('pos_cash_control', '=', False)]}">
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_default_bill_ids" string="Coins/Bills" />
-                                    <div class="text-muted">
-                                        Set of coins/bills that will be used in opening and closing control
-                                    </div>
-                                    <div class="content-group mt16">
-                                        <field name="pos_default_bill_ids" colspan="4" widget="many2many_tags" options="{'no_create_edit': True}" context="{'default_pos_config_ids':[(6, False, [pos_config_id])]}"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="iface_tipproduct"
-                                title="This product is used as reference on customer receipts.">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_iface_tipproduct" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_iface_tipproduct" string="Tips"/>
-                                    <div class="text-muted">
-                                        Accept customer tips or convert their change to a tip
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('pos_iface_tipproduct', '=', False)]}">
-                                        <div class="mt16" id="tip_product">
-                                            <label string="Tip Product" for="pos_tip_product_id" class="o_light_label"/>
-                                            <field name="pos_tip_product_id"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </setting>
+                            <setting help="Print a QR code on the receipt to allow the user to easily request the invoice for an order.">
+                                <field name="point_of_sale_use_ticket_qr_code"/>
+                            </setting>
+                            <setting id="order_reference" groups="base.group_no_one" string="Order Reference" help="Generation of your order references">
+                                <field name="pos_sequence_id" readonly="1"/>
+                            </setting>
+                        </block>
 
-                        <h2>
-                            Payment Terminals
-                            <i class="fa fa-info-circle me-1" title="Those settings are common to all PoS." pos-data-toggle="tooltip"/>
-                        </h2>
-                        <div class="row mt16 o_settings_container" id="pos_payment_terminals_section">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="adyen_payment_terminal_setting"
-                                title="The transactions are processed by Adyen. Set your Adyen credentials on the related payment method.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_pos_adyen"/>
+                        <block title="Payment" id="pos_payment_section">
+                            <setting id="payment_methods_new" string="Payment Methods" help="Payment methods available">
+                                <field name="pos_payment_method_ids" colspan="4" nolabel="1" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)], 'required': [('pos_company_has_template', '=', True)]}" options="{'no_create': True}" />
+                                <div>
+                                    <button name="%(action_payment_methods_tree)d" icon="fa-arrow-right" type="action" string="Payment Methods" class="btn-link"/>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_pos_adyen" string="Adyen"/>
-                                    <div class="text-muted">
-                                        Accept payments with an Adyen payment terminal
+                            </setting>
+                            <setting string="Automatically validate order" help="Automatically validates orders paid with a payment terminal.">
+                                <field name="pos_auto_validate_terminal_payment"/>
+                            </setting>
+                            <setting string="Cash Rounding" documentation="/applications/sales/point_of_sale/shop/cash_rounding.html" help="Define the smallest coinage of the currency used to pay by cash">
+                                <field name="pos_cash_rounding"/>
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_cash_rounding', '=', False)]}">
+                                    <div class="row mt16">
+                                        <label string="Rounding Method" for="pos_rounding_method" class="col-lg-3 o_light_label" />
+                                        <field name="pos_rounding_method" attrs="{'required' : [('pos_cash_rounding', '=', True)]}" domain="[('company_id', '=', company_id)]"/>
+                                    </div>
+                                    <div class="row mt16">
+                                        <label string="Only on cash methods" for="pos_only_round_cash_method" class="col-lg-3 o_light_label" />
+                                        <field name="pos_only_round_cash_method"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="stripe_payment_terminal_setting"
-                                title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_pos_stripe"/>
+                                <div class="mt8">
+                                    <button name="%(account.rounding_list_action)d" icon="fa-arrow-right"
+                                            type="action" string="Cash Roundings" class="btn-link"
+                                            attrs="{'invisible': [('group_cash_rounding', '=', False)]}"/>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_pos_stripe" string="Stripe"/>
-                                    <div class="text-muted">
-                                        Accept payments with a Stripe payment terminal
+                            </setting>
+                            <setting help="Set a maximum difference allowed between the expected and counted money during the closing of the session">
+                                <field name="pos_set_maximum_difference" />
+                                <div class="content-group mt16" attrs="{'invisible': [('pos_set_maximum_difference', '=', False)]}">
+                                    <label for="pos_amount_authorized_diff" string="Authorized Difference" class="fw-normal"/>
+                                    <field name="pos_amount_authorized_diff"/>
+                                </div>
+                            </setting>
+                            <setting attrs="{'invisible': [('pos_cash_control', '=', False)]}" string="Coins/Bills" help="Set of coins/bills that will be used in opening and closing control">
+                                <field name="pos_default_bill_ids" colspan="4" widget="many2many_tags" options="{'no_create_edit': True}" context="{'default_pos_config_ids':[(6, False, [pos_config_id])]}"/>
+                            </setting>
+                            <setting id="iface_tipproduct" title="This product is used as reference on customer receipts." string="Tips" help="Accept customer tips or convert their change to a tip">
+                                <field name="pos_iface_tipproduct" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                                <div class="content-group" attrs="{'invisible': [('pos_iface_tipproduct', '=', False)]}">
+                                    <div class="mt16" id="tip_product">
+                                        <label string="Tip Product" for="pos_tip_product_id" class="o_light_label"/>
+                                        <field name="pos_tip_product_id"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="vantiv_payment_terminal_setting"
-                                title="The transactions are processed by Vantiv. Set your Vantiv credentials on the related payment method.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_pos_mercury"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_pos_mercury" string="Vantiv (US &amp; Canada)"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/sales/point_of_sale/payment/vantiv.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Accept payments with a Vantiv payment terminal
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('module_pos_mercury', '=', False)]}">
-                                        <div class="mt16" id="btn_use_pos_mercury">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" title="The transactions are processed by Six. Set the IP address of the terminal on the related payment method.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_pos_six"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_pos_six" string="Six"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/sales/point_of_sale/payment/six.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Accept payments with a Six payment terminal
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </setting>
+                        </block>
 
-                        <h2>Connected Devices</h2>
-                        <div class="row mt16 o_settings_container" id="pos_connected_devices_section">
-                            <div class="col-12 col-lg-6 o_setting_box" id="pos_other_devices">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_other_devices"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_other_devices" string="ePos Printer"/>
-                                    <div class="text-muted mb16">
-                                        Connect device to your PoS without an IoT Box
+                        <block title="Payment Terminals" help="Those settings are common to all PoS." id="pos_payment_terminals_section">
+                            <setting id="adyen_payment_terminal_setting" title="The transactions are processed by Adyen. Set your Adyen credentials on the related payment method." string="Adyen" help="Accept payments with an Adyen payment terminal">
+                                <field name="module_pos_adyen"/>
+                            </setting>
+                            <setting id="stripe_payment_terminal_setting" title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method." string="Stripe" help="Accept payments with a Stripe payment terminal">
+                                <field name="module_pos_stripe"/>
+                            </setting>
+                            <setting id="vantiv_payment_terminal_setting" title="The transactions are processed by Vantiv. Set your Vantiv credentials on the related payment method." string="Vantiv (US &amp; Canada)" documentation="/applications/sales/point_of_sale/payment/vantiv.html" help="Accept payments with a Vantiv payment terminal">
+                                <field name="module_pos_mercury"/>
+                                <div class="content-group" attrs="{'invisible': [('module_pos_mercury', '=', False)]}">
+                                    <div class="mt16" id="btn_use_pos_mercury">
                                     </div>
                                 </div>
-                            </div>
-                            <div id="customer_display" class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_iface_customer_facing_display_local"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_iface_customer_facing_display_local" string="Customer Display"/>
-                                    <div class="text-muted">
-                                        Show checkout to customers through a second display
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_is_posbox"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_is_posbox" string="IoT Box"/>
-                                    <div class="text-muted mb16">
-                                        Connect devices using an IoT Box
-                                    </div>
-                                    <div class="content-group pos_iot_config" attrs="{'invisible' : [('pos_is_posbox', '=', False)]}">
-                                        <div class="row">
-                                            <label string="IoT Box IP Address" for="pos_proxy_ip" class="col-lg-4 o_light_label"/>
-                                            <field name="pos_proxy_ip"/>
-                                        </div>
-                                        <div class="row iot_barcode_scanner">
-                                            <label string="Barcode Scanner/Card Reader" for="pos_iface_scan_via_proxy" class="col-lg-4 o_light_label"/>
-                                            <field name="pos_iface_scan_via_proxy"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Electronic Scale" for="pos_iface_electronic_scale" class="col-lg-4 o_light_label"/>
-                                            <field name="pos_iface_electronic_scale"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Receipt Printer" for="pos_iface_print_via_proxy" class="col-lg-4 o_light_label"/>
-                                            <field name="pos_iface_print_via_proxy"/>
-                                        </div>
-                                        <div class="row" attrs="{'invisible': [('pos_iface_print_via_proxy', '=', False)]}">
-                                            <label string="Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-4 o_light_label"/>
-                                            <field name="pos_iface_cashdrawer"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Customer Display" for="pos_iface_customer_facing_display_via_proxy" class="col-lg-4 o_light_label"/>
-                                            <field name="pos_iface_customer_facing_display_via_proxy"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </setting>
+                            <setting title="The transactions are processed by Six. Set the IP address of the terminal on the related payment method." string="Six" documentation="/applications/sales/point_of_sale/payment/six.html" help="Accept payments with a Six payment terminal">
+                                <field name="module_pos_six"/>
+                            </setting>
+                        </block>
 
-                        <h2>Inventory</h2>
-                        <div class="row mt16 o_settings_container" id="pos_inventory_section">
-                            <div class="col-12 col-lg-6 o_setting_box" title="Operation types show up in the Inventory dashboard.">
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_picking_type_id" string="Operation Type"/>
-                                    <div class="text-muted">
-                                        Used to record product pickings. Products are consumed from its default source location.
+                        <block title="Connected Devices" id="pos_connected_devices_section">
+                            <setting id="pos_other_devices" string="ePos Printer" help="Connect device to your PoS without an IoT Box">
+                                <field name="pos_other_devices"/>
+                            </setting>
+                            <setting id="customer_display" string="Customer Display" help="Show checkout to customers through a second display">
+                                <field name="pos_iface_customer_facing_display_local"/>
+                            </setting>
+                            <setting string="IoT Box" help="Connect devices using an IoT Box">
+                                <field name="pos_is_posbox"/>
+                                <div class="content-group pos_iot_config" attrs="{'invisible' : [('pos_is_posbox', '=', False)]}">
+                                    <div class="row">
+                                        <label string="IoT Box IP Address" for="pos_proxy_ip" class="col-lg-4 o_light_label"/>
+                                        <field name="pos_proxy_ip"/>
                                     </div>
-                                    <div class="content-group mt16">
-                                        <field name="pos_picking_type_id" domain="[('company_id', '=', company_id)]" attrs="{'required': [('pos_config_id', '!=', False)]}"/>
+                                    <div class="row iot_barcode_scanner">
+                                        <label string="Barcode Scanner/Card Reader" for="pos_iface_scan_via_proxy" class="col-lg-4 o_light_label"/>
+                                        <field name="pos_iface_scan_via_proxy"/>
+                                    </div>
+                                    <div class="row">
+                                        <label string="Electronic Scale" for="pos_iface_electronic_scale" class="col-lg-4 o_light_label"/>
+                                        <field name="pos_iface_electronic_scale"/>
+                                    </div>
+                                    <div class="row">
+                                        <label string="Receipt Printer" for="pos_iface_print_via_proxy" class="col-lg-4 o_light_label"/>
+                                        <field name="pos_iface_print_via_proxy"/>
+                                    </div>
+                                    <div class="row" attrs="{'invisible': [('pos_iface_print_via_proxy', '=', False)]}">
+                                        <label string="Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-4 o_light_label"/>
+                                        <field name="pos_iface_cashdrawer"/>
+                                    </div>
+                                    <div class="row">
+                                        <label string="Customer Display" for="pos_iface_customer_facing_display_via_proxy" class="col-lg-4 o_light_label"/>
+                                        <field name="pos_iface_customer_facing_display_via_proxy"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
+                            </setting>
+                        </block>
+
+                        <block title="Inventory" id="pos_inventory_section">
+                            <setting title="Operation types show up in the Inventory dashboard." string="Operation Type" help="Used to record product pickings. Products are consumed from its default source location.">
+                                <field name="pos_picking_type_id" domain="[('company_id', '=', company_id)]" attrs="{'required': [('pos_config_id', '!=', False)]}"/>
+                            </setting>
+                            <setting string="Allow Ship Later" help="Sell products and deliver them later.">
                                 <field name="pos_ship_later"/>
-                            </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_ship_later" string="Allow Ship Later"/>
-                                    <div class="text-muted">
-                                        Sell products and deliver them later.
-                                    </div>
-                                    <div class="mt16" attrs="{'invisible' : [('pos_ship_later', '=', False)]}">
-                                        <div>
-                                            <label for="pos_warehouse_id" string="Warehouse" class="fw-normal"/>
-                                            <field name="pos_warehouse_id" attrs="{'required': [('pos_ship_later', '=', True)]}"/>
-                                        </div>
-                                        <div groups="stock.group_adv_location">
-                                            <label for="pos_route_id" string="Specific route" class="fw-normal"/>
-                                            <field name="pos_route_id"/>
-                                        </div>
-                                        <div>
-                                            <label for="pos_picking_policy" class="fw-normal"/>
-                                            <field name="pos_picking_policy" attrs="{'required': [('pos_ship_later', '=', True)]}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div id="barcode_scanner" class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Barcodes</span>
-                                    <i class="fa fa-info-circle me-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
-                                    <div class="text-muted">
-                                        Use barcodes to scan products, customer cards, etc.
-                                    </div>
-                                    <div class="content-group mt16 row">
-                                        <label for="barcode_nomenclature_id" string="Barcode Nomenclature" class="col-lg-3 o_light_label"/>
-                                        <field name="barcode_nomenclature_id"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <h2 groups="base.group_no_one">Technical</h2>
-                        <div class="row mt16 o_settings_container" id="pos_technical_section" groups="base.group_no_one">
-                            <div class="col-12 col-lg-6 o_setting_box" id="update_quantities_stock_setting" groups="base.group_no_one">
-                                <div class="o_setting_right_pane">
+                                <div class="mt16" attrs="{'invisible' : [('pos_ship_later', '=', False)]}">
                                     <div>
-                                        <label string="Inventory Management" for="update_stock_quantities"/>
-                                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                        <div class="text-muted">
-                                            Update quantities in stock
-                                        </div>
-                                        <div class="content-group mt16 o_light_label">
-                                            <field name="update_stock_quantities" colspan="4" nolabel="1" widget="radio"/>
-                                        </div>
+                                        <label for="pos_warehouse_id" string="Warehouse" class="fw-normal"/>
+                                        <field name="pos_warehouse_id" attrs="{'required': [('pos_ship_later', '=', True)]}"/>
+                                    </div>
+                                    <div groups="stock.group_adv_location">
+                                        <label for="pos_route_id" string="Specific route" class="fw-normal"/>
+                                        <field name="pos_route_id"/>
+                                    </div>
+                                    <div>
+                                        <label for="pos_picking_policy" class="fw-normal"/>
+                                        <field name="pos_picking_policy" attrs="{'required': [('pos_ship_later', '=', True)]}"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_limited_products_loading"/>
+                            </setting>
+                            <setting id="barcode_scanner">
+                                <span class="o_form_label">Barcodes</span>
+                                <i class="fa fa-info-circle me-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
+                                <div class="text-muted">
+                                    Use barcodes to scan products, customer cards, etc.
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_limited_products_loading" string="Limited Products Loading"/>
-                                    <div class="text-muted">
-                                        Only load most common products at the opening of the PoS.
-                                    </div>
-                                    <div class="content-group mt16" attrs="{'invisible' : [('pos_limited_products_loading', '=', False)]}">
-                                        <div class="row">
-                                            <label for="pos_limited_products_amount" string="Number of Products Loaded" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_limited_products_amount"  class="oe_inline"/>
-                                        </div>
-                                        <div class="mt8">
-                                            <field name="pos_product_load_background" class="oe_inline" />
-                                            <label for="pos_product_load_background" string="Load all remaining products in the background" />
-                                        </div>
-                                    </div>
+                                <div class="content-group mt16 row">
+                                    <label for="barcode_nomenclature_id" string="Barcode Nomenclature" class="col-lg-3 o_light_label"/>
+                                    <field name="barcode_nomenclature_id"/>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="pos_limited_partners_loading"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="pos_limited_partners_loading" string="Limited Partners Loading"/>
-                                    <div class="text-muted">
-                                        Only load a limited number of customers at the opening of the PoS.
+                            </setting>
+                        </block>
+
+                        <block title="Technical" id="pos_technical_section" groups="base.group_no_one">
+                            <setting id="update_quantities_stock_setting" groups="base.group_no_one" string="Inventory Management" company_dependent="1" help="Update quantities in stock">
+                                <field name="update_stock_quantities" colspan="4" widget="radio"/>
+                            </setting>
+                            <setting string="Limited Products Loading" help="Only load most common products at the opening of the PoS.">
+                                <field name="pos_limited_products_loading"/>
+                                <div class="content-group mt16" attrs="{'invisible' : [('pos_limited_products_loading', '=', False)]}">
+                                    <div class="row">
+                                        <label for="pos_limited_products_amount" string="Number of Products Loaded" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_limited_products_amount"  class="oe_inline"/>
                                     </div>
-                                    <div class="content-group mt16" attrs="{'invisible' : [('pos_limited_partners_loading', '=', False)]}">
-                                        <div class="row">
-                                            <label for="pos_limited_partners_amount" string="Number of Partners Loaded" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_limited_partners_amount" class="oe_inline"/>
-                                        </div>
-                                        <div class="mt8">
-                                            <field name="pos_partner_load_background" class="oe_inline" />
-                                            <label for="pos_partner_load_background" string="Load all remaining partners in the background" />
-                                        </div>
+                                    <div class="mt8">
+                                        <field name="pos_product_load_background" class="oe_inline" />
+                                        <label for="pos_product_load_background" string="Load all remaining products in the background" />
                                     </div>
                                 </div>
-                            </div>
-                        </div>
+                            </setting>
+                            <setting string="Limited Partners Loading" help="Only load a limited number of customers at the opening of the PoS.">
+                                <field name="pos_limited_partners_loading"/>
+                                <div class="content-group mt16" attrs="{'invisible' : [('pos_limited_partners_loading', '=', False)]}">
+                                    <div class="row">
+                                        <label for="pos_limited_partners_amount" string="Number of Partners Loaded" class="col-lg-3 o_light_label"/>
+                                        <field name="pos_limited_partners_amount" class="oe_inline"/>
+                                    </div>
+                                    <div class="mt8">
+                                        <field name="pos_partner_load_background" class="oe_inline" />
+                                        <label for="pos_partner_load_background" string="Load all remaining partners in the background" />
+                                    </div>
+                                </div>
+                            </setting>
+                        </block>
                     </div>
-                </div>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/portal/views/res_config_settings_views.xml
+++ b/addons/portal/views/res_config_settings_views.xml
@@ -8,16 +8,11 @@
             <field name="priority" eval="40"/>
             <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//button[@name=%(base.action_apikeys_admin)d]//ancestor::div[hasclass('o_setting_box')]" position="inside">
+                <xpath expr="//button[@name=%(base.action_apikeys_admin)d]//ancestor::setting" position="inside">
                     <div groups="base.group_no_one">
-                        <div class="o_setting_left_pane">
+                        <div class="mt16 content-group">
                             <field name="portal_allow_api_keys"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="portal_allow_api_keys"/>
-                            <div class="text-muted">
-                                Let your customers create developer API keys
-                            </div>
+                            <label string="Customers can generate API Keys" for="portal_allow_api_keys"/>
                         </div>
                     </div>
                 </xpath>

--- a/addons/pos_epson_printer/views/res_config_settings_views.xml
+++ b/addons/pos_epson_printer/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='pos_other_devices']//div[hasclass('o_setting_right_pane')]" position="inside">
+            <xpath expr="//setting[@id='pos_other_devices']" position="inside">
                 <div class="content-group" attrs="{'invisible' : [('pos_other_devices', '=', False)]}">
                     <field name="pos_epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
                     <div class="row" attrs="{'invisible': [('pos_epson_printer_ip', 'in', [False, ''])]}">

--- a/addons/pos_loyalty/views/res_config_settings_view.xml
+++ b/addons/pos_loyalty/views/res_config_settings_view.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='loyalty_program_text']" position="after">
+            <xpath expr="//setting[@id='pos-loyalty']" position="inside">
                 <div class="content-group" attrs="{'invisible': [('module_loyalty', '=', False)]}">
                     <div class="mt16 o_light_label">
                         <field name="pos_gift_card_settings" colspan="4" nolabel="1" widget="radio"/>

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -6,94 +6,43 @@
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <div id="warning_text_pos_restaurant" position="replace"/>
-            <div id="pos_interface_section" position="after">
-                <h2 class="mt16" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">Restaurant &amp; Bar</h2>
-                <div class="row mt16 o_settings_container" id="restaurant_section" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                    <div class="col-12 col-lg-6 o_setting_box"
-                         id="is_table_management"
-                         attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="pos_is_table_management" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="pos_is_table_management" string="Floors &amp; Tables Map"/>
-                            <div class="text-muted">
-                                Design floors and assign orders to tables
+            <block id="pos_interface_section" position="after">
+                <block title="Restaurant &amp; Bar" id="restaurant_section" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                    <setting string="Floors &amp; Tables Map" help="Design floors and assign orders to tables" id="is_table_management" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                        <field name="pos_is_table_management" attrs="{'readonly': [('pos_has_active_session','=', True)]}"/>
+                        <div class="content-group" attrs="{'invisible': [('pos_is_table_management','=',False)]}">
+                            <div class="mt16">
+                                <label string="Floors" for="pos_floor_ids" class="o_light_label"/>
+                                <field name="pos_floor_ids" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)]}" />
                             </div>
-                            <div class="content-group" attrs="{'invisible': [('pos_is_table_management','=',False)]}">
-                                <div class="mt16">
-                                    <label string="Floors" for="pos_floor_ids" class="o_light_label"/>
-                                    <field name="pos_floor_ids" widget="many2many_tags" attrs="{'readonly': [('pos_has_active_session','=', True)]}" />
-                                </div>
-                                <div>
-                                    <button name="%(pos_restaurant.action_restaurant_floor_form)d" icon="fa-arrow-right" type="action" string="Floors" class="btn-link"/>
-                                </div>
+                            <div>
+                                <button name="%(pos_restaurant.action_restaurant_floor_form)d" icon="fa-arrow-right" type="action" string="Floors" class="btn-link"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box"
-                         id="iface_orderline_notes"
-                         attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="pos_iface_orderline_notes"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="pos_iface_orderline_notes" string="Kitchen Notes"/>
-                            <div class="text-muted">
-                                Add internal notes on order lines for the kitchen
+                    </setting>
+                    <setting string="Kitchen Notes" help="Add internal notes on order lines for the kitchen" id="iface_orderline_notes" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                        <field name="pos_iface_orderline_notes"/>
+                    </setting>
+                    <setting string="Early Receipt Printing" help="Allow to print receipt before payment" id="iface_printbill" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                        <field name="pos_iface_printbill"/>
+                    </setting>
+                    <setting help="Split total or order lines" id="iface_splitbill" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                        <field name="pos_iface_splitbill" string="Allow Bill Splitting"/>
+                    </setting>
+                    <setting string="Kitchen Printers" help="Print orders at the kitchen, at the bar, etc." id="is_order_printer" attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
+                        <field name="pos_is_order_printer"/>
+                        <div class="content-group" attrs="{'invisible': [('pos_is_order_printer', '=', False)]}">
+                            <div class="mt16">
+                                <label string="Printers" for="pos_printer_ids" class="o_light_label"/>
+                                <field name="pos_printer_ids" widget="many2many_tags"/>
+                            </div>
+                            <div>
+                                <button name="%(pos_restaurant.action_restaurant_printer_form)d" icon="fa-arrow-right" type="action" string="Printers" class="btn-link"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box"
-                         id="iface_printbill"
-                         attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="pos_iface_printbill"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="pos_iface_printbill" string="Early Receipt Printing" />
-                            <div class="text-muted">
-                                Allow to print receipt before payment
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box"
-                         id="iface_splitbill"
-                         attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="pos_iface_splitbill" string="Allow Bill Splitting"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="pos_iface_splitbill" string="Allow Bill Splitting"/>
-                            <div class="text-muted">
-                                Split total or order lines
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box"
-                         id="is_order_printer"
-                         attrs="{'invisible': [('pos_module_pos_restaurant', '=', False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="pos_is_order_printer"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="pos_is_order_printer" string="Kitchen Printers"/>
-                            <div class="text-muted">
-                                Print orders at the kitchen, at the bar, etc.
-                            </div>
-                            <div class="content-group" attrs="{'invisible': [('pos_is_order_printer', '=', False)]}">
-                                <div class="mt16">
-                                    <label string="Printers" for="pos_printer_ids" class="o_light_label"/>
-                                    <field name="pos_printer_ids" widget="many2many_tags"/>
-                                </div>
-                                <div>
-                                    <button name="%(pos_restaurant.action_restaurant_printer_form)d" icon="fa-arrow-right" type="action" string="Printers" class="btn-link"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </setting>
+                </block>
+            </block>
             <div id="tip_product" position="after">
                 <div attrs="{'invisible': ['|', ('pos_module_pos_restaurant', '=', False), ('pos_iface_tipproduct', '=', False)]}">
                     <field name="pos_set_tip_after_payment" class="oe_inline"/>

--- a/addons/pos_sale/views/res_config_settings_views.xml
+++ b/addons/pos_sale/views/res_config_settings_views.xml
@@ -6,37 +6,20 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="pos_accounting_section" position="after">
-                <h2>Sales</h2>
-                <div class="row mt16 o_settings_container">
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">Sales Team</span>
-                            <div class="text-muted">
-                                Sales are reported to the following sales team
-                            </div>
-                            <div class="content-group mt16">
-                                <field name="pos_crm_team_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]"/>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">Down Payment Product</span>
-                            <div class="text-muted">
-                                This product will be applied when down payment is made
-                            </div>
-                            <div class="content-group mt16">
-                                <field
-                                    name="pos_down_payment_product_id"
-                                    domain="[('type', '=', 'service'), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
-                                    context="{'default_detailed_type': 'service', 'default_taxes_id': False }"
-                                />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <block id="pos_accounting_section" position="after">
+                <block title="Sales">
+                    <setting string="Sales Team" help="Sales are reported to the following sales team">
+                        <field name="pos_crm_team_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]"/>
+                    </setting>
+                    <setting string="Down Payment Product" help="This product will be applied when down payment is made">
+                        <field
+                            name="pos_down_payment_product_id"
+                            domain="[('type', '=', 'service'), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
+                            context="{'default_detailed_type': 'service', 'default_taxes_id': False }"
+                        />
+                    </setting>
+                </block>
+            </block>
         </field>
     </record>
 </odoo>

--- a/addons/product/views/res_config_settings_views.xml
+++ b/addons/product/views/res_config_settings_views.xml
@@ -6,60 +6,27 @@
             <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@id='companies']" position="after">
-                    <h2>Units of Measure</h2>
-                    <div class="row mt16 o_settings_container" id="product_general_settings">
-                        <div class="col-12 col-lg-6 o_setting_box" id="weight_uom_setting">
-                            <div class="o_setting_left_pane">
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="product_weight_in_lbs" string="Weight"/>
-                                <div class="text-muted">
-                                    Define your weight unit of measure
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="product_weight_in_lbs" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="manage_volume_uom_setting">
-                            <div class="o_setting_right_pane">
-                                <label for="product_volume_volume_in_cubic_feet" string="Volume"/>
-                                <div class="text-muted">
-                                    Define your volume unit of measure
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="product_volume_volume_in_cubic_feet" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <block title="Units of Measure" id="product_general_settings">
+                        <setting id="weight_uom_setting" string="Weight" help="Define your weight unit of measure">
+                            <field name="product_weight_in_lbs" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
+                        </setting>
+                        <setting id="manage_volume_uom_setting" string="Volume" help="Define your volume unit of measure">
+                            <field name="product_volume_volume_in_cubic_feet" class="o_light_label" widget="radio" options="{'horizontal': true}"/>
+                        </setting>
+                    </block>
                 </xpath>
                  <xpath expr="//div[@id='product_get_pic_setting']" position="replace">
-                    <div class="col-12 col-lg-6 o_setting_box" id="product_get_pic_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_product_images"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_product_images" string="Google Images"/>
-                            <a href="https://www.odoo.com/documentation/master/applications/sales/sales/products_prices/products/product_images.html"
-                               title="Documentation" class="o_doc_link" target="_blank"/>
-                            <div class="text-muted">
-                                Get product pictures using Barcode
-                            </div>
-                            <div class="content-group mt16"
-                                attrs="{'invisible': [('module_product_images','=',False)]}"
-                                id="msg_module_product_images">
-                                <div class="mt16 text-warning">
-                                    <strong>Save</strong> this page and come back
-                                    here to set up the feature.
-                                </div>
+                    <setting id="product_get_pic_setting" string="Google Images" help="Get product pictures using Barcode" documentation="/applications/sales/sales/products_prices/products/product_images.html">
+                        <field name="module_product_images"/>
+                        <div class="content-group mt16"
+                            attrs="{'invisible': [('module_product_images','=',False)]}"
+                            id="msg_module_product_images">
+                            <div class="mt16 text-warning">
+                                <strong>Save</strong> this page and come back
+                                here to set up the feature.
                             </div>
                         </div>
-                    </div>
+                    </setting>
                  </xpath>
             </field>
         </record>

--- a/addons/product_expiry/views/res_config_settings_views.xml
+++ b/addons/product_expiry/views/res_config_settings_views.xml
@@ -5,18 +5,10 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='group_lot_on_delivery_slip']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': ['|', ('group_lot_on_delivery_slip', '=', False), ('module_product_expiry', '=', False)]}" id="group_expiry_date_on_delivery_slip">
-                    <div class="o_setting_left_pane">
-                        <field name="group_expiry_date_on_delivery_slip"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="group_expiry_date_on_delivery_slip"/>
-                        <div class="text-muted">
-                            Expiration dates will appear on the delivery slip
-                        </div>
-                    </div>
-                </div>
+            <xpath expr="//setting[@id='group_lot_on_delivery_slip']" position="after">
+                <setting help="Expiration dates will appear on the delivery slip" attrs="{'invisible': ['|', ('group_lot_on_delivery_slip', '=', False), ('module_product_expiry', '=', False)]}" id="group_expiry_date_on_delivery_slip">
+                    <field name="group_expiry_date_on_delivery_slip"/>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -6,134 +6,52 @@
             <field name="priority" eval="50"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form" />
             <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Project" string="Project" data-key="project" groups="project.group_project_manager">
-                        <h2>Tasks Management</h2>
-                        <div class="row mt16 o_settings_container" id="tasks_management">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_subtask_project"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_subtask_project"/>
-                                    <div class="text-muted">
-                                        Split your tasks to organize your work into sub-milestones
+                <xpath expr="//form" position="inside">
+                    <app data-string="Project" string="Project" name="project" groups="project.group_project_manager">
+                        <block title="Tasks Management" id="tasks_management">
+                            <setting help="Split your tasks to organize your work into sub-milestones">
+                                <field name="group_subtask_project"/>
+                            </setting>
+                            <setting id="recurring_tasks_setting" help="Auto-generate tasks for regular activities">
+                                <field name="group_project_recurring_tasks"/>
+                            </setting>
+                            <setting id="task_dependencies_setting" help="Determine the order in which to perform tasks">
+                                <field name="group_project_task_dependencies"/>
+                            </setting>
+                            <setting id="project_stages" help="Track the progress of your projects">
+                                <field name="group_project_stages"/>
+                                <div class="content-group" attrs="{'invisible': [('group_project_stages', '=', False)]}">
+                                    <div class="mt8">
+                                        <button name="%(project.project_project_stage_configure)d" icon="fa-arrow-right" type="action" string="Configure Stages" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="recurring_tasks_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_project_recurring_tasks"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_project_recurring_tasks"/>
-                                    <div class="text-muted">
-                                        Auto-generate tasks for regular activities
+                            </setting>
+                            <setting id="project_milestone" help="Track major progress points that must be reached to achieve success">
+                                <field name="group_project_milestone"/>
+                            </setting>
+                        </block>
+                        <block title="Time Management" name="project_time">
+                            <setting id="log_time_tasks_setting" help="Track time spent on projects and tasks">
+                                <field name="module_hr_timesheet"/>
+                            </setting>
+                            <setting name="project_time_management" help="Plan resource allocation across projects and estimate deadlines more accurately">
+                                <field name="module_project_forecast" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                        <block title="Analytics" name="analytic">
+                            <setting id="track_customer_satisfaction_setting" help="Track customer satisfaction on tasks">
+                                <field name="group_project_rating"/>
+                                <div class="content-group" attrs="{'invisible': [('group_project_rating', '=', False)]}">
+                                    <div class="mt16">
+                                        <button name="%(project.open_task_type_form)d" context="{'project_id':id}" icon="fa-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="task_dependencies_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_project_task_dependencies"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_project_task_dependencies"/>
-                                    <div class="text-muted">
-                                        Determine the order in which to perform tasks
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="project_stages">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_project_stages"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_project_stages"/>
-                                    <div class="text-muted">
-                                        Track the progress of your projects
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('group_project_stages', '=', False)]}">
-                                        <div class="mt8">
-                                            <button name="%(project.project_project_stage_configure)d" icon="fa-arrow-right" type="action" string="Configure Stages" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="project_milestone">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_project_milestone"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_project_milestone"/>
-                                    <div class="text-muted">
-                                        Track major progress points that must be reached to achieve success
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Time Management</h2>
-                        <div class="row mt16 o_settings_container" name="project_time">
-                            <div class="col-12 col-lg-6 o_setting_box" id="log_time_tasks_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_hr_timesheet"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_hr_timesheet"/>
-                                    <div class="text-muted">
-                                        Track time spent on projects and tasks
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" name="project_time_management">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_project_forecast" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_project_forecast"/>
-                                    <div class="text-muted" name="project_forecast_msg">
-                                        Plan resource allocation across projects and estimate deadlines more accurately
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2 name="section_analytics">Analytics</h2>
-                        <div class="row mt16 o_settings_container" name="analytic">
-                            <div class="col-12 col-lg-6 o_setting_box" id="track_customer_satisfaction_setting">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_project_rating"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_project_rating"/>
-                                    <div class="text-muted">
-                                        Track customer satisfaction on tasks
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('group_project_rating', '=', False)]}">
-                                        <div class="mt16">
-                                            <button name="%(project.open_task_type_form)d" context="{'project_id':id}" icon="fa-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                 id="default_plan_setting"
-                                 groups="analytic.group_analytic_accounting"
-                                 title="Track the profitability of your projects. Any project, its tasks and timesheets are linked to an analytic account and any analytic account belongs to a plan.">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <label for="analytic_plan_id"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Assign each new project to this plan
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt16">
-                                            <field name="analytic_plan_id"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                            <setting id="default_plan_setting" groups="analytic.group_analytic_accounting" help="Assign each new project to this plan" company_dependent="1" title="Track the profitability of your projects. Any project, its tasks and timesheets are linked to an analytic account and any analytic account belongs to a plan.">
+                                <field name="analytic_plan_id"/>
+                            </setting>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/project_timesheet_holidays/views/res_config_settings_views.xml
+++ b/addons/project_timesheet_holidays/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="hr_timesheet.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='module_project_timesheet_holidays']" position="replace">
+            <xpath expr="//setting[@id='timesheet_off_validation_setting']" position="inside">
                 <div attrs="{'invisible': [('module_project_timesheet_holidays','=',False)]}">
                     <div class="row mt16">
                         <div class="w-100">

--- a/addons/purchase/views/res_config_settings_views.xml
+++ b/addons/purchase/views/res_config_settings_views.xml
@@ -7,161 +7,62 @@
         <field name="priority" eval="25"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Purchase" string="Purchase" data-key="purchase" groups="purchase.group_purchase_manager">
+            <xpath expr="//form" position="inside">
+                <app data-string="Purchase" string="Purchase" name="purchase" groups="purchase.group_purchase_manager">
                     <field name="po_double_validation" invisible="1"/>
                     <field name="company_currency_id" invisible="1"/>
                     <field name="po_lock" invisible="1"/>
-                    <h2>Orders</h2>
-                    <div class="row mt16 o_settings_container" name="purchase_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="po_order_approval">
-                            <div class="o_setting_left_pane">
-                                <field name="po_order_approval"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="po_order_approval"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                <div class="text-muted">
-                                    Request managers to approve orders above a minimum amount
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('po_order_approval', '=', False)]}">
-                                    <div class="row mt16">
-                                        <label for="po_double_validation_amount" class="col-lg-4 o_light_label"/>
-                                        <field name="po_double_validation_amount"/>
-                                    </div>
+                    <block title="Orders" name="purchase_setting_container">
+                        <setting id="po_order_approval" company_dependent="1" help="Request managers to approve orders above a minimum amount">
+                            <field name="po_order_approval"/>
+                            <div class="content-group" attrs="{'invisible': [('po_order_approval', '=', False)]}">
+                                <div class="row mt16">
+                                    <label for="po_double_validation_amount" class="col-lg-4 o_light_label"/>
+                                    <field name="po_double_validation_amount"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="automatic_lock_confirmed_orders">
-                            <div class="o_setting_left_pane">
-                                <field name="lock_confirmed_po"/>
+                        </setting>
+                        <setting id="automatic_lock_confirmed_orders" help="Automatically lock confirmed orders to prevent editing">
+                            <field name="lock_confirmed_po"/>
+                        </setting>
+                        <setting id="get_order_warnings" string="Warnings" help="Get warnings in orders for products or vendors">
+                            <field name="group_warning_purchase"/>
+                        </setting>
+                        <setting id="manage_purchase_agreements" title="Calls for tenders are when you want to generate requests for quotations with several vendors for a given set of products to compare offers." documentation="/applications/inventory_and_mrp/purchase/manage_deals/agreements.html" help="Manage your purchase agreements (call for tenders, blanket orders)">
+                            <field name="module_purchase_requisition"/>
+                            <div class="content-group" attrs="{'invisible': [('module_purchase_requisition', '=', False)]}">
+                                <div id="use_purchase_requisition"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="lock_confirmed_po"/>
-                                <div class="text-muted">
-                                    Automatically lock confirmed orders to prevent editing
+                        </setting>
+                        <setting id="auto_receipt_reminder" help="Automatically remind the receipt date to your vendors">
+                            <field name="group_send_reminder"/>
+                        </setting>
+                    </block>
+                    <block title="Invoicing" name="invoicing_settings_container">
+                        <setting id="quantities_billed_vendor" title="This default value is applied to any new product created. This can be changed in the product detail form." documentation="/applications/inventory_and_mrp/purchase/manage_deals/control_bills.html" help="Quantities billed by vendors">
+                            <field name="default_purchase_method" class="o_light_label" widget="radio"/>
+                        </setting>
+                        <setting id="three_way_matching" title="If enabled, activates 3-way matching on vendor bills : the items must be received in order to pay the invoice." documentation="/applications/inventory_and_mrp/purchase/manage_deals/control_bills.html" help="Make sure you only pay bills for which you received the goods you ordered">
+                            <field name="module_account_3way_match" string="3-way matching" widget="upgrade_boolean"/>
+                        </setting>
+                    </block>
+                    <block title="Products" name="matrix_setting_container">
+                        <setting id="variant_options" help="Purchase variants of a product using attributes (size, color, etc.)" documentation="/applications/sales/sales/products_prices/products/variants.html">
+                            <field name="group_product_variant"/>
+                            <div class="content-group" attrs="{'invisible': [('group_product_variant','=',False)]}">
+                                <div class="mt8">
+                                    <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="get_order_warnings">
-                            <div class="o_setting_left_pane">
-                                <field name="group_warning_purchase"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_warning_purchase" string="Warnings"/>
-                                <div class="text-muted">
-                                    Get warnings in orders for products or vendors
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="manage_purchase_agreements"
-                            title="Calls for tenders are when you want to generate requests for quotations with several vendors for a given set of products to compare offers.">
-                            <div class="o_setting_left_pane">
-                                <field name="module_purchase_requisition"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_purchase_requisition"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/purchase/manage_deals/agreements.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Manage your purchase agreements (call for tenders, blanket orders)
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('module_purchase_requisition', '=', False)]}">
-                                    <div id="use_purchase_requisition"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="auto_receipt_reminder">
-                            <div class="o_setting_left_pane">
-                                <field name="group_send_reminder"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_send_reminder"/>
-                                <div class="text-muted">
-                                    Automatically remind the receipt date to your vendors
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Invoicing</h2>
-                    <div class="row mt16 o_settings_container" name="invoicing_settings_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="quantities_billed_vendor" title="This default value is applied to any new product created. This can be changed in the product detail form.">
-                            <div class="o_setting_left_pane"/>
-                            <div class="o_setting_right_pane">
-                                <label for="default_purchase_method"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/purchase/manage_deals/control_bills.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Quantities billed by vendors
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="default_purchase_method" class="o_light_label" widget="radio"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="three_way_matching"
-                            title="If enabled, activates 3-way matching on vendor bills : the items must be received in order to pay the invoice.">
-                            <div class="o_setting_left_pane">
-                                <field name="module_account_3way_match" string="3-way matching" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_account_3way_match"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/purchase/manage_deals/control_bills.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Make sure you only pay bills for which you received the goods you ordered
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Products</h2>
-                    <div class="row mt16 o_settings_container" name="matrix_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="variant_options">
-                            <div class="o_setting_left_pane">
-                                <field name="group_product_variant"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_product_variant"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/sales/sales/products_prices/products/variants.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Purchase variants of a product using attributes (size, color, etc.)
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('group_product_variant','=',False)]}">
-                                    <div class="mt8">
-                                        <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="product_matrix"
-                            title="If installed, the product variants will be added to purchase orders through a grid entry.">
-                            <div class="o_setting_left_pane">
-                                <field name="module_purchase_product_matrix"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_purchase_product_matrix" string="Variant Grid Entry"/>
-                                <div class="text-muted">
-                                    Add several variants to the purchase order from a grid
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="stock_packaging_purchase"
-                            title="Ability to select a package type in purchase orders and to force a quantity that is a multiple of the number of units per package.">
-                            <div class="o_setting_left_pane">
-                                <field name="group_stock_packaging"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_stock_packaging"/>
-                                <div class="text-muted">
-                                    Purchase products by multiple of unit # per package
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                        </setting>
+                        <setting id="product_matrix" title="If installed, the product variants will be added to purchase orders through a grid entry." string="Variant Grid Entry" help="Add several variants to the purchase order from a grid">
+                            <field name="module_purchase_product_matrix"/>
+                        </setting>
+                        <setting id="stock_packaging_purchase" help="Purchase products by multiple of unit # per package" title="Ability to select a package type in purchase orders and to force a quantity that is a multiple of the number of units per package.">
+                            <field name="group_stock_packaging"/>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/purchase_stock/views/res_config_settings_views.xml
+++ b/addons/purchase_stock/views/res_config_settings_views.xml
@@ -7,23 +7,13 @@
 		<field name="priority" eval="25"/>
 		<field name="inherit_id" ref="purchase.res_config_settings_view_form_purchase"/>
 		<field name="arch" type="xml">
-			<xpath expr="//div[@data-key='purchase']" position="inside">
+			<xpath expr="//app[@name='purchase']" position="inside">
 				<field name="is_installed_sale" invisible="1"/>
-				<h2 attrs="{'invisible': [('is_installed_sale', '=', False)]}">Logistics</h2>
-				<div class="row mt16 o_settings_container" name="request_vendor_setting_container">
-					<div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('is_installed_sale', '=', False)]}" title="This adds a dropshipping route to apply on products in order to request your vendors to deliver to your customers. A product to dropship will generate a purchase request for quotation once the sales order confirmed. This is a on-demand flow. The requested delivery address will be the customer delivery address and not your warehouse.">
-						<div class="o_setting_left_pane">
-							<field name="module_stock_dropshipping"/>
-						</div>
-						<div class="o_setting_right_pane">
-							<label for="module_stock_dropshipping"/>
-							<a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/delivery/dropshipping.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-							<div class="text-muted">
-								Request your vendors to deliver to your customers
-							</div>
-						</div>
-					</div>
-				</div>
+				<block title="Logistics" attrs="{'invisible': [('is_installed_sale', '=', False)]}" name="request_vendor_setting_container">
+					<setting title="This adds a dropshipping route to apply on products in order to request your vendors to deliver to your customers. A product to dropship will generate a purchase request for quotation once the sales order confirmed. This is a on-demand flow. The requested delivery address will be the customer delivery address and not your warehouse." help="Request your vendors to deliver to your customers">
+						<field name="module_stock_dropshipping" documentation="/applications/inventory_and_mrp/inventory/management/delivery/dropshipping.html"/>
+					</setting>
+				</block>
 			</xpath>
 		</field>
 	</record>
@@ -33,44 +23,21 @@
 		<field name="model">res.config.settings</field>
 		<field name="inherit_id" ref="stock.res_config_settings_view_form"/>
 		<field name="arch" type="xml">
-			<xpath expr="//h2[@id='schedule_info']" position="attributes">
+			<xpath expr="//block[@id='schedule_info']" position="attributes">
 				<attribute name="invisible">0</attribute>
 			</xpath>
 			<div id="purchase_po_lead" position="replace">
-				<div class="col-12 col-lg-6 o_setting_box"
-                                    title="Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays."
-                                    name="schedule_receivings_setting_container">
-					<div class="o_setting_left_pane">
-						<field name="use_po_lead"/>
-					</div>
-					<div class="o_setting_right_pane">
-						<label for="use_po_lead"/>
-						<a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Documentation" class="me-2 o_doc_link" target="_blank"></a>
-						<span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-						<div class="text-muted">
-							Schedule request for quotations earlier to avoid delays
-						</div>
-						<div class="content-group">
-							<div class="mt16" attrs="{'invisible': [('use_po_lead','=',False)]}">
-								<span>Move forward expected request creation date by <field name="po_lead" class="oe_inline"/> days</span>
-							</div>
+				<setting company_dependent="1" help="Schedule request for quotations earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays." name="schedule_receivings_setting_container">
+					<field name="use_po_lead"/>
+					<div class="content-group">
+						<div class="mt16" attrs="{'invisible': [('use_po_lead','=',False)]}">
+							<span>Move forward expected request creation date by <field name="po_lead" class="oe_inline"/> days</span>
 						</div>
 					</div>
-				</div>
-				<div class="col-12 col-lg-6 o_setting_box">
-					<div class="o_setting_right_pane">
-						<label for="days_to_purchase"/>
-						<span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-						<div class="text-muted">
-							Days needed to confirm a PO
-						</div>
-						<div class="content-group">
-							<div class="mt16">
-								<span><field name="days_to_purchase" class="oe_inline"/> days</span>
-							</div>
-						</div>
-					</div>
-				</div>
+				</setting>
+				<setting company_dependent="1" help="Days needed to confirm a PO">
+					<field name="days_to_purchase" class="oe_inline"/><span> days</span>
+				</setting>
 			</div>
 		</field>
 	</record>

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -7,426 +7,138 @@
         <field name="priority" eval="10"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block o_not_app"
-                    string="Sales"
-                    data-string="Sales"
-                    data-key="sale_management"
-                    groups="sales_team.group_sale_manager">
-                    <h2>Product Catalog</h2>
-                    <div class="row mt16 o_settings_container" name="catalog_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="variant_options">
-                            <div class="o_setting_left_pane">
-                                <field name="group_product_variant"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_product_variant"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/products_prices/products/variants.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Sell variants of a product using attributes (size, color, etc.)
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('group_product_variant','=',False)]}">
-                                    <div class="mt8">
-                                        <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
-                                    </div>
+            <xpath expr="//form" position="inside">
+                <app notApp="1" string="Sales" data-string="Sales" name="sale_management" groups="sales_team.group_sale_manager">
+                    <block title="Product Catalog" name="catalog_setting_container">
+                        <setting id="variant_options" help="Sell variants of a product using attributes (size, color, etc.)" documentation="/applications/sales/sales/products_prices/products/variants.html">
+                            <field name="group_product_variant"/>
+                            <div class="content-group" attrs="{'invisible': [('group_product_variant','=',False)]}">
+                                <div class="mt8">
+                                    <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="product_matrix">
-                            <div class="o_setting_left_pane">
-                                <field name="module_sale_product_matrix"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_sale_product_matrix" string="Variant Grid Entry"/>
-                                <div class="text-muted">
-                                    Add several variants to an order from a grid
+                        </setting>
+                        <setting string="Variant Grid Entry" help="Add several variants to an order from a grid" id="product_matrix">
+                            <field name="module_sale_product_matrix"/>
+                        </setting>
+                        <setting id="uom_settings" help="Sell and purchase products in different units of measure">
+                            <field name="group_uom"/>
+                            <div class="content-group" attrs="{'invisible': [('group_uom','=',False)]}">
+                                <div class="mt8">
+                                    <button name="%(uom.product_uom_categ_form_action)d" icon="fa-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="uom_settings">
-                            <div class="o_setting_left_pane">
-                                <field name="group_uom"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_uom"/>
-                                <div class="text-muted">
-                                    Sell and purchase products in different units of measure
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('group_uom','=',False)]}">
-                                    <div class="mt8">
-                                        <button name="%(uom.product_uom_categ_form_action)d" icon="fa-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="email_template"
-                            title="Sending an email is useful if you need to share specific information or content about a product (instructions, rules, links, media, etc.). Create and set the email template from the product detail form (in Sales tab).">
-                            <div class="o_setting_left_pane">
-                                <field name="module_product_email_template"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_product_email_template" string="Deliver Content by Email"/>
-                                <div class="text-muted">
-                                    Send a product-specific email once the invoice is validated
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="stock_packaging"
-                            title="Ability to select a package type in sales orders and to force a quantity that is a multiple of the number of units per package.">
-                            <div class="o_setting_left_pane">
-                                <field name="group_stock_packaging"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_stock_packaging"/>
-                                <div class="text-muted">
-                                    Sell products by multiple of unit # per package
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Pricing</h2>
-                    <div class="row mt16 o_settings_container" id="pricing_setting_container">
-                      <div class="col-12 col-lg-6 o_setting_box"
-                           id="discount_sale_order_lines"
-                           title="Apply manual discounts on sales order lines or display discounts computed from pricelists (option to activate in the pricelist configuration).">
-                           <div class="o_setting_left_pane">
-                               <field name="group_discount_per_so_line"/>
-                           </div>
-                           <div class="o_setting_right_pane">
-                               <label for="group_discount_per_so_line"/>
-                               <div class="text-muted">
-                                   Grant discounts on sales order lines
-                               </div>
-                           </div>
-                       </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="coupon_settings"
-                            title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products.">
-                            <div class="o_setting_left_pane">
-                                <field name="module_loyalty"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_loyalty" string="Discounts, Loyalty &amp; Gift Card"/>
-                                <div class="text-muted" id="sale_coupon">
-                                    Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="pricelist_configuration">
-                            <div class="o_setting_left_pane">
-                                <field name="group_product_pricelist"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_product_pricelist"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/products_prices/prices/pricing.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Set multiple prices per product, automated discounts, etc.
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('group_product_pricelist' ,'=', False)]}">
-                                    <div class="mt16">
-                                        <field name="group_sale_pricelist" invisible="1"/>
-                                        <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
-                                    </div>
-                                    <div class="mt8">
-                                        <button name="%(product.product_pricelist_action2)d" icon="fa-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="auth_signup_documents"
-                            title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*.">
-                            <div class="o_setting_left_pane">
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="auth_signup_uninvited"/>
-                                <div class="text-muted">
-                                    Let your customers log in to see their documents
+                        </setting>
+                        <setting id="email_template" title="Sending an email is useful if you need to share specific information or content about a product (instructions, rules, links, media, etc.). Create and set the email template from the product detail form (in Sales tab)." string="Deliver Content by Email" help="Send a product-specific email once the invoice is validated">
+                            <field name="module_product_email_template"/>
+                        </setting>
+                        <setting id="stock_packaging" title="Ability to select a package type in sales orders and to force a quantity that is a multiple of the number of units per package." help="Sell products by multiple of unit # per package">
+                            <field name="group_stock_packaging"/>
+                        </setting>
+                    </block>
+                    <block title="Pricing" id="pricing_setting_container">
+                      <setting id="discount_sale_order_lines" title="Apply manual discounts on sales order lines or display discounts computed from pricelists (option to activate in the pricelist configuration)." help="Grant discounts on sales order lines">
+                            <field name="group_discount_per_so_line"/>
+                       </setting>
+                        <setting id="coupon_settings" title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products." string="Discounts, Loyalty &amp; Gift Card" help="Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet">
+                            <field name="module_loyalty"/>
+                        </setting>
+                        <setting id="pricelist_configuration" documentation="/applications/sales/sales/products_prices/prices/pricing.html" help="Set multiple prices per product, automated discounts, etc.">
+                            <field name="group_product_pricelist"/>
+                            <div class="content-group" attrs="{'invisible': [('group_product_pricelist' ,'=', False)]}">
+                                <div class="mt16">
+                                    <field name="group_sale_pricelist" invisible="1"/>
+                                    <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
                                 </div>
                                 <div class="mt8">
-                                    <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
+                                    <button name="%(product.product_pricelist_action2)d" icon="fa-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="show_margins"
-                            title="The margin is computed as the sum of product sales prices minus the cost set in their detail form.">
-                            <div class="o_setting_left_pane">
-                                <field name="module_sale_margin"/>
+                        </setting>
+                        <setting id="auth_signup_documents" title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*." help="Let your customers log in to see their documents">
+                            <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
+                        </setting>
+                        <setting id="show_margins" help="Show margins on orders" title="The margin is computed as the sum of product sales prices minus the cost set in their detail form.">
+                            <field name="module_sale_margin"/>
+                        </setting>
+                    </block>
+                    <block title="Quotations &amp; Orders" name="quotation_order_setting_container">
+                        <setting id="sale_config_online_confirmation_sign" company_dependent="1" documentation="/applications/sales/sales/send_quotations/get_signature_to_validate.html" help="Request an online signature to confirm orders">
+                            <field name="portal_confirmation_sign"/>
+                        </setting>
+                        <setting id="sale_config_online_confirmation_pay" company_dependent="1" documentation="/applications/sales/sales/send_quotations/get_paid_to_validate.html" help="Request an online payment to confirm orders">
+                            <field name="portal_confirmation_pay"/>
+                            <div class="mt8" attrs="{'invisible': [('portal_confirmation_pay', '=', False)]}">
+                                <button name='%(payment.action_payment_provider)d' icon="fa-arrow-right" type="action" string="Payment Providers" class="btn-link"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_sale_margin"/>
-                                <div class="text-muted">
-                                    Show margins on orders
+                        </setting>
+                        <setting id="quotation_validity_days" company_dependent="1" help="Set a default validity on your quotations">
+                            <field name="use_quotation_validity_days"/>
+                            <div class="content-group"  attrs="{'invisible': [('use_quotation_validity_days','=',False)]}">
+                                <div class="mt16">
+                                    <span class="col-lg-3">Default Limit: <field name="quotation_validity_days" attrs="{'required': [('use_quotation_validity_days', '=', True)]}"/> days</span>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <h2>Quotations &amp; Orders</h2>
-                    <div class="row mt16 o_settings_container" name="quotation_order_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="sale_config_online_confirmation_sign">
-                            <div class="o_setting_left_pane">
-                                <field name="portal_confirmation_sign"/>
+                        </setting>
+                        <setting id="order_warnings" string="Sale Warnings" help="Get warnings in orders for products or customers">
+                            <field name="group_warning_sale"/>
+                        </setting>
+                        <setting id="no_edit_order" help="No longer edit orders once confirmed">
+                            <field name="group_auto_done_setting"/>
+                        </setting>
+                        <setting id="proforma_configuration" help="Allows you to send Pro-Forma Invoice to your customers">
+                            <field name="group_proforma_sales"/>
+                        </setting>
+                    </block>
+                    <block title="Shipping" name="shipping_setting_container">
+                        <setting id="delivery" help="Compute shipping costs on orders">
+                            <field name="module_delivery"/>
+                        </setting>
+                        <setting id="ups" help="Compute shipping costs and ship with UPS">
+                            <field name="module_delivery_ups" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="shipping_costs_dhl" help="Compute shipping costs and ship with DHL">
+                            <field name="module_delivery_dhl" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="shipping_costs_fedex" help="Compute shipping costs and ship with FedEx">
+                            <field name="module_delivery_fedex" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="shipping_costs_usps" help="Compute shipping costs and ship with USPS">
+                            <field name="module_delivery_usps" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="shipping_costs_bpost" help="Compute shipping costs and ship with bpost">
+                            <field name="module_delivery_bpost" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="shipping_costs_easypost" help="Compute shipping costs and ship with Easypost">
+                            <field name="module_delivery_easypost" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting id="shipping_costs_sendcloud" help="Compute shipping costs and ship with Sendcloud">
+                            <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
+                        </setting>
+                    </block>
+                    <block title="Invoicing" name="invoicing_setting_container">
+                        <setting id="sales_settings_invoicing_policy" title="This default value is applied to any new product created. This can be changed in the product detail form." documentation="/applications/sales/sales/invoicing/invoicing_policy.html" help="Quantities to invoice from sales orders">
+                            <field name="default_invoice_policy" class="o_light_label" widget="radio"/>
+                        </setting>
+                        <setting id="automatic_invoicing" help="Generate the invoice automatically when the online payment is confirmed" attrs="{'invisible': ['|', ('default_invoice_policy', '!=', 'order'), ('portal_confirmation_pay', '=', False)]}">
+                            <field name="automatic_invoice"/>
+                            <div  attrs="{'invisible': [('automatic_invoice','=',False)]}" groups="base.group_no_one">
+                                <label for="invoice_mail_template_id" class="o_light_label"/>
+                                <field name="invoice_mail_template_id" class="oe_inline" options="{'no_create': True}"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="portal_confirmation_sign"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/send_quotations/get_signature_to_validate.html" title="Documentation" class="me-2 o_doc_link" target="_blank"></a>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="text-muted">
-                                    Request an online signature to confirm orders
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="sale_config_online_confirmation_pay">
-                            <div class="o_setting_left_pane">
-                                <field name="portal_confirmation_pay"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="portal_confirmation_pay"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/send_quotations/get_paid_to_validate.html" title="Documentation" class="me-2 o_doc_link" target="_blank"></a>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                <div class="text-muted">
-                                    Request an online payment to confirm orders
-                                </div>
-                                <div class="mt8" attrs="{'invisible': [('portal_confirmation_pay', '=', False)]}">
-                                    <button name='%(payment.action_payment_provider)d' icon="fa-arrow-right" type="action" string="Payment Providers" class="btn-link"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="quotation_validity_days">
-                            <div class="o_setting_left_pane">
-                                <field name="use_quotation_validity_days"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="use_quotation_validity_days"/>
-                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                                <div class="text-muted">
-                                    Set a default validity on your quotations
-                                </div>
-                                <div class="content-group"  attrs="{'invisible': [('use_quotation_validity_days','=',False)]}">
-                                    <div class="mt16">
-                                        <span class="col-lg-3">Default Limit: <field name="quotation_validity_days" attrs="{'required': [('use_quotation_validity_days', '=', True)]}"/> days</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="order_warnings">
-                            <div class="o_setting_left_pane">
-                                <field name="group_warning_sale"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_warning_sale" string="Sale Warnings"/>
-                                <div class="text-muted">
-                                    Get warnings in orders for products or customers
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="no_edit_order">
-                            <div class="o_setting_left_pane">
-                                <field name="group_auto_done_setting"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_auto_done_setting"/>
-                                <div class="text-muted">
-                                    No longer edit orders once confirmed
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="proforma_configuration">
-                            <div class="o_setting_left_pane">
-                                <field name="group_proforma_sales"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_proforma_sales"/>
-                                <div class="text-muted">
-                                    Allows you to send Pro-Forma Invoice to your customers
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2 class="mt32">Shipping</h2>
-                    <div class="row mt16 o_settings_container" name="shipping_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="delivery">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery"/>
-                                <div class="text-muted" id="delivery_carrier">
-                                    Compute shipping costs on orders
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="ups">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_ups" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_ups"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with UPS
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_ups"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_dhl">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_dhl" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_dhl"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with DHL
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_dhl"></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_fedex">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_fedex" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_fedex"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with FedEx
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_fedex"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_usps">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_usps" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_usps"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with USPS
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_usps"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_bpost">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_bpost" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_bpost"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with bpost
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_bpost"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_easypost">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_easypost" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_easypost"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with Easypost
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_easypost"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_sendcloud">
-                            <div class="o_setting_left_pane">
-                                <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_delivery_sendcloud"/>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with Sendcloud
-                                </div>
-                                <div class="content-group">
-                                    <div id="sale_delivery_sendcloud"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Invoicing</h2>
-                    <div class="row mt16 o_settings_container" name="invoicing_setting_container">
-                        <div id="sales_settings_invoicing_policy"
-                             class="col-12 col-lg-6 o_setting_box"
-                             title="This default value is applied to any new product created. This can be changed in the product detail form.">
-                            <div class="o_setting_right_pane">
-                                <label for="default_invoice_policy"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/invoicing/invoicing_policy.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Quantities to invoice from sales orders
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="default_invoice_policy" class="o_light_label" widget="radio"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xs-12 col-md-6 o_setting_box"
-                             id="automatic_invoicing"
-                             attrs="{'invisible': ['|', ('default_invoice_policy', '!=', 'order'), ('portal_confirmation_pay', '=', False)]}">
-                            <div class="o_setting_left_pane">
-                                <field name="automatic_invoice"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="automatic_invoice"/>
-                                <div class="text-muted">
-                                    Generate the invoice automatically when the online payment is confirmed
-                                </div>
-                                <div  attrs="{'invisible': [('automatic_invoice','=',False)]}" groups="base.group_no_one">
-                                    <label for="invoice_mail_template_id" class="o_light_label"/>
-                                    <field name="invoice_mail_template_id" class="oe_inline" options="{'no_create': True}"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="down_payments">
-                            <div class="o_setting_left_pane"/>
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Down Payments</span>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/invoicing/down_payment.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Product used for down payments
-                                </div>
-                                <div class="text-muted">
-                                    <field name="deposit_default_product_id" context="{'default_detailed_type': 'service'}"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2 class="mt32">Connectors</h2>
-                    <div class="row mt16 o_settings_container" id="connectors_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box" id="amazon_connector">
-                            <div class="o_setting_left_pane">
-                                <field name="module_sale_amazon" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_sale_amazon"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/sales/sales/amazon_connector/setup.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Import Amazon orders and sync deliveries
-                                </div>
-                                <div class="content-group"
-                                     name="amazon_connector"
-                                     attrs="{'invisible': [('module_sale_amazon', '=', False)]}"/>
-                            </div>
-                        </div>
-                    </div>
+                        </setting>
+                        <setting id="down_payments" string="Down Payments" help="Product used for down payments" documentation="/applications/sales/sales/invoicing/down_payment.html">
+                            <field name="deposit_default_product_id" context="{'default_detailed_type': 'service'}"/>
+                        </setting>
+                    </block>
+                    <block title="Connectors" id="connectors_setting_container">
+                        <setting id="amazon_connector" documentation="/applications/sales/sales/amazon_connector/setup.html" help="Import Amazon orders and sync deliveries">
+                            <field name="module_sale_amazon" widget="upgrade_boolean"/>
+                            <div class="content-group" name="amazon_connector" attrs="{'invisible': [('module_sale_amazon', '=', False)]}"/>
+                        </setting>
+                    </block>
                     <div id="sale_ebay"/>
-                </div>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/sale_management/views/res_config_settings_views.xml
+++ b/addons/sale_management/views/res_config_settings_views.xml
@@ -6,43 +6,27 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='sale_config_online_confirmation_pay']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="standardized_offers_setting">
-                    <div class="o_setting_left_pane">
-                        <field name="group_sale_order_template"/>
-                        <field name="module_sale_quotation_builder" invisible="1"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="group_sale_order_template"/>
-                        <a href="https://www.odoo.com/documentation/master/applications/sales/sales/send_quotations/quote_template.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                        <div class="text-muted">
-                            Create standardized offers with default products
+            <xpath expr="//setting[@id='sale_config_online_confirmation_pay']" position="after">
+                <field name="module_sale_quotation_builder" invisible="1"/>
+                <setting id="standardized_offers_setting" help="Create standardized offers with default products" documentation="/applications/sales/sales/send_quotations/quote_template.html">
+                    <field name="group_sale_order_template"/>
+                    <div class="content-group" attrs="{'invisible': [('group_sale_order_template', '=', False)]}">
+                        <div class="mt16">
+                            <label for="company_so_template_id" class="o_light_label"/>
+                            <field name="company_so_template_id" class="oe_inline"/>
                         </div>
-                        <div class="content-group" attrs="{'invisible': [('group_sale_order_template', '=', False)]}">
-                            <div class="mt16">
-                                <label for="company_so_template_id" class="o_light_label"/>
-                                <field name="company_so_template_id" class="oe_inline"/>
-                            </div>
-                            <div class="mt8">
-                                <button name="%(sale_management.sale_order_template_action)d" icon="fa-arrow-right" type="action" string="Quotation Templates" class="btn-link"/>
-                            </div>
+                        <div class="mt8">
+                            <button name="%(sale_management.sale_order_template_action)d" icon="fa-arrow-right" type="action" string="Quotation Templates" class="btn-link"/>
                         </div>
                     </div>
-                </div>
-                <div class="col-12 col-lg-6 o_setting_box"
-                    id="design_quotation_template_setting"
-                    attrs="{'invisible': [('group_sale_order_template','=',False)]}">
-                    <div class="o_setting_left_pane">
-                        <field name="module_sale_quotation_builder"/>
+                </setting>
+                <setting id="design_quotation_template_setting" attrs="{'invisible': [('group_sale_order_template','=',False)]}">
+                    <field name="module_sale_quotation_builder"/>
+                    <div class="text-muted">
+                        Design your quotation templates using building blocks<br/>
+                        <em attrs="{'invisible': [('module_sale_quotation_builder','=',False)]}">Warning: this option will install the Website app.</em>
                     </div>
-                    <div class="o_setting_right_pane">
-                        <label for="module_sale_quotation_builder"/>
-                        <div class="text-muted">
-                            Design your quotation templates using building blocks<br/>
-                            <em attrs="{'invisible': [('module_sale_quotation_builder','=',False)]}">Warning: this option will install the Website app.</em>
-                        </div>
-                    </div>
-                </div>
+                </setting>
             </xpath>
         </field>
     </record>
@@ -52,8 +36,8 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@data-key='sale_management']" position="attributes">
-                <attribute name="class">app_settings_block</attribute>
+            <xpath expr="//app[@name='sale_management']" position="attributes">
+                <attribute name="notApp">0</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/sale_quotation_builder/views/res_config_settings_views.xml
+++ b/addons/sale_quotation_builder/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale_management.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//label[@for='module_sale_quotation_builder']/following::div/em" position="replace"/>
+            <xpath expr="//field[@name='module_sale_quotation_builder']/following::div/em" position="replace"/>
         </field>
     </record>
 </odoo>

--- a/addons/sale_stock/views/res_config_settings_views.xml
+++ b/addons/sale_stock/views/res_config_settings_views.xml
@@ -6,23 +6,15 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='ups']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="display_incoterms_setting">
-                    <div class="o_setting_left_pane">
-                        <field name="group_display_incoterm"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="group_display_incoterm"/>
-                        <div class="text-muted">
-                            Display incoterms on orders &amp; invoices
-                        </div>
-                        <div class="content-group" attrs="{'invisible': [('group_display_incoterm','=',False)]}">
-                            <div class="mt8">
-                                <button name="%(account.action_incoterms_tree)d" icon="fa-arrow-right" type="action" string="Incoterms" class="btn-link"/>
-                            </div>
+            <xpath expr="//setting[@id='ups']" position="after">
+                <setting id="display_incoterms_setting" help="Display incoterms on orders &amp; invoices">
+                    <field name="group_display_incoterm"/>
+                    <div class="content-group" attrs="{'invisible': [('group_display_incoterm','=',False)]}">
+                        <div class="mt8">
+                            <button name="%(account.action_incoterms_tree)d" icon="fa-arrow-right" type="action" string="Incoterms" class="btn-link"/>
                         </div>
                     </div>
-                </div>
+                </setting>
             </xpath>
         </field>
     </record>
@@ -32,43 +24,23 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="warning_info" position="after">
-                <div class="col-12 col-lg-6 o_setting_box">
-                    <div class="o_setting_right_pane">
-                        <label for="default_picking_policy"/>
-                        <div class="text-muted">
-                            When to start shipping
-                        </div>
-                        <div class="content-group">
-                            <div class="mt16">
-                                <field name="default_picking_policy" class="o_light_label" widget="selection"/>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <xpath expr="//h2[@id='schedule_info']" position="attributes">
+            <setting id="warning_info" position="after">
+                <setting help="When to start shipping">
+                    <field name="default_picking_policy" class="o_light_label" widget="selection"/>
+                </setting>
+            </setting>
+            <xpath expr="//block[@id='schedule_info']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>
             <div id="sale_security_lead" position="replace">
-                <div class="col-12 col-lg-6 o_setting_box" title="Margin of error for dates promised to customers. Products will be scheduled for procurement and delivery that many days earlier than the actual promised date, to cope with unexpected delays in the supply chain.">
-                    <div class="o_setting_left_pane">
-                        <field name="use_security_lead"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="use_security_lead"/>
-                        <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Documentation" class="me-2 o_doc_link" target="_blank"></a>
-                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
-                        <div class="text-muted">
-                            Schedule deliveries earlier to avoid delays
-                        </div>
-                        <div class="content-group">
-                            <div class="mt16" attrs="{'invisible': [('use_security_lead','=',False)]}">
-                                <span>Move forward expected delivery dates by <field name="security_lead" class="oe_inline"/> days</span>
-                            </div>
+                <setting company_dependent="1" help="Schedule deliveries earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Margin of error for dates promised to customers. Products will be scheduled for procurement and delivery that many days earlier than the actual promised date, to cope with unexpected delays in the supply chain.">
+                    <field name="use_security_lead"/>
+                    <div class="content-group">
+                        <div class="mt16" attrs="{'invisible': [('use_security_lead','=',False)]}">
+                            <span>Move forward expected delivery dates by <field name="security_lead" class="oe_inline"/> days</span>
                         </div>
                     </div>
-                </div>
+                </setting>
             </div>
         </field>
     </record>

--- a/addons/sale_timesheet/views/res_config_settings_views.xml
+++ b/addons/sale_timesheet/views/res_config_settings_views.xml
@@ -8,35 +8,14 @@
         <field name="inherit_id" ref="hr_timesheet.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='section_leaves']" position="before">
-                <h2>Billing</h2>
-                <div name="timesheet_billing" class="row mt16 o_settings_container">
-                    <div class="col-12 col-lg-6 o_setting_box" id="time_billing_setting">
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">Time Billing</span>
-                            <div class="text-muted">
-                                Sell services and invoice time spent
-                            </div>
-                            <div class="content-group" name="msg_module_sale_timesheet">
-                                <div class="mt8">
-                                    <div>
-                                        <button name="%(sale_timesheet.product_template_action_default_services)d" string="Configure your services" type="action" class="btn-link" icon="fa-arrow-right"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" name="invoice_policy">
-                        <div class="o_setting_left_pane">
-                            <field name="invoice_policy" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="invoice_policy"/>
-                            <div class="text-muted">
-                                Timesheets taken into account when invoicing your time
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <block title="Billing">
+                    <setting string="Time Billing" help="Sell services and invoice time spent" id="time_billing_setting">
+                        <button name="%(sale_timesheet.product_template_action_default_services)d" string="Configure your services" type="action" class="btn-link" icon="fa-arrow-right"/>
+                    </setting>
+                    <setting help="Timesheets taken into account when invoicing your time" name="invoice_policy">
+                        <field name="invoice_policy" widget="upgrade_boolean"/>
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>

--- a/addons/sms/views/res_config_settings_views.xml
+++ b/addons/sms/views/res_config_settings_views.xml
@@ -5,9 +5,9 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="sms_settings" position="inside">
+            <setting id="sms" position="inside">
                 <widget name="iap_buy_more_credits" service_name="sms" hide_service="1"/>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/snailmail_account/views/res_config_settings_views.xml
+++ b/addons/snailmail_account/views/res_config_settings_views.xml
@@ -14,7 +14,7 @@
                 </div>
             </xpath>
 
-            <div id="snailmail_settings" position="inside">
+            <setting id="send_invoices_followups" position="inside">
                 <div class="mt16" attrs="{'invisible': [('module_snailmail_account', '=', False)]}">
                     <div>
                         <field name="snailmail_color"/>
@@ -33,7 +33,7 @@
                     </div>
                 </div>
                 <widget name="iap_buy_more_credits" service_name="snailmail"/>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -7,461 +7,172 @@
             <field name="priority" eval="30"/>
             <field name="inherit_id" ref="base.res_config_settings_view_form" />
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('settings')]" position="inside" >
-                    <div class="app_settings_block" data-string="Inventory" string="Inventory" data-key="stock" groups="stock.group_stock_manager">
-                        <h2>Operations</h2>
-                        <div class="row mt16 o_settings_container" name="operations_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="product_packs_tracking"
-                                title="Put your products in packs (e.g. parcels, boxes) and track them">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_tracking_lot"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_tracking_lot"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/products/usage.html#packages" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Put your products in packs (e.g. parcels, boxes) and track them
+                <xpath expr="//form" position="inside" >
+                    <app data-string="Inventory" string="Inventory" name="stock" groups="stock.group_stock_manager">
+                        <block title="Operations" name="operations_setting_container">
+                            <setting id="product_packs_tracking" documentation="/applications/inventory_and_mrp/inventory/management/products/usage.html#packages" title="Put your products in packs (e.g. parcels, boxes) and track them" help="Put your products in packs (e.g. parcels, boxes) and track them">
+                                <field name="group_stock_tracking_lot"/>
+                            </setting>
+                            <setting id="process_transfers" help="Process transfers in batch per worker">
+                                <field name="module_stock_picking_batch"/>
+                                <div class="row mt-2" attrs="{'invisible': [('module_stock_picking_batch','=',False)]}">
+                                    <field name="group_stock_picking_wave" class="col-lg-1 ml16 mr0"/>
+                                    <div class="col ps-0">
+                                        <label for="group_stock_picking_wave"/>
+                                        <div class="text-muted">Process operations in wave transfers</div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="process_transfers">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_stock_picking_batch"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_stock_picking_batch"/>
-                                    <div class="text-muted">
-                                        Process transfers in batch per worker
-                                    </div>
-                                    <div class="row mt-2" attrs="{'invisible': [('module_stock_picking_batch','=',False)]}">
-                                        <field name="group_stock_picking_wave" class="col-lg-1 ml16 mr0"/>
-                                        <div class="col ps-0">
-                                            <label for="group_stock_picking_wave"/>
-                                            <div class="text-muted">Process operations in wave transfers</div>
+                            </setting>
+                            <setting id="warning_info" string="Warnings" help="Get informative or blocking warnings on partners">
+                                <field name="group_warning_stock"/>
+                            </setting>
+                            <setting id="quality_control" help="Add quality checks to your transfer operations">
+                                <field name="module_quality_control" widget="upgrade_boolean"/>
+                                <div class="row mt-2" attrs="{'invisible': [('module_quality_control','=',False)]}">
+                                    <field name="module_quality_control_worksheet" widget="upgrade_boolean" class="col-lg-1 ml16 mr0"/>
+                                    <div class="col ps-0">
+                                        <label for="module_quality_control_worksheet"/>
+                                        <div class="text-muted">
+                                            Create customizable worksheets for your quality checks
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="warning_info">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_warning_stock"/>
+                            </setting>
+                            <setting id="annual_inventory_date" groups='stock.group_stock_manager' string="Annual Inventory Day and Month" help="Day and month that annual inventory counts should occur.">
+                                <div class="content-group">
+                                    <field name="annual_inventory_day" class="o_light_label" style="width: 30px;"/>
+                                    <field name="annual_inventory_month" class="o_light_label"/>
                                 </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_warning_stock" string="Warnings"/>
-                                    <div class="text-muted">
-                                        Get informative or blocking warnings on partners
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="quality_control">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_quality_control" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_quality_control"/>
-                                    <div class="text-muted">
-                                        Add quality checks to your transfer operations
-                                    </div>
-                                    <div class="row mt-2" attrs="{'invisible': [('module_quality_control','=',False)]}">
-                                        <field name="module_quality_control_worksheet" widget="upgrade_boolean" class="col-lg-1 ml16 mr0"/>
-                                        <div class="col ps-0">
-                                            <label for="module_quality_control_worksheet"/>
-                                            <div class="text-muted">
-                                                Create customizable worksheets for your quality checks
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="annual_inventory_date" groups='stock.group_stock_manager'>
-                                <div class="o_setting_right_pane">
-                                    <label for="annual_inventory_day" string="Annual Inventory Day and Month"/>
-                                    <div class="text-muted">
-                                        Day and month that annual inventory counts should occur.
-                                    </div>
-                                    <div class="content-group">
-                                        <field name="annual_inventory_day" class="o_light_label" style="width: 30px;"/>
-                                        <field name="annual_inventory_month" class="o_light_label"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="reception_report">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_reception_report"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_reception_report"/>
-                                    <div class="text-muted">
-                                        View and allocate received quantities.
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Barcode</h2>
-                        <div class="row mt16 o_settings_container" name="barcode_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="process_operations_barcodes">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_stock_barcode" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane" id="barcode_settings">
-                                    <label for="module_stock_barcode"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/barcode/setup/software.html" title="Documentation" class="me-2 o_doc_link" target="_blank"></a>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted" name="stock_barcode">
-                                        Process operations faster with barcodes
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="use_product_barcode"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Shipping</h2>
-                        <div class="row mt16 o_settings_container" name="shipping_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="stock_move_email">
-                                <div class="o_setting_left_pane">
-                                    <field name="stock_move_email_validation"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="stock_move_email_validation" string="Email Confirmation"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Send an automatic confirmation email when Delivery Orders are done
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="stock_sms">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_stock_sms"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_stock_sms"/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
-                                    <div class="text-muted">
-                                        Send an automatic confirmation SMS Text Message when Delivery Orders are done
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_confirmation_sms"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="signature_delivery_orders">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_sign_delivery"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_sign_delivery"/>
-                                    <div class="text-muted">
-                                        Require a signature on your delivery orders
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="delivery" title="Shipping connectors allow to compute accurate shipping costs, print shipping labels and request carrier picking at your warehouse to ship to the customer. Apply shipping connector from delivery methods.">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery"/>
-                                    <div class="text-muted" id="delivery_carrier">
-                                        Compute shipping costs
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Shipping Connectors</h2>
-                        <div class="row mt16 o_settings_container" name="product_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_ups">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_ups" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_ups"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with UPS
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_ups"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_dhl">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_dhl" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_dhl"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with DHL
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_dhl"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_fedex">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_fedex" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_fedex"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with FedEx
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_fedex"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_usps">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_usps" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_usps"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with USPS
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_usps"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_bpost">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_bpost" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_bpost"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with bpost
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_bpost"/>
-                                    </div>
-                                </div>
-                            </div>
+                            </setting>
+                            <setting id="reception_report" help="View and allocate received quantities.">
+                                <field name="group_stock_reception_report"/>
+                            </setting>
+                        </block>
+                        <block title="Barcode" name="barcode_setting_container">
+                            <setting id="process_operations_barcodes" help="Process operations faster with barcodes" company_dependent="1" documentation="/applications/inventory_and_mrp/inventory/barcode/setup/software.html">
+                                <field name="module_stock_barcode" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                        <block title="Shipping" name="shipping_setting_container">
+                            <setting id="stock_move_email" company_dependent="1" string="Email Confirmation" help="Send an automatic confirmation email when Delivery Orders are done">
+                                <field name="stock_move_email_validation"/>
+                            </setting>
+                            <setting id="stock_sms" company_dependent="1" help="Send an automatic confirmation SMS Text Message when Delivery Orders are done">
+                                <field name="module_stock_sms"/>
+                            </setting>
+                            <setting id="signature_delivery_orders" help="Require a signature on your delivery orders">
+                                <field name="group_stock_sign_delivery"/>
+                            </setting>
+                            <setting id="delivery" help="Compute shipping costs" title="Shipping connectors allow to compute accurate shipping costs, print shipping labels and request carrier picking at your warehouse to ship to the customer. Apply shipping connector from delivery methods.">
+                                <field name="module_delivery"/>
+                            </setting>
+                        </block>
+                        <block title="Shipping Connectors" name="product_setting_container">
+                            <setting id="compute_shipping_costs_ups" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" help="Compute shipping costs and ship with UPS">
+                                <field name="module_delivery_ups" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="compute_shipping_costs_dhl" help=" Compute shipping costs and ship with DHL" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
+                                <field name="module_delivery_dhl" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="compute_shipping_costs_fedex" help="Compute shipping costs and ship with FedEx" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
+                                <field name="module_delivery_fedex" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="compute_shipping_costs_usps" help="Compute shipping costs and ship with USPS" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
+                                <field name="module_delivery_usps" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="compute_shipping_costs_bpost" help="Compute shipping costs and ship with bpost" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
+                                <field name="module_delivery_bpost" widget="upgrade_boolean"/>
+                            </setting>
 
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_easypost">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_easypost" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_easypost"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with Easypost
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_easypost"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_sendcloud">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_delivery_sendcloud"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Compute shipping costs and ship with Sendcloud
-                                    </div>
-                                    <div class="content-group">
-                                        <div id="stock_delivery_sendcloud"/>
+                            <setting id="compute_shipping_costs_easypost" help="Compute shipping costs and ship with Easypost" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
+                                <field name="module_delivery_easypost" widget="upgrade_boolean"/>
+                            </setting>
+                            <setting id="compute_shipping_costs_sendcloud" help="Compute shipping costs and ship with Sendcloud" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
+                                <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
+                            </setting>
+                        </block>
+                        <block title="Products" name="product_setting_container">
+                            <setting id="product_attributes" help="Set product attributes (e.g. color, size) to manage variants" documentation="/applications/sales/sales/products_prices/products/variants.html">
+                                <field name="group_product_variant"/>
+                                <div class="content-group">
+                                    <div class="mt8" attrs="{'invisible': [('group_product_variant', '=', False)]}">
+                                        <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                        <h2>Products</h2>
-                        <div class="row mt16 o_settings_container" name="product_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box" id="product_attributes">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_product_variant"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_product_variant"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/sales/sales/products_prices/products/variants.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Set product attributes (e.g. color, size) to manage variants
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt8" attrs="{'invisible': [('group_product_variant', '=', False)]}">
-                                            <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
-                                        </div>
+                            </setting>
+                            <setting id="sell_purchase_uom" help="Sell and purchase products in different units of measure" documentation="/applications/inventory_and_mrp/inventory/management/products/uom.html">
+                                <field name="group_uom"/>
+                                <div class="content-group">
+                                    <div class="mt8" attrs="{'invisible': [('group_uom', '=', False)]}">
+                                        <button name="%(uom.product_uom_categ_form_action)d" icon="fa-arrow-right" type="action" string="Units Of Measure" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="sell_purchase_uom">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_uom"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_uom"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/products/uom.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Sell and purchase products in different units of measure
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt8" attrs="{'invisible': [('group_uom', '=', False)]}">
-                                            <button name="%(uom.product_uom_categ_form_action)d" icon="fa-arrow-right" type="action" string="Units Of Measure" class="btn-link"/>
-                                        </div>
+                            </setting>
+                            <setting id="manage_product_packaging" title="Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)" help="Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)" documentation="/applications/inventory_and_mrp/inventory/management/products/usage.html#packaging">
+                                <field name="group_stock_packaging"/>
+                                <div class="content-group">
+                                    <div class="mt8" attrs="{'invisible': [('group_stock_packaging', '=', False)]}">
+                                        <button name="%(product.action_packaging_view)d" icon="fa-arrow-right" type="action" string="Product Packagings" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="manage_product_packaging"
-                                title="Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_packaging"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_packaging"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/products/usage.html#packaging" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt8" attrs="{'invisible': [('group_stock_packaging', '=', False)]}">
-                                            <button name="%(product.action_packaging_view)d" icon="fa-arrow-right" type="action" string="Product Packagings" class="btn-link"/>
-                                        </div>
+                            </setting>
+                        </block>
+                        <block title="Traceability" id="production_lot_info">
+                            <setting id="full_traceability" help="Get a full traceability from vendors to customers" documentation="/applications/inventory_and_mrp/inventory/management/lots_serial_numbers/differences.html">
+                                <field name="group_stock_production_lot"/>
+                                <div class="row mt-2" attrs="{'invisible': [('group_stock_production_lot','=',False)]}">
+                                    <field name="group_stock_lot_print_gs1" class="col-lg-1 ml16 mr0"/>
+                                    <div class="col ps-0">
+                                        <label for="group_stock_lot_print_gs1"/>
+                                        <div class="text-muted">Use GS1 nomenclature datamatrix whenever barcodes are printed for lots and serial numbers.</div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                        <h2>Traceability</h2>
-                        <div class="row mt16 o_settings_container" id="production_lot_info">
-                            <div class="col-12 col-lg-6 o_setting_box" id="full_traceability">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_production_lot"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_production_lot"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/lots_serial_numbers/differences.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Get a full traceability from vendors to customers
-                                    </div>
-                                    <div class="row mt-2" attrs="{'invisible': [('group_stock_production_lot','=',False)]}">
-                                        <field name="group_stock_lot_print_gs1" class="col-lg-1 ml16 mr0"/>
-                                        <div class="col ps-0">
-                                            <label for="group_stock_lot_print_gs1"/>
-                                            <div class="text-muted">Use GS1 nomenclature datamatrix whenever barcodes are printed for lots and serial numbers.</div>
-                                        </div>
+                            </setting>
+                            <setting id="expiration_dates_serial_numbers" help="Set expiration dates on lots &amp; serial numbers" attrs="{'invisible': [('group_stock_production_lot', '=', False)]}" title="Track following dates on lots &amp; serial numbers: best before, removal, end of life, alert. Such dates are set automatically at lot/serial number creation based on values set on the product (in days).">
+                                <field name="module_product_expiry"/>
+                            </setting>
+                            <setting help="Lots &amp; Serial numbers will appear on the delivery slip" attrs="{'invisible': [('group_stock_production_lot', '=', False)]}" id="group_lot_on_delivery_slip">
+                                <field name="group_lot_on_delivery_slip"/>
+                            </setting>
+                            <setting id="owner_stored_products" help="Set owner on stored products" documentation="/applications/inventory_and_mrp/inventory/management/misc/owned_stock.html">
+                                <field name="group_stock_tracking_owner"/>
+                            </setting>
+                        </block>
+                        <block title="Warehouse" name="warehouse_setting_container">
+                            <setting id="track_product_location" help="Track product location in your warehouse" documentation="/applications/inventory_and_mrp/inventory/management/warehouses/difference_warehouse_location.html" title="Store products in specific locations of your warehouse (e.g. bins, racks) and to track inventory accordingly.">
+                                <field name="group_stock_multi_locations"/>
+                                <div class="content-group">
+                                    <div class="mt8" attrs="{'invisible': [('group_stock_multi_locations', '=', False)]}">
+                                        <button name="%(stock.action_location_form)d" icon="fa-arrow-right" type="action" string="Locations" class="btn-link"/><br/>
+                                        <button name="stock.action_putaway_tree" icon="fa-arrow-right" type="action" string="Putaway Rules" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="expiration_dates_serial_numbers"
-                                attrs="{'invisible': [('group_stock_production_lot', '=', False)]}"
-                                title="Track following dates on lots &amp; serial numbers: best before, removal, end of life, alert. Such dates are set automatically at lot/serial number creation based on values set on the product (in days).">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_product_expiry"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_product_expiry"/>
-                                    <div class="text-muted">
-                                        Set expiration dates on lots &amp; serial numbers
+                            </setting>
+                            <setting id="use_own_routes" help="Use your own routes" documentation="/applications/inventory_and_mrp/inventory/routes/concepts/use-routes.html" title="Add and customize route operations to process product moves in your warehouse(s): e.g. unload &gt; quality control &gt; stock for incoming products, pick &gt; pack &gt; ship for outgoing products. You can also set putaway strategies on warehouse locations in order to send incoming products into specific child locations straight away (e.g. specific bins, racks).">
+                                <field name="group_stock_adv_location"/>
+                                <div class="content-group">
+                                    <div class="mt8" attrs="{'invisible': [('group_stock_adv_location', '=', False)]}">
+                                        <button name="%(stock.action_warehouse_form)d" icon="fa-arrow-right" type="action" string="Set Warehouse Routes" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('group_stock_production_lot', '=', False)]}" id="group_lot_on_delivery_slip">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_lot_on_delivery_slip"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_lot_on_delivery_slip"/>
-                                    <div class="text-muted">
-                                        Lots &amp; Serial numbers will appear on the delivery slip
+                            </setting>
+                            <setting id="categorize_locations" help="Categorize your locations for smarter putaway rules" attrs="{'invisible': [('group_stock_multi_locations', '=', False)]}">
+                                <field name="group_stock_storage_categories"/>
+                                <div class="content-group" attrs="{'invisible': [('group_stock_storage_categories', '=', False)]}">
+                                    <div class="mt8">
+                                        <button name="%(stock.action_storage_category)d" icon="fa-arrow-right" type="action" string="Storage Categories" class="btn-link"/>
+                                    </div>
+                                    <div class="mt4" groups="base.group_no_one">
+                                        <button name="%(stock.action_storage_category_capacity)d" icon="fa-arrow-right" type="action" string="Storage Category Capacity" class="btn-link"/>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="owner_stored_products">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_tracking_owner"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_tracking_owner"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/misc/owned_stock.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Set owner on stored products
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2 class="mt32">Warehouse</h2>
-                        <div class="row mt16 o_settings_container" name="warehouse_setting_container">
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="track_product_location"
-                                title="Store products in specific locations of your warehouse (e.g. bins, racks) and to track inventory accordingly.">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_multi_locations"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_multi_locations"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/warehouses/difference_warehouse_location.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Track product location in your warehouse
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt8" attrs="{'invisible': [('group_stock_multi_locations', '=', False)]}">
-                                            <button name="%(stock.action_location_form)d" icon="fa-arrow-right" type="action" string="Locations" class="btn-link"/><br/>
-                                            <button name="stock.action_putaway_tree" icon="fa-arrow-right" type="action" string="Putaway Rules" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="use_own_routes"
-                                title="Add and customize route operations to process product moves in your warehouse(s): e.g. unload &gt; quality control &gt; stock for incoming products, pick &gt; pack &gt; ship for outgoing products. You can also set putaway strategies on warehouse locations in order to send incoming products into specific child locations straight away (e.g. specific bins, racks).">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_adv_location"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_adv_location"/>
-                                    <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/routes/concepts/use-routes.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                    <div class="text-muted">
-                                        Use your own routes
-                                    </div>
-                                    <div class="content-group">
-                                        <div class="mt8" attrs="{'invisible': [('group_stock_adv_location', '=', False)]}">
-                                            <button name="%(stock.action_warehouse_form)d" icon="fa-arrow-right" type="action" string="Set Warehouse Routes" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="categorize_locations"
-                                attrs="{'invisible': [('group_stock_multi_locations', '=', False)]}">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_stock_storage_categories"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="group_stock_storage_categories"/>
-                                    <div class="text-muted">
-                                        Categorize your locations for smarter putaway rules
-                                    </div>
-                                    <div class="content-group" attrs="{'invisible': [('group_stock_storage_categories', '=', False)]}">
-                                        <div class="mt8">
-                                            <button name="%(stock.action_storage_category)d" icon="fa-arrow-right" type="action" string="Storage Categories" class="btn-link"/>
-                                        </div>
-                                        <div class="mt4" groups="base.group_no_one">
-                                            <button name="%(stock.action_storage_category_capacity)d" icon="fa-arrow-right" type="action" string="Storage Category Capacity" class="btn-link"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2 id="schedule_info" invisible="1">Advanced Scheduling</h2>
-                        <div class="row mt16 o_settings_container">
+                            </setting>
+                        </block>
+                        <block title="Advanced Scheduling" id="schedule_info" invisible="1">
                             <div id="sale_security_lead"/>
                             <div id="purchase_po_lead"/>
-                        </div>
-                    </div>
+                        </block>
+                    </app>
                 </xpath>
             </field>
         </record>

--- a/addons/stock_account/views/res_config_settings_views.xml
+++ b/addons/stock_account/views/res_config_settings_views.xml
@@ -6,39 +6,19 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <div id="production_lot_info" position="after">
-                    <h2>Valuation</h2>
-                    <div class="row mt16 o_settings_container" name="valuation_setting_container">
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="additional_cost_setting"
-                            title="Affect landed costs on reception operations and split them among products to update their cost price.">
-                            <div class="o_setting_left_pane">
-                                <field name="module_stock_landed_costs"/>
+                <block id="production_lot_info" position="after">
+                    <block title="Valuation" name="valuation_setting_container">
+                        <setting id="additional_cost_setting" title="Affect landed costs on reception operations and split them among products to update their cost price." documentation="/applications/inventory_and_mrp/inventory/management/reporting/integrating_landed_costs.html" help="Add additional cost (transport, customs, ...) in the value of the product.">
+                            <field name="module_stock_landed_costs"/>
+                            <div class="content-group">
+                                <div name="landed_cost_info"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="module_stock_landed_costs"/>
-                                <a href="https://www.odoo.com/documentation/master/applications/inventory_and_mrp/inventory/management/reporting/integrating_landed_costs.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Add additional cost (transport, customs, ...) in the value of the product.
-                                </div>
-                                <div class="content-group">
-                                    <div name="landed_cost_info"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('group_stock_production_lot', '=', False)]}" id="group_lot_on_invoice">
-                            <div class="o_setting_left_pane">
-                                <field name="group_lot_on_invoice"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_lot_on_invoice"/>
-                                <div class="text-muted">
-                                    Lots &amp; Serial numbers will appear on the invoice
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                        </setting>
+                        <setting attrs="{'invisible': [('group_stock_production_lot', '=', False)]}" id="group_lot_on_invoice" help="Lots &amp; Serial numbers will appear on the invoice">
+                            <field name="group_lot_on_invoice"/>
+                        </setting>
+                    </block>
+                </block>
             </field>
         </record>
     </data>

--- a/addons/stock_sms/views/res_config_settings_views.xml
+++ b/addons/stock_sms/views/res_config_settings_views.xml
@@ -9,10 +9,10 @@
             <xpath expr="//field[@name='module_stock_sms']" position="replace">
                 <field name="stock_move_sms_validation"/>
             </xpath>
-            <xpath expr="//label[@for='module_stock_sms']" position="replace">
-                <label for="stock_move_sms_validation" string="SMS Confirmation"/>
+            <xpath expr="//setting[@id='stock_sms']" position="attributes">
+                <attribute name="string">SMS Confirmation</attribute>
             </xpath>
-            <xpath expr="//div[@id='stock_confirmation_sms']" position="replace">
+            <xpath expr="//setting[@id='stock_sms']" position="inside">
                 <div class="row mt16" attrs="{'invisible': [('stock_move_sms_validation', '=', False)]}">
                     <label for="stock_sms_confirmation_template_id" string="SMS Template" class="col-lg-4 o_light_label"/>
                     <field name="stock_sms_confirmation_template_id" class="oe_inline" attrs="{'required': [('stock_move_sms_validation', '=', True)]}" context="{'default_model': 'stock.picking'}"/>

--- a/addons/web/static/src/views/form/form_label.js
+++ b/addons/web/static/src/views/form/form_label.js
@@ -21,7 +21,7 @@ export class FormLabel extends Component {
         if (empty) {
             classes.push("o_form_label_empty");
         }
-        if (readonly) {
+        if (readonly && !this.props.notMuttedLabel) {
             classes.push("o_form_label_readonly");
         }
         return classes.join(" ");
@@ -64,4 +64,5 @@ FormLabel.props = {
     className: { type: String, optional: true },
     string: { type: String },
     id: { type: String },
+    notMuttedLabel: { type: Boolean, optional: true },
 };

--- a/addons/web/static/src/webclient/settings_form_view/highlight_text/form_label_highlight_text.js
+++ b/addons/web/static/src/webclient/settings_form_view/highlight_text/form_label_highlight_text.js
@@ -15,21 +15,7 @@ export class FormLabelHighlightText extends FormLabel {
             this.upgradeEnterprise = true;
         }
     }
-    get className() {
-        if (this.props.className) {
-            return this.props.className;
-        }
-        return super.className;
-    }
 }
 
 FormLabelHighlightText.template = "web.FormLabelHighlightText";
 FormLabelHighlightText.components = { HighlightText };
-FormLabelHighlightText.props = {
-    fieldInfo: { type: Object, optional: true },
-    className: { type: String, optional: true },
-    record: { type: Object, optional: true },
-    fieldName: { type: String, optional: true },
-    string: { type: String },
-    id: { type: String },
-};

--- a/addons/web/static/src/webclient/settings_form_view/highlight_text/settings_radio_field.js
+++ b/addons/web/static/src/webclient/settings_form_view/highlight_text/settings_radio_field.js
@@ -2,7 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { RadioField } from "@web/views/fields/radio/radio_field";
-import { FormLabelHighlightText } from "./form_label_highlight_text";
+import { HighlightText } from "./highlight_text";
 
 export class SettingsRadioField extends RadioField {}
 
@@ -11,6 +11,6 @@ SettingsRadioField.extractStringExpr = (fieldName, record) => {
     return radioItems.map((r) => r[1]);
 };
 SettingsRadioField.template = "web.SettingsRadioField";
-SettingsRadioField.components = { ...RadioField.components, FormLabelHighlightText };
+SettingsRadioField.components = { ...RadioField.components, HighlightText };
 
 registry.category("fields").add("base_settings.radio", SettingsRadioField);

--- a/addons/web/static/src/webclient/settings_form_view/highlight_text/settings_radio_field.xml
+++ b/addons/web/static/src/webclient/settings_form_view/highlight_text/settings_radio_field.xml
@@ -3,7 +3,9 @@
 
     <t t-name="web.SettingsRadioField" t-inherit="web.RadioField" t-inherit-mode="primary" owl="1">
         <xpath expr="//label" position="replace">
-            <FormLabelHighlightText className="'form-check-label'" id="`${id}_${item[0]}`" string="item[1]"/>
+            <label class="form-check-label o_form_label" t-att-for="`${id}_${item[0]}`">
+                <HighlightText originalText="item[1]"/>
+            </label>
         </xpath>
     </t>
 

--- a/addons/web/static/src/webclient/settings_form_view/settings/setting.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/setting.js
@@ -1,8 +1,10 @@
 /** @odoo-module **/
 
 import { escapeRegExp } from "@web/core/utils/strings";
-
-import { Component, useState, useChildSubEnv } from "@odoo/owl";
+import { HighlightText } from "../highlight_text/highlight_text";
+import { session } from "@web/session";
+import { FormLabelHighlightText } from "../highlight_text/form_label_highlight_text";
+import { Component, useState } from "@odoo/owl";
 
 export class Setting extends Component {
     setup() {
@@ -10,18 +12,61 @@ export class Setting extends Component {
             search: this.env.searchState,
             showAllContainer: this.env.showAllContainer,
         });
-        // Don't search on a header setting
-        if (this.props.type === "header") {
-            useChildSubEnv({ searchState: { value: "" } });
-        }
         this.labels = this.props.labels || [];
+        this.labels.push(this.labelString, this.props.help);
+        if (this.props.fieldName) {
+            this.fieldType = this.props.record.fields[this.props.fieldName].type;
+            if (
+                typeof this.props.fieldInfo.modifiers.readonly === "boolean" &&
+                this.props.fieldInfo.modifiers.readonly === true
+            ) {
+                this.notMuttedLabel = true;
+            }
+        }
+    }
+
+    get classNames() {
+        const { class: _class } = this.props;
+        const classNames = {
+            o_setting_box: true,
+            "col-12": true,
+            "col-lg-6": true,
+            o_searchable_setting: Boolean(this.labels.length),
+            [_class]: Boolean(_class),
+        };
+
+        return classNames;
+    }
+
+    get displayCompanyDependentIcon() {
+        return (
+            this.labelString && this.props.companyDependent && session.display_switch_company_menu
+        );
+    }
+
+    get labelString() {
+        if (this.props.string) {
+            return this.props.string;
+        }
+        const label =
+            this.props.record &&
+            this.props.record.fields[this.props.fieldName] &&
+            this.props.record.fields[this.props.fieldName].string;
+        return label || "";
+    }
+
+    get url() {
+        if (this.props.documentation.startsWith("^https?://")) {
+            return this.props.documentation;
+        } else {
+            const serverVersion = session.server_version.includes("alpha")
+                ? "master"
+                : session.server_version;
+            return "https://www.odoo.com/documentation/" + serverVersion + this.props.documentation;
+        }
     }
     visible() {
         if (!this.state.search.value) {
-            return true;
-        }
-        // Always shown a header setting
-        if (this.props.type === "header") {
             return true;
         }
         if (this.state.showAllContainer.showAllContainer) {
@@ -33,16 +78,24 @@ export class Setting extends Component {
         }
         return false;
     }
-
-    get classNames() {
-        const { class: _class, type } = this.props;
-        const classNames = {
-            o_setting_box: true,
-            o_searchable_setting: this.labels.length && type !== "header",
-            [_class]: Boolean(_class),
-        };
-
-        return classNames;
-    }
 }
+Setting.components = {
+    FormLabelHighlightText,
+    HighlightText,
+};
 Setting.template = "web.Setting";
+Setting.props = {
+    labels: { type: Array, optional: 1 },
+    title: { type: String, optional: 1 },
+    fieldId: { type: String, optional: 1 },
+    help: { type: String, optional: 1 },
+    fieldName: { type: String, optional: 1 },
+    fieldInfo: { type: Object, optional: 1 },
+    class: { type: String, optional: 1 },
+    record: { type: Object, optional: 1 },
+    documentation: { type: String, optional: 1 },
+    string: { type: String, optional: 1 },
+    addLabel: { type: Boolean },
+    companyDependent: { type: Boolean, optional: 1 },
+    slots: { type: Object, optional: 1 },
+};

--- a/addons/web/static/src/webclient/settings_form_view/settings/setting.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/setting.xml
@@ -1,8 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.Setting" owl="1">
-        <div t-att-class="classNames" t-att-title="props.title" t-if="visible()">
-            <t t-slot="default"/>
+        <div t-att-class="classNames" t-if="visible()">
+            <div class="o_setting_left_pane" t-att-data-tooltip="props.title" data-tooltip-delay="800">
+                <t t-if="props.fieldName and fieldType==='boolean'">
+                    <t t-slot="fieldSlot"/>
+                </t>
+            </div>
+            <div class="o_setting_right_pane" t-att-data-tooltip="props.title" data-tooltip-delay="800">
+                <FormLabelHighlightText t-if="props.fieldName and props.addLabel" notMuttedLabel="notMuttedLabel" fieldName="props.fieldName" id="props.fieldId" string="labelString" record="props.record" fieldInfo="props.fieldInfo"/>
+                <t t-if="labelString and !props.fieldName and props.addLabel">
+                    <span class="o_form_label"><HighlightText originalText="labelString"/></span>
+                </t>
+                <t t-if="labelString and props.documentation">
+                    <a t-att-href="url" title="Documentation" class="o_doc_link me-2" target="_blank"></a>
+                </t>
+                <t t-if="displayCompanyDependentIcon">
+                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
+                </t>
+                <t t-if="labelString and props.help">
+                    <div class="text-muted"><HighlightText originalText="props.help"/></div>
+                </t>
+                <div class="mt16">
+                    <t t-if="props.fieldName and fieldType!=='boolean'">
+                        <t t-slot="fieldSlot"/>
+                    </t>
+                    <t t-slot="default"/>
+                </div>
+            </div>
         </div>
     </t>
 </templates>

--- a/addons/web/static/src/webclient/settings_form_view/settings/setting_header.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/setting_header.js
@@ -1,0 +1,17 @@
+/** @odoo-module **/
+
+import { useChildSubEnv } from "@odoo/owl";
+import { Setting } from "./setting";
+
+export class SettingHeader extends Setting {
+    setup() {
+        super.setup();
+        // Don't search on a header setting
+        useChildSubEnv({ searchState: { value: "" } });
+    }
+
+    get labelString() {
+        return this.props.string || this.props.record.fields[this.props.name].string;
+    }
+}
+SettingHeader.template = "web.HeaderSetting";

--- a/addons/web/static/src/webclient/settings_form_view/settings/setting_header.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/setting_header.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.HeaderSetting" owl="1">
+        <div class="app_settings_header row my-0 ms-0 mw-100 bg-warning bg-opacity-25">
+            <div class="col-xs-12 col-md-6 ms-0 o_setting_box">
+                <div class="o_setting_right_pane border-start-0 ms-0 ps-0">
+                    <div class="content-group">
+                        <div class="row flex-row flex-nowrap mt8 align-items-center">
+                            <label class="o_form_label col ps-0 text-nowrap" t-att-for="props.fieldId" >
+                                <t t-esc="labelString"/>
+                            </label>
+                            <t t-slot="fieldSlot"/>
+                            <t t-slot="default"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_app.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_app.js
@@ -27,3 +27,10 @@ export class SettingsApp extends Component {
     }
 }
 SettingsApp.template = "web.SettingsApp";
+SettingsApp.props = {
+    string: String,
+    imgurl: String,
+    key: String,
+    selectedTab: { type: String, optional: 1 },
+    slots: Object,
+};

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_block.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_block.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { HighlightText } from "./../highlight_text/highlight_text";
+import { HighlightText } from "../highlight_text/highlight_text";
 import { escapeRegExp } from "@web/core/utils/strings";
 
 import { Component, useState, useRef, useEffect, onWillRender, useChildSubEnv } from "@odoo/owl";
 
-export class SettingsContainer extends Component {
+export class SettingsBlock extends Component {
     setup() {
         this.state = useState({
             search: this.env.searchState,
@@ -51,7 +51,13 @@ export class SettingsContainer extends Component {
         this.settingsContainerRef.el.classList.toggle("d-none", force);
     }
 }
-SettingsContainer.template = "web.SettingsContainer";
-SettingsContainer.components = {
+SettingsBlock.template = "web.SettingsBlock";
+SettingsBlock.components = {
     HighlightText,
+};
+SettingsBlock.props = {
+    title: { type: String, optional: 1 },
+    tip: { type: String, optional: 1 },
+    slots: Object,
+    class: { type: String, optional: 1 },
 };

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_block.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_block.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="web.SettingsContainer" owl="1">
+    <t t-name="web.SettingsBlock" owl="1">
         <h2 t-if="props.title" t-ref="settingsContainerTitle"><HighlightText originalText="props.title"/></h2>
         <h3 t-if="props.tip" class="o_setting_tip text-muted" t-ref="settingsContainerTip"><HighlightText originalText="props.tip"/></h3>
-        <div t-att-class="props.class" t-ref="settingsContainer">
+        <div class="row mt16 o_settings_container" t-att-class="props.class" t-ref="settingsContainer">
             <t t-slot="default"/>
         </div>
     </t>

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
@@ -65,3 +65,8 @@ export class SettingsPage extends Component {
 }
 SettingsPage.template = "web.SettingsPage";
 SettingsPage.components = { ActionSwiper };
+SettingsPage.props = {
+    modules: Array,
+    initialTab: { type: String, optional: 1 },
+    slots: Object,
+};

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.SettingsPage" owl="1">
-        <div class="settings_tab" t-if="!env.isSmall or state.search.value.length === 0">
-            <t t-foreach="props.modules" t-as="module" t-key="module.key">
-                <div class="tab" t-if="!module.isVisible" t-att-class="(state.selectedTab === module.key and state.search.value.length === 0) ? 'selected': ''" t-att-data-key="module.key" role="tab" t-on-click="() => this.onSettingTabClick(module.key)">
-                    <div class="icon d-none d-md-block" t-attf-style="background : url('{{module.imgurl}}') no-repeat center;background-size:contain;"/> <span class="app_name"><t t-esc="module.string"/></span>
-                </div>
-            </t>
-        </div>
-        <ActionSwiper
-                onRightSwipe = " hasRightSwipe() ? {
-                    action: onRightSwipe.bind(this),
-                } : undefined"
-                onLeftSwipe = " hasLeftSwipe() ? {
-                    action: onLeftSwipe.bind(this),
-                } : undefined"
-                animationOnMove="false"
-                animationType="'forwards'"
-                swipeDistanceRatio="6">
-            <div class="settings" t-ref="settings">
-                <t t-slot="NoContentHelper" t-if="props.slots['NoContentHelper'].isVisible"/>
-                <t t-slot="default" selectedTab="state.selectedTab"/>
+        <div class="o_setting_container">
+            <div class="settings_tab" t-if="!env.isSmall or state.search.value.length === 0">
+                <t t-foreach="props.modules" t-as="module" t-key="module.key">
+                    <div class="tab" t-if="!module.isVisible" t-att-class="(state.selectedTab === module.key and state.search.value.length === 0) ? 'selected': ''" t-att-data-key="module.key" role="tab" t-on-click="() => this.onSettingTabClick(module.key)">
+                        <div class="icon d-none d-md-block" t-attf-style="background : url('{{module.imgurl}}') no-repeat center;background-size:contain;"/> <span class="app_name"><t t-esc="module.string"/></span>
+                    </div>
+                </t>
             </div>
-        </ActionSwiper>
+            <ActionSwiper
+                    onRightSwipe = " hasRightSwipe() ? {
+                        action: onRightSwipe.bind(this),
+                    } : undefined"
+                    onLeftSwipe = " hasLeftSwipe() ? {
+                        action: onLeftSwipe.bind(this),
+                    } : undefined"
+                    animationOnMove="false"
+                    animationType="'forwards'"
+                    swipeDistanceRatio="6">
+                <div class="settings" t-ref="settings">
+                    <t t-slot="NoContentHelper" t-if="props.slots['NoContentHelper'].isVisible"/>
+                    <t t-slot="default" selectedTab="state.selectedTab"/>
+                </div>
+            </ActionSwiper>
+        </div>
     </t>
 </templates>

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_renderer.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_renderer.js
@@ -5,7 +5,8 @@ import { FormRenderer } from "@web/views/form/form_renderer";
 import { FormLabelHighlightText } from "./highlight_text/form_label_highlight_text";
 import { HighlightText } from "./highlight_text/highlight_text";
 import { Setting } from "./settings/setting";
-import { SettingsContainer } from "./settings/settings_container";
+import { SettingHeader } from "./settings/setting_header";
+import { SettingsBlock } from "./settings/settings_block";
 import { SettingsApp } from "./settings/settings_app";
 import { SettingsPage } from "./settings/settings_page";
 
@@ -53,7 +54,8 @@ export class SettingsFormRenderer extends FormRenderer {
 SettingsFormRenderer.components = {
     ...FormRenderer.components,
     Setting,
-    SettingsContainer,
+    SettingHeader,
+    SettingsBlock,
     SettingsPage,
     SettingsApp,
     HighlightText,

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
@@ -2,10 +2,11 @@
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { SettingsContainer } from "../settings/settings_container";
+import { SettingsBlock } from "../settings/settings_block";
 import { Setting } from "../settings/setting";
 
 import { Component, onWillStart } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 /**
  * Widget in the settings that handles the "Developer Tools" section.
@@ -36,8 +37,11 @@ class ResConfigDevTool extends Component {
 
 ResConfigDevTool.template = "res_config_dev_tool";
 ResConfigDevTool.components = {
-    SettingsContainer,
+    SettingsBlock,
     Setting,
+};
+ResConfigDevTool.props = {
+    ...standardWidgetProps,
 };
 
 registry.category("view_widgets").add("res_config_dev_tool", ResConfigDevTool);

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
@@ -2,17 +2,15 @@
 <template>
     <div t-name='res_config_dev_tool' owl="1">
         <div id="developer_tool">
-            <SettingsContainer title="'Developer Tools'" class="'row mt16 o_settings_container'">
-                <Setting class="'col-12 col-lg-6 o_setting_box'" id="devel_tool">
-                    <div class="o_setting_right_pane">
+            <SettingsBlock title="'Developer Tools'">
+                <Setting addLabel="false">
                         <a t-if="!isDebug" class="d-block" href="?debug=1">Activate the developer mode</a>
                         <a t-if="!isAssets" class="d-block" href="?debug=assets">Activate the developer mode (with assets)</a>
                         <a t-if="!isTests" class="d-block" href="?debug=assets,tests">Activate the developer mode (with tests assets)</a>
                         <a t-if="isDebug" class="d-block" href="?debug=">Deactivate the developer mode</a>
                         <a t-if="isDebug and !isDemoDataActive" t-on-click.prevent="onClickForceDemo" class="o_web_settings_force_demo" href="#">Load demo data</a>
-                    </div>
                 </Setting>
-            </SettingsContainer>
+            </SettingsBlock>
         </div>
     </div>
 </template>

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_edition.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_edition.js
@@ -2,8 +2,10 @@
 
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
+import { Setting } from "@web/webclient/settings_form_view/settings/setting";
 
 import { Component } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 const { DateTime } = luxon;
 
 /**
@@ -20,5 +22,8 @@ class ResConfigEdition extends Component {
 }
 
 ResConfigEdition.template = "res_config_edition";
-
+ResConfigEdition.components = { Setting };
+ResConfigEdition.props = {
+    ...standardWidgetProps,
+};
 registry.category("view_widgets").add("res_config_edition", ResConfigEdition);

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_edition.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_edition.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <template>
     <div t-name='res_config_edition' owl="1">
-        <div class="col-12 o_setting_box" id="edition">
-            <div class="o_setting_right_pane">
+        <Setting addLabel="false">
                 <div class="user-heading">
                     <h3 class="px-0">
                         Odoo <t t-esc="serverVersion"/>
@@ -16,7 +15,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
+        </Setting>
     </div>
 </template>

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.js
@@ -6,6 +6,7 @@ import { unique } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, useState, onWillStart } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 class ResConfigInviteUsers extends Component {
     setup() {
@@ -30,7 +31,8 @@ class ResConfigInviteUsers extends Component {
      * @returns {boolean} true if the given email address is valid
      */
     validateEmail(email) {
-        const re = /^([a-z0-9][-a-z0-9_+.]*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i;
+        const re =
+            /^([a-z0-9][-a-z0-9_+.]*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,63}(?:\.[a-z]{2})?)$/i;
         return re.test(email);
     }
 
@@ -124,5 +126,8 @@ class ResConfigInviteUsers extends Component {
 }
 
 ResConfigInviteUsers.template = "res_config_invite_users";
+ResConfigInviteUsers.props = {
+    ...standardWidgetProps,
+};
 
 registry.category("view_widgets").add("res_config_invite_users", ResConfigInviteUsers);

--- a/addons/web/static/tests/mobile/webclient/settings_form_view_tests.js
+++ b/addons/web/static/tests/mobile/webclient/settings_form_view_tests.js
@@ -49,36 +49,20 @@ QUnit.module("Mobile SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="bar"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="bar"/>
-                                            <div class="text-muted">this is bar</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="app_settings_block" string="Project" data-key="project">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="foo"/>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <app string="CRM" name="crm">
+                        <block>
+                            <setting help="this is bar">
+                                <field name="bar"/>
+                            </setting>
+                        </block>
+                    </app>
+                    <app string="Project" name="project">
+                        <block>
+                            <setting help="this is foo">
+                                <field name="foo"/>
+                            </setting>
+                        </block>
+                    </app>
                 </form>`,
         });
 
@@ -125,36 +109,20 @@ QUnit.module("Mobile SettingsFormView", (hooks) => {
                 serverData,
                 arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="bar"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="bar"/>
-                                            <div class="text-muted">this is bar</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="app_settings_block" string="Project" data-key="project">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="foo"/>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <app string="CRM" name="crm">
+                        <block>
+                            <setting help="this is bar">
+                                <field name="bar"/>
+                            </setting>
+                        </block>
+                    </app>
+                    <app string="Project" name="project">
+                        <block>
+                            <setting help="this is foo">
+                                <field name="foo"/>
+                            </setting>
+                        </block>
+                    </app>
                 </form>`,
             });
 

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -69,69 +69,33 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="app_settings_header pt-1 pb-1" style="background-color: #FEF0D0;">
-                                    <div class="col-xs-12 col-md-6 ms-0 o_setting_box">
-                                        <div class="o_setting_right_pane border-start-0 ms-0 ps-0">
-                                            <div class="content-group">
-                                                <div class="row flex-row flex-nowrap mt8 align-items-center">
-                                                    <label class="col text-nowrap ml8 flex-nowrap" string="Foo" for="foo_config_id"/>
-                                                    <field name="foo" title="Foo?."/>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <h2>Title of group Bar</h2>
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="bar"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="bar"/>
-                                            <div class="text-muted">this is bar</div>
-                                        </div>
-                                    </div>
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="bar"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="bar" string="This is Big BAR"/>
-                                            <div class="text-muted">this is big bar</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <h2>Title of group Foo</h2>
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <h2 attrs="{'invisible': [('bar','=',False)]}">Hide group Foo</h2>
-                                <div class="row mt16 o_settings_container" attrs="{'invisible': [('bar','=',False)]}">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Hide Foo</span>
-                                            <div class="text-muted">this is hide foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <app string="CRM" name="crm">
+                        <setting type="header" string="Foo">
+                            <field name="foo" title="Foo?."/>
+                            <button name="nameAction" type="object" string="Button" class="col-auto btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
+                        </setting>
+                        <block title="Title of group Bar">
+                            <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
+                                <field name="bar"/>
+                            </setting>
+                            <setting string="This is Big BAR" help="this is big bar">
+                                <field name="bar"/>
+                            </setting>
+                        </block>
+                        <block title="Title of group Foo">
+                            <setting help="this is foo">
+                                <field name="foo"/>
+                            </setting>
+                            <setting string="Personalize setting" help="this is full personalize setting">
+                                <div>This is a different setting</div>
+                            </setting>
+                        </block>
+                        <block title="Hide group Foo" attrs="{'invisible': [('bar','=',False)]}">
+                            <setting string="Hide Foo" help="this is hide foo">
+                                <field name="foo"/>
+                            </setting>
+                        </block>
+                    </app>
                 </form>`,
         });
 
@@ -146,12 +110,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             "res.config.settings settings show"
         );
         assert.deepEqual(
-            [...target.querySelectorAll(".settings .o_form_label")].map((x) => x.textContent),
-            ["Bar", "This is Big BAR", "Foo"]
+            [...target.querySelectorAll(".settings .o_settings_container .o_form_label")].map(
+                (x) => x.textContent
+            ),
+            ["Bar", "This is Big BAR", "Foo", "Personalize setting"]
         );
         assert.deepEqual(
             [...target.querySelectorAll(".settings .text-muted")].map((x) => x.textContent),
-            ["this is bar", "this is big bar", "this is foo"]
+            ["this is bar", "this is big bar", "this is foo", "this is full personalize setting"]
         );
         assert.deepEqual(
             [...target.querySelectorAll(".settings h2:not(.d-none)")].map((x) => x.textContent),
@@ -166,6 +132,10 @@ QUnit.module("SettingsFormView", (hooks) => {
         assert.containsOnce(
             target,
             ".app_settings_block:not(.d-none) .app_settings_header .o_setting_box"
+        );
+        assert.strictEqual(
+            target.querySelector(".o_setting_box a").href,
+            "https://www.odoo.com/documentation/1.0/applications/technical/web/settings/this_is_a_test.html"
         );
 
         await editSearch(target, "Hello there");
@@ -188,7 +158,9 @@ QUnit.module("SettingsFormView", (hooks) => {
             "b word highlighted"
         );
         assert.deepEqual(
-            [...target.querySelectorAll(".o_setting_box .o_form_label")].map((x) => x.textContent),
+            [...target.querySelectorAll(".o_settings_container .o_setting_box .o_form_label")].map(
+                (x) => x.textContent
+            ),
             ["Bar", "This is Big BAR"],
             "Foo is not shown"
         );
@@ -206,7 +178,9 @@ QUnit.module("SettingsFormView", (hooks) => {
         await editSearch(target, "Big");
         await execTimeouts();
         assert.deepEqual(
-            [...target.querySelectorAll(".o_setting_box .o_form_label")].map((x) => x.textContent),
+            [...target.querySelectorAll(".o_settings_container  .o_setting_box .o_form_label")].map(
+                (x) => x.textContent
+            ),
             ["This is Big BAR"],
             "Only 'Big Bar' is shown"
         );
@@ -223,7 +197,9 @@ QUnit.module("SettingsFormView", (hooks) => {
         await editSearch(target, "group Bar");
         await execTimeouts();
         assert.deepEqual(
-            [...target.querySelectorAll(".o_setting_box .o_form_label")].map((x) => x.textContent),
+            [...target.querySelectorAll(".o_settings_container  .o_setting_box .o_form_label")].map(
+                (x) => x.textContent
+            ),
             ["Bar", "This is Big BAR"],
             "When searching a title, all group is shown"
         );
@@ -252,9 +228,11 @@ QUnit.module("SettingsFormView", (hooks) => {
             "Fo word highlighted"
         );
         assert.deepEqual(
-            [...target.querySelectorAll(".o_setting_box .o_form_label")].map((x) => x.textContent),
-            ["Foo"],
-            "only Foo is shown"
+            [...target.querySelectorAll(".o_settings_container .o_setting_box .o_form_label")].map(
+                (x) => x.textContent
+            ),
+            ["Foo", "Personalize setting"],
+            "only settings in group Foo is shown"
         );
         assert.containsOnce(
             target,
@@ -269,7 +247,9 @@ QUnit.module("SettingsFormView", (hooks) => {
             "Hide settings should not be shown"
         );
         assert.deepEqual(
-            [...target.querySelectorAll(".o_setting_box .o_form_label")].map((x) => x.textContent),
+            [...target.querySelectorAll(".o_settings_container .o_setting_box .o_form_label")].map(
+                (x) => x.textContent
+            ),
             [],
             "Hide settings should not be shown"
         );
@@ -286,24 +266,11 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_right_pane">
-                                            <label for="baz"/>
-                                            <div class="content-group">
-                                                <div class="mt16">
-                                                    <field name="baz" class="o_light_label" widget="radio"/>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <app string="CRM" name="crm">
+                        <block title="Baz">
+                            <field name="baz" class="o_light_label" widget="radio"/>
+                        </block>
+                    </app>
                 </form>`,
         });
         assert.hasAttrValue(
@@ -341,37 +308,18 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="Settings" data-key="settings">
-                                <h2>Setting Header</h2>
-                                <h3 class="o_setting_tip">Settings will appear below</h3>
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="bar"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <label for="bar"/>
-                                            <div class="text-muted">this is bar</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <h2>Title of group Foo</h2>
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <app string="Settings" name="settings">
+                        <block title="Setting Header" help="Settings will appear below">
+                            <setting help="this is bar">
+                                <field name="bar"/>
+                            </setting>
+                        </block>
+                        <block title="Title of group Foo">
+                            <setting help="this is foo">
+                                <field name="foo"/>
+                            </setting>
+                        </block>
+                    </app>
                 </form>`,
         });
         assert.containsOnce(
@@ -415,22 +363,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData.views = {
                 "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <button name="4" string="Execute action" type="action"/>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block>
+                                <setting help="this is foo">
+                                    <field name="foo"/>
+                                </setting>
+                            </block>
+                            <button name="4" string="Execute action" type="action"/>
+                        </app>
                     </form>`,
                 "task,2,list": `
                     <tree>
@@ -478,15 +418,11 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="Base Setting" data-key="base-setting">
-                                <div class="o_setting_box">
+                            <app string="Base Setting" name="base-setting">
+                                <setting>
                                     <field name="bar"/>Make Changes
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                                </setting>
+                            </app>
                 </form>`,
             mockRPC(route, { args, method, model }) {
                 if (method === "create" && model === "res.config.settings") {
@@ -515,20 +451,16 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <label for="foo" string="Label Before" class="a"/>
-                                            <field name="foo" class="b"/>
-                                            <label for="foo" string="Label After" class="c"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </form>`,
+                    <app string="CRM" name="crm">
+                        <block>
+                            <setting>
+                                    <label for="foo" string="Label Before" class="a"/>
+                                    <field name="foo" class="b"/>
+                                    <label for="foo" string="Label After" class="c"/>
+                            </setting>
+                        </block>
+                    </app>
+                </form>`,
         });
 
         assert.hasClass(target.querySelectorAll(".o_form_label")[0], "a");
@@ -550,21 +482,13 @@ QUnit.module("SettingsFormView", (hooks) => {
         serverData.views = {
             "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
+                            <app string="CRM" name="crm">
+                                <block>
+                                    <setting help="this is foo">
                                             <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                                    </setting>
+                                </block>
+                            </app>
                     </form>`,
             "task,2,list": `
                     <tree>
@@ -617,22 +541,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData.views = {
                 "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <button name="4" string="Execute action" type="action"/>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block>
+                                <setting help="this is foo">
+                                    <field name="foo"/>
+                                </setting>
+                            </block>
+                            <button name="4" string="Execute action" type="action"/>
+                        </app>
                     </form>`,
                 "task,2,list": `
                     <tree>
@@ -678,18 +594,14 @@ QUnit.module("SettingsFormView", (hooks) => {
         serverData.views = {
             "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <label for="foo" string=""/>
-                                            <field name="foo"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block>
+                                <setting>
+                                    <label for="foo" string=""/>
+                                    <field name="foo"/>
+                                </setting>
+                            </block>
+                        </app>
                     </form>`,
             "task,2,list": `
                     <tree>
@@ -736,22 +648,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData.views = {
                 "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
+                            <app string="CRM" name="crm">
+                                <block>
+                                    <setting string="Foo" help="this is foo">
+                                        <field name="foo"/>
+                                    </setting>
+                                </block>
                                 <button name="4" string="Execute action" type="action"/>
-                            </div>
-                        </div>
+                            </app>
                     </form>`,
                 "task,2,list": '<tree><field name="display_name"/></tree>',
                 "res.config.settings,false,search": "<search></search>",
@@ -831,8 +735,10 @@ QUnit.module("SettingsFormView", (hooks) => {
             type: "form",
             arch: `
                 <form js_class="base_settings">
-                    <field name="foo" />
-                    <button type="object" name="mymethod" class="myBtn"/>
+                    <app string="CRM" name="crm">
+                        <field name="foo" />
+                        <button type="object" name="mymethod" class="myBtn"/>
+                    </app>
                 </form>`,
             serverData,
             resModel: "res.config.settings",
@@ -870,8 +776,10 @@ QUnit.module("SettingsFormView", (hooks) => {
             type: "form",
             arch: `
                 <form js_class="base_settings">
-                    <field name="foo" />
-                    <button type="object" name="mymethod" class="myBtn"/>
+                    <app string="CRM" name="crm">
+                        <field name="foo" />
+                        <button type="object" name="mymethod" class="myBtn"/>
+                    </app>
                 </form>`,
             serverData,
             resModel: "res.config.settings",
@@ -916,22 +824,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData.views = {
                 "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <button name="4" string="Execute action" type="action" noSaveDialog="true"/>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block>
+                                <setting string="Foo" help="this is foo">
+                                    <field name="foo"/>
+                                </setting>
+                            </block>
+                            <button name="4" string="Execute action" type="action" noSaveDialog="true"/>
+                        </app>
                     </form>`,
                 "task,2,list": '<tree><field name="display_name"/></tree>',
                 "res.config.settings,false,search": "<search></search>",
@@ -968,38 +868,21 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                     <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                        <div class="o_setting_container">
-                            <div class="settings">
-                                <div class="app_settings_block" string="CRM" data-key="crm">
-                                    <h2>CRM</h2>
-                                    <div class="row mt16 o_settings_container">
-                                        <div class="col-12 col-lg-6 o_setting_box">
-                                            <div class="o_setting_left_pane">
-                                                <field name="bar"/>
-                                            </div>
-                                            <div class="o_setting_right_pane">
-                                                <label for="bar"/>
-                                                <div class="text-muted">this is bar</div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="app_settings_block o_not_app" string="Other App" data-key="otherapp">
-                                    <h2>Other app tab</h2>
-                                    <div class="row mt16 o_settings_container">
-                                        <div class="col-12 col-lg-6 o_setting_box">
-                                            <div class="o_setting_left_pane">
-                                                <field name="bar"/>
-                                            </div>
-                                            <div class="o_setting_right_pane">
-                                                <label for="bar"/>
-                                                <div class="text-muted">this is bar</div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block title="CRM">
+                                <setting help="this is bar">
+                                    <field name="bar"/>
+                                </setting>
+                            </block>
+                        </app>
+                        <app notApp="1" string="Other App" name="otherapp">
+                            <h2>Other app tab</h2>
+                            <block>
+                                <setting help="this is bar">
+                                    <field name="bar"/>
+                                </setting>
+                            </block>
+                        </app>
                     </form>`,
         });
 
@@ -1021,15 +904,11 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="Base Setting" data-key="base-setting">
-                                <div class="o_setting_box">
-                                    <field name="bar"/>Make Changes
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <app string="Base Setting" name="base-setting">
+                        <setting>
+                            <field name="bar"/>Make Changes
+                        </setting>
+                    </app>
                 </form>`,
         });
 
@@ -1062,15 +941,11 @@ QUnit.module("SettingsFormView", (hooks) => {
                 },
                 arch: `
                     <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                        <div class="o_setting_container">
-                            <div class="settings">
-                                <div class="app_settings_block" string="Base Setting" data-key="base-setting">
-                                    <div class="o_setting_box">
-                                        <field name="bar"/>Make Changes
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <app string="Base Setting" name="base-setting">
+                            <setting>
+                                <field name="bar"/>Make Changes
+                            </setting>
+                        </app>
                     </form>`,
             });
 
@@ -1115,19 +990,13 @@ QUnit.module("SettingsFormView", (hooks) => {
                 "task,1,list": '<tree><field name="display_name"/></tree>',
                 "res.config.settings,2,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <h2>Title of group</h2>
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane"/>
-                                        <div class="o_setting_right_pane">
-                                            <button name="3" string="Execute action" type="action"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block title="Title of group">
+                                <setting>
+                                    <button name="3" string="Execute action" type="action"/>
+                                </setting>
+                            </block>
+                        </app>
                     </form>`,
                 "task,3,list": '<tree><field name="display_name"/></tree>',
                 "res.config.settings,false,search": "<search></search>",
@@ -1168,18 +1037,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="Base Setting" data-key="base-setting">
-                                <div class="o_setting_box">
-                                    <field name="tasks">
-                                        <tree><field name="display_name"/></tree>
-                                        <form><field name="display_name"/></form>
-                                   </field>
-                               </div>
-                           </div>
-                       </div>
-                    </div>
+                    <app string="Base Setting" name="base-setting">
+                        <setting>
+                            <field name="tasks">
+                                <tree><field name="display_name"/></tree>
+                                <form><field name="display_name"/></form>
+                            </field>
+                        </setting>
+                    </app>
                 </form>`,
         });
 
@@ -1219,22 +1084,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData.views = {
                 "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
+                            <app string="CRM" name="crm">
+                                <block>
+                                    <setting string="Foo" help="this is foo">
                                             <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
+                                    </setting>
                                     <button name="4" string="Execute action" type="action"/>
-                                </div>
-                            </div>
-                        </div>
+                                </block>
+                            </app>
                     </form>
                 `,
                 "res.config.settings,false,search": "<search></search>",
@@ -1293,21 +1150,13 @@ QUnit.module("SettingsFormView", (hooks) => {
         serverData.views = {
             "res.config.settings,1,form": `
                     <form string="Settings" js_class="base_settings">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_left_pane">
-                                            <field name="foo"/>
-                                        </div>
-                                        <div class="o_setting_right_pane">
-                                            <span class="o_form_label">Foo</span>
-                                            <div class="text-muted">this is foo</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <app string="CRM" name="crm">
+                            <block>
+                                <setting string="Foo" help="this is foo">
+                                    <field name="foo"/>
+                                </setting>
+                            </block>
+                        </app>
                     </form>
                 `,
             "res.config.settings,false,search": "<search></search>",
@@ -1374,24 +1223,18 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
-                                <div class="row mt16 o_settings_container">
-                                    <div class="col-12 col-lg-6 o_setting_box">
-                                        <div class="o_setting_right_pane">
-                                            <label for="product_id"/>
-                                            <div class="content-group">
-                                                <div class="mt16">
-                                                    <field name="product_id" class="o_light_label" widget="radio"/>
-                                                </div>
-                                            </div>
-                                        </div>
+                    <app string="CRM" name="crm">
+                        <block>
+                            <setting>
+                                <label for="product_id"/>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="product_id" class="o_light_label" widget="radio"/>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
+                            </setting>
+                        </block>
+                    </app>
                 </form>`,
         });
 
@@ -1435,14 +1278,10 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
                 <form js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings">
-                            <div class="app_settings_block" string="CRM" data-key="crm">
+                            <app string="CRM" name="crm">
                                 <label string="My&quot; little &apos;  Label" for="display_name" class="highhopes"/>
                                 <field name="display_name" />
-                            </div>
-                        </div>
-                    </div>
+                            </app>
                 </form>`,
         });
 
@@ -1452,14 +1291,12 @@ QUnit.module("SettingsFormView", (hooks) => {
         );
 
         const expectedCompiled = `
-        <div class="o_setting_container">
-            <SettingsPage slots="{NoContentHelper:this.props.slots.NoContentHelper}" initialTab="this.props.initialApp" t-slot-scope="settings" modules="[{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;/crm/static/description/icon.png&quot;,&quot;isVisible&quot;:false}]" class="'settings'">
-                <SettingsApp t-props="{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;/crm/static/description/icon.png&quot;,&quot;isVisible&quot;:false}" selectedTab="settings.selectedTab" class="'app_settings_block'">
+            <SettingsPage slots="{NoContentHelper:this.props.slots.NoContentHelper}" initialTab="this.props.initialApp" t-slot-scope="settings" modules="[{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;/crm/static/description/icon.png&quot;}]">
+                <SettingsApp key="\`crm\`" string="\`CRM\`" imgurl="\`/crm/static/description/icon.png\`" selectedTab="settings.selectedTab">
                     <FormLabel id="'display_name'" fieldName="'display_name'" record="this.props.record" fieldInfo="this.props.archInfo.fieldNodes['display_name']" className="&quot;highhopes&quot;" string="\`My&quot; little '  Label\`"/>
                     <Field id="'display_name'" name="'display_name'" record="this.props.record" fieldInfo="this.props.archInfo.fieldNodes['display_name']"/>
                 </SettingsApp>
-            </SettingsPage>
-        </div>`;
+            </SettingsPage>`;
         assert.areEquivalent(compiled.firstChild.innerHTML, expectedCompiled);
     });
 
@@ -1479,24 +1316,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
             <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-            <div class="o_setting_container">
-                <div class="settings">
-                    <div class="app_settings_block" string="CRM" data-key="crm">
-                        <h2>Title of group Bar</h2>
-                        <div class="row mt16 o_settings_container">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
+                    <app string="CRM" name="crm">
+                        <block title="Title of group Bar">
+                            <setting>
                                     <field name="bar"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="bar"/>
                                     <div class="text-muted">this is Baz value: <field name="baz" readonly="1"/> and this is the after text</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                            </setting>
+                        </block>
+                    </app>
         </form>`,
         });
 
@@ -1510,7 +1337,7 @@ QUnit.module("SettingsFormView", (hooks) => {
             <Field id="'baz'" name="'baz'" record="this.props.record" fieldInfo="this.props.archInfo.fieldNodes['baz']"/>
             <HighlightText originalText="\` and this is the after text\`"/>`;
         assert.areEquivalent(
-            compiled.querySelector("Setting div.o_setting_right_pane div.text-muted").innerHTML,
+            compiled.querySelector("Setting div.text-muted").innerHTML,
             expectedCompiled
         );
     });
@@ -1532,21 +1359,14 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
             <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-            <div class="o_setting_container">
-                <div class="settings">
-                    <div class="app_settings_block" string="CRM" data-key="crm">
-                        <h2>Title of group Bar</h2>
-                        <div class="row mt16 o_settings_container">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="textField"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </form>`,
+                <app string="CRM" name="crm">
+                    <block title="Title of group Bar">
+                        <setting>
+                            <field name="textField"/>
+                        </setting>
+                    </block>
+                </app>
+            </form>`,
         });
 
         assert.containsOnce(target, "[name='textField'] input");
@@ -1568,32 +1388,26 @@ QUnit.module("SettingsFormView", (hooks) => {
             serverData,
             arch: `
             <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-            <div class="o_setting_container">
-                <div class="settings">
-                    <div class="app_settings_block" string="CRM" data-key="crm">
-                        <h2>Title of group Bar</h2>
-                        <div class="row mt16 o_settings_container">
-                                <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-                                <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-                                <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-                                <div id="deepDivCrm" />
-                        </div>
-                    </div>
+                <app string="CRM" name="crm">
+                    <block title="Title of group Bar">
+                        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+                        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+                        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+                        <div id="deepDivCrm" />
+                    </block>
+                </app>
 
-                    <div class="app_settings_block" string="OtherApp" data-key="otherapp">
-                        <h2>Title of group Other</h2>
-                        <div class="row mt16 o_settings_container">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-                                <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-                                <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-                                <div id="deepDivOther" />
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </form>`,
+                <app string="OtherApp" name="otherapp">
+                    <block title="Title of group Other">
+                        <setting>
+                            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+                            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+                            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+                            <div id="deepDivOther" />
+                        </setting>
+                    </block>
+                </app>
+            </form>`,
         });
 
         // constrain o_content to have height for its children to be scrollable

--- a/addons/web/static/tests/webclient/settings_form_view/settings_upgrade_boolean_field_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_upgrade_boolean_field_tests.js
@@ -24,7 +24,9 @@ QUnit.module("SettingsUpgradeBoolean", (hooks) => {
             type: "form",
             arch: `
                 <form js_class="base_settings">
-                    <field name="bar" widget="upgrade_boolean"/>
+                    <app string="CRM" name="crm">
+                        <field name="bar" widget="upgrade_boolean"/>
+                    </app>
                 </form>`,
             serverData,
             resModel: "res.config.settings",
@@ -44,10 +46,11 @@ QUnit.module("SettingsUpgradeBoolean", (hooks) => {
             type: "form",
             arch: `
                 <form js_class="base_settings">
-                    <div class="o_field">
-                        <field name="bar" widget="upgrade_boolean"/>
-                    </div>
-                    <div class="o_label"><label for="bar"/><div>Coucou</div></div>
+                    <app string="CRM" name="crm">
+                        <setting string="Coucou">
+                            <field name="bar" widget="upgrade_boolean"/>
+                        </setting>
+                    </app>
                 </form>`,
             serverData,
             resModel: "res.config.settings",
@@ -60,12 +63,12 @@ QUnit.module("SettingsUpgradeBoolean", (hooks) => {
         );
         assert.containsOnce(
             target,
-            ".o_label .badge",
+            ".o_form_label .badge",
             "the upgrade badge should be inside the label section"
         );
         assert.strictEqual(
-            target.querySelector(".o_label").textContent,
-            "BarEnterpriseCoucou",
+            target.querySelector(".o_form_label").textContent,
+            "CoucouEnterprise",
             "the upgrade label should be inside the label section"
         );
     });
@@ -78,7 +81,9 @@ QUnit.module("SettingsUpgradeBoolean", (hooks) => {
                 type: "form",
                 arch: `
                 <form js_class="base_settings">
-                    <field name="bar" widget="upgrade_boolean"/>
+                    <app string="CRM" name="crm">
+                        <field name="bar" widget="upgrade_boolean"/>
+                    </app>
                 </form>`,
                 serverData,
                 resModel: "res.config.settings",
@@ -102,10 +107,11 @@ QUnit.module("SettingsUpgradeBoolean", (hooks) => {
                 type: "form",
                 arch: `
                 <form js_class="base_settings">
-                    <div class="o_field">
-                        <field name="bar" widget="upgrade_boolean"/>
-                    </div>
-                    <div class="o_label"><label for="bar"/><div>Coucou</div></div>
+                    <app string="CRM" name="crm">
+                        <setting string="Coucou">
+                            <field name="bar" widget="upgrade_boolean"/>
+                        </setting>
+                    </app>
                 </form>`,
                 serverData,
                 resModel: "res.config.settings",
@@ -118,12 +124,12 @@ QUnit.module("SettingsUpgradeBoolean", (hooks) => {
             );
             assert.containsNone(
                 target,
-                ".o_label .badge",
+                ".o_form_label .badge",
                 "the upgrade badge shouldn't be inside the label section"
             );
             assert.strictEqual(
-                target.querySelector(".o_label").textContent,
-                "BarCoucou",
+                target.querySelector(".o_form_label").textContent,
+                "Coucou",
                 "the label shouldn't contains the upgrade label"
             );
         }

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
             <!-- Remove customer accounts setting from general settings tab -->
             <!-- It must not be in the view at all to make sure settings can be saved
                 (because auth_signup_uninvited is specified as required) -->
-            <xpath expr="//div[@id='login_documents']" position="replace"></xpath>
+            <xpath expr="//setting[@id='login_documents']" position="replace"></xpath>
         </field>
     </record>
 
@@ -18,281 +18,168 @@
         <field name="priority" eval="20"/>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="Website" string="Website" data-key="website" groups="website.group_website_designer">
-                    <div class="row app_settings_header my-0 ms-0 mw-100 bg-warning bg-opacity-25">
-                        <div class="col-xs-12 col-md-6 ms-0 o_setting_box">
-                            <div class="o_setting_right_pane border-start-0 ms-0 ps-0">
-                                <div class="content-group">
-                                    <div class="row flex-row flex-nowrap mt8 align-items-center">
-                                        <label class="col ps-0 text-nowrap" string="Settings of Website" for="website_id"/>
-                                        <field name="website_id" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this website"/>
-                                        <button name="action_website_create_new" type="object" string="+ New Website" class="col-auto btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
-                                    </div>
+            <xpath expr="//form" position="inside">
+                <app data-string="Website" string="Website" name="website" groups="website.group_website_designer">
+                    <setting type="header" string="Settings of Website">
+                        <field name="website_id" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this website"/>
+                        <button name="action_website_create_new" type="object" string="+ New Website" class="col-auto btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
+                    </setting>
+                    <block title="Website Info" id="website_info_settings">
+                        <setting>
+                            <div class="content-group">
+                                <div class="row mt8">
+                                    <label class="col-lg-3" string="Domain" for="website_domain"/>
+                                    <field name="website_domain" placeholder="https://www.odoo.com" title="Display this website when users visit this domain"/>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
-                    <h2>Website Info</h2>
-                    <div class="col-xs-12 row o_settings_container" id="website_info_settings">
-                        <div class="col-xs-12 col-md-6 o_setting_box">
-                            <div class="o_setting_right_pane border-start-0">
-                                <div class="content-group">
-                                    <div class="row mt8">
-                                        <label class="col-lg-3" string="Domain" for="website_domain"/>
-                                        <field name="website_domain" placeholder="https://www.odoo.com" title="Display this website when users visit this domain"/>
-                                    </div>
-                                    <div class="row mt8">
-                                        <label class="col-lg-3" string="Homepage URL" for="website_homepage_url"/>
-                                        <field name="website_homepage_url" placeholder="/" title="Main page of your website served to visitors"/>
-                                    </div>
-                                    <div class="row mt8">
-                                        <label class="col-lg-3" string="Languages" for="language_ids"/>
-                                        <field name="language_ids" widget="many2many_tags" options="{'no_create': True, 'no_open': True}" attrs="{'required': [('website_id', '!=', False)]}" title="Languages available on your website"/>
-                                    </div>
-                                    <div class="row mt8" attrs="{'invisible': [('website_language_count', '&lt;', 2)]}">
-                                        <field name="website_language_count" invisible="1"/>
-                                        <label class="col-lg-3" string="Default" for="website_default_lang_id"/>
-                                        <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" attrs="{'required': [('website_id', '!=', False)]}"/>
-                                    </div>
-                                    <div class="mt8">
-                                        <button type="action" name="%(base.action_view_base_language_install)d" string="Install languages" class="btn-link" icon="fa-arrow-right"/>
-                                    </div>
+                                <div class="row mt8">
+                                    <label class="col-lg-3" string="Homepage URL" for="website_homepage_url"/>
+                                    <field name="website_homepage_url" placeholder="/" title="Main page of your website served to visitors"/>
                                 </div>
-                            </div>
-                        </div>
-                        <div class="col-xs-12 col-md-6 o_setting_box">
-                            <div class="o_setting_right_pane border-start-0">
-                                <div class="content-group">
-                                    <div class="row mt8">
-                                        <label class="col-lg-3" string="Website Name" for="website_name"/>
-                                        <field name="website_name" attrs="{'required': [('website_id', '!=', False)]}"/>
-                                    </div>
-                                    <div class="row mt8" groups="base.group_multi_company">
-                                        <label class="col-lg-3" string="Company" for="website_company_id"/>
-                                        <field name="website_company_id" attrs="{'required': [('website_id', '!=', False)]}" title="The company this website belongs to"/>
-                                    </div>
-                                    <div class="row mt8">
-                                        <label class="col-lg-3" string="Favicon" for="favicon"/>
-                                        <field name="favicon" widget="image" class="float-start oe_avatar bg-view"/>
-                                    </div>
+                                <div class="row mt8">
+                                    <label class="col-lg-3" string="Languages" for="language_ids"/>
+                                    <field name="language_ids" widget="many2many_tags" options="{'no_create': True, 'no_open': True}" attrs="{'required': [('website_id', '!=', False)]}" title="Languages available on your website"/>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <h2>Email &amp; Marketing</h2>
-                    <div class="row mt16 o_settings_container" id="website_email_marketing">
-                        <div class="col-xs-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="module_website_livechat"/>
-                            </div>
-                            <div class="o_setting_right_pane" id="livechat_right_pane">
-                                <span class="o_form_label">Livechat</span>
-                                <div class="text-muted">
-                                    Alows your visitors to chat with you
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xs-12 col-lg-6 o_setting_box" id="website_marketing_automation">
-                            <div class="o_setting_left_pane">
-                                <field name="module_marketing_automation" widget="upgrade_boolean"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Email Marketing</span>
-                                <div class="text-muted">
-                                    Allows to do mass mailing campaigns to contacts
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <h2>Privacy</h2>
-                    <div class="row mt16 o_settings_container" id="website_settings" attrs="{'invisible': [('website_id', '=', False)]}">
-                        <div class="col-12 col-lg-6 o_setting_box" id="website_cookies_bar_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="website_cookies_bar"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="website_cookies_bar"/>
-                                <div class="text-muted">
-                                    Display a customizable cookies bar on your website
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="shared_user_account_setting" groups="website.group_multi_website">
-                            <div class="o_setting_left_pane">
-                                <field name="shared_user_account"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="shared_user_account"/>
-                                <div class="text-muted">
-                                    Accounts are usable across all your multiple websites
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="website_login_documents"
-                            title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*.">
-                            <div class="o_setting_left_pane">
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="auth_signup_uninvited"/>
-                                <div class="text-muted">
-                                    Let your customers log in to see their documents
+                                <div class="row mt8" attrs="{'invisible': [('website_language_count', '&lt;', 2)]}">
+                                    <field name="website_language_count" invisible="1"/>
+                                    <label class="col-lg-3" string="Default" for="website_default_lang_id"/>
+                                    <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" attrs="{'required': [('website_id', '!=', False)]}"/>
                                 </div>
                                 <div class="mt8">
-                                    <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('auth_signup_uninvited','=','b2b')]}">
-                                    <div class="mt8">
-                                        <button type="object" name="action_open_template_user" string="Default Access Rights" icon="fa-arrow-right" class="btn-link"/>
-                                    </div>
+                                    <button type="action" name="%(base.action_view_base_language_install)d" string="Install languages" class="btn-link" icon="fa-arrow-right"/>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <h2>SEO</h2>
-                    <div class="row mt16 o_settings_container" id="website_settings" attrs="{'invisible': [('website_id', '=', False)]}">
-                        <div class="col-12 col-lg-6 o_setting_box" id="google_analytics_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="has_google_analytics"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="has_google_analytics"/>
-                                <div class="text-muted">
-                                    Track visits using Google Analytics
+                        </setting>
+                        <setting>
+                            <div class="content-group">
+                                <div class="row mt8">
+                                    <label class="col-lg-3" string="Website Name" for="website_name"/>
+                                    <field name="website_name" attrs="{'required': [('website_id', '!=', False)]}"/>
                                 </div>
-                                <div class="content-group" attrs="{'invisible': [('has_google_analytics', '=', False)]}">
-                                    <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" string="Measurement ID" for="google_analytics_key"/>
-                                        <field name="google_analytics_key" placeholder="G-XXXXXXXXXX"
-                                            attrs="{'required': [('has_google_analytics', '=', True)]}"/>
-                                    </div>
+                                <div class="row mt8" groups="base.group_multi_company">
+                                    <label class="col-lg-3" string="Company" for="website_company_id"/>
+                                    <field name="website_company_id" attrs="{'required': [('website_id', '!=', False)]}" title="The company this website belongs to"/>
                                 </div>
-                                <div attrs="{'invisible': [('has_google_analytics', '=', False)]}">
-                                    <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/google_analytics.html"
-                                            class="oe_link" target="_blank">
-                                        <i class="fa fa-arrow-right"/>
-                                        How to get my Measurement ID
-                                    </a>
+                                <div class="row mt8">
+                                    <label class="col-lg-3" string="Favicon" for="favicon"/>
+                                    <field name="favicon" widget="image" class="float-start oe_avatar bg-view"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="cdn_setting" title="A CDN helps you serve your website’s content with high availability and high performance to any visitor wherever they are located." groups="base.group_no_one">
-                            <div class="o_setting_left_pane">
-                                <field name="cdn_activated"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="cdn_activated"/>
-                                <div class="text-muted">
-                                    Use a CDN to optimize the availability of your website's content
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('cdn_activated', '=', False)]}">
-                                    <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" for="cdn_url"/>
-                                        <field name="cdn_url"
-                                               attrs="{'required': [('cdn_activated', '=', True)]}"
-                                               placeholder="//mycompany.mycdn.com/"
-                                               t-translation="off"/>
-                                    </div>
-                                    <div class="row" >
-                                        <label class="col-lg-3 o_light_label" for="cdn_filters"/>
-                                        <field name="cdn_filters" class="oe_inline"
-                                               attrs="{'required': [('cdn_activated', '=', True)]}"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="robots_setting">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Robots.txt</span>
-                                <div class="text-muted">
-                                    Robots.txt: This file tells to search engine crawlers which pages or files they can or can't request from your site.<br/>
-                                </div>
-                                <div class="mt4">
-                                    <button type="object" name="action_open_robots" string="Edit robots.txt" class="btn-link" icon="fa-android" noSaveDialog="true"/>
+                        </setting>
+                    </block>
+
+                    <block title="Email &amp; Marketing" id="website_email_marketing">
+                        <setting id="livechat" string="Livechat" help="Alows your visitors to chat with you">
+                            <field name="module_website_livechat"/>
+                        </setting>
+                        <setting id="website_marketing_automation" string="Email Marketing" help="Allows to do mass mailing campaigns to contacts">
+                            <field name="module_marketing_automation" widget="upgrade_boolean"/>
+                        </setting>
+                    </block>
+
+                    <block title="Privacy" id="website_settings" attrs="{'invisible': [('website_id', '=', False)]}">
+                        <setting id="website_cookies_bar_setting" help="Display a customizable cookies bar on your website">
+                            <field name="website_cookies_bar"/>
+                        </setting>
+                        <setting id="shared_user_account_setting" groups="website.group_multi_website" help="Accounts are usable across all your multiple websites">
+                            <field name="shared_user_account"/>
+                        </setting>
+                        <setting id="website_login_documents" title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*." help="Let your customers log in to see their documents">
+                            <field name="auth_signup_uninvited" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
+                            <div class="content-group" attrs="{'invisible': [('auth_signup_uninvited','=','b2b')]}">
+                                <div class="mt8">
+                                    <button type="object" name="action_open_template_user" string="Default Access Rights" icon="fa-arrow-right" class="btn-link"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="robots_setting">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Sitemap</span>
-                                <div class="text-muted mt8">
-                                    Sitemap.xml: Help search engine crawlers to find out what pages are present and which have recently changed, and to crawl your site accordingly. This file is automatically generated by Odoo.
-                                </div>
-                                <div class="mt4">
-                                    <button type="object" name="action_ping_sitemap" string="Submit sitemap to Google" class='btn-link' icon="fa-google" noSaveDialog="true"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="social_default_image_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="has_default_share_image"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label string="Default Social Share Image" for="has_default_share_image"/>
-                                <div class="text-muted">
-                                    If set, replaces the website logo as the default social share image.
-                                </div>
-                                <field name="social_default_image" widget="image" class="w-25 mt-2" attrs="{'invisible': [('has_default_share_image', '=', False)]}"/>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="google_console_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="has_google_search_console"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="has_google_search_console"/>
-                                <div class="text-muted">
-                                    Monitor Google Search results data
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('has_google_search_console', '=', False)]}">
-                                    <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" string="Code" for="google_search_console"/>
-                                        <field name="google_search_console" placeholder="google1234567890123456.html"
-                                            attrs="{'required': [('has_google_search_console', '=', True)]}"/>
-                                    </div>
-                                </div>
-                                <div attrs="{'invisible': [('has_google_search_console', '=', False)]}">
-                                    <small class='text-muted'>
-                                        <i class="fa fa-info"/>: type some of the first chars after 'google' is enough, we'll guess the rest.
-                                    </small>
+                        </setting>
+                    </block>
+                    <block title="SEO" id="website_settings" attrs="{'invisible': [('website_id', '=', False)]}">
+                        <setting id="google_analytics_setting" help="Track visits using Google Analytics">
+                            <field name="has_google_analytics"/>
+                            <div class="content-group" attrs="{'invisible': [('has_google_analytics', '=', False)]}">
+                                <div class="row mt16">
+                                    <label class="col-lg-3 o_light_label" string="Measurement ID" for="google_analytics_key"/>
+                                    <field name="google_analytics_key" placeholder="G-XXXXXXXXXX"
+                                        attrs="{'required': [('has_google_analytics', '=', True)]}"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="plausbile_setting">
-                            <div class="o_setting_left_pane">
-                                <field name="has_plausible_shared_key"/>
+                            <div attrs="{'invisible': [('has_google_analytics', '=', False)]}">
+                                <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/google_analytics.html"
+                                        class="oe_link" target="_blank">
+                                    <i class="fa fa-arrow-right"/>
+                                    How to get my Measurement ID
+                                </a>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="has_plausible_shared_key"/>
-                                <div class="text-muted">
-                                    Use Plausible.io, Simple and privacy-friendly Google Analytics alternative
+                        </setting>
+                        <setting id="cdn_setting" title="A CDN helps you serve your website’s content with high availability and high performance to any visitor wherever they are located." groups="base.group_no_one" help="Use a CDN to optimize the availability of your website's content">
+                            <field name="cdn_activated"/>
+                            <div class="content-group" attrs="{'invisible': [('cdn_activated', '=', False)]}">
+                                <div class="row mt16">
+                                    <label class="col-lg-3 o_light_label" for="cdn_url"/>
+                                    <field name="cdn_url"
+                                            attrs="{'required': [('cdn_activated', '=', True)]}"
+                                            placeholder="//mycompany.mycdn.com/"
+                                            t-translation="off"/>
                                 </div>
-                                <div class="content-group" attrs="{'invisible': [('has_plausible_shared_key', '=', False)]}">
-                                    <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" string="Shared Link Auth" for="plausible_shared_key"/>
-                                        <field name="plausible_shared_key"
-                                            attrs="{'required': [('has_plausible_shared_key', '=', True)]}"/>
-                                    </div>
-                                    <div class="row mt16">
-                                        <label class="col-lg-3 o_light_label" string="Site" for="plausible_site"/>
-                                        <field name="plausible_site"
-                                            attrs="{'required': [('has_plausible_shared_key', '=', True)]}"/>
-                                    </div>
-                                </div>
-                                <div attrs="{'invisible': [('has_plausible_shared_key', '=', False)]}">
-                                    <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/plausible.html"
-                                            class="oe_link" target="_blank">
-                                        <i class="fa fa-arrow-right"/>
-                                        How to create my Plausible Shared Link
-                                    </a>
+                                <div class="row" >
+                                    <label class="col-lg-3 o_light_label" for="cdn_filters"/>
+                                    <field name="cdn_filters" class="oe_inline"
+                                            attrs="{'required': [('cdn_activated', '=', True)]}"/>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                </div>
+                        </setting>
+                        <setting id="robots_setting" string="Robots.txt" help="Robots.txt: This file tells to search engine crawlers which pages or files they can or can't request from your site.">
+                            <div class="mt4">
+                                <button type="object" name="action_open_robots" string="Edit robots.txt" class="btn-link" icon="fa-android" noSaveDialog="true"/>
+                            </div>
+                        </setting>
+                        <setting id="robots_setting" string="Sitemap" help="Sitemap.xml: Help search engine crawlers to find out what pages are present and which have recently changed, and to crawl your site accordingly. This file is automatically generated by Odoo.">
+                            <div class="mt4">
+                                <button type="object" name="action_ping_sitemap" string="Submit sitemap to Google" class='btn-link' icon="fa-google" noSaveDialog="true"/>
+                            </div>
+                        </setting>
+                        <setting id="social_default_image_setting" string="Default Social Share Image" help="If set, replaces the website logo as the default social share image.">
+                            <field name="has_default_share_image"/>
+                            <field name="social_default_image" widget="image" class="w-25 mt-2" attrs="{'invisible': [('has_default_share_image', '=', False)]}"/>
+                        </setting>
+                        <setting id="google_console_setting" help="Monitor Google Search results data">
+                            <field name="has_google_search_console"/>
+                            <div class="content-group" attrs="{'invisible': [('has_google_search_console', '=', False)]}">
+                                <div class="row mt16">
+                                    <label class="col-lg-3 o_light_label" string="Code" for="google_search_console"/>
+                                    <field name="google_search_console" placeholder="google1234567890123456.html"
+                                        attrs="{'required': [('has_google_search_console', '=', True)]}"/>
+                                </div>
+                            </div>
+                            <div attrs="{'invisible': [('has_google_search_console', '=', False)]}">
+                                <small class='text-muted'>
+                                    <i class="fa fa-info"/>: type some of the first chars after 'google' is enough, we'll guess the rest.
+                                </small>
+                            </div>
+                        </setting>
+                        <setting id="plausbile_setting" help="Use Plausible.io, Simple and privacy-friendly Google Analytics alternative">
+                            <field name="has_plausible_shared_key"/>
+                            <div class="content-group" attrs="{'invisible': [('has_plausible_shared_key', '=', False)]}">
+                                <div class="row mt16">
+                                    <label class="col-lg-3 o_light_label" string="Shared Link Auth" for="plausible_shared_key"/>
+                                    <field name="plausible_shared_key"
+                                        attrs="{'required': [('has_plausible_shared_key', '=', True)]}"/>
+                                </div>
+                                <div class="row mt16">
+                                    <label class="col-lg-3 o_light_label" string="Site" for="plausible_site"/>
+                                    <field name="plausible_site"
+                                        attrs="{'required': [('has_plausible_shared_key', '=', True)]}"/>
+                                </div>
+                            </div>
+                            <div attrs="{'invisible': [('has_plausible_shared_key', '=', False)]}">
+                                <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/plausible.html"
+                                        class="oe_link" target="_blank">
+                                    <i class="fa fa-arrow-right"/>
+                                    How to create my Plausible Shared Link
+                                </a>
+                            </div>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/website_crm_iap_reveal/views/res_config_settings_views.xml
+++ b/addons/website_crm_iap_reveal/views/res_config_settings_views.xml
@@ -5,9 +5,9 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="crm.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="website_crm_iap_reveal_settings" position="inside">
+            <setting id="website_crm_iap_reveal_settings" position="inside">
                 <widget name="iap_buy_more_credits" service_name="reveal"/>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_event/views/res_config_settings_views.xml
+++ b/addons/website_event/views/res_config_settings_views.xml
@@ -6,19 +6,11 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="event.res_config_settings_view_form"/>
         <field name="arch" type="xml"> 
-            <div name="event_settings_website" position="after">
-                <div class="col-12 col-lg-6 o_setting_box">
-                    <div class="o_setting_left_pane">
-                        <field name="module_website_event_questions"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label string="Questions" for="module_website_event_questions"/>
-                        <div class="text-muted">
-                            Ask questions to attendees when registering online
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <setting name="event_settings_website" position="after">
+                <setting string="Questions" help="Ask questions to attendees when registering online">
+                    <field name="module_website_event_questions"/>
+                </setting>
+            </setting>
         </field>
     </record>
 

--- a/addons/website_event_jitsi/views/res_config_settings_views.xml
+++ b/addons/website_event_jitsi/views/res_config_settings_views.xml
@@ -5,13 +5,10 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="event.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='events_setting_container']" position="inside">
-                <div class="col-12 col-lg-6 o_setting_box">
-                    <div class="o_setting_right_pane">
-                        <label for="jitsi_server_domain"/>
-                        <field name="jitsi_server_domain" placeholder="meet.jit.si"/>
-                    </div>
-                </div>
+            <xpath expr="//block[@name='events_setting_container']" position="inside">
+                <setting>
+                    <field name="jitsi_server_domain" placeholder="meet.jit.si"/>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_track/views/res_config_settings_view.xml
+++ b/addons/website_event_track/views/res_config_settings_view.xml
@@ -7,22 +7,20 @@
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <!-- TODO TDE there are two div with website_settings id in the website settings view -->
-            <xpath expr="//div[@id='website_settings']" position="inside">
-                <div class="col-12 col-lg-6 o_setting_box" id="events_app_setting" groups="base.group_no_one">
-                    <div class="o_setting_right_pane">
-                        <label for="events_app_name" string="Events PWA"/>
-                        <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
-                        <div class="text-muted">
-                            Name of your website's Events Progressive Web Application
-                        </div>
-                        <div class="content-group">
-                            <div class="row mt16">
-                                <label class="col-lg-3 o_light_label" string="Name" for="events_app_name"/>
-                                <field name="events_app_name" attrs="{'required': [('website_id', '!=', False)]}"/>
-                            </div>
+            <xpath expr="//block[@id='website_settings']" position="inside">
+                <setting id="events_app_setting" groups="base.group_no_one">
+                    <label for="events_app_name" string="Events PWA"/>
+                    <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
+                    <div class="text-muted">
+                        Name of your website's Events Progressive Web Application
+                    </div>
+                    <div class="content-group">
+                        <div class="row mt16">
+                            <label class="col-lg-3 o_light_label" string="Name" for="events_app_name"/>
+                            <field name="events_app_name" attrs="{'required': [('website_id', '!=', False)]}"/>
                         </div>
                     </div>
-                </div>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/website_livechat/views/res_config_settings_views.xml
+++ b/addons/website_livechat/views/res_config_settings_views.xml
@@ -5,14 +5,14 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="livechat_right_pane" position="inside">
+            <setting id="livechat" position="inside">
                 <div class="content-group mt16">
                     <div class="row">
                         <label class="col-lg-3 o_light_label" string="Channel" for="channel_id"/>
                         <field name="channel_id" class="oe_inline"/>
                     </div>
                 </div>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -6,47 +6,32 @@
         <field name="priority" eval="20"/>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="website_info_settings" position="after">
-                <h2>Shop - Payment</h2>
-                <div class="row mt16 o_settings_container" id="div_website_payment">
-                    <div class="col-12 col-lg-6 o_setting_box" id="website_payment">
-                        <div class="o_setting_right_pane">
-                            <label for="company_id" string="Activate Payments"/>
-                            <div class="text-muted">
-                                Support most payment methods; Visa, Mastercard, Maestro, Google Pay, Apple Pay, etc. as well as recurring charges.
-                            </div>
-                            <div class="content-group">
-                                <div class="row mt8 ms-4" attrs="{'invisible': [('providers_state', '=', 'other_than_paypal')]}">
-                                    <field name="providers_state" invisible="1"/>
-                                    <field name="is_stripe_supported_country" invisible="1"/>
-                                    <button attrs="{'invisible': [('is_stripe_supported_country', '=', False)]}"
-                                            name="action_activate_stripe" type="object" string="Activate Stripe" class="btn-primary col-auto"/>
-                                    <div attrs="{'invisible': [('is_stripe_supported_country', '=', True)]}" class="col-auto" data-bs-toggle="tooltip" title="Stripe Connect is not available in your country, please use another payment provider.">
-                                        <button string="Activate Stripe" class="btn-primary pe-none" disabled=""
-                                                style="pointer-events: none;"/>
-                                    </div>
-                                    <button type="action" name="%(payment.action_payment_provider)d" string="View Alternatives" class="btn-link" icon="fa-arrow-right"/>
+            <block id="website_info_settings" position="after">
+                <block title="Shop - Payment" id="div_website_payment">
+                    <setting id="website_payment" string="Activate Payments" help="Support most payment methods; Visa, Mastercard, Maestro, Google Pay, Apple Pay, etc. as well as recurring charges.">
+                        <div class="content-group">
+                            <div class="row mt8 ms-4" attrs="{'invisible': [('providers_state', '=', 'other_than_paypal')]}">
+                                <field name="providers_state" invisible="1"/>
+                                <field name="is_stripe_supported_country" invisible="1"/>
+                                <button attrs="{'invisible': [('is_stripe_supported_country', '=', False)]}"
+                                        name="action_activate_stripe" type="object" string="Activate Stripe" class="btn-primary col-auto"/>
+                                <div attrs="{'invisible': [('is_stripe_supported_country', '=', True)]}" class="col-auto" data-bs-toggle="tooltip" title="Stripe Connect is not available in your country, please use another payment provider.">
+                                    <button string="Activate Stripe" class="btn-primary pe-none" disabled=""
+                                            style="pointer-events: none;"/>
                                 </div>
-                                <div class="row mt8 ms-4" attrs="{'invisible': [('providers_state', '!=', 'other_than_paypal')]}">
-                                    <button name="action_configure_first_provider" type="object" class="btn-primary col-auto"><field name="first_provider_label" nolabel="1" class="oe_inline"/></button>
-                                    <button type="action" name="%(payment.action_payment_provider)d" string="View other providers " class="btn-link col-auto" icon="fa-arrow-right"/>
-                                </div>
+                                <button type="action" name="%(payment.action_payment_provider)d" string="View Alternatives" class="btn-link" icon="fa-arrow-right"/>
+                            </div>
+                            <div class="row mt8 ms-4" attrs="{'invisible': [('providers_state', '!=', 'other_than_paypal')]}">
+                                <button name="action_configure_first_provider" type="object" class="btn-primary col-auto"><field name="first_provider_label" nolabel="1" class="oe_inline"/></button>
+                                <button type="action" name="%(payment.action_payment_provider)d" string="View other providers " class="btn-link col-auto" icon="fa-arrow-right"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="paypal_settings">
-                        <div class="o_setting_left_pane">
-                            <field name="module_payment_paypal"/>
-                        </div>
-                        <div class="o_setting_right_pane" id="website_payment_right_pane">
-                            <label for="company_id" string="Paypal - Express Checkout"/>
-                            <div class="text-muted">
-                                Support most credit &amp; debit cards like Visa, Mastercard, Maestro, etc.
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </setting>
+                    <setting id="paypal_settings" string="Paypal - Express Checkout" help="Support most credit &amp; debit cards like Visa, Mastercard, Maestro, etc.">
+                        <field name="module_payment_paypal"/>
+                    </setting>
+                </block>
+            </block>
         </field>
     </record>
 </odoo>

--- a/addons/website_payment_authorize/views/res_config_settings_views.xml
+++ b/addons/website_payment_authorize/views/res_config_settings_views.xml
@@ -6,23 +6,11 @@
         <field name="priority" eval="20"/>
         <field name="inherit_id" ref="website_payment.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="paypal_settings" position="before">
-                <div class="col-12 col-lg-6 o_setting_box">
-                    <div class="o_setting_right_pane">
-                        <label for="authorize_capture_method"/>
-                        <div class="text-muted">
-                            Charge order directly or authorize at the order and capture the payment later on, manually.
-                        </div>
-                        <div class="content-group">
-                            <div class="content-group">
-                                <div class="row mt16 ms-4">
-                                    <field name="authorize_capture_method" class="w-75" widget="radio"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <setting id="paypal_settings" position="before">
+                <setting help="Charge order directly or authorize at the order and capture the payment later on, manually.">
+                    <field name="authorize_capture_method" class="w-75" widget="radio" />
+                </setting>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_payment_paypal/views/res_config_settings_views.xml
+++ b/addons/website_payment_paypal/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="priority" eval="20"/>
         <field name="inherit_id" ref="website_payment.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="website_payment_right_pane" position="inside">
+            <setting id="paypal_settings" position="inside">
                 <div class="content-group">
                     <div class="row mt8 ms-4">
                         <label class="col-lg-3" string="Email" for="paypal_email_account"/>
@@ -16,7 +16,7 @@
                         After your first sale, Paypal will email you to link your Paypal account, or setup a new business account, to claim your funds, and setup payment methods.
                     </div>
                 </div>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -25,7 +25,7 @@
             <!-- Remove customer accounts setting from sales settings tab -->
             <!-- It must not be in the view at all to make sure settings can be saved
                 (because auth_signup_uninvited is specified as required) -->
-            <xpath expr="//div[@id='auth_signup_documents']" position="replace"></xpath>
+            <xpath expr="//setting[@id='auth_signup_documents']" position="replace"></xpath>
         </field>
     </record>
 
@@ -34,428 +34,192 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="website_info_settings" position="after">
-                <h2>Shop - Checkout Process</h2>
-                <div class="row mt16 o_settings_container" id="website_shop_checkout">
-                    <div class="col-12 col-lg-6 o_setting_box" id="cart_redirect_setting">
-                        <div class="o_setting_right_pane">
-                            <label for="add_to_cart_action" string="Add to Cart"/>
-                            <div class="text-muted">
-                                What should be done on "Add to Cart"?
-                            </div>
-                            <div class="content-group">
-                                <div class="row mt16 ms-4">
-                                    <field name="add_to_cart_action" widget="radio"/>
-                                </div>
+            <block id="website_info_settings" position="after">
+                <block title="Shop - Checkout Process" id="website_shop_checkout">
+                    <setting id="cart_redirect_setting" string="Add to Cart" help="What should be done on &quot;Add to Cart&quot;?">
+                        <div class="content-group">
+                            <div class="row mt16 ms-4">
+                                <field name="add_to_cart_action" widget="radio"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="enabled_buy_now_button"/>
+                    </setting>
+                    <setting help="Instant checkout, instead of adding to cart">
+                        <field name="enabled_buy_now_button"/>
+                    </setting>
+                    <setting help="Add a customizable form during checkout (after address)">
+                        <field name="enabled_extra_checkout_step"/>
+                        <div class="row mt8 ms-4" attrs="{'invisible': [('enabled_extra_checkout_step', '=', False)]}">
+                            <button type="object" name="action_open_extra_info" string="Configure Form " class="btn-link" icon="fa-arrow-right"/>
                         </div>
-                        <div class="o_setting_right_pane">
-                            <label for="enabled_buy_now_button"/>
-                            <div class="text-muted">
-                                Instant checkout, instead of adding to cart
+                    </setting>
+                    <setting id="digital_content_setting" title="Provide customers with product-specific links or downloadable content in the confirmation page of the checkout process if the payment gets through. To do so, attach some files to a product using the new Files button and publish them." help="Add download link for customers at the end of checkout">
+                        <field name="module_website_sale_digital"/>
+                    </setting>
+                    <setting string="Assignment" help="Assignment of online orders">
+                        <div class="content-group">
+                            <div class="row mt16">
+                                <label class="o_light_label col-lg-3" string="Sales Team" for="salesteam_id"/>
+                                <field name="salesteam_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s" />
+                            </div>
+                            <div class="row">
+                                <label class="o_light_label col-lg-3" for="salesperson_id"/>
+                                <field name="salesperson_id"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="enabled_extra_checkout_step"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="enabled_extra_checkout_step"/>
-                            <div class="text-muted">
-                                Add a customizable form during checkout (after address)
-                            </div>
-                            <div class="row mt8 ms-4" attrs="{'invisible': [('enabled_extra_checkout_step', '=', False)]}">
-                                <button type="object" name="action_open_extra_info" string="Configure Form " class="btn-link" icon="fa-arrow-right"/>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="digital_content_setting" title="Provide customers with product-specific links or downloadable content in the confirmation page of the checkout process if the payment gets through. To do so, attach some files to a product using the new Files button and publish them.">
-                        <div class="o_setting_left_pane">
-                            <field name="module_website_sale_digital"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_website_sale_digital"/>
-                            <div class="text-muted">
-                                Add download link for customers at the end of checkout
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">Assignment</span>
-                            <div class="text-muted">
-                                Assignment of online orders
-                            </div>
-                            <div class="content-group">
-                                <div class="row mt16">
-                                    <label class="o_light_label col-lg-3" string="Sales Team" for="salesteam_id"/>
-                                    <field name="salesteam_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s" />
-                                </div>
-                                <div class="row">
-                                    <label class="o_light_label col-lg-3" for="salesperson_id"/>
-                                    <field name="salesperson_id"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="website_sale_enabled_portal_reorder_button"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="website_sale_enabled_portal_reorder_button"/>
-                            <div class="text-muted">
-                                Allow your customer to add products from previous order in their cart.
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                    </setting>
+                    <setting help="Allow your customer to add products from previous order in their cart.">
+                        <field name="website_sale_enabled_portal_reorder_button"/>
+                    </setting>
+                </block>
 
-                <h2>Shop - Products</h2>
-                <div class="row mt16 o_settings_container" id="sale_product_catalog_settings">
-                    <div class="col-12 col-lg-6 o_setting_box" id="website_tax_inclusion_setting">
-                        <div class="o_setting_right_pane">
-                            <label string="Display Product Prices" for="show_line_subtotals_tax_selection"/>
-                            <div class="text-muted">
-                                Prices displayed on your eCommerce
-                            </div>
-                            <div class="content-group">
-                                <div class="mt16">
-                                    <field name="show_line_subtotals_tax_selection" class="o_light_label" widget="radio"/>
-                                    <field name="group_show_line_subtotals_tax_included" invisible="1"/>
-                                    <field name="group_show_line_subtotals_tax_excluded" invisible="1"/>
-                                </div>
+                <block title="Shop - Products" id="sale_product_catalog_settings">
+                    <setting id="website_tax_inclusion_setting" string="Display Product Prices" help="Prices displayed on your eCommerce">
+                        <div class="content-group">
+                            <div class="mt16">
+                                <field name="show_line_subtotals_tax_selection" class="o_light_label" widget="radio"/>
+                                <field name="group_show_line_subtotals_tax_included" invisible="1"/>
+                                <field name="group_show_line_subtotals_tax_excluded" invisible="1"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="pricelists_setting"  title="With the first mode you can set several prices in the product config form (from Sales tab). With the second one, you set prices and computation rules from Pricelists.">
-                        <div class="o_setting_left_pane">
-                            <field name="group_product_pricelist"/>
+                    </setting>
+                    <setting id="pricelists_setting" title="With the first mode you can set several prices in the product config form (from Sales tab). With the second one, you set prices and computation rules from Pricelists." help="Manage pricelists to apply specific prices per country, customer, products, etc">
+                        <field name="group_product_pricelist"/>
+                        <div class="content-group mt16" attrs="{'invisible': [('group_product_pricelist', '=', False)]}">
+                            <field name="group_sale_pricelist" invisible="1"/>
+                            <field name="group_product_pricelist" invisible="1"/>
+                            <field name="product_pricelist_setting" class="o_light_label w-75" widget="radio"/>
                         </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_product_pricelist"/>
-                            <div class="text-muted">
-                                Manage pricelists to apply specific prices per country, customer, products, etc
-                            </div>
-                            <div class="content-group mt16" attrs="{'invisible': [('group_product_pricelist', '=', False)]}">
-                                <field name="group_sale_pricelist" invisible="1"/>
-                                <field name="group_product_pricelist" invisible="1"/>
-                                <field name="product_pricelist_setting" class="o_light_label w-75" widget="radio"/>
-                            </div>
-                            <div attrs="{'invisible': [('group_product_pricelist', '=', False)]}">
-                                <button type="action" name="%(product.product_pricelist_action2)d" string="Pricelists" class="btn-link" icon="fa-arrow-right"/>
-                            </div>
+                        <div attrs="{'invisible': [('group_product_pricelist', '=', False)]}">
+                            <button type="action" name="%(product.product_pricelist_action2)d" string="Pricelists" class="btn-link" icon="fa-arrow-right"/>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="group_product_price_comparison"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_product_price_comparison"/>
-                            <div class="text-muted">
-                                Add a strikethrough price, as a comparison
+                    </setting>
+                    <setting help="Add a strikethrough price, as a comparison">
+                        <field name="group_product_price_comparison"/>
+                    </setting>
+                    <setting id="ecom_uom_price_option_setting" string="Product Reference Price" help="Add a reference price per UoM on products (i.e $/kg), in addition to the sale price">
+                        <field name="group_show_uom_price"/>
+                    </setting>
+                    <setting id="product_attributes_setting" string="Product Variants" help="One product might have different attributes (size, color, ...)">
+                        <field name="group_product_variant"/>
+                        <div class="content-group" attrs="{'invisible': [('group_product_variant', '=', False)]}">
+                            <div class="mt8">
+                                <button type="action" name="%(product.attribute_action)d" string="Attributes" class="btn-link" icon="fa-arrow-right"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="ecom_uom_price_option_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="group_show_uom_price"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_show_uom_price" string="Product Reference Price"/>
-                            <div class="text-muted">
-                                Add a reference price per UoM on products (i.e $/kg), in addition to the sale price
+                    </setting>
+                    <setting id="promotion_coupon_programs" title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products." string="Discounts, Loyalty &amp; Gift Card" help="Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet">
+                        <field name="module_loyalty" />
+                    </setting>
+                    <setting id="wishlist_option_setting" help="Allow signed-in users to save product in a wishlist">
+                        <field name="module_website_sale_wishlist"/>
+                    </setting>
+                    <setting id="comparator_option_setting" string="Product Comparison Tool" help="Allow shoppers to compare products based on their attributes">
+                        <field name="module_website_sale_comparison"/>
+                    </setting>
+                    <setting id="hide_add_to_cart_setting" help="If product price equals 0, replace 'Add to Cart' by 'Contact us'.">
+                        <field name="website_sale_prevent_zero_price_sale"/>
+                        <div class="content-group" attrs="{'invisible': [('website_sale_prevent_zero_price_sale', '=', False)]}">
+                            <div class="row mt16">
+                                <label class="o_light_label col-lg-3" string="Button url" for="website_sale_contact_us_button_url"/>
+                                <field name="website_sale_contact_us_button_url"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="product_attributes_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="group_product_variant"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_product_variant" string="Product Variants"/>
-                            <div class="text-muted">
-                                One product might have different attributes (size, color, ...)
-                            </div>
-                            <div class="content-group" attrs="{'invisible': [('group_product_variant', '=', False)]}">
-                                <div class="mt8">
-                                    <button type="action" name="%(product.attribute_action)d" string="Attributes" class="btn-link" icon="fa-arrow-right"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box"
-                        id="promotion_coupon_programs"
-                        title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products.">
-                        <div class="o_setting_left_pane">
-                            <field name="module_loyalty" />
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_loyalty" string="Discounts, Loyalty &amp; Gift Card"/>
-                            <div class="text-muted" id="website_sale_loyalty">
-                                Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="wishlist_option_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_website_sale_wishlist"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_website_sale_wishlist"/>
-                            <div class="text-muted">
-                                Allow signed-in users to save product in a wishlist
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="comparator_option_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_website_sale_comparison"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_website_sale_comparison" string="Product Comparison Tool"/>
-                            <div class="text-muted">
-                                Allow shoppers to compare products based on their attributes
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="hide_add_to_cart_setting">
-                          <div class="o_setting_left_pane">
-                            <field name="website_sale_prevent_zero_price_sale"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="website_sale_prevent_zero_price_sale"/>
-                            <div class="text-muted">
-                                If product price equals 0, replace 'Add to Cart' by 'Contact us'.
-                            </div>
-                            <div class="content-group" attrs="{'invisible': [('website_sale_prevent_zero_price_sale', '=', False)]}">
-                                <div class="row mt16">
-                                    <label class="o_light_label col-lg-3" string="Button url" for="website_sale_contact_us_button_url"/>
-                                    <field name="website_sale_contact_us_button_url"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                    </setting>
+                </block>
 
-                <h2>Shipping</h2>
-                <div class="row mt16 o_settings_container" id="sale_shipping_settings">
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_address_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="group_delivery_invoice_address"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_delivery_invoice_address"/>
-                            <div class="text-muted">
-                                Let the customer enter a shipping address
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="delivery_method_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_website_sale_delivery"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="Shipping Costs" for="module_website_sale_delivery"/>
-                            <div class="text-muted" id="msg_delivery_method_setting">
-                                Compute shipping costs on orders
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="ups_provider_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_ups" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="UPS" for="module_delivery_ups"/>
-                            <div class="text-muted" id="website_delivery_ups">
-                                Compute shipping costs and ship with UPS
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_dhl_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_dhl" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="DHL Express Connector" for="module_delivery_dhl"/>
-                            <div class="text-muted" id="website_delivery_dhl">
-                                Compute shipping costs and ship with DHL
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_fedex_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_fedex" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="FedEx" for="module_delivery_fedex"/>
-                            <div class="text-muted" id="website_delivery_fedex">
-                                Compute shipping costs and ship with FedEx
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_usps_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_usps" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="USPS" for="module_delivery_usps"/>
-                            <div class="text-muted" id="website_delivery_usps">
-                                Compute shipping costs and ship with USPS
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_bpost_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_bpost" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="bpost" for="module_delivery_bpost"/>
-                            <div class="text-muted" id="website_delivery_bpost">
-                                Compute shipping costs and ship with bpost
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_easypost_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_easypost" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="Easypost" for="module_delivery_easypost"/>
-                            <div class="text-muted" id="website_delivery_easypost">
-                                Compute shipping cost and ship with Easypost
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_mondialrelay_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_delivery_mondialrelay" widget="upgrade_boolean"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label string="Mondial Relay" for="module_delivery_mondialrelay"/>
-                            <div class="text-muted" id="website_delivery_mondialrelay">
-                                Let the customer select a Mondial Relay shipping point
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="onsite_payment_setting">
-                        <div class="o_setting_left_pane">
-                            <field name="module_website_sale_picking"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_website_sale_picking"/>
-                            <div class="text-muted">
-                                Allow customers to pay in person at your stores
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <block title="Shipping" id="sale_shipping_settings">
+                    <setting id="shipping_address_setting" help="Let the customer enter a shipping address">
+                        <field name="group_delivery_invoice_address"/>
+                    </setting>
+                    <setting id="delivery_method_setting" string="Shipping Costs" help="Compute shipping costs on orders">
+                        <field name="module_website_sale_delivery"/>
+                    </setting>
+                    <setting id="ups_provider_setting" string="UPS" help="Compute shipping costs and ship with UPS">
+                        <field name="module_delivery_ups" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="shipping_provider_dhl_setting" string="DHL Express Connector" help="Compute shipping costs and ship with DHL">
+                        <field name="module_delivery_dhl" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="shipping_provider_fedex_setting" string="FedEx" help="Compute shipping costs and ship with FedEx">
+                        <field name="module_delivery_fedex" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="shipping_provider_usps_setting" string="USPS" help="Compute shipping costs and ship with USPS">
+                        <field name="module_delivery_usps" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="shipping_provider_bpost_setting" string="bpost" help="Compute shipping costs and ship with bpost">
+                        <field name="module_delivery_bpost" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="shipping_provider_easypost_setting" string="Easypost" help="Compute shipping cost and ship with Easypost">
+                        <field name="module_delivery_easypost" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="shipping_provider_mondialrelay_setting" string="Mondial Relay" help="Let the customer select a Mondial Relay shipping point">
+                        <field name="module_delivery_mondialrelay" widget="upgrade_boolean"/>
+                    </setting>
+                    <setting id="onsite_payment_setting" help="Allow customers to pay in person at your stores">
+                        <field name="module_website_sale_picking"/>
+                    </setting>
+                </block>
 
                 <field name='module_account' invisible="1"/>
-                <div attrs="{'invisible': [('module_account', '=', False)]}">
-                    <h2>Invoicing</h2>
-                    <div class="row mt16 o_settings_container" id="sale_invoicing_settings">
-                       <div class="col-12 col-lg-6 o_setting_box" id="invoicing_policy_setting" title="The mode selected here applies as invoicing policy of any new product created but not of products already existing.">
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">Invoicing Policy</span>
-                                <div class="text-muted">
-                                    Issue invoices to customers
-                                </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <field name="default_invoice_policy" class="o_light_label" widget="radio"/>
-                                    </div>
+                    <block title="Invoicing" id="sale_invoicing_settings" attrs="{'invisible': [('module_account', '=', False)]}">
+                        <setting id="invoicing_policy_setting" title="The mode selected here applies as invoicing policy of any new product created but not of products already existing." string="Invoicing Policy" help="Issue invoices to customers">
+                            <div class="content-group">
+                                <div class="mt16">
+                                    <field name="default_invoice_policy" class="o_light_label" widget="radio"/>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box"
-                            id="automatic_invoice_generation"
-                            attrs="{'invisible': [('default_invoice_policy', '=', 'delivery')]}">
-                            <div class="o_setting_left_pane">
-                                <field name="automatic_invoice" nolabel="1"/>
+                        </setting>
+                        <setting id="automatic_invoice_generation" attrs="{'invisible': [('default_invoice_policy', '=', 'delivery')]}" help="Generate the invoice automatically when the online payment is confirmed">
+                            <field name="automatic_invoice" nolabel="1"/>
+                            <div  attrs="{'invisible': [('automatic_invoice','=',False)]}">
+                                <label for="invoice_mail_template_id" class="o_light_label"/>
+                                <field name="invoice_mail_template_id" class="oe_inline"/>
                             </div>
-                            <div class="o_setting_right_pane">
-                                <label for="automatic_invoice"/>
-                                <div class="text-muted">
-                                    Generate the invoice automatically when the online payment is confirmed
-                                </div>
-                                <div  attrs="{'invisible': [('automatic_invoice','=',False)]}">
-                                    <label for="invoice_mail_template_id" class="o_light_label"/>
-                                    <field name="invoice_mail_template_id" class="oe_inline"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                        </setting>
+                    </block>
+            </block>
 
-            <div id="cart_redirect_setting" position="after">
-                <div id="website_login_documents" position="move"/>
-            </div>
-            <xpath expr="//div[@id='website_login_documents']/div[hasclass('o_setting_right_pane')]" position="replace">
-                <div class="o_setting_right_pane">
-                    <label for="account_on_checkout" string="Sign in/up at checkout"/>
-                    <div class="text-muted">
-                        "Optional" allows guests to register from the order confirmation email to track their order.
-                    </div>
-                    <div class="mt8 ms-4">
-                        <field name="account_on_checkout" class="w-75" widget="radio"/>
-                    </div>
-                </div>
+            <setting id="cart_redirect_setting" position="after">
+                <setting id="website_login_documents" position="move"/>
+            </setting>
+            <xpath expr="//setting[@id='website_login_documents']" position="replace">
+                <setting id="website_login_documents" title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*." string="Sign in/up at checkout" help="&quot;Optional&quot; allows guests to register from the order confirmation email to track their order.">
+                    <field name="account_on_checkout" class="w-75" widget="radio"/>
+                </setting>
             </xpath>
 
-            <div id="website_marketing_automation" position="after">
-                <div class="col-xs-12 col-lg-6 o_setting_box" id="abandoned_carts_setting" title="Customer needs to be signed in otherwise the mail address is not known.
+            <setting id="website_marketing_automation" position="after">
+                <setting
+                    id="abandoned_carts_setting"
+                    title="Customer needs to be signed in otherwise the mail address is not known.
     &#10;&#10;- If a potential customer creates one or more abandoned checkouts and then completes a sale before the recovery email gets sent, then the email won't be sent.
     &#10;&#10;- If user has manually sent a recovery email, the mail will not be sent a second time
     &#10;&#10;- If a payment processing error occurred when the customer tried to complete their checkout, then the email won't be sent.
     &#10;&#10;- If your shop does not support shipping to the customer's address, then the email won't be sent.
     &#10;&#10;- If none of the products in the checkout are available for purchase (empty inventory, for example), then the email won't be sent.
-    &#10;&#10;- If all the products in the checkout are free, and the customer does not visit the shipping page to add a shipping fee or the shipping fee is also free, then the email won't be sent.">
-                    <div class="o_setting_left_pane">
-                        <field name="send_abandoned_cart_email"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <span class="o_form_label">Automatically send abandoned checkout emails</span>
-                        <div class="text-muted">
-                            Mail only sent to signed in customers with items available for sale in their cart.
-                        </div>
+    &#10;&#10;- If all the products in the checkout are free, and the customer does not visit the shipping page to add a shipping fee or the shipping fee is also free, then the email won't be sent."
+                    string="Automatically send abandoned checkout emails"
+                    help="Mail only sent to signed in customers with items available for sale in their cart.">
+                    <field name="send_abandoned_cart_email"/>
 
-                        <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="content-group" title="Carts are flagged as abandoned after this delay.">
-                            <div class="row mt16">
-                                <div class="col-12">
-                                  <label for="cart_abandoned_delay" string="Send after" class="o_light_label"/>
-                                  <field class="col-2" name="cart_abandoned_delay" widget="float_time" /> Hours.
-                                </div>
+                    <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="content-group" title="Carts are flagged as abandoned after this delay.">
+                        <div class="row mt16">
+                            <div class="col-12">
+                                <label for="cart_abandoned_delay" string="Send after" class="o_light_label"/>
+                                <field class="col-2" name="cart_abandoned_delay" widget="float_time" /> Hours.
                             </div>
                         </div>
-                        <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="mt8">
-                            <button type="object" name="action_open_abandoned_cart_mail_template" string="Customize Abandoned Email Template" class="btn-link" icon="fa-arrow-right"/>
-                        </div>
                     </div>
-                </div>
-            </div>
+                    <div attrs="{'invisible': [('send_abandoned_cart_email', '=', False)]}" class="mt8">
+                        <button type="object" name="action_open_abandoned_cart_mail_template" string="Customize Abandoned Email Template" class="btn-link" icon="fa-arrow-right"/>
+                    </div>
+                </setting>
+            </setting>
 
-            <xpath expr="//div[@id='google_analytics_setting']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="autocomplete_googleplaces_setting">
-                    <div class="o_setting_left_pane">
-                        <field name="module_website_sale_autocomplete"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="module_website_sale_autocomplete"/>
-                        <div class="text-muted">
-                            Use Google Places API to validate addresses entered by your visitors
-                        </div>
-                    </div>
-                </div>
+            <xpath expr="//setting[@id='google_analytics_setting']" position="after">
+                <setting id="autocomplete_googleplaces_setting" help="Use Google Places API to validate addresses entered by your visitors">
+                    <field name="module_website_sale_autocomplete"/>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/website_sale_autocomplete/views/res_config_settings_views.xml
+++ b/addons/website_sale_autocomplete/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='autocomplete_googleplaces_setting']/div[hasclass('o_setting_right_pane')]" position="inside">
+            <xpath expr="//setting[@id='autocomplete_googleplaces_setting']" position="inside">
                 <div>
                     <div class="content-group row mt16">
                         <label class="col-4" for="google_places_api_key" string="API Key"/>

--- a/addons/website_sale_delivery/views/res_config_settings_views.xml
+++ b/addons/website_sale_delivery/views/res_config_settings_views.xml
@@ -5,48 +5,48 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="msg_delivery_method_setting" position="after">
+            <setting id="delivery_method_setting" position="inside">
                 <div class="content-group" attrs="{'invisible': [('module_website_sale_delivery', '=', False)]}">
                     <div class="mt16">
                         <button type="action" name="%(delivery.action_delivery_carrier_form)d" string="Shipping Methods" class="btn-link" icon="fa-arrow-right"/>
                     </div>
                 </div>
-            </div>
-            <div id="website_delivery_dhl" position="after">
+            </setting>
+            <setting id="shipping_provider_dhl_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_dhl', '=', False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="DHL Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'dhl'}"/>
                     </div>
                 </div>
-            </div>
-            <div id="website_delivery_fedex" position="after">
+            </setting>
+            <setting id="shipping_provider_fedex_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_fedex', '=', False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="FedEx Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'fedex'}"/>
                     </div>
                 </div>
-            </div>
-            <div id="website_delivery_usps" position="after">
+            </setting>
+            <setting id="shipping_provider_usps_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_usps', '=', False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="USPS Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'usps'}"/>
                     </div>
                 </div>
-            </div>
-            <div id="website_delivery_bpost" position="after">
+            </setting>
+            <setting id="shipping_provider_bpost_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_bpost', '=', False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="bpost Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'bpost'}"/>
                     </div>
                 </div>
-            </div>
-            <div id="website_delivery_easypost" position="after">
+            </setting>
+            <setting id="shipping_provider_easypost_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_easypost', '=', False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="Easypost Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'easypost'}"/>
                     </div>
                 </div>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_sale_delivery_mondialrelay/views/res_config_settings_views.xml
+++ b/addons/website_sale_delivery_mondialrelay/views/res_config_settings_views.xml
@@ -5,13 +5,13 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="website_delivery_mondialrelay" position="after">
+            <setting id="shipping_provider_mondialrelay_setting" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_mondialrelay', '=', False)]}">
                         <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="Mondial Relay Shipping Methods" class="btn-link" context="{'search_default_is_mondialrelay': True}"/>
                     </div>
                 </div>
-            </div>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/website_sale_loyalty/views/res_config_settings_views.xml
+++ b/addons/website_sale_loyalty/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='website_sale_loyalty']" position="after">
+            <xpath expr="//setting[@id='promotion_coupon_programs']" position="inside">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_loyalty', '=', False)]}">
                         <button name="%(loyalty.loyalty_program_discount_loyalty_action)d" icon="fa-arrow-right" type="action" string="Loyalty Programs" class="btn-link"/>

--- a/addons/website_sale_picking/views/res_config_settings_views.xml
+++ b/addons/website_sale_picking/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website_sale.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='onsite_payment_setting']/div[hasclass('o_setting_right_pane')]" position="inside">
+            <xpath expr="//setting[@id='onsite_payment_setting']" position="inside">
                 <div class="content-group">
                     <label class="col-lg-3" string="Picking sites" for="picking_site_ids"/>
                     <field name="picking_site_ids" domain="[('delivery_type', '=', 'onsite')]" widget="many2many_tags"

--- a/addons/website_sale_stock/views/res_config_settings_views.xml
+++ b/addons/website_sale_stock/views/res_config_settings_views.xml
@@ -6,52 +6,42 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website_sale.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='comparator_option_setting']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="product_availability_setting">
-                    <div class="o_setting_left_pane">
-                    </div>
-                    <div class="o_setting_right_pane" name="stock_inventory_availability">
-                        <div class="o_form_label">
-                            Inventory Defaults
-                        </div>
-                        <div class="text-muted">
-                            How to display products having low quantities (on hand - reserved)
+            <xpath expr="//setting[@id='comparator_option_setting']" position="after">
+                <setting id="product_availability_setting" string="Inventory Defaults" help="How to display products having low quantities (on hand - reserved)">
+                    <div class="content-group">
+                        <div class="row mt16"
+                            id="website_warehouse_setting"
+                            groups="stock.group_stock_multi_warehouses">
+                            <field name="website_company_id" invisible="1"/>
+                            <label for="website_warehouse_id" string="Warehouse" class="col-lg-3 o_light_label" />
+                            <field name="website_warehouse_id"/>
                         </div>
                         <div class="content-group">
                             <div class="row mt16"
-                                id="website_warehouse_setting"
-                                groups="stock.group_stock_multi_warehouses">
-                                <field name="website_company_id" invisible="1"/>
-                                <label for="website_warehouse_id" string="Warehouse" class="col-lg-3 o_light_label" />
-                                <field name="website_warehouse_id"/>
-                            </div>
-                            <div class="content-group">
-                                <div class="row mt16"
-                                    id="allow_out_of_stock_order_setting"
-                                    title="Default availability mode set on newly created storable products. This can be changed at the product level.">
-                                    <div class="col-12">
-                                        <label for="allow_out_of_stock_order" string="Out-of-Stock" class="p-0 col-4 o_light_label"/>
-                                        <field name="allow_out_of_stock_order" class=" w-auto"/>
-                                        <label for="allow_out_of_stock_order" class="o_light_label" string="Continue Selling"/>
-                                    </div>
+                                id="allow_out_of_stock_order_setting"
+                                title="Default availability mode set on newly created storable products. This can be changed at the product level.">
+                                <div class="col-12">
+                                    <label for="allow_out_of_stock_order" string="Out-of-Stock" class="p-0 col-4 o_light_label"/>
+                                    <field name="allow_out_of_stock_order" class=" w-auto"/>
+                                    <label for="allow_out_of_stock_order" class="o_light_label" string="Continue Selling"/>
                                 </div>
                             </div>
-                            <div class="content-group">
-                                <div class="row"
-                                    id="show_availability_setting"
-                                    title="Default visibility for custom messages.">
-                                    <div class="col-12">
-                                        <label for="show_availability" string="Show Available Qty" class="p-0 col-4 o_light_label mb-3 mt-2"/>
-                                        <field name="show_availability" class="w-auto"/>
-                                        <label for="available_threshold" string="only if below" class="o_light_label" attrs="{'invisible': [('show_availability', '=', False)]}"/>
-                                        <field name="available_threshold" class="oe_inline col-1" widget="integer" attrs="{'invisible': [('show_availability', '=', False)]}"/>
-                                        <span attrs="{'invisible': [('show_availability', '=', False)]}">Units</span>
-                                    </div>
+                        </div>
+                        <div class="content-group">
+                            <div class="row"
+                                id="show_availability_setting"
+                                title="Default visibility for custom messages.">
+                                <div class="col-12">
+                                    <label for="show_availability" string="Show Available Qty" class="p-0 col-4 o_light_label mb-3 mt-2"/>
+                                    <field name="show_availability" class="w-auto"/>
+                                    <label for="available_threshold" string="only if below" class="o_light_label" attrs="{'invisible': [('show_availability', '=', False)]}"/>
+                                    <field name="available_threshold" class="oe_inline col-1" widget="integer" attrs="{'invisible': [('show_availability', '=', False)]}"/>
+                                    <span attrs="{'invisible': [('show_availability', '=', False)]}">Units</span>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/website_slides/views/res_config_settings_views.xml
+++ b/addons/website_slides/views/res_config_settings_views.xml
@@ -5,82 +5,43 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='website_marketing_automation']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="slides_install_setting" groups="website_slides.group_website_slides_manager">
-                    <div class="o_setting_right_pane">
-                        <span class="o_form_label">Slides</span>
-                        <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
-                        <div class="text-muted">
-                            Google Drive API Key
+            <xpath expr="//setting[@id='website_marketing_automation']" position="after">
+                <setting id="slides_install_setting" groups="website_slides.group_website_slides_manager">
+                    <span class="o_form_label">Slides</span>
+                    <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
+                    <div class="text-muted">
+                        Google Drive API Key
+                    </div>
+                    <div class="content-group">
+                        <div class="row mt16">
+                            <label for="website_slide_google_app_key" class="col-lg-3 o_light_label" string="API Key"/>
+                            <field name="website_slide_google_app_key" class="oe_inline"/>
                         </div>
-                        <div class="content-group">
-                            <div class="row mt16">
-                                <label for="website_slide_google_app_key" class="col-lg-3 o_light_label" string="API Key"/>
-                                <field name="website_slide_google_app_key" class="oe_inline"/>
-                            </div>
-                            <div class="oe_link">
-                                <a href="https://console.developers.google.com/flows/enableapi?apiid=drive,youtube"><span class="fa fa-arrow-right"/>
-                                    Create a Google Project and Get a Key
-                                </a>
-                            </div>
+                        <div class="oe_link">
+                            <a href="https://console.developers.google.com/flows/enableapi?apiid=drive,youtube"><span class="fa fa-arrow-right"/>
+                                Create a Google Project and Get a Key
+                            </a>
                         </div>
                     </div>
-                </div>
+                </setting>
             </xpath>
-            <xpath expr="//div[hasclass('settings')]" position="inside">
-                <div class="app_settings_block" data-string="eLearning" string="eLearning" data-key="website_slides" groups="website_slides.group_website_slides_manager">
-                    <h2>eLearning</h2>
-                    <div class="row mt16 o_settings_container" id="website_slides_selection_settings">
-                        <group>
-                            <div class="o_setting_box me-auto" id="website_slide_install_website_slides_survey" colspan="4">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_slides_survey"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_website_slides_survey"/>
-                                    <div class="text-muted">
-                                        Evaluate the knowledge of your Attendees and certify their skills.
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="o_setting_box" id="website_slides_install_sale_slides" colspan="4">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_sale_slides"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_website_sale_slides" string="Paid Courses"/>
-                                    <div class="text-muted">
-                                        Sell access to your courses on your website and track revenues.
-                                    </div>
-                                </div>
-                            </div>
-                        </group>
-                        <group>
-                            <div class="o_setting_box" id="website_slides_install_mass_mailing_slides" colspan="4">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_mass_mailing_slides"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_mass_mailing_slides"/>
-                                    <div class="text-muted">
-                                        Update all your Attendees at once through mass mailings.
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="o_setting_box me-auto" id="website_slide_install_website_slides_forum" colspan="4">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_slides_forum"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_website_slides_forum"/>
-                                    <div class="text-muted me-auto">
-                                        Create a community and let Attendees answer each others' questions.
-                                    </div>
-                                </div>
-                            </div>
-                        </group>
-                    </div>
-                </div>
+            <xpath expr="//form" position="inside">
+                <app data-string="eLearning" string="eLearning" name="website_slides" groups="website_slides.group_website_slides_manager">
+                    <block title="eLearning" id="website_slides_selection_settings">
+                        <setting id="website_slide_install_website_slides_survey" colspan="4" help="Evaluate the knowledge of your Attendees and certify their skills.">
+                            <field name="module_website_slides_survey"/>
+                        </setting>
+                        <setting id="website_slides_install_sale_slides" colspan="4" string="Paid Courses" help="Sell access to your courses on your website and track revenues.">
+                            <field name="module_website_sale_slides"/>
+                        </setting>
+                        <setting id="website_slides_install_mass_mailing_slides" colspan="4" help="Update all your Attendees at once through mass mailings.">
+                            <field name="module_mass_mailing_slides"/>
+                        </setting>
+                        <setting id="website_slide_install_website_slides_forum" colspan="4" help="Create a community and let Attendees answer each others' questions.">
+                            <field name="module_website_slides_forum"/>
+                        </setting>
+                    </block>
+                </app>
             </xpath>
         </field>
     </record>

--- a/addons/website_slides_forum/views/res_config_settings_views.xml
+++ b/addons/website_slides_forum/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="website_slides.res_config_settings_view_form"/>
         <field name="priority">20</field>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='website_slide_install_website_slides_forum']//div[hasclass('text-muted')]" position="after">
+            <xpath expr="//setting[@id='website_slide_install_website_slides_forum']" position="inside">
                 <div class="mt8">
                     <button type="action" name="%(website_slides_forum.forum_forum_action_channel)d" string="Manage Forums" class="btn-link" icon="fa-arrow-right"/>
                 </div>

--- a/addons/website_slides_survey/views/res_config_settings_views.xml
+++ b/addons/website_slides_survey/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="website_slides.res_config_settings_view_form"/>
         <field name="priority">10</field>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='website_slide_install_website_slides_survey']//div[hasclass('text-muted')]" position="after">
+            <xpath expr="//setting[@id='website_slide_install_website_slides_survey']" position="inside">
                 <div class="mt8">
                     <button type="action" name="%(website_slides_survey.survey_survey_action_slides)d" string="Manage Certifications" class="btn-link" icon="fa-arrow-right"/>
                 </div>

--- a/addons/website_twitter/views/res_config_settings_views.xml
+++ b/addons/website_twitter/views/res_config_settings_views.xml
@@ -5,53 +5,47 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="website_email_marketing" position="inside">
-                <div class="col-12 col-lg-6 o_setting_box" id="twitter_roller_install_setting">
-                    <div class="o_setting_right_pane">
-                        <span class="o_form_label">Twitter Roller</span>
-                        <div class="text-muted">
-                            Twitter API Credentials
+            <block id="website_email_marketing" position="inside">
+                <setting id="twitter_roller_install_setting" string="Twitter Roller" help="Twitter API Credentials">
+                    <div class="content-group">
+                        <div class="row mt16">
+                            <label class="col-lg-3 o_light_label" string="API Key" for="twitter_api_key"/>
+                            <field name="twitter_api_key" class="oe_inline"/>
                         </div>
-                        <div class="content-group">
-                            <div class="row mt16">
-                                <label class="col-lg-3 o_light_label" string="API Key" for="twitter_api_key"/>
-                                <field name="twitter_api_key" class="oe_inline"/>
-                            </div>
-                            <div class="row">
-                                <label class="col-lg-3 o_light_label" string="API secret" for="twitter_api_secret"/>
-                                <field name="twitter_api_secret" password="True" class="oe_inline"/>
-                            </div>
-                            <a data-bs-toggle="collapse" href="#" data-bs-target="#twitter_tutorial" aria-label="Twitter tutorial">
-                                <i class="fa fa-arrow-right"/>
-                                Show me how to obtain the Twitter API key and Twitter API secret
-                            </a>
-                            <div class="row mt16 collapse" id="twitter_tutorial">
-                                <blockquote class="small">
-                                    <h2>How to configure the Twitter API access</h2>
-                                    <ol>
-                                        <li>Log in or create an account on <a href="https://developer.twitter.com/" target="new"> https://developer.twitter.com/</a></li>
-                                        <li>Once connected, and if not already done, complete the Twitter portal access process on <a href="https://developer.twitter.com/portal/" target="new">https://developer.twitter.com/portal/</a></li>
-                                        <li>On the <a href="https://developer.twitter.com/portal/" target="new">Twitter Portal</a>, <strong>create a project</strong> with the following information:
-                                            <ul>
-                                                <li><strong>Name: </strong> Odoo Twitter Integration</li>
-                                                <li><strong>Use Case: </strong> Embedding Tweets in a website</li>
-                                                <li><strong>Description: </strong> Odoo Twitter Integration</li>
-                                                <li><strong>App Name: </strong> choose a unique name</li>
-                                            </ul>
-                                        </li>
-                                        <li>Copy/Paste the API Key and API Key Secret values into the above fields</li>
-                                        <li>Get Elevated access by going to <a href="https://developer.twitter.com/en/portal/products" target="new">https://developer.twitter.com/en/portal/products</a>, click on <strong>Elevated</strong> then on <strong>Apply</strong> and finally complete the form.</li>
-                                    </ol>
-                                </blockquote>
-                            </div>
-                            <div class="row">
-                                <label class="col-lg-3 o_light_label" string="Favorites From" for="twitter_screen_name"/>
-                                <field name="twitter_screen_name" class="oe_inline"/>
-                            </div>
+                        <div class="row">
+                            <label class="col-lg-3 o_light_label" string="API secret" for="twitter_api_secret"/>
+                            <field name="twitter_api_secret" password="True" class="oe_inline"/>
+                        </div>
+                        <a data-bs-toggle="collapse" href="#" data-bs-target="#twitter_tutorial" aria-label="Twitter tutorial">
+                            <i class="fa fa-arrow-right"/>
+                            Show me how to obtain the Twitter API key and Twitter API secret
+                        </a>
+                        <div class="row mt16 collapse" id="twitter_tutorial">
+                            <blockquote class="small">
+                                <h2>How to configure the Twitter API access</h2>
+                                <ol>
+                                    <li>Log in or create an account on <a href="https://developer.twitter.com/" target="new"> https://developer.twitter.com/</a></li>
+                                    <li>Once connected, and if not already done, complete the Twitter portal access process on <a href="https://developer.twitter.com/portal/" target="new">https://developer.twitter.com/portal/</a></li>
+                                    <li>On the <a href="https://developer.twitter.com/portal/" target="new">Twitter Portal</a>, <strong>create a project</strong> with the following information:
+                                        <ul>
+                                            <li><strong>Name: </strong> Odoo Twitter Integration</li>
+                                            <li><strong>Use Case: </strong> Embedding Tweets in a website</li>
+                                            <li><strong>Description: </strong> Odoo Twitter Integration</li>
+                                            <li><strong>App Name: </strong> choose a unique name</li>
+                                        </ul>
+                                    </li>
+                                    <li>Copy/Paste the API Key and API Key Secret values into the above fields</li>
+                                    <li>Get Elevated access by going to <a href="https://developer.twitter.com/en/portal/products" target="new">https://developer.twitter.com/en/portal/products</a>, click on <strong>Elevated</strong> then on <strong>Apply</strong> and finally complete the form.</li>
+                                </ol>
+                            </blockquote>
+                        </div>
+                        <div class="row">
+                            <label class="col-lg-3 o_light_label" string="Favorites From" for="twitter_screen_name"/>
+                            <field name="twitter_screen_name" class="oe_inline"/>
                         </div>
                     </div>
-                </div>
-            </div>
+                </setting>
+            </block>
         </field>
     </record>
 </odoo>

--- a/odoo/addons/base/tests/test_res_config.py
+++ b/odoo/addons/base/tests/test_res_config.py
@@ -85,6 +85,7 @@ class TestResConfig(TransactionCase):
         # Check returned value
         self.assertEqual(res.args[0], self.expected_final_error_msg_wo_menu)
 
+    # TODO: ASK DLE if this test can be removed
     def test_40_view_expected_architecture(self):
         """Tests the res.config.settings form view architecture expected by the web client.
         The res.config.settings form view is handled with a custom widget expecting a very specific
@@ -99,11 +100,11 @@ class TestResConfig(TransactionCase):
             'model': 'res.config.settings',
             'inherit_id': self.env.ref('base.res_config_settings_view_form').id,
             'arch': """
-                <xpath expr="//div[hasclass('settings')]" position="inside">
+                <xpath expr="//form" position="inside">
                     <t groups="base.group_system">
-                        <div class="app_settings_block" data-string="Foo" string="Foo" data-key="foo">
+                        <app data-string="Foo" string="Foo" name="foo">
                             <h2>Foo</h2>
-                        </div>
+                        </app>
                     </t>
                 </xpath>
             """,
@@ -112,13 +113,12 @@ class TestResConfig(TransactionCase):
         tree = etree.fromstring(arch)
         self.assertTrue(tree.xpath("""
             //form[@class="oe_form_configuration o_base_settings"]
-            /div[@class="o_setting_container"]
-            /div[@class="settings"]
-            /div[@class="app_settings_block"][@data-key="foo"]
+            /app[@name="foo"]
         """), 'The res.config.settings form view architecture is not what is expected by the web client.')
 
+    # TODO: ASK DLE if this test can be removed
     def test_50_view_expected_architecture_t_node_groups(self):
-        """Tests the behavior of the res.config.settings form view postprocessing when a block `app_settings_block`
+        """Tests the behavior of the res.config.settings form view postprocessing when a block `app`
         is wrapped in a `<t groups="...">`, which is used when you need to display an app settings section
         only for users part of two groups at the same time."""
         view = self.env['ir.ui.view'].create({
@@ -127,12 +127,12 @@ class TestResConfig(TransactionCase):
             'model': 'res.config.settings',
             'inherit_id': self.env.ref('base.res_config_settings_view_form').id,
             'arch': """
-                <xpath expr="//div[hasclass('settings')]" position="inside">
+                <xpath expr="//form" position="inside">
                     <t groups="base.group_system">
-                        <div class="app_settings_block" data-string="Foo"
-                            string="Foo" data-key="foo" groups="base.group_no_one">
+                        <app data-string="Foo"
+                            string="Foo" name="foo" groups="base.group_no_one">
                             <h2>Foo</h2>
-                        </div>
+                        </app>
                     </t>
                 </xpath>
             """,
@@ -143,9 +143,9 @@ class TestResConfig(TransactionCase):
             # The <t> must be removed from the structure
             self.assertFalse(tree.xpath('//t'), 'The `<t groups="...">` block must not remain in the view')
             self.assertTrue(tree.xpath("""
-                //div[@class="settings"]
-                /div[@class="app_settings_block"][@data-key="foo"]
-            """), 'The `class="app_settings_block"` block must be a direct child of the `class="settings"` block')
+                //form
+                /app[@name="foo"]
+            """), 'The `app` block must be a direct child of the `form` block')
 
 
 @tagged('post_install', '-at_install')

--- a/odoo/addons/base/views/res_config_settings_views.xml
+++ b/odoo/addons/base/views/res_config_settings_views.xml
@@ -6,9 +6,6 @@
             <field name="model">res.config.settings</field>
             <field name="arch" type="xml">
                 <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
-                    <div class="o_setting_container">
-                        <div class="settings"/>
-                    </div>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
The aim of this commit is to simplify and standardize the settings archs.

To do this, a small DSL exclusively for the settings was created. This new DSL introduces 3 tags: `app`, `block` and `setting`.

## `app`
The `app` tag is used to declare the application on the settings view. It creates an entry with its logo on the sidebar of the view. It also acts as delimiter when searching.

### Syntax
```xml
    <app string="CRM" name="crm">
    ...
    </app>
```

### Parameters
- `string` : The "display" name of the application.
- `name` : The technical name of the application (the name of the module).
- `logo` *optional* : The relative path to the logo. If not set, the logo is created using the `name` parameter : `/{name}/static/description/icon.png`.

## `block`
The `block` tag is used to declare a group of settings. This group can have a title and a description/help.

### Syntax
```xml
    <block title="Title of group Bar">
    ...
    </block>
```

### Parameters
- `title` *optional* : The title of the block of settings (the old h2), you can perform research on its text.
- `help` *optional* : The description/help of the block of settings (the old h3), you can perform research on its text.

## `setting`
The `setting` tag is used to declare the setting itself. The first field in the setting is used as the main field (optional). This field is placed on the left panel (if it's a boolean field) or on the top of the right panel (otherwise). The field is also used to create the setting label if a `string` is not defined. The `setting` tag can also contain more elements (e.g. html), all of these elements are rendered in the right panel.

### Syntax
```xml
    <setting string="this is bar">
        <field name="bar"/>
        ...More elements
    </setting>
```

### Parameters
- `type` *optional* : By default, a setting is visually separated on two panels (left and right), and is used to edit a given field. By defining `type='header'`, a special kind of setting is rendered instead. This setting is used to modify the scope of the other settings. For example, on the website application, this setting is used to indicate to which website the other settings apply. The header setting is visually represented as a yellow banner on the top of the screen.
- `string` *optional* : The text used as label of the setting. If it's not defined, the first field is used as label.
- `title` *optional* : The text used as tooltip.
- `help` *optional* : The help/description of the setting. This text is displayed just below the setting label (with classname `text-muted`).
- `company_dependent` *optional* : If this attribute is set to "1" an icon is displayed next to the setting label to explicit that this setting is company-specific.
- `documentation` *optional* :  If this attribute is set, an icon is added next to the setting label, this icon is a link to the documentation. Note that you can use relative or absolute path. The relative path is relative to `https://www.odoo.com/documentation/server_version`, so it's not necessary to hard-code the server version on the arch anymore.

## Example
```xml
<app string="CRM" name="crm">
    <setting type="header" string="Foo">
        <field name="foo" title="Foo?."/>
        <button name="nameAction" type="object" string="Button"/>
    </setting>
    <block title="Title of group Bar">
        <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
            <field name="bar"/>
        </setting>
        <setting string="This is Big BAR" company_specific="1">
            <field name="bar"/>
        </setting>
    </block>
    <block title="Title of group Foo">
        <setting string="Personalize setting" help="this is full personalize setting">
            <div>This is a different setting</div>
        </setting>
    </block>
</app>
```
More examples can be found in the code base.

## Example of the simplification of the code
```diff
- <div class="app_settings_block" data-string="CRM" string="CRM" data-key="crm">
+ <app string="CRM" name="crm">
-     <div class="row app_settings_header my-0 ms-0 mw-100 bg-warning bg-opacity-25">
-         <div class="col-xs-12 col-md-6 ms-0 o_setting_box">
-             <div class="o_setting_right_pane border-start-0 ms-0 ps-0">
-                 <div class="content-group">
-                     <div class="row flex-row flex-nowrap mt8 align-items-center">
-                         <label class="col ps-0 text-nowrap" string="Foo" for="foo"/>
-                         <field name="foo" title="Foo?."/>
-                         <button name="nameAction" type="object" string="Button" class="col-auto btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
-                     </div>
-                 </div>
-             </div>
-         </div>
-     </div>
+     <setting type="header" string="Foo">
+         <field name="foo" title="Foo?."/>
+         <button name="nameAction" type="object" string="Button"/>
+     </setting>
-     <h2>Title of group Bar</h2>
-     <div class="col-xs-12 row o_settings_container">
+     <block title="Title of group Bar">
-         <div class="col-xs-12 col-lg-6 o_setting_box">
-             <div class="o_setting_left_pane">
-                 <field name="bar"/>
-             </div>
-             <div class="o_setting_right_pane">
-                 <a href="https://www.odoo.com/documentation/master/applications/technical/web/settings/this_is_a_test.html" title="Documentation" class="o_doc_link" target="_blank"/>
-                 <div class="text-muted">
-                     this is bar
-                 </div>
-             </div>
-         </div>
+         <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
+             <field name="bar"/>
+         </setting>
-         <div class="col-xs-12 col-lg-6 o_setting_box">
-             <div class="o_setting_left_pane">
-                 <field name="bar"/>
-             </div>
-             <div class="o_setting_right_pane">
-                 <label for="bar" string="This is Big BAR" />
-                 <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-             </div>
-         </div>
+         <setting string="This is Big BAR" company_specific="1">
+             <field name="bar"/>
+         </setting>
-     </div>
+     </block>
-     <h2>Title of group Foo</h2>
-     <div class="col-xs-12 row o_settings_container">
-         <div class="col-xs-12 col-lg-6 o_setting_box">
-             <div class="o_setting_left_pane">
-             </div>
-             <div class="o_setting_right_pane">
-                 <span class="o_form_label">Personalize setting</span>
-                 <div class="text-muted">
-                     this is full personalize setting
-                 </div>
-                 <div>This is a different setting</div>
-             </div>
-         </div>
-     </div>
+     <block title="Title of group Foo">
+         <setting string="Personalize setting" help="this is full personalize setting">
+             <div>This is a different setting</div>
+         </setting>
+     </block>
- </div>
+ </app>
```

task-id: 3081367

Co-authored-by: "Michael Mattiello (mcm)" <mcm@odoo.com>