### PR TITLE
[ADD] account_tax_update: Add a way to update taxes from local ta…

### DIFF
--- a/addons/account_tax_update/__init__.py
+++ b/addons/account_tax_update/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import wizard

--- a/addons/account_tax_update/__manifest__.py
+++ b/addons/account_tax_update/__manifest__.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': "Account Tax Update",
+    'description': """
+    
+    """,
+    'category': 'Accounting/Accounting',
+    'version': '1.0',
+    'depends': [
+        'account',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/account_tax_update_views.xml',
+        'views/res_config_settings_views.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/account_tax_update/security/ir.model.access.csv
+++ b/addons/account_tax_update/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_account_tax_update_manager","access.account.tax.update.manager","model_account_tax_update","account.group_account_manager",1,1,1,0

--- a/addons/account_tax_update/tests/__init__.py
+++ b/addons/account_tax_update/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_account_tax_update

--- a/addons/account_tax_update/tests/test_account_tax_update.py
+++ b/addons/account_tax_update/tests/test_account_tax_update.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import SavepointCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestAccountTaxUpdate(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAccountTaxUpdate, cls).setUpClass()
+        cls.chart_template = cls.env.company.chart_template_id
+        cls.inv_base_tag = cls.env['account.account.tag'].create({
+            'name': 'invoice_base',
+            'applicability': 'taxes',
+            'country_id': cls.env.company.country_id.id,
+        })
+        cls.inv_tax_tag = cls.env['account.account.tag'].create({
+            'name': 'invoice_tax',
+            'applicability': 'taxes',
+            'country_id': cls.env.company.country_id.id,
+        })
+        cls.ref_base_tag = cls.env['account.account.tag'].create({
+            'name': 'refund_base',
+            'applicability': 'taxes',
+            'country_id': cls.env.company.country_id.id,
+        })
+        cls.ref_tax_tag = cls.env['account.account.tag'].create({
+            'name': 'refund_tax',
+            'applicability': 'taxes',
+            'country_id': cls.env.company.country_id.id,
+        })
+        cls.template = cls.env['account.tax.template']._load_records([{
+            'xml_id': 'foo.test_tax_template',
+            'values': {
+                'name': 'Tax Test',
+                'amount_type': 'fixed',
+                'type_tax_use': 'sale',
+                'amount': 30,
+                'chart_template_id': cls.chart_template.id,
+                'invoice_repartition_line_ids': [
+                    (0, 0, {'factor_percent': 100, 'repartition_type': 'base', 'tag_ids': [(4, cls.inv_base_tag.id, 0)]}),
+                    (0, 0, {'factor_percent': 100, 'repartition_type': 'tax', 'tag_ids': [(4, cls.inv_tax_tag.id, 0)]}),
+                ],
+                'refund_repartition_line_ids': [
+                    (0, 0, {'factor_percent': 100, 'repartition_type': 'base', 'tag_ids': [(4, cls.ref_base_tag.id, 0)]}),
+                    (0, 0, {'factor_percent': 100, 'repartition_type': 'tax', 'tag_ids': [(4, cls.ref_tax_tag.id, 0)]}),
+                ],
+            },
+            'noupdate': True,
+        }])
+        template_vals = cls.template._get_tax_vals_complete(cls.env.company)
+        tax_id = cls.chart_template.create_record_with_xmlid(cls.env.company, cls.template, 'account.tax', template_vals)
+        cls.tax = cls.env['account.tax'].browse(tax_id)
+
+    def test_xmlid_match_template_match(self):
+        inv_tax_updated_tag = self.env['account.account.tag'].create({
+            'name': 'invoice_tax_updated',
+            'applicability': 'taxes',
+            'country_id': self.env.company.country_id.id,
+        })
+        self.tax.invoice_repartition_line_ids.write({'tag_ids': [(4, inv_tax_updated_tag.id, 0), (3, self.inv_tax_tag.id)]})
+        self.assertNotEqual(self.template.invoice_repartition_line_ids.tag_ids, self.tax.invoice_repartition_line_ids.tag_ids,
+                            "Tax template tags and tax tags should be different.")
+        self.env['account.tax.update'].update_taxes()
+        self.assertEqual(self.template.invoice_repartition_line_ids.tag_ids, self.tax.invoice_repartition_line_ids.tag_ids,
+                         "After update, tax tags should be the same than template tags.")

--- a/addons/account_tax_update/views/account_tax_update_views.xml
+++ b/addons/account_tax_update/views/account_tax_update_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_account_tax_update" model="ir.ui.view">
+            <field name="name">Update taxes</field>
+            <field name="model">account.tax.update</field>
+            <field name="arch" type="xml">
+                <form string="Update taxes from local modules">
+                    <div class="alert alert-warning text-center mb-0 no_print" role="alert">
+                        <span>
+                            To get the latest updates, make sure your localization module is up-to-date. <br/>
+                            This action will create new taxes or update existing ones, but not the ones manually created.
+                        </span>
+                    </div>
+                    <footer>
+                        <button name="update_taxes" string="Update" type="object" class="btn-primary"/>
+                        <button special="cancel" string="Cancel" class="btn-secondary"/>
+                    </footer>
+                </form>
+           </field>
+        </record>
+
+        <record id="action_view_account_tax_update" model="ir.actions.act_window">
+            <field name="name">Update taxes</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">account.tax.update</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account_tax_update/views/res_config_settings_views.xml
+++ b/addons/account_tax_update/views/res_config_settings_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.account.tax.update</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@id='default_taxes']//div[hasclass('content-group')]" position="inside">
+                    <div class="mt8" groups="account.group_account_manager">
+                        <button name="%(account_tax_update.action_view_account_tax_update)d" string="Update taxes" type="action" class="oe_link" icon="fa-refresh"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account_tax_update/wizard/__init__.py
+++ b/addons/account_tax_update/wizard/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_tax_update

