### PR TITLE
[FIX] web: cannot close change password dialog

### DIFF
--- a/addons/web/static/src/legacy/js/widgets/change_password.js
+++ b/addons/web/static/src/legacy/js/widgets/change_password.js
@@ -28,7 +28,7 @@ var ChangePassword = AbstractAction.extend({
         var $button = self.$('.oe_form_button');
         $button.appendTo(this.getParent().$footer);
         $button.eq(1).click(function () {
-            self.$el.parents('.modal').modal('hide');
+            self.$el.parents('.modal').addClass('d-none')
         });
         $button.eq(0).click(function () {
             self._rpc({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- Cannot  close change password dialog

Desired behavior after PR is merged:
- Can close change password dialog



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
