### PR TITLE
[FIX] base: fix message formatting in test_test_suite

### DIFF
--- a/odoo/addons/base/tests/test_test_suite.py
+++ b/odoo/addons/base/tests/test_test_suite.py
@@ -112,7 +112,7 @@ class TestRunnerLoggingCommon(TransactionCase):
             value = self._clean_message(value)
         if value != expected:
             if key != 'msg':
-                self._log_error(f"Key `{key}` => `{value}` is not equal to `{expected}` \n {log_record['str']}")
+                self._log_error(f"Key `{key}` => `{value}` is not equal to `{expected}`")
             else:
                 diff = '\n'.join(difflib.ndiff(value.splitlines(), expected.splitlines()))
                 self._log_error(f"Key `{key}` did not matched expected:\n{diff}")


### PR DESCRIPTION
This fixes KeyError: 'str', that happens on incorrect running tests test_test_suite.

The tests in test_test_suite.py are quite tricky: it analyses logs and expects INFO logs be printed. If we run tests with `--log-level warn`, we face the KeyError instead of getting a message that should give developer a hint what is wrong.

BEFORE

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/tests/test_test_suite.py", line 75, in _feedErrorsToResult
    self._check_log_records(log_records)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/tests/test_test_suite.py", line 105, in _check_log_records
    self._assert_log_equal(log_record, 'level', level)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/tests/test_test_suite.py", line 115, in _assert_log_equal
    self._log_error(f"Key `{key}` => `{value}` is not equal to `{expected}` \n {log_record['str']}")
KeyError: 'str'
```

AFTER

AssertionError: Key `level` => `40` is not equal to `20`

opw-3110640

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
