### PR TITLE
[IMP] account/l10n_es : add modelo 390 tax report

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -444,6 +444,8 @@ class AccountReportExpression(models.Model):
         # with engine 'tax_tags'.
         for vals in vals_list:
             self._strip_formula(vals)
+            if 'formula' in vals and isinstance(vals['formula'], str):
+                vals['formula'] = vals['formula'].replace('\n', '').strip()
 
         result = super().create(vals_list)
 

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -75,6 +75,11 @@
         <field name="applicability">taxes</field>
         <field name="country_id" ref="base.es"/>
     </record>
+    <record id="mod_303_10_4_percent" model="account.account.tag">
+        <field name="name">mod303[10] - 4%</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
     <record id="mod_303_11" model="account.account.tag">
         <field name="name">mod303[11]</field>
         <field name="applicability">taxes</field>
@@ -257,6 +262,286 @@
         <field name="applicability">taxes</field>
         <field name="country_id" ref="base.es"/>
     </record>
+    <record id="mod_390_21" model="account.account.tag">
+        <field name="name">mod390[21]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_22" model="account.account.tag">
+        <field name="name">mod390[22]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_23" model="account.account.tag">
+        <field name="name">mod390[23]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_24" model="account.account.tag">
+        <field name="name">mod390[24]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_25" model="account.account.tag">
+        <field name="name">mod390[25]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_26" model="account.account.tag">
+        <field name="name">mod390[26]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_60" model="account.account.tag">
+        <field name="name">mod390[60]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_61" model="account.account.tag">
+        <field name="name">mod390[61]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_545" model="account.account.tag">
+        <field name="name">mod390[545]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_546" model="account.account.tag">
+        <field name="name">mod390[546]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_547" model="account.account.tag">
+        <field name="name">mod390[547]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+        <record id="mod_390_548" model="account.account.tag">
+        <field name="name">mod390[548]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_551" model="account.account.tag">
+        <field name="name">mod390[551]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_552" model="account.account.tag">
+        <field name="name">mod390[552]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_190" model="account.account.tag">
+        <field name="name">mod390[190]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_191" model="account.account.tag">
+        <field name="name">mod390[191]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_603" model="account.account.tag">
+        <field name="name">mod390[603]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_604" model="account.account.tag">
+        <field name="name">mod390[604]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_605" model="account.account.tag">
+        <field name="name">mod390[605]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_606" model="account.account.tag">
+        <field name="name">mod390[606]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_196" model="account.account.tag">
+        <field name="name">mod390[196]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_197" model="account.account.tag">
+        <field name="name">mod390[197]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_611" model="account.account.tag">
+        <field name="name">mod390[611]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_612" model="account.account.tag">
+        <field name="name">mod390[612]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_613" model="account.account.tag">
+        <field name="name">mod390[613]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_614" model="account.account.tag">
+        <field name="name">mod390[614]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_202" model="account.account.tag">
+        <field name="name">mod390[202]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_203" model="account.account.tag">
+        <field name="name">mod390[203]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_619" model="account.account.tag">
+        <field name="name">mod390[619]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_620" model="account.account.tag">
+        <field name="name">mod390[620]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_621" model="account.account.tag">
+        <field name="name">mod390[621]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_622" model="account.account.tag">
+        <field name="name">mod390[622]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_208" model="account.account.tag">
+        <field name="name">mod390[208]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_209" model="account.account.tag">
+        <field name="name">mod390[209]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_623" model="account.account.tag">
+        <field name="name">mod390[623]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_624" model="account.account.tag">
+        <field name="name">mod390[624]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_625" model="account.account.tag">
+        <field name="name">mod390[625]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_626" model="account.account.tag">
+        <field name="name">mod390[626]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_214" model="account.account.tag">
+        <field name="name">mod390[214]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_215" model="account.account.tag">
+        <field name="name">mod390[215]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_627" model="account.account.tag">
+        <field name="name">mod390[627]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_628" model="account.account.tag">
+        <field name="name">mod390[628]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_629" model="account.account.tag">
+        <field name="name">mod390[629]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_630" model="account.account.tag">
+        <field name="name">mod390[630]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_220" model="account.account.tag">
+        <field name="name">mod390[220]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_221" model="account.account.tag">
+        <field name="name">mod390[221]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_631" model="account.account.tag">
+        <field name="name">mod390[631]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_632" model="account.account.tag">
+        <field name="name">mod390[632]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_633" model="account.account.tag">
+        <field name="name">mod390[633]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_634" model="account.account.tag">
+        <field name="name">mod390[634]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_587" model="account.account.tag">
+        <field name="name">mod390[587]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_588" model="account.account.tag">
+        <field name="name">mod390[588]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_635" model="account.account.tag">
+        <field name="name">mod390[635]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_636" model="account.account.tag">
+        <field name="name">mod390[636]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_637" model="account.account.tag">
+        <field name="name">mod390[637]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_390_638" model="account.account.tag">
+        <field name="name">mod390[638]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
     <record id="account_tax_template_s_iva21b" model="account.tax.template">
         <field name="sequence" eval="0"/>
         <!-- Para que sea el impuesto por defecto de ventas -->
@@ -369,12 +654,12 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_28')],
+                'tag_ids': [ref('mod_303_28'), ref('mod_390_605')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('l10n_es.account_common_472'),
-                'tag_ids': [ref('mod_303_29')],
+                'tag_ids': [ref('mod_303_29'), ref('mod_390_606')],
             }),
          ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -401,11 +686,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_28')],
