### PR TITLE
[IMP] web: x2many: disable form view modal opening

### DIFF
--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -46,7 +46,7 @@
                             <field name="display_on_invoice" string="Display details"/>
 
                             <field name="line_ids" nolabel="1" colspan="2">
-                                <tree string="Payment Terms" editable="top" no_open="True">
+                                <tree string="Payment Terms" editable="top">
                                     <field name="value" string="Due Type"/>
                                     <field name="value_amount" attrs="{'invisible': [('value', '=', 'balance')]}" digits="[2, 2]"/>
                                     <field name="months"/>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -72,7 +72,7 @@
                     <notebook>
                         <page name="tax_mapping" string="Tax Mapping">
                             <field name="tax_ids" widget="one2many" nolabel="1" context="{'append_type_to_tax_name': True}">
-                                <tree name="tax_map_tree" string="Tax Mapping" editable="bottom" no_open="1">
+                                <tree name="tax_map_tree" string="Tax Mapping" editable="bottom">
                                     <field name="tax_src_id"
                                         domain="[
                                             ('type_tax_use', '!=', 'none'),

--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -84,7 +84,6 @@
                                       decoration-bf="id == parent.contract_id"
                                       default_order = "date_start desc, state desc"
                                       editable="bottom"
-                                      no_open="1"
                                       create="0" delete="0">
                                     <button name="action_open_contract_form" type="object" icon="fa-external-link" title="Open Contract"/>
                                     <field name="id" invisible="1"/>

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -71,7 +71,7 @@
                                 Adding fields in the tree arch below makes them accessible to the widget
                             -->
                             <field mode="tree" nolabel="1" name="resume_line_ids" widget="resume_one2many">
-                                <tree>
+                                <tree open_on_click="1">
                                     <field name="line_type_id"/>
                                     <field name="name"/>
                                     <field name="description"/>
@@ -85,7 +85,7 @@
                         <div class="o_hr_skills_editable o_hr_skills_group o_group_skills col-lg-5 d-flex flex-column">
                             <separator string="Skills"/>
                             <field mode="tree" nolabel="1" name="employee_skill_ids" widget="skills_one2many">
-                                <tree>
+                                <tree open_on_click="1">
                                     <field name="skill_type_id" invisible="1"/>
                                     <field name="skill_id"/>
                                     <field name="skill_level_id"/>

--- a/addons/hr_timesheet/views/project_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_sharing_views.xml
@@ -35,7 +35,7 @@
                 <page string="Timesheets" id="timesheets_tab" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
                     <field name="timesheet_ids" mode="tree,kanban"
                           attrs="{'invisible': [('analytic_account_active', '=', False)]}">
-                        <tree string="Timesheet Activities" default_order="date" no_open="1" create="false" delete="0">
+                        <tree string="Timesheet Activities" default_order="date" create="false" delete="0">
                             <field name="date"/>
                             <field name="employee_id"/>
                             <field name="name"/>

--- a/addons/hr_work_entry_contract/wizard/hr_work_entry_regeneration_wizard_views.xml
+++ b/addons/hr_work_entry_contract/wizard/hr_work_entry_regeneration_wizard_views.xml
@@ -39,7 +39,7 @@
                               default_order = "date_start"
 
                               editable="bottom"
-                              no_open="1" decoration-danger="state == 'validated'">
+                              decoration-danger="state == 'validated'">
                             <field name="state" invisible="1"/>
                             <field name="date_start"/>
                             <field name="date_stop"/>

--- a/addons/mrp_subcontracting/views/stock_move_views.xml
+++ b/addons/mrp_subcontracting/views/stock_move_views.xml
@@ -139,10 +139,10 @@
                 <attribute name="options">{'no_open': True}</attribute>
             </xpath>
             <xpath expr="//tree" position="attributes">
-                <attribute name="no_open">1</attribute>
+                <attribute name="open_on_click">0</attribute>
             </xpath>
             <xpath expr="//tree/field[@name='lot_id']" position="attributes">
