### PR TITLE
[FIX] init multiple database with db_name config

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1283,9 +1283,9 @@ def preload_registries(dbnames):
     # TODO: move all config checks to args dont check tools.config here
     dbnames = dbnames or []
     rc = 0
+    update_module = bool(config['init'] or config['update'])
     for dbname in dbnames:
         try:
-            update_module = config['init'] or config['update']
             registry = Registry.new(dbname, update_module=update_module)
 
             # run test_file if provided


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Start a server with multiple database, eg db_name = db1,db2, only the first is properly initialized. 

Current behavior before PR:
`odoo-bin -i base -d db1,db2` only db1 properly initialized

Desired behavior after PR is merged:
Both db1 and db2 shoud be initialized.

Linked issue:
#107188 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
