### PR TITLE
[FIX] base: wkhtml2pdf large documents

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -3,6 +3,8 @@ from odoo import api, fields, models, tools
 
 from odoo.modules import get_resource_path
 
+import base64
+
 try:
     import sass as libsass
 except ImportError:
@@ -278,3 +280,7 @@ class BaseDocumentLayout(models.TransientModel):
             )
         except libsass.CompileError as e:
             raise libsass.CompileError(e.args[0])
+
+    def _get_layout_background(self):
+        with tools.file_open("base/static/img/bg_background_template.jpg", 'rb') as bg_file:
+            return base64.b64encode(bg_file.read()).decode()

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -351,7 +351,7 @@
             </div>
         </div>
 
-        <div t-attf-class="o_company_#{company.id}_layout article o_report_layout_background" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
+        <div t-attf-class="o_company_#{company.id}_layout article o_report_layout_background" t-attf-style="background-image: url({{ 'data:image/png;base64,%s' % company._get_layout_background() }});" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <t t-call="web.address_layout"/>
             <t t-raw="0"/>
         </div>

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -300,3 +300,7 @@ class Company(models.Model):
             main_company = self.env['res.company'].sudo().search([], limit=1, order="id")
 
         return main_company
+
+    def _get_layout_background(self):
+        with tools.file_open("base/static/img/bg_background_template.jpg", 'rb') as bg_file:
+            return base64.b64encode(bg_file.read()).decode()


### PR DESCRIPTION
Step to reproduce:
- Edit documents layout in general setting to add logo and background
- select multiple documents (more than 5) e.g. Inventory> delivery slips
- print all documents.

Bug:
background and logo missing on the last documents because the pages were printed before the browser had time to render them

Fix:
the browser has a default default of 200 ms (--javascript-delay) instead of setting delay to a fixed value use the --window-status flag that waits until window.status is set to a specific value before render and set the value on document load

opw-2951594