### PR TITLE
[FIX] l10n_fr_fec, l10n_account_ebi_ubl_cii_tests: avoid l10n mergebo…

### DIFF
--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -214,7 +214,7 @@ class TestUBLBE(TestUBLCommon):
         self._assert_imported_invoice_from_etree(refund, xml_etree, xml_filename)
 
     def test_encoding_in_attachment_ubl(self):
-        self._test_encoding_in_attachment('ubl_bis3', 'INV_2017_01_0002_ubl_bis3.xml')
+        self._test_encoding_in_attachment('ubl_bis3', 'INV_2017_00002_ubl_bis3.xml')
 
     ####################################################
     # Test import

--- a/addons/l10n_fr_fec/tests/test_wizard.py
+++ b/addons/l10n_fr_fec/tests/test_wizard.py
@@ -31,11 +31,12 @@ class TestAccountFrFec(AccountTestInvoicingCommon):
             'amount': 20,
             'invoice_repartition_line_ids': [
                 Command.create({
+                    'factor_percent': 100.0,
                     'repartition_type': 'base',
                 }),
                 Command.create({
                     'repartition_type': 'tax',
-                    'factor': 100,
+                    'factor_percent': 100.0,
                     'account_id': cls.env['account.account'].search([('code', '=', "445710")], limit=1).id,
                 })
             ]


### PR DESCRIPTION
…t exceptions

- fec: Add missing factor_percent in the creation of a tax in the test for FEC
- ubl: The invoice name supposed the old convention per month while this was changed to on a per year basis anyways for customer invoices.

It caused mergebots to fail, but exceptions were added before that are not needed with these fixes.

Like in https://runbot.odoo.com/runbot/batch/926179/build/22182119

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
