### PR TITLE
[FIX] l10n_ke_edi_tremol: reduce command delay, fix abort message

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/L10nKeEDISerialDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/L10nKeEDISerialDriver.py
@@ -20,13 +20,13 @@ TremolG03Protocol = SerialProtocol(
     bytesize=serial.EIGHTBITS,
     stopbits=serial.STOPBITS_ONE,
     parity=serial.PARITY_NONE,
-    timeout=3,
+    timeout=4,
     writeTimeout=0.2,
     measureRegexp=None,
     statusRegexp=None,
     commandTerminator=b'',
-    commandDelay=0.4,
-    measureDelay=0.4,
+    commandDelay=0.2,
+    measureDelay=3,
     newMeasureDelay=0.2,
     measureCommand=b'',
     emptyAnswerValid=False,
@@ -36,6 +36,16 @@ STX = 0x02
 ETX = 0x0A
 ACK = 0x06
 NACK = 0x15
+
+# Dictionary defining the output size of expected from various commands
+COMMAND_OUTPUT_SIZE = {
+    0x30: 7,
+    0x31: 7,
+    0x38: 157,
+    0x39: 155,
+    0x60: 40,
+    0x68: 23,
+}
 
 FD_ERRORS = {
     0x30: 'OK',
@@ -149,8 +159,14 @@ class TremolG03Driver(SerialDriver):
                 request = struct.pack('B%ds2sB' % (len(core_message)), STX, core_message, self.generate_checksum(core_message), ETX)
                 time.sleep(self._protocol.commandDelay)
                 self._connection.write(request)
-                time.sleep(self._protocol.measureDelay)
-                response = self._connection.read_all()
+                # If we know the expected output size, we can set the read
+                # buffer to match the size of the output.
+                output_size = COMMAND_OUTPUT_SIZE.get(msg[0])
+                if output_size:
+                    response = self._connection.read(COMMAND_OUTPUT_SIZE.get(msg[0]))
+                else:
+                    time.sleep(self._protocol.measureDelay)
+                    response = self._connection.read_all()
                 if not response:
                     self.data['status'] = "no response"
                     _logger.error("Sent request: %s,\n Received no response", request)
@@ -188,16 +204,16 @@ class TremolG03Driver(SerialDriver):
         open otherwise, blocking further invoices being sent.
         """
         self.message_number += 1
-        abort = struct.pack('BBB', 37, self.message_number + 32, 0x39)
+        abort = struct.pack('BBB', 35, self.message_number + 32, 0x39)
         request = struct.pack('B3s2sB', STX, abort, self.generate_checksum(abort), ETX)
-        time.sleep(self._protocol.commandDelay)
         self._connection.write(request)
-        time.sleep(self._protocol.measureDelay)
-        response = self._connection.read_all()
+        response = self._connection.read(COMMAND_OUTPUT_SIZE[0x39])
         if response and response[0] == 0x02:
-            self.data['status'] += "\n The invoice could not be cancelled."
-        else:
             self.data['status'] += "\n The invoice was successfully cancelled"
+            _logger.error("Invoice successfully cancelled")
+        else:
+            self.data['status'] += "\n The invoice could not be cancelled."
+            _logger.error("Failed to cancel invoice, received response: %s", response)
 
 
 class TremolG03Controller(http.Controller):


### PR DESCRIPTION
The command delay on writing to the device is a little too prolonged. After some testing it has been determined that this can be reduced to by reading with the serial.read function (rather than read_all) when we know the expected output length.

The serial read fuction accepts an integer describing how many bytes are expected in the read buffer, and returns when the buffer is filled.

This has much better performance than waiting a fixed length of time, and reduces the chance of getting an empty response (when the device takes longer than expected to process the previous command).

The error message for aborting the post was incorrect, stating the the invoice had been cancelled when it was not successfully cancelled, and vice versa. Loggers have also been added for the cancelling of the invoice.
