### PR TITLE
[FIX] account: tax update country based on template tax tags

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3477,6 +3477,14 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/chart_template.py:0
+#, python-format
+msgid ""
+"Couldn't create tax with template repartition lines having tags with "
+"different countries."
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "Counterpart Values"
 msgstr ""

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -48,6 +48,15 @@ def update_taxes_from_templates(cr, chart_template_xmlid):
             xml_id = old_tax.get_xml_id().get(old_tax.id)
             if xml_id:
                 _remove_xml_id(xml_id)
+
+        # the tax should be instanciated with the tag's country if there is one
+        template_rep_line_ids = template.invoice_repartition_line_ids + template.refund_repartition_line_ids
+        tag_countries = [line._get_tags_to_add().country_id.id for line in template_rep_line_ids if line._get_tags_to_add().country_id]
+        if tag_countries:
+            if tag_countries.count(tag_countries[0]) != len(tag_countries):
+                raise ValidationError(_("Couldn't create tax with template repartition lines having tags with different countries."))
+            template_vals["country_id"] = tag_countries[0]
+
         chart_template.create_record_with_xmlid(company, template, "account.tax", template_vals)
 
     def _update_tax_from_template(template, tax):


### PR DESCRIPTION
When a template repartition line had foreign tags our update didn't create the related tax in that country, but instead created it in our company's country.
It was breaking some migration tests.
This PR fixes that bug.

Related: odoo/odoo#108571