### PR TITLE
[FIX] google_calendar: handle Google events patch's error

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -211,7 +211,7 @@ class Meeting(models.Model):
             values['visibility'] = self.privacy
         if not self.active:
             values['status'] = 'cancelled'
-        if self.user_id and self.user_id != self.env.user:
+        if self.user_id and self.user_id != self.env.user and not bool(self.user_id.sudo().google_calendar_token):
             values['extendedProperties']['shared']['%s_owner_id' % self.env.cr.dbname] = self.user_id.id
         elif not self.user_id:
             # We don't store the real owner identity (mail)
@@ -228,6 +228,9 @@ class Meeting(models.Model):
                 },
             }
         return values
+
+    def _is_allowed_user(self):
+        return not self.user_id or self.user_id == self.env.user or not bool(self.user_id.sudo().google_calendar_token)
 
     def _cancel(self):
         # only owner can delete => others refuse the event

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -176,6 +176,10 @@ class RecurrenceRule(models.Model):
         }
         return values
 
+    def _is_allowed_user(self):
+        base = self.base_event_id
+        return not base.user_id or base.user_id == self.env.user or not bool(base.user_id.sudo().google_calendar_token)
+
     def _notify_attendees(self):
         recurrences = self.filtered(
             lambda recurrence: recurrence.base_event_id.alarm_ids and (

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -5,7 +5,7 @@ from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from unittest.mock import MagicMock, patch
 
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import HttpCase
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
 from odoo.addons.google_account.models.google_service import GoogleService
 from odoo.addons.google_calendar.models.res_users import User
@@ -22,7 +22,7 @@ def patch_api(func):
     return patched
 
 @patch.object(User, '_get_google_calendar_token', lambda user: 'dummy-token')
-class TestSyncGoogle(SavepointCase):
+class TestSyncGoogle(HttpCase):
 
     def setUp(self):
         super().setUp()

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -70,7 +70,8 @@ class GoogleCalendarService():
     def patch(self, event_id, values, token=None, timeout=TIMEOUT):
         url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=all" % event_id
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
-        self.google_service._do_request(url, json.dumps(values), headers, method='PATCH', timeout=timeout)
+        status, _, _ = self.google_service._do_request(url, json.dumps(values), headers, method='PATCH', timeout=timeout)
+        return status
 
     @requires_auth_token
     def delete(self, event_id, token=None, timeout=TIMEOUT):


### PR DESCRIPTION
Before this commit: if user A tries to modify the user B event, it will apply on the Odoo, but Google won't handle it and return an error. But the current implementation will change the need to sync to False.

The solution is to handle the errors during the request.

opw-3067586


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
