### PR TITLE
[IMP] web: input fields in alert messages

### DIFF
--- a/addons/web/static/src/core/alert/alert.scss
+++ b/addons/web/static/src/core/alert/alert.scss
@@ -1,0 +1,4 @@
+.alert {
+    --o-input-placeholder-color: #{$o-gray-600};
+    --o-input-border-color: #{$o-gray-400};
+}

--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -37,6 +37,12 @@
     padding: $o-input-padding-y $o-input-padding-x;
     background-color: var(--o-input-background-color, #{$input-bg});
 
+    &::placeholder {
+        color: var(--o-input-placeholder-color, #{$input-placeholder-color});
+        // Reset the default opacity set on placeholders by Firefox's browser stylesheet
+        opacity: 1;
+    }
+
     // -- Nested o_input(s)
     .o_input {
         border: 0;


### PR DESCRIPTION
Input field's placeholder and border color were not visible enough on alert's colored backgrounds

part of task-2984182

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
