### PR TITLE
[16.0][IMP] mail: set contentHint for videocall local video stream

### DIFF
--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -906,6 +906,19 @@ registerModel({
         },
         /**
          * @private
+         * @param {MediaStream} stream video stream
+         * @param {String} hint 'motion', 'detail' or 'text'
+         */
+        _setVideoTrackContentHints(stream, hint) {
+            const tracks = stream.getVideoTracks();
+            tracks.forEach(track => {
+                if ('contentHint' in track) {
+                    track.contentHint = hint;
+                }
+            });
+        },
+        /**
+         * @private
          * @param {String} type 'user-video' or 'display'
          * @param {boolean} activateVideo true if we want to activate the video
          */
@@ -979,6 +992,7 @@ registerModel({
                     this.messaging.userSetting.update({ useBlur: false });
                 }
             }
+            this._setVideoTrackContentHints(videoStream, type === 'user-video' ? 'motion' : 'text');
             const videoTrack = videoStream ? videoStream.getVideoTracks()[0] : undefined;
             if (videoTrack) {
                 videoTrack.addEventListener('ended', async () => {


### PR DESCRIPTION
this commit sets 'motion' contentHint for user video and 'text' contentHint for display sharing.

it provides higher user experience on slow connection.

more details https://webrtc.github.io/samples/src/content/capture/video-contenthint/
https://www.w3.org/TR/mst-content-hint/


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
