### PR TITLE
[FIX] web_editor: closestElement traceback

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -289,11 +289,11 @@ export function getFurthestUneditableParent(node, parentLimit) {
  */
 export function closestElement(node, selector) {
     const element = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
-    if (selector && element) {
+    if (selector && element && element.nodeType === Node.ELEMENT_NODE) {
         const elementFound = element.closest(selector);
         return elementFound && elementFound.querySelector('.odoo-editor-editable') ? null : elementFound;
     }
-    return selector && element ? element.closest(selector) : element || node;
+    return element || node;
 }
 
 /**


### PR DESCRIPTION
**Current behavior before PR:**

For Safari browser, tracebacks occur while executing `closestElement` because sometimes getting an element as a document object. Thus, it will raise a traceback like `element.closest is not a function`. Steps to reproduce:
                -> open a project task
                -> click the text in `Description` tab
                -> click `Timesheets` tab
                -> click `Description` tab, traceback will raise

**Desired behavior after PR is merged:**

For Safari browser, a `closestElement` function execute without any traceback.

Task-3045002






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
