### PR TITLE
[FIX] stock: open forecast with product product

### DIFF
--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -43,7 +43,7 @@ class StockForecasted extends Component{
             if (actionModel.length && actionModel[0].model) {
                 this.resModel = actionModel[0].model
             }
-        } else if (this.props.action._originalAction) {
+        } else if (!this.resModel && this.props.action._originalAction) {
             const originalContextAction = JSON.parse(this.props.action._originalAction).context;
             if (originalContextAction) {
                 this.resModel = originalContextAction.active_model


### PR DESCRIPTION
Opening the forecast of a storable product either opens the wrong product's forecast report or raises an error

Steps to reproduce:
1. Install Sales and Stock
2. Create a new product with type 'Storable Product'
3. Create a new sale order for any customer and add the new product
4. Confirm the SO and click on the forecast button next to the quantity
5. Click on 'View Forecast', an error is raised (the record does not exist) or it opens the wrong product forecast

Solution:
Get the res model from the context to use the correct report

Problem:
When getting the report values, we used the report of the `product_template` instead of the `product_product`

opw-3099018