### PR TITLE
Master ref pos las juvr

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -114,7 +114,6 @@ class AccountTax(models.Model):
     sequence = fields.Integer(required=True, default=1,
         help="The sequence field is used to define order in which the tax lines are applied.")
     amount = fields.Float(required=True, digits=(16, 4), default=0.0)
-    real_amount = fields.Float(string='Real amount to apply', compute='_compute_real_amount', store=True)
     description = fields.Char(string='Label on Invoices')
     price_include = fields.Boolean(string='Included in Price', default=False,
         help="Check this if the price you use on the product and invoices includes this tax.")
@@ -320,13 +319,6 @@ class AccountTax(models.Model):
     def onchange_price_include(self):
         if self.price_include:
             self.include_base_amount = True
-
-    @api.depends('invoice_repartition_line_ids', 'amount', 'invoice_repartition_line_ids.factor')
-    def _compute_real_amount(self):
-        for tax in self:
-            tax_repartition_lines = tax.invoice_repartition_line_ids.filtered(lambda x: x.repartition_type == 'tax')
-            total_factor = sum(tax_repartition_lines.mapped('factor'))
-            tax.real_amount = tax.amount * total_factor
 
     def _compute_amount(self, base_amount, price_unit, quantity=1.0, product=None, partner=None, fixed_multiplicator=1):
         """ Returns the amount of a single tax. base_amount is the actual amount on which the tax is applied, which is

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -54,6 +54,8 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
+    pos_payment_method_id = fields.Many2one(comodel_name='pos.payment.method', string="POS Payment Method")
+
     def _stock_account_get_anglo_saxon_price_unit(self):
         self.ensure_one()
         if not self.product_id:

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -121,20 +121,29 @@ class TestPoSBasicConfig(TestPoSCommon):
                     ],
                 },
                 'cash_statement': [
-                    ((370, ), {
+                    {
+                        'amount': 170,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 370, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 370, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 170, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 170, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 200,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
+                        ]
+                    },
                 ],
                 'bank_payments': [
-                    ((220, ), {
+                    {
+                        'amount': 220,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 220, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 220, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
             },
         })
@@ -170,8 +179,7 @@ class TestPoSBasicConfig(TestPoSCommon):
         +---------------------+---------+
         | sale                |    -560 |
         | pos receivable cash |     150 |
-        | pos receivable bank |     540 |
-        | receivable          |    -130 |
+        | pos receivable bank |     410 |
         +---------------------+---------+
         | Total balance       |     0.0 |
         +---------------------+---------+
@@ -249,18 +257,19 @@ class TestPoSBasicConfig(TestPoSCommon):
                 '00100-010-0003': {
                     'invoice': {
                         'line_ids': [
-                            {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 30, 'reconciled': False},
+                            {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 130, 'credit': 0, 'reconciled': True},
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 130), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 130, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 130, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 130, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 }
             },
@@ -269,26 +278,34 @@ class TestPoSBasicConfig(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 560, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 540, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 150, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 130, 'reconciled': True},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 410, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((150, ), {
+                    {
+                        'amount': 150,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 150, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 150, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [
-                    ((540, ), {
+                    {
+                        'amount': 130,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 540, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 540, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 130, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 130, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 410,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 410, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 410, 'reconciled': True},
+                        ]
+                    },
                 ],
             },
         })
@@ -309,7 +326,10 @@ class TestPoSBasicConfig(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 0), False),
+                        {
+                            'payment_method_id': self.bank_pm1,
+                            'line_ids': [],
+                        },
                     ],
                 }
             },
@@ -354,23 +374,35 @@ class TestPoSBasicConfig(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 100), {
+                    'cash_statement': [
+                        {
+                            'amount': 100,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 0, 'reconciled': True},
-                    ],
-                },
-                'cash_statement': [],
+                'session_journal_entry': {},
+                'cash_statement': [
+                    {
+                        'amount': -100,
+                        'line_ids': [
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                        ],
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ],
+                    },
+                ],
                 'bank_payments': [],
             },
         })
@@ -403,8 +435,10 @@ class TestPoSBasicConfig(TestPoSCommon):
         +---------------------+---------+
         | account             | balance |
         +---------------------+---------+
-        | sale (sales)        |    -210 |
-        | sale (refund)       |     100 |
+        | pos receivable cash |    -100 |
+        | sales               |    -210 |
+        | sales               |     100 |
+        | pos receivable cash |     100 |
         | pos receivable bank |     110 |
         +---------------------+---------+
         | Total balance       |     0.0 |
@@ -480,19 +514,37 @@ class TestPoSBasicConfig(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 210, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
                         {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 110, 'credit': 0, 'reconciled': True},
                     ],
                 },
-                'cash_statement': [],
+                'cash_statement': [
+                    {
+                        'amount': -100,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
+                        ]
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
+                ],
                 'bank_payments': [
-                    ((110, ), {
+                    {
+                        'amount': 110,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 110, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 110, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
             },
         })
@@ -511,38 +563,40 @@ class TestPoSBasicConfig(TestPoSCommon):
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 590, 'reconciled': False},
                         {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 300, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 70, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 120, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 290, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
-                        'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        ]
-                    }),
-                    ((70, ), {
+                    {
+                        'amount': 70,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 70, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 70, 'reconciled': True},
                         ]
-                    }),
-                    ((120, ), {
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 120,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 120, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 120, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [
-                    ((300, ), {
+                    {
+                        'amount': 300,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 300, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 300, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -550,12 +604,19 @@ class TestPoSBasicConfig(TestPoSCommon):
     def test_rounding_method(self):
         # set the cash rounding method
         self.config.cash_rounding = True
+        self.env.company.account_fiscal_country_id = self.env.ref('base.us')
+
+        profit_account = self.company['default_cash_difference_income_account_id'].copy()
+        loss_account = self.company['default_cash_difference_expense_account_id'].copy()
+        profit_account.name = "Rounding difference (Gain)"
+        loss_account.name = "Rounding difference (Loss)"
+
         self.config.rounding_method = self.env['account.cash.rounding'].create({
             'name': 'add_invoice_line',
             'rounding': 0.05,
             'strategy': 'add_invoice_line',
-            'profit_account_id': self.company['default_cash_difference_income_account_id'].copy().id,
-            'loss_account_id': self.company['default_cash_difference_expense_account_id'].copy().id,
+            'profit_account_id': profit_account.id,
+            'loss_account_id': loss_account.id,
             'rounding_method': 'HALF-UP',
         })
 
@@ -585,9 +646,9 @@ class TestPoSBasicConfig(TestPoSCommon):
         +---------------------+---------+
         | account             | balance |
         +---------------------+---------+
-        | sale                | -596,56 |
-        | pos receivable bank |  516,64 |
-        | Rounding applied    |   -0,01 |
+        | sale                | -529.72 |
+        | pos receivable bank |  529,75 |
+        | Rounding difference |   -0,03 |
         +---------------------+---------+
         | Total balance       |     0.0 |
         +---------------------+---------+
@@ -595,17 +656,15 @@ class TestPoSBasicConfig(TestPoSCommon):
 
         # create orders
         orders = []
-
-        # create orders
-        orders = []
         orders.append(self.create_ui_order_data(
             [(self.product4, 3), (self.product2, 20)],
-            payments=[(self.bank_pm1, 429.90)]
+            payments=[(self.bank_pm1, 429.90)],
         ))
 
         orders.append(self.create_ui_order_data(
             [(self.product1, 6), (self.product4, 4)],
-            payments=[(self.bank_pm1, 99.85)]
+            payments=[(self.bank_pm1, 99.85)],
+            customer=self.partner_a,
         ))
 
         # sync orders
@@ -620,8 +679,23 @@ class TestPoSBasicConfig(TestPoSCommon):
         # check values after the session is closed
         session_account_move = self.pos_session.move_id
 
-        rounding_line = session_account_move.line_ids.filtered(lambda line: line.name == 'Rounding line')
+        rounding_line = session_account_move.line_ids.filtered(lambda line: line.account_id == profit_account)
         self.assertAlmostEqual(rounding_line.credit, 0.03, msg='The credit should be equals to 0.03')
+
+        order = self.env['pos.order'].browse(order[0]['id'])
+        invoice = self.env['account.move'].browse(order.action_pos_order_invoice()['res_id'])
+        self.assertRecordValues(invoice.line_ids.sorted('balance'), [
+            # pylint: disable=bad-whitespace
+            {'balance': -60.0,  'display_type': 'product'},
+            {'balance': -39.84, 'display_type': 'product'},
+            {'balance': -0.01,  'display_type': 'product'},
+            {'balance': 99.85,  'display_type': 'payment_term'},
+        ])
+        self.assertRecordValues(invoice, [{
+            'amount_tax': order.amount_tax,
+            'amount_total': order.amount_paid,
+            'amount_residual': 0.0,
+        }])
 
     def test_correct_partner_on_invoice_receivables(self):
         self._run_test({
@@ -636,8 +710,6 @@ class TestPoSBasicConfig(TestPoSCommon):
                 {'pos_order_lines_ui_args': [(self.product99, 1)], 'payments':[(self.cash_split_pm1, 99)], 'customer': self.customer, 'is_invoiced': False, 'uid': '00100-010-0007'},
                 {'pos_order_lines_ui_args': [(self.product99, 1)], 'payments':[(self.bank_split_pm1, 99)], 'customer': self.customer, 'is_invoiced': False, 'uid': '00100-010-0008'},
                 {'pos_order_lines_ui_args': [(self.product1, 10)], 'payments':[(self.bank_pm1, 100)], 'customer': self.other_customer, 'is_invoiced': True, 'uid': '00100-010-0009'},
-                {'pos_order_lines_ui_args': [(self.product1, 10)], 'payments':[(self.bank_pm1, 100)], 'customer': self.other_customer, 'is_invoiced': True, 'uid': '00100-010-0010'},
-                {'pos_order_lines_ui_args': [(self.product1, 10)], 'payments':[(self.bank_pm1, 100)], 'customer': self.customer, 'is_invoiced': True, 'uid': '00100-010-0011'},
             ],
             'journal_entries_before_closing': {
                 '00100-010-0001': {
@@ -647,14 +719,15 @@ class TestPoSBasicConfig(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 100), {
+                    'cash_statement': [
+                        {
+                            'amount': 100,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 },
                 '00100-010-0002': {
                     'invoice': {
@@ -663,14 +736,13 @@ class TestPoSBasicConfig(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.bank_pm1, 100), {
-                            'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                    'payments': [{
+                        'payment_method_id': self.bank_pm1,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    }]
                 },
                 '00100-010-0003': {
                     'invoice': {
@@ -679,14 +751,13 @@ class TestPoSBasicConfig(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_split_pm1, 100), {
-                            'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                    'cash_statement': [{
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ],
+                    }]
                 },
                 '00100-010-0004': {
                     'invoice': {
@@ -695,14 +766,13 @@ class TestPoSBasicConfig(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.bank_split_pm1, 100), {
-                            'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                    'payments': [{
+                        'payment_method_id': self.bank_split_pm1,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    }]
                 },
                 '00100-010-0009': {
                     'invoice': {
@@ -711,103 +781,92 @@ class TestPoSBasicConfig(TestPoSCommon):
                             {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.bank_pm1, 100), {
-                            'line_ids': [
-                                {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
-                },
-                '00100-010-0010': {
-                    'invoice': {
+                    'payments': [{
+                        'payment_method_id': self.bank_pm1,
                         'line_ids': [
-                            {'account_id': self.sales_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.other_customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    },
-                    'payments': [
-                        ((self.bank_pm1, 100), {
-                            'line_ids': [
-                                {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
-                },
-                '00100-010-0011': {
-                    'invoice': {
-                        'line_ids': [
-                            {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        ]
-                    },
-                    'payments': [
-                        ((self.bank_pm1, 100), {
-                            'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                    }]
                 },
             },
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 398, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 500, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
                         {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 99, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 99, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 400, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
-                        'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        ]
-                    }),
-                    ((99, ), {
+                    {
+                        'amount': 99,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 99, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 99, 'reconciled': True},
                         ]
-                    }),
-                    ((200, ), {
+                    },
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                        ]
-                    }),
-                ],
-                'bank_payments': [
-                    ((100, ), {
-                        'line_ids': [
-                            {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    }),
-                    ((99, ), {
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
+
+                ],
+                'bank_payments': [
+                    {
+                        'amount': 99,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 99, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 99, 'reconciled': True},
                         ]
-                    }),
-                    ((500, ), {
+                    },
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 500, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 500, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 100,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.other_customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ]
+                    },
                 ],
             },
         })
@@ -884,47 +943,3 @@ class TestPoSBasicConfig(TestPoSCommon):
 
         # calling load_pos_data should not raise an error
         self.pos_session.load_pos_data()
-
-    def test_invoice_past_order(self):
-        # create 1 uninvoiced order then close the session
-        self._run_test({
-            'payment_methods': self.cash_pm1 | self.bank_pm1,
-            'orders': [
-                {'pos_order_lines_ui_args': [(self.product99, 1)], 'payments': [(self.bank_pm1, 99)], 'customer': False, 'is_invoiced': False, 'uid': '00100-010-0001'},
-            ],
-            'journal_entries_before_closing': {},
-            'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 99, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 99, 'credit': 0, 'reconciled': True},
-                    ],
-                },
-                'cash_statement': [],
-                'bank_payments': [
-                    ((99, ), {
-                        'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 99, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 99, 'reconciled': True},
-                        ]
-                    })
-                ],
-            },
-        })
-
-        # keep reference of the closed session
-        closed_session = self.pos_session
-        self.assertTrue(closed_session.state == 'closed', 'Session should be closed.')
-
-        order_to_invoice = closed_session.order_ids[0]
-        test_customer = self.env['res.partner'].create({'name': 'Test Customer'})
-
-        with freeze_time(fields.Datetime.now() + relativedelta(days=2)):
-            # create new session after 2 days
-            self.open_new_session(0)
-            # invoice the uninvoiced order
-            order_to_invoice.write({'partner_id': test_customer.id})
-            order_to_invoice.action_pos_order_invoice()
-            # check invoice
-            self.assertTrue(order_to_invoice.account_move, 'Invoice should be created.')
-            self.assertTrue(order_to_invoice.account_move.invoice_date != order_to_invoice.date_order.date(), 'Invoice date should not be the same as order date since the session was closed.')

--- a/addons/point_of_sale/tests/test_pos_multiple_receivable_accounts.py
+++ b/addons/point_of_sale/tests/test_pos_multiple_receivable_accounts.py
@@ -70,14 +70,15 @@ class TestPoSMultipleReceivableAccounts(TestPoSCommon):
         +---------------------+---------+
         | account             | balance |
         +---------------------+---------+
-        | sale_account        | -164.85 |
-        | sale_account        | -281.73 |
-        | other_sale_account  | -272.59 |
-        | tax 7%              |  -31.26 |
-        | tax 10%             |  -55.43 |
+        | tax 7%              |  -11.54 |
+        | tax 7%              |  -19.72 |
+        | tax 10%             |  -27.26 |
+        | tax 10%             |  -28.17 |
+        | sales               | -164.85 |
+        | sales               | -272.59 |
+        | sales               | -281.73 |
+        | pos receivable bank |  158.75 |
         | pos receivable cash |  647.11 |
-        | pos receivable bank |  423.51 |
-        | other receivable    | -264.76 |
         +---------------------+---------+
         | Total balance       |    0.00 |
         +---------------------+---------+
@@ -103,51 +104,64 @@ class TestPoSMultipleReceivableAccounts(TestPoSCommon):
             'journal_entries_before_closing': {
                 '09876-098-0987': {
                     'invoice': {
-                        'line_ids_predicate': lambda line: line.account_id in self.other_sale_account | self.sales_account | self.other_receivable_account,
                         'line_ids': [
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 9.09, 'reconciled': False},
+                            {'account_id': self.taxes['tax7'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 9.86, 'reconciled': False},
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 14.09, 'reconciled': False},
                             {'account_id': self.other_sale_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 90.86, 'reconciled': False},
                             {'account_id': self.sales_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 140.86, 'reconciled': False},
                             {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 264.76, 'credit': 0, 'reconciled': True},
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 264.76), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.other_customer.id, 'debit': 264.76, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 264.76, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 264.76, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 }
             },
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 31.26, 'reconciled': False},
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 55.43, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 11.54, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 19.72, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 27.26, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 28.17, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 164.85, 'reconciled': False},
                         {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.59, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 281.73, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 423.51, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 158.75, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 647.11, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 264.76, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((647.11, ), {
+                    {
+                        'amount': 647.11,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 647.11, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 647.11, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [
-                    ((423.51, ), {
+                    {
+                        'amount': 158.75,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 423.51, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 423.51, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 158.75, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 158.75, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 264.76,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.other_customer.id, 'debit': 264.76, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 264.76, 'reconciled': True},
+                        ]
+                    },
                 ],
             },
         })
@@ -205,84 +219,95 @@ class TestPoSMultipleReceivableAccounts(TestPoSCommon):
             'journal_entries_before_closing': {
                 '09876-098-0987': {
                     'invoice': {
-                        'line_ids_predicate': lambda line: line.account_id in self.other_sale_account | self.sales_account | self.other_receivable_account,
                         'line_ids': [
+                            {'account_id': self.taxes['tax7'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 7.69, 'reconciled': False},
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 18.17, 'reconciled': False},
+                            {'account_id': self.taxes['tax7'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 19.72, 'reconciled': False},
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 28.17, 'reconciled': False},
                             {'account_id': self.sales_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 109.90, 'reconciled': False},
                             {'account_id': self.other_sale_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 181.73, 'reconciled': False},
                             {'account_id': self.sales_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 281.73, 'reconciled': False},
                             {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 647.11, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 647.11), {
+                    'cash_statement': [
+                        {
+                            'amount': 647.11,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.other_customer.id, 'debit': 647.11, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 647.11, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 647.11, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 },
                 '09876-098-0988': {
                     'invoice': {
-                        'line_ids_predicate': lambda line: line.account_id in self.other_sale_account | self.sales_account | self.c1_receivable,
                         'line_ids': [
+                            {'account_id': self.taxes['tax7'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 3.85, 'reconciled': False},
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 9.09, 'reconciled': False},
                             {'account_id': self.sales_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 54.95, 'reconciled': False},
                             {'account_id': self.other_sale_account.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 90.86, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 158.75, 'credit': 0, 'reconciled': True},
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 158.75), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 158.75, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 158.75, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 158.75, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 },
                 '09876-098-0989': {
                     'invoice': {
-                        'line_ids_predicate': lambda line: line.account_id in self.other_sale_account | self.sales_account | self.other_receivable_account,
                         'line_ids': [
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 9.09, 'reconciled': False},
+                            {'account_id': self.taxes['tax7'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 9.86, 'reconciled': False},
+                            {'account_id': self.taxes['tax10'].invoice_repartition_line_ids.account_id.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 14.09, 'reconciled': False},
                             {'account_id': self.other_sale_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 90.86, 'reconciled': False},
                             {'account_id': self.sales_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 140.86, 'reconciled': False},
                             {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 264.76, 'credit': 0, 'reconciled': True},
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 264.76), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.other_customer.id, 'debit': 264.76, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 264.76, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 264.76, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 },
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 423.51, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 647.11, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 647.11, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 423.51, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': {},
                 'cash_statement': [
-                    ((647.11, ), {
+                    {
+                        'amount': 647.11,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 647.11, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 647.11, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.other_customer.id, 'debit': 647.11, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 647.11, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [
-                    ((423.51, ), {
+                    {
+                        'amount': 158.75,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 423.51, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 423.51, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 158.75, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 158.75, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 264.76,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.other_customer.id, 'debit': 264.76, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 264.76, 'reconciled': True},
+                        ]
+                    }
                 ],
             },
         })

--- a/addons/point_of_sale/tests/test_pos_other_currency_config.py
+++ b/addons/point_of_sale/tests/test_pos_other_currency_config.py
@@ -71,15 +71,15 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
 
         Expected Result
         ===============
-        +---------------------+---------+-----------------+
-        | account             | balance | amount_currency |
-        +---------------------+---------+-----------------+
-        | sale_account        | -1119.6 |         -559.80 |
-        | pos receivable bank |   279.9 |          139.95 |
-        | pos receivable cash |   839.7 |          419.85 |
-        +---------------------+---------+-----------------+
-        | Total balance       |     0.0 |            0.00 |
-        +---------------------+---------+-----------------+
+        +---------------------------+---------+-----------------+
+        | account                   | balance | amount_currency |
+        +---------------------------+---------+-----------------+
+        | sale_account              | -1119.6 |         -559.80 |
+        | Total Bank Other payments |   279.9 |          139.95 |
+        | Total Cash Other payments |   839.7 |          419.85 |
+        +---------------------------+---------+-----------------+
+        | Total balance             |     0.0 |            0.00 |
+        +---------------------------+---------+-----------------+
         """
 
         def _before_closing_cb():
