### PR TITLE
[FIX] account_edi: keep error date time

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -161,7 +161,7 @@ class AccountEdiDocument(models.Model):
                     old_attachment = document.attachment_id
                     values = {
                         'attachment_id': move_result['attachment'].id,
-                        'error': move_result.get('error', False),
+                        'error': f'''{move_result.get('error', False)} @ {fields.Datetime.now()} utc''',
                         'blocking_level': move_result.get('blocking_level', DEFAULT_BLOCKING_LEVEL) if 'error' in move_result else False,
                     }
                     if not values.get('error'):


### PR DESCRIPTION
Let's make the life of support people easier with keeping the error date in edi errors, it can be used to find the error details in the logs


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
