### PR TITLE
[FIX] web_editor: fix bug when pasting image url

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -1,6 +1,9 @@
 import {
-    BasicEditor, customErrorMessage,
-    testEditor
+    BasicEditor,
+    testEditor,
+    triggerEvent,
+    setTestSelection,
+    Direction
 } from "../utils.js";
 import {CLIPBOARD_WHITELISTS} from "../../src/OdooEditor.js";
 
@@ -1293,6 +1296,61 @@ describe('Copy and paste', () => {
                     contentAfter: '<p>ab<a href="https://www.xyz.xdc">https://www.xyz.xdc</a> []cd</p>',
                 });
             });
+            it('should paste and transform URL among text', async () => {
+                const url = 'https://www.odoo.com';
+                const imgUrl = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                const videoUrl = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `abc ${url} def`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p>abc <a href="${url}">${url}</a> def[]</p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `abc ${imgUrl} def`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p>abc <a href="${imgUrl}">${imgUrl}</a> def[]</p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `abc ${videoUrl} def`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p>abc <a href="${videoUrl}">${videoUrl}</a> def[]</p>`,
+                });
+            });
+            it('should paste and transform multiple URLs', async () => {
+                const url = 'https://www.odoo.com';
+                const imgUrl = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                const videoUrl = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `${url} ${videoUrl} ${imgUrl}`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]</p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `${url} abc ${videoUrl} def ${imgUrl}`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p><a href="${url}">${url}</a> abc <a href="${videoUrl}">${videoUrl}</a> def <a href="${imgUrl}">${imgUrl}</a>[]</p>`,
+                });
+            });
         });
         describe('range not collapsed', async () => {
             it('should paste and transform an URL in a p', async () => {
@@ -1320,6 +1378,84 @@ describe('Copy and paste', () => {
                         await pasteText(editor, 'http://www.xyz.com');
                     },
                     contentAfter: '<p>a<a href="http://existing.com">bhttp://www.xyz.com[]c</a>d</p>',
+                });
+            });
+            it('should restore selection when pasting plain text followed by UNDO', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'def');
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'www.odoo.com');
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'def www.odoo.com xyz');
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+ 
+            });
+            it('should restore selection after pasting HTML followed by UNDO', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<a href="www.odoo.com">odoo.com</a><br><a href="www.google.com">google.com</a>');
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+            });
+            it('should paste and transform URLs among text or multiple URLs', async () => {
+                const url = 'https://www.odoo.com';
+                const imgUrl = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                const videoUrl = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[xyz]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `abc ${url} def`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p>abc <a href="${url}">${url}</a> def[]<br></p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[xyz]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `abc ${imgUrl} def`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p>abc <a href="${imgUrl}">${imgUrl}</a> def[]<br></p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[xyz]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `abc ${videoUrl} def`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p>abc <a href="${videoUrl}">${videoUrl}</a> def[]<br></p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[xyz]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, `${url} ${videoUrl} ${imgUrl}`);
+                        // Powerbox should not open
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]<br></p>`,
                 });
             });
         });
@@ -1357,12 +1493,76 @@ describe('Copy and paste', () => {
                     contentBefore: '<p>a<a href="http://existing.com">b[]c</a>d</p>',
                     stepFunction: async editor => {
                         await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
-                        // Ensure the powerbox is active
+                        // Ensure the powerbox is active with 2 commands (embed image and paste as text)
                         window.chai.expect(editor.commandBar._active).to.be.true;
+                        window.chai.expect(editor.commandBar._currentFilteredCommands.length).to.be.equal(2);
                         // Force commandBar validation on the default first choice
                         await editor.commandBar._currentValidate();
                     },
                     contentAfter: '<p>a<a href="http://existing.com">b<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]c</a>d</p>',
+                });
+            });
+            it('should paste and not transform an image URL in an existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active with 2 commands (embed image and paste as text)
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        window.chai.expect(editor.commandBar._currentFilteredCommands.length).to.be.equal(2);
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">bhttps://download.odoocdn.com/icons/website/static/description/icon.png[]c</a>d</p>',
+                });
+            });
+            it('should paste an image URL as a link in a p', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p><a href="${url}">${url}</a>[]</p>`,
+                });
+            });
+            it('should not revert a history step when pasting an image URL as a link', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        // paste text to have a history step recorded
+                        await pasteText(editor, "*should not disappear*");
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>*should not disappear*<a href="${url}">${url}</a>[]</p>`,
+                });
+            });
+            it('should paste an image URL as simple text in a p', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>${url}&nbsp;[]</p>`,
                 });
             });
         });
@@ -1406,6 +1606,140 @@ describe('Copy and paste', () => {
                     contentAfter: '<p>a<a href="http://existing.com">b<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]c</a>d</p>',
                 });
             });