@@ -106,20 +106,29 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
                     ],
                 },
                 'cash_statement': [
-                    ((419.85, ), {
+                    {
+                        'amount': 89.95,
                         'line_ids': [
-                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 839.7, 'credit': 0, 'reconciled': False, 'amount_currency': 419.85},
-                            {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 839.7, 'reconciled': True, 'amount_currency': -419.85},
+                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 89.95*2, 'credit': 0, 'reconciled': False, 'amount_currency': 89.95},
+                            {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 89.95*2, 'reconciled': True, 'amount_currency': -89.95},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 329.9,
+                        'line_ids': [
+                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 329.9*2, 'credit': 0, 'reconciled': False, 'amount_currency': 329.9},
+                            {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 329.9*2, 'reconciled': True, 'amount_currency': -329.9},
+                        ]
+                    },
                 ],
                 'bank_payments': [
-                    ((139.95, ), {
+                    {
+                        'amount': 139.95,
                         'line_ids': [
                             {'account_id': self.bank_pm2.outstanding_account_id.id, 'partner_id': False, 'debit': 279.9, 'credit': 0, 'reconciled': False, 'amount_currency': 139.95},
                             {'account_id': self.bank_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 279.9, 'reconciled': True, 'amount_currency': -139.95},
                         ]
-                    }),
+                    }
                 ],
             },
         })
