### PR TITLE
[REM] l10n_ke_edi_tremol: remove unwanted filters

### DIFF
--- a/addons/l10n_ke_edi_tremol/views/account_move_view.xml
+++ b/addons/l10n_ke_edi_tremol/views/account_move_view.xml
@@ -41,21 +41,6 @@
                 </field>
             </field>
         </record>
-
-        <record id="l10n_ke_inherit_account_move_search_view" model="ir.ui.view">
-            <field name="name">l10n.ke.inherit.account.move.search</field>
-            <field name="model">account.move</field>
-            <field name="inherit_id" ref="account.view_account_invoice_filter" />
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='journal_id']" position="after">
-                    <field name="l10n_ke_cu_invoice_number" string="Kenya CU Invoice Number" filter_domain="[('l10n_ke_cu_invoice_number', 'ilike', self')]" />
-                </xpath>
-                <xpath expr="//filter[@name='cancel']" position="after">
-                    <separator/>
-                    <filter name="l10n_ke_edi_to_send" string="To Send to TIMS" domain="[('l10n_ke_cu_invoice_number', '=', False), ('state', '=', 'posted'), ('move_type', 'in', ['out_invoice', 'out_refund']), ('country_code', '=', 'KE')]"/>
-                </xpath>
-            </field>
-        </record>
     </data>
 </odoo>
 


### PR DESCRIPTION
A filter and a search term were added in previous commits (see 1d97d7f and b18caa7) in order to facilitate searching for invoices that need to be signed with the fiscal device in the Kenyan localisation.

Ths filter and search term are no longer wanted. This commit removes the 'l10n_ke_inherit_account_move_search_view' and it's respective filter/search term.
