### PR TITLE
[FIX] web: show debug tooltip on nolabel fields

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -80,6 +80,9 @@ export class Field extends Component {
             const fieldType = this.props.record.fields[this.props.name].type;
             this.FieldComponent = getFieldClassFromRegistry(fieldType, this.props.type);
         }
+        if (typeof this.props.showTooltip == "undefined") {
+            this.props.showTooltip = this.props.fieldInfo.noLabel;
+        }
     }
 
     get classNames() {
@@ -188,6 +191,7 @@ export class Field extends Component {
             const tooltip = getTooltipInfo({
                 field: this.props.record.fields[this.props.name],
                 fieldInfo: this.props.fieldInfo,
+                resModel: this.props.record.resModel,
             });
             if (Boolean(odoo.debug) || (tooltip && JSON.parse(tooltip).field.help)) {
                 return tooltip;

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -9761,6 +9761,72 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("display tooltip for fields that don't have a label", async function (assert) {
+        patchWithCleanup(odoo, { debug: true });
+
+        patchWithCleanup(browser, {
+            setTimeout: (fn) => fn(),
+            clearTimeout: () => {},
+        });
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="foo"/>
+                            <field name="display_name" nolabel="1"/>
+                        </group>
+                    </sheet>
+                </form>`,
+        });
+
+        await mouseEnter(target.querySelector("[name='foo']"));
+        await nextTick();
+
+        assert.containsNone(target, ".o-tooltip--technical", "no tooltip shoud be displayed");
+
+        await mouseEnter(target.querySelector("[name='display_name']"));
+        await nextTick();
+
+        assert.containsOnce(
+            target,
+            '.o-tooltip--technical > li[data-item="field"]',
+            "'field' should be present in the tooltip"
+        );
+        assert.strictEqual(
+            target.querySelector('.o-tooltip--technical > li[data-item="field"]').lastChild
+                .textContent,
+            "display_name",
+            "'field' should be correctly displayed"
+        );
+        assert.containsOnce(
+            target,
+            '.o-tooltip--technical > li[data-item="type"]',
+            "'type' should be present in the tooltip"
+        );
+        assert.strictEqual(
+            target.querySelector('.o-tooltip--technical > li[data-item="type"]').lastChild
+                .textContent,
+            "char",
+            "'type' should be correctly displayed"
+        );
+        assert.containsOnce(
+            target,
+            '.o-tooltip--technical > li[data-item="object"]',
+            "'model' should be present in the tooltip"
+        );
+        assert.strictEqual(
+            target.querySelector('.o-tooltip--technical > li[data-item="object"]').lastChild
+                .textContent,
+            "partner",
+            "'model' should be correctly displayed"
+        );
+    });
+
     QUnit.test("display tooltips for buttons (debug = true)", async function (assert) {
         patchWithCleanup(odoo, {
             debug: true,


### PR DESCRIPTION
## Steps to reproduce
* Activate debug mode
* Go to a form view that has a field without label (e.g., INTERNAL NOTES on a product's form view)
* hover the mouse over the field

The debug tooltip does not appear.

opw-3047994