### PR TITLE
[FIX] test_lint: keep eslint test for eslint blacklisted modules

### DIFF
--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -1,13 +1,5 @@
 {
-  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
-  "parserOptions": {
-    "sourceType": "module"
-  },
-  "env": {
-    "browser": true,
-    "es2022": true,
-    "qunit": true
-  },
+  "extends": ["eslint:recommended", "plugin:prettier/recommended", "./odoo/addons/test_lint/tests/eslintrc.json"],
   "rules": {
     "prettier/prettier": ["error", {
       "tabWidth": 4,
@@ -16,53 +8,10 @@
       "printWidth": 100,
       "endOfLine": "auto"
     }],
-    "no-undef": "error",
-    "no-restricted-globals": ["error", "event", "self"],
-    "no-const-assign": ["error"],
-    "no-debugger": ["error"],
-    "no-dupe-class-members": ["error"],
-    "no-dupe-keys": ["error"],
-    "no-dupe-args": ["error"],
-    "no-dupe-else-if": ["error"],
-    "no-unsafe-negation": ["error"],
-    "no-duplicate-imports": ["error"],
-    "valid-typeof": ["error"],
-    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all" }],
     "curly": ["error", "all"],
     "prefer-const": ["error", {
       "destructuring": "all",
       "ignoreReadBeforeAssign": true
     }]
-  },
-  "globals": {
-    "owl": "readonly",
-    "odoo": "readonly",
-    "$": "readonly",
-    "jQuery": "readonly",
-    "_": "readonly",
-    "Chart": "readonly",
-    "fuzzy": "readonly",
-    "QWeb2": "readonly",
-    "Popover": "readonly",
-    "StackTrace": "readonly",
-    "QUnit": "readonly",
-    "luxon": "readonly",
-    "moment": "readonly",
-    "py": "readonly",
-    "FullCalendar": "readonly",
-    "ClipboardJS": "readonly",
-    "globalThis": "readonly",
-    "Modal": "readonly",
-    "Dropdown": "readonly",
-    "ScrollSpy": "readonly",
-    "Tooltip": "readonly",
-    "Collapse": "readonly",
-    "Alert": "readonly",
-    "module": "readonly",
-    "chai": "readonly",
-    "describe": "readonly",
-    "it": "readonly",
-    "mocha": "readonly",
-    "DOMPurify": "readonly"
-  }
+  }  
 }

--- a/odoo/addons/test_lint/tests/eslintrc.json
+++ b/odoo/addons/test_lint/tests/eslintrc.json
@@ -1,0 +1,56 @@
+{
+    "parserOptions": {
+      "sourceType": "module"
+    },
+    "env": {
+      "browser": true,
+      "es2022": true,
+      "qunit": true
+    },
+    "rules": {
+      "no-undef": "error",
+      "no-restricted-globals": ["error", "event", "self"],
+      "no-const-assign": ["error"],
+      "no-debugger": ["error"],
+      "no-dupe-class-members": ["error"],
+      "no-dupe-keys": ["error"],
+      "no-dupe-args": ["error"],
+      "no-dupe-else-if": ["error"],
+      "no-unsafe-negation": ["error"],
+      "no-duplicate-imports": ["error"],
+      "valid-typeof": ["error"],
+      "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all" }]
+    },
+    "globals": {
+      "owl": "readonly",
+      "odoo": "readonly",
+      "$": "readonly",
+      "jQuery": "readonly",
+      "_": "readonly",
+      "Chart": "readonly",
+      "fuzzy": "readonly",
+      "QWeb2": "readonly",
+      "Popover": "readonly",
+      "StackTrace": "readonly",
+      "QUnit": "readonly",
+      "luxon": "readonly",
+      "moment": "readonly",
+      "py": "readonly",
+      "FullCalendar": "readonly",
+      "ClipboardJS": "readonly",
+      "globalThis": "readonly",
+      "Modal": "readonly",
+      "Dropdown": "readonly",
+      "ScrollSpy": "readonly",
+      "Tooltip": "readonly",
+      "Collapse": "readonly",
+      "Alert": "readonly",
+      "module": "readonly",
+      "chai": "readonly",
+      "describe": "readonly",
+      "it": "readonly",
+      "mocha": "readonly",
+      "DOMPurify": "readonly"
+    }
+}
+  

--- a/odoo/addons/test_lint/tests/test_eslint.py
+++ b/odoo/addons/test_lint/tests/test_eslint.py
@@ -32,7 +32,7 @@ class TestESLint(lint_case.LintCase):
             if not re.match('.*/libs?/.*', p)  # don't check libraries
             if not re.match('.*/o_spreadsheet/o_spreadsheet.js', p) # don't check generated code
         ]
-        eslintrc_path = get_resource_path('test_lint', 'tests', 'eslintrc')
+        eslintrc_path = get_resource_path('test_lint', 'tests', 'eslintrc.json')
 
         _logger.info('Testing %s js files', len(files_to_check))
         # https://eslint.org/docs/user-guide/command-line-interface


### PR DESCRIPTION
There is an eslint test that verify a bunch of basic rules, more functional than about the code style.
As we are going toward a new linting system with the runbot that respect the eslint ignore file, we do still need those basic rules to be tested against the whole code base.

We use eslint config files inheritance to avoid configuration duplication.

