### PR TITLE
[IMP] tools: improve XSD collision avoidance

### DIFF
--- a/addons/account/data/service_cron.xml
+++ b/addons/account/data/service_cron.xml
@@ -22,4 +22,13 @@
         <field name="interval_type">days</field>
         <field name="numbercall">-1</field>
     </record>
+
+    <record id="action_download_xsd" model="ir.actions.server">
+        <field name="name">Download XSD files</field>
+        <field name="model_id" ref="account.model_ir_attachment"/>
+        <field name="binding_model_id" ref="account.model_ir_attachment"/>
+        <field name="binding_view_types">form</field>
+        <field name="state">code</field>
+        <field name="code">action = model.action_download_xsd_files()</field>
+    </record>
 </odoo>

--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -141,3 +141,12 @@ class IrAttachment(models.Model):
         to_process.sort(key=lambda x: x['sort_weight'])
 
         return to_process
+
+    # -------------------------------------------------------------------------
+    # XSD validation
+    # -------------------------------------------------------------------------
+
+    def action_download_xsd_files(self):
+        # To be extended by localisations, where they can download their necessary XSD files
+        # Note: they should always return super().action_download_xsd_files()
+        return

--- a/addons/account/static/src/components/settings_form_view/res_config_dev_tool.js
+++ b/addons/account/static/src/components/settings_form_view/res_config_dev_tool.js
@@ -1,0 +1,25 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+import { ResConfigDevTool } from "@web/webclient/settings_form_view/widgets/res_config_dev_tool";
+
+/**
+ * Override of the widget in the settings that handles the "Developer Tools" section.
+ * Provides a button to download XSD files for XML validation.
+ */
+class ResConfigDevToolDownloadXsd extends ResConfigDevTool {
+    static template = "res_config_dev_tool";
+    /**
+     * Downloads every XSD file, based on installed localisations.
+     */
+    onClickDownloadXSD() {
+        this.action.doAction("account.action_download_xsd");
+    }
+}
+
+const resConfigDevToolDownloadXsd = {
+    component: ResConfigDevToolDownloadXsd,
+};
+
+registry.category("view_widgets").add("res_config_dev_tool", resConfigDevToolDownloadXsd, {force: true});

--- a/addons/account/static/src/components/settings_form_view/res_config_dev_tool.xml
+++ b/addons/account/static/src/components/settings_form_view/res_config_dev_tool.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template>
+    <div t-name='account.res_config_dev_tool' t-inherit="web.res_config_dev_tool" t-inherit-mode="extension" owl="1" primary="1">
+        <xpath expr="//Setting" position="inside">
+            <a t-if="isDebug" class="d-block" t-on-click.prevent="onClickDownloadXSD" href="#">Download XSD files (XML validation)</a>
+        </xpath>
+    </div>
+</template>

--- a/addons/account_edi/tests/common.py
+++ b/addons/account_edi/tests/common.py
@@ -141,7 +141,7 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
         the formats we want to return the files for (in case we want to test specific formats).
         Other formats will still generate documents, they simply won't be returned.
         """
-        moves.edi_document_ids._process_documents_web_services(with_commit=False)
+        moves.edi_document_ids.with_context(skip_xsd=True)._process_documents_web_services(with_commit=False)
 
         documents_to_return = moves.edi_document_ids
         if formats_to_return != None:

--- a/addons/account_edi/tests/common.py
+++ b/addons/account_edi/tests/common.py
@@ -141,7 +141,7 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
         the formats we want to return the files for (in case we want to test specific formats).
         Other formats will still generate documents, they simply won't be returned.
         """
-        moves.edi_document_ids.with_context(skip_xsd=True)._process_documents_web_services(with_commit=False)
+        moves.edi_document_ids._process_documents_web_services(with_commit=False)
 
         documents_to_return = moves.edi_document_ids
         if formats_to_return != None:

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
@@ -13,7 +13,7 @@ import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
  * Can be used to enable/disable the debug modes.
  * Can be used to load the demo data.
  */
-class ResConfigDevTool extends Component {
+export class ResConfigDevTool extends Component {
     static template = "res_config_dev_tool";
     static components = {
         SettingsBlock,


### PR DESCRIPTION
WIP

Currently, saving/fetching XSD attachments is only based on the attachment's name. This means that multiple attachments can share the same name, leading to possible collision.

This commit aims at improving the whole process of fetching XSD attachments from DB by:
(1) reducing the collision chance
(2) handling the case when collision still happens
(3) simplifying/generalizing the use of the load_xsd_files_from_url function, which allows:
(4) not saving ZIP archives, only saving required XSD files inside

These improvements are implemented as follows:
(1) fetch based on XSD name, url and type, and enforce a prefix to all file names
(2) return only one attachment when multiple match the description (the most recently updated one)
(3) rewrite function definition and use a dictionary to provide needed information
(4) do just that

[Enterprise PR](https://github.com/odoo/enterprise/pull/35456)

task id=3010716
