### PR TITLE
[FIX] base: Set USD on the demo company

### DIFF
--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -29,6 +29,16 @@
             <field name="website">www.example.com</field>
         </record>
 
+        <!--
+            As `main_partner` is set in the United States,
+            and `partner_id` of `main_company` is this `main_partner`,
+            Set the currency of the company to USD,
+            so the currency matches the country of the demo company.
+        -->
+        <record id="main_company" model="res.company">
+            <field name="currency_id" ref="base.USD"/>
+        </record>
+
         <record id="user_demo" model="res.users">
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="login">demo</field>

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -71,6 +71,9 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
 
             if country_code:
                 country = env['res.country'].search([('code', 'ilike', country_code)])[0]
+                # Disable all currencies by default, even the ones loaded by demo datas.
+                env['res.currency'].search([]).active = False
+                # Setting the currency from the country on the res.company will automatically enable the currency
                 env['res.company'].browse(1).write({'country_id': country_code and country.id, 'currency_id': country_code and country.currency_id.id})
                 if len(country_timezones.get(country_code, [])) == 1:
                     users = env['res.users'].search([])


### PR DESCRIPTION
Since
https://github.com/odoo/odoo/commit/44029495bc4f85c9f99b16dbab0a49c6ba0f19f9#diff-4514e06704dabbd113ef9a9e219e2f8bcd172734d2966bfc53890c6e767d6abcR1264

The `EUR` currency is disabled by default.

By default, all currencies are disabled
up to the moment you install `account`
and a chart of template,
which will set a currency on the company according to the install chart template, which will enable the currency.

https://github.com/odoo/odoo/blob/f66f3adeaeacee1205ebd346927abc510fd2ba14/addons/account/models/chart_template.py#L260

https://github.com/odoo/odoo/blob/f66f3adeaeacee1205ebd346927abc510fd2ba14/odoo/addons/base/models/res_company.py#L236-L239 or
https://github.com/odoo/odoo/blob/f66f3adeaeacee1205ebd346927abc510fd2ba14/addons/account/models/chart_template.py#L269

This causes a UX issue with demo data, when you only have CRM, fleet, lunch or project installed, without account. These modules uses monetary fields, which require the company currency to be enabled in order to see the currency symbol within the kanban/tree/form views.

As the demo company currency, EUR, is disabled,
the currency name/symbol is not sent to the web client https://github.com/odoo/odoo/blob/f66f3adeaeacee1205ebd346927abc510fd2ba14/addons/web/models/ir_http.py#L120 and no symbol is shown for the monetary fields in the views. Also, it prevents the correct parsing of the value when the users inputs "1500€" in the field input.

The above revision, disabling EUR by default, targets to avoid landing in a multi-currency database as soon as you install a chart of account using another currency than the EUR. (As EUR was, before that revision, enabled by default, and the installation of the chart of template enables another currency, making 2 currencies enabled, therefore triggering the multi-currency group automatically)

This was especially true when you were installing a database with the demo data, because in the demo, the main company is set with as country United States, but the currency EUR. Upon installation of the account module,
the US chart of template is automatically installed based on the company country(US),
therefore enabling the `USD` currency,
making 2 currencies enabled by default when using the demo data: EUR and USD. Therefore making the demo database multi-currency by default.

In order to have the best of both worlds: having currency symbols in the CRM, fleet, lunch, project modules without the account module, and avoiding to be by default in a multi-currency database while using demo, the current revision suggests to set USD as the company currency within the demo data, just after setting the country of the company to United States:
- First, it makes sense to set USD as the company currency when the company country is United States
- Second, setting the currency on the company in the demo data enables the USD currency automatically, making the symbol of monetary field visible in demo data without having to rely on the installation of accounting,
- Third, it avoids in the demo database to be by default in multi-currency, as only USD will be enabled, and not EUR and USD as before.

When using the database manager to create your database, the user fills his country in the database creation form, and the currency is chosen according to this country. To avoid to have USD + the currency of the user country and to be in a multi-currency database by default
when creating a database from the database manager with demo data, disable all currencies after
the installation of the modules, and let
the currency of the user country to be enabled automatically when the country is being set on the company.
