### PR TITLE
[MERGE] mail, various: update composer, use editable fields

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -78,7 +78,6 @@ class AccountInvoiceSend(models.TransientModel):
             if wizard.composer_id:
                 wizard.composer_id.template_id = wizard.template_id.id
                 wizard._compute_composition_mode()
-                wizard.composer_id._onchange_template_id_wrapper()
 
     @api.onchange('is_email')
     def onchange_is_email(self):
@@ -94,7 +93,6 @@ class AccountInvoiceSend(models.TransientModel):
                 self.composer_id.composition_mode = 'comment' if len(res_ids) == 1 else 'mass_mail'
                 self.composer_id.template_id = self.template_id.id
                 self._compute_composition_mode()
-            self.composer_id._onchange_template_id_wrapper()
 
     @api.onchange('is_email')
     def _compute_invoice_without_email(self):

--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -14,10 +14,17 @@
                         <field name="move_types"/>
                     </div>
                     <!-- truly invisible fields for control and options -->
+                    <field name="author_id" invisible="1"/>
                     <field name="composition_mode" invisible="1"/>
-                    <field name="invoice_ids" invisible="1"/>
                     <field name="email_from" invisible="1" />
+                    <field name="invoice_ids" invisible="1"/>
+                    <field name="lang" invisible="1"/>
                     <field name="mail_server_id" invisible="1"/>
+                    <field name="model" invisible="1"/>
+                    <field name="render_model" invisible="1"/>
+                    <field name="res_ids" invisible="1"/>
+                    <field name="subtype_id" invisible="1"/>
+
                     <div name="option_print">
                         <field name="is_print" />
                         <b><label for="is_print"/></b>

--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -28,7 +28,9 @@
                     <div name="option_print">
                         <field name="is_print" />
                         <b><label for="is_print"/></b>
-                        <div name="info_form" attrs="{'invisible': ['|', ('is_print', '=', False), ('composition_mode', '=', 'mass_mail')]}" class="text-center text-muted d-inline-block">
+                        <div name="info_form"
+                             attrs="{'invisible': ['|', ('is_print', '=', False), ('composition_mode', '=', 'mass_mail')]}"
+                             class="text-center text-muted d-inline-block ms-2">
                             Preview as a PDF
                         </div>
                     </div>
@@ -36,8 +38,8 @@
                         <field name="is_email" />
                         <b><label for="is_email"/></b>
                     </div>
-                    <div class="text-start d-inline-block mr8" attrs="{'invisible': ['|', ('is_email','=', False), ('invoice_without_email', '=', False)]}">
-                        <field name="invoice_without_email" class="mr4"/>
+                    <div class="text-start d-inline-block me-3" attrs="{'invisible': ['|', ('is_email','=', False), ('invoice_without_email', '=', False)]}">
+                        <field name="invoice_without_email" class="me-3"/>
                     </div>
                     <div name="mail_form"  attrs="{'invisible': [('is_email', '=', False)]}">
                         <!-- visible wizard -->

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -262,7 +262,7 @@ class AccountEdiDocument(models.Model):
         Can be overridden where e.g. a zip-file needs to be sent with the individual files instead of the entire zip
         IMPORTANT:
         * If the attachment's id is returned, no new attachment will be created, the existing one on the move is linked
-        to the wizard (see _onchange_template_id in mail.compose.message).
+        to the wizard (see computed attachment_ids field in mail.compose.message).
         * If the attachment's content is returned, a new one is created and linked to the wizard. Thus, when sending
         the mail (clicking on 'send & print' in the wizard), a new attachment is added to the move (see
         _action_send_mail in mail.compose.message).

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -113,13 +113,15 @@ class Attendee(models.Model):
                 event_id = attendee.event_id.id
                 ics_file = ics_files.get(event_id)
 
-                attachment_values = []
+                attachment_ids = None
                 if ics_file:
-                    attachment_values = [
-                        (0, 0, {'name': 'invitation.ics',
-                                'mimetype': 'text/calendar',
-                                'datas': base64.b64encode(ics_file)})
-                    ]
+                    attachment_ids = self.env['ir.attachment'].create({
+                        'datas': base64.b64encode(ics_file),
+                        'description': 'invitation.ics',
+                        'mimetype': 'text/calendar',
+                        'name': 'invitation.ics',
+                    }).ids
+
                 body = mail_template._render_field(
                     'body_html',
                     attendee.ids,
@@ -135,8 +137,9 @@ class Attendee(models.Model):
                     subject=subject,
                     partner_ids=attendee.partner_id.ids,
                     email_layout_xmlid='mail.mail_notification_light',
-                    attachment_ids=attachment_values,
-                    force_send=force_send)
+                    attachment_ids=attachment_ids,
+                    force_send=force_send,
+                )
 
     def do_tentative(self):
         """ Makes event invitation as Tentative. """

--- a/addons/contacts/__manifest__.py
+++ b/addons/contacts/__manifest__.py
@@ -15,6 +15,9 @@ You can track your vendors, customers and other contacts.
     'data': [
         'views/contact_views.xml',
     ],
+    'demo': [
+        'data/mail_demo.xml',
+    ],
     'application': True,
     'license': 'LGPL-3',
     'assets': {

--- a/addons/contacts/data/mail_demo.xml
+++ b/addons/contacts/data/mail_demo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data noupdate="1">
+
+    <!-- Message with scheduled notification -->
+    <record id="message_demo_partner_2_0" model="mail.message">
+        <field name="author_id" ref="base.partner_demo"/>
+        <field name="body" type="html"><p>Hello! Could you send us your address ?</p></field>
+        <field name="date" eval="(DateTime.today() - timedelta(days=1)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_2"/>
+        <field name="message_type">email</field>
+        <field name="subtype_id" ref="mail.mt_comment"/>
+    </record>
+    <record id="message_demo_partner_1_5_notif_0" model="mail.message.schedule">
+        <field name="mail_message_id" ref="message_demo_partner_2_0"/>
+        <field name="scheduled_datetime" eval="(DateTime.today() + timedelta(days=2)).strftime('%Y-%m-%d %H:%M:00')"/>
+    </record>
+
+</data></odoo>

--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -175,7 +175,7 @@ class DataRecycleModel(models.Model):
         partner_ids = self.notify_user_ids.partner_id.ids if records_count else []
         if partner_ids:
             menu_id = self.env.ref('data_recycle.menu_data_cleaning_root').id
-            self.env['mail.thread'].with_context(mail_notify_author=True).message_notify(
+            self.env['mail.thread'].message_notify(
                 body=self.env['ir.qweb']._render(
                     'data_recycle.notification',
                     {
@@ -186,6 +186,7 @@ class DataRecycleModel(models.Model):
                     }
                 ),
                 model=self._name,
+                notify_author=True,
                 partner_ids=partner_ids,
                 res_id=self.id,
                 subject=_('Data to Recycle'),

--- a/addons/hr_recruitment_survey/__init__.py
+++ b/addons/hr_recruitment_survey/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from . import wizard

--- a/addons/hr_recruitment_survey/models/__init__.py
+++ b/addons/hr_recruitment_survey/models/__init__.py
@@ -3,4 +3,4 @@
 
 from . import hr_job
 from . import hr_applicant
-from . import survey_invite
+from . import survey_user_input

--- a/addons/hr_recruitment_survey/models/survey_invite.py
+++ b/addons/hr_recruitment_survey/models/survey_invite.py
@@ -31,18 +31,12 @@ class SurveyInvite(models.TransientModel):
 class SurveyUserInput(models.Model):
     _inherit = "survey.user_input"
 
-    applicant_id = fields.One2many('hr.applicant', 'response_id', string='Applicant')
+    applicant_ids = fields.One2many('hr.applicant', 'response_id', string='Applicant')
 
     def _mark_done(self):
         odoobot = self.env.ref('base.partner_root')
         for user_input in self:
-            if user_input.applicant_id:
-                body = _('The applicant "%s" has finished the survey.', user_input.applicant_id.partner_name)
-                user_input.applicant_id.message_post(body=body, author_id=odoobot.id)
+            if user_input.applicant_ids:
+                body = _('The applicant "%s" has finished the survey.', user_input.applicant_ids[:1].partner_name)
+                user_input.applicant_ids.message_post(body=body, author_id=odoobot.id)
         return super()._mark_done()
-
-    @api.model_create_multi
-    def create(self, values_list):
-        if 'default_applicant_id' in self.env.context:
-            self = self.with_context(default_applicant_id=False)
-        return super().create(values_list)

--- a/addons/hr_recruitment_survey/models/survey_user_input.py
+++ b/addons/hr_recruitment_survey/models/survey_user_input.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class SurveyUserInput(models.Model):
+    _inherit = "survey.user_input"
+
+    applicant_ids = fields.One2many('hr.applicant', 'response_id', string='Applicant')
+
+    def _mark_done(self):
+        odoobot = self.env.ref('base.partner_root')
+        for user_input in self:
+            if user_input.applicant_ids:
+                body = _('The applicant "%s" has finished the survey.', user_input.applicant_ids[:1].partner_name)
+                user_input.applicant_ids.message_post(body=body, author_id=odoobot.id)
+        return super()._mark_done()

--- a/addons/hr_recruitment_survey/wizard/__init__.py
+++ b/addons/hr_recruitment_survey/wizard/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import survey_invite

--- a/addons/hr_recruitment_survey/wizard/survey_invite.py
+++ b/addons/hr_recruitment_survey/wizard/survey_invite.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import fields, models, _
 from odoo.tools.misc import clean_context
 
 
@@ -26,17 +26,3 @@ class SurveyInvite(models.TransientModel):
             body = '<p>%s</p>' % content
             self.applicant_id.message_post(body=body)
         return super().action_invite()
-
-
-class SurveyUserInput(models.Model):
-    _inherit = "survey.user_input"
-
-    applicant_ids = fields.One2many('hr.applicant', 'response_id', string='Applicant')
-
-    def _mark_done(self):
-        odoobot = self.env.ref('base.partner_root')
-        for user_input in self:
-            if user_input.applicant_ids:
-                body = _('The applicant "%s" has finished the survey.', user_input.applicant_ids[:1].partner_name)
-                user_input.applicant_ids.message_post(body=body, author_id=odoobot.id)
-        return super()._mark_done()

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -73,6 +73,7 @@ class TestImLivechatMessage(TransactionCase):
             'recipients': [],
             'record_name': "test1 Ernest Employee",
             'res_id': channel_livechat_1.id,
+            'scheduledDatetime': False,
             'sms_ids': [],
             'starred_partner_ids': [],
             'subject': False,

--- a/addons/l10n_generic_coa/tests/test_mail_performance.py
+++ b/addons/l10n_generic_coa/tests/test_mail_performance.py
@@ -302,7 +302,7 @@ class TestAccountComposerPerformance(BaseMailAccountPerformance):
                 )),
             },
             fields_values={
-                'auto_delete': False,
+                'auto_delete': True,
                 'email_from': self.user_account_other.email_formatted,
                 'is_notification': True,  # should keep logs by default
                 'mail_server_id': self.mail_server_global,
@@ -406,7 +406,7 @@ class TestAccountComposerPerformance(BaseMailAccountPerformance):
                 )),
             },
             fields_values={
-                'auto_delete': False,
+                'auto_delete': True,
                 'email_from': self.user_account_other.email_formatted,
                 'is_notification': True,  # should keep logs by default
                 'mail_server_id': self.mail_server_global,

--- a/addons/l10n_generic_coa/tests/test_mail_performance.py
+++ b/addons/l10n_generic_coa/tests/test_mail_performance.py
@@ -269,10 +269,8 @@ class TestAccountComposerPerformance(BaseMailAccountPerformance):
         self.assertEqual(len(print_msg.attachment_ids), 3)
         self.assertNotIn(self.attachments, print_msg.attachment_ids,
                          'Attachments should be duplicated, not just linked')
-        self.assertEqual(print_msg.author_id, self.env.user.partner_id,
-                         'TODO: not synchronized with email_from choice')
-        # self.assertEqual(print_msg.author_id, self.user_account_other.partner_id,
-        #                  'Should take invoice_user_id partner')
+        self.assertEqual(print_msg.author_id, self.user_account_other.partner_id,
+                         'Should take invoice_user_id partner')
         self.assertEqual(print_msg.email_from, self.user_account_other.email_formatted,
                          'Should take invoice_user_id email')
         self.assertEqual(print_msg.notified_partner_ids, test_customer + self.user_accountman.partner_id)
@@ -285,7 +283,7 @@ class TestAccountComposerPerformance(BaseMailAccountPerformance):
         self.assertMailMail(
             test_customer,
             'sent',
-            author=self.user_account.partner_id,  # author: current user, not synchronized with email_from of template
+            author=self.user_account_other.partner_id,  # author: synchronized with email_from of template
             content=f'TemplateBody for {test_move.name}',
             email_values={
                 'attachments_info': [
@@ -373,10 +371,8 @@ class TestAccountComposerPerformance(BaseMailAccountPerformance):
         self.assertEqual(len(print_msg.attachment_ids), 3)
         self.assertNotIn(self.attachments, print_msg.attachment_ids,
                          'Attachments should be duplicated, not just linked')
-        self.assertEqual(print_msg.author_id, self.env.user.partner_id,
-                         'TODO: not synchronized with email_from choice')
-        # self.assertEqual(print_msg.author_id, self.user_account_other.partner_id,
-        #                  'Should take invoice_user_id partner')
+        self.assertEqual(print_msg.author_id, self.user_account_other.partner_id,
+                         'Should take invoice_user_id partner')
         self.assertEqual(print_msg.email_from, self.user_account_other.email_formatted,
                          'Should take invoice_user_id email')
         self.assertEqual(print_msg.notified_partner_ids, test_customer + self.user_accountman.partner_id)
@@ -389,7 +385,7 @@ class TestAccountComposerPerformance(BaseMailAccountPerformance):
         self.assertMailMail(
             test_customer,
             'sent',
-            author=self.user_account.partner_id,  # author: current user, not synchronized with email_from of template
+            author=self.user_account_other.partner_id,  # author: synchronized with email_from of template
             content=f'SpanishBody for {test_move.name}',  # translated version
             email_values={
                 'attachments_info': [

--- a/addons/l10n_generic_coa/tests/test_mail_performance.py
+++ b/addons/l10n_generic_coa/tests/test_mail_performance.py
@@ -61,7 +61,7 @@ class BaseMailAccountPerformance(AccountTestInvoicingCommon, MailCommon):
                        ])
             ],
             'login': 'user_account',
-            'name': 'Ernest Employee',
+            'name': 'Ernest Employee Account',
             'notification_type': 'inbox',
             'signature': '--\nErnest',
         })
@@ -77,7 +77,7 @@ class BaseMailAccountPerformance(AccountTestInvoicingCommon, MailCommon):
                        ])
             ],
             'login': 'user_account_other',
