### PR TITLE
[IMP] l10n_in: clean by removing tax splitting by hsn

### DIFF
--- a/addons/l10n_in/models/account.py
+++ b/addons/l10n_in/models/account.py
@@ -2,54 +2,23 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
-from odoo import tools
-
-
-class AccountMoveLine(models.Model):
-    _inherit = "account.move.line"
-
-    def init(self):
-        tools.create_index(self._cr, 'account_move_line_move_product_index', self._table, ['move_id', 'product_id'])
-
-    @api.depends('move_id.line_ids', 'move_id.line_ids.tax_line_id', 'move_id.line_ids.debit', 'move_id.line_ids.credit')
-    def _compute_tax_base_amount(self):
-        aml = self.filtered(lambda l: l.company_id.account_fiscal_country_id.code == 'IN' and l.tax_line_id  and l.product_id)
-        for move_line in aml:
-            base_lines = move_line.move_id.line_ids.filtered(lambda line: move_line.tax_line_id in line.tax_ids and move_line.product_id == line.product_id)
-            move_line.tax_base_amount = abs(sum(base_lines.mapped('balance')))
-        remaining_aml = self - aml
-        if remaining_aml:
-            return super(AccountMoveLine, remaining_aml)._compute_tax_base_amount()
 
 
 class AccountTax(models.Model):
     _inherit = 'account.tax'
 
-    l10n_in_reverse_charge = fields.Boolean("Reverse charge", help="Tick this if this tax is reverse charge. Only for Indian accounting")
+    l10n_in_reverse_charge = fields.Boolean("Reverse charge",
+                                            help="Tick this if this tax is reverse charge. Only for Indian accounting")
 
-    @api.model
-    def _get_generation_dict_from_base_line(self, line_vals, tax_vals):
-        # EXTENDS account
-        # Group taxes also by product.
-        res = super()._get_generation_dict_from_base_line(line_vals, tax_vals)
-        record = line_vals['record']
-        if isinstance(record, models.Model)\
-                and record._name == 'account.move.line'\
-                and record.company_id.account_fiscal_country_id.code == 'IN':
-            res['product_id'] = record.product_id.id
-            res['product_uom_id'] = record.product_uom_id.id
-        return res
 
-    @api.model
-    def _get_generation_dict_from_tax_line(self, line_vals):
-        # EXTENDS account
-        # Group taxes also by product.
-        res = super()._get_generation_dict_from_tax_line(line_vals)
-        record = line_vals['record']
-        if isinstance(record, models.Model)\
-                and record._name == 'account.move.line'\
-                and record.company_id.account_fiscal_country_id.code == 'IN':
-            res['product_id'] = record.product_id.id
-            res['product_uom_id'] = record.product_uom_id.id
-        return res
+class AccountTaxTemplate(models.Model):
+    _inherit = 'account.tax.template'
+
+    l10n_in_reverse_charge = fields.Boolean("Reverse charge",
+                                            help="Tick this if this tax is reverse charge. Only for Indian accounting")
+
+    def _get_tax_vals(self, company, tax_template_to_tax):
+        val = super(AccountTaxTemplate, self)._get_tax_vals(company, tax_template_to_tax)
+        if self.tax_group_id:
+            val['l10n_in_reverse_charge'] = self.l10n_in_reverse_charge
+        return val

--- a/addons/l10n_in/models/chart_template.py
+++ b/addons/l10n_in/models/chart_template.py
@@ -20,15 +20,3 @@ class AccountChartTemplate(models.Model):
         if self == self.env.ref("l10n_in.indian_chart_template_standard"):
             company.write({'fiscalyear_last_month': '3'})
         return res
-
-
-class AccountTaxTemplate(models.Model):
-    _inherit = 'account.tax.template'
-
-    l10n_in_reverse_charge = fields.Boolean("Reverse charge", help="Tick this if this tax is reverse charge. Only for Indian accounting")
-    
-    def _get_tax_vals(self, company, tax_template_to_tax):
-        val = super(AccountTaxTemplate, self)._get_tax_vals(company, tax_template_to_tax)
-        if self.tax_group_id:
-            val['l10n_in_reverse_charge'] = self.l10n_in_reverse_charge
-        return val


### PR DESCRIPTION
There is no need anymore to split tax lines by hsn as the report now uses the tax details to calculate the taxes again anyways.

And we can group the reverse tax fields on tax and tax template in one file then.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
