### PR TITLE
[FIX] l10n_ar: get the right fiscal position

### DIFF
--- a/addons/l10n_ar/models/account_fiscal_position.py
+++ b/addons/l10n_ar/models/account_fiscal_position.py
@@ -28,13 +28,14 @@ class AccountFiscalPosition(models.Model):
             # partner manually set fiscal position always win
             if delivery.property_account_position_id or partner.property_account_position_id:
                 return delivery.property_account_position_id or partner.property_account_position_id
-            domain = [
-                ('auto_apply', '=', True),
-                ('l10n_ar_afip_responsibility_type_ids', '=', self.env['res.partner'].browse(
-                    partner_id).l10n_ar_afip_responsibility_type_id.id),
-                ('company_id', '=', company.id),
-            ]
-            return self.sudo().search(domain, limit=1)
+            if delivery.country_id:
+                domain = [
+                    ('auto_apply', '=', True),
+                    ('l10n_ar_afip_responsibility_type_ids', '=', partner.l10n_ar_afip_responsibility_type_id.id),
+                    ('company_id', '=', company.id),
+                    '|', ('country_id', '=', delivery.country_id.id), ('country_id', '=', False),
+                ]
+                return self.sudo().search(domain, limit=1, order="country_id")
         return super().get_fiscal_position(partner_id, delivery_id=delivery_id)
 
     @api.onchange('l10n_ar_afip_responsibility_type_ids', 'country_group_id', 'country_id', 'zip_from', 'zip_to')


### PR DESCRIPTION
Steps to reproduce:

  - Install l10n_ar
  - Switch to company `(AR) Responsable Inscripto` (for testing purpose because journals are already created)
  - Create a partner with no country and set `AFIP Responsibility` to `Cliente / Proveedor del Exterior`
  - Create an invoice and add partner

Issue:

  A fiscal position is set on the invoice, while it should not.

  Another issue is that if we set a country on the partner and a
  different one on the fiscal position (that match with AFIP
  Responsibility of the partner), it will retrieve the first
  available one without taking into account the partner country.

Solution:

  In case the country is not set on partner, continue to retrieve the
  fiscal position with the normal flow.
  If set, retrieve the fiscal position that has no country or the same
  one as the partner (And order them by country to prioritize the one
  with a country set).

Part of PR fixing l10n tests : https://github.com/odoo/odoo/pull/101161