### PR TITLE
[IMP] mail: do not send email during install

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -667,6 +667,12 @@ class IrMailServer(models.Model):
             _test_logger.info("skip sending email in test mode")
             return message['Message-Id']
 
+        # Do not actually send emails during an install!
+        if not self.env.registry.loaded:
+            _test_logger.info("skip sending email during install")
+            return message['Message-Id']
+
+
         try:
             message_id = message['Message-Id']
 

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -527,5 +527,6 @@ class TestEmailMessage(TransactionCase):
 
         smtp = FakeSMTP()
         self.patch(threading.current_thread(), 'testing', False)
+        self.patch(self.env.registry, 'loaded', True)
         self.env['ir.mail_server'].send_email(msg, smtp_session=smtp)
         self.assertTrue(smtp.email_sent)


### PR DESCRIPTION
Email sent during an install on the saas can count in the mail limit and are useless. 