### PR TITLE
barcodes: allow regexp quantifiers in barcode rules

### DIFF
--- a/addons/barcodes/models/barcode_rule.py
+++ b/addons/barcodes/models/barcode_rule.py
@@ -33,7 +33,9 @@ class BarcodeRule(models.Model):
             p = rule.pattern.replace('\\\\', 'X').replace('\\{', 'X').replace('\\}', 'X')
             findall = re.findall("[{]|[}]", p)  # p does not contain escaped { or }
             if len(findall) == 2:
-                if not re.search("[{][N]*[D]*[}]", p):
+                if re.search("[{][0-9]*,[0-9]*[}]", p):
+                    pass
+                elif not re.search("[{][N]*[D]*[}]", p):
                     raise ValidationError(_("There is a syntax error in the barcode pattern %(pattern)s: braces can only contain N's followed by D's.", pattern=rule.pattern))
                 elif re.search("[{][}]", p):
                     raise ValidationError(_("There is a syntax error in the barcode pattern %(pattern)s: empty braces.", pattern=rule.pattern))


### PR DESCRIPTION
Barcode pattern is used for js's `match` method. The pattern specification is extended to support weight part of a barcode, e.g. `23.....{NNNDD}`. The weight part is removed from the pattern on client side before passing normal regexp to the `match` method [1].

Server sides makes check if weight part of the pattern is correct. However, that check blocks quantifiers like `{8,12}`. This commit adds partial support for the quantifiers.

For master branch the proper solution could be changing format for the extended part to something like double braces to avoid confusion with regexp quantifiers, i.e. something like ``23.....{{NNNDD}}``

[1]: https://github.com/odoo/odoo/blob/8f30a4bb954390fb5733e4628d668f6b396d575a/addons/barcodes/static/src/js/barcode_parser.js#L138-L140

opw-3068467

close #105729

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
