### PR TITLE
[FIX] sale_purchase: fix duplication of service with subcontract service

### DIFF
--- a/addons/sale_purchase/models/product_template.py
+++ b/addons/sale_purchase/models/product_template.py
@@ -17,6 +17,17 @@ class ProductTemplate(models.Model):
         ('service_to_purchase', "CHECK((type != 'service' AND service_to_purchase != true) or (type = 'service'))", 'Product that is not a service can not create RFQ.'),
     ]
 
+    def copy(self, default=None):
+        self.ensure_one()
+
+        current_state = self.service_to_purchase
+
+        self.service_to_purchase = False
+        new = super().copy(default)
+        self.service_to_purchase = current_state
+
+        return new
+
     @api.constrains('service_to_purchase', 'seller_ids')
     def _check_service_to_purchase(self):
         for template in self:


### PR DESCRIPTION
When trying to duplicate a service in sale > products with "Subcontract Service" enabled, a error message will appear. This is due to the fact that when you are duplicating a product, every vendor in the purchase tab are not carried over to the copy. To fix this easily, we need to disable the "Subcontract Service" on duplicates entry during their creations.

opw-3115827