### PR TITLE
[FIX] mrp: fix traceback when changing duration computation

### DIFF
--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -100,6 +100,7 @@
                                 <field name="blocked_by_operation_ids" widget="many2many_tags" context="{'default_bom_id':bom_id}" attrs="{'invisible': [('allow_operation_dependencies', '=', False)]}"/>
                             </group><group name="workorder">
                                 <field name="workorder_count" invisible="1"/>
+                                <field name="time_computed_on" invisible="1"/>
                                 <field name="time_mode" widget="radio"/>
                                 <label for="time_mode_batch" attrs="{'invisible': [('time_mode', '=', 'manual')]}"/>
                                 <div attrs="{'invisible': [('time_mode', '=', 'manual')]}">


### PR DESCRIPTION
When changing the duration computation on a BOM, a traceback will appear (cannot read property of undefined). 
This is due to the fact that `time_computed_on` is not defined on the view form. 
Adding it as an invisible field solves the issue

opw-3106166