### PR TITLE
[FIX] web: fix disabled checkboxes hover style

### DIFF
--- a/addons/web/static/src/legacy/scss/utils.scss
+++ b/addons/web/static/src/legacy/scss/utils.scss
@@ -147,7 +147,7 @@
 
 @mixin o-field-pointer() {
     // Force `pointer`cursor on  inputs and labels
-    &:not(:disabled):not(.disabled) {
+    &:not(:disabled):not(.disabled):not(:has(:disabled)) {
         &, input, label {
             cursor: pointer;
         }


### PR DESCRIPTION
This commit fixes the appearance of disabled input/select. Since those inputs can be childrens of form-check elements, the mixin used to style the hover state was incorrect. The disabled state should not only be given to the root element with the form-check classname, but might be given to input directly.

This new selector matches all elements that have no disabled attribute, and no disabled attribute on its children.