### PR TITLE
[FIX] {sale_}crm: avoid merge duplicate leads that have multi-company error

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -1715,6 +1715,12 @@ msgid "Lead Generation"
 msgstr ""
 
 #. module: crm
+#: code:addons/crm/models/crm_lead.py:0
+#, python-format
+msgid "Lead Merge Failure Report"
+msgstr ""
+
+#. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.res_config_settings_view_form
 msgid "Lead Mining"
 msgstr ""
@@ -3241,6 +3247,14 @@ msgstr ""
 msgid ""
 "This is the source of the link, e.g. Search Engine, another domain, or name "
 "of email list"
+msgstr ""
+
+#. module: crm
+#: code:addons/crm/models/crm_team.py:0
+#, python-format
+msgid ""
+"This lead could not be merged and has been skipped because it belongs to a "
+"different company."
 msgstr ""
 
 #. module: crm

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1809,6 +1809,13 @@ class Lead(models.Model):
             pass
         return recipients
 
+    def _message_merging_leads_failed(self, body):
+        subject = _('Lead Merge Failure Report')
+        self[0].message_post(body=body, subject=subject)
+        for lead in self[1:]:
+            lead._message_log(body=body, subject=subject)
+        return
+
     @api.model
     def message_new(self, msg_dict, custom_values=None):
         """ Overrides mail_thread message_new that is called by the mailgateway

--- a/addons/sale_crm/i18n/sale_crm.pot
+++ b/addons/sale_crm/i18n/sale_crm.pot
@@ -16,6 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_crm
+#: code:addons/sale_crm/models/crm_team.py:0
+#, python-format
+msgid ""
+"%s could not be merged because at least one of their Sales Orders (%s) is "
+"linked to another Company."
+msgstr ""
+
+#. module: sale_crm
 #: model_terms:ir.ui.view,arch_db:sale_crm.crm_case_form_view_oppor
 msgid "<span class=\"o_stat_text\"> Orders</span>"
 msgstr ""

--- a/addons/sale_crm/models/crm_team.py
+++ b/addons/sale_crm/models/crm_team.py
@@ -42,3 +42,50 @@ class CrmTeam(models.Model):
         if self.use_opportunities and self._context.get('in_sales_app'):
             return "AND state in ('sale', 'done', 'pos_done')"
         return super(CrmTeam,self)._extra_sql_conditions()
+
+    def _merge_leads(self, leads, values):
+        """ Remove opportunities or leads from ["leads_dups_dict"] that
+        have sale orders and the company of the sale order is not the same
+        as the company of the head lead, its sale order, or current company.
+        :param leads: recordset of leads to assign to current team;
+        :param values: dictionary in the following form
+                       {
+                            'leads_assigned': crm.lead(),
+                            'leads_dups_dict': {crm.lead(): crm.lead()}
+                       };
+        :return: Opportunities or leads that have sale orders, and the company
+        of the sale order is not the same as the company of the head lead, its
+        sale order, or current company.
+        """
+        new_leads = self.env['crm.lead']
+        for lead, lead_dups_dict in values['leads_dups_dict'].items():
+            if lead_dups_dict.order_ids \
+               and len(lead_dups_dict.order_ids.company_id + lead_dups_dict.company_id) > 1:
+
+                opportunities = lead_dups_dict._sort_by_confidence_level(reverse=True)
+                head_opportunity = opportunities[0]
+                current_company = head_opportunity.company_id or head_opportunity.order_ids.company_id or self.env['res.company']
+                leads_with_so_different_company = opportunities.filtered(
+                    lambda lead: lead.order_ids and lead.order_ids.company_id != current_company
+                )
+                if not leads_with_so_different_company:
+                    continue
+                leads_compatible_with_head_opportunity = lead_dups_dict - leads_with_so_different_company
+
+                if len(leads_compatible_with_head_opportunity) >= 2:
+                    if lead in leads_with_so_different_company:
+                        new_leads += head_opportunity
+                    values['leads_dups_dict'] = {new_leads or lead: leads_compatible_with_head_opportunity}
+                    opportunities = values['different_company'] = leads_with_so_different_company
+                separator = ', ' if len(opportunities) > 2 else ' and '
+                body = _('%s could not be merged because at least one of their Sales Orders (%s) is linked to another Company.',
+                         separator.join(opportunities.mapped(lambda o: f'{o.name}(ID#{o.id})')),
+                         ", ".join(opportunities.order_ids.mapped('name')))
+
+                opportunities._message_merging_leads_failed(body)
+                if len(leads_compatible_with_head_opportunity) < 2:
+                    return {
+                        'different_company': set(opportunities.ids),
+                    }
+
+        return super(CrmTeam, self)._merge_leads(new_leads or leads, values)

--- a/addons/sale_crm/tests/__init__.py
+++ b/addons/sale_crm/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_crm_lead_convert_quotation
 from . import test_crm_lead_merge
+from . import test_cron_assign_leads

--- a/addons/sale_crm/tests/test_cron_assign_leads.py
+++ b/addons/sale_crm/tests/test_cron_assign_leads.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.test_crm_lead_assignment import TestLeadAssignCommon
+from odoo.tests.common import tagged
+
+
+@tagged('lead_assign')
+class TestSalesLeadAssign(TestLeadAssignCommon):
+    def test_cron_assign_leads(self):
+        """ Test leads assignment with sale orders from different companies are not merged. """
+        def _create_crm_lead(name, email, company_id=False, lead_type="lead"):
+            return self.env['crm.lead'].create({
+                'name': name,
+                'email_from': email,
+                'type': lead_type,
+                'company_id': company_id,
+                'team_id': False,
+                'user_id': False,
+            })
+
+        def is_assigned(opportunity, assigned=False):
+            self.assertTrue(opportunity.exists())
+            self.assertEqual(bool(opportunity.team_id), assigned)
+            self.assertEqual(bool(opportunity.user_id), assigned)
+
+        company_1 = self.env.ref('base.main_company')
+        email = ['test1@test.example.com', 'test2@test.example.com', 'test3@test.example.com', 'test4@test.example.com', 'test5@test.example.com']
+        self._activate_multi_company()
+        self.team_company2.company_id = False
+
+        opportunity1 = _create_crm_lead("Opportunity 1 without sale order and company1", email[0], company_1.id, lead_type="opportunity")
+        dup_opportunity1 = _create_crm_lead("Duplicate of opportunity 1 with sale order and company2", email[0], self.company_2.id)
+
+        opportunity2 = _create_crm_lead("Opportunity 2 without sale order and company 1", email[1], company_1.id, lead_type="opportunity")
+        dup1_opportunity2 = _create_crm_lead("Duplicate of 1 opportunity 2 with sale order and company 2", email[1], self.company_2.id)
+        dup2_opportunity2 = _create_crm_lead("Duplicate 2 of opportunity 2 without sale order and company 1", email[1], company_1.id)
+
+        opportunity3 = _create_crm_lead("Opportunity 3 with sale order and company 2", email[2], self.company_2.id, lead_type="opportunity")
+        dup1_opportunity3 = _create_crm_lead("Duplicate 1 of opportunity 3 without sale order and company", email[2])
+        dup2_opportunity3 = _create_crm_lead("Duplicate 2 of opportunity 3 with sale order and company 1", email[2], company_1.id)
+
+        opportunity4 = _create_crm_lead("Opportunity 4 without sale order and company 2", email[3], self.company_2.id, lead_type="opportunity")
+        dup1_opportunity4 = _create_crm_lead("Duplicate 1 of opportunity 4 without sale order and company 2", email[3], self.company_2.id)
+        dup2_opportunity4 = _create_crm_lead("Duplicate 2 of opportunity 4 with sale order and company 1", email[3], company_1.id)
+        dup3_opportunity4 = _create_crm_lead("Duplicate 3 of opportunity 4 with sale order and company 2", email[3], self.company_2.id)
+
+        opportunity5 = _create_crm_lead("Opportunity 5 without sale order and without company", email[4], lead_type="opportunity")
+        dup1_opportunity5 = _create_crm_lead("Opportunity 5 without sale order and company 2", email[4], self.company_2.id)
+        dup2_opportunity5 = _create_crm_lead("Opportunity 5 witt sale order and company 1", email[4], company_1.id)
+
+        so_of_opportunities = {
+            dup_opportunity1,
+            dup1_opportunity2,
+            opportunity3,
+            dup2_opportunity3,
+            opportunity4,
+            dup2_opportunity4,
+            dup3_opportunity4,
+            dup1_opportunity5,
+        }
+        so_vals = [{
+            'partner_id': self.contact_1.id,
+            'company_id': opportunity.company_id.id or company_1.id,
+            'opportunity_id': opportunity.id
+        } for opportunity in so_of_opportunities]
+
+        self.env['sale.order'].create(so_vals)
+        self.env['crm.team']._cron_assign_leads()
+
+        is_assigned(opportunity1)
+        is_assigned(dup_opportunity1)
+
+        is_assigned(opportunity2, True)
+        is_assigned(dup1_opportunity2)
+        self.assertFalse(dup2_opportunity2.exists())
+
+        is_assigned(opportunity3, True)
+        is_assigned(dup2_opportunity3)
+        self.assertFalse(dup1_opportunity3.exists())
+
+        is_assigned(opportunity4, True)
+        is_assigned(dup2_opportunity4)
+        self.assertFalse(dup1_opportunity4.exists())
+        self.assertFalse(dup3_opportunity4.exists())
+
+        is_assigned(opportunity5, True)
+        is_assigned(dup1_opportunity5, False)
+        self.assertFalse(dup2_opportunity5.exists())


### PR DESCRIPTION
Currently, in the following conditions, merging leads returns a
multi-company error:
- In CRM, there is a sales team that belongs to company A, and there are two
  opportunities, both belonging to company B. When cron tries to merge both
  opportunities, it returns an error because sales team company is different
  than opportunities.
- In sale_crm opportunity 1 belongs to company A. It resembles opportunity 2,
  which belongs to company B and already has a sale order (which also belongs to
  B). When CRON tries to assign a sales team, a sales person, and merge
  opportunities, a match is found, and it attempts to merge them both, but it
  returns an error because the sale order belongs to another company.

This commit solves the above issues by taking the following steps:
- "_allocate_leads_deduplicate" calls "_handle_salesmen_assignment" to set the
  sales team, and "_merge_opportunity" to merge duplicate opportunities. In
  cases of multi-company issues, we do not need to assign a team or merge
  duplicate opportunities. So, this commit splits "_allocate_leads_deduplicate"
  and adds the new method "_merge_leads" to assign sales person and merge
  the opportunities.
- In CRM, if the sales team has a company and the opportunity company is
  different than the sales team, it considers the opportunity an error
  opportunity and removes it from "team_data".
- In sale_crm, override the "_merge_opportunity" and it will return the
  opportunities that have a sale order and whose saleorder company is
  different than the first opportunity company, the first company's
  sale order, or the current company, and the returned opportunities are
  removed from "teams_data",  so do not process any kind of unlink or
  update operation on these opportunities.

task-2955805