### PR TITLE
[FIX] l10n_lu: fix the tax report

### DIFF
--- a/addons/l10n_lu/data/account_tax_report_line.xml
+++ b/addons/l10n_lu/data/account_tax_report_line.xml
@@ -24,38 +24,43 @@
                                 <field name="name">911 - base 16%</field>
                                 <field name="tag_name">911</field>
                                 <field name="sequence">7</field>
+                                <field name="code">LUTAX_911</field>
                             </record>
                             <record id="account_tax_report_line_2b_base_14" model="account.tax.report.line">
                                 <field name="name">713 - base 14%</field>
                                 <field name="tag_name">713</field>
                                 <field name="sequence">8</field>
+                                <field name="code">LUTAX_713</field>
                             </record>
                             <record id="account_tax_report_line_2b_base_13" model="account.tax.report.line">
                                 <field name="name">913 - base 13%</field>
                                 <field name="tag_name">913</field>
                                 <field name="sequence">9</field>
-                                <field name="code">LUTAX_713</field>
+                                <field name="code">LUTAX_913</field>
                             </record>
                             <record id="account_tax_report_line_2b_base_8" model="account.tax.report.line">
                                 <field name="name">715 - base 8%</field>
                                 <field name="tag_name">715</field>
                                 <field name="sequence">10</field>
+                                <field name="code">LUTAX_715</field>
                             </record>
                             <record id="account_tax_report_line_2b_base_7" model="account.tax.report.line">
                                 <field name="name">915 - base 7%</field>
                                 <field name="tag_name">915</field>
                                 <field name="sequence">11</field>
+                                <field name="code">LUTAX_915</field>
                             </record>
                             <record id="account_tax_report_line_2b_base_3" model="account.tax.report.line">
                                 <field name="name">049 - base 3%</field>
                                 <field name="tag_name">049</field>
                                 <field name="sequence">12</field>
+                                <field name="code">LUTAX_049</field>
                             </record>
                             <record id="account_tax_report_line_2b_base_exempt" model="account.tax.report.line">
                                 <field name="name">194 - base exempt</field>
                                 <field name="tag_name">194</field>
                                 <field name="sequence">13</field>
-                                <field name="code">LUTAX_715</field>
+                                <field name="code">LUTAX_194</field>
                             </record>
                             <record id="account_tax_report_line_2b_manufactured_tobacco" model="account.tax.report.line">
                                 <field name="name">719 - of manufactured tobacco (VAT is collected at the exit of the tax warehouse with excise duties)</field>
@@ -80,38 +85,43 @@
                                 <field name="name">921 - for business purposes: base 16%</field>
                                 <field name="tag_name">921</field>
                                 <field name="sequence">4</field>
+                                <field name="code">LUTAX_921</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_base_14" model="account.tax.report.line">
                                 <field name="name">723 - for business purposes: base 14%</field>
                                 <field name="tag_name">723</field>
                                 <field name="sequence">5</field>
+                                <field name="code">LUTAX_723</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_base_13" model="account.tax.report.line">
                                 <field name="name">923 - for business purposes: base 13%</field>
                                 <field name="tag_name">923</field>
                                 <field name="sequence">6</field>
-                                <field name="code">LUTAX_723</field>
+                                <field name="code">LUTAX_923</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_base_8" model="account.tax.report.line">
                                 <field name="name">725 - for business purposes: base 8%</field>
                                 <field name="tag_name">725</field>
                                 <field name="sequence">7</field>
+                                <field name="code">LUTAX_725</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_base_7" model="account.tax.report.line">
                                 <field name="name">925 - for business purposes: base 7%</field>
                                 <field name="tag_name">925</field>
                                 <field name="sequence">8</field>
+                                <field name="code">LUTAX_925</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_base_3" model="account.tax.report.line">
                                 <field name="name">059 - for business purposes: base 3%</field>
                                 <field name="tag_name">059</field>
                                 <field name="sequence">9</field>
+                                <field name="code">LUTAX_059</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_base_exempt" model="account.tax.report.line">
                                 <field name="name">195 - for business purposes: base exempt</field>
                                 <field name="tag_name">195</field>
                                 <field name="sequence">10</field>
