### PR TITLE
[FIX] web_editor: ensure dirty observer target wrapwrap

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -319,7 +319,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         this.observer = new MutationObserver(processRecords);
         const observe = () => {
             if (this.observer) {
-                this.observer.observe(document.body, {
+                this.observer.observe($wrapwrap[0], {
                     childList: true,
                     subtree: true,
                     attributes: true,


### PR DESCRIPTION
Before this commit, the dirty observer was observing the body of the document. This was useless as anything outside the wrapwrap container will never be saved. #106671 is an example of a mutation outside the wrawrap container triggering a bug that could have been avoided by excluding the changes outside the wrapwrap container.

task-3083782




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