-            'name': 'Eglantine Employee',
+            'name': 'Eglantine Employee AccountOther',
             'notification_type': 'inbox',
             'signature': '--\nEglantine',
         })
@@ -133,6 +133,19 @@ class BaseMailAccountPerformance(AccountTestInvoicingCommon, MailCommon):
 @tagged('mail_performance', 'account_performance', 'post_install_l10n', 'post_install', '-at_install')
 class TestAccountComposerPerformance(BaseMailAccountPerformance):
     """ Test performance of custom composer for moves. """
+
+    def test_assert_initial_values(self):
+        """ Test initial values to ease understanding of results and notifications """
+        for move in self.test_account_moves:
+            with self.subTest(move=move):
+                self.assertEqual(
+                    move.invoice_user_id,
+                    self.user_account_other,
+                )
+                self.assertEqual(
+                    move.message_partner_ids,
+                    self.user_accountman.partner_id,
+                )
 
     @users('user_account')
     @warmup

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -68,7 +68,7 @@ class MailTemplate(models.Model):
         'ir.actions.report', relation='mail_template_ir_actions_report_rel',
         column1='mail_template_id',
         column2='ir_actions_report_id',
-        string='Reports to print and attach',
+        string='Dynamic Reports',
         domain="[('model', '=', model)]")
     # options
     mail_server_id = fields.Many2one('ir.mail_server', 'Outgoing Mail Server', readonly=False,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2857,7 +2857,7 @@ class MailThread(models.AbstractModel):
             } for pid in inbox_pids]
             self.env['mail.notification'].sudo().create(notif_create_values)
 
-            message_format_values = message.message_format()[0]
+            message_format_values = message.message_format(msg_vals=msg_vals)[0]
             for partner_id in inbox_pids:
                 bus_notifications.append((self.env['res.partner'].browse(partner_id), 'mail.message/inbox', dict(message_format_values)))
         self.env['bus.bus'].sudo()._sendmany(bus_notifications)

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -76,6 +76,11 @@
                                 on <a class="o_MessageView_originThreadLink fs-6" t-att-href="message.originThread.url" t-on-click="onClickOriginThread"><t t-if="message.originThread.displayName"><t t-esc="message.originThread.displayName"/></t><t t-else="">document</t></a>
                             </t>
                         </small>
