### PR TITLE
[FIX] mail: fix selection kept after textarea blur

### DIFF
--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -237,11 +237,21 @@ class Composer extends Component {
      *
      * @private
      */
-    _onClickAddAttachment() {
+    _onClickAddAttachment(ev) {
+        markEventHandled(ev, 'Composer.onClickAddAttachment');
         this._fileUploaderRef.comp.openBrowserFileUploader();
         if (!this.env.device.isMobile) {
             this.focus();
         }
+    }
+
+    /**
+     * Called when clicking on emoji button.
+     *
+     * @private
+     */
+    _onClickAddEmoji(ev) {
+        markEventHandled(ev, 'Composer.onClickAddEmoji');
     }
 
     /**
@@ -250,8 +260,21 @@ class Composer extends Component {
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickCaptureGlobal(ev) {
-        if (this.contains(ev.target)) {
+    async _onClickCaptureGlobal(ev) {
+        await new Promise(setTimeout);
+        if (!this.el) {
+            return;
+        }
+        if (
+            !this._textInputRef.el.contains(ev.target) &&
+            !this._fileUploaderRef.el.contains(ev.target) &&
+            !isEventHandled(ev, 'Composer.onClickAddAttachment') &&
+            !isEventHandled(ev, 'Composer.onClickAddEmoji') &&
+            !isEventHandled(ev, 'EmojiPopover.onClickEmoji')
+        ) {
+            this._textInputRef.comp.resetSelectionState();
+        }
+        if (this.contains(ev.target) || isEventHandled(ev, "EmojiPopover.onClickEmoji")) {
             return;
         }
         this.composer.discard();

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -103,6 +103,7 @@
                                             'o-open': false and state.displayed,
                                             'o-mobile': env.messaging.device.isMobile,
                                         }"
+                                        t-on-click="_onClickAddEmoji"
                                         t-on-keydown="_onKeydownEmojiButton"
                                         aria-label="Emojis"
                                         t-att-aria-expanded="false and (state.displayed ? 'true' : 'false')"

--- a/addons/mail/static/src/components/composer/composer_tests.js
+++ b/addons/mail/static/src/components/composer/composer_tests.js
@@ -257,6 +257,7 @@ QUnit.test('add emoji replaces (keyboard) text selection', async function (asser
 
     // simulate selection of all the content by keyboard
     composerTextInputTextArea.setSelectionRange(0, composerTextInputTextArea.value.length);
+    composerTextInputTextArea.dispatchEvent(new KeyboardEvent("keyup"));
 
     // select emoji
     await afterNextRender(() => document.querySelector('.o_Composer_buttonEmojis').click());
@@ -267,6 +268,39 @@ QUnit.test('add emoji replaces (keyboard) text selection', async function (asser
         document.querySelector(`.o_ComposerTextInput_textarea`).value,
         "😊",
         "whole text selection should have been replaced by emoji"
+    );
+    // ensure popover is closed
+    await nextAnimationFrame();
+    await nextAnimationFrame();
+    await nextAnimationFrame();
+});
+
+QUnit.test('selected text is not replaced after cancelling the selection', async function (assert) {
+    assert.expect(1);
+
+    await this.start();
+    const composer = this.env.models['mail.composer'].create();
+    await this.createComposerComponent(composer);
+    const composerTextInputTextArea = document.querySelector(`.o_ComposerTextInput_textarea`);
+    await afterNextRender(() => {
+        composerTextInputTextArea.focus();
+        document.execCommand('insertText', false, "Blabla");
+    });
+
+    // simulate selection of all the content by keyboard
+    composerTextInputTextArea.setSelectionRange(0, composerTextInputTextArea.value.length);
+    composerTextInputTextArea.dispatchEvent(new KeyboardEvent("keyup"));
+    // cancel selection
+    await afterNextRender(() => document.querySelector(".o_Composer_sidebarMain").click());
+    // select emoji
+    await afterNextRender(() => document.querySelector('.o_Composer_buttonEmojis').click());
+    await afterNextRender(() =>
+        document.querySelector('.o_EmojisPopover_emoji[data-unicode="😊"]').click()
+    );
+    assert.strictEqual(
+        document.querySelector(`.o_ComposerTextInput_textarea`).value,
+        "Blabla😊",
+        "Text should still be present"
     );
     // ensure popover is closed
     await nextAnimationFrame();

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -212,8 +212,13 @@ class ComposerTextInput extends Component {
      * @private
      */
     _onFocusoutTextarea() {
-        this.saveStateInStore();
         this.composer.update({ hasFocus: false });
+    }
+
+    resetSelectionState() {
+        const { el } = this._textareaRef;
+        el.selectionStart = el.selectionEnd = el.value.length;
+        this.saveStateInStore();
     }
 
     /**

--- a/addons/mail/static/src/components/emojis_popover/emojis_popover.js
+++ b/addons/mail/static/src/components/emojis_popover/emojis_popover.js
@@ -4,6 +4,7 @@ odoo.define('mail/static/src/components/emojis_popover/emojis_popover.js', funct
 const emojis = require('mail.emojis');
 const useShouldUpdateBasedOnProps = require('mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js');
 const useUpdate = require('mail/static/src/component_hooks/use_update/use_update.js');
+const { markEventHandled } = require("mail/static/src/utils/utils.js");
 
 const { Component } = owl;
 
@@ -60,6 +61,7 @@ class EmojisPopover extends Component {
      * @param {MouseEvent} ev
      */
     _onClickEmoji(ev) {
+        markEventHandled(ev, "EmojiPopover.onClickEmoji");
         this.close();
         this.trigger('o-emoji-selection', {
             unicode: ev.currentTarget.dataset.unicode,


### PR DESCRIPTION
Before this commit, the composer selection modelisation was not updated when the textarea lost focus. As a result, selecting text in the composer, unselecting it then adding an emoji would result in the text being replaced by the emoji while the intent of the user was clearly to keep it.

This commit fixes the issue by adapting de saved selection upon the reception of the composer textarea blur event.