-                                <field name="code">LUTAX_725</field>
+                                <field name="code">LUTAX_195</field>
                             </record>
                             <record id="account_tax_report_line_2d_1_manufactured_tobacco" model="account.tax.report.line">
                                 <field name="name">729 - of manufactured tobacco (VAT is collected at the exit of the tax warehouse with excise duties)</field>
@@ -123,23 +133,25 @@
                                 <field name="name">731 - for non-business purposes: base 17%</field>
                                 <field name="tag_name">731</field>
                                 <field name="sequence">12</field>
+                                <field name="code">LUTAX_731</field>
                             </record>
                             <record id="account_tax_report_line_2d_2_base_16" model="account.tax.report.line">
                                 <field name="name">931 - for non-business purposes: base 16%</field>
                                 <field name="tag_name">931</field>
                                 <field name="sequence">13</field>
-                                <field name="code">LUTAX_731</field>
+                                <field name="code">LUTAX_931</field>
                             </record>
                             <record id="account_tax_report_line_2d_2_base_14" model="account.tax.report.line">
                                 <field name="name">733 - for non-business purposes: base 14%</field>
                                 <field name="tag_name">733</field>
                                 <field name="sequence">14</field>
+                                <field name="code">LUTAX_733</field>
                             </record>
                             <record id="account_tax_report_line_2d_2_base_13" model="account.tax.report.line">
                                 <field name="name">933 - for non-business purposes: base 13%</field>
                                 <field name="tag_name">933</field>
                                 <field name="sequence">15</field>
-                                <field name="code">LUTAX_733</field>
+                                <field name="code">LUTAX_933</field>
                             </record>
                             <record id="account_tax_report_line_2d_2_base_8" model="account.tax.report.line">
                                 <field name="name">735 - for non-business purposes: base 8%</field>
@@ -151,7 +163,7 @@
                                 <field name="name">935 - for non-business purposes: base 7%</field>
                                 <field name="tag_name">935</field>
                                 <field name="sequence">17</field>
-                                <field name="code">LUTAX_059</field>
+                                <field name="code">LUTAX_935</field>
                             </record>
                             <record id="account_tax_report_line_2d_2_base_3" model="account.tax.report.line">
                                 <field name="name">063 - for non-business purposes: base 3%</field>
@@ -163,7 +175,7 @@
                                 <field name="name">196 - for non-business purposes: base exempt</field>
                                 <field name="tag_name">196</field>
                                 <field name="sequence">19</field>
-                                <field name="code">LUTAX_195</field>
+                                <field name="code">LUTAX_196</field>
                             </record>
                         </field>
                     </record>
@@ -193,33 +205,37 @@
                                         <field name="name">941 - not exempt within the territory: base 16%</field>
                                         <field name="tag_name">941</field>
                                         <field name="sequence">7</field>
+                                        <field name="code">LUTAX_941</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_1_a_base_14" model="account.tax.report.line">
                                         <field name="name">743 - not exempt within the territory: base 14%</field>
                                         <field name="tag_name">743</field>
                                         <field name="sequence">8</field>
+                                        <field name="code">LUTAX_743</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_1_a_base_13" model="account.tax.report.line">
                                         <field name="name">943 - not exempt within the territory: base 13%</field>
                                         <field name="tag_name">943</field>
                                         <field name="sequence">9</field>
-                                        <field name="code">LUTAX_743</field>
+                                        <field name="code">LUTAX_943</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_1_a_base_8" model="account.tax.report.line">
                                         <field name="name">745 - not exempt within the territory: base 8%</field>
                                         <field name="tag_name">745</field>
                                         <field name="sequence">10</field>
+                                        <field name="code">LUTAX_745</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_1_a_base_7" model="account.tax.report.line">
                                         <field name="name">945 - not exempt within the territory: base 7%</field>
                                         <field name="tag_name">945</field>
                                         <field name="sequence">11</field>
+                                        <field name="code">LUTAX_945</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_1_a_base_3" model="account.tax.report.line">
                                         <field name="name">431 - not exempt within the territory: base 3%</field>
                                         <field name="tag_name">431</field>
                                         <field name="sequence">12</field>
-                                        <field name="code">LUTAX_745</field>
+                                        <field name="code">LUTAX_431</field>
                                     </record>
                                 </field>
                             </record>
@@ -244,38 +260,43 @@
                                         <field name="name">951 - not established or residing within the Community: base 16%</field>
                                         <field name="tag_name">951</field>
                                         <field name="sequence">7</field>
