### PR TITLE
[FIX] update german translation for 'payable by'

### DIFF
--- a/addons/l10n_ch/i18n/de.po
+++ b/addons/l10n_ch/i18n/de.po
@@ -691,7 +691,7 @@ msgstr "<span>Währung</span>"
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template
 msgid "<span>Payable by</span>"
-msgstr "<span>Zahlbar bis</span>"
+msgstr "<span>Zahlbar durch</span>"
 
 #. module: l10n_ch
 #: model_terms:ir.ui.view,arch_db:l10n_ch.l10n_ch_swissqr_template


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
wrong german translation for 'payable by'

Current behavior before PR:
wrong german translation for 'payable by'

Desired behavior after PR is merged:
correct translation



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