--- a/addons/account_tax_update/wizard/account_tax_update.py
+++ b/addons/account_tax_update/wizard/account_tax_update.py
@@ -1,0 +1,132 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountTaxUpdate(models.TransientModel):
+    """
+    This class manages the update of account.tax from account.tax.template.
+    """
+    _name = "account.tax.update"
+    _description = "Update taxes from tax templates"
+
+    def update_taxes(self):
+        company = self.env.company
+        template_to_tax = self._get_template_to_tax_xmlid_mapping(company)
+        templates = self.env['account.tax.template'].search([("chart_template_id", "=", company.chart_template_id.id)])
+        questionable_taxes = []
+        for template in templates:
+            if template.id not in template_to_tax:
+                # if the tax template is not present in the mapping, it means the corresponding tax was removed from
+                # the db, or no xmlid exists for the tax (in the case of old db or new tax)
+                # -> create a new tax
+                self._create_tax_from_template(company, template)
+            else:
+                # there is a corresponding xmlid in taxes, let's check if it's exactly the same taxe
+                tax = self.env["account.tax"].browse(template_to_tax[template.id])
+                if self._tax_and_template_compare(template, tax):
+                    # -> update the tax : we only updates tax tags
+                    tax_rep_lines = tax.invoice_repartition_line_ids + tax.refund_repartition_line_ids
+                    template_rep_lines = template.invoice_repartition_line_ids + template.refund_repartition_line_ids
+                    for tax_line, template_line in zip(tax_rep_lines, template_rep_lines):
+                        tags_to_add = template_line._get_tags_to_add()
+                        tags_to_unlink = tax_line.tag_ids
+                        if tags_to_add != tags_to_unlink:
+                            tax_line.write({"tag_ids": [(6, 0, tags_to_add.ids)]})
+                            self._tags_cleanup(tags_to_unlink)
+                else:
+                    # it's not exactly the same tax
+                    # -> create new tax + drop old tax xmlid
+                    self._create_tax_from_template(company, template, old_tax=tax)
+                    questionable_taxes.append(tax)
+        # we send a message to accountant managers to warn them some taxes might be unrelevant now
+        if questionable_taxes:
+            self._send_message_to_accountants(questionable_taxes)
+
+    def _create_tax_from_template(self, company, template, old_tax=None):
+        """
+        Create a new tax from template with template xmlid, if there was already an old tax with that xmlid we
+        remove the xmlid from it but don't modify anything else.
+        """
+        def _remove_xml_id(xml_id):
+            module, name = xml_id.split(".", 1)
+            self.env['ir.model.data'].search([('module', '=', module), ('name', '=', name)]).unlink()
+
+        template_vals = template._get_tax_vals_complete(company)
+        chart_template = self.env["account.chart.template"].with_context(default_company_id=company.id)
+        if old_tax:
+            xml_id = old_tax.get_xml_id().get(old_tax.id)
+            if xml_id:
+                _remove_xml_id(xml_id)
+        chart_template.create_record_with_xmlid(company, template, "account.tax", template_vals)
+
+    def _get_template_to_tax_xmlid_mapping(self, company):
+        """
+        This function uses ir_model_data to return a mapping between the tax templates and the taxes, using their xmlid
+        :returns: {
+            account.tax.template.id: account.tax.id
+            }
+        """
+        self.env['ir.model.data'].flush()
+        self.env.cr.execute(
+            """
+            SELECT template.res_id AS template_res_id,
+                   tax.res_id AS tax_res_id
+            FROM ir_model_data tax
+            JOIN ir_model_data template
+            ON template.name = substr(tax.name, strpos(tax.name, '_') + 1)
+            WHERE tax.model = 'account.tax'
+            AND tax.name LIKE %s
+            -- tax.name is of the form: {company_id}_{account.tax.template.name}
+            """,
+            [r"%s\_%%" % company.id],
+        )
+        tuples = self.env.cr.fetchall()
+        template_to_tax = dict(tuples)
+        return template_to_tax
+
+    def _tax_and_template_compare(self, template, tax):
+        """
+        This function compares account.tax and account.tax.template repartition lines.
+        A tax is considered the same as the template if they have the same:
+            - amount_type
+            - amount
+            - repartition lines percentages in the same order
+        """
+        if tax.amount_type != template.amount_type or tax.amount != template.amount \
+                or len(tax.invoice_repartition_line_ids) != len(template.invoice_repartition_line_ids) \
+                or len(tax.refund_repartition_line_ids) != len(template.refund_repartition_line_ids):
+            return False
+
+        tax_rep_lines = tax.invoice_repartition_line_ids + tax.refund_repartition_line_ids
+        template_rep_lines = template.invoice_repartition_line_ids + template.refund_repartition_line_ids
+        for rep_line_tax, rep_line_template in zip(tax_rep_lines, template_rep_lines):
+            if rep_line_tax.factor_percent != rep_line_template.factor_percent:
+                return False
+        return True
+
+    def _tags_cleanup(self, tags):
+        """
+        Checks if the tags are still used by move.line or repartition.line.
+        If it's still referenced, we archieve it, else we delete it.
+        """
+        for tag in tags:
+            aml_using_tags = self.env['account.move.line'].sudo().search([('tax_tag_ids', 'in', tag.id)])
+            tax_using_tags = self.env['account.tax.repartition.line'].sudo().search([('tag_ids', 'in', tag.id)])
+            if aml_using_tags or tax_using_tags:
+                tag.active = False
+            else:
+                tag.unlink()
+
+    def _send_message_to_accountants(self, taxes_to_report):
+        # message = self.env['mail.message'].create({
+        #     'subject': _('Invitation to follow %(document_model)s: %(document_name)s', document_model=model_name,
+        #                  document_name=document.display_name),
+        #     'body': wizard.message,
+        #     'record_name': document.display_name,
+        #     'email_from': email_from,
+        #     'reply_to': email_from,
+        #     'model': wizard.res_model,
+        #     'res_id': wizard.res_id,
+        #     'no_auto_thread': True,
+        # })
+        pass


### PR DESCRIPTION
…x templates

When taxes changed for a country (additions, modifications, ...) we were not applying modifications made on templates to regular tax objects. Thus users were forced to modify everything by hand or ask support to do it. We now try to safely update taxes, when we are sure they are the same we update their tax tags, else we create new ones without modifying existing ones.

Task: 3098941