### PR TITLE
[FIX] account: ensure that cash rounding lines are considered invoice lines

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -780,6 +780,27 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             line_form.price_unit = 799.99
         move_form.save()
 
+        rounding_line = {
+            'name': 'add_invoice_line',
+            'product_id': False,
+            'account_id': self.cash_rounding_a.loss_account_id.id,
+            'partner_id': self.partner_a.id,
+            'product_uom_id': False,
+            'quantity': 1,
+            'discount': 0.0,
+            'price_unit': 0.01,
+            'price_subtotal': 0.01,
+            'price_total': 0.01,
+            'tax_ids': [],
+            'tax_line_id': False,
+            'currency_id': self.company_data['currency'].id,
+            'amount_currency': 0.01,
+            'debit': 0.01,
+            'credit': 0.0,
+            'date_maturity': False,
+        }
+        self.assertRecordValues(self.invoice.invoice_line_ids[-1], [rounding_line])
+
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
@@ -792,25 +813,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             self.product_line_vals_2,
             self.tax_line_vals_1,
             self.tax_line_vals_2,
-            {
-                'name': 'add_invoice_line',
-                'product_id': False,
-                'account_id': self.cash_rounding_a.loss_account_id.id,
-                'partner_id': self.partner_a.id,
-                'product_uom_id': False,
-                'quantity': False,
-                'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
-                'tax_ids': [],
-                'tax_line_id': False,
-                'currency_id': self.company_data['currency'].id,
-                'amount_currency': 0.01,
-                'debit': 0.01,
-                'credit': 0.0,
-                'date_maturity': False,
-            },
+            rounding_line,
             self.term_line_vals_1,
         ], self.move_vals)
 
@@ -885,11 +888,11 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'account_id': self.company_data['default_account_tax_purchase'].id,
                 'partner_id': self.partner_a.id,
                 'product_uom_id': False,
-                'quantity': False,
+                'quantity': 1,
                 'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
+                'price_unit': -0.04,
+                'price_subtotal': -0.04,
+                'price_total': -0.04,
                 'tax_ids': [],
                 'tax_line_id': self.tax_purchase_a.id,
                 'tax_repartition_line_id': repartition_line.id,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -464,6 +464,27 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             line_form.price_unit = 799.99
         move_form.save()
 
+        rounding_line = {
+            'name': 'add_invoice_line',
+            'product_id': False,
+            'account_id': self.cash_rounding_a.profit_account_id.id,
+            'partner_id': self.partner_a.id,
+            'product_uom_id': False,
+            'quantity': 1,
+            'discount': 0.0,
+            'price_unit': 0.01,
+            'price_subtotal': 0.01,
+            'price_total': 0.01,
+            'tax_ids': [],
+            'tax_line_id': False,
+            'currency_id': self.company_data['currency'].id,
+            'amount_currency': -0.01,
+            'debit': 0.0,
+            'credit': 0.01,
+            'date_maturity': False,
+        }
+        self.assertRecordValues(self.invoice.invoice_line_ids[-1], [rounding_line])
+
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
@@ -476,25 +497,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             self.product_line_vals_2,
             self.tax_line_vals_1,
             self.tax_line_vals_2,
-            {
-                'name': 'add_invoice_line',
-                'product_id': False,
-                'account_id': self.cash_rounding_a.profit_account_id.id,
-                'partner_id': self.partner_a.id,
-                'product_uom_id': False,
-                'quantity': False,
-                'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
-                'tax_ids': [],
-                'tax_line_id': False,
-                'currency_id': self.company_data['currency'].id,
-                'amount_currency': -0.01,
-                'debit': 0.0,
-                'credit': 0.01,
-                'date_maturity': False,
-            },
+            rounding_line,
             self.term_line_vals_1,
         ], self.move_vals)
 
@@ -568,11 +571,11 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'account_id': self.company_data['default_account_tax_purchase'].id,
                 'partner_id': self.partner_a.id,
                 'product_uom_id': False,
-                'quantity': False,
+                'quantity': 1,
                 'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
+                'price_unit': -0.04,
+                'price_subtotal': -0.04,
+                'price_total': -0.04,
                 'tax_ids': [],
                 'tax_line_id': self.tax_purchase_a.id,
                 'tax_repartition_line_id': repartition_line.id,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1335,6 +1335,27 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             line_form.price_unit = 999.99
         move_form.save()
 
