### PR TITLE
[FIX] l10n_multilang: avoid losing translations when upgrade

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -34,7 +34,7 @@ class AccountAccount(models.Model):
                 account_unaffected_earnings = self.browse(res['ids'])
                 raise ValidationError(_('You cannot have more than one account with "Current Year Earnings" as type. (accounts: %s)', [a.code for a in account_unaffected_earnings]))
 
-    name = fields.Char(string="Account Name", required=True, index='trigram', tracking=True)
+    name = fields.Char(string="Account Name", required=True, index='trigram', tracking=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     currency_id = fields.Many2one('res.currency', string='Account Currency', tracking=True,
         help="Forces all journal items in this account to have a specific currency (i.e. bank journals). If no currency is set, entries can use any currency.")
     code = fields.Char(size=64, required=True, tracking=True)
@@ -785,7 +785,7 @@ class AccountGroup(models.Model):
 
     parent_id = fields.Many2one('account.group', index=True, ondelete='cascade', readonly=True)
     parent_path = fields.Char(index=True, unaccent=False)
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     code_prefix_start = fields.Char()
     code_prefix_end = fields.Char()
     company_id = fields.Many2one('res.company', required=True, readonly=True, default=lambda self: self.env.company)

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -8,7 +8,7 @@ class AccountAccountTag(models.Model):
     _name = 'account.account.tag'
     _description = 'Account Tag'
 
-    name = fields.Char('Tag Name', required=True)
+    name = fields.Char('Tag Name', required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     applicability = fields.Selection([('accounts', 'Accounts'), ('taxes', 'Taxes'), ('products', 'Products')], required=True, default='accounts')
     color = fields.Integer('Color Index')
     active = fields.Boolean(default=True, help="Set active to false to hide the Account Tag without removing it.")

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -62,7 +62,7 @@ class AccountJournal(models.Model):
                     return model
         return 'odoo'
 
-    name = fields.Char(string='Journal Name', required=True)
+    name = fields.Char(string='Journal Name', required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     code = fields.Char(string='Short Code', size=5, required=True, help="Shorter name used for display. The journal entries of this journal will also be named using this prefix by default.")
     active = fields.Boolean(default=True, help="Set active to false to hide the Journal without removing it.")
     type = fields.Selection([

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -85,7 +85,7 @@ class AccountTax(models.Model):
     def _default_tax_group(self):
         return self.env.ref('account.tax_group_taxes')
 
-    name = fields.Char(string='Tax Name', required=True)
+    name = fields.Char(string='Tax Name', required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     name_searchable = fields.Char(store=False, search='_search_name',
           help="This dummy field lets us use another search method on the field 'name'."
                "This allows more freedom on how to search the 'name' compared to 'filter_domain'."
@@ -115,7 +115,7 @@ class AccountTax(models.Model):
         help="The sequence field is used to define order in which the tax lines are applied.")
     amount = fields.Float(required=True, digits=(16, 4), default=0.0)
     real_amount = fields.Float(string='Real amount to apply', compute='_compute_real_amount', store=True)
-    description = fields.Char(string='Label on Invoices')
+    description = fields.Char(string='Label on Invoices', overrides={'l10n_multilang': fields.Char(translate=True)})
     price_include = fields.Boolean(string='Included in Price', default=False,
         help="Check this if the price you use on the product and invoices includes this tax.")
     include_base_amount = fields.Boolean(string='Affect Base of Subsequent Taxes', default=False,

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -189,7 +189,7 @@ class AccountGroupTemplate(models.Model):
     _order = 'code_prefix_start'
 
     parent_id = fields.Many2one('account.group.template', ondelete='cascade')
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     code_prefix_start = fields.Char()
     code_prefix_end = fields.Char()
     chart_template_id = fields.Many2one('account.chart.template', string='Chart Template', required=True)
@@ -201,7 +201,7 @@ class AccountAccountTemplate(models.Model):
     _description = 'Templates for Accounts'
     _order = "code"
 
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     currency_id = fields.Many2one('res.currency', string='Account Currency', help="Forces all moves for this account to have this secondary currency.")
     code = fields.Char(size=64, required=True)
     account_type = fields.Selection(
@@ -263,7 +263,7 @@ class AccountChartTemplate(models.Model):
     _name = "account.chart.template"
     _description = "Account Chart Template"
 
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     parent_id = fields.Many2one('account.chart.template', string='Parent Chart Template')
     code_digits = fields.Integer(string='# of Digits', required=True, default=6, help="No. of Digits to use for account code")
     visible = fields.Boolean(string='Can be Visible?', default=True,
@@ -1074,7 +1074,7 @@ class AccountTaxTemplate(models.Model):
 
     chart_template_id = fields.Many2one('account.chart.template', string='Chart Template', required=True)
 
-    name = fields.Char(string='Tax Name', required=True)
+    name = fields.Char(string='Tax Name', required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     type_tax_use = fields.Selection(TYPE_TAX_USE, string='Tax Type', required=True, default="sale",
         help="Determines where the tax is selectable. Note : 'None' means a tax can't be used by itself, however it can still be used in a group.")
     tax_scope = fields.Selection([('service', 'Service'), ('consu', 'Consumable')], help="Restrict the use of taxes to a type of product.")
@@ -1085,7 +1085,7 @@ class AccountTaxTemplate(models.Model):
     sequence = fields.Integer(required=True, default=1,
         help="The sequence field is used to define order in which the tax lines are applied.")
     amount = fields.Float(required=True, digits=(16, 4), default=0)
-    description = fields.Char(string='Display on Invoices')
+    description = fields.Char(string='Display on Invoices', overrides={'l10n_multilang': fields.Char(translate=True)})
     price_include = fields.Boolean(string='Included in Price', default=False,
         help="Check this if the price you use on the product and invoices includes this tax.")
     include_base_amount = fields.Boolean(string='Affect Subsequent Taxes', default=False,
@@ -1487,11 +1487,11 @@ class AccountFiscalPositionTemplate(models.Model):
     _description = 'Template for Fiscal Position'
 
     sequence = fields.Integer()
-    name = fields.Char(string='Fiscal Position Template', required=True)
+    name = fields.Char(string='Fiscal Position Template', required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     chart_template_id = fields.Many2one('account.chart.template', string='Chart Template', required=True)
     account_ids = fields.One2many('account.fiscal.position.account.template', 'position_id', string='Account Mapping')
     tax_ids = fields.One2many('account.fiscal.position.tax.template', 'position_id', string='Tax Mapping')
-    note = fields.Text(string='Notes')
+    note = fields.Text(string='Notes', overrides={'l10n_multilang': fields.Text(translate=True)})
     auto_apply = fields.Boolean(string='Detect Automatically', help="Apply automatically this fiscal position.")
     vat_required = fields.Boolean(string='VAT required', help="Apply only if partner has a VAT number.")
     country_id = fields.Many2one('res.country', string='Country',

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -20,7 +20,7 @@ class AccountFiscalPosition(models.Model):
     _order = 'sequence'
 
     sequence = fields.Integer()
-    name = fields.Char(string='Fiscal Position', required=True)
+    name = fields.Char(string='Fiscal Position', required=True, overrides={'l10n_multilang': fields.Char(translate=True)})
     active = fields.Boolean(default=True,
         help="By unchecking the active field, you may hide a fiscal position without deleting it.")
     company_id = fields.Many2one(

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -19,6 +19,7 @@ class AccountAnalyticAccount(models.Model):
         index='trigram',
         required=True,
         tracking=True,
+        overrides={'l10n_multilang': fields.Char(translate=True)},
     )
     code = fields.Char(
         string='Reference',

--- a/addons/l10n_multilang/models/account.py
+++ b/addons/l10n_multilang/models/account.py
@@ -62,7 +62,6 @@ class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 
     name = fields.Char(translate=True)
-    note = fields.Html(translate=True)
 
 
 class AccountFiscalPositionTemplate(models.Model):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -27,7 +27,7 @@ from difflib import get_close_matches
 from hashlib import sha256
 
 from .tools import (
-    float_repr, float_round, float_compare, float_is_zero, html_sanitize, human_size,
+    float_repr, float_round, float_compare, float_is_zero, frozendict, html_sanitize, human_size,
     pg_varchar, ustr, OrderedSet, pycompat, sql, date_utils, unique,
     image_process, merge_sequences, SQL_ORDER_BY_TYPE, is_list_of, has_list_types,
 )
@@ -307,6 +307,8 @@ class Field(MetaField('DummyField', (object,), {})):
 
     default_export_compatible = False   # whether the field must be exported by default in an import-compatible export
     exportable = True
+
+    overrides = frozendict()            # {module_name: field}
 
     def __init__(self, string=Default, **kwargs):
         kwargs['string'] = string

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2763,6 +2763,14 @@ class BaseModel(metaclass=MetaModel):
                 for field in klass._field_definitions:
                     definitions[field.name].append(field)
         for name, fields_ in definitions.items():
+            # obscure feature, to be removed later: this is useful to deal with
+            # inconsistent column types; it supports fields that are not
+            # translated yet but are translated in the database because of a
+            # module that will be loaded later
+            if cls.pool._graph:
+                for module, override in fields_[0].overrides.items():
+                    if module not in cls.pool._init_modules and module in cls.pool._graph:
+                        fields_.append(override)
             if len(fields_) == 1 and fields_[0]._direct and fields_[0].model_name == cls._name:
                 cls._fields[name] = fields_[0]
             else:

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -417,6 +417,9 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
             _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
             raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
 
+        # this is needed for the field.overrides trick
+        registry._graph = graph
+
         # processed_modules: for cleanup step after install
         # loaded_modules: to avoid double loading
         report = registry._assertion_report
@@ -484,6 +487,7 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
                     loaded_modules, update_module, models_to_check)
 
         registry.loaded = True
+        registry._graph = None
         registry.setup_models(cr)
 
         # check that all installed modules have been loaded by the registry

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -114,6 +114,7 @@ class Registry(Mapping):
         self.models = {}    # model name/model instance mapping
         self._sql_constraints = set()
         self._init = True
+        self._graph = None
         self._assertion_report = odoo.tests.runner.OdooTestResult()
         self._fields_by_model = None
         self._ordinary_tables = None


### PR DESCRIPTION
if the 'translate' attribute of a field in module A is overridden by another field in module B from `translate=False` to `translate=True`, while upgrading module A, the info of module B hasn't been loaded. As a result, the ORM thinks the field is `translate=False` and changes the column type from jsonb to varchar and drops all translations.

This commit adds a new field attribute `overrides` which allows the ORM to know if the field will be overridden in the future during upgrade.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
