### PR TITLE
[FIX] crm: remove references to `session.company_currency_id`

### DIFF
--- a/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
-import { session } from "@web/session";
 import { useService } from "@web/core/utils/hooks";
 
 const { onWillStart } = owl;
@@ -24,8 +23,8 @@ export class CrmKanbanRenderer extends KanbanRenderer {
         const value = group.getAggregates(rrField.name);
         const title = rrField.string || this.env._t("Count");
         let currency = false;
-        if (value && rrField.currency_field) {
-            currency = session.currencies[session.company_currency_id];
+        if (value && rrField.currency_field && group.list.records.length) {
+            currency = group.list.records[0].data[rrField.currency_field];
         }
         return { value, currency, title };
     }


### PR DESCRIPTION
Currently, there are a few references to a variable called `session.company_currency_id`. This variable used to be defined in the `web_dashboard`, a module that no longer exists.

https://github.com/odoo/enterprise/blob/3d351aa3f8e4943df81bc09640ae16380e9a89f7/web_dashboard/models/ir_http.py#L14 (v15.3)

This commit removes all references to `session.company_currency_id` in the `crm` module.

opw-3033656