### PR TITLE
[IMP] Use secrets library for secure token generation.

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from __future__ import annotations
 
-import binascii
 import collections
 import contextlib
 import datetime
@@ -9,7 +8,7 @@ import hmac
 import ipaddress
 import json
 import logging
-import os
+import secrets
 import time
 from functools import wraps
 from hashlib import sha256
@@ -1575,7 +1574,7 @@ class ResUsersApikeys(models.Model):
         """
         self._check_expiration_date(expiration_date)
         # no need to clear the LRU when *adding* a key, only when removing
-        k = binascii.hexlify(os.urandom(API_KEY_SIZE)).decode()
+        k = secrets.token_hex(API_KEY_SIZE)
         self.env.cr.execute("""
         INSERT INTO {table} (name, user_id, scope, expiration_date, key, index)
         VALUES (%s, %s, %s, %s, %s, %s)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Per PEP 506 [^1]
> The suggestion is that secrets becomes the go-to module for dealing with anything which should remain secret (passwords, tokens, etc.)

This patch simplifies the code a tiny bit and helps draw attention to the secure/secret nature of token generation.

## Current behavior before PR:

`res.users.apikeys` keys are generated with `os.urandom` [^2] and other library functions.

## Desired behavior after PR is merged:

`res.users.apikeys` keys are generated with the `secrets.token_hex` [^3] library function.

[^1]: https://peps.python.org/pep-0506/
[^2]: https://docs.python.org/3/library/os.html#os.urandom
[^3]: https://docs.python.org/3/library/secrets.html#secrets.token_hex

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
