### PR TITLE
[FIX] hr_holidays: avoid double timezone offset for department leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -918,9 +918,11 @@ class HolidaysRequest(models.Model):
                     hour_from = hour_from.hour + hour_from.minute / 60
                     hour_to = hour_to.hour + hour_to.minute / 60
 
-                    values['date_from'] = self._get_start_or_end_from_attendance(hour_from, date_from.date(), employee)
-                    values['date_to'] = self._get_start_or_end_from_attendance(hour_to, date_to.date(), employee)
-                    values['request_date_from'], values['request_date_to'] = values['date_from'].date(), values['date_to'].date()
+                    # If the leave has a parent (e.g. a department leave), timezone offset has already been applied
+                    if not values.get('parent_id'):
+                        values['date_from'] = self._get_start_or_end_from_attendance(hour_from, date_from.date(), employee)
+                        values['date_to'] = self._get_start_or_end_from_attendance(hour_to, date_to.date(), employee)
+                        values['request_date_from'], values['request_date_to'] = values['date_from'].date(), values['date_to'].date()
                     values['number_of_days'] = employee_leave_date_duration[(date_from, date_to)][values['employee_id']]['days']
 
         """ Override to avoid automatic logging of creation """


### PR DESCRIPTION
Steps to reproduce:
	- set work hours to 00:00 until 23h59 (to see the effect of the timezone on the days of the date); 
	- give one day off to a department;
	- approve and validate;
	- go on leave granted for an employee;

Issue:
   For a department, if we request leave for a single day (for example the 12th of the month) `date_from` is going to be 11 and `date_to` is going to be 12 because of the timezone offset (this is normal).

   When we apply this day off to each employee in the department, we will have a `date_from` which will be 10 (this is not normal) and a `date_to` which will be 12.

   So we have an incorrect `date_from` (and also an incorrect `request_date_from`).

Cause:
   We apply the offset of the timezone several times.
   During validation, we take the `date_from` and `date_to` from the department leave to apply it to the employee leaves.
   These dates are already in 'UTC' (even if the `tz` attribute shows us otherwise, it's just the user's timezone).

Solution:
   Check if the leave has a parent and do not apply any changes to the dates in this case.
   The changes have already been applied on the parent.

opw-3096853