### PR TITLE
[FIX] web_editor: Fix traceback with Monetary.from_html

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -515,9 +515,11 @@ class Monetary(models.AbstractModel):
     def from_html(self, model, field, element):
         lang = self.user_lang()
 
-        value = element.find('span').text.strip()
+        value = element.find('span')
+        if value is None or value.text is None:
+            return False
 
-        return float(value.replace(lang.thousands_sep, '')
+        return float(value.text.strip().replace(lang.thousands_sep, '')
                           .replace(lang.decimal_point, '.'))
 
 


### PR DESCRIPTION
A `AttributeError` traceback that occurs in `web_editor/ir_qweb_fields/Monetary:from_html` was caught by Sentry.

Because we are trying to read the text attribute of a non-existent node. A solution is checking the node before reading its value

Traceback:

![image](https://user-images.githubusercontent.com/77889661/205638462-a4a47d45-2d65-40d1-8968-b6a105c3e2ba.png)


opw-3090775