### PR TITLE
[FIX] point_of_sale: correct COGS after validating failed stock picking

### DIFF
--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -160,6 +160,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             'company_id': cls.company.id,
             'sequence': 20
         })
+        cls.sales_account = cls.company_data['default_account_revenue']
         cls.invoice_journal = cls.company_data['default_journal_sale']
         cls.receivable_account = cls.company_data['default_account_receivable']
         cls.tax_received_account = cls.company_data['default_account_tax_sale']
@@ -621,3 +622,15 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         self.bank_pm = self.pos_session.payment_method_ids.filtered(lambda pm: not pm.is_cash_count and not pm.split_transactions)[:1]
         self.cash_split_pm = self.pos_session.payment_method_ids.filtered(lambda pm: pm.is_cash_count and pm.split_transactions)[:1]
         self.bank_split_pm = self.pos_session.payment_method_ids.filtered(lambda pm: not pm.is_cash_count and pm.split_transactions)[:1]
+
+    # Backported from 15.0
+    def _assert_account_move(self, account_move, expected_account_move_vals):
+        if expected_account_move_vals:
+            # We allow partial checks of the lines of the account move if `line_ids_predicate` is specified.
+            # This means that only those that satisfy the predicate are compared to the expected account move line_ids.
+            line_ids_predicate = expected_account_move_vals.pop('line_ids_predicate', lambda _: True)
+            self.assertRecordValues(account_move.line_ids.filtered(line_ids_predicate), expected_account_move_vals.pop('line_ids'))
+            self.assertRecordValues(account_move, [expected_account_move_vals])
+        else:
+            # if the expected_account_move_vals is falsy, the account_move should be falsy.
+            self.assertFalse(account_move)

