### PR TITLE
[FIX] web: supports <widget/> in list view

### DIFF
--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -131,11 +131,10 @@ export class ListArchParser extends XMLParser {
                 );
 
                 const widgetProps = {
-                    ...widgetInfo,
+                    name: widgetInfo.name,
                     // FIXME: this is dumb, we encode it into a weird object so that the widget
                     // can decode it later...
                     node: encodeObjectForTemplate({ attrs: widgetInfo.rawAttrs }).slice(1, -1),
-                    className: node.getAttribute("class"),
                 };
                 columns.push({
                     ...widgetInfo,

--- a/addons/web/static/src/views/widgets/widget.js
+++ b/addons/web/static/src/views/widgets/widget.js
@@ -66,9 +66,8 @@ Widget.parseWidgetNode = function (node) {
         })
     );
     return {
-        options: evaluateExpr(node.getAttribute("options") || "{}"),
         name,
-        rawAttrs: attrs,
+        rawAttrs: { ...attrs, options: node.getAttribute("options") || "{}" },
         WidgetComponent,
     };
 };

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -16328,7 +16328,25 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("view widgets are rendered in list view", async function (assert) {
-        class TestWidget extends Component {}
+        assert.expect(18);
+
+        class TestWidget extends Component {
+            setup() {
+                assert.deepEqual(Object.keys(this.props), ["yop", "yip", "record"]);
+                assert.strictEqual(this.props.yop, "hello");
+                assert.strictEqual(this.props.yip, "Yo");
+            }
+        }
+        TestWidget.extractProps = ({ attrs }) => {
+            assert.deepEqual(attrs, {
+                name: "test_widget",
+                options: { yop: "hello" },
+            });
+            return {
+                yop: attrs.options.yop,
+                yip: "Yo",
+            };
+        };
         TestWidget.template = xml`<div class="test_widget" t-esc="props.record.data.bar"/>`;
         registry.category("view_widgets").add("test_widget", TestWidget);
         await makeView({
@@ -16338,7 +16356,7 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <list>
                     <field name="bar" invisible="1"/>
-                    <widget name="test_widget"/>
+                    <widget name="test_widget" options="{'yop': 'hello'}"/>
                 </list>
             `,
         });

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -432,4 +432,11 @@
         </rng:element>
     </rng:define>
 
+    <rng:define name="widget">
+        <rng:element name="widget">
+            <rng:attribute name="name"/>
+            <rng:optional><rng:attribute name="options"/></rng:optional>
+        </rng:element>
+    </rng:define>
+
 </rng:grammar>

--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -76,6 +76,7 @@
                     </rng:element>
                     <rng:ref name="control"/>
                     <rng:ref name="field"/>
+                    <rng:ref name="widget"/>
                     <rng:ref name="separator"/>
                     <rng:ref name="tree"/>
                     <rng:ref name="groupby"/>


### PR DESCRIPTION
[FIX] web: supports <widget/> in list view
Before this commit, it was possible to define a <widget/> in the arch of
an x2many in list mode. But this was not supported in normal list views.

So in order to unify the api, we decided to support <widget/> in the list
view as well.  We also removed all unnecessary props and passed to
<widget/> in the list view. The goal being to receive only
standardWidgetProps by default.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
