### PR TITLE
[FIX] mrp: fix the issue of mark done with no quantity set and manually introduced consumed products

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2111,7 +2111,7 @@ class MrpProduction(models.Model):
         pd = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for production in self:
             if all(float_is_zero(ml.qty_done, precision_digits=pd) for
-                    ml in production.move_raw_ids.move_line_ids.filtered(lambda m: m.state not in ('done', 'cancel'))
+                    ml in production.move_raw_ids.move_line_ids.filtered(lambda m: m.state not in ('done', 'cancel') and not m.qty_done > 0)
                     ) and float_is_zero(production.qty_producing, precision_digits=pd):
                 immediate_productions |= production
         return immediate_productions

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1428,7 +1428,7 @@ class TestMrpOrder(TestMrpCommon):
 
     def test_immediate_validate_2(self):
         """ In a production with a single available move raw, clicking on mark as done after filling quantity
-        for a stock move only will trigger an error as qty_producing is left to 0."""
+        for a stock move only will not trigger an error as we will get the option of filling the quantity automatically."""
         mo, bom, p_final, p1, p2 = self.generate_mo(qty_final=1, qty_base_1=1, qty_base_2=1)
         self.env['stock.quant']._update_available_quantity(p1, self.stock_location_components, 5.0)
         self.env['stock.quant']._update_available_quantity(p2, self.stock_location_components, 5.0)
@@ -1437,8 +1437,7 @@ class TestMrpOrder(TestMrpCommon):
         with details_operation_form.move_line_ids.new() as ml:
             ml.qty_done = 1
         details_operation_form.save()
-        with self.assertRaises(UserError):
-            res_dict = mo.button_mark_done()
+        mo.button_mark_done()
 
     def test_immediate_validate_3(self):
         """ In a production with a serial number tracked product. Check that the immediate production only creates


### PR DESCRIPTION
Steps to reproduce:

- Go to Manufacturing Orders
- Create a new MO, with one or two products.
- Without selecting any Quantity, set Consumed products to any of the products.
- Try to Mark as Done.

Issue:

We get the message error telling us that the we cannot process a quantity of 0, so we should select the quantity in order to get it.

Solution:

Discussed with the PO, if we don't select a quantity (when it is set to 0), we should consider that we want to process all the quantity, so we should set the quantity to the quantity to produce.

opw-3111746
