### PR TITLE
[IMP] base: raise an exception when use useless with_context in t-field

### DIFF
--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -179,8 +179,8 @@
                 <button disabled="disabled" class="btn btn-primary align-self-start">Create a Room</button>
                 Room creation will be available when event starts at 
                 <span>
-                    <span class="fw-bold" t-field="event.with_context(tz=event.date_tz).date_begin"
-                        t-options="{'format': 'medium'}"/>
+                    <span class="fw-bold" t-field="event.date_begin"
+                        t-options="{'format': 'medium', 'tz_name': event.date_tz}"/>
                     <span class="small">(<t t-out="event.date_tz"/>)</span>
                 </span>
             </div>

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -50,8 +50,8 @@
                 </span>
                 <span class="my-0" t-else="meeting_room.event_id.start_today">
                     starts on
-                    <span t-field="meeting_room.event_id.with_context(tz=meeting_room.event_id.date_tz).date_begin"
-                        t-options="{'format': 'medium'}"/> (<t t-out="meeting_room.event_id.date_tz"/>).
+                    <span t-field="meeting_room.event_id.date_begin"
+                        t-options="{'format': 'medium', 'tz_name': meeting_room.event_id.date_tz}"/> (<t t-out="meeting_room.event_id.date_tz"/>).
                 </span>
                 <br/>
                 <span>Join us there to chat about <b t-out="meeting_room.name"/> !</span>

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -55,8 +55,8 @@
                                     <t t-call="website.record_cover">
                                         <t t-set="_record" t-value="event" />
                                         <div class="o_wevent_event_date position-absolute bg-white shadow-sm text-dark">
-                                            <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'LLL'}" class="o_wevent_event_month" />
-                                            <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit" />
+                                            <span t-field="event.date_begin" t-options="{'format': 'LLL', 'tz_name': event.date_tz}" class="o_wevent_event_month" />
+                                            <span t-field="event.date_begin" t-options="{'format': 'dd', 'tz_name': event.date_tz}" class="o_wevent_event_day oe_hide_on_date_edit" />
                                         </div>
                                         <small class="o_wevent_participating text-bg-success">
                                             <i class="fa fa-check me-2" />

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -63,7 +63,7 @@
                 </span>
                 <span t-else="">
                     starts on
-                    <span t-field="track.event_id.with_context(tz=track.event_id.date_tz).date_begin"
+                    <span t-field="track.event_id.date_begin"
                         t-options="{'format': 'medium', 'tz_name': track.event_id.date_tz, 'hide_seconds': 'True'}"/>
                     (<span t-out="track.event_id.date_tz"/>)
                 </span>

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1925,6 +1925,12 @@ class IrQWeb(models.AbstractModel):
             code.extend(tag_close)
             return code
         elif ttype == 't-field':
+            if '.with_context(' in expr:
+                raise ValueError("The record provided to 't-field' uses the rendering context of the view "
+                    "(or 't-call'), so 'with_context' has no effect and should be removed. You can modify the "
+                    "rendering of widgets by using their respective options from 't-options-*', or by changing the "
+                    "'t-call' options. If you want to use the record context only, you can use 't-out' choosing the "
+                    "widget and its options.")
             record, field_name = expr.rsplit('.', 1)
             code.append(indent_code(f"""
                 field_attrs, content, force_display = self._get_field({self._compile_expr(record, raise_on_missing=True)}, {field_name!r}, {expr!r}, {el.tag!r}, values.pop('__qweb_options__', {{}}), values)
@@ -2381,8 +2387,9 @@ class IrQWeb(models.AbstractModel):
         # get content (the return values from widget are considered to be markup safe)
         content = converter.value_to_html(value, field_options)
         attributes = {}
-        attributes['data-oe-type'] = field_options['type']
-        attributes['data-oe-expression'] = field_options['expression']
+        if field_options['inherit_branding'] or self.env.context.get('inherit_branding_auto'):
+            attributes['data-oe-type'] = field_options['type']
+            attributes['data-oe-expression'] = field_options['expression']
 
         return (attributes, content, inherit_branding)
 

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1199,7 +1199,7 @@ class TestQWebBasic(TransactionCase):
         })
         html = self.env['ir.qweb']._render(view1.id, {'text': """a
         b <b>c</b>"""})
-        self.assertEqual(html, """<root><span data-oe-type="text" data-oe-expression="text">a<br>
+        self.assertEqual(html, """<root><span>a<br>
         b &lt;b&gt;c&lt;/b&gt;</span></root>""")
 
     def test_out_markup(self):
@@ -1490,7 +1490,7 @@ class TestQWebBasic(TransactionCase):
             'type': 'qweb',
             'arch': """
                 <t t-name="base.callee">
-                    <t t-esc="9000000.00" t-options="{'widget': 'float', 'precision': 2}" />
+                    <t t-out="9000000.00" t-options="{'widget': 'float', 'precision': 2}" />
                 </t>
             """
         })
