### PR TITLE
[IMP] web: calendar view: css rule for small event

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -222,6 +222,9 @@ export class CalendarCommonRenderer extends Component {
             if (record.isStriked) {
                 el.classList.add("o_event_striked");
             }
+            if (record.duration <= 0.25 ) {
+                el.classList.add("o_event_oneliner");
+            }
         }
 
         if (!el.querySelector(".fc-bg")) {

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -201,7 +201,7 @@ $o-filter_colors: lighten(#000, 46.7%), #f06050, #f4a460, #f7cd1f, #6cc1ed, #814
                 // Prevent events with similar color to visually overlap each other
                 box-shadow: 0 0 0 1px white;
 
-                &.fc-event:not(.fc-h-event) {
+                &.fc-event:not(.fc-h-event):not(.o_event_oneliner) {
                     border-width: 3px 0 0;
 
                     &.fc-not-start {
@@ -210,6 +210,16 @@ $o-filter_colors: lighten(#000, 46.7%), #f06050, #f4a460, #f7cd1f, #6cc1ed, #814
                         &.fc-not-end {
                             border-width: 0;
                         }
+                    }
+                }
+
+                &.o_event_oneliner {
+                    padding-top: 0;
+                    padding-bottom: 0;
+                    .fc-content {
+                        margin-top: 0;
+                        font-size: 11px !important;
+                        line-height: 0.9;
                     }
                 }
             }


### PR DESCRIPTION
This PR change the css rules for small event so that the title is always readable. On top of that, the top border of a darker color has been removed for these even to allow more space.

This take effect on all event that last <=30 minutes.

task-id : 3114155
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
