### PR TITLE
[FIX] website: generate signup URL for specific website when needed

### DIFF
--- a/addons/website/models/res_partner.py
+++ b/addons/website/models/res_partner.py
@@ -41,3 +41,16 @@ class Partner(models.Model):
     def _compute_display_name(self):
         self2 = self.with_context(display_website=False)
         super(Partner, self2)._compute_display_name()
+
+    def _compute_signup_url(self):
+        # Force website if defined
+        super()._compute_signup_url()
+        for partner in self:
+            if partner.website_id:
+                url = werkzeug.urls.url_parse(partner.signup_url)
+                query = url.decode_query()
+                query.add('path', url.path)
+                partner.signup_url = url.replace(
+                    query=werkzeug.urls.url_encode(query),
+                    path='/website/force/%s' % partner.website_id.id,
+                ).to_url()


### PR DESCRIPTION
In a multiwebsite environment, if a specific website is specified for a portal user (e.g. by adding the website_id field to the user form with Studio), and domains are not specified for the websites, the reset password form fails because it always tries to locate the user inside the default website instead of the one the portal user is restricted to.

This commit solves this by generating reset links that target the specific website.

opw-3082216