@@ -149,10 +158,7 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
         | account             | balance | amount_currency |
         +---------------------+---------+-----------------+
         | sale_account        |  -659.8 |         -329.90 |
-        | pos receivable bank |   279.9 |          139.95 |
-        | pos receivable cash |   839.7 |          419.85 |
-        | invoice receivable  |  -179.9 |          -89.95 |
-        | invoice receivable  |  -279.9 |         -139.95 |
+        | POS receivable cash |   659.8 |          329.90 |
         +---------------------+---------+-----------------+
         | Total balance       |     0.0 |            0.00 |
         +---------------------+---------+-----------------+
@@ -174,23 +180,25 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
             'before_closing_cb': _before_closing_cb,
             'journal_entries_before_closing': {
                 '00100-010-0002': {
-                    'payments': [
-                        ((self.cash_pm2, 89.95), {
+                    'cash_statement': [
+                        {
+                            'amount': 89.95,
                             'line_ids': [
+                                {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 179.90, 'credit': 0, 'reconciled': False, 'amount_currency': 89.95},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 179.90, 'reconciled': True, 'amount_currency': -89.95},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 179.90, 'credit': 0, 'reconciled': False, 'amount_currency': 89.95},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 },
                 '00100-010-0003': {
                     'payments': [
-                        ((self.bank_pm2, 139.95), {
+                        {
+                            'payment_method_id': self.bank_pm2,
                             'line_ids': [
+                                {'account_id': self.bank_pm2.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 279.9, 'credit': 0, 'reconciled': False, 'amount_currency': 139.95},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 279.9, 'reconciled': True, 'amount_currency': -139.95},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 279.9, 'credit': 0, 'reconciled': False, 'amount_currency': 139.95},
                             ]
-                        }),
+                        },
                     ],
                 },
             },
@@ -198,27 +206,33 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 659.8, 'reconciled': False, 'amount_currency': -329.90},
-                        {'account_id': self.bank_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 279.9, 'credit': 0, 'reconciled': True, 'amount_currency': 139.95},
-                        {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 839.7, 'credit': 0, 'reconciled': True, 'amount_currency': 419.85},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 179.90, 'reconciled': True, 'amount_currency': -89.95},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 279.9, 'reconciled': True, 'amount_currency': -139.95},
+                        {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 659.8, 'credit': 0, 'reconciled': True, 'amount_currency': 329.90},
                     ],
                 },
                 'cash_statement': [
-                    ((419.85, ), {
+                    {
+                        'amount': 89.95,
                         'line_ids': [
-                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 839.7, 'credit': 0, 'reconciled': False, 'amount_currency': 419.85},
-                            {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 839.7, 'reconciled': True, 'amount_currency': -419.85},
-                        ]
-                    }),
+                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 179.90, 'credit': 0, 'reconciled': False, 'amount_currency': 89.95},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 179.90, 'reconciled': True, 'amount_currency': -89.95},
+                        ],
+                    },
+                    {
+                        'amount': 329.9,
+                        'line_ids': [
+                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 659.8, 'credit': 0, 'reconciled': False, 'amount_currency': 329.9},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 659.8, 'reconciled': True, 'amount_currency': -329.9},
+                        ],
+                    }
                 ],
                 'bank_payments': [
-                    ((139.95, ), {
+                    {
+                        'amount': 139.95,
                         'line_ids': [
-                            {'account_id': self.bank_pm2.outstanding_account_id.id, 'partner_id': False, 'debit': 279.9, 'credit': 0, 'reconciled': False, 'amount_currency': 139.95},
-                            {'account_id': self.bank_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 279.9, 'reconciled': True, 'amount_currency': -139.95},
+                            {'account_id': self.bank_pm2.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 279.9, 'credit': 0, 'reconciled': False, 'amount_currency': 139.95},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 279.9, 'reconciled': True, 'amount_currency': -139.95},
                         ]
-                    }),
+                    },
                 ],
             },
         })
