### PR TITLE
[FIX] web: fallback on `readonly` from field definition

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -204,6 +204,9 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
     const fields = models[modelName];
     const field = fields[name];
     const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
+    if (!("readonly" in modifiers) && field.readonly) {
+        modifiers.readonly = true;
+    }
     const fieldInfo = {
         name,
         viewType,

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -38,7 +38,7 @@ const serviceRegistry = registry.category("services");
 
 /**
  * @param {MakeViewParams} params
- * @returns {Component}
+ * @returns {Promise<Component>}
  */
 export async function makeView(params) {
     const props = { ...params };

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -16117,4 +16117,30 @@ QUnit.module("Views", (hooks) => {
         await click(target, ".o_field_many2one_selection .o-autocomplete--input");
         assert.verifySteps(["name_search"]);
     });
+
+    QUnit.test("readonly field specified in model but not in arch", async (assert) => {
+        // this test uses the priority widget as it allows to edit a field in readonly
+        serverData.models.foo.fields.priority = {
+            string: "Priority",
+            type: "selection",
+            selection: [
+                [0, "Not Prioritary"],
+                [1, "Prioritary"],
+            ],
+            default: 0,
+            readonly: true,
+        };
+
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `<tree><field name="priority" widget="priority"/></tree>`,
+        });
+
+        assert.hasClass(
+            target.querySelector(".o_field_widget[name=priority]"),
+            "o_readonly_modifier"
+        );
+    });
 });


### PR DESCRIPTION
Since [1], `transfer_field_to_modifiers` no longer writes the readonly/required information of the field definition inside the modifiers (if not set) in readonly views (e.g. a list view without `editable` or `multi-edit` attributes). However, some field widgets are editable even in readonly (e.g. priority, color). Before this commit, those widgets, when used in readonly views, where always considered as non readonly.

For instance, have a non (multi) editable list view with a field with `readonly=True` on its definition, in python, and no readonly attribute (or attrs) set in the view. The field is editable, even though it shouldn't.

This commit fixes the issue by fallbacking on the field definition if the information isn't in the modifiers.

[1] 69c3d5aa25655173ed66a52570559322c650c7df

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
