### PR TITLE
[FIX] l10n_gcc_pos: don't check the country code if not set

### DIFF
--- a/addons/l10n_gcc_pos/static/src/js/OrderReceipt.js
+++ b/addons/l10n_gcc_pos/static/src/js/OrderReceipt.js
@@ -10,7 +10,9 @@ odoo.define('l10n_gcc_pos.OrderReceipt', function (require) {
             get receiptEnv() {
                 let receipt_render_env = super.receiptEnv;
                 let receipt = receipt_render_env.receipt;
-                receipt.is_gcc_country = ['SA', 'AE', 'BH', 'OM', 'QA', 'KW'].includes(receipt_render_env.order.pos.company.country.code);
+                let country = receipt_render_env.order.pos.company.country;
+                let country_code = country && country.code || '';
+                receipt.is_gcc_country = ['SA', 'AE', 'BH', 'OM', 'QA', 'KW'].includes(country_code);
                 return receipt_render_env;
             }
         }


### PR DESCRIPTION
Step to reproduce:

- Install l10n_gcc_pos
- Create a new company with no country set
- Switch to new company
- Go to Settings and set Fiscal Position to : `Configurable Account Chart Template`
- Create a payment method
- Create a new POS and start a new session
- Open browser debugger to see console error
- Add a product and validate the order

Issue:

  Silent error in console + make tests fail.

Cause:

    Trying to check if country.code in list of countries while country
    is not set.

opw-2767684