### PR TITLE
[FIX] l10n_multilang: fix the flow for installing a new language

### DIFF
--- a/addons/l10n_multilang/models/l10n_multilang.py
+++ b/addons/l10n_multilang/models/l10n_multilang.py
@@ -151,10 +151,9 @@ class BaseLanguageInstall(models.TransientModel):
 
     def lang_install(self):
         self.ensure_one()
-        res = super(BaseLanguageInstall, self).lang_install()
-        lang_codes = set(self.lang_ids.mapped('code'))
         installed = {code for code, __ in self.env['res.lang'].get_installed()}
-        to_install = lang_codes - installed
+        res = super(BaseLanguageInstall, self).lang_install()
+        to_install = set(self.lang_ids.mapped('code')) - installed
         if not to_install:
             # update of translations instead of new installation
             # skip to avoid duplicating the translations


### PR DESCRIPTION
Steps to reproduce:
1. Create a CA company (where both French and English are used)
2. Set the CA Chart of Accounts
3. Go to the general settings
4. Add the French language and switch to it
5. Go back to the CoA
6. The CoA is not translated

This is because the variable `installed` is wrongfully placed in the code. In the current flow, we install the new language, then we check the installed language, therefore the new language is marked as an already installed language. Therfore the `to_install` variable will always be empty. This commit fixes this by first storing the already installed languages, then installing the new one, and then compute the ones to install making sure that the newly installed one will be used afterwards to translate the Chart of Accounts.

task-id 3091315
