### PR TITLE
[FIX] l10n_de: Remove empty space on the right of DIN5008 report

### DIFF
--- a/addons/l10n_de/static/src/scss/report_din5008.scss
+++ b/addons/l10n_de/static/src/scss/report_din5008.scss
@@ -1,5 +1,4 @@
 .din_page {
-    width: 180mm;
     margin-left: -1rem;
     font-size: 9pt;
 
@@ -65,7 +64,7 @@
         }
         .page {
             margin-left: 5mm;
-            margin-right: 10mm;
+            margin-right: 5mm;
             > h2, h1, #informations {
                 display: none;
             }
@@ -85,7 +84,7 @@
     }
     &.footer {
         padding-left: 5mm;
-        padding-right: 10mm;
+        padding-right: 5mm;
         .page_number {
             margin-top: 4.23mm;
             width: 100%;


### PR DESCRIPTION
Steps to reproduce:

  - Install l10n_de module
  - Go to Accounting > Configuration > Settings
  - Change the `Document Layout` to `DIN 5008`
  - Go to Accounting > Customers > Invoices
  - Create a new invoice, add a customer and product
  - Print the invoice

Issue:

    The DIN5008 report has a empty space on the right of the report.

Cause:

  Specific width set on the page (180mm) who is not well interpreted
  by wkhtmltopdf.

Solution:

  Remove/Update css.

opw-3050096