### PR TITLE
[FIX] sale_coupon: select best promotion program for specific product

### DIFF
--- a/addons/sale_coupon/models/coupon_program.py
+++ b/addons/sale_coupon/models/coupon_program.py
@@ -196,6 +196,13 @@ class CouponProgram(models.Model):
                self.discount_type == 'percentage' and \
                self.discount_apply_on == 'on_order'
 
+    def _is_discount_specific_product_program(self):
+        self.ensure_one()
+        return self.promo_applicability == 'on_current_order' and \
+               self.reward_type == 'discount' and \
+               self.discount_type == 'percentage' and \
+               self.discount_apply_on == 'specific_products'
+
     def _keep_only_most_interesting_auto_applied_global_discount_program(self):
         '''Given a record set of programs, remove the less interesting auto
         applied global discount to keep only the most interesting one.
@@ -207,4 +214,11 @@ class CouponProgram(models.Model):
         if not programs: return self
         most_interesting_program = max(programs, key=lambda p: p.discount_percentage)
         # remove least interesting programs
+        return self - (programs - most_interesting_program)
+
+    def _keep_only_most_interesting_discount_specific_product_program(self):
+        programs = self.filtered(lambda p: p._is_discount_specific_product_program() and p.promo_code_usage == 'no_code_needed')
+        if not programs:
+            return self
+        most_interesting_program = max(programs, key=lambda p: p.discount_percentage)
         return self - (programs - most_interesting_program)

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -376,6 +376,7 @@ class SaleOrder(models.Model):
         order = self
         programs = order._get_applicable_no_code_promo_program()
         programs = programs._keep_only_most_interesting_auto_applied_global_discount_program()
+        programs = programs._keep_only_most_interesting_discount_specific_product_program()
         for program in programs:
             # VFE REF in master _get_applicable_no_code_programs already filters programs
             # why do we need to reapply this bunch of checks in _check_promo_code ????
@@ -465,6 +466,7 @@ class SaleOrder(models.Model):
         if applied_programs:
             applicable_programs = order._get_applicable_programs() + order._get_valid_applied_coupon_program()
             applicable_programs = applicable_programs._keep_only_most_interesting_auto_applied_global_discount_program()
+            applicable_programs = applicable_programs._keep_only_most_interesting_discount_specific_product_program()
         programs_to_remove = applied_programs - applicable_programs
 
         reward_product_ids = applied_programs.discount_line_product_id.ids


### PR DESCRIPTION
Steps to reproduce:
    - create two promotion programs triggered with different order quantity;
    - select "On Specific Products" for "Discount Apply On";
    - select the same specific product for both promotional programs;
    - create a sale order which triggers the promotion program with the highest quantity;
    - click on the "PROMOTIONS" button.

Issue:
    Both promotion programs are applied instead of only the most advantageous.

Cause:
	When preparing sales order lines for promotion programs, we do not look for the most advantageous offer for a specific product.

Solution:
    Add a method that allows to keep only the most advantageous promotion program for a specific product.

Remark:
    We do not modify `_keep_only_most_interesting_auto_applied_global_discount_program` and `_is_global_discount_program` methods not to change the name of these functions which are very explicit.

opw-3076331