### PR TITLE
[FIX] mrp: display routes with lead times in overview

### DIFF
--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -40,7 +40,7 @@
         <td t-if="showLeadTimes" class="text-end">
             <span t-if="hasLeadTime"><t t-esc="data.lead_time"/> Days</span>
         </td>
-        <td>
+        <td t-if="showLeadTimes">
             <div t-if="data.route_name">
                 <span><t t-esc="data.route_name"/>: </span>
                 <a href="#" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-esc="data.route_detail"/>

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -21,7 +21,7 @@
         <td t-if="showAvailabilities"/>
         <td t-if="showAvailabilities"/>
         <td t-if="showLeadTimes"/>
-        <td/>
+        <td t-if="showLeadTimes"/>
         <td name="bom_cost" t-if="showCosts" class="text-end">
             <span t-if="props.type == 'operations'" t-esc="formatMonetary(data.operations_cost)"/>
             <span t-elif="props.type == 'byproducts'" t-esc="formatMonetary(data.byproducts_cost)"/>

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
@@ -32,7 +32,7 @@
                             <th t-if="showAvailabilities" class="text-end" title="Availabilities on products.">Free to Use / On Hand</th>
                             <th t-if="showAvailabilities" class="text-center" title="Reception time estimation.">Availability</th>
                             <th t-if="showLeadTimes" class="text-end" title="Resupply lead time.">Lead Time</th>
-                            <th>Route</th>
+                            <th t-if="showLeadTimes">Route</th>
                             <th t-if="showCosts" class="text-end" title="This is the cost based on the BoM of the product. It is computed by summing the costs of the components and operations needed to build the product.">BoM Cost</th>
                             <th t-if="showCosts" class="text-end" title="This is the cost defined on the product.">Product Cost</th>
                             <th t-if="showAttachments" class="text-center" title="Files attached to the product.">Attachments</th>
@@ -61,7 +61,7 @@
                             <td t-if="showAvailabilities"/>
                             <td t-if="showAvailabilities"/>
                             <td t-if="showLeadTimes"/>
-                            <td/>
+                            <td t-if="showLeadTimes"/>
                             <td class="text-end" t-esc="formatMonetary(data.bom_cost / data.quantity)"/>
                             <td class="text-end" t-esc="formatMonetary(data.prod_cost / data.quantity)"/>
                             <td t-if="showAttachments"/>
@@ -75,7 +75,7 @@
                                 <td t-if="showAvailabilities"/>
                                 <td t-if="showAvailabilities"/>
                                 <td t-if="showLeadTimes"/>
-                                <td/>
+                                <td t-if="showLeadTimes"/>
                                 <td class="text-end" t-esc="formatMonetary(byproduct.bom_cost / byproduct.quantity)"/>
                                 <td class="text-end" t-esc="formatMonetary(byproduct.prod_cost / byproduct.quantity)"/>
                                 <td t-if="showAttachments"/>


### PR DESCRIPTION
In the BoM Overview, routes were always displayed regardless of the display options selected in the filter. Since lead times are only relevant when checking their associated routes (as they determine them), it makes sense to add the display of the routes in the lead times filter.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
