### PR TITLE
[FIX] web: respect currency symbol position in monetary widget

### DIFF
--- a/addons/web/static/src/views/fields/monetary/monetary_field.xml
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.xml
@@ -4,8 +4,9 @@
     <t t-name="web.MonetaryField" owl="1">
         <span t-if="props.readonly" t-esc="formattedValue" />
         <div class="text-nowrap d-inline-flex w-100 align-items-baseline" t-else="">
-            <span t-if="!props.hideSymbol and currency" t-out="currencySymbol" />
+            <span t-if="!props.hideSymbol and currency and currency.position != 'after'" t-out="currencySymbol" />
             <input t-ref="numpadDecimal" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" class="o_input flex-grow-1 flex-shrink-1"/>
+            <span t-if="!props.hideSymbol and currency and currency.position == 'after'" t-out="currencySymbol" />
         </div>
     </t>
 


### PR DESCRIPTION
The currency symbol position matters!

STEPS:
1. Set Symbol Position to *After Amount*
2. Open product form

PROBLEM

The $ sign is still before the amoutn

SOLUTION

Update widget template

opw-3049783

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
