### PR TITLE
[REF] base: clean ir.lang

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -149,10 +149,12 @@ def url_lang(path_or_uri, lang_code=None):
     # relative URL with either a path or a force_lang
     if url and not url.netloc and not url.scheme and (url.path or force_lang):
         location = werkzeug.urls.url_join(request.httprequest.path, location)
-        lang_url_codes = [url_code for _, url_code, *_ in Lang.get_available()]
         lang_code = pycompat.to_text(lang_code or request.context['lang'])
-        lang_url_code = Lang._lang_code_to_urlcode(lang_code)
-        lang_url_code = lang_url_code if lang_url_code in lang_url_codes else lang_code
+        # Lang.get_available() = languages on the current website OR all lang in DB if no website
+        available_langs = Lang.get_available()
+        lang_url_codes = [lang[1] for lang in available_langs]
+        matching_url_codes = next((url_code for code, url_code, *_ in available_langs if lang_code == code), None)
+        lang_url_code = matching_url_codes or lang_code
         if (len(lang_url_codes) > 1 or force_lang) and is_multilang_url(location, lang_url_codes):
             loc, sep, qs = location.partition('?')
             ps = loc.split(u'/')

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -437,9 +437,9 @@ class IrHttp(models.AbstractModel):
             context_lang = cls.get_nearest_lang(real_env.context.get('lang'))
             default_lang = cls._get_default_lang()
             request.lang = request.env['res.lang']._lang_get(
-                nearest_url_lang or cookie_lang or context_lang or default_lang._get_cached('code')
+                nearest_url_lang or cookie_lang or context_lang or default_lang.code
             )
-            request_url_code = request.lang._get_cached('url_code')
+            request_url_code = request.lang.url_code
         finally:
             request.env = real_env
 
@@ -463,28 +463,28 @@ class IrHttp(models.AbstractModel):
         elif not url_lang_str:
             _logger.debug("%r (lang: %r) missing lang in url, redirect", path, request_url_code)
             redirect = request.redirect_query(f'/{request_url_code}{path}', request.httprequest.args)
-            redirect.set_cookie('frontend_lang', request.lang._get_cached('code'))
+            redirect.set_cookie('frontend_lang', request.lang.code)
             werkzeug.exceptions.abort(redirect)
 
         # See /6, default lang in url, /en/home -> /home
         elif url_lang_str == default_lang.url_code and allow_redirect:
             _logger.debug("%r (lang: %r) default lang in url, redirect", path, request_url_code)
             redirect = request.redirect_query(path_no_lang, request.httprequest.args)
-            redirect.set_cookie('frontend_lang', default_lang._get_cached('code'))
+            redirect.set_cookie('frontend_lang', default_lang.code)
             werkzeug.exceptions.abort(redirect)
 
         # See /7, lang alias in url, /fr_FR/home -> /fr/home
         elif url_lang_str != request_url_code and allow_redirect:
             _logger.debug("%r (lang: %r) lang alias in url, redirect", path, request_url_code)
             redirect = request.redirect_query(f'/{request_url_code}{path_no_lang}', request.httprequest.args, code=301)
-            redirect.set_cookie('frontend_lang', request.lang._get_cached('code'))
+            redirect.set_cookie('frontend_lang', request.lang.code)
             werkzeug.exceptions.abort(redirect)
 
         # See /8, homepage with trailing slash. /fr_BE/ -> /fr_BE
         elif path == f'/{url_lang_str}/' and allow_redirect:
             _logger.debug("%r (lang: %r) homepage with trailing slash, redirect", path, request_url_code)
             redirect = request.redirect_query(path[:-1], request.httprequest.args, code=301)
-            redirect.set_cookie('frontend_lang', default_lang._get_cached('code'))
+            redirect.set_cookie('frontend_lang', default_lang.code)
             werkzeug.exceptions.abort(redirect)
 
         # See /9, valid lang in url
@@ -571,9 +571,9 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _frontend_pre_dispatch(cls):
-        request.update_context(lang=request.lang._get_cached('code'))
-        if request.httprequest.cookies.get('frontend_lang') != request.lang._get_cached('code'):
-            request.future_response.set_cookie('frontend_lang', request.lang._get_cached('code'))
+        request.update_context(lang=request.lang.code)
+        if request.httprequest.cookies.get('frontend_lang') != request.lang.code:
+            request.future_response.set_cookie('frontend_lang', request.lang.code)
 
     @classmethod
     def _get_exception_code_values(cls, exception):

