### PR TITLE
[FIX] l10n_fr_pos_cert: do not allow removing order

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/TicketScreen.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/TicketScreen.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import TicketScreen from 'point_of_sale.TicketScreen';
+import Registries from 'point_of_sale.Registries';
+
+
+export const PosFrTicketScreen = (TicketScreen) =>
+    class PosFrTicketScreen extends TicketScreen {
+        shouldHideDeleteButton(order) {
+            return this.env.pos.is_french_country() || super.shouldHideDeleteButton(order);
+        }
+    };
+
+Registries.Component.extend(TicketScreen, PosFrTicketScreen);


### PR DESCRIPTION
Before this fix, it was possible to delete an order that was synched to the server. But the law do not allow order deletion.

This fix remove the order deletion button.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