+                'tag_ids': [ref('mod_303_28'), ref('mod_390_605')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_29')],
+                'tag_ids': [ref('mod_303_29'), ref('mod_390_606')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -433,11 +718,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_10'), ref('mod_303_36')],
+                'tag_ids': [ref('mod_303_10'), ref('mod_303_36'), ref('mod_390_637'), ref('mod_390_551')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_37')],
+                'tag_ids': [ref('mod_303_37'), ref('mod_390_638'), ref('mod_390_552')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -477,11 +762,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10'), ref('mod_390_629'), ref('mod_390_25')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_37')],
+                'tag_ids': [ref('mod_303_37'), ref('mod_390_630'), ref('mod_390_26')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -521,11 +806,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_10'), ref('mod_303_38')],
+                'tag_ids': [ref('mod_303_10'), ref('mod_303_38'), ref('mod_390_633')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_39')],
+                'tag_ids': [ref('mod_303_39'), ref('mod_390_634')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -565,11 +850,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_32')],
+                'tag_ids': [ref('mod_303_32'), ref('mod_390_621')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_33')],
+                'tag_ids': [ref('mod_303_33'), ref('mod_390_622')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -597,11 +882,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_34')],
+                'tag_ids': [ref('mod_303_34'), ref('mod_390_625')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_35')],
+                'tag_ids': [ref('mod_303_35'), ref('mod_390_626')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -794,11 +1079,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10'), ref('mod_390_21'), ref('mod_390_214')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_37')],
+                'tag_ids': [ref('mod_303_37'), ref('mod_390_22'), ref('mod_390_215')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -838,11 +1123,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_38'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_38'), ref('mod_303_10'), ref('mod_390_220')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_39')],
+                'tag_ids': [ref('mod_303_39'), ref('mod_390_221')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -882,11 +1167,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10'), ref('mod_390_23'), ref('mod_390_627')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_37')],
+                'tag_ids': [ref('mod_303_37'), ref('mod_390_24'), ref('mod_390_628')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -926,11 +1211,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_38'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_38'), ref('mod_303_10'), ref('mod_390_631')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_39')],
+                'tag_ids': [ref('mod_303_39'), ref('mod_390_632')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {
@@ -1130,11 +1415,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_32')],
+                'tag_ids': [ref('mod_303_32'), ref('mod_390_202')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_33')],
+                'tag_ids': [ref('mod_303_33'), ref('mod_390_203')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1162,11 +1447,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_34')],
+                'tag_ids': [ref('mod_303_34'), ref('mod_390_208')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_35')],
+                'tag_ids': [ref('mod_303_35'), ref('mod_390_209')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1194,11 +1479,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_32')],
+                'tag_ids': [ref('mod_303_32'), ref('mod_390_619')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_33')],
+                'tag_ids': [ref('mod_303_33'), ref('mod_390_620')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1226,11 +1511,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_34')],
+                'tag_ids': [ref('mod_303_34'), ref('mod_390_623')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_35')],
+                'tag_ids': [ref('mod_303_35'), ref('mod_390_624')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1258,11 +1543,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_30')],
+                'tag_ids': [ref('mod_303_30'), ref('mod_390_196')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_31')],
+                'tag_ids': [ref('mod_303_31'), ref('mod_390_197')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1290,11 +1575,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_28')],
+                'tag_ids': [ref('mod_303_28'), ref('mod_390_190')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_29')],
+                'tag_ids': [ref('mod_303_29'), ref('mod_390_191')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1357,11 +1642,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_30')],
+                'tag_ids': [ref('mod_303_30'), ref('mod_390_611')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_31')],
+                'tag_ids': [ref('mod_303_31'), ref('mod_390_612')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1389,11 +1674,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_30')],
+                'tag_ids': [ref('mod_303_30'), ref('mod_390_613')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_31')],
+                'tag_ids': [ref('mod_303_31'), ref('mod_390_614')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1421,11 +1706,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_28')],
+                'tag_ids': [ref('mod_303_28'), ref('mod_390_603')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_29')],
+                'tag_ids': [ref('mod_303_29'), ref('mod_390_604')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1453,11 +1738,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_28')],
+                'tag_ids': [ref('mod_303_28'), ref('mod_390_190')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_29')],
+                'tag_ids': [ref('mod_303_29'), ref('mod_390_191')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
          ]"/>
@@ -1485,12 +1770,12 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_28')],
+                'tag_ids': [ref('mod_303_28'), ref('mod_390_603')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('l10n_es.account_common_472'),
-                'tag_ids': [ref('mod_303_29')],
+                'tag_ids': [ref('mod_303_29'), ref('mod_390_604')],
             }),
          ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2361,7 +2646,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('l10n_es.account_common_472'),
-                'tag_ids': [ref('mod_303_42')],
+                'tag_ids': [ref('mod_303_42'), ref('mod_390_60')],
             }),
          ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -2369,7 +2654,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('l10n_es.account_common_472'),
-                'tag_ids': [ref('mod_303_42')],
+                'tag_ids': [ref('mod_303_42'), ref('mod_390_61')],
             }),
         ]"/>
     </record>
@@ -2789,12 +3074,12 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10'), ref('mod_390_635'), ref('mod_390_547')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('l10n_es.account_common_472'),
-                'tag_ids': [ref('mod_303_37')],
+                'tag_ids': [ref('mod_303_37'), ref('mod_390_636'), ref('mod_390_548')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -2833,11 +3118,11 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10'), ref('mod_390_587'), ref('mod_390_545')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
-                'tag_ids': [ref('mod_303_37')],
+                'tag_ids': [ref('mod_303_37'), ref('mod_390_588'), ref('mod_390_546')],
                 'account_id': ref('l10n_es.account_common_472'),
             }),
             (0,0, {


### PR DESCRIPTION
The modelo 390 is the annual tax report in l10n_es.

It contains most informations from the modelo 303 tax report and some more.

It also details the informations contained in the modelo 303, for instance splitting the 'bienes' and 'servicios', while they are aggregated in the modelo 303.

task-2894615