+                                        <field name="code">LUTAX_951</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_2_base_14" model="account.tax.report.line">
                                         <field name="name">753 - not established or residing within the Community: base 14%</field>
                                         <field name="tag_name">753</field>
                                         <field name="sequence">8</field>
+                                        <field name="code">LUTAX_753</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_2_base_13" model="account.tax.report.line">
                                         <field name="name">953 - not established or residing within the Community: base 13%</field>
                                         <field name="tag_name">953</field>
                                         <field name="sequence">9</field>
-                                        <field name="code">LUTAX_753</field>
+                                        <field name="code">LUTAX_953</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_2_base_8" model="account.tax.report.line">
                                         <field name="name">755 - not established or residing within the Community: base 8%</field>
                                         <field name="tag_name">755</field>
                                         <field name="sequence">10</field>
+                                        <field name="code">LUTAX_755</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_2_base_7" model="account.tax.report.line">
                                         <field name="name">955 - not established or residing within the Community: base 7%</field>
                                         <field name="tag_name">955</field>
                                         <field name="sequence">11</field>
+                                        <field name="code">LUTAX_955</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_2_base_3" model="account.tax.report.line">
                                         <field name="name">441 - not established or residing within the Community: base 3%</field>
                                         <field name="tag_name">441</field>
                                         <field name="sequence">12</field>
+                                        <field name="code">LUTAX_441</field>
                                     </record>
                                     <record id="account_tax_report_line_2e_2_exempt" model="account.tax.report.line">
                                         <field name="name">445 - not established or residing within the Community: exempt</field>
                                         <field name="tag_name">445</field>
                                         <field name="sequence">13</field>
-                                        <field name="code">LUTAX_755</field>
+                                        <field name="code">LUTAX_445</field>
                                     </record>
                                 </field>
                             </record>
@@ -294,6 +315,7 @@
                                         <field name="name">961 - suppliers established within the territory: base 16%</field>
                                         <field name="tag_name">961</field>
                                         <field name="sequence">2</field>
+                                        <field name="code">LUTAX_961</field>
                                     </record>
                                 </field>
                             </record>
@@ -314,17 +336,19 @@
                                 <field name="name">901 - base 16%</field>
                                 <field name="tag_name">901</field>
                                 <field name="sequence">7</field>
+                                <field name="code">LUTAX_901</field>
                             </record>
                             <record id="account_tax_report_line_2a_base_14" model="account.tax.report.line">
                                 <field name="name">703 - base 14%</field>
                                 <field name="tag_name">703</field>
                                 <field name="sequence">8</field>
+                                <field name="code">LUTAX_703</field>
                             </record>
                             <record id="account_tax_report_line_2a_base_13" model="account.tax.report.line">
                                 <field name="name">903 - base 13%</field>
                                 <field name="tag_name">903</field>
                                 <field name="sequence">9</field>
-                                <field name="code">LUTAX_703</field>
+                                <field name="code">LUTAX_903</field>
                             </record>
                             <record id="account_tax_report_line_2a_base_8" model="account.tax.report.line">
                                 <field name="name">705 - base 8%</field>
@@ -336,11 +360,13 @@
                                 <field name="name">905 - base 7%</field>
                                 <field name="tag_name">905</field>
                                 <field name="sequence">11</field>
+                                <field name="code">LUTAX_905</field>
                             </record>
                             <record id="account_tax_report_line_2a_base_3" model="account.tax.report.line">
                                 <field name="name">031 - base 3%</field>
                                 <field name="tag_name">031</field>
                                 <field name="sequence">12</field>
+                                <field name="code">LUTAX_031</field>
                             </record>
                             <record id="account_tax_report_line_2a_base_0" model="account.tax.report.line">
                                 <field name="name">033 - base 0%</field>
@@ -365,6 +391,7 @@
                                 <field name="name">963 - base 7%</field>
                                 <field name="tag_name">963</field>
                                 <field name="sequence">2</field>
+                                <field name="code">LUTAX_963</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
The conflict in odoo/odoo#108298 was not resolved correctly and the report lines codes were missing/incorrect. This commit fixes these codes.

Only needs to be merged in saas-15.2 and saas-15.3. This is fixed in 16.0 already.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