@@ -272,19 +286,20 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
+                        {'account_id': self.output_account.id, 'partner_id': False, 'debit': 0, 'credit': 2375.99, 'reconciled': True, 'amount_currency': -2375.99},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 7153.90, 'reconciled': False, 'amount_currency': -3576.95},
                         {'account_id': self.expense_account.id, 'partner_id': False, 'debit': 2375.99, 'credit': 0, 'reconciled': False, 'amount_currency': 2375.99},
                         {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 7153.90, 'credit': 0, 'reconciled': True, 'amount_currency': 3576.95},
-                        {'account_id': self.output_account.id, 'partner_id': False, 'debit': 0, 'credit': 2375.99, 'reconciled': True, 'amount_currency': -2375.99},
                     ],
                 },
                 'cash_statement': [
-                    ((3576.95, ), {
+                    {
+                        'amount': amount,
                         'line_ids': [
-                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 7153.90, 'credit': 0, 'reconciled': False, 'amount_currency': 3576.95},
-                            {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 7153.90, 'reconciled': True, 'amount_currency': -3576.95},
+                            {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': amount * 2, 'credit': 0, 'reconciled': False, 'amount_currency': amount},
+                            {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': amount * 2, 'reconciled': True, 'amount_currency': -amount},
                         ]
-                    }),
+                    } for amount in [22.65, 494.45, 1050, 2009.85]
                 ],
                 'bank_payments': [],
             },
