### PR TITLE
[FIX] utm, *: allow quick creation of campaigns

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -271,7 +271,7 @@
                                         <field name="company_id"
                                             groups="base.group_multi_company"
                                             options="{'no_create': True}"/>
-                                        <field name="campaign_id" />
+                                        <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
                                         <field name="medium_id"/>
                                         <field name="source_id"/>
                                         <field name="referred"/>
@@ -317,7 +317,7 @@
                                         </div>
                                     </group>
                                     <group string="Marketing">
-                                        <field name="campaign_id" />
+                                        <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
                                         <field name="medium_id" />
                                         <field name="source_id" />
                                         <field name="referred"/>

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -44,7 +44,7 @@
                                 <field name="short_url"/>
                             </group>
                             <group name="utm" string="UTM">
-                                <field name="campaign_id"/>
+                                <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
                                 <field name="medium_id"/>
                                 <field name="source_id"/>
                             </group>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -352,6 +352,7 @@
                                         <field name="campaign_id"
                                             string="Campaign"
                                             groups="mass_mailing.group_mass_mailing_campaign"
+                                            options="{'create_name_field': 'title', 'always_reload': True}"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <field name="medium_id"
                                              string="Medium"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -624,7 +624,7 @@
                                     <field name="origin"/>
                                 </group>
                                 <group name="utm_link" colspan="2" class="mt-0">
-                                    <field name="campaign_id"/>
+                                    <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
                                     <field name="medium_id"/>
                                     <field name="source_id"/>
                                 </group>

--- a/addons/utm/models/utm_campaign.py
+++ b/addons/utm/models/utm_campaign.py
@@ -42,6 +42,8 @@ class UtmCampaign(models.Model):
         for vals in vals_list:
             if not vals.get('title') and vals.get('name'):
                 vals['title'] = vals['name']
+            elif vals.get('title') and not vals.get('name'):
+                vals['name'] = vals['title']
         new_names = self.env['utm.mixin']._get_unique_names(self._name, [vals.get('name') for vals in vals_list])
         for vals, new_name in zip(vals_list, new_names):
             vals['name'] = new_name


### PR DESCRIPTION
Purpose:
========
Since the introduction of the required "title" field in the utm_campaign model in commit [1], quick creation of campaigns from many2one widgets is not possible anymore (the slow creation modal is opened when clicking on "Create"), and the name value entered is not copied into the name field of the creation form.

This is because the model now has a field "name", and a field "title", which are both required. The creation using the many2one widget tries to create a record using the entered value as title and no name, which fails.

This commit makes sure that if a title but no name is given when creating a new campaign record, the name will be computed using the given title.

It also makes sure that the value entered before clicking on the "create and edit" button is copied in the form, by adding the "create_name_field" option on the many2one fields (the form uses the title field, not the name).

[1]: https://github.com/odoo/odoo/commit/4dbcefb5e5b1878e81fe9be9fe48a785f813334f

Task-3113954

