### PR TITLE
[FIX] l10n_eg_edi_eta: retry registering submissionID if not found

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -78,6 +78,10 @@ class AccountEdiFormat(models.Model):
         }
         response_data = self._l10n_eg_eta_connect_to_server(request_data, request_url, 'POST', production_enviroment=invoice.company_id.l10n_eg_production_env)
         if response_data.get('error'):
+            error = response_data.get('error').json()
+            if isinstance(error, dict) and error.get('code') == 'NotFound' and error.get('target') == 'GetSubmissionDetailsQueryHandler':
+                # if the error is due to the invoice not being signed, we can retry by getting a new one and sending it
+                invoice.l10n_eg_submission_number = False
             return response_data
         response_data = response_data.get('response').json()
         if response_data.get('rejectedDocuments', False) and isinstance(response_data.get('rejectedDocuments'), list):


### PR DESCRIPTION
[FIX] l10n_eg_edi_eta: retry registering submissionID if not found

Some invoices are stuck with error:
```JSON
{'code': 'NotFound', 'message': None, 'target': 'GetSubmissionDetailsQueryHandler', 'details': [{'code': None, 'target': 'SubmissionUUID', 'message': 'SubmissionUUID: Q5...G10 is not found'}]}
```
In retry `_post_invoice_edi` we check if there is a submission uuid we do not post the invoice again in case of error, but for this error we need to try resending the invoice.

Related ticket: [2972808](https://www.odoo.com/my/tasks/2972808)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