@@ -300,18 +315,19 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 3.43, 'reconciled': False, 'amount_currency': -1.715, 'tax_base_amount': 49},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 3.43, 'reconciled': False, 'amount_currency': -1.715, 'tax_base_amount': 24.5},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 49, 'reconciled': False, 'amount_currency': -24.5, 'tax_base_amount': 0},
                         {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 52.43, 'credit': 0, 'reconciled': True, 'amount_currency': 26.215, 'tax_base_amount': 0},
                     ],
                 },
                 'cash_statement': [
-                    ((26.215, ), {
+                    {
+                        'amount': 26.215,
                         'line_ids': [
                             {'account_id': self.cash_pm2.journal_id.default_account_id.id, 'partner_id': False, 'debit': 52.43, 'credit': 0, 'reconciled': False, 'amount_currency': 26.215},
                             {'account_id': self.cash_pm2.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 52.43, 'reconciled': True, 'amount_currency': -26.215},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [],
             },

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -91,30 +91,41 @@ class TestPoSProductsWithTax(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 24.89, 'reconciled': False},
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 51.82, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 7.7, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 17.19, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 24.55, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 27.27, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 110, 'reconciled': False},
-                        {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.73, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 245.45, 'reconciled': False},
+                        {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.73, 'reconciled': False},
                         {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 230.25, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 474.64, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((474.64, ), {
+                    {
+                        'amount': 207,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 474.64, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 474.64, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 207, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 207, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 267.64,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 267.64, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 267.64, 'reconciled': True},
+                        ]
+                    },
                 ],
                 'bank_payments': [
-                    ((230.25, ), {
+                    {
+                        'amount': 230.25,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 230.25, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 230.25, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
             },
         })
@@ -145,7 +156,7 @@ class TestPoSProductsWithTax(TestPoSCommon):
             total tax 10% only
                 5.45 + 36.36 => 41.81 + 2.73 = 44.54
 
-        Thus, manually_calculated_taxes = (-6.81, -44.54)
+        Thus, manually_calculated_taxes = (-1.91, -2.73, -4.9, -41.81)
         """
 
         def _before_closing_cb():
@@ -164,12 +175,12 @@ class TestPoSProductsWithTax(TestPoSCommon):
             session_move = self.pos_session.move_id
             tax_lines = session_move.line_ids.filtered(lambda line: line.account_id == self.tax_received_account)
 
-            manually_calculated_taxes = (-6.81, -44.54)
+            manually_calculated_taxes = (-1.91, -2.73, -4.9, -41.81)
             self.assertAlmostEqual(sum(manually_calculated_taxes), sum(tax_lines.mapped('balance')))
             for t1, t2 in zip(sorted(manually_calculated_taxes), sorted(tax_lines.mapped('balance'))):
                 self.assertAlmostEqual(t1, t2, msg='Taxes should be correctly combined.')
 
-            base_amounts = (97.27, 445.46)  # computation does not include invoiced order.
+            base_amounts = (27.27, 27.27, 60.0, 54.55)  # computation does not include invoiced order.
             self.assertAlmostEqual(sum(base_amounts), sum(tax_lines.mapped('tax_base_amount')))
 
         self._run_test({
@@ -184,22 +195,24 @@ class TestPoSProductsWithTax(TestPoSCommon):
             'journal_entries_before_closing': {
                 '09876-098-0987': {
                     'payments': [
-                        ((self.bank_pm1, 426.09), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 426.09, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 426.09, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 426.09, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 },
                 '00100-010-0004': {
                     'payments': [
-                        ((self.bank_pm1, 54.99), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 54.99, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 54.99, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 54.99, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 },
             },
@@ -207,31 +220,48 @@ class TestPoSProductsWithTax(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 6.81, 'reconciled': False},
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 44.54, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 1.91, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 2.73, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 4.9, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 27.27, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 41.81, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 70, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 418.19, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 891.78, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 156.11, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 481.08, 'reconciled': True},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 410.7, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((156.11, ), {
+                    {
+                        'amount': 156.11,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 156.11, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 156.11, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [
-                    ((891.78, ), {
+                    {
+                        'amount': 54.99,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 891.78, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 891.78, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 54.99, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 54.99, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 410.7,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 410.7, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 410.7, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 426.09,
+                        'line_ids': [
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 426.09, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 426.09, 'reconciled': True},
+                        ]
+                    },
                 ],
             },
         })
@@ -253,7 +283,7 @@ class TestPoSProductsWithTax(TestPoSCommon):
         However, the return order is not invoiced, thus, the journal items are in the session_move,
         which will contain the tax lines of the returned products.
 
-        manually_calculated_taxes = (4.01, 6.37)
+        manually_calculated_taxes = (2.1, 3.64, 1.91, 2.73)
         """
 
         def _before_closing_cb():
@@ -277,7 +307,7 @@ class TestPoSProductsWithTax(TestPoSCommon):
             self.assertAlmostEqual(refund_order.amount_paid, -104.01, msg='Amount paid for return order should be negative.')
 
         def _after_closing_cb():
-            manually_calculated_taxes = (4.01, 6.37)  # should be positive since it is return order
+            manually_calculated_taxes = (2.1, 3.64, 1.91, 2.73)  # should be positive since it is return order
             tax_lines = self.pos_session.move_id.line_ids.filtered(lambda line: line.account_id == self.tax_received_account)
             self.assertAlmostEqual(sum(manually_calculated_taxes), sum(tax_lines.mapped('balance')))
             for t1, t2 in zip(sorted(manually_calculated_taxes), sorted(tax_lines.mapped('balance'))):
@@ -291,29 +321,47 @@ class TestPoSProductsWithTax(TestPoSCommon):
             'before_closing_cb': _before_closing_cb,
             'journal_entries_before_closing': {
                 '12345-123-1234': {
-                    'payments': [
-                        ((self.cash_pm1, 104.01), {
+                    'cash_statement': [
+                        {
+                            'amount': 104.01,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 104.01, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 104.01, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 104.01, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 },
             },
             'after_closing_cb': _after_closing_cb,
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 4.01, 'credit': 0, 'reconciled': False},
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 6.37, 'credit': 0, 'reconciled': False},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 104.01, 'reconciled': True},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 1.91, 'credit': 0, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 2.1, 'credit': 0, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 2.73, 'credit': 0, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 3.64, 'credit': 0, 'reconciled': False},
+                        {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 27.27, 'credit': 0, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 30, 'credit': 0, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 36.36, 'credit': 0, 'reconciled': False},
-                        {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 27.27, 'credit': 0, 'reconciled': False},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 104.01, 'reconciled': True},
                     ],
                 },
-                'cash_statement': [],
+                'cash_statement': [
+                    {
+                        'amount': -104.01,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 104.01, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 104.01, 'reconciled': False},
+                        ],
+                    },
+                    {
+                        'amount': 104.01,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 104.01, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 104.01, 'reconciled': True},
+                        ],
+                    }
+                ],
                 'bank_payments': [],
             },
         })

