### PR TITLE
[FIX] point_of_sale: Customer Display Corrections

### DIFF
--- a/addons/point_of_sale/static/src/app/customer_display_service.js
+++ b/addons/point_of_sale/static/src/app/customer_display_service.js
@@ -38,7 +38,9 @@ export class LocalDisplay extends Reactive {
         displayBody.appendChild(container.querySelector(".pos-customer_facing_display"));
 
         const orderLines = displayBody.querySelector(".pos_orderlines_list");
-        orderLines.scrollTop = orderLines.scrollHeight;
+        if (orderLines) {
+            orderLines.scrollTop = orderLines.scrollHeight;
+        }
     }
 }
 

--- a/addons/point_of_sale/static/src/app/customer_display_service.js
+++ b/addons/point_of_sale/static/src/app/customer_display_service.js
@@ -37,9 +37,15 @@ export class LocalDisplay extends Reactive {
         displayBody.textContent = "";
         displayBody.appendChild(container.querySelector(".pos-customer_facing_display"));
 
-        const orderLines = displayBody.querySelector(".pos_orderlines_list");
-        if (orderLines) {
-            orderLines.scrollTop = orderLines.scrollHeight;
+        const currentScreen = this.globalState.get_order()?.get_screen_data().name;
+        if (currentScreen === "ProductScreen") {
+            const orderlinesList = displayBody.querySelector(".pos_orderlines_list");
+            if (orderlinesList) {
+                const selectedOrderline = orderlinesList.querySelector(".selected_orderline");
+                if (selectedOrderline) {
+                    selectedOrderline.scrollIntoView({ behavior: "instant", block: "start" });
+                }
+            }
         }
     }
 }

