### PR TITLE
[FIX] mrp: merge moves with the same product from same BoM

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -125,6 +125,7 @@ class StockMove(models.Model):
         'mrp.workorder', 'Work Order To Consume', copy=False, check_company=True)
     # Quantities to process, in normalized UoMs
     bom_line_id = fields.Many2one('mrp.bom.line', 'BoM Line', check_company=True)
+    bom_id = fields.Many2one('mrp.bom', related='bom_line_id.bom_id', store=False)
     byproduct_id = fields.Many2one(
         'mrp.bom.byproduct', 'By-products', check_company=True,
         help="By-product line that generated the move in a manufacturing order")
@@ -489,7 +490,7 @@ class StockMove(models.Model):
 
     @api.model
     def _prepare_merge_moves_distinct_fields(self):
-        return super()._prepare_merge_moves_distinct_fields() + ['created_production_id', 'cost_share', 'bom_line_id']
+        return super()._prepare_merge_moves_distinct_fields() + ['created_production_id', 'cost_share', 'bom_id']
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):


### PR DESCRIPTION
**Stpes to reproduce the bug:**
- Go to warehouse → Enable “Pick components and then manufacture (2 steps)”

- Create a storable product “P1” with BoM:
    - Type: manufacture
    - operation: OP1 and OP2
    - component:
        - C1, 1unit consumed in OP1
        - C1, 1unit consumed in OP2

- Create a MO to produce 1 unit of P1:
    - Confirm the MO
    - Go to the picking


**Problem:**
The move lines for the component C1 are not grouped in a single line

Since this fix: https://github.com/odoo/odoo/pull/86083 The lines are not merged, because we separate them by 'bom_line_id' instead of 'bom_id'.

**Solution:**
Those which are in the same BoM should be grouped, and the bug with the kits will be avoided too

opw-3112142