### PR TITLE
[FIX] onboarding: Fix expected singleton in _compute_current_progress

### DIFF
--- a/addons/onboarding/models/onboarding_onboarding.py
+++ b/addons/onboarding/models/onboarding_onboarding.py
@@ -46,7 +46,7 @@ class Onboarding(models.Model):
     def _compute_current_progress(self):
         for onboarding in self:
             current_progress_id = onboarding.progress_ids.filtered(
-                lambda progress: progress.company_id.id in {False, self.env.company.id})
+                lambda progress: progress.company_id.id in {False, self.env.company.id})[:1]
             if current_progress_id:
                 onboarding.current_onboarding_state = current_progress_id.onboarding_state
                 onboarding.current_progress_id = current_progress_id


### PR DESCRIPTION
 A `ValueError` traceback that occurs in `onboarding/Onboarding:_compute_current_progress` was caught by Sentry

This expected singleton happens because we use the variable `current_progress_id` expecting it to contain only one record without being sure

A solution is to get the first element in any case

Sentry traceback:

![image](https://user-images.githubusercontent.com/77889661/207584772-d5ee3ab3-2e1a-460f-acaa-7ade6dd16331.png)


opw-3101215