### PR TITLE
[FIX] l10n_generic_coa : Removed duplicate cash discount accounts from generic charts of account template.

### DIFF
--- a/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
@@ -26,8 +26,6 @@
             <field name="default_pos_receivable_account_id" ref="pos_receivable"/>
             <field name="property_tax_payable_account_id" ref="tax_payable"/>
             <field name="property_tax_receivable_account_id" ref="tax_receivable"/>
-            <field name="account_journal_early_pay_discount_loss_account_id" ref="cash_discount_loss"/>
-            <field name="account_journal_early_pay_discount_gain_account_id" ref="cash_discount_gain"/>
         </record>
         <record id="sale_tax_template" model="account.tax.template">
             <field name="chart_template_id" ref="configurable_chart_template"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR remove the duplicate cash discount accounts from generic charts of account template data.

Impacted versions:
- 16.0

**Current behaviour before PR:**
Added double cash discount gain and loss accounts in generic charts of template data definition

**Desired behaviour after PR is merged:**
Fixed double cash discount gain and loss accounts from generic charts of template data definition.

Duplicate Code Commit Reference:
[591757902](https://github.com/odoo/odoo/commit/591757902dcdf1e3609d9c5ae23e2b134ee8e4da#diff-4401e08d3dd4c7c8044d3c9536fc1018385099807fb9824ad9920b26e4d796d5R29)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
