### PR TITLE
[IMP] base: Allow rendering barcodes as SVG

### DIFF
--- a/addons/web/controllers/report.py
+++ b/addons/web/controllers/report.py
@@ -8,6 +8,7 @@ from werkzeug.urls import url_parse
 
 from odoo import http
 from odoo.http import content_disposition, request
+from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.misc import html_escape
 from odoo.tools.safe_eval import safe_eval, time
 
@@ -69,6 +70,7 @@ class ReportController(http.Controller):
         'Standard93', 'UPCA', 'USPS_4State'
         :param width: Pixel width of the barcode
         :param height: Pixel height of the barcode
+        :param format: format of the generated image, 'png' (default) or 'svg'.
         :param humanreadable: Accepted values: 0 (default) or 1. 1 will insert the readable value
         at the bottom of the output image
         :param quiet: Accepted values: 0 (default) or 1. 1 will display white
@@ -85,8 +87,9 @@ class ReportController(http.Controller):
             raise werkzeug.exceptions.HTTPException(description='Cannot convert into barcode.')
 
         return request.make_response(barcode, headers=[
-            ('Content-Type', 'image/png'),
+            ('Content-Type', guess_mimetype(barcode)),
             ('Cache-Control', f'public, max-age={http.STATIC_CACHE_LONG}, immutable'),
+            ('Content-Security-Policy', "default-src 'none'; style-src 'self' 'unsafe-inline'"),
         ])
 
     @http.route(['/report/download'], type='http', auth="user")

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1615,6 +1615,10 @@ class TestQWebBasic(TransactionCase):
         auto_rendered = self.env['ir.qweb']._render(view.id, values={'partner': partner}).strip()
         self.assertRegex(auto_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
+        view.arch = """<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'width': 100, 'height': 30, 'format': 'svg', 'img_alt': 'SVG Barcode'}"/>"""
+        auto_rendered = self.env['ir.qweb']._render(view.id, values={'partner': partner}).strip()
+        self.assertRegex(auto_rendered, r'<div><img alt="SVG Barcode" src="data:image/svg\+xml;base64,\S+"></div>')
+
     def test_render_comment_tail(self):
         """ Test the rendering of a tail text, near a comment.
         """


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Introduce a new `format` parameter which can be used to choose among 'png' (default) and 'svg' for the barcode rendering.

SVGs have unlimited scaling capabilities, which is great when printing really small or really big barcodes in labels, etc; as there's absolutely no quality loss when resizing


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
