### PR TITLE
[FIX] Add missing timesheet revenues sequence

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -363,6 +363,7 @@ class Project(models.Model):
             'billable_milestones': _lt('Timesheets (Billed on Milestones)'),
             'billable_manual': _lt('Timesheets (Billed Manually)'),
             'non_billable': _lt('Timesheets (Non Billable)'),
+            'timesheet_revenues': _lt('Timesheets revenues'),
         }
 
     def _get_profitability_sequence_per_invoice_type(self):
@@ -373,6 +374,7 @@ class Project(models.Model):
             'billable_milestones': 3,
             'billable_manual': 4,
             'non_billable': 5,
+            'timesheet_revenues': 6,
         }
 
     def _get_profitability_aal_domain(self):


### PR DESCRIPTION
When trying to access the Project Update model, this traceback can appear.

```
Traceback (most recent call last):
  File "/home/odoo/src/version/16.0/odoo/odoo/http.py", line 1579, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/version/16.0/odoo/odoo/service/model.py", line 134, in retrying
    result = func()
  File "/home/odoo/src/version/16.0/odoo/odoo/http.py", line 1608, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/version/16.0/odoo/odoo/http.py", line 1805, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/version/16.0/odoo/addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo/src/version/16.0/odoo/odoo/addons/base/models/ir_http.py", line 144, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/version/16.0/odoo/odoo/http.py", line 698, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/version/16.0/odoo/addons/web/controllers/dataset.py", line 42, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/version/16.0/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/version/16.0/odoo/odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/src/version/16.0/odoo/odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/version/16.0/odoo/addons/sale_timesheet/models/project.py", line 306, in get_panel_data
    panel_data = super(Project, self).get_panel_data()
  File "/home/odoo/src/version/16.0/odoo/addons/sale_project/models/project.py", line 258, in get_panel_data
    panel_data = super().get_panel_data()
  File "/home/odoo/src/version/16.0/enterprise/project_account_budget/models/project.py", line 53, in get_panel_data
    panel_data = super().get_panel_data()
  File "/home/odoo/src/version/16.0/odoo/addons/project/models/project.py", line 854, in get_panel_data
    profitability_items = self._get_profitability_items()
  File "/home/odoo/src/version/16.0/odoo/addons/sale_timesheet/models/project.py", line 499, in _get_profitability_items
    return self._get_profitability_items_from_aal(
  File "/home/odoo/src/version/16.0/odoo/addons/sale_timesheet/models/project.py", line 481, in _get_profitability_items_from_aal
    {'data': convert_dict_into_profitability_data(revenues_dict, False), 'total': total_revenues},
  File "/home/odoo/src/version/16.0/odoo/addons/sale_timesheet/models/project.py", line 444, in convert_dict_into_profitability_data
    data = {'id': invoice_type, 'sequence': sequence_per_invoice_type[invoice_type], **vals}
KeyError: 'timesheet_revenues'
```

This happens because the sequence for timesheet_revenues is missing from the sequence_per_invoice_type dict.

After adding it to `_get_profitability_sequence_per_invoice_type`, the traceback ceased to appear and the problem is fixed.