### PR TITLE
[FIX] mail: do not vacuum all mail in the email sending CRON

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -659,9 +659,8 @@ class Message(models.Model):
         self.mapped('attachment_ids').filtered(
             lambda attach: attach.res_model == self._name and (attach.res_id in self.ids or attach.res_id == 0)
         ).unlink()
-        for elem in self:
-            if elem.is_thread_message():
-                elem._invalidate_documents()
+        if not self.env.context.get('mail_gc_cron'):
+            self.filtered(lambda message: message.is_thread_message())._invalidate_documents()
         return super(Message, self).unlink()
 
     @api.model


### PR DESCRIPTION
Purpose
=======
The email sending CRON was cleaning all <mail.mail>, which can be very slow. This operation was locking the <mailing.trace> table. Because of that, when people receive email, the email couldn't be marked as opened because the table was locked.