### PR TITLE
[FIX] l10n_*: report_invoice_document template inherit

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -247,7 +247,7 @@
                         </div>
                         <div id="qrcode" class="d-flex mb-3 avoid-page-break-inside" t-if="o.display_qr_code and o.amount_residual > 0">
                             <div class="qrcode me-3" id="qrcode_image">
-                                <t t-set="qr_code_url" t-value="o._generate_qr_code(silent_errors=True)"/>
+                                <t t-set="qr_code_url" t-value="qr_code_urls.get(o.id) or o._generate_qr_code(silent_errors=True)"/>
                                 <p t-if="qr_code_url" class="position-relative mb-0">
                                     <img t-att-src="qr_code_url"/>
                                     <img src="/account/static/src/img/Odoo_logo_O.svg"

--- a/addons/l10n_ae/models/__init__.py
+++ b/addons/l10n_ae/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_move
 from . import account_move_line
 from . import account_chart_template

--- a/addons/l10n_ae/models/account_move.py
+++ b/addons/l10n_ae/models/account_move.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMove(models.Model):
+
+    _inherit = 'account.move'
+
+    def _get_name_invoice_report(self):
+        self.ensure_one()
+        if self.company_id.account_fiscal_country_id.code == 'AE':
+            return 'l10n_ae.report_invoice'
+        return super()._get_name_invoice_report()

--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//div[@name='payment_term']" position="after">
             <p t-if="o.company_id.country_id.code == 'AE' and o.partner_id.country_id.code != 'AE' and o.env.ref('l10n_ae.gcc_countries_group') in o.partner_id.country_id.country_group_ids">
                 Supply between <b>United Arab Emirates</b> and
@@ -58,6 +58,21 @@
                        t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
                 </div>
             </div>
+        </xpath>
+    </template>
+
+    <!-- FIXME: Temp fix to allow fetching invoice_documemt in Studio Reports with localisation -->
+    <template id="report_invoice_inherit_l10n_ae" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_ae.report_invoice_document'"
+                t-call="l10n_ae.report_invoice_document" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments_inherit_l10n_ae" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_ae.report_invoice_document'"
+                t-call="l10n_ae.report_invoice_document" t-lang="lang"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/l10n_ca/models/account_move.py
+++ b/addons/l10n_ca/models/account_move.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import models
 
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_rs_turnover_date = fields.Date(string='Turnover Date')
-
     def _get_name_invoice_report(self):
         self.ensure_one()
-        if self.company_id.account_fiscal_country_id.code == 'RS':
-            return 'l10n_rs.report_invoice_document_inherit'
+        if self.company_id.account_fiscal_country_id.code == 'CA':
+            return 'l10n_ca.l10n_ca_report_invoice_document_inherit'
         return super()._get_name_invoice_report()

--- a/addons/l10n_ca/views/report_invoice.xml
+++ b/addons/l10n_ca/views/report_invoice.xml
@@ -1,5 +1,5 @@
 <odoo>
-    <template id="l10n_ca_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+    <template id="l10n_ca_report_invoice_document_inherit" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//div[hasclass('row')]//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
             <div>PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
         </xpath>
@@ -8,6 +8,21 @@
         </xpath>
         <xpath expr="//div[hasclass('row')]//div[@name='no_shipping']//t[@t-set='address']" position="inside">
             <div>PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
+        </xpath>
+    </template>
+
+    <!-- FIXME: Temp fix to allow fetching invoice_documemt in Studio Reports with localisation -->
+    <template id="report_invoice_inherit_l10n_ca" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_ca.l10n_ca_report_invoice_document_inherit'"
+                t-call="l10n_ca.l10n_ca_report_invoice_document_inherit" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments_inherit_l10n_ca" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_ca.l10n_ca_report_invoice_document_inherit'"
+                t-call="l10n_ca.l10n_ca_report_invoice_document_inherit" t-lang="lang"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -93,3 +93,9 @@ class AccountMove(models.Model):
         # TO OVERRIDE
         self.ensure_one()
         return False
+
+    def _get_name_invoice_report(self):
+        self.ensure_one()
+        if self.company_id.account_fiscal_country_id.code == 'IN':
+            return 'l10n_in.l10n_in_report_invoice_document_inherit'
+        return super()._get_name_invoice_report()

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="l10n_in_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+    <template id="l10n_in_report_invoice_document_inherit" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//address[@t-field='o.partner_id']" position="after">
             <span t-field="o.l10n_in_gstin" t-if="o.company_id.account_fiscal_country_id.code == 'IN'"/>
         </xpath>
@@ -58,6 +58,21 @@
             </h2>
         </xpath>
 
