### PR TITLE
[FIX] barcodes: No details on Promise reject

### DIFF
--- a/addons/barcodes/static/src/js/barcode_parser.js
+++ b/addons/barcodes/static/src/js/barcode_parser.js
@@ -19,7 +19,8 @@ var BarcodeParser = Class.extend({
     // only when those data have been loaded
     load: function(){
         if (!this.nomenclature_id) {
-            return this.nomenclature ? Promise.resolve() : Promise.reject();
+            return this.nomenclature ? Promise.resolve() :
+                Promise.reject(new TypeError("The barcode nomenclature is missing"));
         }
         var id = this.nomenclature_id[0];
         return rpc.query({


### PR DESCRIPTION
Before this commit:
 If a BarcodeParser was created without
 `nomenclature_id` and `nomenclature` the
 initialisation will give a rejected
 Promise without any details as of why
 it failed.

After this commit:
 The error on the rejected Promise
 can be catched to display more detailed
 error message

opw-3110204

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