+            it('should paste an image URL as a link in a p', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>ab<a href="${url}">${url}</a>[]cd</p>`,
+                });
+            });
+            it('should not revert a history step when pasting an image URL as a link', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        // paste text (to have a history step recorded)
+                        await pasteText(editor, "abxxxcd");
+                        // select xxx in "<p>ab[xxx]cd</p>""
+                        const p = editor.editable.querySelector('p')
+                        let selection = {
+                            direction: Direction.FORWARD,
+                            anchorNode: p.childNodes[1],
+                            anchorOffset: 2,
+                            focusNode: p.childNodes[1],
+                            focusOffset: 5,
+                        }
+                        setTestSelection(selection, editor.document);
+                        editor._computeHistorySelection();
+                        // paste url
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>ab<a href="${url}">${url}</a>[]cd</p>`,
+                });
+            });
+            it('should paste an image URL as simple text in a p', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>ab${url}[]cd</p>`,
+                });
+            });
+            it('should paste an image URL as simple text and add a space when at end of a line', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>${url}&nbsp;[]</p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br>abc</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>${url}&nbsp;[]<br>abc</p>`,
+                });
+            });
+            it('should restore selection after pasting image URL followed by UNDO', async () => {
+                const url = 'https://download.odoocdn.com/icons/website/static/description/icon.png';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick first command (Embed image)
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                        // Undo
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                        // Undo
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                        // Undo
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+            });
         });
     });
     describe('youtube video', () => {
@@ -1447,6 +1781,83 @@ describe('Copy and paste', () => {
                     contentAfter: '<p>a<a href="http://existing.com">bhttps://youtu.be/dQw4w9WgXcQ[]c</a>d</p>',
                 });
             });
+            it('should paste a youtube URL as a link in a p', async () => {
+                const url = 'https://youtu.be/dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p><a href="${url}">${url}</a>[]</p>`,
+                });
+            });
+            it('should not revert a history step when pasting a youtube URL as a link', async () => {
+                const url = 'https://youtu.be/dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        // paste text to have a history step recorded
+                        await pasteText(editor, "*should not disappear*");
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>*should not disappear*<a href="${url}">${url}</a>[]</p>`,
+                });
+            });
+            it('should paste a youtube URL as simple text in a p', async () => {
+                const url = 'https://youtu.be/dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[] abc</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>${url}[] abc</p>`,
+                });
+            });
+            it('should paste a youtube URL as simple text and add a space when at end of a line', async () => {
+                const url = 'https://youtu.be/dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>${url}&nbsp;[]</p>`,
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br>abc</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>${url}&nbsp;[]<br>abc</p>`,
+                });
+            });
         });
         describe('range not collapsed', async () => {
             it('should paste and transform a youtube URL in a p', async () => {
@@ -1484,6 +1895,112 @@ describe('Copy and paste', () => {
                         window.chai.expect(editor.commandBar._active).to.be.false;
                     },
                     contentAfter: '<p>a<a href="http://existing.com">bhttps://www.youtube.com/watch?v=dQw4w9WgXcQ[]c</a>d</p>',
+                });
+            });
+            it('should paste a youtube URL as a link in a p', async () => {
+                const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>ab<a href="${url}">${url}</a>[]cd</p>`,
+                });
+            });
+            it('should not revert a history step when pasting a youtube URL as a link', async () => {
+                const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]</p>',
+                    stepFunction: async editor => {
+                        // paste text (to have a history step recorded)
+                        await pasteText(editor, "abxxxcd");
+                        // select xxx in "<p>ab[xxx]cd</p>"
+                        const p = editor.editable.querySelector('p')
+                        let selection = {
+                            direction: Direction.FORWARD,
+                            anchorNode: p.childNodes[1],
+                            anchorOffset: 2,
+                            focusNode: p.childNodes[1],
+                            focusOffset: 5,
+                        }
+                        setTestSelection(selection, editor.document);
+                        editor._computeHistorySelection();
+
+                        // paste url
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>ab<a href="${url}">${url}</a>[]cd</p>`,
+                });
+            });
+            it('should paste a youtube URL as simple text in a p', async () => {
+                const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick the third command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                    },
+                    contentAfter: `<p>ab${url}[]cd</p>`,
+                });
+            });
+            it('should restore selection after pasting video URL followed by UNDO', async () => {
+                const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick first command (Embed video)
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                        // Undo
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick second command (Paste as URL)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                        // Undo
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[abc]</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, url);
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Pick third command (Paste as text)
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown' });
+                        triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
+                        // Undo
+                        editor.historyUndo();
+                    },
+                    contentAfter: '<p>[abc]</p>',
                 });
             });
         });


### PR DESCRIPTION
Before this commit, pasting an image url as simple text was failing, and pasting it as a link was undoing the last modification before it.

This happens because Powerbox.preValidate() reverts one history step before calling the callback attached to the Powerbox command. This is undesired when pasting the url as simple text, as it means deleting the already inserted text.
In case of pasting the url as a link, the callback to this command already performs a historyUndo(), and reverting history one step further leads to loss of previously inserted text.

Defining a "shouldPreValidate" method (returning "false") in the command passed to Powerbox.open() skips the preValidate() call.

task-3099012
