### PR TITLE
[FIX] sale_project: set the right partner in task and project when it's changed in sale order

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -113,6 +113,17 @@ class SaleOrder(models.Model):
     def write(self, values):
         if 'state' in values and values['state'] == 'cancel':
             self.project_id.sudo().sale_line_id = False
+        # Handle the change of sale order partner's id in project and task too
+        if 'partner_id' in values:
+            for sale_order_line in self.order_line:
+                service_tracking = sale_order_line.product_id.service_tracking
+                if service_tracking == "task_global_project":
+                    sale_order_line.project_id.write({'partner_id': values['partner_id']})
+                    sale_order_line.task_id.write({'partner_id': values['partner_id']})
+                elif service_tracking == "task_in_project":
+                    sale_order_line.task_id.write({'partner_id': values['partner_id']})
+                elif service_tracking == "project_only":
+                    sale_order_line.project_id.write({'partner_id': values['partner_id']})
         return super(SaleOrder, self).write(values)
 
 


### PR DESCRIPTION
Steps to reproduce:
- Create a service product with service tracking set to project and task
- Create a sale order with the product and confirm it
- Cancel the sale order
- Set the sale order to quotation
- Change the customer
- Confirm the sale order
- Go to the project associated - invoicing
- try to add sale order line

Issue:
When trying to retrieve sale order items you will get in the dropdown list the sale order lines of the first customer,
 or nothing.

Cause:
When changing the partner_id in sale.order,it doesn't propagate to the project and task associated.

Solution:
Check when writing on a sale.order check if it's the partner_id and if change also in project and task of each order line depending on the service tracking type of the product

opw-3062685