### PR TITLE
[FIX] account: fix payment view

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -312,7 +312,6 @@
                             </group>
                         </group>
                     </sheet>
-                    <div class="o_attachment_preview"/>
                     <div class="oe_chatter">
                         <field name="message_follower_ids" groups="base.group_user"/>
                         <field name="activity_ids"/>


### PR DESCRIPTION
The payment view has a o_attachment_preview div inside it. From the look of it, this is a remnant of the past, as the preview is added next to the form view automatically and does not need to be included inside it.
What happens at the moment is that the div appears in some case either empty but taking some place, or even duplicating the attachment.

Task id #3104741

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
