### PR TITLE
[FIX] mrp, stock: speedup MO FormView opening

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -330,7 +330,7 @@ class MrpWorkcenterProductivity(models.Model):
         return company_id
 
     production_id = fields.Many2one('mrp.production', string='Manufacturing Order', related='workorder_id.production_id', readonly='True')
-    workcenter_id = fields.Many2one('mrp.workcenter', "Work Center", required=True, check_company=True)
+    workcenter_id = fields.Many2one('mrp.workcenter', "Work Center", required=True, check_company=True, index=True)
     company_id = fields.Many2one(
         'res.company', required=True, index=True,
         default=lambda self: self._get_default_company_id())

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -81,7 +81,7 @@ class StockMoveLine(models.Model):
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    created_production_id = fields.Many2one('mrp.production', 'Created Production Order', check_company=True)
+    created_production_id = fields.Many2one('mrp.production', 'Created Production Order', check_company=True, index=True)
     production_id = fields.Many2one(
         'mrp.production', 'Production Order for finished products', check_company=True, index=True)
     raw_material_production_id = fields.Many2one(

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -439,9 +439,10 @@ class StockMove(models.Model):
                 ['id'],
             )]
             ForecastedReport = self.env['report.stock.report_product_product_replenishment']
-            forecast_lines = ForecastedReport.with_context(warehouse=warehouse.id)._get_report_lines(None, product_variant_ids, wh_location_ids)
+            forecast_lines = list(filter(lambda report_line: report_line["move_out"] and report_line["replenishment_filled"],
+                ForecastedReport.with_context(warehouse=warehouse.id, fast_prepare_report_line=True)._get_report_lines(None, product_variant_ids, wh_location_ids)))
             for move in moves:
-                lines = [l for l in forecast_lines if l["move_out"] == move._origin and l["replenishment_filled"] is True]
+                lines = [l for l in forecast_lines if l["move_out"].id == move._origin.id]
                 if lines:
                     move.forecast_availability = sum(m['quantity'] for m in lines)
                     move_ins_lines = list(filter(lambda report_line: report_line['move_in'], lines))


### PR DESCRIPTION
In some databases opening the MO FormView can become a bit slow, sometimes up to 11s. This usually happens in databases with lots of stock_move, fewer products than stock_moves and MO with lots of lines (>50 lines by MO). In that case there are mainly two bottlenecks regarding FormView opening.

The first bottleneck is a lack of indexes on some fields that are used in queries produced when opening the view. This commit adds two new indexes on `mrp_workcenter_productivity.workorder_id` and `stock_move.created_production_id`.

The second bottleneck is the computation of the non-stored fields forecast_availability and forecast_expected_date. Both fields call the same compute function, `_compute_forecast_information`. This method calls `report_stock_forecasted._get_report_lines`. The issue here is that `_get_report_lines` will return a lot more information about each line than what is needed by `_compute_forecast_information`. Stuff like receipt/delivery_date and document_in/out are useful when displaying the forecasted report but not when computing forecast_information. This commit adds a faster version of `_prepare_report_line` that returns only the data useful to `_compute_forecast_information`. This cuts the opening time in half for some MOs in big databases.

Adding a filter and then a comparison on `line['move_out'].id = move._origin.id` is a bit faster than comparing two singletons.


#### Speedup

Customer database with 15K products, 400K stock_move/stock_move_lines, 7800 mrp_production.
MO FormView avg opening time changing the number of move_raw_ids.

| move_raw_ids | Before PR | After PR |
|:--------------:|:----------:|:---------:|
| 5 | 787ms | 707ms |
| 10 | 3.85s | 2.57s |
| 35 | 1.15s | 1.16s |
| 45 | 1.72s | 1.55s |
| 55 | 7.5s | 4.65s |

Overall, the time to open the FormView is less correlated to the number of move_raw_ids and more to the number of move_raw_ids.product_id that show up in lots of other moves. Still, for some MOs (move_raw_ids 10 and 55) the fix gives
a significant speedup, close to a factor 2 speedup for individual MOs.

[pgbadger link for new indexes relevance](https://drive.google.com/file/d/1He-ymn2j9SyoCMpval92ASyIaF6tWMk0/view?usp=share_link). Targeted queries are queries 2 and 6 of Top > Histogram of query times > Times consuming queries.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
