### PR TITLE
[FIX] web: fix test failing on split builds

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_model.js
+++ b/addons/web/static/src/views/kanban/kanban_model.js
@@ -283,16 +283,24 @@ class KanbanGroup extends Group {
      */
     async validateQuickCreate() {
         const record = this.list.quickCreateRecord;
+        let saved = false;
         if (record) {
-            const saved = await record.save();
-            if (saved) {
-                this.addRecord(this.removeRecord(record), 0);
-                this.count++;
-                this.list.count++;
-                return record;
-            }
+            saved = await this.model.mutex.exec(async () => {
+                const saved = await record._save({ noReload: true, stayInEdition: true });
+                if (saved) {
+                    this.count++;
+                    if (record.parentActiveFields) {
+                        record.setActiveFields(record.parentActiveFields);
+                        record.parentActiveFields = false;
+                    }
+                    await this.model.reloadRecords(record);
+                    record.switchMode("readonly");
+                    this.addRecord(this.removeRecord(record), 0);
+                }
+                return saved;
+            });
         }
-        return false;
+        return saved ? record : false;
     }
 
     // ------------------------------------------------------------------------

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1412,6 +1412,7 @@ export class Record extends DataPoint {
             delete this.virtualId;
             this.data.id = this.resId;
             this.resIds.push(this.resId);
+            this._changes = {};
             this.invalidateCache();
         } else if (keys.length > 0) {
             try {
@@ -1422,14 +1423,10 @@ export class Record extends DataPoint {
                 }
                 throw e;
             }
+            this._changes = {};
             this.invalidateCache();
         }
 
-        // Switch to the parent active fields
-        if (this.parentActiveFields) {
-            this.setActiveFields(this.parentActiveFields);
-            this.parentActiveFields = false;
-        }
         this.isInQuickCreation = false;
         if (shouldReload) {
             await this.model.reloadRecords(this);


### PR DESCRIPTION
Before this commit, test "click on the progressBar of a new column" deterministically failed on split builds. It only passed with all addons installed, and passed by chance with all addons installed.

The reason is that the flow of quick creating a record in a grouped kanban with progressbars wasn't concurrency proof at all. Commit [1] simply added a hook at the end of the `_save` function of the model, which highlighted the problem: the progressbars were updated before the group's count was incremented, so if the quick created record was the only record of the group, the progressbar was still empty after the quick creation.

This commit makes the quick create code more robust.

We couldn't find a way to write a qunit test for this, but it still fixes an error in nightly builds.

[1] a882b725bb6bf3d11c898a69e3fa5502802c1b78

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