--- a/addons/point_of_sale/tests/test_pos_simple_invoiced_orders.py
+++ b/addons/point_of_sale/tests/test_pos_simple_invoiced_orders.py
@@ -32,30 +32,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 100), {
+                    'cash_statement': [
+                        {
+                            'amount': 100,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
+                # It's just the same cash statement line as created before
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        ]
-                    })
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ],
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -77,33 +75,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 100), {
-                            'journal_id': self.config.journal_id.id,
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
-                    ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'journal_id': self.config.journal_id.id,
-                    'line_ids': [
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [],
+                # It's just the same account_payment as created before
                 'bank_payments': [
-                    ((100, ), {
-                        'journal_id': self.bank_pm1.journal_id.id,
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -149,33 +142,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_split_pm1, 100), {
-                            'journal_id': self.config.journal_id.id,
+                        {
+                            'payment_method_id': self.bank_split_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
-                    ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'journal_id': self.config.journal_id.id,
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [],
+                # It's just the same account_payment as created before
                 'bank_payments': [
-                    ((100, ), {
-                        'journal_id': self.bank_split_pm1.journal_id.id,
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -194,30 +182,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_split_pm1, 100), {
+                    'cash_statement': [
+                        {
+                            'amount': 100,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
+                # It's just the same cash statement line as created before
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        ]
-                    })
+                        ],
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -237,31 +223,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 200), {
+                    'cash_statement': [
+                        {
+                            'amount': 200,
                             'line_ids': [
-                                # needs to check the residual because it's supposed to be partial reconciled
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
+                # same cash statement as above
                 'cash_statement': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -282,31 +265,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 200), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
                                 # needs to check the residual because it's supposed to be partial reconciled
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                             ]
-                        }),
+                        },
                     ],
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -325,31 +305,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_split_pm1, 200), {
+                    'cash_statement': [
+                        {
+                            'amount': 200,
                             'line_ids': [
-                                # needs to check the residual because it's supposed to be partial reconciled
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -370,31 +346,28 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_split_pm1, 200), {
+                        {
+                            'payment_method_id': self.bank_split_pm1,
                             'line_ids': [
                                 # needs to check the residual because it's supposed to be partial reconciled
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
                             ]
-                        }),
+                        },
                     ],
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
-                            {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False, 'amount_residual': 200},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': False, 'amount_residual': -100},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -413,36 +386,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 200), {
+                    'cash_statement': [
+                        {
+                            'amount': 100,
                             'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                        ((self.cash_pm1, -100), {
-                            'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                            ],
+                        },
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        ]
-                    })
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ],
+                    },
                 ],
                 'bank_payments': [],
             },
@@ -463,45 +427,51 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 200), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
-                        ((self.cash_pm1, -100), {
+                        },
+                        {
+                            'payment_method_id': self.cash_pm1,
                             'line_ids': [
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
+                    'cash_statement': [
+                        {
+                            'amount': -100,
+                            'line_ids': [
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                            ],
+                        },
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((-100, ), {
+                    {
+                        'amount': -100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        ]
-                    })
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                        ],
+                    },
                 ],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -521,45 +491,51 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_split_pm1, 200), {
+                        {
+                            'payment_method_id': self.bank_split_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
-                        ((self.cash_pm1, -100), {
+                        },
+                        {
+                            'payment_method_id': self.cash_pm1,
                             'line_ids': [
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
+                    'cash_statement': [
+                        {
+                            'amount': -100,
+                            'line_ids': [
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                            ],
+                        },
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((-100, ), {
+                    {
+                        'amount': -100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        ]
-                    })
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                        ],
+                    },
                 ],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -578,44 +554,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_split_pm1, 200), {
+                    'cash_statement': [
+                        {
+                            'amount': 100,
                             'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                        ((self.cash_split_pm1, -100), {
-                            'line_ids': [
-                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                                {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                            ],
+                        },
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((200, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
-                        ]
-                    }),
-                    ((-100, ), {
-                        'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        ]
-                    })
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        ],
+                    },
                 ],
                 'bank_payments': [],
             },
@@ -636,30 +595,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'amount_residual': 50},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_pm1, 50), {
+                    'cash_statement': [
+                        {
+                            'amount': 50,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
-                        ]
-                    })
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
+                        ],
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -681,30 +637,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_pm1, 50), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
-                    ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [],
                 'bank_payments': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -725,30 +678,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                         ]
                     },
                     'payments': [
-                        ((self.bank_split_pm1, 50), {
+                        {
+                            'payment_method_id': self.bank_split_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
-                    ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [],
                 'bank_payments': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -768,30 +718,27 @@ class TestPosSimpleInvoicedOrders(TestPoSCommon):
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False, 'amount_residual': 50},
                         ]
                     },
-                    'payments': [
-                        ((self.cash_split_pm1, 50), {
+                    'cash_statement': [
+                        {
+                            'amount': 50,
                             'line_ids': [
+                                {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
-                    ],
+                            ],
+                        }
+                    ]
                 }
             },
             'journal_entries_after_closing': {
-                'session_journal_entry': {
-                    'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
-                    ],
-                },
+                'session_journal_entry': False,
                 'cash_statement': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
-                        ]
-                    })
+                        ],
+                    }
                 ],
                 'bank_payments': [],
             },

--- a/addons/point_of_sale/tests/test_pos_simple_orders.py
+++ b/addons/point_of_sale/tests/test_pos_simple_orders.py
@@ -33,12 +33,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -60,12 +61,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -105,12 +107,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -130,12 +133,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -151,17 +155,18 @@ class TestPosSimpleOrders(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -183,12 +188,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -203,18 +209,19 @@ class TestPosSimpleOrders(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                         {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -234,12 +241,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -256,17 +264,18 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
                     ],
                 },
                 'cash_statement': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -289,12 +298,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -315,12 +325,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                     ],
                 },
                 'cash_statement': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -337,18 +348,19 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
                         {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -364,16 +376,18 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((100, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -390,25 +404,27 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((-100, ), {
+                    {
+                        'amount': -100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -424,25 +440,27 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((-100, ), {
+                    {
+                        'amount': -100,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 100, 'credit': 0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [
-                    ((200, ), {
+                    {
+                        'amount': 200,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -458,23 +476,18 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
                         {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((200, ), {
+                    {
+                        'amount': 100,
                         'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 200, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 200, 'reconciled': True},
+                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': True},
                         ]
-                    }),
-                    ((-100, ), {
-                        'line_ids': [
-                            {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 100, 'reconciled': False},
-                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 100, 'credit': 0, 'reconciled': True},
-                        ]
-                    })
+                    },
                 ],
                 'bank_payments': [],
             },
@@ -491,17 +504,18 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                     ],
                 },
                 'cash_statement': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },
@@ -524,12 +538,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 50, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 50, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -551,12 +566,13 @@ class TestPosSimpleOrders(TestPoSCommon):
                 },
                 'cash_statement': [],
                 'bank_payments': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
                             {'account_id': self.bank_split_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
             },
         })
@@ -572,17 +588,18 @@ class TestPosSimpleOrders(TestPoSCommon):
                 'session_journal_entry': {
                     'line_ids': [
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 100, 'reconciled': False},
-                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                         {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                     ],
                 },
                 'cash_statement': [
-                    ((50, ), {
+                    {
+                        'amount': 50,
                         'line_ids': [
                             {'account_id': self.cash_split_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 50, 'credit': 0, 'reconciled': False},
                             {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 50, 'reconciled': True},
                         ]
-                    })
+                    }
                 ],
                 'bank_payments': [],
             },

--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -97,19 +97,34 @@ class TestPoSStock(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
+                        {'account_id': self.output_account.id, 'partner_id': False, 'debit': 0, 'credit': 327, 'reconciled': True},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 1010.0, 'reconciled': False},
                         {'account_id': self.expense_account.id, 'partner_id': False, 'debit': 327, 'credit': 0, 'reconciled': False},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 1010.0, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.output_account.id, 'partner_id': False, 'debit': 0, 'credit': 327, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((1010.0, ), {
+                    {
+                        'amount': 300,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 1010.0, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 1010.0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 300, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 300, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 350,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 350, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 350, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 360,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 360.0, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 360.0, 'reconciled': True},
+                        ]
+                    },
                 ],
                 'bank_payments': [],
             },
@@ -128,8 +143,7 @@ class TestPoSStock(TestPoSCommon):
         | account             | balance |
         +---------------------+---------+
         | sale_account        |  -650.0 |
-        | pos_receivable-cash |  1010.0 |
-        | receivable          |  -360.0 |
+        | pos_receivable-cash |   650.0 |
         | expense_account     |   206.0 |
         | output_account      |  -206.0 |
         +---------------------+---------+
@@ -165,37 +179,60 @@ class TestPoSStock(TestPoSCommon):
             'journal_entries_before_closing': {
                 '00100-010-0003': {
                     'payments': [
-                        ((self.cash_pm1, 360.0), {
+                        {
+                            'payment_method_id': self.cash_pm1,
                             'line_ids': [
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 360.0, 'reconciled': True},
                                 {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 360.0, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
+                    ],
+                    'cash_statement': [
+                        {
+                            'amount': 360,
+                            'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 360, 'credit': 0, 'reconciled': False},
+                                {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 360, 'reconciled': True},
+                            ]
+                        },
                     ],
                 },
             },
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
+                        {'account_id': self.output_account.id, 'partner_id': False, 'debit': 0, 'credit': 206, 'reconciled': True},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 650, 'reconciled': False},
                         {'account_id': self.expense_account.id, 'partner_id': False, 'debit': 206, 'credit': 0, 'reconciled': False},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 1010.0, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 360, 'reconciled': True},
-                        {'account_id': self.output_account.id, 'partner_id': False, 'debit': 0, 'credit': 206, 'reconciled': True},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 650, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((1010.0, ), {
+                    {
+                        'amount': 300,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 1010.0, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 1010.0, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 300, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 300, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 350,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 350, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 350, 'reconciled': True},
+                        ]
+                    },
+                    {
+                        'amount': 360,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.customer.id, 'debit': 360, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 360, 'reconciled': True},
+                        ]
+                    },
                 ],
                 'bank_payments': [],
             },
         })
