### PR TITLE
[FIX] web: mock server many2one ref inverse

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1927,6 +1927,7 @@ export class MockServer {
                 continue;
             }
             const relatedRecordIds = Array.isArray(record[fname]) ? record[fname] : [record[fname]];
+            const comodel_inverse_field = this.models[comodelName].fields[inverseFieldName];
             // we only want to set a value for comodel inverse field if the model field has a value.
             if (record[fname]) {
                 for (const relatedRecordId of relatedRecordIds) {
@@ -1946,15 +1947,14 @@ export class MockServer {
                     if (Array.isArray(relatedFieldValue)) {
                         inverseFieldNewValue = [...relatedFieldValue, record.id];
                     }
-                    this.writeRecord(
-                        comodelName,
-                        { [inverseFieldName]: inverseFieldNewValue },
-                        relatedRecordId
-                    );
+                    const data = { [inverseFieldName]: inverseFieldNewValue };
+                    if (comodel_inverse_field.type === "many2one_reference") {
+                        data[comodel_inverse_field.model_name_ref_fname] = modelName;
+                    }
+                    this.writeRecord(comodelName, data, relatedRecordId);
                 }
             } else if (field.type === "many2one_reference") {
                 // we need to clean the many2one_field as well.
-                const comodel_inverse_field = this.models[comodelName].fields[inverseFieldName];
                 const model_many2one_field =
                     comodel_inverse_field.inverse_fname_by_model_name[modelName];
                 this.writeRecord(modelName, { [model_many2one_field]: false }, record.id);

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -33,6 +33,11 @@ QUnit.module("MockServer", (hooks) => {
                                 ["done", "Done"],
                             ],
                         },
+                        foo_ids: {
+                            type: "one2many",
+                            relation: "foo",
+                            inverse_fname_by_model_name: { foo: "res_id" },
+                        },
                         many2one_field: { type: "many2one", relation: "foo" },
                         one2many_field: {
                             type: "one2many",
@@ -123,6 +128,11 @@ QUnit.module("MockServer", (hooks) => {
                             type: "many2one_reference",
                             model_name_ref_fname: "res_model",
                             inverse_fname_by_model_name: { bar: "one2many_field" },
+                        },
+                        res_id: {
+                            type: "many2one_reference",
+                            model_name_ref_fname: "res_model",
+                            inverse_fname_by_model_name: { bar: "foo_ids" },
                         },
                         res_model: { type: "char" },
                     },
@@ -1283,6 +1293,18 @@ QUnit.module("MockServer", (hooks) => {
         mockServer.mockWrite("foo", [[2], { many2one_reference: false }]);
         assert.deepEqual(mockServer.models.bar.records[0].one2many_field, []);
     });
+
+    QUnit.test(
+        "Inverse of many2one_ref should update both many2one_ref and model field",
+        async function (assert) {
+            data.models.foo.records = [{ id: 1 }];
+            data.models.bar.records = [{ id: 2 }];
+            const mockServer = new MockServer(data);
+            mockServer.mockWrite("bar", [[2], { foo_ids: [1] }]);
+            assert.strictEqual(data.models.foo.records[0].res_model, "bar");
+            assert.strictEqual(data.models.foo.records[0].res_id, 2);
+        }
+    );
     QUnit.test("List View: invisible on processed Arch", async function (assert) {
         data.views = {
             "bar,10001,list": `


### PR DESCRIPTION
Before this PR, writing on the inverse field of a many2one reference in the mock environment would not update the model_field of the record holding the many2one_reference.

This PR fixes the issue.