### PR TITLE
[FIX] website: fix input default value translation

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -138,11 +138,13 @@
         'web.assets_frontend_minimal': [
             'website/static/src/js/content/inject_dom.js',
             'website/static/src/js/content/auto_hide_menu.js',
+            'website/static/src/js/content/adapt_content.js',
         ],
         'web.assets_frontend_lazy': [
             # Remove assets_frontend_minimal
             ('remove', 'website/static/src/js/content/inject_dom.js'),
             ('remove', 'website/static/src/js/content/auto_hide_menu.js'),
+            ('remove', 'website/static/src/js/content/adapt_content.js'),
         ],
         'web._assets_primary_variables': [
             'website/static/src/scss/primary_variables.scss',

--- a/addons/website/static/src/js/content/adapt_content.js
+++ b/addons/website/static/src/js/content/adapt_content.js
@@ -1,0 +1,19 @@
+/** @odoo-module */
+
+document.addEventListener('DOMContentLoaded', () => {
+    const htmlEl = document.documentElement;
+    const editTranslations = !!htmlEl.dataset.edit_translations;
+    // Hack: on translation editor, textareas with translatable text content
+    // will get a `<span/>` as translation value which stays visible until
+    // the values are updated on the editor. The same issue was fixed on CSS
+    // for `placeholder` and `value` attributes (since we can get the elements
+    // with attribute translation on CSS). But here, we need to hide the text
+    // on JS until the editor's code sets the right values on textareas.
+    if (editTranslations) {
+        [...document.querySelectorAll('textarea')].map(textarea => {
+            if (textarea.value.indexOf('data-oe-translation-id') !== -1) {
+                textarea.classList.add('o_text_hide'); 
+            }
+        });
+    }
+});

--- a/addons/website/static/src/js/menu/translate.js
+++ b/addons/website/static/src/js/menu/translate.js
@@ -240,7 +240,8 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                     translation['textContent'] = $trans[0];
                     $node.val(match[2]);
 
-                    $node.addClass('o_translatable_text').data('translation', translation);
+                    $node.addClass('o_translatable_text').removeClass('o_text_hide')
+                        .data('translation', translation);
                 });
                 $edited = $edited.add(textEdit);
 

--- a/addons/website/static/src/js/menu/translate.js
+++ b/addons/website/static/src/js/menu/translate.js
@@ -77,10 +77,16 @@ var AttributeTranslateDialog = weDialog.extend({
             $input.on('change keyup', function () {
                 var value = $input.val();
                 $node.html(value).trigger('change', node);
-                if ($node.data('attribute')) {
-                    $node.data('$node').attr($node.data('attribute'), value).trigger('translate');
+                const $originalNode = $node.data('$node');
+                const nodeAttribute = $node.data('attribute');
+                if (nodeAttribute) {
+                    $originalNode.attr(nodeAttribute, value);
+                    if (nodeAttribute === 'value') {
+                        $originalNode[0].value = value;
+                    }
+                    $originalNode.trigger('translate');
                 } else {
-                    $node.data('$node').val(value).trigger('translate');
+                    $originalNode.val(value).trigger('translate');
                 }
                 $node.trigger('change');
             });
@@ -223,6 +229,12 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
 
                         translation[attr] = $trans[0];
                         $node.attr(attr, match[2]);
+                        // Using jQuery attr() to update the "value" will not change what appears in the
+                        // DOM and will not update the value property on inputs. We need to force the
+                        // right value instead of the original translation <span/>.
+                        if (attr === 'value') {
+                            $node[0].value = match[2];
+                        }
 
                         $node.addClass('o_translatable_attribute').data('translation', translation);
                     });

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -257,12 +257,12 @@ body.editor_enable {
 // target all inputs and/or target specific snippets in their own app.
 .editor_enable {
     .s_website_form, .s_searchbar_input, .js_subscribe, .s_group, .s_donation_form {
-        input {
+        input:not(.o_translatable_attribute) {
             pointer-events: none;
         }
     }
     .s_website_form {
-        [data-toggle="datetimepicker"], textarea {
+        [data-toggle="datetimepicker"], textarea:not(.o_translatable_attribute):not(.o_translatable_text) {
             pointer-events: none;
         }
     }

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1606,6 +1606,9 @@ ul.o_checklist > li.o_checked::after {
 // "value" will get HTML content as translation value for the attributes.
 // The goal here is to hide these values until the editor's code sets the right
 // ones on elements.
+.o_text_hide {
+    color: transparent !important;
+}
 [placeholder*="data-oe-translation-id"] {
     &::-webkit-input-placeholder{ /* WebKit */
         color: transparent;
@@ -1615,6 +1618,9 @@ ul.o_checklist > li.o_checked::after {
         color: transparent;
         opacity: 0;
     }
+}
+input[value*="data-oe-translation-id"] {
+    @extend .o_text_hide;
 }
 
 //------------------------------------------------------------------------------

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1602,6 +1602,21 @@ ul.o_checklist > li.o_checked::after {
     display: none !important;
 }
 
+// On translation editor, inputs & textareas with translatable "placeholder" and
+// "value" will get HTML content as translation value for the attributes.
+// The goal here is to hide these values until the editor's code sets the right
+// ones on elements.
+[placeholder*="data-oe-translation-id"] {
+    &::-webkit-input-placeholder{ /* WebKit */
+        color: transparent;
+        opacity: 0;
+    }
+    &::-moz-placeholder { /* Firefox */
+        color: transparent;
+        opacity: 0;
+    }
+}
+
 //------------------------------------------------------------------------------
 // Website Animate
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Issue:

- Go to website > edit mode > add a form
- On one of the form fields, add a default value > save
- Change language > translate > the input has html code shown as value.

On translation editor, the default html values we get from translation mapping
(see 'ir.translation' > _get_terms_mapping()) are used on the editor's JS code
(beforeEditorActive()) to set the right translatable attributes values on DOM
elements, and since the use of jQuery "attr()" won't update the "value" property
on inputs, we force it to replace the default translation html.

Remark: the same issue will prevent updating the "value" property on the input
when "AttributeTranslateDialog" is used for translation.

task-3042522