### PR TITLE
[IMP] survey: add clone action on question

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -386,6 +386,16 @@ class SurveyQuestion(models.Model):
     # CRUD
     # ------------------------------------------------------------
 
+    @api.returns('self', lambda value: value.id)
+    def copy(self, default=None):
+        self.ensure_one()
+        clone = super().copy(default)
+        if self.is_conditional:
+            clone.is_conditional = True
+            clone.triggering_question_id = self.triggering_question_id.id
+            clone.triggering_answer_id = self.triggering_answer_id.id
+        return clone
+
     def unlink(self):
         """ Makes sure no question is left depending on the question we're deleting."""
         depending_questions = self.env['survey.question'].search([('triggering_question_id', 'in', self.ids)])

--- a/addons/survey/static/src/question_page/question_page_list_renderer.js
+++ b/addons/survey/static/src/question_page/question_page_list_renderer.js
@@ -50,6 +50,14 @@ export class QuestionPageListRenderer extends ListRenderer {
         return classNames.join(" ");
     }
 
+    getCellClass(column, record) {
+        const classNames = super.getCellClass(column, record);
+        if (column.type === "button_group") {
+            return `${classNames} text-end`;
+        }
+        return classNames;
+    }
+
     getSectionColumns(columns) {
         const sectionColumns = [];
 

--- a/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
+++ b/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
@@ -73,12 +73,7 @@ export class SurveyQuestionTriggerWidget extends Component {
             return "";
         }
         const triggerId = record.data.triggering_question_id[0];
-        let triggerRecord;
-        if (this.props.isSurveyForm) { // embedded list
-            triggerRecord = record.model.root.data.question_and_page_ids.records.find(rec => rec.data.id === triggerId);
-        } else {
-            triggerRecord = record.model.root.records.find(rec => rec.resId === triggerId);
-        }
+        let triggerRecord = record.model.root.data.question_and_page_ids.records.find(rec => rec.data.id === triggerId);
 
         if (!triggerRecord) {
             return "MISSING_TRIGGER_ERROR";
@@ -97,17 +92,6 @@ export class SurveyQuestionTriggerWidget extends Component {
 SurveyQuestionTriggerWidget.template = "survey.surveyQuestionTrigger";
 SurveyQuestionTriggerWidget.props = {
     ...standardWidgetProps,
-    isSurveyForm: { type: Boolean, optional: true },
-};
-
-SurveyQuestionTriggerWidget.defaultProps = {
-    isSurveyForm: false
-};
-
-SurveyQuestionTriggerWidget.extractProps = ({ attrs }) => {
-    return {
-        isSurveyForm: attrs.options.isSurveyForm
-    };
 };
 
 SurveyQuestionTriggerWidget.displayName = 'Trigger';

--- a/addons/survey/static/tests/components/survey_question_trigger_widget_tests.js
+++ b/addons/survey/static/tests/components/survey_question_trigger_widget_tests.js
@@ -77,7 +77,6 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                             <field name="name"/>
                             <field name="triggering_answer_id" invisible="1"/>
                             <field name="triggering_question_id" invisible="1"/> 
-                            <widget name="survey_question_trigger" nolabel="1"/>
                         </group>
                     </form>
                 `,
@@ -101,7 +100,7 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                             <field name="name"/>
                             <field name="triggering_answer_id" invisible="1"/>
                             <field name="triggering_question_id" invisible="1"/> 
-                            <widget name="survey_question_trigger" options="{'isSurveyForm': True}"/>
+                            <widget name="survey_question_trigger"/>
                         </tree>
                     </field>
                 </form>

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -267,13 +267,10 @@
         <field name="model">survey.question</field>
         <field name="arch" type="xml">
             <tree string="Survey Question" create="false">
-                <field name="sequence" widget="handle"/>
                 <field name="title"/>
                 <field name="survey_id"/>
                 <field name="question_type"/>
-                <field name="triggering_question_id" invisible="1"/>
-                <field name="triggering_answer_id" invisible="1"/>
-                <widget name="survey_question_trigger"/>
+                <field name="constr_mandatory" optional="1"/>
             </tree>
         </field>
     </record>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -71,6 +71,7 @@
                                     <field name="title" widget="survey_description_page"/>
                                     <field name="background_image" invisible="1"/>
                                     <field name="question_type" />
+                                    <field name="constr_mandatory" optional="1"/>
                                     <field name="is_page" invisible="1"/>
                                     <field name="questions_selection" invisible="1"/>
                                     <field name="suggested_answer_ids" invisible="1"/>
@@ -83,7 +84,8 @@
                                     <field name="triggering_answer_id" invisible="1"/>
                                     <field name="is_placed_before_trigger" invisible="1"/>
                                     <field name="allowed_triggering_question_ids" invisible="1"/>
-                                    <widget name="survey_question_trigger" options="{'isSurveyForm': True}"/>
+                                    <widget name="survey_question_trigger"/>
+                                    <button name="copy" type="object" icon="fa-clone" title="Duplicate Question"/>
                                     <control>
                                         <create name="add_question_control" string="Add a question"/>
                                         <create name="add_section_control" string="Add a section" context="{'default_is_page': True, 'default_questions_selection': 'all'}"/>


### PR DESCRIPTION
This PR adds a button on Questions lines in the survey form, it allows the user to duplicate the question.
The duplicated question will be displayed just below the original one.

This commit also remove the is_conditional icon on the overall questions tree view.

Task-3088848


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