-
 
     def test_03_order_product_w_owner(self):
         """

--- a/addons/point_of_sale/tests/test_pos_with_fiscal_position.py
+++ b/addons/point_of_sale/tests/test_pos_with_fiscal_position.py
@@ -109,13 +109,13 @@ class TestPoSWithFiscalPosition(TestPoSCommon):
         +---------------------+---------+
         | account             | balance |
         +---------------------+---------+
-        | sale_account        | -154.95 |  (for the 7% base amount)
-        | sale_account        |  -90.86 |  (for the 10% base amount)
-        | other_sale_account  | -474.75 |  (for the 17% base amount)
-        | other_sale_account  | -272.59 |  (for the 10% base amount)
-        | tax 17%             |  -80.70 |
-        | tax 10%             |  -36.35 |
         | tax 7%              |  -10.85 |
+        | tax 10%             |  -36.35 |
+        | tax 17%             |  -80.70 |
+        | sale_account        |  -90.86 |  (for the 10% base amount)
+        | sale_account        | -154.95 |  (for the 7% base amount)
+        | other_sale_account  | -272.59 |  (for the 10% base amount)
+        | other_sale_account  | -474.75 |  (for the 17% base amount)
         | pos receivable bank |  265.75 |
         | pos receivable cash |  855.30 |
         +---------------------+---------+
@@ -143,32 +143,41 @@ class TestPoSWithFiscalPosition(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 80.70, 'reconciled': False},
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 36.35, 'reconciled': False},
                         {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 10.85, 'reconciled': False},
-                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 474.75, 'reconciled': False},
-                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.59, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 36.35, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 80.70, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 90.86, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 154.95, 'reconciled': False},
+                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.59, 'reconciled': False},
+                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 474.75, 'reconciled': False},
                         {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 265.75, 'credit': 0, 'reconciled': True},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 855.30, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((855.30, ), {
+                    {
+                        'amount': 164.24,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 855.30, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 855.30, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 164.24, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 164.24, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 691.06,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 691.06, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 691.06, 'reconciled': True},
+                        ]
+                    }
                 ],
                 'bank_payments': [
-                    ((265.75, ), {
+                    {
+                        'amount': 265.75,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 265.75, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 265.75, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
             },
         })
@@ -197,14 +206,14 @@ class TestPoSWithFiscalPosition(TestPoSCommon):
         +---------------------+---------+
         | account             | balance |
         +---------------------+---------+
-        | sale_account        | -154.95 |  (for the 7% base amount)
+        | tax 7%              |  -10.85 |
+        | tax 10%             |  -36.35 |
         | sale_account        |  -90.86 |  (for the 10% base amount)
+        | sale_account        | -154.95 |  (for the 7% base amount)
         | other_sale_account  | -272.59 |  (for the 10% base amount)
         | other_sale_account  | -474.75 |  (no tax)
-        | tax 10%             |  -36.35 |
-        | tax 7%              |  -10.85 |
-        | pos receivable bank |  885.45 |
         | pos receivable cash |   154.9 |
+        | pos receivable bank |  885.45 |
         +---------------------+---------+
         | Total balance       |     0.0 |
         +---------------------+---------+
@@ -230,31 +239,33 @@ class TestPoSWithFiscalPosition(TestPoSCommon):
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 36.35, 'reconciled': False},
                         {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 10.85, 'reconciled': False},
-                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 474.75, 'reconciled': False},
-                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.59, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 36.35, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 90.86, 'reconciled': False},
                         {'account_id': self.sales_account.id, 'partner_id': False, 'debit': 0, 'credit': 154.95, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 885.45, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 272.59, 'reconciled': False},
+                        {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 474.75, 'reconciled': False},
                         {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 154.9, 'credit': 0, 'reconciled': True},
+                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 885.45, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((154.9, ), {
+                    {
+                        'amount': 154.9,
                         'line_ids': [
                             {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 154.9, 'credit': 0, 'reconciled': False},
                             {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 154.9, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
                 'bank_payments': [
-                    ((885.45, ), {
+                    {
+                        'amount': 885.45,
                         'line_ids': [
                             {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 885.45, 'credit': 0, 'reconciled': False},
                             {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 885.45, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
             },
         })
@@ -283,14 +294,11 @@ class TestPoSWithFiscalPosition(TestPoSCommon):
         +---------------------+---------+
         | account             | balance |
         +---------------------+---------+
-        | other_sale_account  |  -54.95 |  (for the 17% base amount)
-        | other_sale_account  |  -90.86 |  (for the 10% base amount)
         | tax 10%             |   -9.09 |
         | tax 17%             |   -9.34 |
-        | pos receivable cash |  429.99 |
-        | pos receivable bank |  691.06 |
-        | receivable          | -691.06 |
-        | other receivable    | -265.75 |
+        | other_sale_account  |  -54.95 |  (for the 17% base amount)
+        | other_sale_account  |  -90.86 |  (for the 10% base amount)
+        | pos receivable cash |  164.24 |
         +---------------------+---------+
         | Total balance       |     0.0 |
         +---------------------+---------+
@@ -323,53 +331,61 @@ class TestPoSWithFiscalPosition(TestPoSCommon):
             'journal_entries_before_closing': {
                 '00100-010-0001': {
                     'payments': [
-                        ((self.bank_pm1, 691.06), {
+                        {
+                            'payment_method_id': self.bank_pm1,
                             'line_ids': [
+                                {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 691.06, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 691.06, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 691.06, 'credit': 0, 'reconciled': False},
                             ]
-                        }),
+                        },
                     ],
                 },
                 '00100-010-0003': {
-                    'payments': [
-                        ((self.cash_pm1, 265.75), {
+                    'cash_statement': [
+                        {
+                            'amount': 265.75,
                             'line_ids': [
+                                {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.other_customer.id, 'debit': 265.75, 'credit': 0, 'reconciled': False},
                                 {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 265.75, 'reconciled': True},
-                                {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 265.75, 'credit': 0, 'reconciled': False},
-                            ]
-                        }),
+                            ],
+                        }
                     ],
                 },
             },
             'journal_entries_after_closing': {
                 'session_journal_entry': {
                     'line_ids': [
-                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 9.34, 'reconciled': False},
                         {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 9.09, 'reconciled': False},
+                        {'account_id': self.tax_received_account.id, 'partner_id': False, 'debit': 0, 'credit': 9.34, 'reconciled': False},
                         {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 54.95, 'reconciled': False},
                         {'account_id': self.other_sale_account.id, 'partner_id': False, 'debit': 0, 'credit': 90.86, 'reconciled': False},
-                        {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 691.06, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 429.99, 'credit': 0, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 691.06, 'reconciled': True},
-                        {'account_id': self.pos_receivable_account.id, 'partner_id': False, 'debit': 0, 'credit': 265.75, 'reconciled': True},
+                        {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 164.24, 'credit': 0, 'reconciled': True},
                     ],
                 },
                 'cash_statement': [
-                    ((429.99, ), {
+                    {
+                        'amount': 164.24,
                         'line_ids': [
-                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 429.99, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 429.99, 'reconciled': True},
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': False, 'debit': 164.24, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.cash_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 164.24, 'reconciled': True},
                         ]
-                    }),
+                    },
+                    {
+                        'amount': 265.75,
+                        'line_ids': [
+                            {'account_id': self.cash_pm1.journal_id.default_account_id.id, 'partner_id': self.other_customer.id, 'debit': 265.75, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.other_receivable_account.id, 'partner_id': self.other_customer.id, 'debit': 0, 'credit': 265.75, 'reconciled': True},
+                        ]
+                    },
                 ],
                 'bank_payments': [
-                    ((691.06, ), {
+                    {
+                        'amount': 691.06,
                         'line_ids': [
-                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': False, 'debit': 691.06, 'credit': 0, 'reconciled': False},
-                            {'account_id': self.bank_pm1.receivable_account_id.id, 'partner_id': False, 'debit': 0, 'credit': 691.06, 'reconciled': True},
+                            {'account_id': self.bank_pm1.outstanding_account_id.id, 'partner_id': self.customer.id, 'debit': 691.06, 'credit': 0, 'reconciled': False},
+                            {'account_id': self.c1_receivable.id, 'partner_id': self.customer.id, 'debit': 0, 'credit': 691.06, 'reconciled': True},
                         ]
-                    }),
+                    },
                 ],
             },
         })

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -61,10 +61,12 @@ class TestPoSSaleReport(TestPoSCommon):
         product_1 = product_template._create_product_variant(prod_tmpl_attrs[0])
         product_1.weight = 1
         product_1.volume = 1
+        product_1.taxes_id.country_id = self.env.company.country_id
 
         product_2 = product_template._create_product_variant(prod_tmpl_attrs[1])
         product_2.weight = 2
         product_2.volume = 2
+        product_2.taxes_id.country_id = self.env.company.country_id
 
         self.open_new_session()
         session = self.pos_session


### PR DESCRIPTION
**1st commit:**

Remove the account.tax field `real_amount` and fix the js `compute_all`
function by using the sum of the factors from the repartition lines (with type == 'tax').

Previously, the `real_amount` was used in the client instead of the `amount` field s.t.:
	real_amount = tax.amount * sum(tax.repartition_lines.factor)
And then setting:
	amount = real_amount
Just before passing the data to the client.

Now, we pass the sum(tax.repartition_lines.factor_percent)/100, which is equivalent to  sum(tax.repartition_line.factor) to the client and leave tax.amount untouched.

Thus, to remain equal, we multiply the tax.amount by the sum of repartition lines' factors in the `compute_all` function.

Both `compute_all` functions now operate using the same `tax.amount` and we get rid of the `real_amount` field.
Prepare for the next commit where the `compute_all` functions are splitted, requiring that all arguments in both are semantically the same.

**2nd commit:**

1) Fix the taxes computation

Previously, the computation was done for the whole pos orders at the same time without rounding the amounts for each tax repartition line like it's done on invoices.
Therefore, there was a discrepancy between both computations. After that, since we allow the users to request an invoice later, it could lead to some remaining tax amounts that are not correctly accounted.
Also, in order to prevent a discrepancy between the taxes computation js-side and python-side, a new json field has been added to keep the amounts for each tax separately. Then, the taxes are corrected by this extra field python-side if necessary.

2) Fix the cash rounding

The implementation of the cash rounding is quite messy because this feature is implemented differently in POS and on invoices because it's handling the cash rounding for different countries.
Indeed, the cash rounding implemented on the POS is the one available in Belgium (rounding cash transactions or all transactions but not the business document itself). On the other side, the invoice is implementing the cash rounding for Switzerland and nordic countries. Indeed, 0.01 and 0.02 coins are no longer used in those countries. In that case, the whole business document is rounded.
To prevent this inconsistency, the cash rounding from POS is no longer copied on the created invoices and an extra rounding line is added like a regular invoice line.

3) Fix the payment_state on invoices

When creating an account.payment for an invoice, the payment_state is 'in_payment' meaning we are awaiting a confirmation from the bank to set the invoice as paid. That's the purpose of the statement line that will make the invoice paid after matching either the payment, either the invoice directly.
When looking at an invoice after a POS session, the payment_state is always 'in_payment' and never becomes 'paid' because the POS is creating intermediate journal entry between account.payment/account.bank.statement.line and the invoices.
That is also very bad for Mexico since we need to send the payments to the government with the matched invoices. In that case, the code is not handling this extra journal entry.

To fix that, the flow is now a bit different:
When paying a pos order with a 'bank' payment method, an extra bank journal entry is still created and reconciled with the closing entry.
When the customer asks for an invoice, this bank journal entry is reversed and an account.payment is created and linked to the invoice.

When paying a pos order with 'cash' payment method, a statement line is created and reconciled with the closing entry.
When the customer asks for an invoice, the statement line is unreconciled from the closing entry and reconciled with the invoice.

task-3042653