+                        <div t-if="message.scheduledDatetime" class="o_MessageView_headerScheduledDatetime" t-att-class="{ 'ms-2': isInChatWindowAndIsAlignedRight }" t-att-title="scheduledFromNow">
+                            <span class="text-600 cursor-pointer">
+                                <i class="fa fa-calendar-o"></i>
+                            </span>
+                        </div>
                         <div t-if="messageListViewItemOwner and message.originThread and message.originThread === messageListViewItemOwner.messageListViewOwner.threadViewOwner.thread and message.notifications.length > 0" t-att-class="{ 'ms-2': isInChatWindowAndIsAlignedRight }">
                             <span t-if="message.failureNotifications.length > 0" class="o_MessageView_notificationIconClickable o-error cursor-pointer text-danger" role="button" tabindex="0" t-on-click="onClickFailure">
                                 <i class="o_MessageView_notificationIcon" t-att-class="failureNotificationIconClassName" role="img" aria-label="Delivery failure"/> <span t-if="failureNotificationIconLabel" t-out="failureNotificationIconLabel"/>

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -99,6 +99,9 @@ Model({
             if ("recipients" in data) {
                 data2.recipients = data.recipients;
             }
+            if ("scheduledDatetime" in data) {
+                data2.scheduledDatetime = data.scheduledDatetime;
+            }
             if ("starred_partner_ids" in data && this.messaging.currentPartner) {
                 data2.isStarred = data.starred_partner_ids.includes(
                     this.messaging.currentPartner.id
@@ -698,6 +701,23 @@ Model({
             },
         }),
         recipients: many("Partner"),
+        /**
+         * In case of delayed notification, a scheduled datetime linked to the
+         * message scheduler is given in order to display it new to the post
+         * datetime.
+         */
+        scheduledDatetime: attr(),
+        scheduledMomentDate: attr({
+            compute() {
+                if (!this.scheduledDatetime) {
+                    return clear();
+                }
+                if (!moment.isMoment(this.scheduledDatetime)) {
+                    return moment(str_to_datetime(this.scheduledDatetime));
+                }
+                return this.scheduledDatetime;
+            },
+        }),
         shortTime: attr({
             compute() {
                 if (!this.momentDate) {

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -713,5 +713,22 @@ Model({
                 return this.env._t("Read More");
             },
         }),
+        /**
+         * Scheduled for sending
+         */
+        scheduledFromNow: attr({
+            compute() {
+                if (!this.message) {
+                    return clear();
+                }
+                if (!this.message.scheduledMomentDate) {
+                    return clear();
+                }
+                if (!this.clockWatcher.clock.date) {
+                    return clear();
+                }
+                return this.message.scheduledMomentDate.fromNow();
+            },
+        }),
     },
 });

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1072,7 +1072,7 @@ class MailCommon(common.TransactionCase, MailCase):
         return cls.user_portal
 
     @classmethod
-    def _create_records_for_batch(cls, model, count, additional_values=None, prefix=None):
+    def _create_records_for_batch(cls, model, count, additional_values=None, prefix=''):
         additional_values = additional_values or {}
         records = cls.env[model]
         partners = cls.env['res.partner']

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -149,6 +149,7 @@ class MailComposer(models.TransientModel):
     composition_batch = fields.Boolean(
         'Batch composition', compute='_compute_composition_batch')  # more than 1 record (raw source)
     model = fields.Char('Related Document Model')
+    model_is_thread = fields.Boolean('Thread-Enabled', compute='_compute_model_is_thread')
     res_ids = fields.Text('Related Document IDs')
     res_domain = fields.Text('Active domain')
     res_domain_user_id = fields.Many2one(
@@ -226,6 +227,13 @@ class MailComposer(models.TransientModel):
                 continue
             res_ids = composer._evaluate_res_ids()
             composer.composition_batch = len(res_ids) > 1 if res_ids else False
+
+    @api.depends('model')
+    def _compute_model_is_thread(self):
+        """ Determine if model is thread enabled. """
+        for composer in self:
+            model = self.env['ir.model']._get(composer.model)
+            composer.model_is_thread = model.is_mail_thread
 
     @api.depends('subtype_id')
     def _compute_subtype_is_log(self):

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -498,6 +498,8 @@ class MailComposer(models.TransientModel):
         messages = self.env['mail.message']
         for res_id, post_values in post_values_all.items():
             if ActiveModel._name == 'mail.thread':
+                post_values.pop('message_type')  # forced to user_notification
+                post_values.pop('parent_id', False)  # not supported in notify
                 if self.model:
                     post_values['model'] = self.model
                     post_values['res_id'] = res_id

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -228,9 +228,12 @@ class MailComposer(models.TransientModel):
 
     @api.depends('subtype_id')
     def _compute_subtype_is_log(self):
+        """ In comment mode, tells whether the subtype is a note. Subtype has
+        no use in email mode, and this field will be False. """
         note_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
-        for composer in self:
-            composer.subtype_is_log = not composer.subtype_id or composer.subtype_id.id == note_id
+        self.subtype_is_log = False
+        for composer in self.filtered('subtype_id'):
+            composer.subtype_is_log = composer.subtype_id.id == note_id
 
     @api.depends('reply_to_force_new')
     def _compute_reply_to_mode(self):

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -19,6 +19,7 @@
                         <field name="lang" invisible="1"/>
                         <field name="mail_server_id" invisible="1"/>
                         <field name="model" invisible="1"/>
+                        <field name="model_is_thread" invisible="1"/>
                         <field name="parent_id" invisible="1"/>
                         <field name="record_name" invisible="1"/>
                         <field name="render_model" invisible="1"/>

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -495,7 +495,7 @@ class MailGroup(models.Model):
 
         for group in groups:
             moderators_to_notify = group.moderator_ids
-            MailThread = self.env['mail.thread'].with_context(mail_notify_author=True)
+            MailThread = self.env['mail.thread']
             for moderator in moderators_to_notify:
                 body = self.env['ir.qweb']._render('mail_group.mail_group_notify_moderation', {
                     'moderator': moderator,
@@ -508,6 +508,7 @@ class MailGroup(models.Model):
                     body=body,
                     email_from=email_from,
                     model='mail.group',
+                    notify_author=True,
                     res_id=group.id,
                 )
 

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class MailComposeMessage(models.TransientModel):
@@ -11,13 +11,6 @@ class MailComposeMessage(models.TransientModel):
     campaign_id = fields.Many2one('utm.campaign', string='Mass Mailing Campaign', ondelete='set null')
     mass_mailing_name = fields.Char(string='Mass Mailing Name', help='If set, a mass mailing will be created so that you can track its results in the Email Marketing app.')
     mailing_list_ids = fields.Many2many('mailing.list', string='Mailing List')
-    model_is_thread = fields.Boolean(compute='_compute_model_is_thread')
-
-    @api.depends('model')
-    def _compute_model_is_thread(self):
-        for composer in self:
-            model = self.env['ir.model']._get(composer.model)
-            composer.model_is_thread = model.is_mail_thread
 
     def _action_send_mail(self, auto_commit=False):
         """ Override to generate the mass mailing in case only the name was

--- a/addons/mass_mailing/wizard/mail_compose_message_views.xml
+++ b/addons/mass_mailing/wizard/mail_compose_message_views.xml
@@ -8,7 +8,6 @@
             <field name="inherit_id" ref="mail.email_compose_message_wizard_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='auto_delete_keep_log']" position="after">
-                    <field name="model_is_thread" invisible="1"/>
                     <field name="campaign_id" groups="mass_mailing.group_mass_mailing_campaign"
                         attrs="{'invisible': ['|', ('composition_mode', '!=', 'mass_mail'), ('model_is_thread', '!=', True)]}"/>
                     <field name="mass_mailing_name"

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -334,8 +334,8 @@ class PurchaseOrder(models.Model):
         if self.env.context.get('mark_rfq_as_sent'):
             self.filtered(lambda o: o.state == 'draft').write({'state': 'sent'})
         po_ctx = {'mail_post_autofollow': self.env.context.get('mail_post_autofollow', True)}
-        if self.env.context.get('mark_rfq_as_sent'):
-            po_ctx['mail_notify_author'] = self.env.user.partner_id.id in (kwargs.get('partner_ids') or [])
+        if self.env.context.get('mark_rfq_as_sent') and 'notify_author' not in kwargs:
+            kwargs['notify_author'] = self.env.user.partner_id.id in (kwargs.get('partner_ids') or [])
         return super(PurchaseOrder, self.with_context(**po_ctx)).message_post(**kwargs)
 
     def _notify_get_recipients_groups(self, msg_vals=None):

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -26,8 +26,8 @@ class MailMessage(models.Model):
         ])
         return [('id', 'in', ratings.mapped('message_id').ids)]
 
-    def message_format(self, format_reply=True):
-        message_values = super().message_format(format_reply=format_reply)
+    def message_format(self, format_reply=True, msg_vals=None):
+        message_values = super().message_format(format_reply=format_reply, msg_vals=msg_vals)
         rating_mixin_messages = self.filtered(lambda message:
             message.model
             and message.res_id

--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -110,7 +110,7 @@ class ResCompany(models.Model):
         sample_sales_order = self._get_sample_sales_order()
         template = self.env.ref('sale.email_template_edi_sale', False)
 
-        message_composer = self.env['mail.compose.message'].with_context(
+        self.env['mail.compose.message'].with_context(
             mark_so_as_sent=True,
             default_email_layout_xmlid='mail.mail_notification_layout_with_responsible_signature',
             proforma=self.env.context.get('proforma', False),
@@ -120,15 +120,7 @@ class ResCompany(models.Model):
             'template_id': template.id if template else False,
             'model': sample_sales_order._name,
             'composition_mode': 'comment',
-        })
-
-        # Simulate the onchange (like trigger in form the view)
-        update_values = message_composer._onchange_template_id(
-            template.id, 'comment', sample_sales_order._name, sample_sales_order.ids
-        )['value']
-        message_composer.write(update_values)
-
-        message_composer._action_send_mail()
+        })._action_send_mail()
 
         self.set_onboarding_step_done('sale_onboarding_sample_quotation_state')
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1232,8 +1232,8 @@ class SaleOrder(models.Model):
         if self.env.context.get('mark_so_as_sent'):
             self.filtered(lambda o: o.state == 'draft').with_context(tracking_disable=True).write({'state': 'sent'})
         so_ctx = {'mail_post_autofollow': self.env.context.get('mail_post_autofollow', True)}
-        if self.env.context.get('mark_so_as_sent'):
-            so_ctx['mail_notify_author'] = self.env.user.partner_id.id in (kwargs.get('partner_ids') or [])
+        if self.env.context.get('mark_so_as_sent') and 'mail_notify_author' not in kwargs:
+            kwargs['notify_author'] = self.env.user.partner_id.id in (kwargs.get('partner_ids') or [])
         return super(SaleOrder, self.with_context(**so_ctx)).message_post(**kwargs)
 
     def _notify_get_recipients_groups(self, msg_vals=None):

--- a/addons/sms/models/mail_message.py
+++ b/addons/sms/models/mail_message.py
@@ -33,13 +33,13 @@ class MailMessage(models.Model):
             return ['&', ('notification_ids.notification_status', '=', 'exception'), ('notification_ids.notification_type', '=', 'sms')]
         raise NotImplementedError()
 
-    def message_format(self, format_reply=True):
+    def message_format(self, format_reply=True, msg_vals=None):
         """ Override in order to retrieves data about SMS (recipient name and
             SMS status)
 
         TDE FIXME: clean the overall message_format thingy
         """
-        message_values = super(MailMessage, self).message_format(format_reply=format_reply)
+        message_values = super(MailMessage, self).message_format(format_reply=format_reply, msg_vals=msg_vals)
         all_sms_notifications = self.env['mail.notification'].sudo().search([
             ('mail_message_id', 'in', [r['id'] for r in message_values]),
             ('notification_type', '=', 'sms')

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -78,6 +78,9 @@ class TestServerActionsEmail(TestMailCommon, TestServerActionsBase):
         with self.assertSinglePostNotifications(
                 [{'partner': self.test_partner, 'type': 'email', 'status': 'ready'}],
                 message_info={'content': 'Hello %s' % self.test_partner.name,
+                              'fields_values': {
+                                'author_id': self.env.user.partner_id,
+                              },
                               'message_type': 'notification',
                               'subtype': 'mail.mt_comment',
                              }

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -764,8 +764,6 @@ class TestComposerInternals(TestMailComposer):
 
                 # changing template should update its content
                 composer.write({'template_id': self.template.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:
@@ -799,8 +797,6 @@ class TestComposerInternals(TestMailComposer):
                 # update with template with void values: void value is not forced in
                 # rendering mode as well as in raw mode
                 composer.write({'template_id': template_void.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 if composition_mode == 'comment' and not batch:
                     self.assertEqual(composer.body, '<p>Back to my amazing body <t t-out="record.name>/></p>')
@@ -817,18 +813,14 @@ class TestComposerInternals(TestMailComposer):
 
                 # reset template should reset values
                 composer.write({'template_id': False})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
-                # values are reset with default_get call / compute field
+                # values are reset with compute field
                 if composition_mode == 'comment' and not batch:
                     self.assertFalse(composer.body)
                     self.assertFalse(composer.mail_server_id.id)
                     self.assertEqual(composer.record_name, 'Manual update',
                                      'MailComposer: record name does not depend on template')
-                    # self.assertFalse(composer.scheduled_date)
-                    self.assertEqual(composer.scheduled_date, '{{ datetime.datetime(2023, 1, 10, 10, 0, 0) }}',
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.scheduled_date)
                     self.assertEqual(composer.subject, self.test_record._message_compute_subject())
                     self.assertIn(f'Ticket for {self.test_record.name}', composer.subject,
                                   'Check effective content')
@@ -837,9 +829,7 @@ class TestComposerInternals(TestMailComposer):
                     self.assertFalse(composer.mail_server_id.id)
                     self.assertEqual(composer.record_name, 'Manual update',
                                      'MailComposer: record name does not depend on template')
-                    # self.assertFalse(composer.scheduled_date)
-                    self.assertEqual(composer.scheduled_date, '{{ datetime.datetime(2023, 1, 10, 10, 0, 0) }}',
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.scheduled_date)
                     self.assertFalse(composer.subject)
 
                 # 2. check with default
@@ -847,8 +837,6 @@ class TestComposerInternals(TestMailComposer):
                 composer = self.env['mail.compose.message'].with_context(ctx).create({
                     'template_id': self.template.id,
                 })
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:
@@ -869,8 +857,6 @@ class TestComposerInternals(TestMailComposer):
                 composer = self.env['mail.compose.message'].with_context(ctx).create({
                     'template_id': self.template.id,
                 })
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -484,8 +484,6 @@ class TestComposerInternals(TestMailComposer):
                 composer = self.env['mail.compose.message'].with_context(ctx).create({
                     'body': '<p>Test Body</p>',
                 })
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values coming from template: attachment_ids + report in comment
                 if composition_mode == 'comment' and not batch:
@@ -515,29 +513,22 @@ class TestComposerInternals(TestMailComposer):
                 else:
                     self.assertEqual(composer.attachment_ids, attachs + extra_attach)
 
-                # update with template with void values: values are kept
+                # update with template with void values: values are kept, void
+                # value is not forced in rendering mode as well as when copying
+                # template values
                 composer.write({'template_id': template_void.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.attachment_ids, attachs + extra_attach + generated,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertEqual(composer.attachment_ids, attachs + extra_attach + generated)
                 else:
-                    self.assertEqual(composer.attachment_ids, attachs + extra_attach,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertEqual(composer.attachment_ids, attachs + extra_attach)
 
-                # reset template: values are kept
+                # reset template: values are reset
                 composer.write({'template_id': False})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
-
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.attachment_ids, attachs + extra_attach + generated,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.attachment_ids)
                 else:
-                    self.assertEqual(composer.attachment_ids, attachs + extra_attach,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.attachment_ids)
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -1098,10 +1089,8 @@ class TestComposerInternals(TestMailComposer):
             self._get_web_context(self.test_record)
         ).create({
             'body': '<p>Template Body</p>',
-            'partner_ids': [self.partner_employee_2.id],
             'template_id': template_1.id,
         })
-        composer._onchange_template_id_wrapper()
         composer._action_send_mail()
 
         self.assertEqual(

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -128,7 +128,7 @@ class TestComposerForm(TestMailComposer):
             self._get_web_context(self.test_record, add_web=True)
         ))
         self.assertTrue(composer_form.auto_delete, 'MailComposer: comment mode should remove notification emails by default')
-        self.assertTrue(composer_form.auto_delete_keep_log)
+        self.assertFalse(composer_form.auto_delete_keep_log, 'MailComposer: keep_log makes no sense in comment mode, only auto_delete')
         self.assertEqual(composer_form.author_id, self.env.user.partner_id)
         self.assertFalse(composer_form.body)
         self.assertFalse(composer_form.composition_batch)
@@ -206,7 +206,7 @@ class TestComposerForm(TestMailComposer):
             self._get_web_context(self.test_record, add_web=True, default_template_id=self.template.id)
         ))
         self.assertTrue(composer_form.auto_delete, 'Should take template value')
-        self.assertTrue(composer_form.auto_delete_keep_log)
+        self.assertFalse(composer_form.auto_delete_keep_log, 'MailComposer: keep_log makes no sense in comment mode, only auto_delete')
         self.assertEqual(composer_form.author_id, self.env.user.partner_id)
         self.assertEqual(composer_form.body, f'<p>TemplateBody {self.test_record.name}</p>')
         self.assertFalse(composer_form.composition_batch)
@@ -236,7 +236,7 @@ class TestComposerForm(TestMailComposer):
                 default_template_id=self.template.id),
         ))
         self.assertTrue(composer_form.auto_delete, 'Should take composer value')
-        self.assertTrue(composer_form.auto_delete_keep_log)
+        self.assertFalse(composer_form.auto_delete_keep_log, 'MailComposer: keep_log makes no sense in comment mode, only auto_delete')
         self.assertEqual(composer_form.author_id, self.env.user.partner_id)
         self.assertEqual(composer_form.body, self.template.body_html,
                          'MailComposer: comment in batch mode should have template raw body if template')
@@ -267,7 +267,7 @@ class TestComposerForm(TestMailComposer):
             default_template_id=self.template.id,
         ))
         self.assertTrue(composer_form.auto_delete, 'Should take composer value')
-        self.assertTrue(composer_form.auto_delete_keep_log)
+        self.assertFalse(composer_form.auto_delete_keep_log, 'MailComposer: keep_log makes no sense in comment mode, only auto_delete')
         self.assertEqual(composer_form.author_id, self.env.user.partner_id)
         self.assertEqual(composer_form.body, self.template.body_html,
                          'MailComposer: comment in batch mode should have template raw body if template')
@@ -299,7 +299,7 @@ class TestComposerForm(TestMailComposer):
             default_template_id=self.template.id,
         ))
         self.assertTrue(composer_form.auto_delete, 'Should take composer value')
-        self.assertTrue(composer_form.auto_delete_keep_log)
+        self.assertFalse(composer_form.auto_delete_keep_log, 'MailComposer: keep_log makes no sense in comment mode, only auto_delete')
         self.assertEqual(composer_form.author_id, self.env.user.partner_id)
         self.assertEqual(composer_form.body, '<p>TemplateBody </p>')
         self.assertFalse(composer_form.composition_batch)
@@ -327,7 +327,7 @@ class TestComposerForm(TestMailComposer):
             self._get_web_context(self.test_records, add_web=True)
         ))
         self.assertFalse(composer_form.auto_delete)
-        self.assertTrue(composer_form.auto_delete_keep_log)
+        self.assertFalse(composer_form.auto_delete_keep_log, 'MailComposer: if emails are kept, logs are automatically kept')
         self.assertEqual(composer_form.author_id, self.env.user.partner_id)
         self.assertFalse(composer_form.body)
         self.assertTrue(composer_form.composition_batch)
@@ -659,9 +659,10 @@ class TestComposerInternals(TestMailComposer):
                 # default creation values
                 if composition_mode == 'comment':
                     self.assertTrue(composer.auto_delete, 'By default, remove notification emails')
+                    self.assertFalse(composer.auto_delete_keep_log, 'Not used in comment mode')
                 else:
                     self.assertFalse(composer.auto_delete, 'By default, keep mailing emails')
-                self.assertTrue(composer.auto_delete_keep_log)
+                    self.assertFalse(composer.auto_delete_keep_log, 'Emails are not unlinked, logs are already kept')
                 self.assertTrue(composer.email_add_signature)
                 self.assertEqual(composer.email_layout_xmlid, 'mail.test_layout')
                 self.assertEqual(composer.message_type, 'comment')
@@ -675,7 +676,7 @@ class TestComposerInternals(TestMailComposer):
                 # values come from template
                 if composition_mode == 'comment':
                     self.assertTrue(composer.auto_delete)
-                    self.assertTrue(composer.auto_delete_keep_log)
+                    self.assertFalse(composer.auto_delete_keep_log, 'Not used in comment mode')
                     self.assertTrue(composer.email_add_signature, 'TODO: should be False as template negates this config')
                     self.assertEqual(composer.email_layout_xmlid, 'mail.test_layout')
                     self.assertEqual(composer.message_type, 'comment')
@@ -704,14 +705,12 @@ class TestComposerInternals(TestMailComposer):
                 composer._onchange_template_id_wrapper()
 
                 if composition_mode == 'comment':
-                    # self.assertFalse(composer.auto_delete, 'TODO: should be updated')
-                    self.assertTrue(composer.auto_delete)
+                    self.assertFalse(composer.auto_delete)
                     self.assertEqual(composer.message_type, 'notification')
                     self.assertEqual(composer.subtype_id, self.env.ref('mail.mt_note'))
                     self.assertTrue(composer.subtype_is_log)
                 else:
-                    # self.assertFalse(composer.auto_delete, 'TODO: should be updated')
-                    self.assertTrue(composer.auto_delete)
+                    self.assertFalse(composer.auto_delete)
                     self.assertEqual(composer.message_type, 'notification')
                     self.assertEqual(composer.subtype_id, self.env.ref('mail.mt_note'))
                     self.assertTrue(composer.subtype_is_log)
@@ -1238,7 +1237,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             'partner_ids': [(4, self.partner_1.id), (4, self.partner_2.id)]
         })
         self.assertTrue(composer.auto_delete, 'Comment mode removes notification emails by default')
-        self.assertTrue(composer.auto_delete_keep_log)
+        self.assertFalse(composer.auto_delete_keep_log, 'Not used in comment mode')
         with self.mock_mail_gateway(mail_unlink_sent=True):
             composer._action_send_mail()
 
@@ -1260,7 +1259,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             'partner_ids': [(4, self.partner_1.id), (4, self.partner_2.id)]
         })
         self.assertFalse(composer.auto_delete)
-        self.assertTrue(composer.auto_delete_keep_log)
+        self.assertFalse(composer.auto_delete_keep_log, 'Not used in comment mode')
         with self.mock_mail_gateway(mail_unlink_sent=True):
             composer._action_send_mail()
 
@@ -1684,8 +1683,7 @@ class TestComposerResultsMass(TestMailComposer):
 
         self.assertEqual(len(self._mails), 2, 'Should have sent 1 email per record')
         self.assertEqual(len(self._new_mails), 2, 'Should have created 1 mail.mail per record')
-        # self.assertEqual(self._new_mails.exists(), self._new_mails, 'Should not have deleted mail.mail records')
-        self.assertFalse(self._new_mails.exists(), 'TODO: Template is forced over composer value, which is not correct')
+        self.assertEqual(self._new_mails.exists(), self._new_mails, 'Should not have deleted mail.mail records')
         self.assertEqual(len(self._new_msgs), 2, 'Should have created 1 mail.mail per record')
         self.assertEqual(self._new_msgs.exists(), self._new_msgs, 'Should not have deleted mail.message records')
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -310,7 +310,7 @@ class TestComposerForm(TestMailComposer):
         self.assertFalse(composer_form.scheduled_date)
         self.assertFalse(composer_form.subject, 'MailComposer: mass mode should have void default subject if no template')
         self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
-        self.assertFalse(composer_form.subtype_is_log)
+        self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
     @users('employee')
     def test_mail_composer_mass_wtpl(self):
@@ -337,7 +337,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(composer_form.subject, self.template.subject,
                          'MailComposer: mass mode should have template raw subject if template')
         self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
-        self.assertFalse(composer_form.subtype_is_log)
+        self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
     @users('employee')
     def test_mail_composer_mass_wtpl_norecords(self):
@@ -368,7 +368,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(composer_form.subject, self.template.subject,
                          'MailComposer: mass mode should have template raw subject if template')
         self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
-        self.assertFalse(composer_form.subtype_is_log)
+        self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
 
 @tagged('mail_composer')

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -570,51 +570,62 @@ class TestComposerInternals(TestMailComposer):
                 self.assertEqual(composer.composition_mode, composition_mode)
                 self.assertEqual(composer.email_from, self.env.user.email_formatted)
 
-                # author values reset email (FIXME: currently not synchronized)
+                # author update should reset email (FIXME: currently not synchronized)
                 composer.write({'author_id': self.partner_1})
                 self.assertEqual(composer.author_id, self.partner_1)
-                self.assertEqual(composer.email_from, self.env.user.email_formatted)
+                self.assertEqual(composer.email_from, self.env.user.email_formatted,
+                                 'MailComposer: TODO: author / email_from are not synchronized')
                 # self.assertEqual(composer.email_from, self.partner_1.email_formatted)
 
                 # changing template should update its email_from
-                composer.write({'template_id': self.template.id, 'author_id': self.env.user.partner_id})
+                composer.write({'template_id': self.template.id})
                 # currently onchange necessary
                 composer._onchange_template_id_wrapper()
-                self.assertEqual(composer.author_id, self.env.user.partner_id,
-                                 'MailComposer: should take value given by user')
+
                 if composition_mode == 'comment' and not batch:
+                    self.assertEqual(composer.author_id, self.partner_1,
+                                     'MailComposer: TODO: should try to synchronize with email_from')
                     self.assertEqual(composer.email_from, self.test_record.user_id.email_formatted,
                                      f'MailComposer: should take email_from rendered from template ({composition_mode}-{batch})')
                 else:
+                    self.assertEqual(composer.author_id, self.partner_1,
+                                     'MailComposer: TODO: email_from is raw, what to do with it ?')
                     self.assertEqual(composer.email_from, self.template.email_from,
                                      f'MailComposer: should take email_from raw from template ({composition_mode}-{batch})')
 
                 # manual values are kept over template values
                 composer.write({'email_from': self.test_from})
-                self.assertEqual(composer.author_id, self.env.user.partner_id)
-                self.assertEqual(composer.email_from, self.test_from)
+                self.assertEqual(composer.author_id, self.partner_1)
+                self.assertEqual(composer.email_from, self.test_from,
+                                 'MailComposer: TODO: author / email_from are not synchronized')
 
                 # update with template with void values: void value is not forced in
                 # rendering mode as well as when copying template values
                 composer.write({'template_id': template_void.id})
                 # currently onchange necessary
                 composer._onchange_template_id_wrapper()
+
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.author_id, self.env.user.partner_id)
+                    self.assertEqual(composer.author_id, self.partner_1,
+                                     'MailComposer: TODO: author / email_from are not synchronized')
                     self.assertEqual(composer.email_from, self.test_from)
                 else:
-                    self.assertEqual(composer.author_id, self.env.user.partner_id)
+                    self.assertEqual(composer.author_id, self.partner_1,
+                                     'MailComposer: TODO: author / email_from are not synchronized')
                     self.assertEqual(composer.email_from, self.test_from)
 
                 # reset template: values are reset due to call to default_get
                 composer.write({'template_id': False})
                 # currently onchange necessary
                 composer._onchange_template_id_wrapper()
+
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.author_id, self.env.user.partner_id)
+                    self.assertEqual(composer.author_id, self.partner_1,
+                                     'MailComposer: TODO: author / email_from are not synchronized')
                     self.assertEqual(composer.email_from, self.env.user.email_formatted)
                 else:
-                    self.assertEqual(composer.author_id, self.env.user.partner_id)
+                    self.assertEqual(composer.author_id, self.partner_1,
+                                     'MailComposer: TODO: author / email_from are not synchronized')
                     self.assertEqual(composer.email_from, self.env.user.email_formatted)
 
     @users('employee')
@@ -1397,6 +1408,18 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                 # open a composer and run it in comment mode
                 composer_form = Form(self.env['mail.compose.message'].with_context(ctx))
                 composer = composer_form.save()
+
+                # ensure some parameters used afterwards
+                if batch:
+                    author = self.env.user.partner_id
+                    self.assertEqual(composer.author_id, author,
+                                     'Author cannot be synchronized with a raw email_from')
+                    self.assertEqual(composer.email_from, self.template.email_from)
+                else:
+                    author = self.env.user.partner_id
+                    self.assertEqual(composer.author_id, author,
+                                     'Author cannot be synchronized with a raw email_from')
+                    self.assertEqual(composer.email_from, self.partner_employee_2.email_formatted)
                 self.assertFalse(composer.reply_to_force_new, 'Mail: thread-enabled models should use auto thread by default')
 
                 # due to scheduled_date, cron for sending notification will be used
@@ -1469,7 +1492,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                     message = test_record.message_ids[0]
                     self.assertMailMail(self.partner_employee_2, 'sent',
                                         mail_message=message,
-                                        author=self.partner_employee,  # author != email_from (template sets only email_from)
+                                        author=author,  # author != email_from (template sets only email_from)
                                         email_values={
                                             'body_content': f'TemplateBody {test_record.name}',
                                             'email_from': test_record.user_id.email_formatted,  # set by template
@@ -1487,7 +1510,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
                                        )
                     self.assertMailMail(test_record.customer_id + new_partners, 'sent',
                                         mail_message=message,
-                                        author=self.partner_employee,  # author != email_from (template sets only email_from)
+                                        author=author,  # author != email_from (template sets only email_from)
                                         email_values={
                                             'body_content': f'TemplateBody {test_record.name}',
                                             'email_from': test_record.user_id.email_formatted,  # set by template
@@ -1762,6 +1785,12 @@ class TestComposerResultsMass(TestMailComposer):
                                   default_template_id=self.template.id)
         ))
         composer = composer_form.save()
+        # ensure some parameters used afterwards
+        author = self.env.user.partner_id
+        self.assertEqual(composer.author_id, author,
+                         'Author cannot be synchronized with a raw email_from')
+        self.assertEqual(composer.email_from, self.template.email_from)
+
         with self.mock_mail_gateway(mail_unlink_sent=False), \
              freeze_time(self.reference_now):
             composer._action_send_mail()
@@ -1798,7 +1827,7 @@ class TestComposerResultsMass(TestMailComposer):
             self.assertMailMail(record.customer_id + new_partners + self.partner_admin,
                                 'sent',
                                 mail_message=message,
-                                author=self.partner_employee,
+                                author=author,
                                 email_values={
                                     'attachments_info': [
                                         {'name': 'AttFileName_00.txt', 'raw': b'AttContent_00', 'type': 'text/plain'},
@@ -1843,7 +1872,7 @@ class TestComposerResultsMass(TestMailComposer):
             self.assertMailMail(record.customer_id + new_partners + self.partner_admin,
                                 'sent',
                                 mail_message=record.message_ids[0],
-                                author=self.partner_employee,
+                                author=author,
                                 email_values={
                                     'email_from': self.partner_employee_2.email_formatted,
                                     'reply_to': self.partner_employee_2.email_formatted,

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -945,8 +945,6 @@ class TestComposerInternals(TestMailComposer):
                 # rendering mode as well as when copying template values (and recipients
                 # are not computed until sending in rendering mode)
                 composer.write({'template_id': template_void.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 if composition_mode == 'comment':
                     self.assertEqual(composer.partner_ids, base_recipients)
@@ -959,8 +957,8 @@ class TestComposerInternals(TestMailComposer):
 
                 # changing template should update its content
                 composer.write({'template_id': self.template.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
+                composer.flush_recordset()  # to be able to search for new partners
+
                 new_partners = self.env['res.partner'].search(
                     [('email_normalized', 'in', ['test.cc.1@test.example.com',
                                                  'test.cc.2@test.example.com'])
@@ -985,18 +983,14 @@ class TestComposerInternals(TestMailComposer):
 
                 # reset template should reset values
                 composer.write({'template_id': False})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
-                # values are kept, should probably be reset
+                # values are reset
                 if composition_mode == 'comment' and not batch:
-                    self.assertEqual(composer.partner_ids, self.partner_admin,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.partner_ids)
                     self.assertFalse(composer.reply_to)
                     self.assertFalse(composer.reply_to_force_new)
                 else:
-                    self.assertEqual(composer.partner_ids, self.partner_admin,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.partner_ids)
                     self.assertFalse(composer.reply_to)
                     self.assertFalse(composer.reply_to_force_new)
 
@@ -1005,8 +999,6 @@ class TestComposerInternals(TestMailComposer):
                 composer = self.env['mail.compose.message'].with_context(ctx).create({
                     'template_id': self.template.id,
                 })
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:
@@ -1025,8 +1017,6 @@ class TestComposerInternals(TestMailComposer):
                 composer = self.env['mail.compose.message'].with_context(ctx).create({
                     'template_id': self.template.id,
                 })
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values come from template
                 if composition_mode == 'comment' and not batch:

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -820,8 +820,7 @@ class TestComposerInternals(TestMailComposer):
                 # currently onchange necessary
                 composer._onchange_template_id_wrapper()
 
-                # values are reset with default_get call, if it returns value
-                # (aka subject for comment mode)
+                # values are reset with default_get call / compute field
                 if composition_mode == 'comment' and not batch:
                     self.assertFalse(composer.body)
                     # self.assertFalse(composer.mail_server_id.id)
@@ -845,9 +844,7 @@ class TestComposerInternals(TestMailComposer):
                     # self.assertFalse(composer.scheduled_date)
                     self.assertEqual(composer.scheduled_date, '{{ datetime.datetime(2023, 1, 10, 10, 0, 0) }}',
                                      'TODO: Values are kept (should be reset ?)')
-                    # self.assertFalse(composer.subject)
-                    self.assertEqual(composer.subject, 'Back to my amazing subject for {{ record.name }}',
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.subject)
 
                 # 2. check with default
                 ctx['default_template_id'] = self.template.id

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -343,7 +343,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(sorted(literal_eval(composer_form.res_ids)), sorted(self.test_records.ids))
         self.assertFalse(composer_form.scheduled_date)
         self.assertFalse(composer_form.subject, 'MailComposer: mass mode should have void default subject if no template')
-        self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
+        self.assertFalse(composer_form.subtype_id, 'MailComposer: subtype is not used in mail mode')
         self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
     @users('employee')
@@ -372,7 +372,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(composer_form.scheduled_date, self.template.scheduled_date)
         self.assertEqual(composer_form.subject, self.template.subject,
                          'MailComposer: mass mode should have template raw subject if template')
-        self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
+        self.assertFalse(composer_form.subtype_id, 'MailComposer: subtype is not used in mail mode')
         self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
     @users('employee')
@@ -405,7 +405,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(composer_form.scheduled_date, self.template.scheduled_date)
         self.assertEqual(composer_form.subject, self.template.subject,
                          'MailComposer: mass mode should have template raw subject if template')
-        self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
+        self.assertFalse(composer_form.subtype_id, 'MailComposer: subtype is not used in mail mode')
         self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
     @users('employee')
@@ -436,7 +436,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(composer_form.scheduled_date, self.template.scheduled_date)
         self.assertEqual(composer_form.subject, self.template.subject,
                          'MailComposer: mass mode should have template raw subject if template')
-        self.assertEqual(composer_form.subtype_id, self.env.ref('mail.mt_comment'))
+        self.assertFalse(composer_form.subtype_id, 'MailComposer: subtype is not used in mail mode')
         self.assertFalse(composer_form.subtype_is_log, 'MailComposer: subtype is log has no meaning in mail mode')
 
 
@@ -654,18 +654,17 @@ class TestComposerInternals(TestMailComposer):
                 if composition_mode == 'comment':
                     self.assertTrue(composer.auto_delete, 'By default, remove notification emails')
                     self.assertFalse(composer.auto_delete_keep_log, 'Not used in comment mode')
+                    self.assertEqual(composer.subtype_id, self.env.ref('mail.mt_comment'))
                 else:
                     self.assertFalse(composer.auto_delete, 'By default, keep mailing emails')
                     self.assertFalse(composer.auto_delete_keep_log, 'Emails are not unlinked, logs are already kept')
+                    self.assertFalse(composer.subtype_id)
                 self.assertTrue(composer.email_add_signature)
                 self.assertEqual(composer.email_layout_xmlid, 'mail.test_layout')
                 self.assertEqual(composer.message_type, 'comment')
-                self.assertEqual(composer.subtype_id, self.env.ref('mail.mt_comment'))
 
                 # changing template should update its content
                 composer.write({'template_id': self.template.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 # values come from template
                 if composition_mode == 'comment':
@@ -681,7 +680,7 @@ class TestComposerInternals(TestMailComposer):
                     self.assertTrue(composer.email_add_signature, 'TODO: should be False as template negates this config')
                     self.assertEqual(composer.email_layout_xmlid, 'mail.test_layout')
                     self.assertEqual(composer.message_type, 'comment')
-                    self.assertEqual(composer.subtype_id, self.env.ref('mail.mt_comment'))
+                    self.assertFalse(composer.subtype_id)
 
                 # manual update
                 composer.write({
@@ -695,8 +694,6 @@ class TestComposerInternals(TestMailComposer):
                 # update with template with void values: void value is forced for
                 # booleans, cannot distinguish
                 composer.write({'template_id': template_falsy.id})
-                # currently onchange necessary
-                composer._onchange_template_id_wrapper()
 
                 if composition_mode == 'comment':
                     self.assertFalse(composer.auto_delete)

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -823,9 +823,7 @@ class TestComposerInternals(TestMailComposer):
                 # values are reset with default_get call / compute field
                 if composition_mode == 'comment' and not batch:
                     self.assertFalse(composer.body)
-                    # self.assertFalse(composer.mail_server_id.id)
-                    self.assertEqual(composer.mail_server_id, self.mail_server_global,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.mail_server_id.id)
                     self.assertEqual(composer.record_name, 'Manual update',
                                      'MailComposer: record name does not depend on template')
                     # self.assertFalse(composer.scheduled_date)
@@ -836,9 +834,7 @@ class TestComposerInternals(TestMailComposer):
                                   'Check effective content')
                 else:
                     self.assertFalse(composer.body)
-                    # self.assertFalse(composer.mail_server_id.id)
-                    self.assertEqual(composer.mail_server_id, self.mail_server_global,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.mail_server_id.id)
                     self.assertEqual(composer.record_name, 'Manual update',
                                      'MailComposer: record name does not depend on template')
                     # self.assertFalse(composer.scheduled_date)

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -819,16 +819,14 @@ class TestComposerInternals(TestMailComposer):
                 composer._onchange_template_id_wrapper()
 
                 # values are reset with default_get call, if it returns value
-                # (aka subject for comment mode), and not record_name because
-                # it was forgotten probably
+                # (aka subject for comment mode)
                 if composition_mode == 'comment' and not batch:
                     self.assertFalse(composer.body)
                     # self.assertFalse(composer.mail_server_id.id)
                     self.assertEqual(composer.mail_server_id, self.mail_server_global,
                                      'TODO: Values are kept (should be reset ?)')
-                    # self.assertEqual(composer.record_name, self.test_record.name)
                     self.assertEqual(composer.record_name, 'Manual update',
-                                     'TODO: Reset not called')
+                                     'MailComposer: record name does not depend on template')
                     # self.assertFalse(composer.scheduled_date)
                     self.assertEqual(composer.scheduled_date, '{{ datetime.datetime(2023, 1, 10, 10, 0, 0) }}',
                                      'TODO: Values are kept (should be reset ?)')
@@ -840,9 +838,8 @@ class TestComposerInternals(TestMailComposer):
                     # self.assertFalse(composer.mail_server_id.id)
                     self.assertEqual(composer.mail_server_id, self.mail_server_global,
                                      'TODO: Values are kept (should be reset ?)')
-                    # self.assertFalse(composer.record_name)
                     self.assertEqual(composer.record_name, 'Manual update',
-                                     'TODO: Reset not called')
+                                     'MailComposer: record name does not depend on template')
                     # self.assertFalse(composer.scheduled_date)
                     self.assertEqual(composer.scheduled_date, '{{ datetime.datetime(2023, 1, 10, 10, 0, 0) }}',
                                      'TODO: Values are kept (should be reset ?)')

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1013,14 +1013,12 @@ class TestComposerInternals(TestMailComposer):
                 if composition_mode == 'comment' and not batch:
                     self.assertEqual(composer.partner_ids, self.partner_admin,
                                      'TODO: Values are kept (should be reset ?)')
-                    self.assertEqual(composer.reply_to, 'info@test.example.com',
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.reply_to)
                     self.assertFalse(composer.reply_to_force_new)
                 else:
                     self.assertEqual(composer.partner_ids, self.partner_admin,
                                      'TODO: Values are kept (should be reset ?)')
-                    self.assertEqual(composer.reply_to, self.template.reply_to,
-                                     'TODO: Values are kept (should be reset ?)')
+                    self.assertFalse(composer.reply_to)
                     self.assertFalse(composer.reply_to_force_new)
 
                 # 2. check with default

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -8,7 +8,7 @@ from werkzeug.urls import url_parse, url_decode
 from odoo import exceptions
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestMailCommon, TestRecipients
-from odoo.tests.common import tagged, HttpCase, users
+from odoo.tests.common import tagged, Form, HttpCase, users
 from odoo.tools import mute_logger
 
 
@@ -472,6 +472,67 @@ class TestNoThread(TestMailCommon, TestRecipients):
                 res_id=test_record.id,
                 subject='Test Notify',
             )
+
+    @users('employee')
+    def test_message_notify_composer(self):
+        """ Test comment mode on composer which triggers a notify when model
+        does not inherit from mail thread. """
+        test_records, _test_partners = self._create_records_for_batch('mail.test.nothread', 2)
+
+        test_reports = self.env['ir.actions.report'].sudo().create([
+            {
+                'name': 'Test Report on Mail Test Ticket',
+                'model': test_records._name,
+                'print_report_name': "'TestReport for %s' % object.name",
+                'report_type': 'qweb-pdf',
+                'report_name': 'test_mail.mail_test_ticket_test_template',
+            }, {
+                'name': 'Test Report 2 on Mail Test Ticket',
+                'model': test_records._name,
+                'print_report_name': "'TestReport2 for %s' % object.name",
+                'report_type': 'qweb-pdf',
+                'report_name': 'test_mail.mail_test_ticket_test_template_2',
+            }
+        ])
+        test_template = self.env['mail.template'].create({
+            'auto_delete': True,
+            'body_html': '<p>TemplateBody <t t-esc="object.name"></t></p>',
+            'email_from': '{{ (user.email_formatted) }}',
+            'email_to': '',
+            'mail_server_id': self.mail_server_domain.id,
+            'partner_to': '{{ object.customer_id.id if object.customer_id else "" }}',
+            'name': 'TestTemplate',
+            'model_id': self.env['ir.model']._get(test_records._name).id,
+            'reply_to': '{{ ctx.get("custom_reply_to") or "info@test.example.com" }}',
+            'report_template_ids': [(6, 0, test_reports.ids)],
+            'scheduled_date': '{{ (object.create_date or datetime.datetime(2022, 12, 26, 18, 0, 0)) + datetime.timedelta(days=2) }}',
+            'subject': 'TemplateSubject {{ object.name }}',
+        })
+        attachment_data = self._generate_attachments_data(2, test_template._name, test_template.id)
+        test_template.write({'attachment_ids': [(0, 0, a) for a in attachment_data]})
+
+        ctx = {
+            'default_composition_mode': 'comment',
+            'default_model': test_records._name,
+            'default_res_domain': [('id', 'in', test_records.ids)],
+            'default_template_id': test_template.id,
+        }
+        # open a composer and run it in comment mode
+        composer_form = Form(self.env['mail.compose.message'].with_context(ctx))
+        composer = composer_form.save()
+
+        with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_mail_app():
+            _, messages = composer._action_send_mail()
+
+        self.assertEqual(len(messages), 2)
+        for record, message in zip(test_records, messages):
+            self.assertEqual(
+                sorted(message.mapped('attachment_ids.name')),
+                sorted(['AttFileName_00.txt', 'AttFileName_01.txt',
+                        f'TestReport2 for {record.name}.html',
+                        f'TestReport for {record.name}.html'])
+            )
+        self.assertEqual(len(messages.attachment_ids), 8, 'No attachments should be shared')
 
     @users('employee')
     def test_message_notify_norecord(self):

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1231,7 +1231,7 @@ class TestMessagePostHelpers(TestMessagePostCommon):
                 fields_values={
                     'auto_delete': False,
                     'is_internal': False,
-                    'is_notification': True,  # auto_delete_keep_log -> keep underlying mail.message
+                    'is_notification': False,  # no to_delete -> no keep_log
                     'message_type': 'email',
                     'model': test_record._name,
                     'notified_partner_ids': self.env['res.partner'],

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -216,19 +216,19 @@ class TestBaseMailPerformance(BaseMailPerformance):
     @warmup
     def test_create_mail_with_tracking(self):
         """ Create records inheriting from 'mail.thread' (with field tracking). """
-        with self.assertQueryCount(admin=8, demo=8):
+        with self.assertQueryCount(admin=7, demo=7):
             self.env['mail.performance.thread'].create({'name': 'X'})
 
     @users('admin', 'employee')
     @warmup
     def test_create_mail_simple(self):
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=6, employee=6):
             self.env['mail.test.simple'].create({'name': 'Test'})
 
     @users('admin', 'employee')
     @warmup
     def test_create_mail_simple_multi(self):
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=6, employee=6):
             self.env['mail.test.simple'].create([{'name': 'Test'}] * 5)
 
     @users('admin', 'employee')
@@ -256,7 +256,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_adv_activity(self):
         model = self.env['mail.test.activity']
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=6, employee=6):
             model.create({'name': 'Test'})
 
     @users('admin', 'employee')
@@ -321,7 +321,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=19, employee=19):  # com+tm 18/18
+        with self.assertQueryCount(admin=18, employee=18):  # com+tm 17/17
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications
@@ -337,7 +337,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer(self):
         test_record, _test_template = self._create_test_records()
         customer_id = self.customer.id
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -347,7 +347,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=32, employee=32):
+        with self.assertQueryCount(admin=29, employee=29):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -357,7 +357,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -368,7 +368,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer.id)],
             })
 
-        with self.assertQueryCount(admin=37, employee=37):
+        with self.assertQueryCount(admin=33, employee=33):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -378,7 +378,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=13, employee=13):  # tm 12/12
+        with self.assertQueryCount(admin=11, employee=11):
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -392,7 +392,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=47, employee=47):  # tm+com 46/46
+        with self.assertQueryCount(admin=43, employee=43):  # tm+com 42/42
             composer._action_send_mail()
 
         # notifications
@@ -406,7 +406,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_mass_w_template(self):
         _partners, test_records, test_template = self._create_test_records_for_batch()
 
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'mass_mail',
                 'default_model': test_records._name,
@@ -414,7 +414,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=141, employee=141), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=118, employee=121), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)
@@ -425,7 +425,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_nodelete(self):
         test_record, _test_template = self._create_test_records()
         customer_id = self.customer.id
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -436,7 +436,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=32, employee=32):
+        with self.assertQueryCount(admin=29, employee=29):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -454,7 +454,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=31, employee=31):
+        with self.assertQueryCount(admin=28, employee=28):
             composer._action_send_mail()
 
         # notifications
@@ -470,7 +470,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=26, employee=26):  # tm 16/16 / com 25/25
+        with self.assertQueryCount(admin=25, employee=25):  # tm 15/15 / com 24/24
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -478,7 +478,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=44, employee=44):
+        with self.assertQueryCount(admin=39, employee=39):
             composer._action_send_mail()
 
         # notifications
@@ -499,7 +499,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=37, employee=37):  # tm 26/26 / com 36/36
+        with self.assertQueryCount(admin=37, employee=37):  # tm 27/27 / com 36/36
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -510,7 +510,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=41, employee=41):
+        with self.assertQueryCount(admin=38, employee=38):
             composer._action_send_mail()
 
         # notifications
@@ -529,7 +529,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=38, employee=38):  # tm 27/27 / com 37/37
+        with self.assertQueryCount(admin=37, employee=37):  # tm 27/27 / com 36/36
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -540,7 +540,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=64, employee=64):
+        with self.assertQueryCount(admin=59, employee=59):
             composer._action_send_mail()
 
         # notifications
@@ -567,7 +567,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=28, employee=28):
+        with self.assertQueryCount(admin=25, employee=25):
             record.write({
                 'user_id': self.user_test_email.id,
             })
@@ -576,7 +576,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=20, employee=20):
+        with self.assertQueryCount(admin=18, employee=18):
             record.write({
                 'user_id': self.user_test_inbox.id,
             })
@@ -650,7 +650,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=26, employee=26):
+        with self.assertQueryCount(admin=24, employee=24):
             record.message_post(
                 body='<p>Test Post Performances with an email ping</p>',
                 partner_ids=self.customer.ids,
@@ -662,7 +662,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=18, employee=18):
+        with self.assertQueryCount(admin=17, employee=17):
             record.message_post(
                 body='<p>Test Post Performances with an inbox ping</p>',
                 partner_ids=self.user_test.partner_id.ids,
@@ -675,7 +675,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_subscribe_default(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=6, employee=6):
+        with self.assertQueryCount(admin=5, employee=5):
             record.message_subscribe(partner_ids=self.user_test.partner_id.ids)
 
         with self.assertQueryCount(admin=3, employee=3):
@@ -688,7 +688,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
         subtype_ids = (self.env.ref('test_mail.st_mail_test_simple_external') | self.env.ref('mail.mt_comment')).ids
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=4, employee=4):
             record.message_subscribe(partner_ids=self.user_test.partner_id.ids, subtype_ids=subtype_ids)
 
         with self.assertQueryCount(admin=2, employee=2):
@@ -844,7 +844,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=36, employee=36):
+        with self.assertQueryCount(admin=35, employee=34):
             record.message_post(
                 body='<p>Test Post Performances</p>',
                 message_type='comment',
@@ -862,7 +862,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=45, employee=45):
+        with self.assertQueryCount(admin=42, employee=41):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -878,8 +878,8 @@ class TestMailComplexPerformance(BaseMailPerformance):
     def test_complex_message_post_view(self):
         _partners, test_records, test_template = self._create_test_records_for_batch()
 
-        with self.assertQueryCount(admin=4, employee=4):
-            composer = self.env['mail.compose.message'].with_context({
+        with self.assertQueryCount(admin=3, employee=3):
+            _composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'mass_mail',
                 'default_model': test_records._name,
                 'default_res_ids': test_records.ids,
@@ -913,7 +913,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id)
 
         # subscribe new followers with forced given subtypes
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=3, employee=3):
             rec.message_subscribe(
                 partner_ids=pids[:4],
                 subtype_ids=subtype_ids
@@ -922,7 +922,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners[:4])
 
         # subscribe existing and new followers with force=False, meaning only some new followers will be added
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=4, employee=4):
             rec.message_subscribe(
                 partner_ids=pids[:6],
                 subtype_ids=None
@@ -931,7 +931,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners[:6])
 
         # subscribe existing and new followers with force=True, meaning all will have the same subtypes
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=3, employee=3):
             rec.message_subscribe(
                 partner_ids=pids,
                 subtype_ids=subtype_ids
@@ -952,7 +952,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
-        with self.assertQueryCount(admin=26, employee=26):
+        with self.assertQueryCount(admin=23, employee=23):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -972,7 +972,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(admin=58, employee=58):  # tm 58/58
+        with self.assertQueryCount(admin=52, employee=52):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -1001,7 +1001,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
-        with self.assertQueryCount(admin=36, employee=36):
+        with self.assertQueryCount(admin=33, employee=33):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1038,7 +1038,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=36, employee=36):
+        with self.assertQueryCount(admin=33, employee=33):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -1071,7 +1071,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=22, employee=22):
+        with self.assertQueryCount(admin=21, employee=21):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,
@@ -1301,7 +1301,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
         # enable_logging = self.cr._enable_logging() if self.warm else nullcontext()
         # with self.assertQueryCount(employee=49), enable_logging:
-        with self.assertQueryCount(employee=49):
+        with self.assertQueryCount(employee=45):
             record_container.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',
                 subject='Test Subject',

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -337,7 +337,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer(self):
         test_record, _test_template = self._create_test_records()
         customer_id = self.customer.id
-        with self.assertQueryCount(admin=2, employee=2):
+        with self.assertQueryCount(admin=4, employee=4):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -357,7 +357,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=3, employee=3):
+        with self.assertQueryCount(admin=5, employee=5):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -406,7 +406,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_mass_w_template(self):
         _partners, test_records, test_template = self._create_test_records_for_batch()
 
-        with self.assertQueryCount(admin=3, employee=3):
+        with self.assertQueryCount(admin=4, employee=4):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'mass_mail',
                 'default_model': test_records._name,
@@ -426,7 +426,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_nodelete(self):
         test_record, _test_template = self._create_test_records()
         customer_id = self.customer.id
-        with self.assertQueryCount(admin=2, employee=2):
+        with self.assertQueryCount(admin=4, employee=4):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -447,7 +447,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=24, employee=24):  # tm 14/14 / com 23/23
+        with self.assertQueryCount(admin=25, employee=25):  # tm 15/15 / com 24/24
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -472,7 +472,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=25, employee=25):  # tm 15/15 / com 24/24
+        with self.assertQueryCount(admin=26, employee=26):  # tm 16/16 / com 25/25
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -865,7 +865,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=44, employee=44):
+        with self.assertQueryCount(admin=45, employee=45):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -881,7 +881,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
     def test_complex_message_post_view(self):
         _partners, test_records, test_template = self._create_test_records_for_batch()
 
-        with self.assertQueryCount(admin=3, employee=3):
+        with self.assertQueryCount(admin=4, employee=4):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'mass_mail',
                 'default_model': test_records._name,
@@ -1075,7 +1075,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=21, employee=21):
+        with self.assertQueryCount(admin=22, employee=22):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1187,7 +1187,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             ]
         }])
 
-        with self.assertQueryCount(employee=6):
+        with self.assertQueryCount(employee=7):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1196,7 +1196,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=19):
+        with self.assertQueryCount(employee=20):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1217,14 +1217,14 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'res_id': record.id
         } for record in records])
 
-        with self.assertQueryCount(employee=5):
+        with self.assertQueryCount(employee=6):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=14):
+        with self.assertQueryCount(employee=15):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -147,14 +147,14 @@ class TestBaseMailPerformance(BaseMailPerformance):
             }
         ])
 
-    @users('__system__', 'demo')
+    @users('admin', 'demo')
     @warmup
     def test_read_mail(self):
         """ Read records inheriting from 'mail.thread'. """
         records = self.env['mail.performance.thread'].search([])
         self.assertEqual(len(records), 5)
 
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(admin=2, demo=2):
             # without cache
             for record in records:
                 record.partner_id.country_id.name
@@ -169,27 +169,27 @@ class TestBaseMailPerformance(BaseMailPerformance):
             for record in records:
                 record.value_pc
 
-    @users('__system__', 'demo')
+    @users('admin', 'demo')
     @warmup
     def test_write_mail(self):
         """ Write records inheriting from 'mail.thread' (no recomputation). """
         records = self.env['mail.performance.thread'].search([])
         self.assertEqual(len(records), 5)
 
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(admin=2, demo=2):
             records.write({'name': 'X'})
 
-    @users('__system__', 'demo')
+    @users('admin', 'demo')
     @warmup
     def test_write_mail_with_recomputation(self):
         """ Write records inheriting from 'mail.thread' (with recomputation). """
         records = self.env['mail.performance.thread'].search([])
         self.assertEqual(len(records), 5)
 
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(admin=2, demo=2):
             records.write({'value': 42})
 
-    @users('__system__', 'demo')
+    @users('admin', 'demo')
     @warmup
     def test_write_mail_with_tracking(self):
         """ Write records inheriting from 'mail.thread' (with field tracking). """
@@ -200,42 +200,42 @@ class TestBaseMailPerformance(BaseMailPerformance):
             'partner_id': self.res_partner_12.id,
         })
 
-        with self.assertQueryCount(__system__=3, demo=3):
+        with self.assertQueryCount(admin=3, demo=3):
             record.track = 'X'
 
-    @users('__system__', 'demo')
+    @users('admin', 'demo')
     @warmup
     def test_create_mail(self):
         """ Create records inheriting from 'mail.thread' (without field tracking). """
         model = self.env['mail.performance.thread']
 
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(admin=2, demo=2):
             model.with_context(tracking_disable=True).create({'name': 'X'})
 
-    @users('__system__', 'demo')
+    @users('admin', 'demo')
     @warmup
     def test_create_mail_with_tracking(self):
         """ Create records inheriting from 'mail.thread' (with field tracking). """
-        with self.assertQueryCount(__system__=8, demo=8):
+        with self.assertQueryCount(admin=8, demo=8):
             self.env['mail.performance.thread'].create({'name': 'X'})
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_create_mail_simple(self):
-        with self.assertQueryCount(__system__=7, employee=7):
+        with self.assertQueryCount(admin=7, employee=7):
             self.env['mail.test.simple'].create({'name': 'Test'})
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_create_mail_simple_multi(self):
-        with self.assertQueryCount(__system__=7, employee=7):
+        with self.assertQueryCount(admin=7, employee=7):
             self.env['mail.test.simple'].create([{'name': 'Test'}] * 5)
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_write_mail_simple(self):
         rec = self.env['mail.test.simple'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=1, employee=1):
+        with self.assertQueryCount(admin=1, employee=1):
             rec.write({
                 'name': 'Test2',
                 'email_from': 'test@test.com',
@@ -251,15 +251,15 @@ class TestMailAPIPerformance(BaseMailPerformance):
         # automatically follow activities, for backward compatibility concerning query count
         self.env.ref('mail.mt_activities').write({'default': True})
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_adv_activity(self):
         model = self.env['mail.test.activity']
 
-        with self.assertQueryCount(__system__=7, employee=7):
+        with self.assertQueryCount(admin=7, employee=7):
             model.create({'name': 'Test'})
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.models.unlink')
     def test_adv_activity_full(self):
@@ -268,7 +268,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             'default_res_model': 'mail.test.activity',
         })
 
-        with self.assertQueryCount(__system__=6, employee=6):
+        with self.assertQueryCount(admin=6, employee=6):
             activity = MailActivity.create({
                 'summary': 'Test Activity',
                 'res_id': record.id,
@@ -278,16 +278,16 @@ class TestMailAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(__system__=12, employee=13):
+        with self.assertQueryCount(admin=13, employee=13):
             activity.action_feedback(feedback='Zizisse Done !')
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.models.unlink')
     def test_adv_activity_mixin(self):
         record = self.env['mail.test.activity'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=6, employee=6):
+        with self.assertQueryCount(admin=6, employee=6):
             activity = record.action_start('Test Start')
             # read activity_type to normalize cache between enterprise and community
             # voip module read activity_type during create leading to one less query in enterprise on action_close
@@ -295,12 +295,12 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(__system__=13, employee=15):
+        with self.assertQueryCount(admin=15, employee=15):
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.models.unlink')
     def test_adv_activity_mixin_w_attachments(self):
@@ -313,7 +313,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             for values in self.test_attachments_vals
         ])
 
-        with self.assertQueryCount(__system__=6, employee=6):
+        with self.assertQueryCount(admin=6, employee=6):
             activity = record.action_start('Test Start')
             #read activity_type to normalize cache between enterprise and community
             #voip module read activity_type during create leading to one less query in enterprise on action_close
@@ -321,7 +321,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(__system__=16, employee=19):  # com+tm 15/18
+        with self.assertQueryCount(admin=19, employee=19):  # com+tm 18/18
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications
@@ -331,13 +331,13 @@ class TestMailAPIPerformance(BaseMailPerformance):
             set(['AttFileName_00.txt', 'AttFileName_01.txt', 'AttFileName_02.txt'])
         )
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer(self):
         test_record, _test_template = self._create_test_records()
         customer_id = self.customer.id
-        with self.assertQueryCount(__system__=2, employee=2):
+        with self.assertQueryCount(admin=2, employee=2):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -347,17 +347,17 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(__system__=26, employee=32):
+        with self.assertQueryCount(admin=32, employee=32):
             composer._action_send_mail()
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_attachments(self):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(__system__=3, employee=3):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -368,17 +368,17 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer.id)],
             })
 
-        with self.assertQueryCount(__system__=29, employee=37):
+        with self.assertQueryCount(admin=37, employee=37):
             composer._action_send_mail()
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_form_attachments(self):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(__system__=13, employee=13):  # tm 12/12
+        with self.assertQueryCount(admin=13, employee=13):  # tm 12/12
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -392,7 +392,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=39, employee=47):  # tm+com 38/46
+        with self.assertQueryCount(admin=47, employee=47):  # tm+com 46/46
             composer._action_send_mail()
 
         # notifications
@@ -400,13 +400,13 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(message.attachment_ids, attachments)
         self.assertEqual(message.notified_partner_ids, customer + self.user_test.partner_id)
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_mass_w_template(self):
         _partners, test_records, test_template = self._create_test_records_for_batch()
 
-        with self.assertQueryCount(__system__=3, employee=3):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'mass_mail',
                 'default_model': test_records._name,
@@ -415,18 +415,18 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=108, employee=141), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=141, employee=141), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_nodelete(self):
         test_record, _test_template = self._create_test_records()
         customer_id = self.customer.id
-        with self.assertQueryCount(__system__=2, employee=2):
+        with self.assertQueryCount(admin=2, employee=2):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -437,17 +437,17 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(__system__=26, employee=32):
+        with self.assertQueryCount(admin=32, employee=32):
             composer._action_send_mail()
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_w_template(self):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(__system__=23, employee=24):  # tm 13/14 / com 22/23
+        with self.assertQueryCount(admin=24, employee=24):  # tm 14/14 / com 23/23
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -456,7 +456,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=25, employee=31):
+        with self.assertQueryCount(admin=31, employee=31):
             composer._action_send_mail()
 
         # notifications
@@ -466,13 +466,13 @@ class TestMailAPIPerformance(BaseMailPerformance):
         # remove created partner to ensure tests are the same each run
         self.env['res.partner'].sudo().search([('email', '=', 'nopartner.test@example.com')]).unlink()
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(__system__=24, employee=25):  # tm 14/15 / com 23/24
+        with self.assertQueryCount(admin=25, employee=25):  # tm 15/15 / com 24/24
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -481,7 +481,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=33, employee=44):
+        with self.assertQueryCount(admin=44, employee=44):
             composer._action_send_mail()
 
         # notifications
@@ -494,7 +494,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         # remove created partner to ensure tests are the same each run
         self.env['res.partner'].sudo().search([('email', '=', 'nopartner.test@example.com')]).unlink()
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_w_template_form(self):
@@ -502,7 +502,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(__system__=35, employee=37):  # tm 24/26 / com 34/36
+        with self.assertQueryCount(admin=37, employee=37):  # tm 26/26 / com 36/36
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -513,7 +513,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=35, employee=41):
+        with self.assertQueryCount(admin=41, employee=41):
             composer._action_send_mail()
 
         # notifications
@@ -525,14 +525,14 @@ class TestMailAPIPerformance(BaseMailPerformance):
         # remove created partner to ensure tests are the same each run
         new_partner.unlink()
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.tests')
     def test_mail_composer_w_template_form_attachments(self):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(__system__=36, employee=38):  # tm 25/27 / com 35/37
+        with self.assertQueryCount(admin=38, employee=38):  # tm 27/27 / com 37/37
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -543,7 +543,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=47, employee=64):
+        with self.assertQueryCount(admin=64, employee=64):
             composer._action_send_mail()
 
         # notifications
@@ -559,7 +559,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         new_partner.unlink()
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_assignation_email(self):
         # Changing the `notification_type` of a user adds or removes him a group
@@ -570,31 +570,31 @@ class TestMailAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=27, employee=28):
+        with self.assertQueryCount(admin=28, employee=28):
             record.write({
                 'user_id': self.user_test_email.id,
             })
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=18, employee=20):
+        with self.assertQueryCount(admin=20, employee=20):
             record.write({
                 'user_id': self.user_test_inbox.id,
             })
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_log(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=1, employee=1):
+        with self.assertQueryCount(admin=1, employee=1):
             record._message_log(
                 body='<p>Test _message_log</p>',
                 message_type='comment')
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_log_batch(self):
         records = self.env['mail.test.simple'].create([
@@ -602,7 +602,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             for idx in range(10)
         ])
 
-        with self.assertQueryCount(__system__=1, employee=1):
+        with self.assertQueryCount(admin=1, employee=1):
             records._message_log_batch(
                 bodies=dict(
                     (record.id, '<p>Test _message_log</p>')
@@ -610,7 +610,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 ),
                 message_type='comment')
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_log_with_view(self):
         records = self.env['mail.test.simple'].create([
@@ -618,29 +618,29 @@ class TestMailAPIPerformance(BaseMailPerformance):
             for idx in range(10)
         ])
 
-        with self.assertQueryCount(__system__=2, employee=2):
+        with self.assertQueryCount(admin=2, employee=2):
             records._message_log_with_view(
                 'test_mail.mail_template_simple_test',
                 render_values={'partner': self.customer.with_env(self.env)}
             )
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_log_with_post(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=4, employee=7):
+        with self.assertQueryCount(admin=7, employee=7):
             record.message_post(
                 body='<p>Test message_post as log</p>',
                 subtype_xmlid='mail.mt_note',
                 message_type='comment')
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_post_no_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=4, employee=7):
+        with self.assertQueryCount(admin=7, employee=7):
             record.message_post(
                 body='<p>Test Post Performances basic</p>',
                 partner_ids=[],
@@ -648,24 +648,24 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 subtype_xmlid='mail.mt_comment')
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=23, employee=26):
+        with self.assertQueryCount(admin=26, employee=26):
             record.message_post(
                 body='<p>Test Post Performances with an email ping</p>',
                 partner_ids=self.customer.ids,
                 message_type='comment',
                 subtype_xmlid='mail.mt_comment')
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=14, employee=18):
+        with self.assertQueryCount(admin=18, employee=18):
             record.message_post(
                 body='<p>Test Post Performances with an inbox ping</p>',
                 partner_ids=self.user_test.partner_id.ids,
@@ -673,47 +673,47 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 subtype_xmlid='mail.mt_comment')
 
     @mute_logger('odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_subscribe_default(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=6, employee=6):
+        with self.assertQueryCount(admin=6, employee=6):
             record.message_subscribe(partner_ids=self.user_test.partner_id.ids)
 
-        with self.assertQueryCount(__system__=3, employee=3):
+        with self.assertQueryCount(admin=3, employee=3):
             record.message_subscribe(partner_ids=self.user_test.partner_id.ids)
 
     @mute_logger('odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_subscribe_subtypes(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
         subtype_ids = (self.env.ref('test_mail.st_mail_test_simple_external') | self.env.ref('mail.mt_comment')).ids
 
-        with self.assertQueryCount(__system__=5, employee=5):
+        with self.assertQueryCount(admin=5, employee=5):
             record.message_subscribe(partner_ids=self.user_test.partner_id.ids, subtype_ids=subtype_ids)
 
-        with self.assertQueryCount(__system__=2, employee=2):
+        with self.assertQueryCount(admin=2, employee=2):
             record.message_subscribe(partner_ids=self.user_test.partner_id.ids, subtype_ids=subtype_ids)
 
     @mute_logger('odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_message_track(self):
         record = self.env['mail.performance.tracking'].create({'name': 'Zizizatestname'})
-        with self.assertQueryCount(__system__=3, employee=3):
+        with self.assertQueryCount(admin=3, employee=3):
             record.write({'name': 'Zizizanewtestname'})
 
-        with self.assertQueryCount(__system__=3, employee=3):
+        with self.assertQueryCount(admin=3, employee=3):
             record.write({'field_%s' % (i): 'Tracked Char Fields %s' % (i) for i in range(3)})
 
-        with self.assertQueryCount(__system__=4, employee=4):
+        with self.assertQueryCount(admin=4, employee=4):
             record.write({'field_%s' % (i): 'Field Without Cache %s' % (i) for i in range(3)})
             record.flush_recordset()
             record.write({'field_%s' % (i): 'Field With Cache %s' % (i) for i in range(3)})
 
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_notification_reply_to_batch(self):
         test_records_sudo = self.env['mail.test.container'].sudo().create([
@@ -723,7 +723,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             } for index in range(10)
         ])
 
-        with self.assertQueryCount(__system__=1, employee=1):
+        with self.assertQueryCount(admin=1, employee=1):
             test_records = self.env['mail.test.container'].browse(test_records_sudo.ids)
             reply_to = test_records._notify_get_reply_to(
                 default=self.env.user.email_formatted
@@ -772,7 +772,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.env.flush_all()
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_mail_mail_send(self):
         message = self.env['mail.message'].sudo().create({
@@ -795,11 +795,11 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'mail_message_id': message.id,
             'recipient_ids': [(4, pid) for pid in self.partners.ids],
         })
-        with self.assertQueryCount(__system__=9, employee=9):
+        with self.assertQueryCount(admin=9, employee=9):
             self.env['mail.mail'].sudo().browse(mail.ids).send()
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_mail_mail_send_batch_complete(self):
         """ A more complete use case: 10 mails, attachments, servers, ... And
@@ -828,7 +828,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         } for idx in range(12)])
         mails[-2].write({'email_cc': False, 'email_to': 'strange@example¢¡.com', 'recipient_ids': [(5, 0)]})
         mails[-1].write({'email_cc': False, 'email_to': 'void', 'recipient_ids': [(5, 0)]})
-        with self.assertQueryCount(__system__=43, employee=43):
+        with self.assertQueryCount(admin=43, employee=43):
             self.env['mail.mail'].sudo().browse(mails.ids).send()
 
         for mail in mails[:-2]:
@@ -840,14 +840,14 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertTrue(mails[-1].to_delete, 'Mail: mails with invalid recipient are also to be unlinked')
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_message_post(self):
         self.container.message_subscribe(self.user_portal.partner_id.ids)
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(__system__=35, employee=36):
+        with self.assertQueryCount(admin=36, employee=36):
             record.message_post(
                 body='<p>Test Post Performances</p>',
                 message_type='comment',
@@ -857,7 +857,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(record.message_ids[0].notified_partner_ids, self.partners | self.user_portal.partner_id)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_message_post_template(self):
         self.container.message_subscribe(self.user_portal.partner_id.ids)
@@ -865,7 +865,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(__system__=43, employee=44):
+        with self.assertQueryCount(admin=44, employee=44):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -876,12 +876,12 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(record.message_ids[0].notified_partner_ids, self.partners | self.user_portal.partner_id | self.customer)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_message_post_view(self):
         _partners, test_records, test_template = self._create_test_records_for_batch()
 
-        with self.assertQueryCount(__system__=3, employee=3):
+        with self.assertQueryCount(admin=3, employee=3):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'mass_mail',
                 'default_model': test_records._name,
@@ -890,7 +890,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=111, employee=131):
+        with self.assertQueryCount(admin=131, employee=131):
             messages_as_sudo = test_records.message_post_with_source(
                 'test_mail.mail_template_simple_test',
                 render_values={'partner': self.user_test.partner_id},
@@ -900,7 +900,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(len(messages_as_sudo), 10)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_message_subscribe(self):
         pids = self.partners.ids
@@ -917,7 +917,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id)
 
         # subscribe new followers with forced given subtypes
-        with self.assertQueryCount(__system__=4, employee=4):
+        with self.assertQueryCount(admin=4, employee=4):
             rec.message_subscribe(
                 partner_ids=pids[:4],
                 subtype_ids=subtype_ids
@@ -926,7 +926,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners[:4])
 
         # subscribe existing and new followers with force=False, meaning only some new followers will be added
-        with self.assertQueryCount(__system__=5, employee=5):
+        with self.assertQueryCount(admin=5, employee=5):
             rec.message_subscribe(
                 partner_ids=pids[:6],
                 subtype_ids=None
@@ -935,7 +935,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners[:6])
 
         # subscribe existing and new followers with force=True, meaning all will have the same subtypes
-        with self.assertQueryCount(__system__=4, employee=4):
+        with self.assertQueryCount(admin=4, employee=4):
             rec.message_subscribe(
                 partner_ids=pids,
                 subtype_ids=subtype_ids
@@ -944,7 +944,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_tracking_assignation(self):
         """ Assignation performance test on already-created record """
@@ -956,7 +956,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
-        with self.assertQueryCount(__system__=25, employee=26):
+        with self.assertQueryCount(admin=26, employee=26):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -968,7 +968,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(len(rec1.message_ids), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_tracking_subscription_create(self):
         """ Creation performance test involving auto subscription, assignation, tracking with subtype and template send. """
@@ -976,7 +976,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=57, employee=58):  # tm 57/58
+        with self.assertQueryCount(admin=58, employee=58):  # tm 58/58
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -992,7 +992,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(len(rec1.message_ids), 1)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_tracking_subscription_subtype(self):
         """ Write performance test involving auto subscription, tracking with subtype """
@@ -1005,7 +1005,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
-        with self.assertQueryCount(__system__=36, employee=36):
+        with self.assertQueryCount(admin=36, employee=36):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1021,7 +1021,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(len(rec1.message_ids), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_tracking_subscription_write(self):
         """ Write performance test involving auto subscription, tracking with subtype and template send """
@@ -1042,7 +1042,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(__system__=36, employee=36):
+        with self.assertQueryCount(admin=36, employee=36):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -1059,7 +1059,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.assertEqual(len(rec1.message_ids), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    @users('__system__', 'employee')
+    @users('admin', 'employee')
     @warmup
     def test_complex_tracking_template(self):
         """ Write performance test involving assignation, tracking with template """
@@ -1075,7 +1075,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(__system__=20, employee=21):
+        with self.assertQueryCount(admin=21, employee=21):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -413,7 +413,6 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_res_ids': test_records.ids,
                 'default_template_id': test_template.id,
             }).create({})
-            composer._onchange_template_id_wrapper()
 
         with self.assertQueryCount(admin=141, employee=141), self.mock_mail_gateway():
             composer._action_send_mail()
@@ -454,7 +453,6 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_res_ids': test_record.ids,
                 'default_template_id': test_template.id,
             }).create({})
-            composer._onchange_template_id_wrapper()
 
         with self.assertQueryCount(admin=31, employee=31):
             composer._action_send_mail()
@@ -479,7 +477,6 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_res_ids': test_record.ids,
                 'default_template_id': test_template.id,
             }).create({})
