### PR TITLE
[Fix] Fleet: images not displayed in tree view

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -17,7 +17,7 @@ MODEL_FIELDS_TO_VEHICLE = {
 }
 
 class FleetVehicle(models.Model):
-    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _inherit = ['mail.thread', 'mail.activity.mixin', 'avatar.mixin']
     _name = 'fleet.vehicle'
     _description = 'Vehicle'
     _order = 'license_plate asc, acquisition_date asc'

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -19,6 +19,7 @@ FUEL_TYPES = [
 
 class FleetVehicleModel(models.Model):
     _name = 'fleet.vehicle.model'
+    _inherit = ['avatar.mixin']
     _description = 'Model of a vehicle'
     _order = 'name asc'
 

--- a/doc/cla/individual/kira-oussama.md
+++ b/doc/cla/individual/kira-oussama.md
@@ -1,0 +1,11 @@
+Algeria, 2022-11-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Amri Abdelkrim sm19992910@gmail.com https://github.com/kira-oussama

--- a/doc/cla/individual/kira-oussama.md
+++ b/doc/cla/individual/kira-oussama.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Amri Abdelkrim sm19992910@gmail.com https://github.com/kira-oussama
+Amri Abdelkrim 34043356+kira-oussama@@users.noreply.github.com https://github.com/kira-oussama


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Module: Fleet
Images not displayed in list view in menus
fleet > vehicles
fleet > services

The widget 'many2one_avatar' which is used by the field vehicle_id displays the field 'avatar_128' that can be available by inheriting the mixin 'avatar.mixin' which is not the case in the current code.

Current behavior before PR:
Images do not show in field vehicle in tree view
![Selection_006](https://user-images.githubusercontent.com/34043356/204668600-94082618-771a-4528-b17a-fbd3b8799399.png)
![Selection_005](https://user-images.githubusercontent.com/34043356/204668606-b1eb777d-14ce-4e70-bd35-6da38ef7b6e4.png)

Desired behavior after PR is merged:
Images must be displayed in tree view



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
