### PR TITLE
[FIX] point_of_sale: fix product search domain

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
@@ -53,7 +53,7 @@ odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
                 let ProductIds = await this.rpc({
                     model: 'product.product',
                     method: 'search',
-                    args: [['&',['available_in_pos', '=', true], '|','|','|',
+                    args: [['&',['available_in_pos', '=', true], '|','|',
                      ['name', 'ilike', this.searchWordInput.el.value],
                      ['default_code', 'ilike', this.searchWordInput.el.value],
                      ['barcode', 'ilike', this.searchWordInput.el.value]]],


### PR DESCRIPTION
This PR (https://github.com/odoo/odoo/pull/105748) introduced a bug by having an extra `OR` operator in the domain.

This commit fixes the error.

opw-3099849


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
