### PR TITLE
[FIX] mail: add translation to kanban on hover

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -563,7 +563,7 @@ var KanbanActivity = BasicActivity.extend({
         this._super.apply(this, arguments);
         var selection = {};
         _.each(record.fields.activity_state.selection, function (value) {
-            selection[value[0]] = value[1];
+            selection[value[0]] = _t(value[1]);
         });
         this.selection = selection;
         this._setState(record);


### PR DESCRIPTION
When hovering on certain widgets in debug mode (like in sign or CRM) while using any translations, it's possible to observe that the title of those widgets aren't translated.

opw-3083818