### PR TITLE
[FIX] stock: Fix opening of forecast from so line

### DIFF
--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -44,8 +44,9 @@ class StockForecasted extends Component{
                 this.resModel = actionModel[0].model
             }
         } else if (this.props.action._originalAction) {
-            const originalContextAction = JSON.parse(this.props.action._originalAction).context;
-            if (originalContextAction) {
+            let originalContextAction = JSON.parse(this.props.action._originalAction).context;
+            originalContextAction = typeof originalContextAction === "string" ? JSON.parse(originalContextAction) : originalContextAction ;
+            if (originalContextAction && Object.keys(originalContextAction).length !== 0) {
                 this.resModel = originalContextAction.active_model
             }
         }


### PR DESCRIPTION
Steps to reproduce :
- Create a new storable product
- Create a sale order
- Add a product
- Click on the forecast widget -> View Forecast An error is raised indicating that the record may have been deleted. And if no error is raised, the forecast isn't for the right product.

This happens because even though the widgets calls for the `product.product` forecast, the `product.template` forecast will be called anyway using the `product.product` id. Which can lead to either a non-existant or different `product.template`.

opw-3094214
opw-3100964

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
