### PR TITLE
[FIX] web_editor: add history step when checking stars from stars widget

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3958,6 +3958,7 @@ export class OdooEditor extends EventTarget {
                     star.classList.toggle('fa-star', false);
                 };
             }
+            this.historyStep();
         }
 
         // Handle table selection.


### PR DESCRIPTION
When clicking on a star from the (3|5)-stars widgets, the stars light up in yellow to reflect a rating. We weren't making a history step when this happened, meaning that an undo or a rollback of anything that happened just after clicking, would undo that rating change as well.

task-3084709

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