@@ -1513,6 +1513,63 @@ class TestQWebBasic(TransactionCase):
 
         rendered = self.env['ir.qweb'].with_context(lang=current_lang)._render(view2.id).strip()
         self.assertEqual(rendered, '9/000/000*00')
+
+    def test_render_t_field_context(self):
+        current_lang = 'en_US'
+        other_lang = 'fr_FR'
+
+        self.env['res.lang']._activate_lang(other_lang)
+
+        country_current = self.env['res.country'].with_context(lang=current_lang).browse(1)
+        country_other = self.env['res.country'].with_context(lang=other_lang).browse(1)
+
+        view = self.env['ir.ui.view'].create({
+            'name': "callee",
+            'type': 'qweb',
+            'arch': """
+                <t t-name="base.callee">
+                    <span t-field="country.name"/>
+                    <p t-out="country.name"/>
+                </t>
+            """
+        })
+
+        rendered = self.env['ir.qweb'].with_context(lang=current_lang)._render(view.id, {'country': country_other})
+        self.assertEqual(str(rendered).strip(), f'''<span>{country_current.name}</span>
+                    <p>{country_other.name}</p>''')
+
+        rendered = self.env['ir.qweb'].with_context(lang=other_lang)._render(view.id, {'country': country_other})
+        self.assertEqual(str(rendered).strip(), f'''<span>{country_other.name}</span>
+                    <p>{country_other.name}</p>''')
+
+        view = self.env['ir.ui.view'].create({
+            'name': "callee",
+            'type': 'qweb',
+            'arch': """
+                <t t-name="base.callee">
+                    <span t-field="country.name"/>
+                    <p t-out="country.with_context(lang=%r).name"/>
+                </t>
+            """ % other_lang
+        })
+
+        rendered = self.env['ir.qweb'].with_context(lang=current_lang)._render(view.id, {'country': country_current})
+        self.assertEqual(str(rendered).strip(), f'''<span>{country_current.name}</span>
+                    <p>{country_other.name}</p>''')
+
+        view = self.env['ir.ui.view'].create({
+            'name': "callee",
+            'type': 'qweb',
+            'arch': """
+                <t t-name="base.callee">
+                    <span t-field="country.with_context(lang=%r).name"/>
+                    <p t-out="env.user.id"/>
+                </t>
+            """ % other_lang
+        })
+
+        with self.assertRaises(QWebException, msg=r"has no effect"):
+            self.env['ir.qweb']._render(view.id, {'country': country_other})
 
     def test_render_barcode(self):
         partner = self.env['res.partner'].create({


### PR DESCRIPTION
The record provided to 't-field' uses the rendering context of the view (or 't-call'), so 'with_context' has no effect and should be removed. You can modify the rendering of widgets by using their respective options from 't-options-*', or by changing the 't-call' options.

If you want to use the record context only, you can use 't-out' choosing the widget and its options.

Another change: add the branding for the t-outs only if it is necessary.