-            composer._onchange_template_id_wrapper()
 
         with self.assertQueryCount(admin=44, employee=44):
             composer._action_send_mail()
@@ -888,7 +885,6 @@ class TestMailComplexPerformance(BaseMailPerformance):
                 'default_res_ids': test_records.ids,
                 'default_template_id': test_template.id,
             }).create({})
-            composer._onchange_template_id_wrapper()
 
         with self.assertQueryCount(admin=131, employee=131):
             messages_as_sudo = test_records.message_post_with_source(

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -320,8 +320,6 @@ class TestPortalFlow(MailCommon, HttpCase):
         Other tests below check that that same link has the correct behavior.
         This test follows the common use case by using a template while the next send the mail without a template."""
         composer = self._get_composer_with_context(self.mail_template.id).create({})
-        # currently onchange necessary
-        composer._onchange_template_id_wrapper()
 
         with self.mock_mail_gateway(mail_unlink_sent=True):
             composer._action_send_mail()

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -47,7 +47,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +2 compared to local
-        with self.assertQueryCount(__system__=426, marketing=427):  # tm 424/425
+        with self.assertQueryCount(__system__=427, marketing=428):  # tm 425/426
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -94,7 +94,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +2 compared to local
-        with self.assertQueryCount(__system__=488, marketing=489):  # tm 486/487
+        with self.assertQueryCount(__system__=489, marketing=490):  # tm 487/488
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -56,7 +56,7 @@ class TestWebsiteBlogFlow(TestWebsiteBlogCommon):
             'website_blog: peuple following a blog should be notified of a published post')
 
         # Armand posts a message -> becomes follower
-        self.test_blog_post.sudo().message_post(
+        self.test_blog_post.with_user(self.user_employee).message_post(
             body='Armande BlogUser Commented',
             message_type='comment',
             author_id=self.user_employee.partner_id.id,


### PR DESCRIPTION
RATIONALE

Remove _onchange_template_id / defaults usage for composer fields. It
lacks control and make value computation hard to understand and predict.

SPECIFICATIONS

Remove _onchange_template_id / defaults usage for composer fields. It
lacks control and make value computation hard to understand and predict.

Split _onchange_template_id + default_get + get_record_data usage into editable
computed stored fields. Each field should have its own method with its triggers
(template, composition mode, ...).

OTHER CHANGES

Improve 'message_notify' to behave like 'message_post' with attachments.
Add some parameters to the notification process to lessen a bit context
usage.

Improve wording of recently added features.

Improve test coverage of recently modified features.

Cleanup hr_recruitment_survey field naming and file organization, done when
fixing a bug not really related to this branch.

Fixup mail template preview wizard, some rare bugs when previewing notably
attachments.

LINKS

This PR is build on previously merged content that originated form this PR.
See notably odoo/odoo#99482 / Task-2710804 (Mail: Clean MailThread API).

Task-3093257 (Mail: The Composer Update)
Task-2088884 (Mail: Use editable computed stored fields in compose
Prepares Task-3149286 (Account: Cleanup account.invoice.send wizard)
