### PR TITLE
[FIX] hr_expense: singleton error when registering batch payment

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1201,7 +1201,7 @@ class HrExpenseSheet(models.Model):
             'context': {
                 'active_model': 'account.move',
                 'active_ids': self.account_move_id.ids,
-                'default_partner_bank_id': self.employee_id.sudo().bank_account_id.id,
+                'default_partner_bank_id': self.employee_id.sudo().bank_account_id[:1].id,
             },
             'target': 'new',
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When registering multiple payment on hr_expense, a Expected singleton exception will raise 

STEPS TO REPRODUCE THE ISSUE:
* Take any two employees - In my example I took Abigail and Marc Demo
* Go to Employee, Under the Private Information enter a unique bank account number for both these employees
* Go to Expenses, create the new expense reports for both employees and post
* Go to Expenses Reports > Report to pay > Select both these expense report > Click register payment
* The singleton error occurs

opw-3061525


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
