### PR TITLE
[FIX] mail: add password true for twilio_account_token field

### DIFF
--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -61,7 +61,7 @@
                                     </div>
                                     <div class="row mt16" id="mail_twilio_auth_token">
                                         <label for="twilio_account_token" class="col-lg-3"/>
-                                        <field name="twilio_account_token" placeholder="e.g. 65ea4f9e948b693N5156F350256bd152"/>
+                                        <field name="twilio_account_token" password="True" placeholder="e.g. 65ea4f9e948b693N5156F350256bd152"/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
currently when the twilio_account_token is entered in the settings, it is currently displayed in the form, adding password true for the field and protect twilio_account_token field value.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