--- a/addons/portal/models/ir_http.py
+++ b/addons/portal/models/ir_http.py
@@ -11,14 +11,3 @@ class IrHttp(models.AbstractModel):
     def _get_translation_frontend_modules_name(cls):
         mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
         return mods + ['portal']
-
-    @classmethod
-    def _get_frontend_langs(cls):
-        # _get_frontend_langs() is used by @http_routing:IrHttp._match
-        # where is_frontend is not yet set and when no backend endpoint
-        # matched. We have to assume we are going to match a frontend
-        # route, hence the default True. Elsewhere, request.is_frontend
-        # is set.
-        if request and getattr(request, 'is_frontend', True):
-            return [lang[0] for lang in filter(lambda l: l[3], request.env['res.lang'].get_available())]
-        return super()._get_frontend_langs()

--- a/addons/portal/models/ir_qweb.py
+++ b/addons/portal/models/ir_qweb.py
@@ -15,9 +15,7 @@ class IrQWeb(models.AbstractModel):
         irQweb = super()._prepare_frontend_environment(values)
         values.update(
             is_html_empty=is_html_empty,
-            languages=lazy(lambda: [lang for
-                    lang in irQweb.env['res.lang'].get_available()
-                    if lang[0] in irQweb.env['ir.http']._get_frontend_langs()])
+            languages=lazy(irQweb.env['res.lang'].get_available)
         )
         for key in irQweb.env.context:
             if key not in values:

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="frontend_layout" name="Main Frontend Layout" inherit_id="web.frontend_layout">
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-attf-class" add="#{request.env['res.lang']._lang_get_direction(request.env.lang) == 'rtl' and 'o_rtl' or ''}" separator=" "/>
+            <attribute name="t-attf-class" add="#{request.env['res.lang']._lang_get(request.env.lang).direction == 'rtl' and 'o_rtl' or ''}" separator=" "/>
             <attribute name="t-attf-class" add="#{'o_portal' if is_portal else ''}" separator=" "/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']/header/img" position="replace">

--- a/addons/website/models/res_lang.py
+++ b/addons/website/models/res_lang.py
@@ -15,10 +15,9 @@ class Lang(models.Model):
         return super(Lang, self).write(vals)
 
     @api.model
-    @tools.ormcache_context(keys=("website_id",))
     def get_available(self):
         if request and getattr(request, 'is_frontend', True):
-            return self.env['website'].get_current_website().language_ids.get_sorted()
+            return self.env['website'].get_current_website()._get_available_langs()
         return super().get_available()
 
     def action_activate_langs(self):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -920,6 +920,10 @@ class Website(models.Model):
         website_id = self._get_current_website_id(domain_name, fallback=fallback)
         return self.browse(website_id)
 
+    @tools.ormcache('self.id')
+    def _get_available_langs(self):
+        return self.language_ids.get_sorted()
+
     @tools.cache('domain_name', 'fallback')
     @api.model
     def _get_current_website_id(self, domain_name, fallback=True):

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -14,7 +14,7 @@ class TestBlogPerformance(UtilPerf):
 
     def test_10_perf_sql_blog_standard_data(self):
         self.assertEqual(self._get_url_hot_query('/blog'), 11)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 24)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 23)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -27,9 +27,9 @@ class TestBlogPerformance(UtilPerf):
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
         self.assertEqual(self._get_url_hot_query('/blog'), 11)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 31)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 16)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 18)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 30)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 15)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 17)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -257,14 +257,6 @@ class Lang(models.Model):
         return self._get_cached_values()[field]
 
     @api.model
-    @tools.ormcache('code')
-    def _lang_code_to_urlcode(self, code):
-        for c, urlc, name, *_ in self.get_available():
-            if c == code:
-                return urlc
-        return self._lang_get(code).url_code
-
-    @api.model
     @tools.ormcache()
     def get_installed(self):
         """ Return the installed languages as a list of (code, name) sorted by name. """


### PR DESCRIPTION
[FIX] *: ormcache works with annotation

The `ormcache` decorator fails to create the key method
(`determine_key`) when the method signature contains any annotation.
Fix it by removing annotation of the signature.

[REF] base: remove some ormcache from res.lang

There is 8 methods with ormcache on `res.lang` model. 3 of these
methods fetch the same data than other ones.
In order to reduce the warmup and reduce the number of
entry used in the ormcache, we remove these 3 extra ormcache
and used the remain ones to have the same result in term of SQL
query number.