### PR TITLE
[IMP] spreadsheet: mark two functions to be hidden

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/translation.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/translation.js
@@ -13,4 +13,5 @@ functionRegistry.add("_t", {
         return _t(toString(value));
     },
     returns: ["STRING"],
+    hidden: true,
 });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
Two odoo functions `odoo.pivot.position` and `_t` should not be presented to end users.

### Current behavior before PR:
They are presented in the auto-complete dropdown. 

### Desired behavior after PR is merged:
They are not presented in the dropdown so users should not know their existences. However, the formula assistant will still be opened if they are typed in. 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
