### PR TITLE
[FIX] mail: add missing field for mass editing in studio

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -203,6 +203,7 @@
                     decoration-danger="date_deadline &lt; current_date"
                     decoration-success="date_deadline == current_date"
                     default_order="date_deadline" create="false">
+                <field name="res_model" invisible="1"/>
                 <field name="res_name"/>
                 <field name="activity_type_id"/>
                 <field name="summary"/>


### PR DESCRIPTION
In studio while being in settings > technical / discuss / activities, enable mass-editing. An error will be displayed saying that the field `res_model` is missing from the view, which makes the solving of the domain of the field `activity_type_id` impossible.

opw-3076769

