### PR TITLE
[FIX] web_editor: o_not_editable shouldn't switch to nearest editable.

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -3041,6 +3041,10 @@ export class OdooEditor extends EventTarget {
         ) {
             this.setContenteditableLink(link);
         }
+        if (ev.target.querySelector('.o_not_editable') || closestElement(ev.target, '.o_not_editable')) {
+            ev.preventDefault();
+            this.document.getSelection().removeAllRanges();
+        }
         // Ignore any changes that might have happened before this point.
         this.observer.takeRecords();
 


### PR DESCRIPTION
**Current behavior before PR:**

Selecting the snippet which is not editable and start typing will switch to the nearest editable area.

**Desired behavior after PR is merged:**

Now, selecting not editable snippet and typing will not switch to the nearest editable area.

Task-2977246
