### PR TITLE
[FIX] base_setup: Fix Button text issue on res setting

### DIFF
--- a/addons/base_setup/static/src/xml/res_config_invite_users.xml
+++ b/addons/base_setup/static/src/xml/res_config_invite_users.xml
@@ -4,7 +4,7 @@
         <p class="o_form_label">Invite New Users</p>
         <div class="d-flex">
             <input class="o_user_emails o_input mt8 text-truncate" type="text" placeholder="Enter e-mail address"/>
-            <button class="btn btn-primary o_web_settings_invite" data-loading-text="Inviting..."><strong>Invite</strong></button>
+            <button class="btn btn-primary o_web_settings_invite text-truncate w-25" data-loading-text="Inviting..."><strong>Invite</strong></button>
         </div>
 
         <t t-if="widget.pending_users.length">


### PR DESCRIPTION
Before This Commit: when open a res setting , then the invite button size was increased when button name was bigger

After This Commit:The button text size will remain standard with depending on button width

task-3098157

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