--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -247,3 +247,315 @@ class TestPoSStock(TestPoSCommon):
 
         # close the session
         self.pos_session.action_pos_session_validate()
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPoSFailedStockPicking(TestPoSCommon):
+    """ Tests for anglo-saxon accounting when a stock picking fails when closing a POS session. These tests check that
+    the COGS lines are corrected when the user fixes the failed stock picking afterwards.
+    """
+    def setUp(self):
+        super(TestPoSFailedStockPicking, self).setUp()
+
+        # Using the 'closing' setting because the main use case where the correction is needed is when you have multiple
+        # orders in the session but one of them results in a failed stock picking, resulting in the inventory valuation
+        # for the entire session amounting to 0 when the 'closing' method is used. If the 'real' method is used, the
+        # impact is more limited.
+        self.company_data['company'].write({
+            'point_of_sale_update_stock_quantities': 'closing',
+        })
+
+        self.config = self.basic_config
+        # Product 1 requires a serial number for tracking purposes
+        self.product1 = self.create_product('Product 1', self.categ_anglo, 20.0, 10.0)
+        self.product1.tracking = 'serial'
+        # Product 2 doesn't have any tracking
+        self.product2 = self.create_product('Product 2', self.categ_anglo, 30.0, 15.0)
+        self.product2.tracking = 'none'
+        # start inventory with 1 item for each product
+        self.adjust_inventory([self.product1, self.product2], [1, 1])
+
+        self.output_account = self.categ_anglo.property_stock_account_output_categ_id
+        self.expense_account = self.categ_anglo.property_account_expense_categ_id
+        self.valuation_account = self.categ_anglo.property_stock_valuation_account_id
+
+    def test_selling_a_product_with_a_valid_picking(self):
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(self.product2, 1)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # picking should be in done state
+        self.assertEqual(self.pos_session.picking_ids[0].state, 'done', 'Picking should be in done state.')
+
+        self._assert_account_move(self.pos_session.move_id, {
+            'line_ids': [
+                {'account_id': self.sales_account.id, 'debit': 0, 'credit': 30, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 15, 'credit': 0, 'reconciled': False},
+                {'account_id': self.cash_pm.receivable_account_id.id, 'debit': 30, 'credit': 0, 'reconciled': True},
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 15, 'reconciled': True},
+            ],
+        })
+
+        # Verify the expected inventory valuation entry was created
+        stock_picking_account_moves = self.pos_session.picking_ids[0].move_lines.account_move_ids
+        self.assertEqual(len(stock_picking_account_moves), 1)
+        self._assert_account_move(stock_picking_account_moves[0], {
+            'line_ids': [
+                {'account_id': self.valuation_account.id, 'debit': 0, 'credit': 15, 'reconciled': False},
+                {'account_id': self.output_account.id, 'debit': 15, 'credit': 0, 'reconciled': True},
+            ],
+        })
+
+    def test_selling_a_product_with_an_invalid_picking(self):
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(self.product1, 1)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # picking should be in confirmed state
+        self.assertEqual(self.pos_session.picking_ids[0].state, 'confirmed', 'Picking should be in confirmed state.')
+
+        # The expense and stock output lines will be 0 because the stock picking failed. The stock output line won't
+        # be reconciled.
+        self._assert_account_move(self.pos_session.move_id, {
+            'line_ids': [
+                {'account_id': self.sales_account.id, 'debit': 0, 'credit': 20, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 0, 'credit': 0, 'reconciled': False},
+                {'account_id': self.cash_pm.receivable_account_id.id, 'debit': 20, 'credit': 0, 'reconciled': True},
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Set a serial number for the product
+        lot = self.env['stock.production.lot'].create({
+            'name': 'lot1',
+            'product_id': self.product1.id,
+            'company_id': self.env.company.id,
+        })
+
+        self.assertEqual(len(self.pos_session.picking_ids[0].move_line_ids), 1)
+        self.pos_session.picking_ids[0].move_line_ids[0].write({
+            'lot_id': lot.id
+        })
+
+        # Validate the stock picking
+        self.pos_session.picking_ids[0].button_validate()
+
+        # Verify the expected stock picking account moves were created
+        stock_picking_account_moves = self.pos_session.picking_ids[0].move_lines.account_move_ids
+        self.assertEqual(len(stock_picking_account_moves), 2)
+        # Sort the moves in the order they were created in
+        stock_picking_account_moves = sorted(stock_picking_account_moves, key=lambda x: x.name)
+
+        # Verify the expected inventory valuation entry was created. The output account line will not be reconciled.
+        self._assert_account_move(stock_picking_account_moves[0], {
+            'line_ids': [
+                {'account_id': self.valuation_account.id, 'debit': 0, 'credit': 10, 'reconciled': False},
+                {'account_id': self.output_account.id, 'debit': 10, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Verify the additional COGS entry was created
+        self._assert_account_move(stock_picking_account_moves[1], {
+            'line_ids': [
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 10, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 10, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+    def test_selling_products_with_a_partially_invalid_picking(self):
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(self.product1, 1), (self.product2, 1)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # picking should be in confirmed state
+        self.assertEqual(self.pos_session.picking_ids[0].state, 'confirmed', 'Picking should be in confirmed state.')
+
+        # The expense and stock output lines will be 0 because the stock picking failed. The stock output line won't
+        # be reconciled.
+        self._assert_account_move(self.pos_session.move_id, {
+            'line_ids': [
+                {'account_id': self.sales_account.id, 'debit': 0, 'credit': 50, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 0, 'credit': 0, 'reconciled': False},
+                {'account_id': self.cash_pm.receivable_account_id.id, 'debit': 50, 'credit': 0, 'reconciled': True},
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Set a serial number for the product
+        lot = self.env['stock.production.lot'].create({
+            'name': 'lot1',
+            'product_id': self.product1.id,
+            'company_id': self.env.company.id,
+        })
+
+        self.assertEqual(len(self.pos_session.picking_ids[0].move_line_ids), 2)
+        picking_move_lines = sorted(self.pos_session.picking_ids[0].move_line_ids, key=lambda x: x.product_id.name)
+        picking_move_lines[0].write({
+            'lot_id': lot.id
+        })
+
+        # Validate the stock picking
+        self.pos_session.picking_ids[0].button_validate()
+
+        # Verify the expected stock picking account moves were created
+        stock_picking_account_moves = self.pos_session.picking_ids[0].move_lines.account_move_ids
+        self.assertEqual(len(stock_picking_account_moves), 4)
+        # Sort the moves in the order they were created in
+        stock_picking_account_moves = sorted(stock_picking_account_moves, key=lambda x: x.name)
+
+        # Verify the expected inventory valuation entry was created for product1. The output account line will not be
+        # reconciled.
+        self._assert_account_move(stock_picking_account_moves[0], {
+            'line_ids': [
+                {'account_id': self.valuation_account.id, 'debit': 0, 'credit': 10, 'reconciled': False},
+                {'account_id': self.output_account.id, 'debit': 10, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Verify the additional COGS entry was created for product1.
+        self._assert_account_move(stock_picking_account_moves[1], {
+            'line_ids': [
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 10, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 10, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Verify the expected inventory valuation entry was created for product2. The output account line will not be
+        # reconciled.
+        self._assert_account_move(stock_picking_account_moves[2], {
+            'line_ids': [
+                {'account_id': self.valuation_account.id, 'debit': 0, 'credit': 15, 'reconciled': False},
+                {'account_id': self.output_account.id, 'debit': 15, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Verify the additional COGS entry was created for product2.
+        self._assert_account_move(stock_picking_account_moves[3], {
+            'line_ids': [
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 15, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 15, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+    def test_refunding_a_product_with_a_valid_picking(self):
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(self.product2, -1)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # picking should be in done state
+        self.assertEqual(self.pos_session.picking_ids[0].state, 'done', 'Picking should be in done state.')
+
+        self._assert_account_move(self.pos_session.move_id, {
+            'line_ids': [
+                {'account_id': self.sales_account.id, 'debit': 30, 'credit': 0, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 0, 'credit': 15, 'reconciled': False},
+                {'account_id': self.cash_pm.receivable_account_id.id, 'debit': 0, 'credit': 30, 'reconciled': True},
+                {'account_id': self.output_account.id, 'debit': 15, 'credit': 0, 'reconciled': True},
+            ],
+        })
+
+        # Verify the expected inventory valuation entry was created
+        stock_picking_account_moves = self.pos_session.picking_ids[0].move_lines.account_move_ids
+        self.assertEqual(len(stock_picking_account_moves), 1)
+        self._assert_account_move(stock_picking_account_moves[0], {
+            'line_ids': [
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 15, 'reconciled': True},
+                {'account_id': self.valuation_account.id, 'debit': 15, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+    def test_refunding_a_product_with_an_invalid_picking(self):
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(self.product1, -1)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # picking should be in confirmed state
+        self.assertEqual(self.pos_session.picking_ids[0].state, 'assigned', 'Picking should be in assigned state.')
+
+        # The expense and stock output lines will be 0 because the stock picking failed. The stock output line won't
+        # be reconciled.
+        self._assert_account_move(self.pos_session.move_id, {
+            'line_ids': [
+                {'account_id': self.sales_account.id, 'debit': 20, 'credit': 0, 'reconciled': False},
+                {'account_id': self.expense_account.id, 'debit': 0, 'credit': 0, 'reconciled': False},
+                {'account_id': self.cash_pm.receivable_account_id.id, 'debit': 0, 'credit': 20, 'reconciled': True},
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Set a serial number for the product
+        lot = self.env['stock.production.lot'].create({
+            'name': 'lot1',
+            'product_id': self.product1.id,
+            'company_id': self.env.company.id,
+        })
+
+        # Odoo will create 2 move lines: a first with reserved qty 1 and done qty 0, and a second with reserved qty 0
+        # and done qty 1. Delete the second line. Set the done qty to 1 on the first line, which is what also happens
+        # in the UI if you assign a serial number.
+        self.assertEqual(len(self.pos_session.picking_ids[0].move_line_ids), 2)
+        self.pos_session.picking_ids[0].move_line_ids[0].write({
+            'lot_id': lot.id,
+            'qty_done': 1,
+        })
+        self.pos_session.picking_ids[0].move_line_ids[1].unlink()
+
+        # Validate the stock picking
+        self.pos_session.picking_ids[0].button_validate()
+
+        # Verify the expected stock picking account moves were created
+        stock_picking_account_moves = self.pos_session.picking_ids[0].move_lines.account_move_ids
+        self.assertEqual(len(stock_picking_account_moves), 2)
+        # Sort the moves in the order they were created in
+        stock_picking_account_moves = sorted(stock_picking_account_moves, key=lambda x: x.name)
+
+        # Verify the expected inventory valuation entry was created. The output account line will not be reconciled.
+        self._assert_account_move(stock_picking_account_moves[0], {
+            'line_ids': [
+                {'account_id': self.output_account.id, 'debit': 0, 'credit': 10, 'reconciled': False},
+                {'account_id': self.valuation_account.id, 'debit': 10, 'credit': 0, 'reconciled': False},
+            ],
+        })
+
+        # Verify the additional COGS entry was created
+        self._assert_account_move(stock_picking_account_moves[1], {
+            'line_ids': [
+                {'account_id': self.expense_account.id, 'debit': 0, 'credit': 10, 'reconciled': False},
+                {'account_id': self.output_account.id, 'debit': 10, 'credit': 0, 'reconciled': False},
+            ],
+        })


### PR DESCRIPTION
Suppose your inventory management is configured to generate a single stock picking after closing the POS session. If a product in one of the orders requires a valid serial number for tracking purposes, but none was provided, the stock picking will fail to validate and no stock valuation layer is generated. When using anglo-saxon accounting, this means the generated COGS line amount will be 0 for the entire session. Likewise, the Stock Interim (Delivered) line will be 0.

If you correct the stock picking afterwards and validate, an inventory valuation journal entry will be created that would also have been created if the stock picking hadn't failed. But the 0 lines are not corrected. The purpose of this commit is to do so by creating another journal entry.

I've assumed the main POS use cases are selling products and refunding returned products. The generic stock picking implementation allows for purchasing products from other companies, returning them and using dropshipping, but I haven't implemented COGS corrections for those since I assume those cases aren't relevant to the POS workflow.

opw-2988701