### PR TITLE
[FIX] web_editor: should not loose gradient on changing font color

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -228,9 +228,8 @@ function colorElement(element, color, mode) {
         .replace(/\btext-gradient\b/g, '') // cannot be combined with setting a background
         .replace(/\s+/, ' ');
     element.className !== newClassName && (element.className = newClassName);
-    element.style['background-image'] = '';
     if (mode === 'backgroundColor') {
-        element.style['background'] = '';
+        element.style['background-image'] = '';
     }
     if (color.startsWith('text') || color.startsWith('bg-')) {
         element.style[mode] = '';


### PR DESCRIPTION
**Current behavior before PR:**

After applying font color to the text with gradient, it removes the gradient completely which it should not.

**Desired behavior after PR is merged:**

Now when font color is changed the gradient remains the same.

**Task-3084716**
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