-                <attribute name="options">{'no_create_edit': True, 'no_open': True}</attribute>
+                <attribute name="options">{'no_create_edit': True, 'open_on_click': False}</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/mrp_subcontracting/views/subcontracting_portal_views.xml
+++ b/addons/mrp_subcontracting/views/subcontracting_portal_views.xml
@@ -22,7 +22,7 @@
                     <notebook>
                         <page string="Operations" name="operations">
                             <field name="move_ids_without_package" mode="tree">
-                                <tree no_open="1">
+                                <tree>
                                     <field name="id" readonly="1" invisible="1"/>
                                     <field name="product_id" readonly="1"/>
                                     <field name="show_details_visible" invisible="1"/>

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -16,7 +16,7 @@
                         'readonly': [('state', 'in', ('purchase', 'to approve','done', 'cancel'))],
                         'required': [('display_type', '=', False)],
                     }"
-                    options="{'no_open': True}"
+                    options="{'open_on_click': False}"
                     context="{'partner_id': parent.partner_id}"
                     widget="pol_product_many2one"/>
                 <field name="product_template_attribute_value_ids" invisible="1"/>

--- a/addons/survey/static/tests/components/question_page_one2many_field_tests.js
+++ b/addons/survey/static/tests/components/question_page_one2many_field_tests.js
@@ -98,7 +98,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
             arch: `
                 <form>
                     <field name="question_and_page_ids" widget="question_page_one2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="is_page" invisible="1" />
                             <field name="title" />
                             <field name="random_questions_count" />
@@ -146,7 +146,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
                 <form>
                     <field name="favorite_color"/>
                     <field name="question_and_page_ids" widget="question_page_one2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="is_page" invisible="1" />
                             <field name="title" />
                             <field name="random_questions_count" />
@@ -177,7 +177,7 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
             arch: `
                 <form>
                     <field name="question_and_page_ids" widget="question_page_one2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="is_page" invisible="1" />
                             <field name="title" />
                             <field name="random_questions_count" />

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -66,7 +66,7 @@
                     <notebook>
                         <page string="Questions" name="questions">
                             <field name="question_and_page_ids" nolabel="1" widget="question_page_one2many" mode="tree,kanban" context="{'default_survey_id': active_id}">
-                                <tree decoration-bf="is_page">
+                                <tree decoration-bf="is_page" open_on_click="1">
                                     <field name="sequence" widget="handle"/>
                                     <field name="title" widget="survey_description_page"/>
                                     <field name="background_image" invisible="1"/>

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -158,6 +158,10 @@ export class X2ManyField extends Component {
             return props;
         }
 
