### PR TITLE
[REF] l10n_mx: diot report as tax report

### DIFF
--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Mexico - Accounting",
-    "version": "2.0",
+    "version": "2.1",
     "author": "Vauxoo",
     'category': 'Accounting/Localizations/Account Charts',
     "description": """

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -40,6 +40,7 @@ With this module you will have:
         "data/l10n_mx_chart_post_data.xml",
         "data/account_tax_group_data.xml",
         "data/account.group.template.csv",
+        "data/account_report_diot.xml",
         "data/account_tax_data.xml",
         "data/fiscal_position_data.xml",
         "data/account_chart_template_data.xml",

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -32,6 +32,7 @@ With this module you will have:
     """,
     "depends": [
         "account",
+        "base_iban", # TODO: discuss with OCO if we can bring more logic from account.report in standard instead of this hack that tweak dependancy graph so that account_reports if any is loaded before
     ],
     "data": [
         "data/account.account.tag.csv",

--- a/addons/l10n_mx/data/account.account.tag.csv
+++ b/addons/l10n_mx/data/account.account.tag.csv
@@ -2,13 +2,5 @@ id,name,applicability,country_id/id,color
 tag_iva,IVA,taxes,base.mx,0
 tag_isr,ISR,taxes,base.mx,0
 tag_ieps,IEPS,taxes,base.mx,0
-tag_diot_16,DIOT: 16%,taxes,base.mx,0
-tag_diot_16_non_cre,DIOT: 16% NO ACREDITABLE,taxes,base.mx,0
-tag_diot_16_imp,DIOT: 16% IMP,taxes,base.mx,0
-tag_diot_0,DIOT: 0%,taxes,base.mx,0
-tag_diot_8,DIOT: 8%,taxes,base.mx,0
-tag_diot_8_non_cre,DIOT: 8% NO ACREDITABLE,taxes,base.mx,0
-tag_diot_ret,DIOT: Retención,taxes,base.mx,0
-tag_diot_exento,DIOT: Exento,taxes,base.mx,0
 tag_debit_balance_account,Debit Balance Account,accounts,base.mx,0
 tag_credit_balance_account,Credit Balance Account,accounts,base.mx,0

--- a/addons/l10n_mx/data/account_report_diot.xml
+++ b/addons/l10n_mx/data/account_report_diot.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="diot_report" model="account.report">
+        <field name="name">DIOT</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="filter_show_draft" eval="False"/>
+        <field name="filter_period_comparison" eval="False"/>
+        <field name="load_more_limit" eval="80"/>
+        <field name="filter_unfold_all" eval="False"/>
+        <field name="default_opening_date_filter">this_month</field>
+        <field name="filter_date_range" eval="True"/>
+        <field name="filter_partner" eval="True"/>
+        <field name="filter_multi_company">selector</field>
+        <field name="country_id" ref="base.mx"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="diot_report_paid_16" model="account.report.column">
+                <field name="name">Paid 16%</field>
+                <field name="expression_label">paid_16</field>
+            </record>
+            <record id="diot_report_paid_16_non_cred" model="account.report.column">
+                <field name="name">Paid 16% - Non-Creditable</field>
+                <field name="expression_label">paid_16_non_cred</field>
+            </record>
+            <record id="diot_report_paid_8" model="account.report.column">
+                <field name="name">Paid 8 %</field>
+                <field name="expression_label">paid_8</field>
+            </record>
+            <record id="diot_report_paid_8_non_cred" model="account.report.column">
+                <field name="name">Paid 8 % - Non-Creditable</field>
+                <field name="expression_label">paid_8_non_cred</field>
+            </record>
+            <record id="diot_report_importation_16" model="account.report.column">
+                <field name="name">Importation 16%</field>
+                <field name="expression_label">importation_16</field>
+            </record>
+            <record id="diot_report_paid_0" model="account.report.column">
+                <field name="name">Paid 0%</field>
+                <field name="expression_label">paid_0</field>
+            </record>
+            <record id="diot_report_exempt" model="account.report.column">
+                <field name="name">Exempt</field>
+                <field name="expression_label">exempt</field>
+            </record>
+            <record id="diot_report_withheld" model="account.report.column">
+                <field name="name">Withheld</field>
+                <field name="expression_label">withheld</field>
+            </record>
+            <record id="diot_report_refunds" model="account.report.column">
+                <field name="name">Refunds</field>
+                <field name="expression_label">refunds</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="diot_report_line" model="account.report.line">
+                <field name="name">DIOT</field>
+                <field name="groupby">partner_id, id</field>
+                <field name="expression_ids">
+                    <record id="tax_report_mx_diot_paid_16_tag" model="account.report.expression">
+                        <field name="label">paid_16</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: 16%</field>
+                    </record>
+                    <record id="tax_report_mx_diot_paid_16_non_cred_tag" model="account.report.expression">
+                        <field name="label">paid_16_non_cred</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: 16% NO ACREDITABLE</field>
+                    </record>
+                    <record id="tax_report_mx_diot_paid_8_tag" model="account.report.expression">
+                        <field name="label">paid_8</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: 8%</field>
+                    </record>
+                    <record id="tax_report_mx_diot_paid_8_non_cred_tag" model="account.report.expression">
+                        <field name="label">paid_8_non_cred</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: 8% NO ACREDITABLE</field>
+                    </record>
+                    <record id="tax_report_mx_diot_importation_16_tag" model="account.report.expression">
+                        <field name="label">importation_16</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: 16% IMP</field>
+                    </record>
+                    <record id="tax_report_mx_diot_paid_0_tag" model="account.report.expression">
+                        <field name="label">paid_0</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: 0%</field>
+                    </record>
+                    <record id="tax_report_mx_diot_exempt_tag" model="account.report.expression">
+                        <field name="label">exempt</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: Exento</field>
+                    </record>
+                    <record id="tax_report_mx_diot_withheld_tag" model="account.report.expression">
+                        <field name="label">withheld</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: Retención</field>
+                    </record>
+                    <record id="tax_report_mx_diot_refunds_tag" model="account.report.expression">
+                        <field name="label">refunds</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">DIOT: Refunds</field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -82,21 +82,21 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'minus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
         </record>
@@ -115,21 +115,21 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'minus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
         </record>
@@ -206,21 +206,21 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'minus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
         </record>
@@ -239,21 +239,21 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_ret')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta216_10_20'),
+                'minus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
             }),
         ]"/>
         </record>
