### PR TITLE
[FIX] mail: avoid copying notified_partner_ids field

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -133,7 +133,7 @@ class Message(models.Model):
     # mainly usefull for testing
     notified_partner_ids = fields.Many2many(
         'res.partner', 'mail_notification', string='Partners with Need Action',
-        context={'active_test': False}, depends=['notification_ids'])
+        context={'active_test': False}, depends=['notification_ids'], copy=False)
     needaction = fields.Boolean(
         'Need Action', compute='_compute_needaction', search='_search_needaction',
         help='Need Action')


### PR DESCRIPTION
The field `notified_partner_ids` has type Many2many with relation table `mail_notificaiton`. The `mail_notificaiton` is a regular model with some extra fields. One of those fields is required: `notification_type`.

On copying `mail.message` record, ORM copies Many2many fields directly without using `default_get` method for `mail.notification` model. Particularly, `notification_type` get null value and we get an error.

STEPS

1. Create Server Action for `mail.message` model:

```py
for message in (records or record):
    message.copy({
        "subject": message.subject + "(SA copied)",
    })
```

2. Add contextual action
3. Open `mail.message` which has non-empty value on `notified_partner_ids` (*Partners with Need Action*)
4. Run the Server action via Action menu.

PROBLEM

```
ValueError: <class 'psycopg2.errors.NotNullViolation'>: "null value in column
"notification_type" of relation "mail_notification" violates not-null constraint
DETAIL: Failing row contains (11, 210, null, 3, null, null, null, null, null,
null, null, null, null).
```

SOLUTION

Fix it by adding `copy=False`, because we don't want to copy those values anyway (confirmed by TDE).

opw-3069556

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
