### PR TITLE
[FIX] web: remove references to `session.company_currency_id`

### DIFF
--- a/addons/web/static/src/legacy/js/views/sample_server.js
+++ b/addons/web/static/src/legacy/js/views/sample_server.js
@@ -1,6 +1,5 @@
 /** @odoo-module alias=web.SampleServer **/
 
-    import session from 'web.session';
     import utils from 'web.utils';
     import Registry from 'web.Registry';
     import viewUtils from 'web.viewUtils';
@@ -249,7 +248,7 @@
                     return this._getRandomInt(SampleServer.MAX_MONETARY);
                 case "many2one":
                     if (field.relation === 'res.currency') {
-                        return session.company_currency_id;
+                        return 1;
                     }
                     if (field.relation === 'ir.attachment') {
                         return false;

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -9,7 +9,6 @@ import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { useSortable } from "@web/core/utils/sortable";
 import { sprintf } from "@web/core/utils/strings";
-import { session } from "@web/session";
 import { isAllowedDateField } from "@web/views/relational_model";
 import { isNull, isRelational } from "@web/views/utils";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
@@ -284,8 +283,8 @@ export class KanbanRenderer extends Component {
         const value = group.getAggregates(sumField && sumField.name);
         const title = sumField ? sumField.string : this.env._t("Count");
         let currency = false;
-        if (sumField && value && sumField.currency_field) {
-            currency = session.currencies[session.company_currency_id];
+        if (sumField && value && sumField.currency_field && group.list.records.length) {
+            currency = group.list.records[0].data[sumField.currency_field];
         }
         return { value, currency, title };
     }

--- a/addons/web/static/tests/legacy/views/sample_server_tests.js
+++ b/addons/web/static/tests/legacy/views/sample_server_tests.js
@@ -2,8 +2,6 @@ odoo.define('web.sample_server_tests', function (require) {
     "use strict";
 
     const SampleServer = require('web.SampleServer');
-    const session = require('web.session');
-    const { mock } = require('web.test_utils');
 
     const {
         MAIN_RECORDSET_SIZE, SEARCH_READ_LIMIT, // Limits
@@ -83,10 +81,6 @@ odoo.define('web.sample_server_tests', function (require) {
         QUnit.test("Sample data: people type + all field names", async function (assert) {
             assert.expect(26);
 
-            mock.patch(session, {
-                company_currency_id: 4,
-            });
-
             const allFieldNames = Object.keys(this.fields['res.users']);
             const server = new DeterministicSampleServer('res.users', this.fields['res.users']);
             const { records } = await server.mockRpc({
@@ -145,7 +139,7 @@ odoo.define('web.sample_server_tests', function (require) {
             assert.ok(selectionValues.includes(rec.type));
 
             // Relational fields
-            assert.strictEqual(rec.currency[0], 4);
+            assert.strictEqual(rec.currency[0], 1);
             // Currently we expect the currency name to be a latin string, which
             // is not important; in most case we only need the ID. The following
             // assertion can be removed if needed.
@@ -166,7 +160,6 @@ odoo.define('web.sample_server_tests', function (require) {
                 (id) => typeof id === 'number')
             );
 
-            mock.unpatch(session);
         });
 
         QUnit.test("Sample data: country type", async function (assert) {


### PR DESCRIPTION
Currently, there are a few references to a variable called `session.company_currency_id`. This variable used to be defined in the `web_dashboard`, a module that no longer exists.

https://github.com/odoo/enterprise/blob/3d351aa3f8e4943df81bc09640ae16380e9a89f7/web_dashboard/models/ir_http.py#L14 (v15.3)

This commit removes all references to `session.company_currency_id` in the `web` module.

opw-3033656