### PR TITLE
[PROPOSITION - DONT MERGE] tooling: improve browsers compatibility check

### DIFF
--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -44,6 +44,8 @@ web_studio/static/tests/**/legacy/*
 # whitelist new code
 !addons/base_import
 !addons/base_import/**/*
+# blackList libs
+addons/base_import/static/lib/*
 # blacklist legacy
 addons/base_import/static/src/legacy/**/*
 
@@ -73,6 +75,8 @@ web_cohort/static/tests/legacy/**/*
 # whitelist new code
 !web_map
 !web_map/**/*
+# blackList libs
+web_map/static/lib/*
 
 # blacklist legacy
 web_map/static/src/legacy/**/*
@@ -93,6 +97,8 @@ web_map/static/tests/legacy/**/*
 # Whitelist spreadsheet
 !addons/spreadsheet
 !addons/spreadsheet/**/*
+# blackList libs
+addons/spreadsheet/static/lib/*
 
 # blacklist o-spreadsheet lib
 addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
@@ -151,3 +157,5 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 # Whitelist mail
 !addons/mail/
 !addons/mail/**/*
+# blackList libs
+addons/mail/static/lib/*

--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -1,5 +1,6 @@
 {
-  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "plugins": ["compat"],
+  "extends": ["eslint:recommended", "plugin:prettier/recommended", "plugin:compat/recommended"],
   "parserOptions": {
     "sourceType": "module"
   },

--- a/addons/web/tooling/_package.json
+++ b/addons/web/tooling/_package.json
@@ -13,6 +13,7 @@
     "devDependencies": {
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-compat": "^4.0.2",
         "eslint-plugin-diff": "^2.0.1",
         "eslint-plugin-prettier": "^4.2.1",
         "lint-staged": "^13.0.3",
@@ -26,5 +27,12 @@
         "*.{js}": [
             "eslint --fix"
         ]
-    }
+    },
+    "browserslist": [
+        "last 5 Chrome major versions",
+        "last 5 Firefox major versions and Firefox ESR",
+        "last 5 ChromeAndroid major versions",
+        "iOS >= 14",
+        "Safari >= 14"
+    ]
 }


### PR DESCRIPTION
Proposal to replace `es-check`.

Uses https://github.com/browserslist/browserslist to define the browsers support level and integrate into `eslint` using https://github.com/amilajack/eslint-plugin-compat.

:warning: **Obviously, browser support list should be discussed**