### PR TITLE
[FIX] website_slide_survey: add group on kanban view

### DIFF
--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -58,7 +58,7 @@
                 <field name="slide_channel_count"/>
             </xpath>
             <xpath expr="//div[@name='o_survey_kanban_card_section_success']" position="after">
-                <div class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                <div class="col-lg-1 col-sm-4 col-6 py-0 my-2" groups="website_slides.group_website_slides_officer">
                     <a t-if="record.slide_channel_count.raw_value"
                        type="object"
                        name="action_survey_view_slide_channels"


### PR DESCRIPTION
The field slide_channel_count is only visible for the groups website_slides.group_website_slides_officer so the field use in a qweb should be protected with the same group





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
