### PR TITLE
[FIX] sms_composer: fix default phone number and traceback

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -230,7 +230,7 @@ class SendSMS(models.TransientModel):
         # on the numbers in the database.
         records = records if records is not None else self._get_records()
         records.ensure_one()
-        if self.recipient_single_number_itf and self.recipient_single_number_itf != self.recipient_single_number:
+        if self.number_field_name and self.number_field_name in records._fields and self.recipient_single_number_itf and self.recipient_single_number_itf != self.recipient_single_number:
             records.write({self.number_field_name: self.recipient_single_number_itf})
         return self._action_send_sms_comment(records=records)
 


### PR DESCRIPTION
Steps:

install stock_sms, calendar_sms  app.
In SMS templates enable Add context Action for stock and calendar go to inventory > operations > transfers > form view > action > send SMS go to calendar > list view(meetings) > form view > action > send SMS.

Issue:

The phone number is not getting by default even partner has a phone number. Traceback after trying to send an SMS after changing or entering a phone number.

Cause:

while creating a dictionary in _sms_get_recipients_info of mail.thread it was not considering default value when present
number_field_name trying to write in the field even when it was not present

Fix:

Updated dictionary with the default value when present in partner_id

task-3084701

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
