### PR TITLE
[REF] web_editor, website: name link-related entry point to update form

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -17,7 +17,7 @@ const Link = Widget.extend({
     events: {
         'input': '_onAnyChange',
         'change': '_onAnyChange',
-        'input input[name="url"]': '__onURLInput',
+        'input input[name="url"]': '_onURLInput',
         'change input[name="url"]': '_onURLInputChange',
     },
 
@@ -144,8 +144,7 @@ const Link = Widget.extend({
         if (this.data.url) {
             var match = /mailto:(.+)/.exec(this.data.url);
             this.$('input[name="url"]').val(match ? match[1] : this.data.url);
-            this._onURLInput();
-            this._savedURLInputOnDestroy = false;
+            this._adaptForm();
         }
 
         if (!this.noFocusUrl) {
@@ -239,6 +238,18 @@ const Link = Widget.extend({
      * @private
      */
     _adaptPreview: function () {},
+    /**
+     * Adapt the link setup form to changes.
+     *
+     * @private
+     */
+    _adaptForm() {
+        const $linkUrlInput = this.$('#o_link_dialog_url_input');
+        const value = $linkUrlInput.val();
+        const isLink = value.indexOf('@') < 0;
+        this._getIsNewWindowFormRow().toggleClass('d-none', !isLink);
+        this.$('.o_strip_domain').toggleClass('d-none', value.indexOf(window.location.origin) !== 0);
+    },
     /**
      * @private
      */
@@ -495,32 +506,11 @@ const Link = Widget.extend({
         }
     },
     /**
-     * @todo Adapt in master: in stable _onURLInput was both used as an event
-     * handler responding to url input events + a private method called at the
-     * widget lifecycle start. Originally both points were to update the link
-     * tools/dialog UI. It was later wanted to actually update the DOM... but
-     * should only be done in event handler part.
-     *
-     * This allows to differentiate the event handler part. In master, we should
-     * take the opportunity to also update the `_updatePreview` concept which
-     * updates the "preview" of the original link dialog but actually updates
-     * the real DOM for the "new" link tools.
-     *
-     * @private
-     */
-    __onURLInput: function () {
-        this._onURLInput(...arguments);
-    },
-    /**
      * @private
      */
     _onURLInput: function () {
         this._savedURLInputOnDestroy = true;
-        var $linkUrlInput = this.$('#o_link_dialog_url_input');
-        let value = $linkUrlInput.val();
-        let isLink = value.indexOf('@') < 0;
-        this._getIsNewWindowFormRow().toggleClass('d-none', !isLink);
-        this.$('.o_strip_domain').toggleClass('d-none', value.indexOf(window.location.origin) !== 0);
+        this._adaptForm();
     },
     /**
      * @private

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -64,6 +64,13 @@ const _DialogLinkWidget = Link.extend({
     /**
      * @override
      */
+    _adaptForm() {
+        this._super(...arguments);
+        this._adaptPreview();
+    },
+    /**
+     * @override
+     */
     _adaptPreview: function () {
         var data = this._getData();
         if (data === null) {
@@ -166,7 +173,6 @@ const _DialogLinkWidget = Link.extend({
     _onURLInput: function () {
         this._super(...arguments);
         this.$('#o_link_dialog_url_input').closest('.o_url_input').removeClass('o_has_error').find('.form-control, .form-select').removeClass('is-invalid');
-        this._adaptPreview();
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -434,7 +434,7 @@ const LinkTools = Link.extend({
     /**
      * @override
      */
-    __onURLInput() {
+    _onURLInput() {
         this._super(...arguments);
         this.options.wysiwyg.odooEditor.historyPauseSteps('_onURLInput');
         this._adaptPreview();

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -43,6 +43,13 @@ weWidgets.LinkTools.include({
     //--------------------------------------------------------------------------
 
     /**
+     * @override
+     */
+    _adaptForm() {
+        this._super.apply(this, arguments);
+        this._adaptPageAnchor();
+    },
+    /**
      * @private
      */
     _adaptPageAnchor: function () {
@@ -77,13 +84,6 @@ weWidgets.LinkTools.include({
      */
     _onAutocompleteClose: function () {
         this._onURLInput();
-    },
-    /**
-     * @override
-     */
-    _onURLInput: function () {
-        this._super.apply(this, arguments);
-        this._adaptPageAnchor();
     },
     /**
      * @override


### PR DESCRIPTION
The link-related classes were updated in [1] to distinguish between the update of their "edition form" and the update of the link "preview". To make this change possible without breaking stable versions, some of the old method names had to be kept.

This commit makes the changes that could not be done in stable to differentiate the event handler parts: the intermediary `__onURLInput` is removed, and an `_adaptForm` is introduced to specifically handle the edition form part.

[1]: https://github.com/odoo/odoo/commit/54746012d37c457d4c2f32d419b03f21cd8718f9

opw-3086198
task-3096806
