### PR TITLE
[IMP] l10n_fr: localized company registry label

### DIFF
--- a/addons/account/static/src/components/localized_label/localized_label.js
+++ b/addons/account/static/src/components/localized_label/localized_label.js
@@ -1,0 +1,54 @@
+/** @odoo-module **/
+
+import {registry} from "@web/core/registry";
+import {standardWidgetProps} from "@web/views/widgets/standard_widget_props";
+import {Component, onWillUpdateProps, useState} from "@odoo/owl";
+import {getTooltipInfo} from "@web/views/fields/field_tooltip";
+
+class LocalizedLabel extends Component {
+    setup() {
+        super.setup();
+        this.field = this.props.record.fields[this.props.for];
+        this.state = useState({term: this.props.record.data[this.props.label_compute_field]});
+
+        onWillUpdateProps((nextProps) => {
+            const nextLabel = nextProps.record.data[this.props.label_compute_field];
+            if (this.state.term !== nextLabel) {
+                this.state.term = nextLabel;
+            }
+        });
+    }
+
+    get tooltipInfo() {
+        if (this.field) {
+            const fieldInfo = this.props.record.activeFields[this.props.for];
+            const tooltip = getTooltipInfo({
+                field: this.field,
+                fieldInfo: fieldInfo,
+            });
+            if (Boolean(odoo.debug) || (tooltip && JSON.parse(tooltip).field.help)) {
+                return tooltip;
+            }
+        }
+        return false;
+    }
+}
+
+LocalizedLabel.template = "account.LocalizedLabel";
+LocalizedLabel.props = {
+    ...standardWidgetProps,
+    // Set this to the name of the compute field holding the label string.
+    label_compute_field: {type: String},
+    // Set this to the name of the field the label is for. We can use it to recreate the tooltip.
+    for: {type: String},
+};
+
+export const localizedLabel = {
+    component: LocalizedLabel,
+    extractProps: ({attrs}) => ({
+        label_compute_field: attrs.label_compute_field,
+        for: attrs.for,
+    })
+};
+
+registry.category("view_widgets").add("localized_label", localizedLabel);

--- a/addons/account/static/src/components/localized_label/localized_label.xml
+++ b/addons/account/static/src/components/localized_label/localized_label.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+
+    <t t-name="account.LocalizedLabel" owl="1">
+        <span t-esc="this.state.term" class="fw-bold"/><sup class="btn-link p-1" t-if="this.field.help" t-att="{'data-tooltip-template': 'web.FieldTooltip', 'data-tooltip-info': tooltipInfo, 'data-tooltip-touch-tap-to-show': 'true'}">?</sup>
+    </t>
+
+</templates>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -297,5 +297,18 @@
               </p>
             </field>
         </record>
+
+        <record id="view_partner_form" model="ir.ui.view">
+            <field name="name">res.partner.form.inherit.account</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='company_registry']" position="replace">
+                    <field name="company_registry_label" invisible="1"/>
+                    <widget name="localized_label" label_compute_field="company_registry_label" for="company_registry" class="o_td_label"/>
+                    <field name="company_registry" nolabel="1"/>
+                </xpath>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -15,6 +15,11 @@
                     <field name="message_ids"/>
                 </div>
             </xpath>
+            <xpath expr="//field[@name='company_registry']" position="replace">
+                <field name="company_registry_label" invisible="1"/>
+                <widget name="localized_label" label_compute_field="company_registry_label" for="company_registry" class="o_td_label"/>
+                <field name="company_registry" nolabel="1"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/l10n_fr/__manifest__.py
+++ b/addons/l10n_fr/__manifest__.py
@@ -33,6 +33,7 @@ configuration of their taxes and fiscal positions manually.
     'data': [
         'data/account_chart_template_data.xml',
         'views/l10n_fr_view.xml',
+        'views/report_invoice.xml',
         'data/tax_report_data.xml',
         'data/res_country_data.xml',
     ],

--- a/addons/l10n_fr/models/__init__.py
+++ b/addons/l10n_fr/models/__init__.py
@@ -2,3 +2,4 @@
 from . import template_fr
 from . import res_partner
 from . import res_company
+from . import base_document_layout

--- a/addons/l10n_fr/models/base_document_layout.py
+++ b/addons/l10n_fr/models/base_document_layout.py
@@ -1,0 +1,21 @@
+from markupsafe import Markup
+
+from odoo import api, models, fields
+from odoo.addons.base.models.ir_qweb_fields import nl2br
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_company_details(self):
+        default_company_details = super()._default_company_details()
+        if self.env.company.country_code == 'FR':
+            # In france, displaying the SIRET number on any invoices is required
+            company = self.env.company
+            if 'SIRET' not in default_company_details and company.siret:
+                default_company_details += Markup(nl2br('\nSIRET: %s')) % company.siret
+
+        return default_company_details
+
+    company_details = fields.Html(default=_default_company_details)

--- a/addons/l10n_fr/models/res_partner.py
+++ b/addons/l10n_fr/models/res_partner.py
@@ -1,9 +1,17 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import fields, models, api, _
+
+from odoo import fields, models, api
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     siret = fields.Char(string='SIRET', size=14)
+
+    @api.model
+    def _get_company_registry_label(self, country_code):
+        self.ensure_one()
+        if country_code == 'FR':
+            return 'SIREN'
+        else:
+            return super()._get_company_registry_label(country_code)

--- a/addons/l10n_fr/views/report_invoice.xml
+++ b/addons/l10n_fr/views/report_invoice.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="report_invoice_document_fr" inherit_id="account.report_invoice_document">
+            <xpath expr="//t[@t-if='o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)']/div/t/div[@t-if='o.partner_id.vat']" position="after">
+                <div t-if="o.partner_id.siret and o.partner_id.country_code == 'FR'">
+                    SIRET: <t t-out="o.partner_id.siret"/>
+                </div>
+            </xpath>
+
+            <xpath expr="//t[@t-elif='o.partner_shipping_id and (o.partner_shipping_id == o.partner_id)']/div/t[@t-set='address']/div[@t-if='o.partner_id.vat']" position="after">
+                <div t-if="o.partner_id.siret and o.partner_id.country_code == 'FR'">
+                    SIRET: <t t-out="o.partner_id.siret"/>
+                </div>
+            </xpath>
+
+            <xpath expr="//t[@t-else='']/div/t/div[@t-if='o.partner_id.vat']" position="after">
+                <div t-if="o.partner_id.siret and o.partner_id.country_code == 'FR'">
+                    SIRET: <t t-out="o.partner_id.siret"/>
+                </div>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
Adds a way to have dynamic fields label based on the record country_id field.
This will be used in l10n_fr to have the company_registry field named SIREN if the partner or company has its address in France.

task id #2827661

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
