### PR TITLE
[FIX] web: make TranslationButton not crash with no user lang

### DIFF
--- a/addons/web/static/src/core/user_service.js
+++ b/addons/web/static/src/core/user_service.js
@@ -48,7 +48,7 @@ export const userService = {
                 return context.uid;
             },
             get lang() {
-                return context.lang;
+                return context.lang || "en_US";
             },
             get tz() {
                 return context.tz;

--- a/addons/web/static/tests/views/fields/char_field_tests.js
+++ b/addons/web/static/tests/views/fields/char_field_tests.js
@@ -406,16 +406,16 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
-    QUnit.test("translation dialog should close if field is not there anymore", async function (assert) {
-        // In this test, we simulate the case where the field is removed from the view
-        // this can happend for example if the user click the back button of the browser.
+    QUnit.test("char field translatable without user language set", async function (assert) {
         serverData.models.partner.fields.foo.translate = true;
         serviceRegistry.add("localization", makeFakeLocalizationService({ multiLang: true }), {
             force: true,
         });
         patchWithCleanup(session.user_context, {
-            lang: "en_US",
+            lang: false,
         });
+        let call_get_field_translations = 0;
+
         await makeView({
             type: "form",
             resModel: "partner",
@@ -425,8 +425,7 @@ QUnit.module("Fields", (hooks) => {
                 <form>
                     <sheet>
                         <group>
-                            <field name="int_field" />
-                            <field name="foo"  attrs="{'invisible': [('int_field', '==', 9)]}"/>
+                            <field name="foo" />
                         </group>
                     </sheet>
                 </form>`,
@@ -435,31 +434,95 @@ QUnit.module("Fields", (hooks) => {
                     return Promise.resolve([
                         ["en_US", "English"],
                         ["fr_BE", "French (Belgium)"],
-                        ["es_ES", "Spanish"],
                     ]);
                 }
                 if (route === "/web/dataset/call_kw/partner/get_field_translations") {
-                    return Promise.resolve([
-                        [
-                            { lang: "en_US", source: "yop", value: "yop" },
-                            { lang: "fr_BE", source: "yop", value: "valeur français" },
-                            { lang: "es_ES", source: "yop", value: "yop español" },
-                        ],
-                        { translation_type: "char", translation_show_source: false },
-                    ]);
+                    if (call_get_field_translations === 0) {
+                        call_get_field_translations = 1;
+                        return Promise.resolve([
+                            [
+                                { lang: "en_US", source: "yop", value: "yop" },
+                                { lang: "fr_BE", source: "yop", value: "valeur français" },
+                                { lang: "es_ES", source: "yop", value: "yop español" },
+                            ],
+                            { translation_type: "char", translation_show_source: false },
+                        ]);
+                    }
                 }
             },
         });
 
         assert.hasClass(target.querySelector("[name=foo] input"), "o_field_translate");
 
-        await click(target, ".o_field_char .btn.o_field_translate");
-        assert.containsOnce(target, ".modal", "a translate modal should be visible");
-        await editInput(target, ".o_field_widget[name=int_field] input", "9");
-        await nextTick();
-        assert.containsNone(target, "[name=foo] input", "the field foo should be invisible");
-        assert.containsNone(target, ".modal", "a translate modal should not be visible");
+        assert.containsOnce(
+            target,
+            ".o_field_char .btn.o_field_translate",
+            "should have a translate button"
+        );
+        assert.strictEqual(
+            target.querySelector(".o_field_char .btn.o_field_translate").textContent,
+            "EN",
+            "the button should display the default language from the database as the current language"
+        );
     });
+
+    QUnit.test(
+        "translation dialog should close if field is not there anymore",
+        async function (assert) {
+            // In this test, we simulate the case where the field is removed from the view
+            // this can happend for example if the user click the back button of the browser.
+            serverData.models.partner.fields.foo.translate = true;
+            serviceRegistry.add("localization", makeFakeLocalizationService({ multiLang: true }), {
+                force: true,
+            });
+            patchWithCleanup(session.user_context, {
+                lang: "en_US",
+            });
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="int_field" />
+                            <field name="foo"  attrs="{'invisible': [('int_field', '==', 9)]}"/>
+                        </group>
+                    </sheet>
+                </form>`,
+                mockRPC(route, { args, method, model }) {
+                    if (route === "/web/dataset/call_kw/res.lang/get_installed") {
+                        return Promise.resolve([
+                            ["en_US", "English"],
+                            ["fr_BE", "French (Belgium)"],
+                            ["es_ES", "Spanish"],
+                        ]);
+                    }
+                    if (route === "/web/dataset/call_kw/partner/get_field_translations") {
+                        return Promise.resolve([
+                            [
+                                { lang: "en_US", source: "yop", value: "yop" },
+                                { lang: "fr_BE", source: "yop", value: "valeur français" },
+                                { lang: "es_ES", source: "yop", value: "yop español" },
+                            ],
+                            { translation_type: "char", translation_show_source: false },
+                        ]);
+                    }
+                },
+            });
+
+            assert.hasClass(target.querySelector("[name=foo] input"), "o_field_translate");
+
+            await click(target, ".o_field_char .btn.o_field_translate");
+            assert.containsOnce(target, ".modal", "a translate modal should be visible");
+            await editInput(target, ".o_field_widget[name=int_field] input", "9");
+            await nextTick();
+            assert.containsNone(target, "[name=foo] input", "the field foo should be invisible");
+            assert.containsNone(target, ".modal", "a translate modal should not be visible");
+        }
+    );
 
     QUnit.test("html field translatable", async function (assert) {
         assert.expect(5);


### PR DESCRIPTION
This commit fixes the TranslationButton behavior. Before the conversion of the button to Owl, the widget used the database default language in the case where the user language is not set (user_context.lang = false). Now, the default installed language is displayed, as it is the one used by default to display odoo to users in that case.

Before this fix, the view would crash, since the component couldn't find the user language to display in its template.

A test has been added to assert the presence of the button, even if the user language is missing.