### PR TITLE
[FIX] website_sale: Show the right list of pricelist when user logs in

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -152,7 +152,7 @@ class Website(models.Model):
 
         if show_visible:
             # Only show selectable or currently used pricelist (cart or session)
-            check_pricelist = lambda pl: pl.selectable or pl.id in (current_pl_id, order_pl_id)
+            check_pricelist = lambda pl: pl.selectable or pl.id in (current_pl_id, order_pl_id, partner_pl_id)
         else:
             check_pricelist = lambda _pl: True
 


### PR DESCRIPTION
Steps to reproduce:
- Create a pricelist and assign it to a user
- Go to website -> Shop (without login).
- Login with the user assigned to the pricelist.

Issue:
The custom  pricelist doesn't show in the list

Cause:
When trying to retrieve pricelists to show, the partner_pricelist wasn't considered.

Solution:
Add the current user pricelist id to the list of ids to check in.

opw-3082635