### PR TITLE
[FIX] website_event: sort properly event snippet

### DIFF
--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -11,7 +11,7 @@
 <!--TEMPLATES-->
 
 <template id="dynamic_filter_template_event_event_picture" name="Picture Layout" priority="5">
-    <figure t-foreach="records" t-as="data" class="w-100 s_events_event">
+    <figure t-foreach="reversed(records)" t-as="data" class="w-100 s_events_event">
         <t t-set="record" t-value="data['_record']._set_tz_context()"/>
         <a class="s_events_event_cover position-relative d-flex flex-column shadow-sm overflow-hidden rounded text-decoration-none"
            t-att-href="data['call_to_action_url']">


### PR DESCRIPTION
In the current state of Odoo, the event snippet display the events ordered by their begin_date wrong (from from the farthest in time to the closest). 

This fix revert it from closest to farthest.

opw-3099944