--- a/addons/point_of_sale/static/src/css/customer_facing_display.css
+++ b/addons/point_of_sale/static/src/css/customer_facing_display.css
@@ -46,6 +46,10 @@ body .pos-customer_facing_display {
   -ms-flex-direction: row;
   -o-flex-direction: row;
   flex-direction: row;
+  overflow: hidden;
+}
+body .pos-customer_facing_display .pos-customer_products {
+    overflow: auto;
 }
 body .pos-customer_facing_display .pos-customer_products,
 body .pos-customer_facing_display .pos-payment_info {
@@ -67,6 +71,64 @@ body .pos-customer_facing_display .pos-payment_info {
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
+
+.pos-customer_facing_display .pos_orderlines_list {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table {
+    text-align: center;
+    vertical-align: middle;
+    border-collapse: separate;
+    border-spacing: 0 10px;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table th {
+    position: sticky;
+    top: 0;
+    padding: 0.5rem;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table td {
+    word-wrap: break-word;
+    max-width: min(13vw, 8rem);
+    padding: 0 0.3vw;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table td.product_text_info {
+    min-width: 15vw;
+    max-width: 30vw;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table .product_text_info ul {
+    text-align: left;
+    margin: 0;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table td.product_img {
+    max-width: 20vw;
+}
+
+.pos-customer_facing_display .pos_orderlines_list table td.product_img img {
+    width: auto;
+    height: min(20vh, 20vw);
+}
+
+.pos-customer_facing_display .order-empty {
+    text-align: center;
+    margin: 5vw;
+}
+
+.pos-customer_facing_display .order-empty .fa {
+    font-size: 64px;
+}
+
+.pos-customer_facing_display .order-empty h1 {
+    font-size: 20px;
+}
+
 body .pos-customer_facing_display .pos_orderlines {
   width: 100%;
   height: 100%;
@@ -87,35 +149,17 @@ body .pos-customer_facing_display .pos_orderlines .pos_orderlines_list {
   position: relative;
   height: 100%;
 }
+.pos-customer_facing_display .pos_orderlines .pos_orderlines_item td:first-child, .pos-customer_facing_display .pos_orderlines .pos_orderlines_item td:last-child {
+    border-left-style: solid;
+    border-top-left-radius: 0.3vw;
+    border-bottom-left-radius: 0.3vw;
+}
 body .pos-customer_facing_display .pos_orderlines .pos_orderlines_item {
-  margin-bottom: 1vw;
   padding: 1%;
   border-radius: 0.3vw;
-  height: auto;
-  -webkit-box-flex: 0 1 auto;
-  -webkit-flex: 0 1 auto;
-  -moz-box-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-display: flex;
-  -moz-display: flex;
-  -ms-display: flex;
-  -o-display: flex;
-  display: flex;
-  -webkit-flex-direction: row;
-  -moz-flex-direction: row;
-  -ms-flex-direction: row;
-  -o-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -moz-box-align: center;
-  -ms-flex-align: center;
-  -ms-grid-row-align: center;
-  align-items: center;
 }
-body .pos-customer_facing_display .pos_orderlines .pos_orderlines_item:last-of-type {
-  animation: item_in 1s ease;
+body .pos-customer_facing_display .pos_orderlines_list .selected_orderline.animate {
+    animation: item_in 1s ease;
 }
 body .pos-customer_facing_display .pos_orderlines .pos_orderlines_item.pos_orderlines_header {
   background-color: transparent;
@@ -292,14 +336,6 @@ body .pos-customer_facing_display .pos-payment_info .pos-payment_info_details .p
     -o-flex-direction: column;
     flex-direction: column;
   }
-  body .pos-customer_facing_display:before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 17vh;
-  }
   body .pos-customer_facing_display .pos-payment_info .pos-adv {
     position: fixed;
     top: 0;
@@ -321,9 +357,8 @@ body .pos-customer_facing_display .pos-payment_info .pos-payment_info_details .p
     padding-top: 0;
   }
   body .pos-customer_facing_display .pos-customer_products {
-    padding-top: 17vh;
     height: 72vw;
-    overflow: hidden;
+    overflow: auto;
   }
   body .pos-customer_facing_display .pos-customer_products .pos_orderlines {
     -webkit-box-flex: 1 0 auto;
@@ -461,6 +496,9 @@ body .pos-hidden {
   background: #f6f6f6;
   color: #585858;
 }
+.pos-palette_01.pos-customer_facing_display .pos_orderlines_list table th {
+    background-color: #f6f6f6;
+}
 .pos-palette_01 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
   color: #3E3E3E;
@@ -482,6 +520,9 @@ body .pos-hidden {
 .pos-palette_02 .pos-customer_products {
   background: #ecf2f6;
   color: #364152;
+}
+.pos-palette_02.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ecf2f6;
 }
 .pos-palette_02 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
@@ -505,6 +546,9 @@ body .pos-hidden {
   background: #ececec;
   color: #585858;
 }
+.pos-palette_03.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
+}
 .pos-palette_03 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
   color: #3E3E3E;
@@ -526,6 +570,9 @@ body .pos-hidden {
 .pos-palette_04 .pos-customer_products {
   background: #efeeec;
   color: #585858;
+}
+.pos-palette_04.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #efeeec;
 }
 .pos-palette_04 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
@@ -549,6 +596,9 @@ body .pos-hidden {
   background: #ececec;
   color: #585858;
 }
+.pos-palette_05.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
+}
 .pos-palette_05 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
   color: #3E3E3E;
@@ -570,6 +620,9 @@ body .pos-hidden {
 .pos-palette_06 .pos-customer_products {
   background: #f6f6f6;
   color: #585858;
+}
+.pos-palette_06.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #f6f6f6;
 }
 .pos-palette_06 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
@@ -593,6 +646,9 @@ body .pos-hidden {
   background: #ececec;
   color: #585858;
 }
+.pos-palette_07.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
+}
 .pos-palette_07 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
   color: #3E3E3E;
@@ -614,6 +670,9 @@ body .pos-hidden {
 .pos-palette_08 .pos-customer_products {
   background: #ececec;
   color: #585858;
+}
+.pos-palette_08.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
 }
 .pos-palette_08 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
@@ -637,6 +696,9 @@ body .pos-hidden {
   background: #ececec;
   color: #585858;
 }
+.pos-palette_09.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
+}
 .pos-palette_09 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
   color: #3E3E3E;
@@ -658,6 +720,9 @@ body .pos-hidden {
 .pos-palette_10 .pos-customer_products {
   background: #ececec;
   color: #585858;
+}
+.pos-palette_10.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
 }
 .pos-palette_10 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
@@ -681,6 +746,9 @@ body .pos-hidden {
   background: #ececec;
   color: #585858;
 }
+.pos-palette_11.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #ececec;
+}
 .pos-palette_11 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: white;
   color: #3E3E3E;
@@ -703,6 +771,9 @@ body .pos-hidden {
   background: #5b5b5b;
   color: #bdb9b9;
 }
+.pos-palette_12.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #5b5b5b;
+}
 .pos-palette_12 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: #f5f5f5;
   color: #3E3E3E;
@@ -724,6 +795,9 @@ body .pos-hidden {
 .pos-palette_13 .pos-customer_products {
   background: #a2a2ab;
   color: #f6f6f6;
+}
+.pos-palette_13.pos-customer_facing_display .pos_orderlines_list table th {
+  background-color: #a2a2ab;
 }
 .pos-palette_13 .pos-customer_products .pos_orderlines_list .pos_orderlines_item {
   background-color: #f6f6f6;

--- a/addons/point_of_sale/static/src/css/customer_facing_display.css
+++ b/addons/point_of_sale/static/src/css/customer_facing_display.css
@@ -168,6 +168,13 @@ body .pos-customer_facing_display .pos_orderlines .pos_orderlines_item > div div
   padding-top: 75%;
   display: block;
 }
+body .pos-customer_facing_display .pos-thank-you-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 2rem;
+}
 body .pos-customer_facing_display .pos-payment_info {
   max-width: 30%;
   padding: 2% 2% 1% 2%;

--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -130,9 +130,6 @@ export class ReceiptScreen extends AbstractReceiptScreen {
         this._addNewOrder();
         const { name, props } = this.nextScreen;
         this.pos.showScreen(name, props);
-        if (this.env.pos.config.iface_customer_facing_display) {
-            this.env.pos.send_current_order_to_customer_facing_display();
-        }
     }
     resumeOrder() {
         this.env.pos.removeOrder(this.currentOrder);

--- a/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
+++ b/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
@@ -51,22 +51,53 @@
 
     <t t-name="CustomerFacingDisplayOrderLines" owl="1">
         <div class="pos_orderlines">
-            <div class="pos_orderlines_item pos_orderlines_header">
-                <div/>
-                <div/>
-                <div>Quantity</div>
-                <div>Price</div>
-            </div>
-            <div class="pos_orderlines_list">
-                <t t-if="order">
-                    <div t-foreach="order.get_orderlines()" t-as="orderline" t-key="orderline_index" class="pos_orderlines_item">
-                        <div><div t-attf-style="background-image:url(#{productImages[orderline.product.id]})"/></div>
-                        <div t-esc="orderline.get_full_product_name()"/>
-                        <div t-esc="orderline.get_quantity_str()"/>
-                        <div t-esc="pos.format_currency(orderline.get_display_price())"/>
+            <!-- if there is an order -->
+            <!-- and if the order is not already paid for -->
+            <!-- we show the order items -->
+            <t t-if="order">
+            <!-- in order to see if the order has been paid for ( validated ), -->
+            <!-- we look at the state of the POS screen: -->
+            <!-- if the screen state is 'ReceiptScreen', -->
+            <!-- that means that the order has been validated -->
+                <t t-if ="order.get_screen_data().name != 'ReceiptScreen'">
+                    <div class="pos_orderlines_item pos_orderlines_header">
+                        <div/>
+                        <div/>
+                        <div>Quantity</div>
+                        <div>Price</div>
+                    </div>
+                    <div class="pos_orderlines_list">
+                        <div t-foreach="order.get_orderlines()" t-as="orderline" class="pos_orderlines_item">
+                            <div><div t-attf-style="background-image:url(#{productImages[orderline.product.id]})"/></div>
+                                <ul>
+                                    <li class="info">
+                                        <!-- name of item -->
+                                        <div t-esc="orderline.get_full_product_name()"/>
+                                    </li>
+                                    <!-- we show the specific discount applied to this item -->
+                                    <li class="info">
+                                        <t t-if="orderline.get_discount_str() !== '0'">
+                                            <em>
+                                            With a
+                                                <t t-esc="orderline.get_discount_str()" />%
+                                            discount
+                                            </em>
+                                        </t>
+                                    </li>
+                                </ul>
+                            <div t-esc="orderline.get_quantity_str()"/>
+                            <div t-esc="pos.format_currency(orderline.get_display_price())"/>
+                        </div>
                     </div>
                 </t>
-            </div>
+                <!-- after the order has been validated -->
+                <!-- we show the 'thank you' message -->
+                <t t-else="">
+                    <div class="pos-thank-you-message">
+                        <span>Thank you for your purchase!</span>
+                    </div>
+                </t>
+            </t>
         </div>
     </t>
 

--- a/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
+++ b/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
@@ -67,7 +67,7 @@
                         <div>Price</div>
                     </div>
                     <div class="pos_orderlines_list">
-                        <div t-foreach="order.get_orderlines()" t-as="orderline" class="pos_orderlines_item">
+                        <div t-foreach="order.get_orderlines()" t-key="orderline.id" t-as="orderline" class="pos_orderlines_item">
                             <div><div t-attf-style="background-image:url(#{productImages[orderline.product.id]})"/></div>
                                 <ul>
                                     <li class="info">

--- a/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
+++ b/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
@@ -75,15 +75,15 @@
                                         <div t-esc="orderline.get_full_product_name()"/>
                                     </li>
                                     <!-- we show the specific discount applied to this item -->
-                                    <li class="info">
-                                        <t t-if="orderline.get_discount_str() !== '0'">
+                                    <t t-if="orderline.get_discount_str() !== '0'">
+                                        <li class="info">
                                             <em>
                                             With a
                                                 <t t-esc="orderline.get_discount_str()" />%
                                             discount
                                             </em>
-                                        </t>
-                                    </li>
+                                        </li>
+                                    </t>
                                 </ul>
                             <div t-esc="orderline.get_quantity_str()"/>
                             <div t-esc="pos.format_currency(orderline.get_display_price())"/>

--- a/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
+++ b/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
@@ -55,40 +55,65 @@
             <!-- and if the order is not already paid for -->
             <!-- we show the order items -->
             <t t-if="order">
-            <!-- in order to see if the order has been paid for ( validated ), -->
-            <!-- we look at the state of the POS screen: -->
-            <!-- if the screen state is 'ReceiptScreen', -->
-            <!-- that means that the order has been validated -->
-                <t t-if ="order.get_screen_data().name != 'ReceiptScreen'">
-                    <div class="pos_orderlines_item pos_orderlines_header">
-                        <div/>
-                        <div/>
-                        <div>Quantity</div>
-                        <div>Price</div>
-                    </div>
-                    <div class="pos_orderlines_list">
-                        <div t-foreach="order.get_orderlines()" t-key="orderline.id" t-as="orderline" class="pos_orderlines_item">
-                            <div><div t-attf-style="background-image:url(#{productImages[orderline.product.id]})"/></div>
-                                <ul>
-                                    <li class="info">
-                                        <!-- name of item -->
-                                        <div t-esc="orderline.get_full_product_name()"/>
-                                    </li>
-                                    <!-- we show the specific discount applied to this item -->
-                                    <t t-if="orderline.get_discount_str() !== '0'">
-                                        <li class="info">
-                                            <em>
-                                            With a
-                                                <t t-esc="orderline.get_discount_str()" />%
-                                            discount
-                                            </em>
-                                        </li>
-                                    </t>
-                                </ul>
-                            <div t-esc="orderline.get_quantity_str()"/>
-                            <div t-esc="pos.format_currency(orderline.get_display_price())"/>
+                <!-- in order to see if the order has been paid for ( validated ), -->
+                <!-- we look at the state of the POS screen: -->
+                <!-- if the screen state is 'ReceiptScreen', -->
+                <!-- that means that the order has been validated -->
+                <t t-if="order.get_screen_data().name != 'ReceiptScreen'">
+                    <t t-if="order.get_orderlines().length > 0">
+                        <div class="pos_orderlines_list">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th></th>
+                                        <th>Quantity</th>
+                                        <th>Price</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="order.get_orderlines()" t-key="orderline.id" t-as="orderline" class="pos_orderlines_item" t-att-class="{ 'selected_orderline': orderline.id === order.get_selected_orderline().id, 'animate': order.get_screen_data().name === 'ProductScreen'}">
+                                        <td class="product_img">
+                                            <img t-attf-src="#{productImages[orderline.product.id]}" />
+                                        </td>
+                                        <td class="product_text_info">
+                                            <ul>
+                                                <li class="info">
+                                                    <!-- name of item -->
+                                                    <div t-esc="orderline.get_full_product_name()" />
+                                                </li>
+                                                <!-- we show the specific discount applied to this item -->
+                                                <t t-if="orderline.get_discount_str() !== '0'">
+                                                    <li class="info">
+                                                        <em> With a <t t-esc="orderline.get_discount_str()" />% discount </em>
+                                                    </li>
+                                                </t>
+                                                <t t-if="orderline.get_customer_note()">
+                                                    <li class="info orderline-note">
+                                                        <i class="fa fa-sticky-note" role="img" aria-label="Customer Note" title="Customer Note"/>
+                                                        <em> Note: <t t-esc="orderline.get_customer_note()" /></em>
+                                                    </li>
+                                                </t>
+                                            </ul>
+                                        </td>
+                                        <td>
+                                            <div t-esc="orderline.get_quantity_str()" /><div t-esc="orderline.get_unit().name" />
+                                        </td>
+                                        <td>
+                                            <div t-esc="pos.format_currency(orderline.get_display_price())" />
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
-                    </div>
+                    </t>
+                    <t t-else="">
+                        <div class='order-empty'>
+                            <i class='fa fa-shopping-cart' role="img" aria-label="Shopping cart"
+                                title="Shopping cart" />
+                            <h1>This order is empty</h1>
+                        </div>
+                    </t>
                 </t>
                 <!-- after the order has been validated -->
                 <!-- we show the 'thank you' message -->


### PR DESCRIPTION
[FIX] point_of_sale: Customer Display Corrections

Currently, the customer display has a few misleading behaviors.

1. Display doesn't reset when expected

After successful payment, the details of the previous order remain visible until the 1st product of the next order is encoded —> We now show a _Thank You_ Message after successful payment. 

2. Discount lines are not shown in the Customer Display

Currently, when a discount is applied to the whole order, a new line appears, showing this discount, but if a discount is applied to a specific product, there is no indication on the Customer Display —> we now also display a discount line under the product name for each product where a specific discount is applied.

Link to task:
https://www.odoo.com/web#id=2906039&cids=1&menu_id=4720&action=333&active_id=1737&model=project.task&view_type=form






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
