### PR TITLE
[IMP] l10n_se: Add demo company registry number

### DIFF
--- a/addons/l10n_se/demo/demo_company.xml
+++ b/addons/l10n_se/demo/demo_company.xml
@@ -16,6 +16,7 @@
     <record id="demo_company_se" model="res.company">
         <field name="name">SE Company</field>
         <field name="partner_id" ref="partner_demo_company_se"/>
+        <field name="company_registry">555555-5555</field>
     </record>
 
     <function model="res.company" name="_onchange_country_id">


### PR DESCRIPTION
Add a company_registry number to the demo company, as it would be needed by l10n_se_sie_import

task-2826514

Signed-off-by: Julien Alardot (jual) <jual@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