+    </template>
+
+    <!-- FIXME: Temp fix to allow fetching invoice_documemt in Studio Reports with localisation -->
+    <template id="report_invoice_inherit_l10n_in" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_in.l10n_in_report_invoice_document_inherit'"
+                t-call="l10n_in.l10n_in_report_invoice_document_inherit" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments_inherit_l10n_in" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_in.l10n_in_report_invoice_document_inherit'"
+                t-call="l10n_in.l10n_in_report_invoice_document_inherit" t-lang="lang"/>
+        </xpath>
     </template>
 
 </odoo>

--- a/addons/l10n_in_edi/views/edi_pdf_report.xml
+++ b/addons/l10n_in_edi/views/edi_pdf_report.xml
@@ -62,7 +62,7 @@
         </xpath>
     </template>
 
-    <template id="l10n_in_einvoice_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+    <template id="l10n_in_einvoice_report_invoice_document_inherit" inherit_id="l10n_in.l10n_in_report_invoice_document_inherit">
         <xpath expr="//div[@id='informations']" position="inside">
             <t t-set="l10n_in_einvoice_json" t-value="o._get_l10n_in_edi_response_json()"/>
             <div class="col-auto col-3 mw-100 mb-2" t-if="l10n_in_einvoice_json" name="ack_no">

--- a/addons/l10n_it/data/report_invoice.xml
+++ b/addons/l10n_it/data/report_invoice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//p[@name='note']" position="replace">
             <p name="note">
                 <t t-if="o.move_type == 'out_invoice' and o.fiscal_position_id.note">
@@ -10,6 +10,21 @@
                     <span/>
                 </t>
             </p>
+        </xpath>
+    </template>
+
+    <!-- FIXME: Temp fix to allow fetching invoice_documemt in Studio Reports with localisation -->
+    <template id="report_invoice_inherit_l10n_it" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_it.report_invoice_document'"
+                t-call="l10n_it.report_invoice_document" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments_inherit_l10n_it" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_it.report_invoice_document'"
+                t-call="l10n_it.report_invoice_document" t-lang="lang"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/l10n_it/models/__init__.py
+++ b/addons/l10n_it/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move
 from . import account_report
 from . import account_chart_template

--- a/addons/l10n_it/models/account_move.py
+++ b/addons/l10n_it/models/account_move.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import models
 
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_rs_turnover_date = fields.Date(string='Turnover Date')
-
     def _get_name_invoice_report(self):
         self.ensure_one()
-        if self.company_id.account_fiscal_country_id.code == 'RS':
-            return 'l10n_rs.report_invoice_document_inherit'
+        if self.company_id.account_fiscal_country_id.code == 'IT':
+            return 'l10n_it.report_invoice_document'
         return super()._get_name_invoice_report()

--- a/addons/l10n_rs/views/account_move.xml
+++ b/addons/l10n_rs/views/account_move.xml
@@ -12,12 +12,4 @@
         </field>
     </record>
 
-    <template id="report_invoice_document_inherit" inherit_id="account.report_invoice_document">
-        <xpath expr="//address" position="after">
-            <div t-if="o.company_id.account_fiscal_country_id.code == 'RS' and o.partner_id.company_registry" class="mt16">
-                <p>Company ID: <span t-field="o.partner_id.company_registry"/></p>
-            </div>
-        </xpath>
-    </template>
-
 </odoo>

--- a/addons/l10n_rs/views/report_invoice.xml
+++ b/addons/l10n_rs/views/report_invoice.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+    <template id="report_invoice_document_inherit" inherit_id="account.report_invoice_document" primary="True">
         <xpath expr="//address" position="after">
-            <div t-if="o.company_id.account_fiscal_country_id.code == 'RS' and o.partner_id.company_registry" class="mt16">
+            <div t-if="o.partner_id.company_registry" class="mt16">
                 <p>Company ID: <span t-field="o.partner_id.company_registry"/></p>
             </div>
+        </xpath>
+    </template>
+
+    <!-- FIXME: Temp fix to allow fetching invoice_documemt in Studio Reports with localisation -->
+    <template id="report_invoice_inherit_l10n_rs" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_rs.report_invoice_document_inherit'"
+                t-call="l10n_rs.report_invoice_document_inherit" t-lang="lang"/>
+        </xpath>
+    </template>
+
+    <template id="report_invoice_with_payments_inherit_l10n_rs" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-if="o._get_name_invoice_report() == 'l10n_rs.report_invoice_document_inherit'"
+                t-call="l10n_rs.report_invoice_document_inherit" t-lang="lang"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
There are some issues with the implementation of the `report_invoice` template in some localisations. They inherit the template without making them primary, causing errors related to xpath replacement/insertion when some localisation are both installed (l10n_ar and l10n_ae for instance).

Also adds a small commit fixing an issue introduced with odoo/odoo#106605. 

see odoo/enterprise#35048

Task id=3100225