### PR TITLE
[FIX] purchase_stock: update picking location type view

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -372,7 +372,7 @@ class PurchaseOrderLine(models.Model):
                         note=_('The quantities on your purchase order indicate less than billed. You should ask for a refund.'))
 
                 # If the user increased quantity of existing line or created a new line
-                pickings = line.order_id.picking_ids.filtered(lambda x: x.state not in ('done', 'cancel') and x.location_dest_id.usage in ('internal', 'transit', 'customer'))
+                pickings = line.order_id.picking_ids.filtered(lambda x: x.state not in ('done', 'cancel') and x.location_dest_id.usage in ('internal', 'transit', 'customer', 'view'))
                 picking = pickings and pickings[0] or False
                 if not picking:
                     res = line.order_id._prepare_picking()


### PR DESCRIPTION
Steps to reproduce:
- create a PO with a storage location of type view
- decrease PO quantity to zero
- a new picking is created with no stock move

Bug:
the already existing picking is ignored if location type is view

Fix:
only ignore cancelled and picking

opw-3018479