### PR TITLE
[FIX] stock: add store=true in relational field to fix groupby

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -99,7 +99,7 @@ class StockQuant(models.Model):
     in_date = fields.Datetime('Incoming Date', readonly=True, required=True, default=fields.Datetime.now)
     tracking = fields.Selection(related='product_id.tracking', readonly=True)
     on_hand = fields.Boolean('On Hand', store=False, search='_search_on_hand')
-    product_categ_id = fields.Many2one(related='product_tmpl_id.categ_id',store=True)
+    product_categ_id = fields.Many2one(related='product_tmpl_id.categ_id', store=True)
 
     # Inventory Fields
     inventory_quantity = fields.Float(

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -99,7 +99,7 @@ class StockQuant(models.Model):
     in_date = fields.Datetime('Incoming Date', readonly=True, required=True, default=fields.Datetime.now)
     tracking = fields.Selection(related='product_id.tracking', readonly=True)
     on_hand = fields.Boolean('On Hand', store=False, search='_search_on_hand')
-    product_categ_id = fields.Many2one(related='product_tmpl_id.categ_id')
+    product_categ_id = fields.Many2one(related='product_tmpl_id.categ_id',store=True)
 
     # Inventory Fields
     inventory_quantity = fields.Float(


### PR DESCRIPTION
A groupby was inserted in commit 6adf1d8011211a9292e0066b26ce55021b365f72 and it won't work because of the error message when you try to use it 'field <field> is not a stored field, only stored fields are valid for the groupby parameter'
I just made it stored

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
