### PR TITLE
[FIX] web: display of JSON error in get_file

### DIFF
--- a/addons/web/static/src/js/core/ajax.js
+++ b/addons/web/static/src/js/core/ajax.js
@@ -293,6 +293,10 @@ function get_file(options) {
         var decoder = new FileReader();
         decoder.onload = function () {
             var contents = decoder.result;
+            if (xhr.response.type === 'application/json'){
+                options.error(JSON.parse(contents));
+                return;
+            }
 
             var err;
             var doc = new DOMParser().parseFromString(contents, 'text/html');


### PR DESCRIPTION
__Description of the issue/feature this PR addresses:__
When there is a server error while downloading a file. The error is not correctly parsed when it is formatted as a JSON. This result in the display of an empty error for the user.

__Current behavior before PR:__
An error with an empty message appears (but the message is still in the response of the HTTP request as a JSON)

<ins>Example of steps to reproduce this kind of issue on runbot:</ins>
- Install l10n_nl_reports
- Set the company to "NL Company"
- Set the city of Azure Interior to more than 50 characters (in order to induce an error)
- Go to Accounting > Reporting > General Ledger > Export (XAF)

__Desired behavior after PR is merged:__
The error is correctly parsed as a JSON if the HTTP response type is `application/json` and therefore it is well displayed to the user

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
