### PR TITLE
[FIX] mass_mailing, web_editor: call cleanForSave on cloned element

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1016,10 +1016,10 @@ const Wysiwyg = Widget.extend({
     closestElement(...args) {
         return closestElement(...args);
     },
-    async cleanForSave() {
-        this.odooEditor && this.odooEditor.cleanForSave();
+    async cleanForSave(element, { includeSnippetMenu = true } = {}) {
+        this.odooEditor && this.odooEditor.cleanForSave(element);
 
-        if (this.snippetsMenu) {
+        if (this.snippetsMenu && includeSnippetMenu) {
             await this.snippetsMenu.cleanForSave();
         }
     },


### PR DESCRIPTION
Before this commit, undoing a change after the call of `to_inline` replaces the content by the output of `to_inline`.

The method `commitChanges` in `mass_mailing_html_fields.js` is called each time the editor is blurred and the editable is mutated by the method `to_inline` in order to compute the email to send.

Editing the editable even with the mutation observer unactive is an error prone strategy for the `to_inline` as all sorts of side effects could happen.

In order to make the code more reliable and fix the issue with the undo a clone of the element is passed to `to_inline`.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
