### PR TITLE
[FIX] sale: fix the computation of the salesperson for quotations

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -403,8 +403,9 @@ class SaleOrder(models.Model):
     @api.depends('partner_id')
     def _compute_user_id(self):
         for order in self:
-            if not order.user_id:
-                order.user_id = order.partner_id.user_id or order.partner_id.commercial_partner_id.user_id or self.env.user
+            partner_user = order.partner_id.user_id or order.partner_id.commercial_partner_id.user_id
+            if not order.user_id or partner_user:
+                order.user_id = partner_user or self.env.user
 
     @api.depends('partner_id', 'user_id')
     def _compute_team_id(self):


### PR DESCRIPTION
Steps to reproduce:

- Go to Sales app.
- Create a quotation.
- Set a salesperson for a new company (or an existing one).
- Select that company in the quotation and check the salesperson in the quotation.

Issue:

The salesperson is not the one set in the company as the default salesperson and it will never change to the right one.

Solution:

Added a way to handle the companies default salesperson for quotations.

FW - port: master

opw-3094068
