### PR TITLE
[FIX] web_editor: closest to comment nodes

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -265,6 +265,9 @@ export function findNode(domPath, findCallback = () => true, stopCallback = () =
  * @returns {HTMLElement}
  */
 export function closestElement(node, selector, restrictToEditable=false) {
+    if (node.nodeType === Node.COMMENT_NODE) {
+        return false;
+    }
     let element = node;
     while (element && element.nodeType !== Node.ELEMENT_NODE) {
         element = element.parentNode;


### PR DESCRIPTION
Comment nodes do not have a 'closest' function
to fetch the closest parent matching some selector.

This causes the parser to throw an error when data containing such nodes is given to them
(e.g from a template in the back-end).

This updates closestElement to correctly handle
comment nodes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
