### PR TITLE
[FIX] mrp: accessing product template view without mrp right access

### DIFF
--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="stock.view_template_property_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//label[@for='sale_delay']" position="before">
-                    <field name="bom_count" string="Bill of Materials" invisible="1"/>
+                    <field name="bom_count" string="Bill of Materials" invisible="1" groups="mrp.group_mrp_user"/>
                     <label for="produce_delay" string="Manuf. Lead Time" attrs="{'invisible':[('type','=','service')]}"/>
                     <div attrs="{'invisible':[('type','=','service')]}">
                         <field name="produce_delay" class="oe_inline"/> days
@@ -18,6 +18,7 @@
                         <field name="days_to_prepare_mo" class="oe_inline"/> days
                         <button name="action_compute_bom_days" string="Compute from BoM" type="object" attrs="{'invisible':['|', ('type', '=', 'service'), ('bom_count', '=', 0)]}"
                                 help="Compute the days required to resupply all components from BoM, by either buying or manufacturing the components and/or subassemblies."
+                                groups="mrp.group_mrp_user"
                                 class="oe_link pt-0"/>
                     </div>
                 </xpath>


### PR DESCRIPTION
Steps to reproduce:

- Create or modify an user to have User rights for Inventory, Administration rights for Purchase and no rights for Manufacturing.
- Try to go i.e. to the product template view throught Purchase app.
- Purchase > Products > Click on Any Product

Issue:

We won't be able to access the product view even we can Create products, because we require certain rights to access the 'compute bom days' button.

Solution:

Added the proper access rights neede for the views to not crash when we don't have the Manufacturing rights.

opw-3086407
