### PR TITLE
[FIX] product_expiry: Correct alert date

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -54,8 +54,8 @@ class StockMoveLine(models.Model):
         if self.expiration_date:
             res.update({
                 'expiration_date': self.expiration_date,
-                'use_date': self.product_id.use_time and self.expiration_date - datetime.timedelta(days=(self.product_id.expiration_time - self.product_id.use_time)),
-                'removal_date': self.product_id.removal_time and self.expiration_date - datetime.timedelta(days=(self.product_id.expiration_time - self.product_id.removal_time)),
-                'alert_date': self.product_id.alert_time and self.expiration_date - datetime.timedelta(days=(self.product_id.expiration_time - self.product_id.alert_time))
+                'use_date': self.expiration_date - datetime.timedelta(days=self.product_id.use_time),
+                'removal_date': self.expiration_date - datetime.timedelta(days=self.product_id.removal_time),
+                'alert_date': self.expiration_date - datetime.timedelta(days=self.product_id.alert_time),
             })
         return res


### PR DESCRIPTION
Previous to this, alert date would be added to expiry date on lots. 
Now, its substracts it as expected.
OPW-2990209


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
