### PR TITLE
[FIX] account: remove UserError on account creation

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -690,7 +690,6 @@ class AccountAccount(models.Model):
         if 'import_file' in self.env.context:
             code, name = self._split_code_name(name)
             return self.create({'code': code, 'name': name}).name_get()[0]
-        raise UserError(_("Please create new accounts from the Chart of Accounts menu."))
 
     def write(self, vals):
         # Do not allow changing the company_id when account_move_line already exist

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -159,8 +159,6 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         """name_create should only be possible when importing
            Code and Name should be split
         """
-        with self.assertRaises(UserError):
-            self.env['account.account'].name_create('550003 Existing Account')
         account_id = self.env['account.account'].with_context(import_file=True).name_create('550003 Existing Account')[0]
         account = self.env['account.account'].browse(account_id)
         self.assertEqual(account.code, "550003")


### PR DESCRIPTION
- Create an account model
- Type a new name on the Depreciation Account field.
- Create this account 
=> A UserError is thrown, while the account is in fact created. 
Even more, we want accounts to be able to be created from here. 

We then remove this UserError, the creation of the accounts should be prevented directly on the views where they should.

task-2937569
(where we do want the creation of the account)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
