### PR TITLE
[ADD] account_edi_purchase: automatically match PO when importing bill

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3363,6 +3363,10 @@ class AccountMove(models.Model):
 
         return to_post
 
+    def _find_and_set_purchase_orders(self, po_references, partner_id, amount_total, prefer_purchase_line=False, timeout=10):
+        # hook to be used with purchase, so that vendor bills are sync/autocompleted with purchase orders
+        self.ensure_one()
+
     # -------------------------------------------------------------------------
     # PUBLIC ACTIONS
     # -------------------------------------------------------------------------

--- a/addons/account_edi/models/account_journal.py
+++ b/addons/account_edi/models/account_journal.py
@@ -81,3 +81,12 @@ class AccountJournal(models.Model):
             protected_edi_formats = journal.edi_format_ids.filtered(lambda e: e.id in protected_edi_format_ids)
 
             journal.edi_format_ids = enabled_edi_formats + protected_edi_formats
+
+    def _create_document_from_attachment(self, attachment_ids=None):
+        # tries to match purchasing orders
+        moves = super()._create_document_from_attachment(attachment_ids)
+        for move in moves:
+            if move.move_type == 'in_invoice':
+                references = [move.invoice_origin] if move.invoice_origin else []
+                move._find_and_set_purchase_orders(references, move.partner_id.id, move.amount_total, timeout=4)
+        return moves

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -246,6 +246,12 @@ class AccountEdiXmlCII(models.AbstractModel):
         if ref_node is not None:
             invoice.ref = ref_node.text
 
+        # ==== Invoice origin ====
+
+        invoice_origin_node = tree.find('./{*}OrderReference/{*}ID')
+        if invoice_origin_node is not None:
+            invoice.invoice_origin = invoice_origin_node.text
+
         # === Note/narration ====
 
         narration = ""

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -493,6 +493,12 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if ref_node is not None:
             invoice.ref = ref_node.text
 
+        # ==== Invoice origin ====
+
+        invoice_origin_node = tree.find('./{*}OrderReference/{*}ID')
+        if invoice_origin_node is not None:
+            invoice.invoice_origin = invoice_origin_node.text
+
         # === Note/narration ====
 
         narration = ""

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 from odoo.tests.common import Form
@@ -57,6 +59,34 @@ class TestPurchaseToInvoiceCommon(AccountTestInvoicingCommon):
             'default_code': 'PROD_DEL',
             'taxes_id': False,
         })
+
+    @classmethod
+    def init_purchase(cls, partner=None, confirm=False, products=None, taxes=None, company=False):
+        date_planned = fields.Datetime.now() - timedelta(days=1)
+        po_form = Form(cls.env['purchase.order'] \
+                    .with_company(company or cls.env.company) \
+                    .with_context(tracking_disable=True))
+        po_form.partner_id = partner or cls.partner_a
+        po_form.partner_ref = 'my_match_reference'
+
+        for product in (products or []):
+            with po_form.order_line.new() as line_form:
+                line_form.product_id = product
+                line_form.price_unit = product.list_price
+                line_form.product_qty = 1
+                line_form.product_uom = product.uom_id
+                line_form.date_planned = date_planned
+                if taxes:
+                    line_form.tax_ids.clear()
+                    for tax in taxes:
+                        line_form.tax_ids.add(tax)
+
+        rslt = po_form.save()
+
+        if confirm:
+            rslt.button_confirm()
+
+        return rslt
 
 
 @tagged('post_install', '-at_install')
@@ -560,3 +590,78 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
         # Ensure price unit is updated when changing quantity on PO confirmed and line NOT linked to an invoice line
         po_line.write({'product_qty': 4})
         self.assertEqual(40.0, po_line.price_unit, "Unit price should be set to 40.0 for 4 quantity")
+
+
+@tagged('post_install', '-at_install')
+class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
+
+    def test_total_match_via_partner(self):
+        po = self.init_purchase(confirm=True, partner=self.partner_a, products=[self.product_order])
+        invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order])
+
+        invoice._find_and_set_purchase_orders(
+            [], invoice.partner_id.id, invoice.amount_total)
+
+        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertEqual(invoice.amount_total, po.amount_total)
+
+    def test_total_match_via_po_reference(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order])
+        invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order])
+
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total)
+
+        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertEqual(invoice.amount_total, po.amount_total)
+
+    def test_subset_total_match_prefer_purchase(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
+        invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order])
+
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, prefer_purchase_line=True)
+        additional_unmatch_po_line = po.order_line.filtered(lambda l: l.product_id == self.service_order)
+
+        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(additional_unmatch_po_line.id in invoice.line_ids.purchase_line_id.ids)
+        self.assertTrue(invoice.line_ids.filtered(lambda l: l.purchase_line_id == additional_unmatch_po_line).quantity == 0)
+
+    def test_subset_total_match_reject_purchase(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
+        invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order])
+
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, prefer_purchase_line=False)
+        additional_unmatch_po_line = po.order_line.filtered(lambda l: l.product_id == self.service_order)
+
+        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(additional_unmatch_po_line.id not in invoice.line_ids.purchase_line_id.ids)
+
+    def test_po_match_prefer_purchase(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
+        invoice = self.init_invoice('in_invoice', products=[self.product_a])
+
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, prefer_purchase_line=True)
+
+        self.assertTrue(invoice.id in po.invoice_ids.ids)
+
+    def test_po_match_reject_purchase(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
+        invoice = self.init_invoice('in_invoice', products=[self.product_a])
+
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, prefer_purchase_line=False)
+
+        self.assertTrue(invoice.id not in po.invoice_ids.ids)
+        self.assertNotEqual(invoice.amount_total, po.amount_total)
+
+    def test_no_match(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
+        invoice = self.init_invoice('in_invoice', products=[self.product_a])
+
+        invoice._find_and_set_purchase_orders(
+            ['other_reference'], invoice.partner_id.id, invoice.amount_total, prefer_purchase_line=False)
+
+        self.assertTrue(invoice.id not in po.invoice_ids.ids)


### PR DESCRIPTION
When a vendor bill document is uploaded (EDI, PDF,..) the link with
the purchase order is often lost.

We want to reuse the purchase.order OCR' matching logic to enhance
vendor bill extracted from documents.

To sum up the logic;

- if we find a partner or reference match (invoice_origin)
AND the same amount, we use autocomplete and replace the line in the vendor
bill with the purchase order one.

- if we find a match with the reference and some line in the purchase order
sum up to the vendor bill total, we add those line in the vendor bill
but we set the qty to zero (the accountant can  manually remove the XML
line and link the new one afterwards).

task-id: 2828521
[community](https://github.com/odoo/odoo/pull/109093)
[enterprise](https://github.com/odoo/enterprise/pull/35436)