### PR TITLE
[FIX] web: fix the traceback

### DIFF
--- a/addons/web/static/src/views/fields/parsers.js
+++ b/addons/web/static/src/views/fields/parsers.js
@@ -136,8 +136,11 @@ export function parseInteger(value) {
             truncate: true,
         });
         if (!Number.isInteger(parsed)) {
-            throw new InvalidNumberError(`"${value}" is not a correct number`);
+            throw new InvalidNumberError(`"${value}" is not a valid integer`);
         }
+    }
+    if (parsed % 1 || parsed < -2147483648 || parsed > 2147483647) {
+        throw new InvalidNumberError(`"${value}" is not a valid integer`);
     }
     return parsed;
 }

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -4,7 +4,7 @@ import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
-import { parseFloat } from "../parsers";
+import { parseInteger, parseFloat } from "../parsers";
 import { standardFieldProps } from "../standard_field_props";
 
 import { Component, onWillUpdateProps, useRef, useState, useExternalListener } from "@odoo/owl";
@@ -73,7 +73,11 @@ export class ProgressBarField extends Component {
     onCurrentValueChange(ev) {
         let parsedValue;
         try {
-            parsedValue = parseFloat(ev.target.value);
+            if (this.props.type === 'integer') {
+                parsedValue = parseInteger(ev.target.value);
+            } else {
+                parsedValue = parseFloat(ev.target.value);
+            }
         } catch {
             this.props.record.setInvalidField(this.props.name);
             return;
@@ -91,7 +95,11 @@ export class ProgressBarField extends Component {
     onMaxValueChange(ev) {
         let parsedValue;
         try {
-            parsedValue = parseFloat(ev.target.value);
+            if (this.props.type === 'integer') {
+                parsedValue = parseInteger(ev.target.value);
+            } else {
+                parsedValue = parseFloat(ev.target.value);
+            }
         } catch {
             this.props.record.setInvalidField(this.props.name);
             return;

--- a/addons/web/static/tests/views/fields/parsers_tests.js
+++ b/addons/web/static/tests/views/fields/parsers_tests.js
@@ -81,6 +81,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(parseInteger("1,000,000"), 1000000);
         expectInvalidNumberError(assert, parseInteger, "1.000.000");
         expectInvalidNumberError(assert, parseInteger, "1,234.567");
+        expectInvalidNumberError(assert, parseInteger, "2147483648");
 
         patchWithCleanup(localization, { decimalPoint: ",", thousandsSep: "." });
 

--- a/addons/web/static/tests/views/fields/progress_bar_field_tests.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field_tests.js
@@ -548,10 +548,10 @@ QUnit.module("Fields", (hooks) => {
     );
 
     QUnit.test(
-        "ProgressBarField: write float instead of int works, in locale",
+        "ProgressBarField: write float in progressbar, in locale",
         async function (assert) {
             assert.expect(5);
-            serverData.models.partner.records[0].int_field = 99;
+            serverData.models.partner.records[0].float_field = 99;
 
             await makeView({
                 serverData,
@@ -559,13 +559,13 @@ QUnit.module("Fields", (hooks) => {
                 resModel: "partner",
                 arch: `
                     <form>
-                        <field name="int_field" widget="progressbar" options="{'editable': true}"/>
+                        <field name="float_field" widget="progressbar" options="{'editable': true}"/>
                     </form>`,
                 resId: 1,
                 mockRPC: function (route, { method, args }) {
                     if (method === "write") {
                         assert.strictEqual(
-                            args[1].int_field,
+                            args[1].float_field,
                             1037,
                             "New value of progress bar saved"
                         );
@@ -650,4 +650,27 @@ QUnit.module("Fields", (hooks) => {
             assert.verifySteps(["Show error message"], "The error message was shown correctly");
         }
     );
+
+    QUnit.test(
+        "ProgressBarField: writing overflowing int throws warning",
+        async function (assert) {
+            serverData.models.partner.records[0].int_field = 99;
+            await makeView({
+                serverData,
+                type: "form",
+                resModel: "partner",
+                arch: `
+                    <form>
+                        <field name="int_field" widget="progressbar" options="{'editable': true}"/>
+                    </form>`,
+                resId: 1,
+            });
+
+            await click(target.querySelector(".o_progress"));
+            await editInput(target, ".o_field_widget input", "1037000000000000000000000000000");
+            assert.hasClass(target.querySelector("div.o_field_progressbar"),'o_field_invalid', "Integer field should be displayed as invalid");
+
+        }
+    );
+
 });


### PR DESCRIPTION
1.  fix the trackback when we add larger value in integer field

        Why trackback occur:
             Currently,  the range of integer is not checked, so when we entering a large value, an
             out of range exception is thrown.
        Steps to reproduce:
           - Installed Contacts
           - Open the  Abigail Peterson
           - Add the Level Weight  ex-999999999999999999999
           - Save the record

2. Fix the trackback in progressbar field

       Why trackback occur:
             When entering larger value in integer progressbar, an out of range exception is thrown
              because the check parseFloat.

       Steps to reproduce:

        -Installed project  app
        -Open Project > Go to project update
        -Add value in Progress field(Ex-999999999999999)
        -Save the record

task-3070721