### PR TITLE
[FIX] stock_account: fix product cost in FIFO auto

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -317,6 +317,7 @@ class ProductProduct(models.Model):
         ])
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates
+        price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         for candidate in candidates:
             qty_taken_on_candidate = min(qty_to_take_on_candidates, candidate.remaining_qty)
 
@@ -338,8 +339,10 @@ class ProductProduct(models.Model):
 
             if float_is_zero(qty_to_take_on_candidates, precision_rounding=self.uom_id.rounding):
                 if float_is_zero(candidate.remaining_qty, precision_rounding=self.uom_id.rounding):
-                    next_candidates = candidates.filtered(lambda svl: svl.remaining_qty > 0)
-                    new_standard_price = next_candidates and next_candidates[0].unit_cost or new_standard_price
+                    next_candidate = candidates.filtered(lambda svl: svl.remaining_qty > 0)[:1]
+                    next_candidate_cost = next_candidate.quantity and next_candidate.value / next_candidate.quantity or 0.0
+                    if not float_is_zero(next_candidate_cost, precision_digits=price_unit_prec):
+                        new_standard_price = next_candidate_cost
                 break
 
         # Update the standard price with the price of the last used candidate, if any.


### PR DESCRIPTION
To Reproduce
============
- in settings, set decimal accuracy of Product price to 6
- create a storable product with FIFO as category and Automatic as Inventory Valuation.
- purchase 1 unit of this product at 10$
- then purchase 100 unit at 0.001$/unit
- sell 1 unit of the product
- check the cost of this product : it's 10$

Problem
=======
the cost should be 0.001$ because we only have 100 unit that we bought at 0.001$. the issue is caused when we compute the FIFO logic, we compute the new cost using the `unit_price` which is `Monetary` field that will be rounded to 2 decimal digits so 0.001$ -> 0.00$ then we have a null cost we think that we have no stock of this product so we keep the old cost.

Solution
========
to avoid this issue we recompute the `unit_cost` using `total/quantity`

opw-3072692