### PR TITLE
[IMP] web_editor, *: enable to use image options after saving an image

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -809,3 +809,22 @@ class ProductProduct(models.Model):
         if lst_price:
             return (lst_price - self._get_contextual_price()) / lst_price
         return 0.0
+
+    def _get_attachment(self, res_field):
+        # OVERRIDE
+        res_field_variant = 'image_variant_' + re.search(r'\d+', res_field)[0]
+        if (self[res_field_variant]):
+            # The product has multiple variants with dedicated images, the
+            # attachment should be the one of the variant.
+            return super()._get_attachment(res_field_variant)
+        else:
+            # The product has only one variant, or multiples variants but no images
+            # associated to them so the attachment should be the one of the
+            # associated template.
+            return self.env['ir.attachment'].search(
+                domain=[
+                    ('res_model', '=', 'product.template'),
+                    ('res_id', '=', self.product_tmpl_id.id),
+                    ('res_field', '=', res_field),
+                ],
+                limit=1)

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -509,7 +509,7 @@ class Web_Editor(http.Controller):
         return files_data_by_bundle
 
     @http.route('/web_editor/modify_image/<model("ir.attachment"):attachment>', type="json", auth="user", website=True)
-    def modify_image(self, attachment, res_model=None, res_id=None, name=None, data=None, original_id=None, mimetype=None, alt_data=None):
+    def modify_image(self, attachment, res_model=None, res_id=None, name=None, data=None, mimetype=None, alt_data=None):
         """
         Creates a modified copy of an attachment and returns its image_src to be
         inserted into the DOM.

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -90,6 +90,16 @@ const BACKGROUND_IMAGE_ATTRIBUTES = new Set([
     "mimetypeBeforeConversion",
 ]);
 
+// Fields returned by cropperjs 'getData' method.
+const CROPPER_DATA_FIELDS = ["width", "height", "rotate", "scaleX", "scaleY", "x", "y",
+];
+const IMAGE_ATTRIBUTES_STORED_IN_ATTACHMENT = [
+    "shapeColors", "shapeFlip", "shapeRotate", "shape", "glFilter", "quality", "resizeWidth",
+    "aspectRatio", "originalMimetype", ...CROPPER_DATA_FIELDS,
+];
+const CLASSES_STORED_IN_ATTACHMENT = [
+    "o_we_image_cropped",
+];
 /**
  * Computes the number of "px" needed to make a "rem" unit. Subsequent calls
  * returns the cached computed value.
@@ -464,11 +474,14 @@ function _shouldEditableMediaBeEditable(mediaEl) {
 }
 
 export default {
+    CLASSES_STORED_IN_ATTACHMENT: CLASSES_STORED_IN_ATTACHMENT,
     COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES: COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES,
+    CROPPER_DATA_FIELDS: CROPPER_DATA_FIELDS,
     CSS_SHORTHANDS: CSS_SHORTHANDS,
     CSS_UNITS_CONVERSION: CSS_UNITS_CONVERSION,
     DEFAULT_PALETTE: DEFAULT_PALETTE,
     EDITOR_COLOR_CSS_VARIABLES: EDITOR_COLOR_CSS_VARIABLES,
+    IMAGE_ATTRIBUTES_STORED_IN_ATTACHMENT: IMAGE_ATTRIBUTES_STORED_IN_ATTACHMENT,
     computePxByRem: _computePxByRem,
     convertValueToUnit: _convertValueToUnit,
     convertNumericToUnit: _convertNumericToUnit,

--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -437,12 +437,15 @@ export async function activateCropper(image, aspectRatio, dataset) {
  * @param {HTMLImageElement} img the image whose attachment data should be found
  * @param {Function} rpc a function that can be used to make the RPC. Typically
  *   this would be passed as 'this._rpc.bind(this)' from widgets.
+ * @param {Object} odooEditor the editor needed to pause the observer during the
+ * loading of the image information. Indeed, we do not want this process to be
+ * responsible of marking an editable element as "dirty".
  * @param {string} [attachmentSrc=''] specifies the URL of the corresponding
  * attachment if it can't be found in the 'src' attribute.
  * @param {string} resField the field name of the image if it is linked to a
  * model.
  */
-export async function loadImageInfo(img, rpc, attachmentSrc = "", resField = "") {
+export async function loadImageInfo(img, rpc, odooEditor, attachmentSrc = "", resField = "") {
     const src = attachmentSrc || img.getAttribute('src');
     // If there is a marked originalSrc, the data is already loaded.
     // If the image does not have the "mimetypeBeforeConversion" attribute, it
@@ -472,6 +475,7 @@ export async function loadImageInfo(img, rpc, attachmentSrc = "", resField = "")
     // The "redirect" check is for when it is a redirect image attachment due to
     // an external URL upload.
     if (original && original.image_src && !/\/web\/image\/\d+-redirect\//.test(original.image_src)) {
+        odooEditor.observerUnactive("loadImageInfo");
         if (!img.dataset.mimetype) {
             // The mimetype has to be added only if it is not already present as
             // we want to avoid to reset a mimetype set by the user.
@@ -514,6 +518,7 @@ export async function loadImageInfo(img, rpc, attachmentSrc = "", resField = "")
                 }
             }
         }
+        odooEditor.observerActive("loadImageInfo");
     }
 }
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5821,6 +5821,17 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             // above the original format one of the same size.
             widths[maxWidth - 0.1] = [_t("%spx", maxWidth), 'image/webp'];
         }
+        const currentMimetype = this._getImageMimetype(img);
+        if (currentMimetype !== "image/webp" &&
+            (!widths[img.naturalWidth] || widths[img.naturalWidth][1] !== currentMimetype)) {
+            // The format of the saved image is not already listed.
+            if (widths[img.naturalWidth]) {
+                // Avoid a key collision by subtracting 0.1 -  putting the webp
+                // above the original format one of the same size.
+                widths[img.naturalWidth - 0.1] = widths[img.naturalWidth];
+            }
+            widths[img.naturalWidth] = [_t("%spx (Saved)", img.naturalWidth), currentMimetype];
+        }
         return Object.entries(widths)
             .filter(([width]) => width <= maxWidth)
             .sort(([v1], [v2]) => v1 - v2);

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5879,7 +5879,8 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     async _loadImageInfo(attachmentSrc = '') {
         const img = this._getImg();
         const editableEl = this.$target[0].closest("[data-oe-field]");
-        await loadImageInfo(img, this.rpc, attachmentSrc, editableEl.dataset.oeField);
+        await loadImageInfo(img, this.rpc, this.options.wysiwyg.odooEditor, attachmentSrc,
+            editableEl.dataset.oeField);
         if (!img.dataset.originalId) {
             this.originalId = null;
             this.originalSrc = null;
@@ -6057,6 +6058,7 @@ registry.ImageTools = ImageHandlerOption.extend({
             activeOnStart: true,
             media: img,
             mimetype: this._getImageMimetype(img),
+            odooEditor: this.options.wysiwyg.odooEditor,
         });
 
         await new Promise(resolve => {
@@ -6120,6 +6122,7 @@ registry.ImageTools = ImageHandlerOption.extend({
             activeOnStart: true,
             media: img,
             mimetype: this._getImageMimetype(img),
+            odooEditor: this.options.wysiwyg.odooEditor,
         });
         await imageCropWrapper.component.mountedPromise;
         await imageCropWrapper.component.reset();

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5867,7 +5867,8 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     async _loadImageInfo(attachmentSrc = '') {
         const img = this._getImg();
-        await loadImageInfo(img, this.rpc, attachmentSrc);
+        const editableEl = this.$target[0].closest("[data-oe-field]");
+        await loadImageInfo(img, this.rpc, attachmentSrc, editableEl.dataset.oeField);
         if (!img.dataset.originalId) {
             this.originalId = null;
             this.originalSrc = null;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import {applyModifications, cropperDataFields, activateCropper, loadImage, loadImageInfo} from "@web_editor/js/editor/image_processing";
+import {applyModifications, activateCropper, loadImage, loadImageInfo} from "@web_editor/js/editor/image_processing";
+import weUtils from "@web_editor/js/common/utils";
 import { _t } from "@web/core/l10n/translation";
 import {
     Component,
@@ -182,7 +183,7 @@ export class ImageCrop extends Component {
         // Mark the media for later creation of cropped attachment
         this.media.classList.add('o_modified_image_to_save');
 
-        [...cropperDataFields, 'aspectRatio'].forEach(attr => {
+        [...weUtils.CROPPER_DATA_FIELDS, 'aspectRatio'].forEach(attr => {
             delete this.media.dataset[attr];
             const value = this._getAttributeValue(attr);
             if (value) {
@@ -201,7 +202,7 @@ export class ImageCrop extends Component {
      * @private
      */
     _getAttributeValue(attr) {
-        if (cropperDataFields.includes(attr)) {
+        if (weUtils.CROPPER_DATA_FIELDS.includes(attr)) {
             return this.$cropperImage.cropper('getData')[attr];
         }
         return this[attr];

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -22,6 +22,7 @@ export class ImageCrop extends Component {
         activeOnStart: { type: Boolean, optional: true },
         media: { optional: true },
         mimetype: { type: String, optional: true },
+        odooEditor: {type: Object, optional: true},
     };
     static defaultProps = {
         activeOnStart: false,
@@ -124,7 +125,7 @@ export class ImageCrop extends Component {
                 'image/jpeg';
         this.mimetype = this.props.mimetype || mimetype;
 
-        await loadImageInfo(this.media, this.props.rpc);
+        await loadImageInfo(this.media, this.props.rpc, props.odooEditor);
         const isIllustration = /^\/web_editor\/shape\/illustration\//.test(this.media.dataset.originalSrc);
         this.uncroppable = false;
         if (this.media.dataset.originalSrc && !isIllustration) {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -134,6 +134,7 @@ export class Wysiwyg extends Component {
         showCount: 0,
         media: undefined,
         mimetype: undefined,
+        odooEditor: undefined,
     });
     state = useState({
         linkToolProps: false,
@@ -1782,6 +1783,7 @@ export class Wysiwyg extends Component {
             if (!this.lastMediaClicked) {
                 return;
             }
+            this.imageCropProps.odooEditor = this.odooEditor;
             this.imageCropProps.media = this.lastMediaClicked;
             this.imageCropProps.showCount++;
             this.odooEditor.toolbarHide();

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -323,6 +323,8 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         // Use `data-src` instead of `src` when the SRC is an URL that would
         // make a call to the server.
         const getImageContainerHTML = (src, isModified) => {
+            const srcAttr = `${src.startsWith("/web") ? 'data-src="' : 'src="'}${src}"`;
+            const tmpAttr = `data-oe-tmp-embedded="| aspectRatio:0/0 width:50 height:50 scaleX:1 scaleY:1 classes:o_we_image_cropped |"`;
             return `
                 <p>
                     <img
@@ -335,7 +337,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
                         data-scale-x="1"
                         data-scale-y="1"
                         data-aspect-ratio="0/0"
-                        ${src.startsWith("/web") ? 'data-src="' : 'src="'}${src}"
+                        ${isModified ? srcAttr + ' ' + tmpAttr : tmpAttr + ' ' + srcAttr}
                     >
                     <br>
                 </p>
@@ -380,7 +382,10 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
                     assert.equal(args.res_model, 'partner');
                     assert.equal(args.res_id, 1);
                     await modifyImagePromise;
-                    return newImageSrc;
+                    return {
+                        "original_id": imageRecord.id,
+                        "new_attachment_src": newImageSrc,
+                    };
                 } else {
                     // Fail the test if too many modify_image are called.
                     assert.ok(modifyImageCount === 0, "The image should only have been modified once during this test");


### PR DESCRIPTION
[REM] web_editor: remove unused original_id parameter

This commit removes the `original_id` parameter of the declaration of
the `modify_image()` function as it is not used inside of the function
since [1].

[1]: https://github.com/odoo/odoo/commit/aa8d2a8be2c8f713b4b39b2aa1ea2aaf1839396c

task-3046425


---------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] base, *: enable to use image options after saving an image

*: product, web_editor

Before this commit, the options "Shape, "Filter", "Format", "Quality"
and "Transform" disappeared after replacing and saving any images stored
in the database. The goal of this commit is to enable the use of these
options even after saving a replaced image. To do so, the data related
to those options are stored in the "description" field of the attachment
linked to the image. This attachment can be recovered thanks to the
model name from where the image comes from, the id of the model and the
field name of the image in the model.

Here is the flow that happens at the save of an image:
- In `_saveModifiedImage()`, the data attributes and classes related to
the options are collected and the description that will be stored in the
attachment is build. It has the form
`| dataX:valueX ... classes:A,B,... |`. In this expression, `| ` and
` |` are only there to easily recover the data in the description of the
attachment (as this solution also works if the description of the
attachment is not originally empty).
- At the call of `save_embedded_field()` in the backend,
`_update_attachment_metadata()` is called leading to the update of the
description field of the attachment linked to the image. Note that this
is done after the `write` of the field. Indeed, it is only after this
step that the attachment linked to the image is created in the case of
a new product where its product image has been uploaded through the
media dialog.

At the load of an image (`loadImageInfo()`), the backend provides the
description of the attachment linked to the image. Thanks to it, the
data attributes of the image can be correctly set and the options
displays the correct values.

task-3046425

---------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] *: display the format of a saved image on the image options

*: web_editor

Steps to reproduce the problem:
- Replace a product image by one of your own (jpeg for example).
- Since [this commit], the mimetype of the image is webp. Replace the
format of the image by the original one.
- Save and edit.
- Click on the image to display its options.

-> Problem: "None" is display as the "Format".

The problem is that the `naturalWidth` of the image changes after the
save request. Let's say that it is 1281px at the upload through the
media dialog, it stays the same up to the reload of the iframe at the
save request. More investigation would be needed to know why but after
that, the `naturalWidth` of the image changes. This leads the "Format"
option to display `None`. Indeed, `_computeWidgetState()` returns the
new `naturalWidth` of the image and its mimetype. However, as it is not
listed by `_computeAvailableFormats()`, `None` is displayed for the
"Format".

[this commit]: https://github.com/odoo/odoo/commit/0449fe85cb0e1d639a4e1aeba26e90906f79254d

task-3046425

---------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] web_editor: pause the editor observer while loading an image

The goal of this commit is to pause the editor observer when loading the
image information. Indeed, without this commit, `.o_dirty` would be
added on the product image when selecting this image on the editor. This
was not the case in stable version because:
- If the image was not an embedded field (inside an `arch` for example
-> image on the website main page): the `loadImageInfo()` operation was
done at the drop of the image on the page (through
`_initializeImage()`). At the save of the `arch` field, the
`originalSrc` attribute was saved inside the field so the
`loadImageInfo()` process was not done the next time the user edited the
page and clicked on the image. In this case, `.o_dirty` was added
because there was a new image on the page.
- If the image was linked to an embedded field (`image_1920` of
`product.template` for example), the `loadImageInfo()` process was only
done if the user uploaded a new image (and so `.o_dirty` had to be
added). Indeed, in this case, the `/web_editor/get_image_info` rpc
returned a correct `original` leading to the complete `loadImageInfo()`
process flow. If the image was not a new uploaded image, the rpc was not
able to return the correct `original`.

Since one of the goals of this task is to adapt the
`/web_editor/get_image_info` rpc so that it returns the correct
attachment linked to a field of a record and because the `originalSrc`
attribute is not saved for embedded fields, the `loadImageInfo()` logic
will always apply when a user enters in edit mode and clicks on an
image linked to an embedded field. As we do not want the `o_dirty` class
to be added after this flow, the editor observer has to be paused when
loading the image information.

task-3046425
