### PR TITLE
[IMP] base,l10n_{in,latam_base,sg}: added new `vat_label` field in the partner

### DIFF
--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -9,7 +9,7 @@
             <xpath expr="//field[@name='vat']" position="attributes">
                 <attribute name="attrs">{'required':[('l10n_in_gst_treatment', 'in', ['regular', 'composition', 'special_economic_zone', 'deemed_export'])], 'readonly': [('parent_id', '!=', False)]}</attribute>
             </xpath>
-            <xpath expr="//field[@name='vat']" position="before">
+            <xpath expr="//div[@name='vat']" position="before">
                 <field name="l10n_in_gst_treatment" attrs="{'readonly': [('parent_id', '!=', False)], 'invisible': [('fiscal_country_codes', 'not ilike', 'IN')]}"/>
             </xpath>
         </field>

--- a/addons/l10n_latam_base/views/res_partner_view.xml
+++ b/addons/l10n_latam_base/views/res_partner_view.xml
@@ -7,6 +7,9 @@
         <field name="model">res.partner</field>
         <field name="priority">100</field>
         <field type="xml" name="arch">
+            <div name="vat" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </div>
             <field name="vat" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>

--- a/addons/l10n_sg/views/res_partner_view.xml
+++ b/addons/l10n_sg/views/res_partner_view.xml
@@ -6,7 +6,7 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='vat']" position="before">
+                <xpath expr="//div[@name='vat']" position="before">
                     <field name="l10n_sg_unique_entity_number" attrs="{'invisible': [('fiscal_country_codes', 'not ilike', 'SG')]}"/>
                 </xpath>
             </field>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -155,7 +155,7 @@
             <field name="arch" type="xml">
                 <form string="Partners">
                 <div class="alert alert-warning oe_edit_only" role="alert" attrs="{'invisible': [('same_vat_partner_id', '=', False)]}">
-                  A partner with the same <span><span class="o_vat_label">Tax ID</span></span> already exists (<field name="same_vat_partner_id"/>), are you sure to create a new one?
+                  A partner with the same <span><span class="o_vat_label"><field name="vat_label"/></span></span> already exists (<field name="same_vat_partner_id"/>), are you sure to create a new one?
                 </div>
                 <div class="alert alert-warning oe_edit_only" role="alert" attrs="{'invisible': [('same_company_registry_partner_id', '=', False)]}">
                   A partner with the same <span><span class="o_vat_label">Company Registry</span></span> already exists (<field name="same_company_registry_partner_id"/>), are you sure to create a new one?
@@ -211,7 +211,10 @@
                                         attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                                 </div>
                             </div>
-                            <field name="vat" placeholder="e.g. BE0477472701" attrs="{'readonly': [('parent_id','!=',False)]}"/>
+                            <div class="o_form_label o_td_label" name="vat" title="The Tax Identification Number. Complete it if the contact is subjected to government taxes. Used in some legal statements.">
+                                <field name="vat_label"/>
+                            </div>
+                            <field name="vat" placeholder="e.g. BE0477472701" attrs="{'readonly': [('parent_id','!=',False)]}" nolabel="1"/>
                         </group>
                         <group>
                             <field name="function" placeholder="e.g. Sales Director"


### PR DESCRIPTION
In this commit, I added a new compute field `vat_label` in the partner. in the
compute method, if the partner country has a vat label then set it, if not then
check the vat label in the company country. the default value is 'Tax ID'.
Also, updated form views of partners that are using the vat field.

TaskID - 47184