+        if (props.archInfo.openOnClick === null) {
+            props.archInfo.openOnClick = false;
+        }
+
         // handle column_invisible modifiers
         const columns = archInfo.columns
             .map((col) => {

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -202,7 +202,10 @@ export class ListArchParser extends XMLParser {
                 const groupsLimitAttr = node.getAttribute("groups_limit");
                 treeAttr.groupsLimit = groupsLimitAttr && parseInt(groupsLimitAttr, 10);
 
-                treeAttr.noOpen = archParseBoolean(node.getAttribute("no_open") || "");
+                treeAttr.openOnClick =
+                    node.getAttribute("open_on_click") === null
+                        ? null
+                        : archParseBoolean(node.getAttribute("open_on_click") || "");
                 treeAttr.expand = archParseBoolean(xmlDoc.getAttribute("expand") || "");
                 treeAttr.decorations = getDecoration(xmlDoc);
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -94,6 +94,9 @@ export class ListRenderer extends Component {
 
         this.cellToFocus = null;
         this.activeRowId = null;
+
+        this.openOnClick =
+            this.props.archInfo.openOnClick || this.props.archInfo.openOnClick === null;
         onMounted(() => {
             this.activeElement = this.uiService.activeElement;
         });
@@ -920,7 +923,7 @@ export class ListRenderer extends Component {
             }
         } else if (this.props.list.editedRecord && this.props.list.editedRecord !== record) {
             this.props.list.unselectRecord(true);
-        } else if (!this.props.archInfo.noOpen) {
+        } else if (this.openOnClick) {
             this.props.openRecord(record);
         }
     }
@@ -1500,7 +1503,7 @@ export class ListRenderer extends Component {
                     return true;
                 }
 
-                if (!this.props.archInfo.noOpen) {
+                if (this.openOnClick) {
                     this.props.openRecord(record);
                     return true;
                 }

--- a/addons/web/static/tests/views/fields/datetime_field_tests.js
+++ b/addons/web/static/tests/views/fields/datetime_field_tests.js
@@ -464,7 +464,7 @@ QUnit.module("Fields", (hooks) => {
                 arch: `
                     <form>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="datetime" />
                             </tree>
                             <form>
@@ -507,7 +507,7 @@ QUnit.module("Fields", (hooks) => {
                 arch: `
                     <form>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="datetime" />
                             </tree>
                             <form>

--- a/addons/web/static/tests/views/fields/many2many_checkboxes_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_checkboxes_field_tests.js
@@ -319,7 +319,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree><field name="id"/></tree>
+                        <tree open_on_click="1"><field name="id"/></tree>
                         <form>
                             <field name="timmy" widget="many2many_checkboxes"/>
                         </form>

--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -647,7 +647,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="timmy">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/><field name="float_field"/>
                         </tree>
                         <form>
@@ -1538,7 +1538,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="turtles">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="turtle_foo"/>
                         </tree>
                     </field>

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -972,7 +972,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="turtles">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="partner_ids" widget="many2many_tags"/>
                         </tree>
                         <form>
@@ -1565,8 +1565,7 @@ QUnit.module("Fields", (hooks) => {
             type: "form",
             resModel: "partner",
             serverData,
-            arch:
-                '<form><field name="timmy" widget="many2many_tags" placeholder="Placeholder"/></form>',
+            arch: '<form><field name="timmy" widget="many2many_tags" placeholder="Placeholder"/></form>',
         });
 
         assert.strictEqual(

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -517,7 +517,7 @@ QUnit.module("Fields", (hooks) => {
                         <field name="turtle_trululu" context="{'show_address': 1}" options="{'always_reload': 1}" />
                     </form>`,
                 "turtle,false,list": `
-                    <tree>
+                    <tree open_on_click="1">
                         <field name="display_name" />
                     </tree>`,
             };
@@ -560,7 +560,7 @@ QUnit.module("Fields", (hooks) => {
                         <field name="turtle_trululu" context="{'show_address': 1}" options="{'always_reload': 1}" />
                     </form>`,
                 "turtle,false,list": `
-                    <tree>
+                    <tree open_on_click="1">
                         <field name="display_name" />
                         <field name="turtle_trululu" />
                     </tree>`,

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -1701,7 +1701,7 @@ QUnit.module("Fields", (hooks) => {
                 <form>
                     <field name="foo"/>
                     <field name="turtles">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="turtle_foo"/>
                         </tree>
                         <form>
@@ -1811,12 +1811,12 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <field name="foo"/>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtles"/>
                             </tree>
                             <form>
                                 <field name="turtles">
-                                    <tree editable="top">
+                                    <tree editable="top" open_on_click="1">
                                         <field name="turtle_foo"/>
                                     </tree>
                                 </field>
@@ -1871,7 +1871,7 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <field name="foo"/>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtles" widget="many2many_tags"/>
                             </tree>
                             <form>
@@ -2564,7 +2564,7 @@ QUnit.module("Fields", (hooks) => {
             serverData.models.partner.onchanges.turtles = function () {};
             serverData.views = {
                 "turtle,false,list": `
-                    <tree>
+                    <tree open_on_click="1">
                         <field name="turtle_foo"/>
                     </tree>`,
                 "turtle,false,form": `
@@ -2780,7 +2780,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p" widget="many2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                         </tree>
                     </field>
@@ -3181,7 +3181,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                             <field name="qux"/>
                         </tree>
@@ -4616,7 +4616,7 @@ QUnit.module("Fields", (hooks) => {
                             <field name="product_id"/>
                             <field name="int_field"/>
                         </form>
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="product_id"/>
                             <field name="foo"/>
                         </tree>
@@ -4705,7 +4705,7 @@ QUnit.module("Fields", (hooks) => {
                             <form>
                                 <field name="product_id" context="{'partner_foo':parent.foo, 'lalala': parent.product_id}"/>
                             </form>
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="product_id"/>
                             </tree>
                         </field>
@@ -5122,7 +5122,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="turtles" widget="many2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="turtle_foo"/>
                             <field name="turtle_qux"/>
                             <field name="turtle_int"/>
@@ -5904,7 +5904,7 @@ QUnit.module("Fields", (hooks) => {
                                     <field name="partner_ids"/>
                                 </group>
                             </form>
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="display_name"/>
                             </tree>
                         </field>
@@ -5931,7 +5931,7 @@ QUnit.module("Fields", (hooks) => {
                     <form edit="0">
                         <group>
                             <field name="turtles">
-                                <tree>
+                                <tree open_on_click="1">
                                     <field name="partner_ids"/>
                                 </tree>
                                 <form>
@@ -5967,7 +5967,7 @@ QUnit.module("Fields", (hooks) => {
                 <form>
                     <group>
                         <field name="turtles">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtle_foo"/>
                             </tree>
                             <form>
@@ -6127,7 +6127,7 @@ QUnit.module("Fields", (hooks) => {
                 <form>
                     <field name="bar"/>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="turtles"/>
                         </tree>
                         <form>
@@ -6198,7 +6198,7 @@ QUnit.module("Fields", (hooks) => {
                 <form>
                     <field name="bar"/>
                     <field name="p" widget="one2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="turtles"/>
                         </tree>
                     </field>
@@ -6227,7 +6227,7 @@ QUnit.module("Fields", (hooks) => {
             serverData.models.partner.records[0].p = [1];
             serverData.views = {
                 "partner,false,list": `
-                    <tree>
+                    <tree open_on_click="1">
                         <field name="turtles"/>
                     </tree>`,
                 "partner,false,form": `
@@ -6272,7 +6272,7 @@ QUnit.module("Fields", (hooks) => {
                     <form edit="0">
                         <group>
                             <field name="turtles">
-                                <tree>
+                                <tree open_on_click="1">
                                     <field name="display_name"/>
                                 </tree>
                             </field>
@@ -6313,7 +6313,7 @@ QUnit.module("Fields", (hooks) => {
                 arch: `
                     <form>
                         <field name="turtles">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtle_foo"/>
                             </tree>
                         </field>
@@ -7379,7 +7379,7 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <field name="name"/>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="display_name"/>
                             </tree>
                             <form>
@@ -7431,11 +7431,11 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <field name="name"/>
                         <field name="p" attrs="{'readonly': [['name', '=', 'readonly']]}">
-                            <tree><field name="display_name"/></tree>
+                            <tree open_on_click="1"><field name="display_name"/></tree>
                             <form>
                                 <field name="display_name"/>
                                 <field name="p">
-                                    <tree><field name="display_name"/></tree>
+                                    <tree open_on_click="1"><field name="display_name"/></tree>
                                     <form><field name="display_name"/></form>
                                 </field>
                             </form>
@@ -8072,7 +8072,7 @@ QUnit.module("Fields", (hooks) => {
                 arch: `
                     <form>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtles"/>
                             </tree>
                             <form>
@@ -8130,7 +8130,7 @@ QUnit.module("Fields", (hooks) => {
                     <sheet>
                         <field name="display_name"/>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="display_name"/>
                             </tree>
                             <form>
@@ -8807,7 +8807,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                         </tree>
                         <form>
@@ -9036,7 +9036,7 @@ QUnit.module("Fields", (hooks) => {
             mockRPC(route, args) {
                 if (args.method === "test_button") {
                     assert.step("test_button");
-                    assert.strictEqual(args.kwargs.context.parent_name, 'first record');
+                    assert.strictEqual(args.kwargs.context.parent_name, "first record");
                     return true;
                 }
             },
@@ -9104,7 +9104,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                         </tree>
                         <form>
@@ -9185,7 +9185,7 @@ QUnit.module("Fields", (hooks) => {
                                         </tree>
                                     </field>
                                 </form>
-                                <tree>
+                                <tree open_on_click="1">
                                     <field name="display_name"/>
                                 </tree>
                             </field>
@@ -10376,7 +10376,7 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <field name="bar"/>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtles" widget="many2many_tags"/>
                             </tree>
                             <form>
@@ -10454,7 +10454,7 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <field name="bar"/>
                         <field name="p">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="turtles" widget="many2many_tags"/>
                             </tree>
                             <form>
@@ -10909,7 +10909,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
-        "prevent the dialog in readonly x2many tree view with option no_open True",
+        "prevent the dialog in readonly x2many tree view with option open_on_click False",
         async function (assert) {
             await makeView({
                 type: "form",
@@ -10919,7 +10919,7 @@ QUnit.module("Fields", (hooks) => {
                     <form>
                         <sheet>
                             <field name="turtles">
-                                <tree editable="bottom" no_open="True">
+                                <tree editable="bottom">
                                     <field name="turtle_foo"/>
                                 </tree>
                             </field>
@@ -11075,7 +11075,7 @@ QUnit.module("Fields", (hooks) => {
                                 </tree>
                             </field>
                         </form>
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                         </tree>
                     </field>
@@ -12059,7 +12059,7 @@ QUnit.module("Fields", (hooks) => {
             type: "form",
             arch: `<form>
                 <field name="p" context="{ 'form_view_ref': 1234 }">
-                    <tree><field name="display_name" /></tree>
+                    <tree open_on_click="1"><field name="display_name" /></tree>
                 </field>
             </form>`,
             serverData,
@@ -12401,7 +12401,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                         </tree>
                         <form>
@@ -12442,7 +12442,7 @@ QUnit.module("Fields", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                         </tree>
                         <form>
@@ -12469,6 +12469,49 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(target, ".modal .o_data_row td[name=display_name]");
     });
 
+    QUnit.test("x2many should not open view form on click by default", async function (assert) {
+        serverData.models.partner.records[0].p = [1];
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="p">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+            resId: 1,
+        });
+        await click(target.querySelector(".o_data_row td"));
+        assert.containsNone(target, ".modal");
+    });
+
+    QUnit.test(
+        "x2many should open view form on click when open_on_click attribute is set",
+        async function (assert) {
+            serverData.models.partner.records[0].p = [1];
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                <form>
+                    <field name="p">
+                        <tree open_on_click="1">
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+                resId: 1,
+            });
+            await click(target.querySelector(".o_data_row td"));
+            assert.containsOnce(target, ".modal");
+        }
+    );
+
     QUnit.test('Add a line, click on "Save & New" with an invalid form', async function (assert) {
         await makeView({
             type: "form",
@@ -12492,12 +12535,20 @@ QUnit.module("Fields", (hooks) => {
         await addRow(target);
         assert.containsOnce(target, ".o_dialog .o_form_view");
 
-        // Click on "Save & New" with an invalid form 
+        // Click on "Save & New" with an invalid form
         await click(target, ".o_dialog .o_form_button_save_new");
         assert.containsOnce(target, ".o_dialog .o_form_view");
 
         // Check that no buttons are disabled
-        assert.hasAttrValue(target.querySelector(".o_dialog .o_form_button_save_new"), "disabled", undefined);
-        assert.hasAttrValue(target.querySelector(".o_dialog .o_form_button_cancel"), "disabled", undefined);
+        assert.hasAttrValue(
+            target.querySelector(".o_dialog .o_form_button_save_new"),
+            "disabled",
+            undefined
+        );
+        assert.hasAttrValue(
+            target.querySelector(".o_dialog .o_form_button_cancel"),
+            "disabled",
+            undefined
+        );
     });
 });

--- a/addons/web/static/tests/views/fields/reference_field_tests.js
+++ b/addons/web/static/tests/views/fields/reference_field_tests.js
@@ -271,7 +271,7 @@ QUnit.module("Fields", (hooks) => {
                     <field name="reference" />
                 </form>`,
             "partner,false,list": `
-                <tree>
+                <tree open_on_click="1">
                     <field name="display_name"/>
                     <field name="reference" />
                 </tree>`,
@@ -324,7 +324,7 @@ QUnit.module("Fields", (hooks) => {
                     <field name="reference" />
                 </form>`,
             "partner,false,list": `
-                <tree>
+                <tree open_on_click="1">
                     <field name="display_name"/>
                     <field name="reference" />
                 </tree>`,
@@ -503,41 +503,44 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
-    QUnit.test("computed reference field changed by onchange to 'False,0' value", async function (assert) {
-        assert.expect(1);
+    QUnit.test(
+        "computed reference field changed by onchange to 'False,0' value",
+        async function (assert) {
+            assert.expect(1);
 
-        serverData.models.partner.onchanges = {
-            bar(obj) {
-                if (!obj.bar) {
-                    obj.reference_char = "False,0";
-                }
-            },
-        };
-        await makeView({
-            type: "form",
-            resModel: "partner",
-            serverData,
-            arch: `
+            serverData.models.partner.onchanges = {
+                bar(obj) {
+                    if (!obj.bar) {
+                        obj.reference_char = "False,0";
+                    }
+                },
+            };
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
                 <form>
                     <field name="bar"/>
                     <field name="reference_char" widget="reference"/>
                 </form>`,
-            mockRPC(route, { args, method }) {
-                if (method === "create") {
-                    assert.deepEqual(args[0], {
-                        bar: false,
-                        reference_char: "False,0",
-                    });
-                }
-            },
-        });
+                mockRPC(route, { args, method }) {
+                    if (method === "create") {
+                        assert.deepEqual(args[0], {
+                            bar: false,
+                            reference_char: "False,0",
+                        });
+                    }
+                },
+            });
 
-        // trigger the onchange to set a value for the reference field
-        await click(target, ".o_field_boolean input");
+            // trigger the onchange to set a value for the reference field
+            await click(target, ".o_field_boolean input");
 
-        // save
-        await clickSave(target);
-    });
+            // save
+            await clickSave(target);
+        }
+    );
 
     QUnit.test("interact with reference field changed by onchange", async function (assert) {
         assert.expect(2);

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -670,7 +670,7 @@ QUnit.module("Views", (hooks) => {
                 arch: `
                 <form edit="0">
                     <field name="partner_ids">
-                        <tree editable="top">
+                        <tree editable="top" open_on_click="1">
                             <field name="display_name"/>
                             <field name="timmy" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         </tree>
@@ -703,7 +703,7 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="foo" widget="my_widget"/>
                         </tree>
                     </field>
@@ -4494,10 +4494,10 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <form>
                     <field name="timmy">
-                        <tree><field name="display_name"/></tree>
+                        <tree open_on_click="1"><field name="display_name"/></tree>
                         <form>
                             <field name="partner_ids">
-                                <tree><field name="display_name"/></tree>
+                                <tree open_on_click="1"><field name="display_name"/></tree>
                                 <form><field name="display_name"/></form>
                             </field>
                         </form>
@@ -5920,7 +5920,7 @@ QUnit.module("Views", (hooks) => {
                     <field name="foo"/>
                     <field name="int_field"/>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="display_name"/>
                             <field name="int_field"/>
                         </tree>
@@ -6104,7 +6104,7 @@ QUnit.module("Views", (hooks) => {
                             <field name="foo" widget="domain"/>
                         </group>
                         <field name="timmy">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="display_name"/>
                             </tree>
                             <form>
@@ -6142,7 +6142,7 @@ QUnit.module("Views", (hooks) => {
                     <group>
                         <field name="foo"/>
                         <field name="timmy">
-                            <tree><field name="name"/></tree>
+                            <tree open_on_click="1"><field name="name"/></tree>
                             <form>
                                 <field name="name"/>
                                 <field name="color"/>
@@ -6601,7 +6601,7 @@ QUnit.module("Views", (hooks) => {
                     <field name="foo"/>
                     <field name="int_field"/>
                     <field name="p">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="foo"/>
                             <field name="bar"/>
                         </tree>
@@ -6737,7 +6737,7 @@ QUnit.module("Views", (hooks) => {
                     <form>
                         <field name="foo"/>
                         <field name="p" string="custom label">
-                            <tree>
+                            <tree open_on_click="1">
                                 <field name="foo"/>
                             </tree>
                             <form>
@@ -7634,7 +7634,7 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <form>
                     <field name="product_ids" widget="one2many">
-                        <tree create="0">
+                        <tree create="0" open_on_click="1">
                             <field name="display_name"/>
                             <field name="partner_type_ids"/>
                         </tree>
@@ -8429,7 +8429,7 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree default_order="foo desc">
+                        <tree open_on_click="1" default_order="foo desc">
                             <field name="display_name"/>
                             <field name="foo"/>
                         </tree>
@@ -8905,7 +8905,7 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <form>
                     <field name="p" widget="many2many" string="custom label">
-                        <tree><field name="display_name"/></tree>
+                        <tree open_on_click="1"><field name="display_name"/></tree>
                         <form><field name="display_name"/></form>
                     </field>
                 </form>`,
@@ -9778,7 +9778,7 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <form>
                     <field name="p">
-                        <tree><field name="display_name"/></tree>
+                        <tree open_on_click="1"><field name="display_name"/></tree>
                         <form>
                             <field name="display_name"/>
                             <field name="foo" attrs="{'readonly': [['display_name', '=', 'readonly']]}"/>

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -534,7 +534,7 @@ QUnit.module("ActionManager", (hooks) => {
             serverData.views["partner,false,form"] = `
                 <form>
                     <field name="o2m">
-                    <tree><field name="foo"/></tree>
+                    <tree open_on_click="1"><field name="foo"/></tree>
                     <form><field name="foo"/></form>
                     </field>
                 </form>
@@ -558,7 +558,7 @@ QUnit.module("ActionManager", (hooks) => {
             serverData.views["partner,false,form"] = `
                 <form>
                     <field name="o2m">
-                    <tree><field name="foo"/></tree>
+                    <tree open_on_click="1"><field name="foo"/></tree>
                     <form><field name="foo"/></form>
                     </field>
                 </form>

--- a/addons/website_slides/static/tests/qunit_suite_tests/components/slide_category_one2many_field_tests.js
+++ b/addons/website_slides/static/tests/qunit_suite_tests/components/slide_category_one2many_field_tests.js
@@ -96,7 +96,7 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
             arch: `
                 <form>
                     <field name="lines" widget="slide_category_one2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="is_category" invisible="1" />
                             <field name="name" />
                             <field name="int" />
@@ -141,7 +141,7 @@ QUnit.module("SlideCategoryOneToManyField", (hooks) => {
             arch: `
                 <form>
                     <field name="lines" widget="slide_category_one2many">
-                        <tree>
+                        <tree open_on_click="1">
                             <field name="is_category" invisible="1" />
                             <field name="name" />
                             <field name="int" />

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -74,7 +74,7 @@
                         <notebook colspan="4">
                             <page name="content" string="Content">
                                 <field name="slide_ids" string="Content" colspan="4" nolabel="1" widget="slide_category_one2many" mode="tree,kanban" context="{'default_channel_id': active_id, 'form_view_ref' : 'website_slides.view_slide_slide_form_wo_channel_id'}">
-                                     <tree decoration-bf="is_category" editable="bottom">
+                                     <tree decoration-bf="is_category" editable="bottom" open_on_click="1">
                                         <field name="sequence" widget="handle"/>
                                         <field name="name"/>
                                         <field name="slide_category" attrs="{'invisible': [('slide_category', '=', 'category')]}"/>

--- a/odoo/addons/test_new_api/views/test_new_api_views.xml
+++ b/odoo/addons/test_new_api/views/test_new_api_views.xml
@@ -54,7 +54,7 @@
                         <notebook>
                             <page string="Messages">
                                 <field name="messages">
-                                    <tree string="Messages">
+                                    <tree string="Messages" open_on_click="1">
                                         <field name="name"/>
                                         <field name="body"/>
                                         <field name="important"/>


### PR DESCRIPTION
This commit disable by default the opening of the form view when
clicking on a record in a x2many list field.

Before when clicking on a record in a x2many list field:
- sometimes it goes into inline edition mode
- sometimes it opens the record in a modal form
- sometimes it does nothing

With this commit, we remove the "popup" option and the behavior becomes
more logical: it goes into inline edition if the field is editable,
otherwise nothing happens.

For specific cases, it is possible to activate this behaviour in the
tree arch with the `open_on_click="0"` attribute. This option was
previously named `no_open` but the double negation needed to open a
record (`no_open="0"`) is not clear enough.

If the x2many field renders a kanban, it stills open the records in a
modal by default because unlike the list, the kanban does not contain
all/most of the required information of the record.

task-id: 2964320