### PR TITLE
[FIX] hr_gamification: show participants when no user domain provided

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -181,7 +181,7 @@ class Challenge(models.Model):
         """Overwrite the create method to add the user of groups"""
         for vals in vals_list:
             users = self._get_challenger_users(
-                ustr(vals.get('user_domain')) if vals.get('user_domain') else "[('active', '=', True)]")
+                ustr(vals.get('user_domain', "[('active', '=', True)]"))
 
             if not vals.get('user_ids'):
                 vals['user_ids'] = []

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -180,12 +180,13 @@ class Challenge(models.Model):
     def create(self, vals_list):
         """Overwrite the create method to add the user of groups"""
         for vals in vals_list:
-            if vals.get('user_domain'):
-                users = self._get_challenger_users(ustr(vals.get('user_domain')))
+            users = self._get_challenger_users(
+                ustr(vals.get('user_domain')) if vals.get('user_domain') else "[('active', '=', True)]")
 
-                if not vals.get('user_ids'):
-                    vals['user_ids'] = []
-                vals['user_ids'].extend((4, user.id) for user in users)
+            if not vals.get('user_ids'):
+                vals['user_ids'] = []
+            vals['user_ids'].extend((4, user.id) for user in users)
+
 
         return super().create(vals_list)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: /

Current behavior before PR:
While creating a challenge, if no user domain is set on the view form, no domain will be set. This will result on having no participant on the challenge.

Desired behavior after PR is merged:
If no user domain is provided on the hr_challenge view,  it will set the user domain to all active users 


Ticket: opw-3075313



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
