### PR TITLE
[FIX] web: adjust grid style

### DIFF
--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -26,7 +26,7 @@
                 <t t-else="">
                     <div
                         class="o_cell flex-grow-1 flex-sm-grow-0"
-                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}{{ cell.width ? 'width: ' + cell.width + '%' + ';' : '' }}"
+                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : 'grid-column: 2;' }}{{ cell.width ? 'width: ' + cell.width + '%' + ';' : '' }}"
                         t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label w-100 text-break text-900' : null }}"
                         t-if="cell.isVisible">
                         <t t-slot="{{ cell.name }}" />


### PR DESCRIPTION
To reproduce
============
- on a form view add columns with studio
- in one of the columns add html field
- close studio and edit forum view using developer tools
- add `nolabel="1"` to the added html field

the field will be too small like not visible

Problem
=======
the field is grid that wasn't expecting a single item, so when removing the label this behaviour happens

Solution
========
adjusting the style

opw-3104715