@@ -272,7 +272,7 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_0')],
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_paid_0_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -282,7 +282,7 @@
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_0')],
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_refunds_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -305,7 +305,7 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_16')],
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_paid_16_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -315,7 +315,7 @@
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_16')],
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_refunds_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -338,7 +338,7 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_8')],
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_paid_8_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -348,7 +348,7 @@
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'tag_ids': [ref('tag_diot_8')],
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_refunds_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -100,6 +100,40 @@
             }),
         ]"/>
         </record>
+        <record id="tax18" model="account.tax.template">
+            <field name="sequence" eval="20"/>
+            <field name="active" eval="0"/>
+            <field name="chart_template_id" ref="mx_coa"/>
+            <field name="name">RET IVA RESICO 1.25%</field>
+            <field name="description">Retención IVA(-1.25%)</field>
+            <field name="amount">-1.25</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_iva_ret_1_25"/>
+            <field name="tax_exigibility">on_payment</field>
+            <field name="cash_basis_transition_account_id" ref="cuenta216_10"/>
+            <field name="l10n_mx_tax_type">Tasa</field>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('cuenta216_10_20'),
+                'plus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
+            }),
+        ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('cuenta216_10_20'),
+                'minus_report_expression_ids': [ref('tax_report_mx_diot_withheld_tag')],
+            }),
+        ]"/>
+        </record>
         <record id="tax2" model="account.tax.template">
             <field name="sequence" eval="10"/>
             <field name="chart_template_id" ref="mx_coa"/>

--- a/addons/l10n_mx/data/account_tax_group_data.xml
+++ b/addons/l10n_mx/data/account_tax_group_data.xml
@@ -13,6 +13,10 @@
             <field name="name">IVA 8%</field>
             <field name="country_id" ref="base.mx"/>
         </record>
+        <record id="tax_group_iva_ret_1_25" model="account.tax.group">
+            <field name="name">IVA Retencion 1.25%</field>
+            <field name="country_id" ref="base.mx"/>
+        </record>
         <record id="tax_group_iva_ret_4" model="account.tax.group">
             <field name="name">IVA Retencion 4%</field>
             <field name="country_id" ref="base.mx"/>

--- a/addons/l10n_mx/migrations/2.1/post-migrate_update_taxes.py
+++ b/addons/l10n_mx/migrations/2.1/post-migrate_update_taxes.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.account.models.chart_template import update_taxes_from_templates
+
+
+def migrate(cr, version):
+    update_taxes_from_templates(cr, 'l10n_mx.mx_coa')


### PR DESCRIPTION
The mexican DIOT report is now a tax report and enjoy more Reportalypse' features (less menuitems, tax_tags engine)

The export functinality will remain in enterprise version.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
