### PR TITLE
[IMP] website_slides: Fix the display of the archived course

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1179,7 +1179,7 @@ class WebsiteSlides(WebsiteProfile):
 
     def _prepare_user_slides_profile(self, user):
         courses = request.env['slide.channel.partner'].sudo().search([('partner_id', '=', user.partner_id.id)])
-        courses_completed = courses.filtered(lambda c: c.completed)
+        courses_completed = courses.filtered(lambda c: c.completed and c.channel_id.active)
         courses_ongoing = courses - courses_completed
         values = {
             'uid': request.env.user.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix the display of the archived course in the completed course list at the user's profile in Website

Current behavior before PR:
- Archived courses are displayed on the list of Completed Courses in user's profile at the Website. This causes users who are not officers or managers to access the course resulting in a 403 error message, which is inconvenient for users.

![image](https://user-images.githubusercontent.com/106688997/206106382-23135d8f-b610-4e9c-8043-0701a56d127b.png)
![image](https://user-images.githubusercontent.com/106688997/206106230-9b7913d8-f3d4-4154-be73-d0bf256b35bd.png)
![image](https://user-images.githubusercontent.com/106688997/206106622-f9ab4a60-8ac9-4cfb-ac76-0a8efb664467.png)



Desired behavior after PR is merged:

- Archived courses aren't displayed on the list of Completed Courses in user's profile




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
