### PR TITLE
[ADD] test_lint: New check to prefer odoo.tools.groupby

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -207,7 +207,8 @@ class AutomaticEntryWizard(models.TransientModel):
             'journal_id': self.journal_id.id,
         }}
         # complete the account.move data
-        for date, grouped_lines in groupby(self.move_line_ids, lambda m: m.move_id.date):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for date, grouped_lines in groupby(self.move_line_ids, lambda m: m.move_id.date):  # pylint: disable=prefer-odoo-tools-groupby
             grouped_lines = list(grouped_lines)
             amount = sum(l.balance for l in grouped_lines)
             move_data[date] = {

--- a/addons/lunch/populate/lunch.py
+++ b/addons/lunch/populate/lunch.py
@@ -2,10 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 from datetime import datetime, timedelta
-from itertools import groupby
 
 from odoo import models
-from odoo.tools import populate
+from odoo.tools import groupby, populate
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -134,7 +134,8 @@ class StockPicking(models.Model):
 
     def _create_move_from_pos_order_lines(self, lines):
         self.ensure_one()
-        lines_by_product = groupby(sorted(lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        lines_by_product = groupby(sorted(lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)  # pylint: disable=prefer-odoo-tools-groupby
         move_vals = []
         lines_data = defaultdict(dict)
         for product_id, olines in lines_by_product:

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -2,13 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
-from itertools import groupby
 from pytz import timezone, UTC
 from werkzeug.urls import url_encode
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, groupby
 from odoo.tools.float_utils import float_is_zero
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.misc import formatLang, get_lang, format_amount

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -115,7 +115,8 @@ class StockRule(models.Model):
             procurements = self._merge_procurements(procurements_to_merge)
 
             po_lines_by_product = {}
-            grouped_po_lines = groupby(po.order_line.filtered(lambda l: not l.display_type and l.product_uom == l.product_id.uom_po_id).sorted(lambda l: l.product_id.id), key=lambda l: l.product_id.id)
+            # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+            grouped_po_lines = groupby(po.order_line.filtered(lambda l: not l.display_type and l.product_uom == l.product_id.uom_po_id).sorted(lambda l: l.product_id.id), key=lambda l: l.product_id.id)  # pylint: disable=prefer-odoo-tools-groupby
             for product, po_lines in grouped_po_lines:
                 po_lines_by_product[product] = self.env['purchase.order.line'].concat(*list(po_lines))
             po_line_values = []
@@ -192,7 +193,8 @@ class StockRule(models.Model):
         """
         procurements_to_merge = []
 
-        for k, procurements in groupby(sorted(procurements, key=self._get_procurements_to_merge_sorted), key=self._get_procurements_to_merge_groupby):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for _k, procurements in groupby(sorted(procurements, key=self._get_procurements_to_merge_sorted), key=self._get_procurements_to_merge_groupby):  # pylint: disable=prefer-odoo-tools-groupby
             procurements_to_merge.append(list(procurements))
         return procurements_to_merge
 

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -739,7 +739,8 @@ Reason(s) of this behavior could be:
             new_invoice_vals_list = []
             invoice_grouping_keys = self._get_invoice_grouping_keys()
             invoice_vals_list = sorted(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys])
-            for grouping_keys, invoices in groupby(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys]):
+            # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+            for _grouping_keys, invoices in groupby(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys]):  # pylint: disable=prefer-odoo-tools-groupby
                 origins = set()
                 payment_refs = set()
                 refs = set()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -834,7 +834,8 @@ class StockMove(models.Model):
         for candidate_moves in candidate_moves_list:
             # First step find move to merge.
             candidate_moves = candidate_moves.with_context(prefetch_fields=False)
-            for k, g in groupby(sorted(candidate_moves, key=self._prepare_merge_move_sort_method), key=itemgetter(*distinct_fields)):
+            # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+            for _k, g in groupby(sorted(candidate_moves, key=self._prepare_merge_move_sort_method), key=itemgetter(*distinct_fields)):  # pylint: disable=prefer-odoo-tools-groupby
                 moves = self.env['stock.move'].concat(*g).filtered(lambda m: m.state not in ('done', 'cancel', 'draft'))
                 # If we have multiple records we will merge then in a single one.
                 if len(moves) > 1:
@@ -998,7 +999,8 @@ class StockMove(models.Model):
         type (moves should already have them identical). Otherwise, create a new
         picking to assign them to. """
         Picking = self.env['stock.picking']
-        grouped_moves = groupby(sorted(self, key=lambda m: [f.id for f in m._key_assign_picking()]), key=lambda m: [m._key_assign_picking()])
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        grouped_moves = groupby(sorted(self, key=lambda m: [f.id for f in m._key_assign_picking()]), key=lambda m: [m._key_assign_picking()])  # pylint: disable=prefer-odoo-tools-groupby
         for group, moves in grouped_moves:
             moves = self.env['stock.move'].concat(*list(moves))
             new_picking = False
@@ -1368,7 +1370,8 @@ class StockMove(models.Model):
                         return (ml.location_dest_id.id, ml.lot_id.id, ml.result_package_id.id, ml.owner_id.id)
 
                     grouped_move_lines_in = {}
-                    for k, g in groupby(sorted(move_lines_in, key=_keys_in_sorted), key=itemgetter(*keys_in_groupby)):
+                    # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+                    for k, g in groupby(sorted(move_lines_in, key=_keys_in_sorted), key=itemgetter(*keys_in_groupby)):  # pylint: disable=prefer-odoo-tools-groupby
                         qty_done = 0
                         for ml in g:
                             qty_done += ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
@@ -1388,12 +1391,14 @@ class StockMove(models.Model):
                         return (ml.location_id.id, ml.lot_id.id, ml.package_id.id, ml.owner_id.id)
 
                     grouped_move_lines_out = {}
-                    for k, g in groupby(sorted(move_lines_out_done, key=_keys_out_sorted), key=itemgetter(*keys_out_groupby)):
+                    # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+                    for k, g in groupby(sorted(move_lines_out_done, key=_keys_out_sorted), key=itemgetter(*keys_out_groupby)):  # pylint: disable=prefer-odoo-tools-groupby
                         qty_done = 0
                         for ml in g:
                             qty_done += ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
                         grouped_move_lines_out[k] = qty_done
-                    for k, g in groupby(sorted(move_lines_out_reserved, key=_keys_out_sorted), key=itemgetter(*keys_out_groupby)):
+                    # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+                    for k, g in groupby(sorted(move_lines_out_reserved, key=_keys_out_sorted), key=itemgetter(*keys_out_groupby)):  # pylint: disable=prefer-odoo-tools-groupby
                         grouped_move_lines_out[k] = sum(self.env['stock.move.line'].concat(*list(g)).mapped('product_qty'))
                     available_move_lines = {key: grouped_move_lines_in[key] - grouped_move_lines_out.get(key, 0) for key in grouped_move_lines_in.keys()}
                     # pop key if the quantity available amount to 0

--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -179,11 +179,13 @@ class StockPackageLevel(models.Model):
             return [object.product_id.id, object.lot_id.id]
 
         grouped_quants = {}
-        for k, g in groupby(sorted(package.quant_ids, key=sorted_key), key=itemgetter(*keys)):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for k, g in groupby(sorted(package.quant_ids, key=sorted_key), key=itemgetter(*keys)):  # pylint: disable=prefer-odoo-tools-groupby
             grouped_quants[k] = sum(self.env['stock.quant'].concat(*list(g)).mapped('quantity'))
 
         grouped_ops = {}
-        for k, g in groupby(sorted(pack_move_lines, key=sorted_key), key=itemgetter(*keys)):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for k, g in groupby(sorted(pack_move_lines, key=sorted_key), key=itemgetter(*keys)):  # pylint: disable=prefer-odoo-tools-groupby
             grouped_ops[k] = sum(self.env['stock.move.line'].concat(*list(g)).mapped(field))
         if any(grouped_quants.get(key, 0) - grouped_ops.get(key, 0) != 0 for key in grouped_quants) \
                 or any(grouped_ops.get(key, 0) - grouped_quants.get(key, 0) != 0 for key in grouped_ops):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -843,11 +843,13 @@ class Picking(models.Model):
         precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 
         grouped_quants = {}
-        for k, g in groupby(sorted(package.quant_ids, key=attrgetter(*keys_ids)), key=itemgetter(*keys)):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for k, g in groupby(sorted(package.quant_ids, key=attrgetter(*keys_ids)), key=itemgetter(*keys)):  # pylint: disable=prefer-odoo-tools-groupby
             grouped_quants[k] = sum(self.env['stock.quant'].concat(*list(g)).mapped('quantity'))
 
         grouped_ops = {}
-        for k, g in groupby(sorted(pack_move_lines, key=attrgetter(*keys_ids)), key=itemgetter(*keys)):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for k, g in groupby(sorted(pack_move_lines, key=attrgetter(*keys_ids)), key=itemgetter(*keys)):  # pylint: disable=prefer-odoo-tools-groupby
             grouped_ops[k] = sum(self.env['stock.move.line'].concat(*list(g)).mapped('product_qty'))
         if any(not float_is_zero(grouped_quants.get(key, 0) - grouped_ops.get(key, 0), precision_digits=precision_digits) for key in grouped_quants) \
                 or any(not float_is_zero(grouped_ops.get(key, 0) - grouped_quants.get(key, 0), precision_digits=precision_digits) for key in grouped_ops):
@@ -1152,7 +1154,8 @@ class Picking(models.Model):
         visited_documents = {}
         if stream == 'DOWN':
             if sorted_method and groupby_method:
-                grouped_moves = groupby(sorted(origin_objects.mapped(stream_field), key=sorted_method), key=groupby_method)
+                # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+                grouped_moves = groupby(sorted(origin_objects.mapped(stream_field), key=sorted_method), key=groupby_method)  # pylint: disable=prefer-odoo-tools-groupby
             else:
                 raise UserError(_('You have to define a groupby and sorted method and pass them as arguments.'))
         elif stream == 'UP':

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1869,7 +1869,8 @@ class Export(http.Controller):
         # export lists with no sub-fields (e.g. import_compatible lists with
         # no o2m) are even more efficient (from the same 6s to ~170ms, as
         # there's a single fields_get to execute)
-        for (base, length), subfields in itertools.groupby(
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for (base, length), subfields in itertools.groupby(  # pylint: disable=prefer-odoo-tools-groupby
                 sorted(export_fields),
                 lambda field: (field.split('/', 1)[0], len(field.split('/', 1)))):
             subfields = list(subfields)

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -53,8 +53,8 @@ class WebsiteBlog(http.Controller):
 
             group['month'] = babel.dates.format_datetime(start, format='MMMM', tzinfo=tzinfo, locale=locale)
             group['year'] = babel.dates.format_datetime(start, format='yyyy', tzinfo=tzinfo, locale=locale)
-
-        return OrderedDict((year, [m for m in months]) for year, months in itertools.groupby(groups, lambda g: g['year']))
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        return OrderedDict((year, [m for m in months]) for year, months in itertools.groupby(groups, lambda g: g['year']))  # pylint: disable=prefer-odoo-tools-groupby
 
     def _prepare_blog_values(self, blogs, blog=False, date_begin=False, date_end=False, tags=False, state=False, page=False, search=None):
         """ Prepare all values to display the blogs index page or one specific blog"""

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import itertools
 import logging
 import re
 import psycopg2
@@ -14,7 +13,7 @@ from psycopg2 import sql
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import pycompat, unique, OrderedSet
+from odoo.tools import groupby, pycompat, unique, OrderedSet
 from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
 
 _logger = logging.getLogger(__name__)
@@ -2180,7 +2179,9 @@ class IrModelData(models.Model):
                     delete(records[half_size:])
 
         # remove non-model records first, grouped by batches of the same model
-        for model, items in itertools.groupby(unique(records_items), itemgetter(0)):
+
+        # TODO: Improve this call (drop the uniquification)
+        for model, items in groupby(unique(records_items), itemgetter(0)):
             delete(self.env[model].browse(item[1] for item in items))
 
         # Remove copied views. This must happen after removing all records from

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -901,7 +901,8 @@ class IrTranslation(models.Model):
             ('comments', 'like', 'openerp-web'), ('value', '!=', False),
             ('value', '!=', '')],
             ['module', 'src', 'value', 'lang'], order='module')
-        for mod, msg_group in itertools.groupby(messages, key=operator.itemgetter('module')):
+        # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+        for mod, msg_group in itertools.groupby(messages, key=operator.itemgetter('module')):  # pylint: disable=prefer-odoo-tools-groupby 
             translations_per_module.setdefault(mod, {'messages': []})
             translations_per_module[mod]['messages'].extend({
                 'id': m['src'],

--- a/odoo/addons/test_lint/tests/_odoo_checker_groupby.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_groupby.py
@@ -1,0 +1,29 @@
+from pylint import checkers, interfaces
+
+
+class OdooBaseChecker(checkers.BaseChecker):
+    __implements__ = interfaces.IAstroidChecker
+    name = "odoo"
+
+    msgs = {
+        "E8602": (
+            "Prefer `odoo.tools.groupby` instead of `itertools.groupby` "
+            "or disable with `# pylint: disable=prefer-odoo-tools-groupby` if the iterable is sorted by the key",
+            "prefer-odoo-tools-groupby",
+            "See https://github.com/odoo/odoo/issues/105376",
+        )
+    }
+
+    @checkers.utils.check_messages("prefer-odoo-tools-groupby")
+    def visit_call(self, node):
+        if "groupby" not in node.func.as_string():
+            # safe_infer is a heavy method
+            # So, call it only if the method name is related to "groupby" word
+            return
+        infer_node = checkers.utils.safe_infer(node.func)
+        if infer_node and infer_node.qname() == "itertools.groupby":
+            self.add_message("prefer-odoo-tools-groupby", node=node)
+
+
+def register(linter):
+    linter.register_checker(OdooBaseChecker(linter))

--- a/odoo/addons/test_lint/tests/test_pylint.py
+++ b/odoo/addons/test_lint/tests/test_pylint.py
@@ -32,6 +32,7 @@ class TestPyLint(TransactionCase):
         # custom checkers
         'sql-injection',
         'gettext-variable',
+        'prefer-odoo-tools-groupby',
     ]
 
     BAD_FUNCTIONS = [
@@ -69,7 +70,7 @@ class TestPyLint(TransactionCase):
             '--enable=%s' % ','.join(self.ENABLED_CODES),
             '--reports=n',
             "--msg-template='{msg} ({msg_id}) at {path}:{line}'",
-            '--load-plugins=pylint.extensions.bad_builtin,_odoo_checker_sql_injection,_odoo_checker_gettext',
+            '--load-plugins=pylint.extensions.bad_builtin,_odoo_checker_sql_injection,_odoo_checker_gettext,_odoo_checker_groupby',
             '--bad-functions=%s' % ','.join(self.BAD_FUNCTIONS),
             '--deprecated-modules=%s' % ','.join(self.BAD_MODULES)
         ]

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -888,7 +888,8 @@ def stripped_sys_argv(*strip_args):
     assert all(config.parser.has_option(s) for s in strip_args)
     takes_value = dict((s, config.parser.get_option(s).takes_value()) for s in strip_args)
 
-    longs, shorts = list(tuple(y) for _, y in itergroupby(strip_args, lambda x: x.startswith('--')))
+    # Disable prefer-odoo-tools-groupby lint since the iterable is sorted by the key
+    longs, shorts = list(tuple(y) for _, y in itergroupby(strip_args, lambda x: x.startswith('--')))  # pylint: disable=prefer-odoo-tools-groupby
     longs_eq = tuple(l + '=' for l in longs if takes_value[l])
 
     args = sys.argv[:]


### PR DESCRIPTION
Add new check `prefer-odoo-tools-groupby`

See https://github.com/odoo/odoo/issues/105376


Notice the output of runbot before to fix all the cases

```txt
FAIL: TestPyLint.test_pylint
Traceback (most recent call last):
  File "/data/build/odoo/odoo/addons/test_lint/tests/test_pylint.py", line 93, in test_pylint
    self.fail("pylint test failed:\n" + (b"\n" + out + b"\n" + err).decode('utf-8').strip())
AssertionError: pylint test failed:
************* Module odoo.addons.base.models.ir_translation
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/odoo/addons/base/models/ir_translation.py:904
************* Module odoo.addons.base.models.ir_model
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/odoo/addons/base/models/ir_model.py:2183
************* Module odoo.tools.misc
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/odoo/tools/misc.py:891
************* Module purchase.models.purchase
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/purchase/models/purchase.py:513
************* Module lunch.populate.lunch
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/lunch/populate/lunch.py:42
************* Module sale.models.sale
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/sale/models/sale.py:742
************* Module account.wizard.account_automatic_entry_wizard
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/account/wizard/account_automatic_entry_wizard.py:210
************* Module point_of_sale.models.stock_picking
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/point_of_sale/models/stock_picking.py:137
************* Module website_blog.controllers.main
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/website_blog/controllers/main.py:57
************* Module web.controllers.main
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/web/controllers/main.py:1872
************* Module stock.models.stock_move
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_move.py:837
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_move.py:1001
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_move.py:1371
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_move.py:1391
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_move.py:1396
************* Module stock.models.stock_picking
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_picking.py:846
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_picking.py:850
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_picking.py:1155
************* Module stock.models.stock_package_level
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_package_level.py:182
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/stock/models/stock_package_level.py:186
************* Module purchase_stock.models.stock_rule
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/purchase_stock/models/stock_rule.py:118
Prefer `odoo.tools.groupby` instead of `itertools.groupby` (E8602) at odoo/addons/purchase_stock/models/stock_rule.py:195
```
