### PR TITLE
[IMP] mail: improve internal and external link behavior

### DIFF
--- a/addons/mail/static/src/core/common/chat_window_service.js
+++ b/addons/mail/static/src/core/common/chat_window_service.js
@@ -17,6 +17,7 @@ export class ChatWindowService {
     }
 
     setup(env, services) {
+        this.chatter = null;
         this.env = env;
         /** @type {import("@mail/core/common/store_service").Store} */
         this.store = services["mail.store"];
@@ -57,7 +58,7 @@ export class ChatWindowService {
     }
 
     get hidden() {
-        return this.store.chatWindows.filter((chatWindow) => chatWindow.hidden);
+        return this.store.chatWindows.filter((chatWindow) => chatWindow.thread !== this.chatter?.state.thread && chatWindow.hidden);
     }
 
     get maxVisible() {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -355,6 +355,8 @@ export class Message extends Component {
                     views: [[false, "form"]],
                     res_id: id,
                 });
+            } else if (ev.target.closest(".o_mail_internal") && ev.target.href !== window.location.href) {
+                this.threadService.open(this.message.originThread, false);
             }
             return;
         }

--- a/addons/mail/static/src/core/web/activity.js
+++ b/addons/mail/static/src/core/web/activity.js
@@ -69,6 +69,12 @@ export class Activity extends Component {
         this.state.showDetails = !this.state.showDetails;
     }
 
+    onClickActivityNote(ev) {
+        if (ev.target.closest(".o_mail_internal") && ev.target.href !== window.location.href) {
+            this.threadService.open(this.thread, false);
+        }
+    }
+
     async onClickMarkAsDone(ev) {
         if (this.popover.isOpen) {
             this.popover.close();

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -38,7 +38,7 @@
                     </tbody>
                 </table>
             </div>
-            <div t-if="activity.note" class="o-mail-Activity-note text-break" t-out="activity.note"/>
+            <div t-if="activity.note" class="o-mail-Activity-note text-break" t-on-click="onClickActivityNote" t-out="activity.note"/>
             <div t-if="activity.mail_template_ids.length > 0" class="o-mail-Activity-mailTemplates">
                 <ActivityMailTemplate activity="activity" onUpdate="props.onUpdate"/>
             </div>

--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -4,6 +4,7 @@ import { Follower } from "@mail/core/common/follower_model";
 import { ThreadService, threadService } from "@mail/core/common/thread_service";
 import { parseEmail } from "@mail/js/utils";
 import { createLocalId } from "@mail/utils/common/misc";
+import { addLink, parseAndTransform } from "@mail/utils/common/format";
 
 import { markup } from "@odoo/owl";
 
@@ -53,7 +54,7 @@ patch(ThreadService.prototype, "mail/core/web", {
             const existingIds = new Set();
             for (const activity of result.activities) {
                 if (activity.note) {
-                    activity.note = markup(activity.note);
+                    activity.note = markup(parseAndTransform(activity.note, addLink));
                 }
                 existingIds.add(this.activityService.insert(activity).id);
             }

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -109,7 +109,8 @@ function linkify(text) {
         result += _escapeEntities(text.slice(curIndex, match.index));
         const url = match[0];
         const href = encodeURI(!/^https?:\/\//i.test(url) ? "http://" + url : url);
-        result += `<a target="_blank" rel="noreferrer noopener" href="${href}">${_escapeEntities(
+        const [target, classVal] = (new URL(href)).origin === window.location.origin ? ["_self", "o_mail_internal"] : ["_blank", "o_mail_external"];
+        result += `<a target="${target}" rel="noreferrer noopener" class="${classVal}" href="${href}">${_escapeEntities(
             url
         )}</a>`;
         curIndex = match.index + match[0].length;
@@ -133,6 +134,13 @@ export function addLink(node, transformChildren) {
         return node.textContent;
     }
     if (node.tagName === "A") {
+        node.target = node.target || (node.origin === window.location.origin ? "_self" : "_blank");
+        if (node.target === "_self") {
+            node.classList.add("o_mail_internal");
+        } else {
+            node.rel = "noreferrer noopener";
+            node.classList.add("o_mail_external");
+        }
         return node.outerHTML;
     }
     transformChildren();

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -35,19 +35,19 @@ QUnit.test("addLink: utility function and special entities", function (assert) {
     const testInputs = {
         // textContent not unescaped
         "<p>https://example.com/?&amp;currency_id</p>":
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/?&amp;currency_id">https://example.com/?&amp;currency_id</a></p>',
+            '<p><a target="_blank" rel="noreferrer noopener" class="o_mail_external" href="https://example.com/?&amp;currency_id">https://example.com/?&amp;currency_id</a></p>',
         // entities not unescaped
         "&amp; &amp;amp; &gt; &lt;": "&amp; &amp;amp; &gt; &lt;",
         // > and " not linkified since they are not in URL regex
         "<p>https://example.com/&gt;</p>":
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>&gt;</p>',
+            '<p><a target="_blank" rel="noreferrer noopener" class="o_mail_external" href="https://example.com/">https://example.com/</a>&gt;</p>',
         '<p>https://example.com/"hello"&gt;</p>':
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>"hello"&gt;</p>',
+            '<p><a target="_blank" rel="noreferrer noopener" class="o_mail_external" href="https://example.com/">https://example.com/</a>"hello"&gt;</p>',
         // & and ' linkified since they are in URL regex
         "<p>https://example.com/&amp;hello</p>":
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/&amp;hello">https://example.com/&amp;hello</a></p>',
+            '<p><a target="_blank" rel="noreferrer noopener" class="o_mail_external" href="https://example.com/&amp;hello">https://example.com/&amp;hello</a></p>',
         "<p>https://example.com/'yeah'</p>":
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/\'yeah\'">https://example.com/\'yeah\'</a></p>',
+            '<p><a target="_blank" rel="noreferrer noopener" class="o_mail_external" href="https://example.com/\'yeah\'">https://example.com/\'yeah\'</a></p>',
         // normal character should not be escaped
         ":'(": ":'(",
         // special character in smileys should be escaped


### PR DESCRIPTION
**Current behavior before PR:**

We want to differentiate the behavior of internal links to Odoo documents and
the external links to any web page in order to allow the user to navigate
smoothly through Odoo from Discuss.

**Desired behavior after PR is merged:**

When a user clicks on an internal link in Discuss to an Odoo document:
- The document is open in the same tab in the browser
- The chat window opens with the conversation where the link was shared.

When a user clicks on an external link it should open in a new tab.

The same behavior should apply to the link shared in Chatter/Activity Log Note.

Task-2636465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