+        rounding_line = {
+            'name': 'add_invoice_line',
+            'product_id': False,
+            'account_id': self.cash_rounding_a.profit_account_id.id,
+            'partner_id': self.partner_a.id,
+            'product_uom_id': False,
+            'quantity': 1,
+            'discount': 0.0,
+            'price_unit': 0.01,
+            'price_subtotal': 0.01,
+            'price_total': 0.01,
+            'tax_ids': [],
+            'tax_line_id': False,
+            'currency_id': self.company_data['currency'].id,
+            'amount_currency': -0.01,
+            'debit': 0.0,
+            'credit': 0.01,
+            'date_maturity': False,
+        }
+        self.assertRecordValues(self.invoice.invoice_line_ids[-1], [rounding_line])
+
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
@@ -1347,25 +1368,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             self.product_line_vals_2,
             self.tax_line_vals_1,
             self.tax_line_vals_2,
-            {
-                'name': 'add_invoice_line',
-                'product_id': False,
-                'account_id': self.cash_rounding_a.profit_account_id.id,
-                'partner_id': self.partner_a.id,
-                'product_uom_id': False,
-                'quantity': False,
-                'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
-                'tax_ids': [],
-                'tax_line_id': False,
-                'currency_id': self.company_data['currency'].id,
-                'amount_currency': -0.01,
-                'debit': 0.0,
-                'credit': 0.01,
-                'date_maturity': False,
-            },
+            rounding_line,
             self.term_line_vals_1,
         ], self.move_vals)
 
@@ -1439,11 +1442,11 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'account_id': self.company_data['default_account_tax_sale'].id,
                 'partner_id': self.partner_a.id,
                 'product_uom_id': False,
-                'quantity': False,
+                'quantity': 1,
                 'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
+                'price_unit': -0.04,
+                'price_subtotal': -0.04,
+                'price_total': -0.04,
                 'tax_ids': [],
                 'tax_line_id': self.tax_sale_a.id,
                 'tax_repartition_line_id': repartition_line.id,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -458,6 +458,27 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             line_form.price_unit = 999.99
         move_form.save()
 
+        rounding_line = {
+            'name': 'add_invoice_line',
+            'product_id': False,
+            'account_id': self.cash_rounding_a.loss_account_id.id,
+            'partner_id': self.partner_a.id,
+            'product_uom_id': False,
+            'quantity': 1,
+            'discount': 0.0,
+            'price_unit': 0.01,
+            'price_subtotal': 0.01,
+            'price_total': 0.01,
+            'tax_ids': [],
+            'tax_line_id': False,
+            'currency_id': self.company_data['currency'].id,
+            'amount_currency': 0.01,
+            'debit': 0.01,
+            'credit': 0.0,
+            'date_maturity': False,
+        }
+        self.assertRecordValues(self.invoice.invoice_line_ids[-1], [rounding_line])
+
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
@@ -470,25 +491,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             self.product_line_vals_2,
             self.tax_line_vals_1,
             self.tax_line_vals_2,
-            {
-                'name': 'add_invoice_line',
-                'product_id': False,
-                'account_id': self.cash_rounding_a.loss_account_id.id,
-                'partner_id': self.partner_a.id,
-                'product_uom_id': False,
-                'quantity': False,
-                'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
-                'tax_ids': [],
-                'tax_line_id': False,
-                'currency_id': self.company_data['currency'].id,
-                'amount_currency': 0.01,
-                'debit': 0.01,
-                'credit': 0.0,
-                'date_maturity': False,
-            },
+            rounding_line,
             self.term_line_vals_1,
         ], self.move_vals)
 
@@ -562,11 +565,11 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'account_id': self.company_data['default_account_tax_sale'].id,
                 'partner_id': self.partner_a.id,
                 'product_uom_id': False,
-                'quantity': False,
+                'quantity': 1,
                 'discount': 0.0,
-                'price_unit': 0.0,
-                'price_subtotal': 0.0,
-                'price_total': 0.0,
+                'price_unit': -0.04,
+                'price_subtotal': -0.04,
+                'price_total': -0.04,
                 'tax_ids': [],
                 'tax_line_id': self.tax_sale_a.id,
                 'tax_repartition_line_id': repartition_line.id,


### PR DESCRIPTION
## Steps to reproduce
* activate Cash Rounding
* create a new cash rounding method with Rounding Strategy set to `Add a rounding line`
* create an invoice and add a product, so that a rounding is necessary
* in the Other Info tab, set the rounding method you made

You should see that the rounding line is not displayed in the invoice lines.

opw-3071496