### PR TITLE
 keep edi error log 

### DIFF
--- a/addons/account_edi/i18n/account_edi.pot
+++ b/addons/account_edi/i18n/account_edi.pot
@@ -27,6 +27,18 @@ msgid "Account Invoice Send"
 msgstr ""
 
 #. module: account_edi
+#: code:addons/account_edi/models/account_edi_document.py:0
+#, python-format
+msgid "An error occurred during cancelling electronic document"
+msgstr ""
+
+#. module: account_edi
+#: code:addons/account_edi/models/account_edi_document.py:0
+#, python-format
+msgid "An error occurred during posting electronic document"
+msgstr ""
+
+#. module: account_edi
 #: model:ir.model,name:account_edi.model_ir_attachment
 #: model:ir.model.fields,field_description:account_edi.field_account_edi_document__attachment_id
 msgid "Attachment"

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -174,6 +174,13 @@ class AccountEdiDocument(models.Model):
                         'error': move_result.get('error', False),
                         'blocking_level': move_result.get('blocking_level', DEFAULT_BLOCKING_LEVEL) if 'error' in move_result else False,
                     })
+                    title = _('An error occurred during posting electronic document')
+                    document.move_id.message_post(
+                        title=title,
+                        body=move_result.get('error', False),
+                        messag_type='comment',
+                        subtype_xmlid='mail.mt_note',
+                    )
 
             # Attachments that are not explicitly linked to a business model could be removed because they are not
             # supposed to have any traceability from the user.
@@ -207,6 +214,13 @@ class AccountEdiDocument(models.Model):
                         'error': move_result.get('error', False),
                         'blocking_level': move_result.get('blocking_level', DEFAULT_BLOCKING_LEVEL) if move_result.get('error') else False,
                     })
+                    title = _('An error occurred during cancelling electronic document')
+                    document.move_id.message_post(
+                        title=title,
+                        body=move_result.get('error', False),
+                        messag_type='comment',
+                        subtype_xmlid='mail.mt_note',
+                    )
 
             if invoice_ids_to_cancel:
                 invoices = self.env['account.move'].browse(list(invoice_ids_to_cancel))


### PR DESCRIPTION
[FIX] account_edi: Keep error history

We only keep the last error occurred during edit interaction, it makes it very hard for the support team to find the root cause of the error. Often, the new error is different, e.g. 'grace period for sending the document is over' or 'maximum retry reached' and we have no clue what was the original error.

Also, for finding the log at that time, the support team usually have to ask the client to click on retry and tell the exact time they have done it so the team can check the new log, which wastes a lot of time in correspondence.

The logging is not done in a unique way too. Proper logging makes it possible for the internal team (SaaS and odoo.sh) to find the errors in the logs and monitor it to alarm if and edi is not working as expected, which can happen if the governments have change something that we are still not aware of.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
