### PR TITLE
[FIX] web_editor: handle undefined recordId

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2822,12 +2822,15 @@ const Many2manyUserValueWidget = UserValueWidget.extend({
             return;
         }
         const { model, recordId, m2oField } = this.options;
-        const [record] = await this._rpc({
-            model: model,
-            method: 'read',
-            args: [[parseInt(recordId)], [m2oField]],
-        });
-        const selectedRecordIds = record[m2oField];
+        let selectedRecordIds = [];
+        if (parseInt(recordId)) {
+            const [record] = await this._rpc({
+                model: model,
+                method: 'read',
+                args: [[parseInt(recordId)], [m2oField]],
+            });
+            selectedRecordIds = record[m2oField];
+        }
         // TODO: handle no record
         const modelData = await this._rpc({
             model: model,
@@ -2838,11 +2841,14 @@ const Many2manyUserValueWidget = UserValueWidget.extend({
         this.m2oModel = modelData[m2oField].relation;
         this.m2oName = modelData[m2oField].field_description; // Use as string attr?
 
-        const selectedRecords = await this._rpc({
-            model: this.m2oModel,
-            method: 'read',
-            args: [selectedRecordIds, ['display_name']],
-        });
+        let selectedRecords = []
+        if (selectedRecordIds.length) {
+            selectedRecords = await this._rpc({
+                model: this.m2oModel,
+                method: 'read',
+                args: [selectedRecordIds, ['display_name']],
+            });
+        }
         // TODO: reconcile the fact that this widget sets its own initial value
         // instead of it coming through setValue(_computeWidgetState)
         this._value = JSON.stringify(selectedRecords);


### PR DESCRIPTION
Steps to reproduce:
- go to website on Events or Blog tab;
- for Events: try to add an "Events" blocks;
- for Blog: try to edit the website banner.

Issue:
A traceback appears.

Cause:
For events, `this.tagIDs = JSON.parse(this.$target[0].dataset.filterByTagIds || '[]');` returns no data.
For the blog, `this.blogPostID = parseInt(this.$target[0].dataset.blogId);` returns no data.
Therefore the following rpc call:
```
const { model, recordId, m2oField } = this.options;
const [record] = await this._rpc({
  model: model,
  method: 'read',
  args: [[parseInt(recordId)], [m2oField]],
});
```
`parseInt` of an undefined variable will give an `NaN` value. This empty list will be translated in the SQL query as `... IN () ...`.

Solution:
Handle, on the client side, the case where `recordId` is undefined or equal to `'NaN'`.

opw-3104957
opw-3108985